### PR TITLE
Fix 9332 fanout TX_DROP which causes TestQosSai::testQosSaiDwrr failure

### DIFF
--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202012.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202012.yml
@@ -50,3 +50,8 @@
       shell: "bcmcmd 'fp detach' && bcmcmd 'fp init'"
       become: yes
   when: "'broadcom' in fanout_sonic_version.asic_type"
+
+- name: Run config qos reload command to load qos settings in order to fix 9332 Wdrr testcase failure
+  shell: config qos reload
+  become: yes
+  when: "'DellEMC-Z9332f-O32' in device_info[inventory_hostname]['HwSku']"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes 9332 fanout TX_DROP which causes TestQosSai::testQosSaiDwrr failure

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
When running qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr,
If the fanout is 9332, there will be TX_DROP on interface to root fanout.
The reason is the 9332 QoS configuration is empty after deploy the fanout.

#### How did you do it?
Add "config qos reload" when deploying 9332 fanout, if fanout sonic version is 202012.

#### How did you verify/test it?
1. Manually run: ansible-playbook fanout.yml -i str2 --limit str2-z9332f-03 -b --vault-password-file group_vars/all/secrets.json
2. After running the testcase(testQosSaiDwrr), the TX_DROP is 0.
3.
Before change:
```
admin@str2-z9332f-05:~$ show queue watermark unicast                                                                                                     
COUNTERS_BUFFER_POOL_NAME_MAP is empty!
```

After change:
```
admin@str2-z9332f-05:~$ show queue watermark unicast                                                                                                     
Egress shared pool occupancy per unicast queue:                                                                                                          
       Port    UC0    UC1    UC2    UC3    UC4    UC5    UC6    UC7                                                                                      
-----------  -----  -----  -----  -----  -----  -----  -----  -----                                                                                      
  Ethernet0      0      0      0      0      0      0      0      0                                                                                      
  Ethernet8      0      0      0      0      0      0      0      0                                                                                      
 Ethernet16      0      0      0      0      0      0      0      0                                                                                      
 Ethernet24      0      0      0      0      0      0      0      0                                                                                      
 Ethernet32      0      0      0      0      0      0      0      0                                                                                      
 Ethernet40      0      0      0      0      0      0      0      0                                                                                      
 Ethernet48      0      0      0      0      0      0      0      0                                                                                      
 Ethernet56      0      0      0      0      0      0      0      0                                                                                      
 Ethernet64      0      0      0      0      0      0      0      0                                                                                      
 Ethernet72      0      0      0      0      0      0      0      0                                                                                      
 Ethernet80      0      0      0      0      0      0      0      0                                                                                      
 Ethernet88      0      0      0      0      0      0      0      0                                                                                      
 Ethernet96      0      0      0      0      0      0      0      0                                                                                      
Ethernet104      0      0      0      0      0      0      0      0                                                                                      
Ethernet112      0      0      0      0      0      0      0      0                                                                                      
Ethernet120      0      0      0      0      0      0      0      0                                                                                      
Ethernet128      0      0      0      0      0      0      0      0                                                                                      
Ethernet136      0      0      0      0      0      0      0      0                                                                                      
Ethernet144      0      0      0      0      0      0      0      0                                                                                      
Ethernet152      0      0      0      0      0      0      0      0                                                                                      
Ethernet160      0      0      0      0      0      0      0      0                                                                                      
Ethernet168      0      0      0      0      0      0      0      0                                                                                      
Ethernet176      0      0      0      0      0      0      0      0                                                                                      
Ethernet184      0      0      0      0      0      0      0      0                                                                                      
Ethernet192      0      0      0      0      0      0      0      0                                                                                      
Ethernet200      0      0      0      0      0      0      0      0                                                                                      
Ethernet208      0      0      0      0      0      0      0      0                                                                                      
Ethernet216      0      0      0      0      0      0      0      0                                                                                      
Ethernet224      0      0      0      0      0      0      0      0                                                                                      
Ethernet232      0      0      0      0      0      0      0      0                                                                                      
Ethernet240      0      0      0      0      0      0      0      0                                                                                      
Ethernet248      0      0      0      0      0      0      0      0                                                                                      
Ethernet256      0      0      0      0      0      0   7620      0                                                                                      
Ethernet257      0      0      0      0      0      0      0      0
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
