### PR TITLE
Update bgpmon test for t2 to be able to run on any Linecard

### DIFF
--- a/tests/bgp/test_bgpmon_v6.py
+++ b/tests/bgp/test_bgpmon_v6.py
@@ -76,7 +76,7 @@ def get_uplink_route_mac(duthosts, port):
             # if this duthost has peer of type RH/AZNG, then it is uplink LC
             # return the router mac for that duthost/asic
             if v['type'] == "RegionalHub" or v['type'] == "AZNGHub":
-                #Get the router_mac based on which asic the port belongs to in this dut
+                # Get the router_mac based on which asic the port belongs to in this dut
                 return duthost.get_port_asic_instance(port).get_router_mac()
 
 
@@ -190,7 +190,6 @@ def test_bgpmon_v6(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostnam
     # Verify syn packet on ptf
     (rcvd_port_index, rcvd_pkt) = testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_packet,
                                                                    ports=peer_ports, timeout=BGP_CONNECT_TIMEOUT)
-
 
     # Find the local dut port that is mapped to this received ptf interface, get the router_mac for that asic
     # For packet chassis router mac is different across asics

--- a/tests/bgp/test_bgpmon_v6.py
+++ b/tests/bgp/test_bgpmon_v6.py
@@ -14,7 +14,6 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.utilities import wait_tcp_connection
 from bgp_helpers import BGPMON_TEMPLATE_FILE, BGPMON_CONFIG_FILE, BGP_MONITOR_NAME, BGP_MONITOR_PORT
-from test_bgpmon import get_default_route_ports
 pytestmark = [
     pytest.mark.topology('t2'),
 ]
@@ -25,6 +24,7 @@ MAX_TIME_FOR_BGPMON = 180
 ZERO_ADDR = r'0.0.0.0/0'
 ZERO_V6_ADDR = r'::/0'
 logger = logging.getLogger(__name__)
+
 
 def get_all_uplink_ptf_recv_ports(duthosts, tbinfo):
     """
@@ -55,6 +55,7 @@ def get_all_uplink_ptf_recv_ports(duthosts, tbinfo):
 
     return port_indices
 
+
 def get_uplink_route_mac(duthosts):
     """
     This function returns the router mac of dut which has connectivity to T3 (RNG/AZH) layer.
@@ -69,10 +70,12 @@ def get_uplink_route_mac(duthosts):
         for k, v in device_neighbor_metadata.items():
             if v['type'] == "RegionalHub" or v['type'] == "AZNGHub":
                 return duthost.facts["router_mac"]
-                break;
+                break
+
 
 @pytest.fixture
-def common_v6_setup_teardown(duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index):
+def common_v6_setup_teardown(duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_hostname,
+                             enum_rand_one_frontend_asic_index):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     peer_addr = generate_ip_through_default_v6_route(duthost)
     router_id = generate_ip_through_default_route(duthost)
@@ -149,8 +152,10 @@ def build_v6_syn_pkt(local_addr, peer_addr):
 
     return exp_packet
 
-def test_bgpmon_v6(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index,
-                   common_v6_setup_teardown, set_timeout_for_bgpmon, ptfadapter, ptfhost):
+
+def test_bgpmon_v6(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname,
+                   enum_rand_one_frontend_asic_index, common_v6_setup_teardown,
+                   set_timeout_for_bgpmon, ptfadapter, ptfhost):
     """
     Add a bgp monitor on ptf and verify that DUT is attempting to establish connection to it
     """
@@ -206,8 +211,8 @@ def test_bgpmon_v6(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostnam
         ptfhost.shell("ifconfig %s hw ether %s" % (ptf_interface, original_mac))
 
 
-def test_bgpmon_no_ipv6_resolve_via_default(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index,
-                                            common_v6_setup_teardown, ptfadapter):
+def test_bgpmon_no_ipv6_resolve_via_default(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                            enum_rand_one_frontend_asic_index, common_v6_setup_teardown, ptfadapter):
     """
     Verify no syn for BGP is sent when 'ipv6 nht resolve-via-default' is disabled.
     """

--- a/tests/bgp/test_bgpmon_v6.py
+++ b/tests/bgp/test_bgpmon_v6.py
@@ -206,7 +206,8 @@ def test_bgpmon_v6(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostnam
     finally:
         ptfhost.exabgp(name=BGP_MONITOR_NAME, state="absent")
         ptfhost.shell("ip -6 route del %s dev %s" % (local_addr + "/128", ptf_interface))
-        ptfhost.shell("ip -6 neigh del %s lladdr %s dev %s" % (local_addr, get_uplink_route_mac(duthosts), ptf_interface))
+        ptfhost.shell("ip -6 neigh del %s lladdr %s dev %s" % (local_addr, get_uplink_route_mac(duthosts),
+                      ptf_interface))
         ptfhost.shell("ip -6 addr del %s dev %s" % (peer_addr + "/128", ptf_interface))
         ptfhost.shell("ifconfig %s hw ether %s" % (ptf_interface, original_mac))
 

--- a/tests/bgp/test_bgpmon_v6.py
+++ b/tests/bgp/test_bgpmon_v6.py
@@ -77,7 +77,8 @@ def get_uplink_route_mac(duthosts, port):
             # return the router mac for that duthost/asic
             if v['type'] == "RegionalHub" or v['type'] == "AZNGHub":
                 # Get the router_mac based on which asic the port belongs to in this dut
-                return duthost.get_port_asic_instance(port).get_router_mac()
+                return duthost.get_port_asic_instance(port).get_router_mac() \
+                                    if duthost.is_multi_asic else duthost.facts["router_mac"]
 
 
 @pytest.fixture


### PR DESCRIPTION
### Description of PR
Update bgpmon test for t2 to be able to run on any Linecard. Currently it can be run only on uplink linecard connected to T3 devices

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

Update bgpmon test for t2 to be able to run on any Linecard. Currently it can be run only on uplink linecard connected to T3 devices


#### How did you do it?

The following changes are made
1. Added a new API get_all_uplink_ptf_recv_ports() which will get the ptf interfaces and the corresponding local dut port interfaces where the T3 neighbors are connected to
2. Add a new API get_uplink_route_mac() to get the router mac based on the interface. In case of multi-asic device the router-macs's could be different between asics
3. Based on the recv_ptf port, get the corresponding local dut port using local_ports[rcvd_port_index]
4. Use this router mac to configure neighbor in the ptfhost, So that that the bgp packets coming into the uplink linecard from ptf will be forwarded correctly either to local LC or remote LC based on the duthost selected.

#### How did you verify/test it?

Ran the test on both uplink and downlink linecards 

```
On LC1, uplink LC

bgp/test_bgpmon_v6.py::test_bgpmon_v6[str2-xxxx-lc1-2-0] PASSED                                                                                                                                                                                          [ 50%]
bgp/test_bgpmon_v6.py::test_bgpmon_no_ipv6_resolve_via_default[str2-xxxx-lc1-2-1]  PASSED           

On LC2, downlink LC

bgp/test_bgpmon_v6.py::test_bgpmon_v6[str2-xxxx-lc2-2-0] PASSED                                                                                                                                                                                          [ 50%]
bgp/test_bgpmon_v6.py::test_bgpmon_no_ipv6_resolve_via_default[str2-xxxx-lc2-2-0]  PASSED      
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
