### PR TITLE
Skip test_kdump on Nokia-7215 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -763,6 +763,15 @@ platform_tests/test_advanced_reboot.py::test_fast_reboot_from_other_vendor:
       - https://github.com/sonic-net/sonic-mgmt/issues/11007
 
 #######################################
+####        test_kdump.py         #####
+#######################################
+platform_tests/test_kdump.py:
+  skip:
+    reason: "Not supported on Nokia-7215 platform"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+
+#######################################
 ####  test_memory_exhaustion.py   #####
 #######################################
 platform_tests/test_memory_exhaustion.py:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip test_kdump on Nokia-7215 platform. Kernel dump is not supported on Nokia-7215 yet.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Skip test_kdump on Nokia-7215 platform. Kernel dump is not supported on Nokia-7215 yet.

#### How did you do it?
Updated conditional mark file.

#### How did you verify/test it?
Verified on Nokia-7215 testbed.

```
=============================================== short test summary info ================================================
SKIPPED [1] platform_tests/test_kdump.py: Not supported on Nokia-7215 platform
```

#### Any platform specific information?

This PR for Nokia-7215 only.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

