### PR TITLE
[Framework] Add get_vlan_brief method to SonicHost

### DIFF
--- a/docs/api_wiki/README.md
+++ b/docs/api_wiki/README.md
@@ -207,6 +207,8 @@ def test_fun(duthosts, rand_one_dut_hostname, ptfhost):
 
 - [get_vlan_intfs](sonichost_methods/get_vlan_intfs.md) - Retrieves list of interfaces belonging to a VLAN.
 
+- [get_vlan_brief](sonichost_methods/get_vlan_brief.md) - Returns a dict contians all vlans with their brief information
+
 - [hostname](sonichost_methods/hostname.md) - Provides hostname for device.
 
 - [is_backend_portchannel](sonichost_methods/is_backend_portchannel.md) - Returns whether or not a provided portchannel is a backend portchannel.

--- a/docs/api_wiki/sonichost_methods/get_vlan_brief.md
+++ b/docs/api_wiki/sonichost_methods/get_vlan_brief.md
@@ -1,0 +1,49 @@
+# get_vlan_brief
+
+- [Overview](#overview)
+- [Examples](#examples)
+- [Arguments](#arguments)
+- [Expected Output](#expected-output)
+- [Potential Exception](#potential-exception)
+
+## Overview
+
+Read vlan brief information from running config.
+
+## Examples
+
+```python
+def test_fun(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    vlan_brief = duthost.get_vlan_brief()
+```
+
+## Arguments
+
+None
+
+## Expected Output
+
+Returns an dict, key is vlan name and value is brief information.
+
+Example output:
+
+```
+{
+    "Vlan1000": {
+        "interface_ipv4": [],
+        "interface_ipv6": [],
+        "members": ['Ethernet0', 'Ethernet1']
+    },
+    "Vlan2000": {
+        "interface_ipv4": [],
+        "interface_ipv6": [],
+        "members": ['Ethernet3', 'Ethernet4']
+    }
+}
+```
+
+## Potential Exception
+
+- [Exception from function get_running_config_facts](sonichost_methods/get_running_config_facts.md)
+- `KeyError` - If vlan name and count is not match between VLAN_MEMBER and VLAN_INTERFACE in running config.

--- a/docs/api_wiki/sonichost_methods/get_vlan_brief.md
+++ b/docs/api_wiki/sonichost_methods/get_vlan_brief.md
@@ -45,5 +45,5 @@ Example output:
 
 ## Potential Exception
 
-- [Exception from function get_running_config_facts](sonichost_methods/get_running_config_facts.md)
+- [Exception from function get_running_config_facts](get_running_config_facts.md)
 - `KeyError` - If vlan name and count is not match between VLAN_MEMBER and VLAN_INTERFACE in running config.

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1762,6 +1762,42 @@ Totals               6450                 6449
 
         return vlan_intfs
 
+    def get_vlan_brief(self):
+        """
+        Get vlan brief
+        Sample output:
+            {
+                "Vlan1000": {
+                    "interface_ipv4": [],
+                    "interface_ipv6": [],
+                    "members": ['Ethernet0', 'Ethernet1']
+                },
+                "Vlan2000": {
+                    "interface_ipv4": [],
+                    "interface_ipv6": [],
+                    "members": ['Ethernet3', 'Ethernet4']
+                }
+            }
+        """
+        config = self.get_running_config_facts()
+        vlan_brief = {}
+        for vlan_name, members in config["VLAN_MEMBER"].items():
+            vlan_brief[vlan_name] = {
+                "interface_ipv4": [],
+                "interface_ipv6": [],
+                "members": list(members.keys())
+            }
+        for vlan_name, vlan_info in config["VLAN_INTERFACE"].items():
+            if vlan_name not in vlan_brief:
+                continue
+            for prefix in vlan_info.keys():
+                ip = prefix.split('/')[0]
+                if '.' in ip:
+                    vlan_brief[vlan_name]["interface_ipv4"].append(ip)
+                elif ':' in ip:
+                    vlan_brief[vlan_name]["interface_ipv6"].append(ip)
+        return vlan_brief
+
     def get_interfaces_status(self):
         '''
         Get intnerfaces status by running 'show interfaces status' on the DUT, and parse the result into a dict.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added get_vlan_brief method to SonicHost. Test cases can use this method to get VLAN information including members and interfaces IP addresses.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Some test cases need to get VLAN information including members and interfaces IP addresses to setup test.
With this method, we can group test cases per VLAN.
#### How did you do it?
Added get_vlan_brief method to SonicHost.
#### How did you verify/test it?
Verified in some ACL testcases.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
