### PR TITLE
Add expected "-d Multicast -j DROP" rule in test_ebtables_application

### DIFF
--- a/tests/cacl/test_ebtables_application.py
+++ b/tests/cacl/test_ebtables_application.py
@@ -13,6 +13,7 @@ def generate_expected_rules(duthost):
     ebtables_rules.append("-d BGA -j DROP")
     ebtables_rules.append("-p ARP -j DROP")
     ebtables_rules.append("-p 802_1Q --vlan-encap ARP -j DROP")
+    ebtables_rules.append("-d Multicast -j DROP")
     return ebtables_rules
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
After change in https://github.com/sonic-net/sonic-buildimage/pull/18064, need to update expected rules for ebtables

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fix the following failure
```
>       pytest_assert(len(unexpected_ebtables_rules) == 0, "Unexpected ebtables rules: {}"
                      .format(repr(unexpected_ebtables_rules)))
E       Failed: Unexpected ebtables rules: {'-d Multicast -j DROP'}

```
#### How did you do it?
Add -d Multicast -j DROP in expected rule;

#### How did you verify/test it?
Run test_ebtables_application against master/202305/202311 image.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
