### PR TITLE
Fix logrotate config not set during testing

### DIFF
--- a/tests/syslog/test_logrotate.py
+++ b/tests/syslog/test_logrotate.py
@@ -63,8 +63,10 @@ def simulate_small_var_log_partition(rand_selected_dut, localhost):
 
         config_reload(duthost, safe_reload=True)
 
-        logger.info('Start logrotate-config service')
-        duthost.shell('sudo service logrotate-config start')
+        # Restart in case logrotate-config was started already before
+        # Just running 'start' does not update logrotate config
+        logger.info('Restart logrotate-config service')
+        duthost.shell('sudo service logrotate-config restart')
 
     yield
 


### PR DESCRIPTION
Fix logrotate config not getting updated if logrotate-config service has already been started before test_logrotate_small_size

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Ensure logrotate is configured properly by using `restart` instead of `start` for configuring logrotate after creating the small `/var/log` parition.
Fixes #75

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

To run `test_logrotate_small_size()`, a small `/var/log` partition is created to simulate a smaller size. Currently, `sudo service logrotate-config start` is used to reconfigure `logrotate` from its original configuration. However, this may not update the config properly as `sudo service logrotate-config start` has been ran before. To ensure it is reconfigured, we should use `restart` instead.

#### How did you do it?
Replacing `sudo service logrotate-config start` with `sudo service logrotate-config restart`.

#### How did you verify/test it?
Tests previously fail on `test_logrotate_small_size()`. After this fix all logrotate tests pass.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
