### PR TITLE
update component version index in fwutil common

### DIFF
--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -26,6 +26,7 @@ REBOOT_TYPES = {
     WARM_REBOOT: "warm-reboot",
     FAST_REBOOT: "fast-reboot"
 }
+LATEST_VERSION_IDX = 0
 
 
 def find_pattern(lines, pattern):
@@ -301,8 +302,8 @@ def call_fwutil(duthost, localhost, pdu_ctrl, fw_pkg, component=None, next_image
     defined_components = get_defined_components(duthost, fw_pkg, chassis)
     final_components = final_versions["chassis"][chassis]["component"]
     for comp in list(paths.keys()):
-        if defined_components[comp][0]["version"] != final_components[comp] and \
-                boot in defined_components[comp][0]["reboot"] + [None] and \
+        if defined_components[comp][LATEST_VERSION_IDX]["version"] != final_components[comp] and \
+                boot in defined_components[comp][LATEST_VERSION_IDX]["reboot"] + [None] and \
                 not paths[comp].get("upgrade_only", False):
             update_needed["chassis"][chassis]["component"][comp] = defined_components[comp]
     if len(list(update_needed["chassis"][chassis]["component"].keys())) > 0:


### PR DESCRIPTION

### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In fwutil tests, it will always revert the component version to the version at index 0, 
since this index is expected to be the latest version.

This is based on the assumption that the firmware.json file is maintained with the same structure.
The JSON file will list 2 versions per FW component (i.e, ONIE/BIOS/CPLD),
The 2 versions are always listed in the same order which is:
1. The first version is the newer version
2. The second version is the older version


Summary:

1. Giving index 0 a meaningful name will help the user better understand the JSON structure and test flow
2. Help debug and avoid file errors
3. better coding practice since we remove the use of magic numbers.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

1. Giving index 0 a meaningful name will help the user better understand the JSON structure and test flow
2. Help debug and avoid file errors
3. better coding practice since we remove the use of magic numbers.

#### How did you do it?
Defined a global for index 0 and updated it in necessary places in the code.

#### How did you verify/test it?
 rerun the tests

#### Any platform specific information?
no 

