### PR TITLE
[devutils] Fix issue of parsing output_watts of PDU

### DIFF
--- a/ansible/devutils
+++ b/ansible/devutils
@@ -305,9 +305,9 @@ def pdu_action_on_dut(host, attrs, action):
         ret['Summary'].append('Unsupported action {}.'.format(action))
         return ret
 
-    status = pduman.get_outlet_status()
+    outlet_status = pduman.get_outlet_status()
     psu_status = {}
-    for outlet in status:
+    for outlet in outlet_status:
         ret['PDU status'].append(outlet)
         psu_name = outlet['psu_name']
         status = psu_status.get(psu_name, {
@@ -318,7 +318,15 @@ def pdu_action_on_dut(host, attrs, action):
         if 'output_watts' not in outlet:
             status['output_watts'] = 'N/A'
         else:
-            status['output_watts'] = status['output_watts'] + int(outlet.get('output_watts', 0))
+            raw_outlet_watts = outlet['output_watts']
+            if not raw_outlet_watts:
+                outlet_watts = 0
+            else:
+                try:
+                    outlet_watts = int(outlet['output_watts'])
+                except ValueError:
+                    outlet_watts = 0
+            status['output_watts'] = status['output_watts'] + outlet_watts
         psu_status[psu_name] = status
     ret['PSU status'] = psu_status
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The devutils tool may raise exception like below if the output_watts of PDU is empty string `''`:

ValueError("invalid literal for int() with base 10: \'\'")

#### How did you do it?
This change improved the code of parsing output_watts. Another issue is that a temporary variable named `status` conflicts with another variable. This change also fixed that.

#### How did you verify/test it?
Verified by trying to get pdu status using the devutils tool.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
