### PR TITLE
[platform_tests] fix interfaces_wait_time not expected problem

### DIFF
--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -96,7 +96,7 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list,
 
 
 def check_interfaces_and_services(dut, interfaces, xcvr_skip_list,
-                                  interfaces_wait_time=MAX_WAIT_TIME_FOR_INTERFACES, reboot_type=None):
+                                  interfaces_wait_time=None, reboot_type=None):
     """
     Perform a further check after reboot-cause, including transceiver status, interface status
     @param localhost: The Localhost object.
@@ -105,6 +105,9 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list,
     """
     logging.info("Wait until all critical services are fully started")
     wait_critical_processes(dut)
+
+    if interfaces_wait_time is None:
+        interfaces_wait_time = MAX_WAIT_TIME_FOR_INTERFACES
 
     if dut.is_supervisor_node():
         logging.info("skipping interfaces related check for supervisor")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Interfaces_wait_time can be a custom value, but in function the old value was used, because the function default value is initialized when custom value is applied. Fix the bug.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fix bug to make interfaces_wait_time as expected.

#### How did you do it?

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
