### PR TITLE
[macsec]: Fix minigraph_ptf_indices key error

### DIFF
--- a/tests/macsec/__init__.py
+++ b/tests/macsec/__init__.py
@@ -150,6 +150,9 @@ class MacsecPlugin(object):
         def filter(interface, neighbor, mg_facts, tbinfo):
             if self.downstream_neighbor(tbinfo, neighbor):
                 port = mg_facts["minigraph_neighbors"][interface]["port"]
+                if interface not in mg_facts["minigraph_ptf_indices"]:
+                    logger.info("Interface {} not in minigraph_ptf_indices".format(interface))
+                    return
                 links[interface] = {
                     "name": neighbor["name"],
                     "ptf_port_id": mg_facts["minigraph_ptf_indices"][interface],
@@ -172,6 +175,9 @@ class MacsecPlugin(object):
                             # The address of DUT
                             peer_ipv4_addr = item["peer_addr"]
                             break
+                if interface not in mg_facts["minigraph_ptf_indices"]:
+                    logger.info("Interface {} not in minigraph_ptf_indices".format(interface))
+                    return
                 port = mg_facts["minigraph_neighbors"][interface]["port"]
                 links[interface] = {
                     "name": neighbor["name"],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Got the following error:
```
    def filter(interface, neighbor, mg_facts, tbinfo):
        if self.downstream_neighbor(tbinfo, neighbor):
            port = mg_facts["minigraph_neighbors"][interface]["port"]
            links[interface] = {
                "name": neighbor["name"],
>               "ptf_port_id": mg_facts["minigraph_ptf_indices"][interface],
                "port": port
            }
E           KeyError: '['

interface  = '['
links      = defaultdict(<class 'dict'>, {})
mg_facts   = {'deployment_id': '1', 'dhcp_servers': ['192.0.0.1', '192.0.0.2', '192.0.0.3', '192.0.0.4'], 'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2', 'fc02:2000::3', 'fc02:2000::4'], 'forced_mgmt_routes': ['172.17.0.1/24'], ...}
neighbor   = {'name': 'Servers524', 'namespace': '', 'port': 'eth0'}
port       = 'eth0'
self       = <tests.macsec.MacsecPluginT0 object at 0x7fda66e14b80>
tbinfo     = {'auto_recover': 'False', 'comment': 'Tests virtual switch vm', 'conf-name': 'vms-kvm-t0-64-32', 'duts': ['vlab-02'], ...}

macsec/__init__.py:155: KeyError
```

The neighbor devices from eth0(management port) are leaked into the minigraph but they are not managed by PTF.
```
  "minigraph_neighbors": {
    " ": {
      "name": "Servers542",
      "namespace": "",
      "port": "eth0"
    },
    "'": {
      "name": "Servers541",
      "namespace": "",
      "port": "eth0"
    },
    "8": {
      "name": "Servers357",
      "namespace": "",
      "port": "eth0"
    },
    "9": {
      "name": "Servers379",
      "namespace": "",
      "port": "eth0"
    },
    "E": {
      "name": "Servers534",
      "namespace": "",
      "port": "eth0"
    },
...
    "Ethernet0": {
      "name": "ARISTA01T1",
      "namespace": "",
      "port": "Ethernet1"
    },
    "Ethernet1": {
      "name": "ARISTA01T1",
      "namespace": "",
      "port": "Ethernet2"
    },
    "Ethernet16": {
      "name": "ARISTA03T1",
      "namespace": "",
      "port": "Ethernet1"
    },
    "Ethernet17": {
      "name": "ARISTA03T1",
      "namespace": "",
      "port": "Ethernet2"
    },
...
}
```

#### How did you do it?
To skip these uncontrolled neighbor devices because they will not be used for MACsec

#### How did you verify/test it?

Check Azp and internal branch

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
