### PR TITLE
Skip GCU dhcp tests for backend topologies

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -616,9 +616,11 @@ generic_config_updater:
 
 generic_config_updater/test_dhcp_relay.py:
   skip:
-    reason: "Need to skip for platform x86_64-8111_32eh_o-r0"
+    reason: "Need to skip for platform x86_64-8111_32eh_o-r0 or backend topology"
+    conditions_logical_operator: "OR"
     conditions:
       - "platform in ['x86_64-8111_32eh_o-r0']"
+      - "'backend' in topo_name"
 
 generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Skip GCU dhcp tests on t0-backend and t1-backend topologies

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [xTestbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

#### How did you verify/test it?
'''
collected 4 items                                                                                                                            

generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc1_rm_nonexist SKIPPED (Need to skip for platform x86_64-8111_32eh_o-r...)
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc2_add_exist SKIPPED (Need to skip for platform x86_64-8111_32eh_o-r0 ...)
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc3_add_and_rm SKIPPED (Need to skip for platform x86_64-8111_32eh_o-r0...)
generic_config_updater/test_dhcp_relay.py::test_dhcp_relay_tc4_replace SKIPPED (Need to skip for platform x86_64-8111_32eh_o-r0 or...)

============================================================== warnings summary ==============================================================
../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml ----------------------------------------
========================================================== short test summary info ===========================================================
SKIPPED [4] generic_config_updater/test_dhcp_relay.py: Need to skip for platform x86_64-8111_32eh_o-r0 or backend topology
======================================================= 4 skipped, 1 warning in 22.64s =======================================================
'''