### PR TITLE
Add script `arp/test_stress_arp.py` into nightly test

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -17,7 +17,7 @@ ENTRIES_NUMBERS = 12000
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('t0')
 ]
 
 LOOP_TIMES_LEVEL_MAP = {

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -45,12 +45,6 @@ arp/test_arp_dualtor.py::test_proxy_arp_for_standby_neighbor:
     conditions:
       - "release not in ['202012']"
 
-arp/test_stress_arp.py:
-  skip:
-    resason: "Extremely long long run time."
-    conditions:
-      - https://github.com/sonic-net/sonic-mgmt/issues/7874
-
 arp/test_unknown_mac.py:
   skip:
     reason: "Behavior on cisco-8000 & Innovium(Marvell) platform for unknown MAC is flooding rather than DROP, hence skipping."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Because of the issue [#7874](https://github.com/sonic-net/sonic-mgmt/issues/7874), we skip script `arp/test_stress_arp.py`. In PR #11922 , we fix this issue, so add this script into nightly test again. 

Summary:
Fixes #7874

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Because of the issue [#7874](https://github.com/sonic-net/sonic-mgmt/issues/7874), we skip script `arp/test_stress_arp.py`. In PR #11922 , we fix this issue, so add this script into nightly test again. 

#### How did you do it?
Remove the condition in `tests_mark_conditions.yaml` and add the pytest mark. 
This test is only for topology t0, because we need to get VLAN_INTERFACE in config, which is available for t0. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
