### PR TITLE
advanced-reboot: Fix timeout not being present in Python 2

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1784,20 +1784,15 @@ class ReloadTest(BaseTest):
             process.terminate()
 
         for process in processes_list:
-            process.wait(timeout=5)
+            wait_timer = timer.Timer(5, process.kill)
+            try:
+                wait_timer.start()
+                process.wait()
+            finally:
+                wait_timer.cancel()
             # Return code here could be 0, so we need to explicitly check for None
             if process.returncode is not None:
                 self.log("Tcpdump process {} terminated".format(process.args))
-
-        for process in processes_list:
-            if process.returncode is not None:
-                continue
-            self.log("Killing tcpdump process {}".format(process.args))
-            process.kill()
-            process.wait(timeout=5)
-            # Return code here could be 0, so we need to explicitly check for None
-            if process.returncode is not None:
-                self.log("Tcpdump process {} killed".format(process.args))
 
         self.log("Killed all tcpdump processes")
 

--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1784,7 +1784,7 @@ class ReloadTest(BaseTest):
             process.terminate()
 
         for process in processes_list:
-            wait_timer = timer.Timer(5, process.kill)
+            wait_timer = threading.Timer(5, process.kill)
             try:
                 wait_timer.start()
                 process.wait()


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

Because of #10960 needing to be cherry-picked to 202305, there was some Python 3-only syntax present that caused failures on 202305, since the advanced-reboot script is run on the PTF container under Python 2. Specifically, `subprocess.wait` doesn't recognize the `timeout` argument.

#### How did you do it?

Work around that by starting a timer where a kill signal is sent to the process if it hasn't terminated in 5 seconds. This probably won't be actually needed, though.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
