### PR TITLE
Validate alternate passwords

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -1,9 +1,7 @@
 ansible_ssh_user: admin
 ansible_connection: multi_passwd_ssh
 ansible_altpassword: YourPaSsWoRd
-# ansible_altpasswords:
-#   - fakepassword1
-#   - fakepassword2
+ansible_altpasswords: "{{ secret_group_vars['str']['altpasswords'] }}"
 
 sonic_version: "v2"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #11812, the multi_passwd_ssh plugin was enhanced to support a list of alternate passwords. Subsequent testing in this PR has led to its validation.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
In PR #11812, the multi_passwd_ssh plugin was enhanced to support a list of alternate passwords. Subsequent testing in this PR has led to its validation.

#### How did you do it?
Get the value of ansible_altpasswords from `secrets.json`

#### How did you verify/test it?
After updating the casual password of the DUT, which was not previously included in `secrets.json`, I executed an ansible module in docker using the command such like `ansible -m dut_basic_facts.py -i <inventory> <dut_name>`. As anticipated, the output was not retrievable due to an ssh connection failure. However, upon adding the new password to `secrets.json`, the command was executed successfully, and the desired output was obtained.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
