### PR TITLE
Add python3 support to case test_ipinip_hash and test_ipinip_hash_negative of fib test

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -379,24 +379,28 @@ def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files
     else:
         src_ip_range = SRC_IPV6_RANGE
         dst_ip_range = DST_IPV6_RANGE
-    ptf_runner(ptfhost,
-               "ptftests",
-               "hash_test.IPinIPHashTest",
-               platform_dir="ptftests",
-               params={"fib_info_files": fib_info_files_per_function[:3],   # Test at most 3 DUTs
-                       "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url,
-                                                              duts_running_config_facts, duts_minigraph_facts),
-                       "hash_keys": hash_keys,
-                       "src_ip_range": ",".join(src_ip_range),
-                       "dst_ip_range": ",".join(dst_ip_range),
-                       "vlan_ids": VLANIDS,
-                       "ignore_ttl": ignore_ttl,
-                       "single_fib_for_duts": single_fib_for_duts,
-                       "ipver": ipver
-                       },
-               log_file=log_file,
-               qlen=PTF_QLEN,
-               socket_recv_size=16384)
+    ptf_runner(
+        ptfhost,
+        "ptftests",
+        "hash_test.IPinIPHashTest",
+        platform_dir="ptftests",
+        params={
+            "fib_info_files": fib_info_files_per_function[:3],   # Test at most 3 DUTs
+            "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url,
+                                                   duts_running_config_facts, duts_minigraph_facts),
+            "hash_keys": hash_keys,
+            "src_ip_range": ",".join(src_ip_range),
+            "dst_ip_range": ",".join(dst_ip_range),
+            "vlan_ids": VLANIDS,
+            "ignore_ttl": ignore_ttl,
+            "single_fib_for_duts": single_fib_for_duts,
+            "ipver": ipver
+        },
+        log_file=log_file,
+        qlen=PTF_QLEN,
+        socket_recv_size=16384,
+        is_python3=True
+    )
 
 # The test is to verify the hashing logic is not using unexpected field as keys
 # Only inner frame length is tested at this moment
@@ -416,24 +420,26 @@ def test_ipinip_hash_negative(add_default_route_to_dut, duthosts, fib_info_files
     else:
         src_ip_range = SRC_IPV6_RANGE
         dst_ip_range = DST_IPV6_RANGE
-    ptf_runner(ptfhost,
-               "ptftests",
-               "hash_test.IPinIPHashTest",
-               platform_dir="ptftests",
-               params={"fib_info_files": fib_info_files_per_function[:3],   # Test at most 3 DUTs
-                       "ptf_test_port_map": ptf_test_port_map_active_active(
-                           ptfhost, tbinfo, duthosts, mux_server_url,
-                           duts_running_config_facts, duts_minigraph_facts,
-                           mux_status_from_nic_simulator()
-               ),
-                   "hash_keys": hash_keys,
-                   "src_ip_range": ",".join(src_ip_range),
-                   "dst_ip_range": ",".join(dst_ip_range),
-                   "vlan_ids": VLANIDS,
-                   "ignore_ttl": ignore_ttl,
-                   "single_fib_for_duts": single_fib_for_duts,
-                   "ipver": ipver
-               },
-               log_file=log_file,
-               qlen=PTF_QLEN,
-               socket_recv_size=16384)
+    ptf_runner(
+        ptfhost,
+        "ptftests",
+        "hash_test.IPinIPHashTest",
+        platform_dir="ptftests",
+        params={
+            "fib_info_files": fib_info_files_per_function[:3],   # Test at most 3 DUTs
+            "ptf_test_port_map": ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url,
+                                                                 duts_running_config_facts, duts_minigraph_facts,
+                                                                 mux_status_from_nic_simulator()),
+            "hash_keys": hash_keys,
+            "src_ip_range": ",".join(src_ip_range),
+            "dst_ip_range": ",".join(dst_ip_range),
+            "vlan_ids": VLANIDS,
+            "ignore_ttl": ignore_ttl,
+            "single_fib_for_duts": single_fib_for_duts,
+            "ipver": ipver
+        },
+        log_file=log_file,
+        qlen=PTF_QLEN,
+        socket_recv_size=16384,
+        is_python3=True
+    )


### PR DESCRIPTION
### Description of PR
Add python 3 support to fib test

Including 2 cases test_ipinip_hash and test_ipinip_hash_negative

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
It was found that the 2 cases are still using python 2 when running PTF test
#### How did you do it?
Add python 3 support
#### How did you verify/test it?
Validate it by local run
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
