### PR TITLE
[Recover via console] Avoid entering into rescue model of ONIE. 

### DIFF
--- a/.azure-pipelines/recover_testbed/common.py
+++ b/.azure-pipelines/recover_testbed/common.py
@@ -6,8 +6,8 @@ import socket
 import time
 import pexpect
 import ipaddress
-from constants import OS_VERSION_IN_GRUB, ONIE_ENTRY_IN_GRUB, INSTALL_OS_IN_ONIE, \
-    ONIE_START_TO_DISCOVERY, SONIC_PROMPT, MARVELL_ENTRY, BOOTING_INSTALL_OS
+from constants import OS_VERSION_IN_GRUB, ONIE_ENTRY_IN_GRUB, ONIE_INSTALL_MODEL, \
+    ONIE_START_TO_DISCOVERY, SONIC_PROMPT, MARVELL_ENTRY, BOOTING_INSTALL_OS, ONIE_RESCUE_MODEL
 
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, "../.."))
@@ -80,9 +80,13 @@ def posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=False, is_nokia=F
                     dut_console.remote_conn.send(b'\x1b[B')
                     continue
 
-                if ONIE_ENTRY_IN_GRUB in x and INSTALL_OS_IN_ONIE not in x:
+                if ONIE_ENTRY_IN_GRUB in x and ONIE_INSTALL_MODEL not in x and ONIE_RESCUE_MODEL not in x:
                     dut_console.remote_conn.send("\n")
                     enter_onie_flag = False
+
+                if ONIE_RESCUE_MODEL in x:
+                    dut_console.remote_conn.send(b'\x1b[A')
+                    dut_console.remote_conn.send("\n")
 
                 if is_celestica and BOOTING_INSTALL_OS in x:
                     dut_console.remote_conn.send("\n")

--- a/.azure-pipelines/recover_testbed/constants.py
+++ b/.azure-pipelines/recover_testbed/constants.py
@@ -38,7 +38,8 @@ ONIE_ENTRY_IN_GRUB = "*ONIE"
 #       Press enter to boot the selected OS, `e' to edit the commands
 #       before booting or `c' for a command-line.
 
-INSTALL_OS_IN_ONIE = "Install OS"
+ONIE_INSTALL_MODEL = "Install"
+ONIE_RESCUE_MODEL = "Rescue"
 
 # While entering into ONIE, we will get some output like
 # " Booting `ONIE: Install OS' "


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We observed a misalignment issue on 4600c dualtor testbeds, where the first line of each screen was not consistent. When we tried to select ONIE mode, it would go into ONIE Rescue mode with our previous code. To fix this, we added a condition to check if the output string contained "Rescue", and if so, we would send the arrow key "UP" to enter into ONIE Install mode.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
We observed a misalignment issue on 4600c dualtor testbeds, where the first line of each screen was not consistent. When we tried to select ONIE mode, it would go into ONIE Rescue mode with our previous code. To fix this, we added a condition to check if the output string contained "Rescue", and if so, we would send the arrow key "UP" to enter into ONIE Install mode.

#### How did you do it?
To fix this, we added a condition to check if the output string contained "Rescue", and if so, we would send the arrow key "UP" to enter into ONIE Install mode.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
