### PR TITLE
Adding fix for the TypeError from param gen for 8111.

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -99,8 +99,8 @@ class QosParamCisco(object):
         found = False
         exp = 1
         mantissa = 0
-        reduced_thr = thr >> 4
-        further_reduced_thr = thr >> 5
+        reduced_thr = int(thr) >> 4
+        further_reduced_thr = int(thr) >> 5
         for i in range(32):
             ith_bit = 1 << i
             if further_reduced_thr < ith_bit <= reduced_thr:


### PR DESCRIPTION
### Description of PR
Summary:
Fixes this error in cisco param_gen:
        exp = 1
        mantissa = 0
>       reduced_thr = thr >> 4
E       TypeError: unsupported operand type(s) for >>: 'float' and 'int'

exp        = 1
found      = False

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205
- [X] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?
Fixing the type error from qos-param gen in qos-sai.
#### How did you do it?
Typecast the values to int.
#### How did you verify/test it?
Verification in progress.
#### Any platform specific information?
Specific to  cisco 8111 platforms.