### PR TITLE
Add callback for thread to call after invoking ptf command

### DIFF
--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -212,6 +212,7 @@ def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
     new_state = "Established" if original_state.lower() == "active" else "Active"
 
     def callback(result):
+        logger.info("Assert that ptf client output is non empty and contains on change update")
         try:
             assert result != "", "Did not get output from PTF client"
         finally:
@@ -226,8 +227,7 @@ def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
     wait_until(5, 1, 0, check_gnmi_cli_running, ptfhost)
     duthost.shell("sonic-db-cli STATE_DB HSET \"NEIGH_STATE_TABLE|{}\" \"state\" {}".format(bgp_neighbor,
                                                                                             new_state))
-
-    client_thread.join(30)
+    client_thread.join(60) # max timeout of 60s, expect update to come in <=30s
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -190,11 +190,10 @@ def test_virtualdb_table_streaming(duthosts, enum_rand_one_per_hwsku_hostname, p
                  "Timestamp markers for each update message in:\n{0}".format(result))
 
 
-def invoke_py_cli_from_ptf(ptfhost, cmd, results):
+def invoke_py_cli_from_ptf(ptfhost, cmd, callback):
     ret = ptfhost.shell(cmd)
     assert ret["rc"] == 0, "PTF docker did not get a response"
-    if results is not None and len(results) > 0:
-        results[0] = ret["stdout"]
+    callback(ret["stdout"])
 
 
 def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, localhost, gnxi_path):
@@ -205,13 +204,21 @@ def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               submode=SUBMODE_ONCHANGE, update_count=2, xpath="NEIGH_STATE_TABLE",
                               target="STATE_DB")
-    results = [""]
 
     bgp_nbrs = list(duthost.get_bgp_neighbors().keys())
     bgp_neighbor = random.choice(bgp_nbrs)
     bgp_info = duthost.get_bgp_neighbor_info(bgp_neighbor)
     original_state = bgp_info["bgpState"]
     new_state = "Established" if original_state.lower() == "active" else "Active"
+
+    def callback(result):
+        try:
+            assert result != "", "Did not get output from PTF client"
+        finally:
+            duthost.shell("sonic-db-cli STATE_DB HSET \"NEIGH_STATE_TABLE|{}\" \"state\" {}".format(bgp_neighbor,
+                                                                                                    original_state))
+        ret = parse_gnmi_output(result, 1, bgp_neighbor)
+        assert ret is True, "Did not find key in update"
 
     client_thread = threading.Thread(target=invoke_py_cli_from_ptf, args=(ptfhost, cmd, results,))
     client_thread.start()
@@ -221,14 +228,6 @@ def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
                                                                                             new_state))
 
     client_thread.join(30)
-
-    try:
-        assert results[0] != "", "Did not get output from PTF client"
-    finally:
-        duthost.shell("sonic-db-cli STATE_DB HSET \"NEIGH_STATE_TABLE|{}\" \"state\" {}".format(bgp_neighbor,
-                                                                                                original_state))
-    ret = parse_gnmi_output(results[0], 1, bgp_neighbor)
-    assert ret is True, "Did not find key in update"
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -227,7 +227,7 @@ def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
     wait_until(5, 1, 0, check_gnmi_cli_running, ptfhost)
     duthost.shell("sonic-db-cli STATE_DB HSET \"NEIGH_STATE_TABLE|{}\" \"state\" {}".format(bgp_neighbor,
                                                                                             new_state))
-    client_thread.join(60) # max timeout of 60s, expect update to come in <=30s
+    client_thread.join(60)  # max timeout of 60s, expect update to come in <=30s
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -220,7 +220,7 @@ def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
         ret = parse_gnmi_output(result, 1, bgp_neighbor)
         assert ret is True, "Did not find key in update"
 
-    client_thread = threading.Thread(target=invoke_py_cli_from_ptf, args=(ptfhost, cmd, results,))
+    client_thread = threading.Thread(target=invoke_py_cli_from_ptf, args=(ptfhost, cmd, callback,))
     client_thread.start()
 
     wait_until(5, 1, 0, check_gnmi_cli_running, ptfhost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 27085944

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

In one test case failure, we saw that 30 second max timeout was not enough time for the on change update to come. Increasing it to 60 seconds, but we expect the notification to come <=30 seconds.

Improve thread communication via passing a callback function instead of passing a results array

#### How did you do it?

Code change

#### How did you verify/test it?

Manual test / pipeline

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
