### PR TITLE
Add timing for interface to go up/down before toggling

### DIFF
--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -4,6 +4,7 @@ import logging
 import time
 
 from run_events_test import run_test
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 tag = "sonic-events-swss"
@@ -48,8 +49,14 @@ def shutdown_interface(duthost):
     ret = duthost.shell("config interface shutdown {}".format(if_state_test_port))
     assert ret["rc"] == 0, "Failing to shutdown interface {}".format(if_state_test_port)
 
+    # Wait until port goes down
+    wait_until(15, 1, 0, verify_port_admin_oper_status, duthost, if_state_test_port, "down")
+
     ret = duthost.shell("config interface startup {}".format(if_state_test_port))
     assert ret["rc"] == 0, "Failing to startup interface {}".format(if_state_test_port)
+
+    # Wait until port comes back up
+    wait_until(15, 1, 0, verify_port_admin_oper_status, duthost, if_state_test_port, "up")
 
 
 def generate_pfc_storm(duthost):
@@ -89,3 +96,10 @@ def trigger_crm_threshold_exceeded(duthost):
     duthost.shell("crm config thresholds ipv4 route type free")
     duthost.shell("crm config thresholds ipv4 route low {}".format(CRM_DEFAULT_IPV4_ROUTE_LOW))
     duthost.shell("crm config thresholds ipv4 route high {}".format(CRM_DEFAULT_IPV4_ROUTE_HIGH))
+
+
+def verify_port_admin_oper_status(duthost, interface, state):
+    interface_facts = duthost.get_interfaces_status()[interface]
+    admin_status = interface_facts["admin"]
+    oper_status = interface_facts["oper"]
+    return admin_status == state and oper_status == state


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 27001043

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

There is a timing issue when toggling interface admin status such that we don't see if-state event after interface is shut down or started up. In our test, we will verify that port is up/down after starting/shutting down the interface before toggling.

#### How did you do it?

Code change

#### How did you verify/test it?

Manual test/Pipeline

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
