### PR TITLE
Fix slow test_stress_routes with wait_until

### DIFF
--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -73,7 +73,7 @@ def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conple
         ipv6_route_used_after = get_crm_resources(duthost, "ipv6_route", "used")
 
         return (abs(ipv4_route_used_after - ipv4_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS and
-                abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS )
+                abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS)
 
     pytest_assert(wait_until(10*60, CRM_POLLING_INTERVAL, 0, routesRestored),
                   "ipv4/ipv6 route used after is not equal to it used before")

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -68,12 +68,12 @@ def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conple
         announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name)
         loop_times -= 1
 
-    sleep_to_wait(CRM_POLLING_INTERVAL * 120)
+    def routesRestored():
+        ipv4_route_used_after = get_crm_resources(duthost, "ipv4_route", "used")
+        ipv6_route_used_after = get_crm_resources(duthost, "ipv6_route", "used")
 
-    ipv4_route_used_after = get_crm_resources(duthost, "ipv4_route", "used")
-    ipv6_route_used_after = get_crm_resources(duthost, "ipv6_route", "used")
+        return (abs(ipv4_route_used_after - ipv4_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS and
+                abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS )
 
-    pytest_assert(abs(ipv4_route_used_after - ipv4_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
-                  "ipv4 route used after is not equal to it used before")
-    pytest_assert(abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
-                  "ipv6 route used after is not equal to it used before")
+    pytest_assert(wait_until(10*60, CRM_POLLING_INTERVAL, 0, routesRestored),
+                  "ipv4/ipv6 route used after is not equal to it used before")


### PR DESCRIPTION
### Description of PR

Summary:
st_announce_withdraw_route(..) can take several minutes to process, so instead of a sleep_to_wait(..) this change adds a wait_until(..) call which will poll the status, until the operation is complete.

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [X] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?
Fixing the bug. 

#### How did you do it?
See summary.

#### How did you verify/test it?
Ran the tests against multiple SKUs.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA


