### PR TITLE
Add test case skip for mellanox platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -80,6 +80,12 @@ bfd/test_bfd.py::test_bfd_basic:
     conditions:
       - "platform in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0']"
 
+bfd/test_bfd.py::test_bfd_multihop:
+  skip:
+    reason: "Skip on the Mellanox platforms due to feature limitation, remove it after the feature included"
+    conditions:
+      - "asic_type in ['mellanox'] and 't1' in topo_name"
+
 bfd/test_bfd.py::test_bfd_scale:
   skip:
     reason: "Test not supported for cisco-8102 as it doesnt support single hop BFD. Skipping the test"
@@ -125,6 +131,12 @@ bgp/test_bgp_queue.py:
     reason: "Unsupported topology"
     conditions:
       - "topo_type in ['m0', 'mx']"
+
+bgp/test_bgp_queue.py::test_bgp_queues:
+  skip:
+    reason: "Skip on the Mellanox platforms due to feature limitation, remove it after the feature included"
+    conditions:
+      - "asic_type in ['mellanox'] and 't1' in topo_name"
 
 bgp/test_bgp_slb.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add skip for test_bfd.py::test_bfd_multihop and test_bgp_queue.py::test_bgp_queues due to the limitation on Mellanox platform.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
