### PR TITLE
Fix for vxlan_decap test failure on dualtor-aa

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan-decap.py
@@ -169,7 +169,7 @@ class Vxlan(BaseTest):
                 else:
                     addr += 1  # skip gw
             res[port] = host_ip
-            #skip soc IPs for aa dualtor
+            # skip soc IPs for aa dualtor
             if self.is_active_active_dualtor:
                 addr += 2
             else:
@@ -495,7 +495,7 @@ class Vxlan(BaseTest):
 
         exp_packet = Mask(exp_packet)
         exp_packet.set_do_not_care_scapy(scapy.Ether, "dst")
-        #skip smac check for aa dualtor
+        # skip smac check for aa dualtor
         if self.is_active_active_dualtor:
             exp_packet.set_do_not_care_scapy(scapy.Ether, "src")
 

--- a/ansible/roles/test/files/ptftests/py3/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan-decap.py
@@ -225,9 +225,9 @@ class Vxlan(BaseTest):
             self.net_ports.extend(members)
             if self.is_active_active_dualtor:
                 self.all_active_net_ports.extend(members)
-                    members = [graph['minigraph_unselected_port_indices'][member]
-                               for member in val['members']]
-                    self.all_active_net_ports.extend(members)
+                members = [graph['minigraph_unselected_port_indices'][member]
+                           for member in val['members']]
+                self.all_active_net_ports.extend(members)
             ip = None
 
             for d in graph['minigraph_portchannel_interfaces']:

--- a/ansible/roles/test/files/ptftests/py3/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan-decap.py
@@ -48,7 +48,7 @@ from ptf.mask import Mask
 from device_connection import DeviceConnection
 
 
-def count_matched_packets_helper(test, exp_packet, exp_packet_number, port, device_number=0, timeout=1):
+def count_matched_packets_helper(test, exp_packet, exp_packet_number, port=None, device_number=0, timeout=1):
     """
     Add exp_packet_number to original ptf interface in order to
     stop waiting when expected number of packets is received
@@ -169,7 +169,10 @@ class Vxlan(BaseTest):
                 else:
                     addr += 1  # skip gw
             res[port] = host_ip
-            addr += 1
+            if self.is_active_active_dualtor:
+                addr += 2
+            else:
+                addr += 1
 
         return res
 
@@ -177,6 +180,7 @@ class Vxlan(BaseTest):
         self.dataplane = ptf.dataplane_instance
 
         self.test_params = testutils.test_params_get()
+        self.is_active_active_dualtor = self.test_params.get("is_active_active_dualtor", False)
         if 'vxlan_enabled' in self.test_params and self.test_params['vxlan_enabled']:
             self.vxlan_enabled = True
 
@@ -214,10 +218,16 @@ class Vxlan(BaseTest):
 
         self.pc_info = []
         self.net_ports = []
+        self.all_active_net_ports = []
         for name, val in graph['minigraph_portchannels'].items():
             members = [graph['minigraph_port_indices'][member]
                        for member in val['members']]
             self.net_ports.extend(members)
+            if self.is_active_active_dualtor:
+                    self.all_active_net_ports.extend(members)
+                    members = [graph['minigraph_unselected_port_indices'][member]
+                               for member in val['members']]
+                    self.all_active_net_ports.extend(members)
             ip = None
 
             for d in graph['minigraph_portchannel_interfaces']:
@@ -426,11 +436,12 @@ class Vxlan(BaseTest):
         self.work_test()
 
     def Vxlan(self, test):
-        for i, n in enumerate(test['acc_ports']):
-            for j, a in enumerate(test['acc_ports']):
-                res, out = self.checkVxlan(a, n, test, self.vlan_mac)
-                if not res:
-                    return False, out + " | net_port_rel(acc)=%d acc_port_rel=%d" % (i, j)
+        if not self.is_active_active_dualtor:
+            for i, n in enumerate(test['acc_ports']):
+                for j, a in enumerate(test['acc_ports']):
+                    res, out = self.checkVxlan(a, n, test, self.vlan_mac)
+                    if not res:
+                        return False, out + " | net_port_rel(acc)=%d acc_port_rel=%d" % (i, j)
 
         for i, n in enumerate(self.net_ports):
             for j, a in enumerate(test['acc_ports']):
@@ -483,17 +494,27 @@ class Vxlan(BaseTest):
 
         exp_packet = Mask(exp_packet)
         exp_packet.set_do_not_care_scapy(scapy.Ether, "dst")
+        if self.is_active_active_dualtor:
+            exp_packet.set_do_not_care_scapy(scapy.Ether, "src")
 
         self.dataplane.flush()
         for i in range(self.nr):
             testutils.send_packet(self, acc_port, packet)
-        nr_rcvd = count_matched_packets_all_ports_helper(
-            self, exp_packet, self.nr, pc_ports, timeout=20)
+        if self.is_active_active_dualtor:
+            nr_rcvd = count_matched_packets_all_ports_helper(
+                self, exp_packet, self.nr, self.all_active_net_ports, timeout=20)
+        else:
+            nr_rcvd = count_matched_packets_all_ports_helper(
+                self, exp_packet, self.nr, pc_ports, timeout=20)
         rv = nr_rcvd == self.nr
         out = ""
         if not rv:
-            arg = self.nr, nr_rcvd, str(acc_port), str(
-                pc_ports), src_mac, dst_mac, src_ip, dst_ip
+            if self.is_active_active_dualtor:
+                arg = self.nr, nr_rcvd, str(acc_port), str(
+                    self.all_active_net_ports), src_mac, dst_mac, src_ip, dst_ip
+            else:
+                arg = self.nr, nr_rcvd, str(acc_port), str(
+                    pc_ports), src_mac, dst_mac, src_ip, dst_ip
             out = "sent = %d rcvd = %d | src_port=%s dst_ports=%s | src_mac=%s dst_mac=%s src_ip=%s dst_ip=%s" % arg
         return rv, out
 
@@ -565,8 +586,12 @@ class Vxlan(BaseTest):
         self.dataplane.flush()
         for i in range(self.nr):
             testutils.send_packet(self, net_port, packet)
-        nr_rcvd = count_matched_packets_helper(
-            self, inpacket, self.nr, acc_port, timeout=20)
+        if self.is_active_active_dualtor:
+            nr_rcvd = count_matched_packets_helper(
+                self, inpacket, self.nr, timeout=20)
+        else:
+            nr_rcvd = count_matched_packets_helper(
+                self, inpacket, self.nr, acc_port, timeout=20)
         rv = nr_rcvd == self.nr
         out = ""
         if not rv:

--- a/ansible/roles/test/files/ptftests/py3/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan-decap.py
@@ -169,6 +169,7 @@ class Vxlan(BaseTest):
                 else:
                     addr += 1  # skip gw
             res[port] = host_ip
+            #skip soc IPs for aa dualtor
             if self.is_active_active_dualtor:
                 addr += 2
             else:
@@ -494,6 +495,7 @@ class Vxlan(BaseTest):
 
         exp_packet = Mask(exp_packet)
         exp_packet.set_do_not_care_scapy(scapy.Ether, "dst")
+        #skip smac check for aa dualtor
         if self.is_active_active_dualtor:
             exp_packet.set_do_not_care_scapy(scapy.Ether, "src")
 

--- a/ansible/roles/test/files/ptftests/py3/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan-decap.py
@@ -225,7 +225,7 @@ class Vxlan(BaseTest):
             self.net_ports.extend(members)
             if self.is_active_active_dualtor:
                 self.all_active_net_ports.extend(members)
-                members = [graph['minigraph_unselected_port_indices'][member]
+                members = [graph['mg_unslctd_port_idx'][member]
                            for member in val['members']]
                 self.all_active_net_ports.extend(members)
             ip = None

--- a/ansible/roles/test/files/ptftests/py3/vxlan-decap.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan-decap.py
@@ -224,7 +224,7 @@ class Vxlan(BaseTest):
                        for member in val['members']]
             self.net_ports.extend(members)
             if self.is_active_active_dualtor:
-                    self.all_active_net_ports.extend(members)
+                self.all_active_net_ports.extend(members)
                     members = [graph['minigraph_unselected_port_indices'][member]
                                for member in val['members']]
                     self.all_active_net_ports.extend(members)

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -56,7 +56,8 @@ def prepare_ptf(ptfhost, mg_facts, duthost, unselected_mg_facts=None):
 
     vxlan_decap = {
         "minigraph_port_indices": mg_facts["minigraph_ptf_indices"],
-        "minigraph_unselected_port_indices": [] if unselected_mg_facts is None else unselected_mg_facts["minigraph_ptf_indices"],
+        "minigraph_unselected_port_indices": [] if unselected_mg_facts is None
+            else unselected_mg_facts["minigraph_ptf_indices"],
         "minigraph_portchannel_interfaces": mg_facts["minigraph_portchannel_interfaces"],
         "minigraph_portchannels": mg_facts["minigraph_portchannels"],
         "minigraph_lo_interfaces": mg_facts["minigraph_lo_interfaces"],

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -57,7 +57,7 @@ def prepare_ptf(ptfhost, mg_facts, duthost, unselected_mg_facts=None):
     vxlan_decap = {
         "minigraph_port_indices": mg_facts["minigraph_ptf_indices"],
         "minigraph_unselected_port_indices": [] if unselected_mg_facts is None
-            else unselected_mg_facts["minigraph_ptf_indices"],
+                                             else unselected_mg_facts["minigraph_ptf_indices"],
         "minigraph_portchannel_interfaces": mg_facts["minigraph_portchannel_interfaces"],
         "minigraph_portchannels": mg_facts["minigraph_portchannels"],
         "minigraph_lo_interfaces": mg_facts["minigraph_lo_interfaces"],

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -29,7 +29,7 @@ VNI_BASE = 336
 COUNT = 1
 
 
-def prepare_ptf(ptfhost, mg_facts, duthost, unselected_mg_facts=None):
+def prepare_ptf(ptfhost, mg_facts, duthost, unslctd_mg_facts=None):
     """Prepare arp responder configuration and store temporary vxlan decap related information to PTF docker
 
     Args:
@@ -56,8 +56,7 @@ def prepare_ptf(ptfhost, mg_facts, duthost, unselected_mg_facts=None):
 
     vxlan_decap = {
         "minigraph_port_indices": mg_facts["minigraph_ptf_indices"],
-        "minigraph_unselected_port_indices": [] if unselected_mg_facts is None
-                                             else unselected_mg_facts["minigraph_ptf_indices"],
+        "mg_unslctd_port_idx": [] if unslctd_mg_facts is None else unslctd_mg_facts["mg_ptf_idx"],
         "minigraph_portchannel_interfaces": mg_facts["minigraph_portchannel_interfaces"],
         "minigraph_portchannels": mg_facts["minigraph_portchannels"],
         "minigraph_lo_interfaces": mg_facts["minigraph_lo_interfaces"],
@@ -118,14 +117,14 @@ def setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     if bool(active_active_ports):
         idx = duthosts.index(duthost)
         unselected_duthost = duthosts[1 - idx]
-        unselected_mg_facts = unselected_duthost.minigraph_facts(host=unselected_duthost.hostname)['ansible_facts']
-        unselected_mg_facts['minigraph_ptf_indices'] = unselected_mg_facts['minigraph_port_indices'].copy()
+        unslctd_mg_facts = unselected_duthost.minigraph_facts(host=unselected_duthost.hostname)['ansible_facts']
+        unslctd_mg_facts['mg_ptf_idx'] = unslctd_mg_facts['minigraph_port_indices'].copy()
         try:
             map = tbinfo['topo']['ptf_map'][str(1 - idx)]
             if map:
-                for port, index in list(unselected_mg_facts['minigraph_port_indices'].items()):
+                for port, index in list(unslctd_mg_facts['minigraph_port_indices'].items()):
                     if str(index) in map:
-                        unselected_mg_facts['minigraph_ptf_indices'][port] = map[str(index)]
+                        unslctd_mg_facts['mg_ptf_idx'][port] = map[str(index)]
         except (ValueError, KeyError):
             pass
 
@@ -138,7 +137,7 @@ def setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
 
     logger.info("Prepare PTF")
     if bool(active_active_ports):
-        prepare_ptf(ptfhost, mg_facts, duthost, unselected_mg_facts)
+        prepare_ptf(ptfhost, mg_facts, duthost, unslctd_mg_facts)
     else:
         prepare_ptf(ptfhost, mg_facts, duthost)
 


### PR DESCRIPTION
### Description of PR
vxaln decaptTest adaptation for DToR A/A topology

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/11683

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
vxlan/test_vxlan_decap.py failure on DToR AA with below error
```
FAIL\n\n==================================================================      ====\nFAIL: vxlan-decap.Vxlan\n----------------------------------------------------------------------\nTraceback (most recen      t call last):\n  File \"ptftests/py3/vxlan-decap.py\", line 424, in runTest\n    self.warmup()\n  File \"ptftests/py3/vxlan-      decap.py\", line 358, in warmup\n    raise AssertionError(\"Warmup failed\")\nAssertionError: Warmup failed\n\n-------------      ---------------------------------------------------------\nRan 1 test in 87.954s\n\nFAILED (failures=1)", "rc": 1, "invocati      on": {"module_args": {"creates": null, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "/r      oot/env-python3/bin/ptf --test-dir ptftests/py3 vxlan-decap.Vxlan --platform-dir ptftests --qlen=10000 --platform remote -t       'vxlan_enabled=False;config_file='\"'\"'/tmp/vxlan_decap.json'\"'\"';count=1;sonic_admin_user='\"'\"'cisco'\"'\"';sonic_admi      n_password='\"'\"'cisco123'\"'\"';sonic_admin_alt_password='\"'\"'YourPaSsWoRd'\"'\"';dut_hostname='\"'\"'1.75.47.10'\"'\"''       --relax --debug info --log-file /tmp/vxlan-decap.Vxlan.NoVxLAN.2024-01-18-16:11:47.log", "removes": null, "argv": null, "wa      rn": true, "chdir": "/root", "stdin_add_newline": true, "stdin": null}}, "start": "2024-01-18 16:11:47.820253", "msg": "non-      zero return code", "stdout_lines": ["Using packet manipulation module: ptf.packet_scapy", "", "*****************************      *************", "ATTENTION: SOME TESTS DID NOT PASS!!!", "", "The following tests failed:", "Vxlan", "", "******************      ************************"], "stderr_lines": ["/root/env-python3/bin/ptf:19: DeprecationWarning: the imp module is deprecated       in favour of importlib; see the module's documentation for alternative uses", "  import imp", "vxlan-decap.Vxlan ... FAIL",       "", "======================================================================", "FAIL: vxlan-decap.Vxlan", "-----------------      -----------------------------------------------------", "Traceback (most recent call last):", "  File \"ptftests/py3/vxlan-d      ecap.py\", line 424, in runTest", "    self.warmup()", "  File \"ptftests/py3/vxlan-decap.py\", line 358, in warmup", "    r      aise AssertionError(\"Warmup failed\")", "AssertionError: Warmup failed", "", "---------------------------------------------
```

#### How did you do it?
Adapted the test for DToR AA.
Part - 1:
vxlan decap test to skip the SoC IPs while generating VLAN Prefixes.

Part - 2:
After Part-1, warm up and "lag to vlan" started passing but "vlan to lag" and vxlan were still failing because expected test pkts were going to the unselected active ToR.
vxlan decap test in A/A topology to consider the possibility of northbound test pkts going to unselected active ToR and check for test pkts on unselected active ToR too.

#### How did you verify/test it?
verified that vxlan/test_vxlan_decap.py passes on T0 DToR AA, AS and standalone setups

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
NA