### PR TITLE
[Recover via console] Support recovering `Force10-S6100` devices via console

### DIFF
--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -45,7 +45,7 @@ def recover_via_console(sonichost, conn_graph_facts, localhost, mgmt_ip, image_u
             posix_shell_aboot(dut_console, mgmt_ip, image_url)
         elif device_type in ["nexus"]:
             posix_shell_onie(dut_console, mgmt_ip, image_url, is_nexus=True)
-        elif device_type in ["mellanox", "cisco", "acs", "celestica"]:
+        elif device_type in ["mellanox", "cisco", "acs", "celestica", "force10"]:
             is_celestica = device_type in ["celestica"]
             posix_shell_onie(dut_console, mgmt_ip, image_url, is_celestica=is_celestica)
         elif device_type in ["nokia"]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #10806, we support auto recovery of testbeds via console. But at that time, we didn't support Force10-S6100 testbeds at that time. Force10-S6100 testbeds use ONIE as boot loader so we directly add Force10-S6100 into the branch which will be recoverd by ONIE.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
In PR #10806, we support auto recovery of testbeds via console. But at that time, we didn't support Force10-S6100 testbeds at that time. Force10-S6100 testbeds use ONIE as boot loader so we directly add Force10-S6100 into the branch which will be recoverd by ONIE.

#### How did you do it?
Add Force10-S6100 into the branch which will be recoverd by ONIE.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
