### PR TITLE
Cherry-picked from PR 6022: Added support for running T2 vsonic(KVM)

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -270,12 +270,18 @@ def skip_if_no_lags(duthosts):
 @pytest.mark.parametrize("testcase", ["single_lag",
                                       "lacp_rate",
                                       "fallback"])
-def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts, conn_graph_facts, enum_dut_portchannel_with_completeness_level, testcase):
+def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts,
+             conn_graph_facts, enum_dut_portchannel_with_completeness_level, testcase, request):     # noqa F811
     # We can't run single_lag test on vtestbed since there is no leaffanout
     if testcase == "single_lag" and is_vtestbed(duthosts[0]):
         pytest.skip("Skip single_lag test on vtestbed")
     if 'PortChannel201' in enum_dut_portchannel_with_completeness_level:
         pytest.skip("PortChannel201 is a specific configuration of t0-56-po2vlan topo, which is not supported by test")
+
+    # Skip lacp_rate testcases on KVM since setting lacp rate it is not supported on KVM
+    if testcase == "lacp_rate":
+        if request.config.getoption("--neighbor_type") == 'sonic':
+            pytest.skip("lacp_rate is not supported in vsonic")
 
     ptfhost = common_setup_teardown
 

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -25,9 +25,9 @@ from voq_helpers import poll_neighbor_table_delete
 from voq_helpers import get_inband_info
 from voq_helpers import get_ptf_port
 from voq_helpers import get_vm_with_ip
+from tests.common.devices.eos import EosHost
 
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory  # lgtm[py/unused-import]
-
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory  # noqa F401
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -128,16 +128,13 @@ def restore_bgp(duthosts, nbrhosts, all_cfg_facts):
 
                     for peer in nbr['conf']['bgp']['peers']:
                         for neighbor in nbr['conf']['bgp']['peers'][peer]:
-                            nbr['host'].eos_config(
-                                lines=["no neighbor %s shutdown" % neighbor],
-                                parents=['router bgp {}'.format(nbr['conf']['bgp']['asn'])])
-
-                            if ":" in address:
+                            if isinstance(nbr['host'], EosHost):
                                 nbr['host'].eos_config(
-                                    lines=["no ipv6 route ::/0 %s " % neighbor])
+                                    lines=["no neighbor %s shutdown" % neighbor],
+                                    parents=['router bgp {}'.format(nbr['conf']['bgp']['asn'])])
                             else:
-                                nbr['host'].eos_config(
-                                    lines=["no ip route 0.0.0.0/0 %s " % neighbor])
+                                nbr['host'].shell("sudo vtysh -c 'configure terminal' -c 'router bgp " + str(
+                                    nbr['conf']['bgp']['asn']) + "' -c 'no neighbor {} shutdown'".format(neighbor))
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -220,21 +217,25 @@ def setup(duthosts, nbrhosts, all_cfg_facts):
             'disable neighbors {} on neighbor host {}'.format(node['conf']['bgp']['peers'], node['host'].hostname))
         for peer in node['conf']['bgp']['peers']:
             for neighbor in node['conf']['bgp']['peers'][peer]:
-                node_results.append(node['host'].eos_config(
-                    lines=["neighbor %s shutdown" % neighbor],
-                    parents=['router bgp {}'.format(node['conf']['bgp']['asn'])],
-                    module_ignore_errors=True)
-                )
-                if ":" in neighbor:
+                if isinstance(node['host'], EosHost):
                     node_results.append(node['host'].eos_config(
-                        lines=["ipv6 route ::/0 %s " % neighbor],
+                        lines=["neighbor %s shutdown" % neighbor],
+                        parents=['router bgp {}'.format(node['conf']['bgp']['asn'])],
                         module_ignore_errors=True)
                     )
+                    if ":" in neighbor:
+                        node_results.append(node['host'].eos_config(
+                            lines=["ipv6 route ::/0 %s " % neighbor],
+                            module_ignore_errors=True)
+                        )
+                    else:
+                        node_results.append(node['host'].eos_config(
+                            lines=["ip route 0.0.0.0/0 %s " % neighbor],
+                            module_ignore_errors=True)
+                        )
                 else:
-                    node_results.append(node['host'].eos_config(
-                        lines=["ip route 0.0.0.0/0 %s " % neighbor],
-                        module_ignore_errors=True)
-                    )
+                    node_results.append(node['host'].shell("sudo vtysh -c 'configure terminal' -c 'router bgp " + str(
+                        node['conf']['bgp']['asn']) + "' -c 'neighbor {} shutdown'".format(neighbor)))
 
         results[node['host'].hostname] = node_results
 
@@ -311,36 +312,47 @@ def teardown(duthosts, nbrhosts, all_cfg_facts):
         for peer in node['conf']['bgp']['peers']:
             for neighbor in node['conf']['bgp']['peers'][peer]:
                 try:
-                    node_results.append(node['host'].eos_config(
-                        lines=["no neighbor %s shutdown" % neighbor],
-                        parents=['router bgp {}'.format(node['conf']['bgp']['asn'])])
-                    )
-                    if ":" in neighbor:
+                    if isinstance(node['host'], EosHost):
                         node_results.append(node['host'].eos_config(
-                            lines=["no ipv6 route ::/0 %s " % neighbor])
+                            lines=["no neighbor %s shutdown" % neighbor],
+                            parents=['router bgp {}'.format(node['conf']['bgp']['asn'])])
                         )
+                        if ":" in neighbor:
+                            node_results.append(node['host'].eos_config(
+                                lines=["no ipv6 route ::/0 %s " % neighbor])
+                            )
+                        else:
+                            node_results.append(node['host'].eos_config(
+                                lines=["no ip route 0.0.0.0/0 %s " % neighbor],
+                            )
+                            )
                     else:
-                        node_results.append(node['host'].eos_config(
-                            lines=["no ip route 0.0.0.0/0 %s " % neighbor],
-                        )
-                        )
+                        node_results.append(node['host'].shell(
+                            "sudo vtysh -c 'configure terminal' -c 'router bgp " + str(
+                                node['conf']['bgp']['asn']) + "' -c 'no neighbor {} shutdown'".format(neighbor)))
+
                 except Exception:
                     logger.warning("Enable of neighbor on VM: %s failed, retrying", node['host'].hostname)
                     time.sleep(10)
-                    node_results.append(node['host'].eos_config(
-                        lines=["no neighbor %s shutdown" % neighbor],
-                        parents=['router bgp {}'.format(node['conf']['bgp']['asn'])])
-                    )
-                    if ":" in neighbor:
+                    if isinstance(node['host'], EosHost):
                         node_results.append(node['host'].eos_config(
-                            lines=["no ipv6 route ::/0 %s " % neighbor],
+                            lines=["no neighbor %s shutdown" % neighbor],
+                            parents=['router bgp {}'.format(node['conf']['bgp']['asn'])])
                         )
-                        )
+                        if ":" in neighbor:
+                            node_results.append(node['host'].eos_config(
+                                lines=["no ipv6 route ::/0 %s " % neighbor],
+                            )
+                            )
+                        else:
+                            node_results.append(node['host'].eos_config(
+                                lines=["no ip route 0.0.0.0/0 %s " % neighbor],
+                            )
+                            )
                     else:
-                        node_results.append(node['host'].eos_config(
-                            lines=["no ip route 0.0.0.0/0 %s " % neighbor],
-                        )
-                        )
+                        node_results.append(node['host'].shell(
+                            "sudo vtysh -c 'configure terminal' -c 'router bgp " + str(
+                                node['conf']['bgp']['asn']) + "' -c 'no neighbor {} shutdown'".format(neighbor)))
 
         results[node['host'].hostname] = node_results
 
@@ -436,12 +448,26 @@ def change_vm_intefaces(nbrhosts, nbr_vms, state="up"):
         for eos_intf in nbr['conf']['interfaces'].keys():
             if "Loopback" in eos_intf:
                 continue
+
             if state == "up":
-                logger.info("Startup EOS %s interface %s", node, eos_intf)
-                node_results.append(nbr['host'].eos_config(lines=["no shutdown"], parents=["interface %s" % eos_intf]))
+                logger.info("Startup Nbr %s interface %s", node, eos_intf)
+                if isinstance(nbr['host'], EosHost):
+                    node_results.append(
+                        nbr['host'].eos_config(lines=["no shutdown"], parents=["interface %s" % eos_intf]))
+                else:
+                    if "port-channel" in eos_intf.lower():
+                        # convert PortChannel-1 to PortChannel1
+                        eos_intf = "PortChannel" + eos_intf[-1]
+                    node_results.append(nbr['host'].shell("config interface startup {}".format(eos_intf)))
             else:
-                logger.info("Shutdown EOS %s interface %s", node, eos_intf)
-                node_results.append(nbr['host'].eos_config(lines=["shutdown"], parents=["interface %s" % eos_intf]))
+                logger.info("Shutdown Nbr %s interface %s", node, eos_intf)
+                if isinstance(nbr['host'], EosHost):
+                    node_results.append(nbr['host'].eos_config(lines=["shutdown"], parents=["interface %s" % eos_intf]))
+                else:
+                    if "port-channel" in eos_intf.lower():
+                        # convert PortChannel-1 to PortChannel1
+                        eos_intf = "PortChannel" + eos_intf[-1]
+                    node_results.append(nbr['host'].shell("config interface shutdown {}".format(eos_intf)))
 
         results[node] = node_results
 

--- a/tests/voq/voq_helpers.py
+++ b/tests/voq/voq_helpers.py
@@ -6,6 +6,7 @@ import pytest
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.sonic_db import AsicDbCli, AppDbCli, VoqDbCli, SonicDbKeyNotFound
+from tests.common.devices.eos import EosHost
 
 logger = logging.getLogger(__name__)
 
@@ -406,12 +407,20 @@ def get_eos_mac(nbr, nbr_intf):
     Returns:
         A dictionary with the mac address and shell interface name.
     """
-    if "port-channel" in nbr_intf.lower():
-        # convert Port-Channel1 to po1
-        shell_intf = "po" + nbr_intf[-1]
+
+    if isinstance(nbr['host'], EosHost):
+        if "port-channel" in nbr_intf.lower():
+            # convert Port-Channel1 to po1
+            shell_intf = "po" + nbr_intf[-1]
+        else:
+            # convert Ethernet1 to eth1
+            shell_intf = "eth" + nbr_intf[-1]
     else:
-        # convert Ethernet1 to eth1
-        shell_intf = "eth" + nbr_intf[-1]
+        if "port-channel" in nbr_intf.lower():
+            # convert Port-Channel1 to PortChannel1
+            shell_intf = "PortChannel" + nbr_intf[-1]
+        else:
+            shell_intf = nbr_intf
 
     output = nbr['host'].command("ip addr show dev %s" % shell_intf)
     # 8: Ethernet0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 ...


### PR DESCRIPTION

### Description of PR
Added support for running T2 applicable tests using vsonic(KVM) for neighbors


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
To add support for vsonic/KVM commands on neighbors, as the commands are different from Eo

How did you do it?
Fix for test_lldp testcase:
KVM neighbors do not advertise port ifname. They instead advertise 'descr'. We will use ifname for EosHost and descr for KVM

Fix for voq tests
BGP:
- Use vtysh for BGP configuration on vsonic
Interface up/down:
- Use shut/no shut commands

voq_helper
Interface name and numbering:

Neighbors interface name is difference on vsonic vs Eos.
On Eos, inerfaces are named 'eth' (Ex. eth1) and portchannels are named po (Ex. po1).
On vsonic, interfaces are named Ethernet (Ex. Ethernet1) and portchannels are named PortChannel (PortChannel1).

Fix for test_lag interface
There is no support for setting lacp rate in vsonic. So, skipping these tests.

How did you do it?
#### How did you verify/test it?
Tested the code on a dut that uses Eos VM as it's neighbors in one setup and against vsonic neighbors in another setup.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
