### PR TITLE
cisco-8000:Skip compensating leakout for multi-asic.

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4514,7 +4514,7 @@ class PGDropTest(sai_base_test.ThriftInterfaceDataPlane):
                 send_packet(self, src_port_id, pkt, pkt_num)
 
                 # Account for leakout
-                if 'cisco-8000' in asic_type:
+                if 'cisco-8000' in asic_type and not is_multi_asic:
                     queue_counters = sai_thrift_read_queue_occupancy(
                         self.dst_client, "dst", dst_port_id)
                     occ_pkts = queue_counters[queue] // (packet_length + 24)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

For single asic we are adding some leakout packets to account for case where packets might have leaked out of VOQ to OQ even though port tx has been disable.

For multi-asic case leakout packets is already accounted as part of overflow_egress calculation so we don;t need to add again.
 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [] 202205
- [X] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?
PGDrop test fails in single-asic mode due to calling dynamic fill of egr mem in single asic mode.
#### How did you do it?
Skip the dynamic fill-mem.
#### How did you verify/test it?
Ran the test.
#### Any platform specific information?
Specific to cisco-8000 only.