### PR TITLE
Fix hard coded arguments in config_simulated_y_cable.yml

### DIFF
--- a/ansible/dualtor/config_simulated_y_cable.yml
+++ b/ansible/dualtor/config_simulated_y_cable.yml
@@ -14,7 +14,7 @@
   when: restart_pmon is not defined and restart_pmon|bool == true
 
 - name: Get host server address
-  script: scripts/vmhost_server_address.py --inv-file veos_vtb --server-name server_1
+  script: scripts/vmhost_server_address.py --inv-file {{ vm_file }} --server-name {{ testbed_facts['server'] }}
   args:
     executable: python
   delegate_to: localhost


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
PR #11804 accidentally left hardcoded arguments for testing purpose in committed code.

This caused mux server address is always "172.17.0.1" in /etc/sonic/mux_simulator.json after deploy-mg is executed on dualtor testbeds.

#### How did you do it?
This change updated the hardcoded arguments to variables.

#### How did you verify/test it?
Tested on physical dualtor testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
