### PR TITLE
Updated qos test params for 400g and 100g port speeds

### DIFF
--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -220,15 +220,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 110474
+                    pkts_num_trig_ingr_drp: 114068
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 110474
+                    pkts_num_trig_ingr_drp: 114068
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -237,30 +237,30 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 35208
-                    pkts_num_hdrm_full: 362
+                    pkts_num_trig_pfc: 110474
+                    pkts_num_hdrm_full: 3593
                     pkts_num_hdrm_partial: 182
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 110474
+                    pkts_num_trig_ingr_drp: 114068
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 110474
+                    pkts_num_dismiss_pfc: 3318
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 110474
+                    pkts_num_dismiss_pfc: 3318
                     pkts_num_margin: 150
                 lossy_queue_1:
                     dscp: 7
@@ -272,7 +272,7 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_fill_min: 51
+                    pkts_num_fill_min: 0
                     pkts_num_trig_pfc: 9874
                     packet_size: 64
                     cell_size: 4096
@@ -281,7 +281,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_fill_min: 51
+                    pkts_num_fill_min: 0
                     pkts_num_trig_egr_drp: 2396745
                     packet_size: 64
                     cell_size: 4096
@@ -291,7 +291,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_ingr_drp: 114068
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -299,9 +299,9 @@ qos_params:
                     pg: 3
                     queue: 3
                     pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
-                    pkts_num_fill_egr_min: 8
+                    pkts_num_trig_pfc: 110474
+                    pkts_num_trig_ingr_drp: 114068
+                    pkts_num_fill_egr_min: 0
                     cell_size: 4096
                 wm_q_shared_lossy:
                     dscp: 8
@@ -432,15 +432,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 750848
+                    pkts_num_trig_pfc: 117028
+                    pkts_num_trig_ingr_drp: 856648
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 750848
+                    pkts_num_trig_pfc: 117028
+                    pkts_num_trig_ingr_drp: 856648
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -449,31 +449,31 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 37549
-                    pkts_num_hdrm_full: 362
-                    pkts_num_hdrm_partial: 182
+                    pkts_num_trig_pfc: 117028
+                    pkts_num_hdrm_full: 739620
+                    pkts_num_hdrm_partial: 369810
                     margin: 1
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 750848
+                    pkts_num_trig_pfc: 117028
+                    pkts_num_trig_ingr_drp: 856648
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 117028
+                    pkts_num_dismiss_pfc: 13107
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 117028
+                    pkts_num_dismiss_pfc: 13107
                     pkts_num_margin: 150
                 lossy_queue_1:
                     dscp: 7
@@ -485,8 +485,8 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_fill_min: 71
-                    pkts_num_trig_pfc: 37449
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 117028
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -494,7 +494,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_fill_min: 71
+                    pkts_num_fill_min: 0
                     pkts_num_trig_egr_drp: 2396745
                     packet_size: 64
                     cell_size: 4096
@@ -504,7 +504,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 750848
+                    pkts_num_trig_ingr_drp: 856648
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -512,9 +512,9 @@ qos_params:
                     pg: 3
                     queue: 3
                     pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_pfc: 28160
-                    pkts_num_trig_ingr_drp: 750848
-                    pkts_num_fill_egr_min: 8
+                    pkts_num_trig_pfc: 117028
+                    pkts_num_trig_ingr_drp: 856648
+                    pkts_num_fill_egr_min: 0
                     cell_size: 4096
                 wm_q_shared_lossy:
                     dscp: 8


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Updated test params for 400g/100g buffer settings

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
