### PR TITLE
Add skip for fast reboot test on some mellanox platform by github issue

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -983,6 +983,11 @@ platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset:
       - "platform in ['x86_64-cel_e1031-r0'] or 't2' in topo_name"
       - https://github.com/sonic-net/sonic-mgmt/issues/6218
 
+platform_tests/test_advanced_reboot.py::test_fast_reboot:
+  skip:
+    reason: "Testcase ignored due to github issue: https://github.com/sonic-net/sonic-buildimage/issues/17792"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/17792 and 'sn2700' in platform"
 
 platform_tests/test_auto_negotiation.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add skip for fast reboot test on some mellanox SN2 paltform by github issue:  https://github.com/sonic-net/sonic-buildimage/issues/17792
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
