### PR TITLE
Valid interfaces on a KVM neighbor should be Ethernet instead of eth

### DIFF
--- a/tests/macsec/test_fault_handling.py
+++ b/tests/macsec/test_fault_handling.py
@@ -38,8 +38,8 @@ class TestFaultHandling():
             while retry > 0:
                 retry -= 1
                 try:
-                    nbr["host"].shell("ifconfig {} down && sleep 1 && ifconfig {} up".format(
-                        nbr_eth_port, nbr_eth_port))
+                    nbr["host"].shell("config interface shutdown {}  && sleep 1 && config interface startup {}".format(
+                        nbr["port"], nbr["port"]))
                     _, _, _, dut_egress_sa_table_new, dut_ingress_sa_table_new = get_appl_db(
                         duthost, port_name, nbr["host"], nbr["port"])
                     assert dut_egress_sa_table_orig == dut_egress_sa_table_new
@@ -56,8 +56,8 @@ class TestFaultHandling():
             sleep(TestFaultHandling.MKA_TIMEOUT)
             nbr["host"].no_shutdown(nbr_eth_port)
         else:
-            nbr["host"].shell("ifconfig {} down && sleep {} && ifconfig {} up".format(
-                nbr_eth_port, TestFaultHandling.MKA_TIMEOUT, nbr_eth_port))
+            nbr["host"].shell("config interface shutdown {}  && sleep {} && config interface startup {}".format(
+                nbr["port"], TestFaultHandling.MKA_TIMEOUT, nbr["port"]))
 
         def check_new_mka_session():
             _, _, _, dut_egress_sa_table_new, dut_ingress_sa_table_new = get_appl_db(
@@ -124,3 +124,4 @@ class TestFaultHandling():
         disable_macsec_port(duthost, port_name)
         disable_macsec_port(nbr["host"], nbr["port"])
         delete_macsec_profile(nbr["host"], nbr["port"], profile_name)
+        sleep(300)


### PR DESCRIPTION
### Description of PR
command "ifconfig <nbr_eth_port> down/up" fails of KVM nbr.

Test case data/tests/macsec/test_fault_handling.py/test_link_flap fails with the error: 
"ifconfig eth1 down  && sleep 1 && ifconfig eth1 up" Error: Interface name is invalid. Please enter a valid interface name

We need to provide Ethernet port instead of eth port.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Providing a valid interface (Ethernet instead of eth) to down/up the KVM neighbour's interface.

#### How did you do it?
It can be down with one of the following commands. I chose number 2.
1. ifconfig Ethernet1 down && sleep 1 && ifconfig Ethernet up
2. config interface shutdown Ethernet1 && sleep 1 && config interface startup Ethernet1

#### How did you verify/test it?
Tested the code on a dut with KVM (vsonic) neighbours

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
