### PR TITLE
[ROUTE] Improve test_forced_mgmt_route UT failed because interface change delay.

### DIFF
--- a/tests/route/test_forced_mgmt_route.py
+++ b/tests/route/test_forced_mgmt_route.py
@@ -86,10 +86,10 @@ def check_ip_rule_exist(duthost, address, check_exist):
     dstlen = address.split("/")[1]
     for ip_rule in ip_rules:
         if (ip_rule.get("priority", "") == FORCED_MGMT_ROUTE_PRIORITY and
-            ip_rule.get("src", "") == 'all' and
-            ip_rule.get("dst", "") == dst and
-            ip_rule.get("dstlen", "") == int(dstlen) and
-            ip_rule.get("table", "") == 'default'):
+                ip_rule.get("src", "") == 'all' and
+                ip_rule.get("dst", "") == dst and
+                ip_rule.get("dstlen", "") == int(dstlen) and
+                ip_rule.get("table", "") == 'default'):
             exist = True
 
     return check_exist == exist

--- a/tests/route/test_forced_mgmt_route.py
+++ b/tests/route/test_forced_mgmt_route.py
@@ -32,26 +32,30 @@ def backup_restore_config(duthosts, enum_rand_one_per_hwsku_hostname):
     #  Restore config after test finish
     restore_config(duthost, CONFIG_DB, CONFIG_DB_BACKUP)
 
+
 def get_file_hash(duthost, file):
     hash = duthost.command("sha1sum {}".format(file))["stdout"]
     logger.debug("file hash: {}".format(hash))
 
     return hash
 
+
 def wait_for_file_changed(duthost, file, action, *args, **kwargs):
     original_hash = get_file_hash(duthost, file)
 
     action(*args, **kwargs)
 
-    def sha_changed(duthost, file):
+    def hash_changed(duthost, file):
         latest_hash = get_file_hash(duthost, file)
         return latest_hash != original_hash
 
-    exist = wait_until(10, 1, 0, sha_changed, duthost, file)
+    exist = wait_until(10, 1, 0, hash_changed, duthost, file)
     pytest_assert(exist, "File {} does not change after 10 seconds.".format(file))
+
 
 def address_type(address):
     return type(ipaddress.ip_network(str(address), False))
+
 
 def check_ip_rule_exist(duthost, ip, check_exist):
     logging.warning("check_ip_rule_exist for ip:{} exist:{}".format(ip, check_exist))
@@ -68,6 +72,7 @@ def check_ip_rule_exist(duthost, ip, check_exist):
         return rule in ip_rules
     else:
         return rule not in ip_rules
+
 
 def test_forced_mgmt_route_add_and_remove_by_mgmt_port_status(
                                     duthosts,
@@ -133,15 +138,15 @@ def test_forced_mgmt_route_add_and_remove_by_mgmt_port_status(
     interfaces = duthost.command("cat /etc/network/interfaces")['stdout']
     logging.debug("interfaces: {}".format(interfaces))
     pytest_assert("iface eth1 inet static" in interfaces)
-    pytest_assert("up ip -4 rule add pref 32764 to {} table default"\
+    pytest_assert("up ip -4 rule add pref 32764 to {} table default"
                   .format(ipv4_forced_mgmt_address) in interfaces)
-    pytest_assert("pre-down ip -4 rule delete pref 32764 to {} table default"\
+    pytest_assert("pre-down ip -4 rule delete pref 32764 to {} table default"
                   .format(ipv4_forced_mgmt_address) in interfaces)
     pytest_assert("iface eth1 inet6 static" in interfaces)
-    pytest_assert("up ip -6 rule add pref 32764 to {} table default"\
+    pytest_assert("up ip -6 rule add pref 32764 to {} table default"
                   .format(ipv6_forced_mgmt_address) in interfaces)
-    pytest_assert("pre-down ip -6 rule delete pref 32764 to {} table default"\
-                  .format(ipv6_forced_mgmt_address)  in interfaces)
+    pytest_assert("pre-down ip -6 rule delete pref 32764 to {} table default"
+                  .format(ipv6_forced_mgmt_address) in interfaces)
 
     # startup eth1 and check forced mgmt route exist
     duthost.command("sudo ifup eth1")

--- a/tests/route/test_forced_mgmt_route.py
+++ b/tests/route/test_forced_mgmt_route.py
@@ -79,6 +79,8 @@ def check_ip_rule_exist(duthost, address, check_exist):
     exist = False
     dst = address.split("/")[0]
     dstlen = address.split("/")[1]
+    # forced mgmt route priority hardcoded to 32764 in following j2 template:
+    # https://github.com/sonic-net/sonic-buildimage/blob/a33330941c26a98927c57ed93beeddbe98281fd3/files/image_config/interfaces/interfaces.j2#L82
     for ip_rule in ip_rules:
         if (ip_rule.get("priority", "") == 32764 and
             ip_rule.get("src", "") == 'all' and


### PR DESCRIPTION
[ROUTE] Improve test_forced_mgmt_route UT failed because interface change delay.

### Description of PR
[ROUTE] Improve test_forced_mgmt_route UT failed because interface change delay.

##### Work item tracking
- Microsoft ADO: 27024909

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
route.test_forced_mgmt_route randomly failed on hardware and KVM caused by a delay between interface-config service finish and interface change take effect.

#### How did you do it?
Add retry code to wait untill interface change take effect.

#### How did you verify/test it?
Pass all UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
