### PR TITLE
Remove unnecessary steps in script `test_stress_arp.py` to save running time. 

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -125,12 +125,6 @@ def ipv6_packets_for_test(ip_and_intf_info, fake_src_mac, fake_src_addr):
     return ns_pkt
 
 
-def get_ipv6_entries_status(duthost, ipv6_addr):
-    ipv6_entry = duthost.shell("ip -6 neighbor | grep -w {}".format(ipv6_addr))["stdout_lines"][0]
-    ipv6_entry_status = ipv6_entry.split(" ")[-1]
-    return (ipv6_entry_status == 'REACHABLE')
-
-
 def add_nd(duthost, ptfhost, ptfadapter, config_facts, tbinfo, ip_and_intf_info, ptf_intf_index, nd_avaliable):
     for entry in range(0, nd_avaliable):
         nd_entry_mac = IntToMac(MacToInt(ARP_SRC_MAC) + entry)
@@ -141,7 +135,6 @@ def add_nd(duthost, ptfhost, ptfadapter, config_facts, tbinfo, ip_and_intf_info,
 
         ptfadapter.dataplane.flush()
         testutils.send_packet(ptfadapter, ptf_intf_index, ns_pkt)
-        wait_until(20, 1, 0, get_ipv6_entries_status, duthost, fake_src_addr)
         ptfhost.shell("ip -6 addr del {}/64 dev eth1".format(fake_src_addr))
 
 

--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -120,22 +120,17 @@ def ipv6_packets_for_test(ip_and_intf_info, fake_src_mac, fake_src_addr):
     ns_pkt /= IPv6(dst=inet_ntop(socket.AF_INET6, multicast_tgt_addr), src=fake_src_addr)
     ns_pkt /= ICMPv6ND_NS(tgt=tgt_addr)
     ns_pkt /= ICMPv6NDOptSrcLLAddr(lladdr=fake_src_mac)
-    logging.info(repr(ns_pkt))
 
     return ns_pkt
 
 
-def add_nd(duthost, ptfhost, ptfadapter, config_facts, tbinfo, ip_and_intf_info, ptf_intf_index, nd_avaliable):
+def add_nd(ptfadapter, ip_and_intf_info, ptf_intf_index, nd_avaliable):
     for entry in range(0, nd_avaliable):
         nd_entry_mac = IntToMac(MacToInt(ARP_SRC_MAC) + entry)
         fake_src_addr = generate_global_addr(nd_entry_mac)
         ns_pkt = ipv6_packets_for_test(ip_and_intf_info, nd_entry_mac, fake_src_addr)
 
-        ptfhost.shell("ip -6 addr add {}/64 dev eth1".format(fake_src_addr))
-
-        ptfadapter.dataplane.flush()
         testutils.send_packet(ptfadapter, ptf_intf_index, ns_pkt)
-        ptfhost.shell("ip -6 addr del {}/64 dev eth1".format(fake_src_addr))
 
 
 def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
@@ -156,7 +151,7 @@ def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
 
     while loop_times > 0:
         loop_times -= 1
-        add_nd(duthost, ptfhost, ptfadapter, config_facts, tbinfo, ip_and_intf_info, ptf_intf_index, nd_avaliable)
+        add_nd(ptfadapter, ip_and_intf_info, ptf_intf_index, nd_avaliable)
 
         pytest_assert(wait_until(20, 1, 0, lambda: get_fdb_dynamic_mac_count(duthost) >= nd_avaliable),
                       "Neighbor Table Add failed")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We optimize this script from two sides:
1. We sent ipv6 ND_NS packets with fake source IP addresses to DUT. DUT could not establish a connection with them because of the fake IP. However, our test objective was to add the entries on DUT regardless of their status. Therefore, in this PR, we remove the function wait_until to reduce the test execution time.
2. We removed the unnecessary step of assigning a fake IP address to the eth1 of ptf and deleting it after sending the packet. This step was not required for sending the packet to DUT. Each command in this step took about one second, which increased the execution time significantly. Therefore, we optimized the code by eliminating these commands.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
We optimize this script from two sides:
1. We sent ipv6 ND_NS packets with fake source IP addresses to DUT. DUT could not establish a connection with them because of the fake IP. However, our test objective was to add the entries on DUT regardless of their status. Therefore, in this PR, we remove the function wait_until to reduce the test execution time.
2. We removed the unnecessary step of assigning a fake IP address to the eth1 of ptf and deleting it after sending the packet. This step was not required for sending the packet to DUT. Each command in this step took about one second, which increased the execution time significantly. Therefore, we optimized the code by eliminating these commands.

#### How did you do it?
We optimize this script from two sides:
1. Remove the function wait_until to reduce the test execution time.
2. Eliminatie the command of adding and deleting IP address to the eth1 of ptf.

#### How did you verify/test it?
For debug level(run each test only once), I reduce the time to 4 mins 
```
======================================================== 2 passed, 3 warnings in 265.39s (0:04:25) =========================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
