### PR TITLE
Add multi-asic support for config_reload running_golden_config

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -127,9 +127,13 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
             sonic_host.shell(cmd, executable="/bin/bash")
 
     elif config_source == 'running_golden_config':
-        cmd = 'config reload -y -l /etc/sonic/running_golden_config.json &>/dev/null'
+        golden_path = '/etc/sonic/running_golden_config.json'
+        if sonic_host.is_multi_asic:
+            for asic in sonic_host.asics:
+                golden_path = f'{golden_path},/etc/sonic/running_golden_config{asic.asic_index}.json'
+        cmd = f'config reload -y -l {golden_path} &>/dev/null'
         if config_force_option_supported(sonic_host):
-            cmd = 'config reload -y -f -l /etc/sonic/running_golden_config.json &>/dev/null'
+            cmd = f'config reload -y -f -l {golden_path} &>/dev/null'
         sonic_host.shell(cmd, executable="/bin/bash")
 
     modular_chassis = sonic_host.get_facts().get("modular_chassis")


### PR DESCRIPTION
Signed-off-by: Anand Mehra anamehra@cisco.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Added support for multi-asic to generate the correct running_golden_config file list for 'config reload -l' command for multi-asic systems

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/11945

During sonic-mgmgt tests, if sanity precheck fails, the scripts try to recover the setup by executing ‘config reload’ with running_golden_config files saved.

the command executed is 'config reload -f -l /etc/sonic/running_golden_config.json'

This command works fine on single asic systems but does not work on multi-asic cards.

For multi asic cards, the config reload expects one global config file and one namespace config file for each namespace:

e.g: for 2 asic LC:

config reload -f -l /etc/sonic/running_golden_config.json,/etc/sonic/running_golden_config0.json,/etc/sonic/running_golden_config2.json


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
recovery via config_reload using running_golden_config files does not work.

#### How did you do it?
Added support to generate the file list for multi-asic

#### How did you verify/test it?
stop one of swss service on multi-asic DUT. Trigger a test with presanity.
Presanity detects docker down and triggers recovery.
Check syslogs for proper config reload options.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

logs
```
Mar  8 06:26:02.628496 sfd-lc0 INFO python[40007]: ansible-ansible.legacy.command Invoked with executable=/bin/bash _raw_params=config reload -h _uses_shell=True warn=False stdin_add_newline=True strip_empty_ends=True argv=None chdir=None creates=None removes=None stdin=None
Mar  8 06:26:04.090387 sfd-lc0 INFO python[40065]: ansible-ansible.legacy.command Invoked with executable=/bin/bash _raw_params=config reload -y -f -l /etc/sonic/running_golden_config.json,/etc/sonic/running_golden_config0.json,/etc/sonic/running_golden_config1.json,/etc/sonic/running_golden_config2.json &>/dev/null _uses_shell=True warn=False stdin_add_newline=True strip_empty_ends=True argv=None chdir=None creates=None removes=None stdin=None                                                               
Mar  8 06:26:04.960886 sfd-lc0 NOTICE CCmisApi: 'reload' executing with command: config reload -y -f -l /etc/sonic/running_golden_config.json,/etc/sonic/running_golden_config0.json,/etc/sonic/running_golden_config1.json,/etc/sonic/running_golden_config2.json
root@sfd-lc0:/home/cisco# vi /var/log/syslog
root@sfd-lc0:/home/cisco# grep -i unmonit /var/log/syslog
Mar  8 06:26:04.995417 sfd-lc0 INFO monit[743]: 'container_checker' unmonitor on user request
Mar  8 06:26:05.018424 sfd-lc0 INFO monit[743]: 'container_checker' unmonitor action done
```
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
