### PR TITLE
Adding loganalyzer exception to ignore ERR syncd#dsserve: _ds2tty broken pipe error.

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -69,6 +69,8 @@ def ignore_expected_loganalyzer_exception(get_src_dst_asic_and_duts, loganalyzer
         # The following error log is related to the bug of https://github.com/sonic-net/sonic-buildimage/issues/13265
         ".*ERR lldp#lldpmgrd.*Command failed.*lldpcli.*configure.*ports.*lldp.*unknown command from argument"
         ".*configure.*command was failed.*times, disabling retry.*"
+        # Error related to syncd socket-timeout intermittenly
+        ".*ERR syncd[0-9]*#dsserve: _ds2tty broken pipe.*"
     ]
 
     if loganalyzer:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In qos test runs, we intermittently see- “ERR syncd1#dsserve: _ds2tty broken pipe” error.
This error occurs during ‘bcmcmd ‘executes credit-watchdog enable\disable in test run.
 
Logs:
Oct 15 20:51:13.890515 ixre-egl-board1 INFO syncd1#supervisord: message repeated 7 times: [ syncd sai_thrift_get_queue_stats#015]
Oct 15 20:51:13.890515 ixre-egl-board1 INFO syncd1#supervisord: syncd sai_thrift_set_port#015
Oct 15 20:51:14.143547 ixre-egl-board1 NOTICE syncd0#syncd: :- threadFunction: time span 1 ms for 'get:SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000'
Oct 15 20:51:16.850876 ixre-egl-board1 INFO syncd1#supervisord: syncd sai_thrift_get_port_stats#015
Oct 15 20:51:16.852078 ixre-egl-board1 INFO syncd1#supervisord: syncd sai_thrift_get_port_attribute#015
Oct 15 20:51:16.899319 ixre-egl-board1 **ERR syncd1#dsserve: _ds2tty broken pipe**
Oct 15 20:51:16.899389 ixre-egl-board1 INFO syncd1#supervisord: syncd [3] _ds2tty broken pipe
Oct 15 20:51:16.900255 ixre-egl-board1 INFO syncd1#supervisord: syncd sai_thrift_get_queue_stats#015
 
bcmcmd communicates with ASIC via  syncd socket and dsserve is listening on this socket. 
bcmcmd <--> dsserve <--> syncd <--> SDK/ASIC
**admin@xxxx:~$ docker exec -it syncd0 bash -c "netstat -alnp|grep dsserve"
unix  2      [ ACC ]     STREAM     LISTENING     1567259  21/dsserve           /var/run/sswsyncd/sswsyncd.socket**

But sometimes this socket is timed-out and fails with broken pipe error.
We have existing retry mechanism in the qos test, so when the bcmcmd fails or times out, it retries and the test never fails to disable/enable the credit watchdog, but the test run errors with the log analyzer catching this error message.

Currently we do not have the enable/disable credit watchdog as part of SAI attributes & the cli is patched separately.
Once BCM adds it as new SAI attribute, this error may not be seen. 
Till then ignoring this error in test_qos_sai

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The test run fails with error "ERR syncd0#dsserve: _ds2tty broken pipe" in teardown intermittently. 
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
