### PR TITLE
Remove redundant argument `output` in script `recover_testbed.py`

### DIFF
--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -200,14 +200,6 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "-o", "--output",
-        type=str,
-        dest="output",
-        required=False,
-        help="Output duts version to the specified file."
-    )
-
-    parser.add_argument(
         "--image",
         type=str,
         dest="image",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The argument `output` is redundant in script `recover_testbed.py`. To keep the clean of the code, we remove this argument in script. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The argument `output` is redundant in script `recover_testbed.py`. To keep the clean of the code, we remove this argument in script. 

#### How did you do it?
Remove redundant argument `output` in script `recover_testbed.py`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
