### PR TITLE
Qos params changes for J2C+ t2 topo w.r.t vsq_threshold buffer_config 10M change in MSFT image 55

### DIFF
--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -237,9 +237,10 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 94781
-                    pkts_num_hdrm_full: 362
-                    pkts_num_hdrm_partial: 182
+                    pkts_num_trig_pfc: 93635
+                    pkts_num_hdrm_full: 3510
+                    pkts_num_hdrm_partial: 3500
+                    margin: 5
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
@@ -343,9 +344,10 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 93781
-                    pkts_num_hdrm_full: 362
-                    pkts_num_hdrm_partial: 182
+                    pkts_num_trig_pfc: 93635
+                    pkts_num_hdrm_full: 176849
+                    pkts_num_hdrm_partial: 176749
+                    margin: 100
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
@@ -449,10 +451,10 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_hdrm_full: 362
-                    pkts_num_hdrm_partial: 182
-                    margin: 1
+                    pkts_num_trig_pfc: 93635
+                    pkts_num_hdrm_full: 713000
+                    pkts_num_hdrm_partial: 712950
+                    margin: 300
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1

--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -237,7 +237,7 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_pfc: 94781
                     pkts_num_hdrm_full: 362
                     pkts_num_hdrm_partial: 182
                 wm_pg_headroom:
@@ -299,8 +299,8 @@ qos_params:
                     pg: 3
                     queue: 3
                     pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 97133
+                    pkts_num_trig_pfc: 35108
+                    pkts_num_trig_ingr_drp: 38619
                     pkts_num_fill_egr_min: 8
                     cell_size: 4096
                 wm_q_shared_lossy:
@@ -405,8 +405,8 @@ qos_params:
                     pg: 3
                     queue: 3
                     pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 272237
+                    pkts_num_trig_pfc: 37549
+                    pkts_num_trig_ingr_drp: 216064
                     pkts_num_fill_egr_min: 8
                     cell_size: 4096
                 wm_q_shared_lossy:
@@ -512,8 +512,8 @@ qos_params:
                     pg: 3
                     queue: 3
                     pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 807021
+                    pkts_num_trig_pfc: 28160
+                    pkts_num_trig_ingr_drp: 750848
                     pkts_num_fill_egr_min: 8
                     cell_size: 4096
                 wm_q_shared_lossy:

--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -327,14 +327,14 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 807021
+                    pkts_num_trig_ingr_drp: 272237
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 807021
+                    pkts_num_trig_ingr_drp: 272237
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -351,7 +351,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 807021
+                    pkts_num_trig_ingr_drp: 272237
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
@@ -397,7 +397,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 807021
+                    pkts_num_trig_ingr_drp: 272237
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -406,7 +406,7 @@ qos_params:
                     queue: 3
                     pkts_num_fill_ingr_min: 0
                     pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 807021
+                    pkts_num_trig_ingr_drp: 272237
                     pkts_num_fill_egr_min: 8
                     cell_size: 4096
                 wm_q_shared_lossy:

--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -326,15 +326,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 216064
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 807021
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 216064
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 807021
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -343,29 +343,29 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 37549
+                    pkts_num_trig_pfc: 93781
                     pkts_num_hdrm_full: 362
                     pkts_num_hdrm_partial: 182
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 216064
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 807021
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
+                    pkts_num_trig_pfc: 93622
                     pkts_num_dismiss_pfc: 200
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 37449
+                    pkts_num_trig_pfc: 93622
                     pkts_num_dismiss_pfc: 200
                     pkts_num_margin: 150
                 lossy_queue_1:
@@ -379,7 +379,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 51
-                    pkts_num_trig_pfc: 37449
+                    pkts_num_trig_pfc: 93622
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -397,7 +397,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 216064
+                    pkts_num_trig_ingr_drp: 807021
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -405,8 +405,8 @@ qos_params:
                     pg: 3
                     queue: 3
                     pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_pfc: 37549
-                    pkts_num_trig_ingr_drp: 216064
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 807021
                     pkts_num_fill_egr_min: 8
                     cell_size: 4096
                 wm_q_shared_lossy:

--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -220,15 +220,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 97133
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 97133
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -237,29 +237,29 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 35208
+                    pkts_num_trig_pfc: 93622
                     pkts_num_hdrm_full: 362
                     pkts_num_hdrm_partial: 182
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 97133
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
+                    pkts_num_trig_pfc: 93622
                     pkts_num_dismiss_pfc: 200
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 35108
+                    pkts_num_trig_pfc: 93622
                     pkts_num_dismiss_pfc: 200
                     pkts_num_margin: 150
                 lossy_queue_1:
@@ -273,7 +273,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 51
-                    pkts_num_trig_pfc: 9874
+                    pkts_num_trig_pfc: 93622
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -291,7 +291,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_ingr_drp: 97133
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -299,8 +299,8 @@ qos_params:
                     pg: 3
                     queue: 3
                     pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 97133
                     pkts_num_fill_egr_min: 8
                     cell_size: 4096
                 wm_q_shared_lossy:
@@ -432,15 +432,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 750848
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 807021
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 750848
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 807021
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -449,7 +449,7 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 37549
+                    pkts_num_trig_pfc: 93622
                     pkts_num_hdrm_full: 362
                     pkts_num_hdrm_partial: 182
                     margin: 1
@@ -457,22 +457,22 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 750848
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 807021
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
+                    pkts_num_trig_pfc: 93622
                     pkts_num_dismiss_pfc: 200
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 37449
+                    pkts_num_trig_pfc: 93622
                     pkts_num_dismiss_pfc: 200
                     pkts_num_margin: 150
                 lossy_queue_1:
@@ -504,7 +504,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 750848
+                    pkts_num_trig_ingr_drp: 807021
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -512,8 +512,8 @@ qos_params:
                     pg: 3
                     queue: 3
                     pkts_num_fill_ingr_min: 0
-                    pkts_num_trig_pfc: 28160
-                    pkts_num_trig_ingr_drp: 750848
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 807021
                     pkts_num_fill_egr_min: 8
                     cell_size: 4096
                 wm_q_shared_lossy:

--- a/tests/qos/files/qos_params.jr2.yaml
+++ b/tests/qos/files/qos_params.jr2.yaml
@@ -114,15 +114,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 97133
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 97133
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -131,29 +131,30 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 35208
-                    pkts_num_hdrm_full: 362
-                    pkts_num_hdrm_partial: 182
+                    pkts_num_trig_pfc: 93635
+                    pkts_num_hdrm_full: 3510
+                    pkts_num_hdrm_partial: 3500
+                    margin: 5
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 97133
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
+                    pkts_num_trig_pfc: 93622
                     pkts_num_dismiss_pfc: 200
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 35108
+                    pkts_num_trig_pfc: 93622
                     pkts_num_dismiss_pfc: 200
                     pkts_num_margin: 150
                 lossy_queue_1:
@@ -167,7 +168,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 51
-                    pkts_num_trig_pfc: 9874
+                    pkts_num_trig_pfc: 93622
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -185,7 +186,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_ingr_drp: 97133
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -220,15 +221,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 272237
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 272237
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -237,29 +238,29 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 37549
-                    pkts_num_hdrm_full: 362
-                    pkts_num_hdrm_partial: 182
+                    pkts_num_trig_pfc: 93635
+                    pkts_num_hdrm_full: 176849
+                    pkts_num_hdrm_partial: 176749
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_ingr_drp: 272237
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
+                    pkts_num_trig_pfc: 93622
                     pkts_num_dismiss_pfc: 200
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 37449
+                    pkts_num_trig_pfc: 93622
                     pkts_num_dismiss_pfc: 200
                     pkts_num_margin: 150
                 lossy_queue_1:
@@ -273,7 +274,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 51
-                    pkts_num_trig_pfc: 37449
+                    pkts_num_trig_pfc: 93622
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -291,7 +292,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 55808
+                    pkts_num_trig_ingr_drp: 272237
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The Qos params changes in qos.yaml is for J2C+t2 topo w.r.t. the vsq_threshold 10M change in MSFT image 55.
These params changes are specific to broadcom-dnx chassis for MSFT image 55.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Executed qos test for t2 topo & verified.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
