### PR TITLE
Use configured bgp neighbor info for holdtime timer

### DIFF
--- a/tests/telemetry/events/bgp_events.py
+++ b/tests/telemetry/events/bgp_events.py
@@ -17,6 +17,10 @@ def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
 
 
 def drop_tcp_packets(duthost):
+    bgp_neighbor = list(duthost.get_bgp_neighbors().keys())[0]
+
+    holdtime_timer_ms = duthost.get_bgp_neighbor_info(bgp_neighbor)["bgpTimerConfiguredHoldTimeMsecs"]
+
     logger.info("Adding rule to drop TCP packets to test bgp-notification")
 
     ret = duthost.shell("iptables -I INPUT -p tcp --dport 179 -j DROP")
@@ -28,7 +32,7 @@ def drop_tcp_packets(duthost):
     ret = duthost.shell("iptables -L")
     assert ret["rc"] == 0, "Unable to list iptables rules"
 
-    time.sleep(180)  # Give time for hold timer expiry notif to fire, val from frr conf
+    time.sleep(holdtime_timer_ms / 1000)  # Give time for hold timer expiry event, val from configured bgp neighbor info
 
     ret = duthost.shell("iptables -D INPUT -p tcp --dport 179 -j DROP")
     assert ret["rc"] == 0, "Unable to remove DROP rule from iptables"

--- a/tests/telemetry/events/bgp_events.py
+++ b/tests/telemetry/events/bgp_events.py
@@ -28,7 +28,7 @@ def drop_tcp_packets(duthost):
     ret = duthost.shell("iptables -L")
     assert ret["rc"] == 0, "Unable to list iptables rules"
 
-    time.sleep(10)  # Give time for hold timer expiry notif to fire, val from config db
+    time.sleep(180)  # Give time for hold timer expiry notif to fire, val from frr conf
 
     ret = duthost.shell("iptables -D INPUT -p tcp --dport 179 -j DROP")
     assert ret["rc"] == 0, "Unable to remove DROP rule from iptables"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 26963525

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

We should use configured holdtime timer value from bgp neighbor instead of predetermined value, as config may be overwritten.

#### How did you do it?

Fetch value bgpTimerConfiguredHoldTimeMsecs from bgp neighbor 

#### How did you verify/test it?

Manual test/pipeline

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
