### PR TITLE
[upgrade test]Fix issues when the image path is not url

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -183,16 +183,14 @@ def download_new_sonic_image(module, new_image_url, save_as):
 
 def install_new_sonic_image(module, new_image_url, save_as=None, required_space=1600):
     log("install new sonic image")
-
-    log("Clean-up previous downloads first")
-    exec_command(
-        module,
-        cmd="rm -f {}".format("/host/downloaded-sonic-image"),
-        msg="clean up previously downloaded image",
-        ignore_error=True
-    )
-
     if not save_as:
+        log("Clean-up previous downloads first")
+        exec_command(
+            module,
+            cmd="rm -f {}".format("/host/downloaded-sonic-image"),
+            msg="clean up previously downloaded image",
+            ignore_error=True
+        )
         avail = get_disk_free_size(module, "/host")
         save_as = "/host/downloaded-sonic-image" if avail >= 2000 else "/tmp/tmpfs/downloaded-sonic-image"
 
@@ -393,10 +391,7 @@ def main():
     required_space = module.params['required_space']
 
     try:
-        if not new_image_url:
-            reduce_installed_sonic_images(module)
-            free_up_disk_space(module, disk_used_pcent)
-        else:
+        if new_image_url or save_as:
             results["current_stage"] = "start"
 
             work_around_for_reboot(module)
@@ -411,6 +406,9 @@ def main():
 
             install_new_sonic_image(module, new_image_url, save_as, required_space)
             results["current_stage"] = "complete"
+        else:
+            reduce_installed_sonic_images(module)
+            free_up_disk_space(module, disk_used_pcent)
     except Exception:
         err = str(sys.exc_info())
         module.fail_json(msg="Exception raised during image upgrade", results=results, err=err)


### PR DESCRIPTION
When the image path is not url, it will fail to download image. need to support the save_as as previously 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: When the image path is not url, it will fail to download image. need to support the save_as as previously 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?
if the image is downloaded already before run the reduce_and_add_sonic_images.py, use the downloaded image. 
#### How did you verify/test it?
After the fix, run the test case with image path specified as not url format, test could pass
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
