### PR TITLE
Fix Unexpected DHCP iptables rules for test_cacl_application_dualtor

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -28,7 +28,9 @@ def duthost_dualtor(request, upper_tor_host, lower_tor_host):       # noqa F811
     else:
         logger.info("Select upper tor...")
         dut = upper_tor_host
-    return dut
+    dut.shell("sudo config mux mode manual all")
+    yield dut
+    dut.shell("sudo config mux mode auto all")
 
 
 @pytest.fixture


### PR DESCRIPTION
…case

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
On latest master image, test_cacl_application_dualtor case could fail due to the following reason:
`Failed: Missing expected iptables rules: {'-A DHCP -m mark --mark 0x67005 -j DROP'}`

This is caused by the oscillation logic: https://github.com/sonic-net/sonic-linkmgrd/pull/221

As there is no icmp_responder running, the mux will start flap, if it flaps betrween expected_dhcp_rules_for_standby fixture and 
the real iptables check, there could be some unexpected dhcp iptables which will cause case failure.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Fix Unexpected DHCP iptables rules for test_cacl_application_dualtor


#### How did you do it?
test_cacl_application_dualtor is used to verify dhcp iptables on dualtor, not oscillation.
Before dualtor case, set mux mode to manual
`sudo config mux mode manual all`
in test teardown, run to set to auto back.
`sudo config mux mode auto all`


#### How did you verify/test it?
Run `cacl/test_cacl_application.py::test_cacl_application_dualtor `on dualtor testbed against master image.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
