### PR TITLE
Catch eos fanout host unreachable in pretest by running show command

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -310,6 +310,9 @@ class EosHost(AnsibleHostBase):
         autoneg_enabled = output['stdout'][0]['interfaceStatuses'][interface_name]['autoNegotiateActive']
         return autoneg_enabled
 
+    def get_version(self):
+        return self.eos_command(commands=["show version"])
+
     def _reset_port_speed(self, interface_name):
         out = self.eos_config(
                 lines=['default speed'],

--- a/tests/common/devices/fanout.py
+++ b/tests/common/devices/fanout.py
@@ -43,6 +43,8 @@ class FanoutHost(object):
             self.os = 'eos'
             self.host = EosHost(ansible_adhoc, hostname, user, passwd,
                                 shell_user=eos_shell_user, shell_passwd=eos_shell_passwd)
+            # Check eos fanout reachability by running show command
+            self.host.get_version()
 
     def __getattr__(self, module_name):
         return getattr(self.host, module_name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Catch eos fanout host unreachable in pretest by running show command.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Catch eos fanout host unreachable in pretest by running show command.

#### How did you do it?
Run show version command after eos fanout host initializing to check reachability.

#### How did you verify/test it?
Test pretest on reachable&unreachable eos fanout host, both results are as expected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
