### PR TITLE
Disable proxy_arp at the end of test_proxy_arp

### DIFF
--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -311,6 +311,7 @@ def proxy_arp_enabled(rand_selected_dut, config_facts):
     proxy_arp_del_cmd = 'sonic-db-cli CONFIG_DB HDEL "VLAN_INTERFACE|Vlan{}" proxy_arp'
     for vid, proxy_arp_val in list(old_proxy_arp_vals.items()):
         if 'enabled' not in proxy_arp_val:
+            duthost.shell(proxy_arp_config_cmd.format(vid, 'disabled'))
             # Delete the DB entry instead of using the config command to satisfy check_dut_health_status
             duthost.shell(proxy_arp_del_cmd.format(vid))
 

--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -311,7 +311,9 @@ def proxy_arp_enabled(rand_selected_dut, config_facts):
     proxy_arp_del_cmd = 'sonic-db-cli CONFIG_DB HDEL "VLAN_INTERFACE|Vlan{}" proxy_arp'
     for vid, proxy_arp_val in list(old_proxy_arp_vals.items()):
         if 'enabled' not in proxy_arp_val:
+            # Disable proxy_arp explicitly
             duthost.shell(proxy_arp_config_cmd.format(vid, 'disabled'))
+            time.sleep(2)
             # Delete the DB entry instead of using the config command to satisfy check_dut_health_status
             duthost.shell(proxy_arp_del_cmd.format(vid))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to add a cleanup at the end of test `test_proxy_arp`.
Before this change, the code only deleted the DB entry from CONFIG_DB. However, `proxy_arp` is not disabled in the Vlan, which caused some issue for the subsequent test cases.
This PR addressed the issue by calling `config vlan proxy_arp VID disabled` at the end of the fixture.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR is to add a cleanup at the end of test `test_proxy_arp`.

#### How did you do it?
This PR addressed the issue by calling `config vlan proxy_arp VID disabled` at the end of the fixture.

#### How did you verify/test it?
The change is verified on a physical testbed.
```
collected 3 items                                                                                                                                                                                     

arp/test_arp_extended.py::test_arp_garp_enabled[str2-msn2700-spy-1-None] PASSED                                                                                                                 [ 33%]
arp/test_arp_extended.py::test_proxy_arp[v4-str2-msn2700-spy-1-None] PASSED                                                                                                                     [ 66%]
arp/test_arp_extended.py::test_proxy_arp[v6-str2-msn2700-spy-1-None] PASSED                                                                                                                     [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
