### PR TITLE
[IPv6 only]Enhance IPv6 only conversion fixture to detect the availability of IPv6 addr

### DIFF
--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -9,6 +9,9 @@ from paramiko.ssh_exception import AuthenticationException, NoValidConnectionsEr
 
 from ansible.plugins import connection
 
+logging.basicConfig()
+logging.getLogger("paramiko").setLevel(logging.WARNING)
+
 logger = logging.getLogger(__name__)
 
 # HACK: workaround to import the SSH connection plugin

--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -74,6 +74,8 @@ def _password_retry(func):
                         ssh_args[idx] = hostv6
                 self.host = hostv6
                 self.set_option("host", hostv6)
+            except BaseException:
+                pass
 
         password = self.get_option("password") or self._play_context.password
         conn_passwords = [password]

--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -10,7 +10,7 @@ from paramiko.ssh_exception import AuthenticationException, NoValidConnectionsEr
 from ansible.plugins import connection
 
 logging.basicConfig()
-logging.getLogger("paramiko").setLevel(logging.WARNING)
+logging.getLogger("paramiko").setLevel(logging.CRITICAL)
 
 logger = logging.getLogger(__name__)
 

--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -1,9 +1,12 @@
 import imp
 import os
 import logging
+import paramiko
 
 from functools import wraps
-from ansible.errors import AnsibleAuthenticationFailure, AnsibleConnectionFailure
+from ansible.errors import AnsibleAuthenticationFailure
+from paramiko.ssh_exception import AuthenticationException, NoValidConnectionsError
+
 from ansible.plugins import connection
 
 logger = logging.getLogger(__name__)
@@ -34,15 +37,11 @@ DOCUMENTATION += """
               - name: ansible_hostv6
 """.lstrip("\n")
 
-# A sample error message that host unreachable:
-# 'Failed to connect to the host via ssh: ssh: connect to host 192.168.0.2 port 22: Connection timed out'
-CONNECTION_TIMEOUT_ERR_FLAG = "Connection timed out"
-
 
 def _password_retry(func):
     """
     Decorator to retry ssh/scp/sftp in the case of invalid password
-
+    Will retry with IPv6 addr is IPv4 addr is unavailable
     Will retry for password in (ansible_password, ansible_altpassword, ansible_altpasswords):
     """
     @wraps(func)
@@ -56,28 +55,25 @@ def _password_retry(func):
             hostv6 = None
 
         if hostv6:
+            ssh_client = paramiko.SSHClient()
+            ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             try:
-                return func(self, *args, **kwargs)
-            except AnsibleConnectionFailure as e:
-                logger.info("First connection failed: {}".format(str(e)))
-                if CONNECTION_TIMEOUT_ERR_FLAG in e.message:
-                    self._play_context.remote_addr = hostv6
-                    # args sample:
-                    # ( [b'sshpass', b'-d18', b'ssh', b'-o', b'ControlMaster=auto', b'-o', b'ControlPersist=120s', b'-o', b'UserKnownHostsFile=/dev/null', b'-o', b'StrictHostKeyChecking=no', b'-o', b'StrictHostKeyChecking=no', b'-o', b'User="admin"', b'-o', b'ConnectTimeout=60', b'-o', b'ControlPath="/home/user/.ansible/cp/376bdcc730"', 'fc00:1234:5678:abcd::2', b'/bin/sh -c \'echo PLATFORM; uname; echo FOUND; command -v \'"\'"\'python3.10\'"\'"\'; command -v \'"\'"\'python3.9\'"\'"\'; command -v \'"\'"\'python3.8\'"\'"\'; command -v \'"\'"\'python3.7\'"\'"\'; command -v \'"\'"\'python3.6\'"\'"\'; command -v \'"\'"\'python3.5\'"\'"\'; command -v \'"\'"\'/usr/bin/python3\'"\'"\'; command -v \'"\'"\'/usr/libexec/platform-python\'"\'"\'; command -v \'"\'"\'python2.7\'"\'"\'; command -v \'"\'"\'/usr/bin/python\'"\'"\'; command -v \'"\'"\'python\'"\'"\'; echo ENDFOUND && sleep 0\''], None) # noqa: E501
-                    # args[0] are the parameters of ssh connection
-                    ssh_args = args[0]
-                    # Change the IPv4 host in the ssh_args to IPv6
-                    for idx in range(len(ssh_args)):
-                        if type(ssh_args[idx]) == bytes and ssh_args[idx].decode() == self.host:
-                            ssh_args[idx] = hostv6
-                    self.host = hostv6
-                    self.set_option("host", hostv6)
-            except BaseException as e:
-                # Only catch the connection error, won't block the multi-password functionality
-                logger.info("First connection failed: {}".format(str(e)))
-
-            # Reset the sshpass_pipe for the new connections to be created
-            self.sshpass_pipe = os.pipe()
+                ssh_client.connect(self.host, username="WRONG_USER", password="WRONG_PWD", timeout=15)
+            except AuthenticationException:
+                # Authentication Exception means host(generally IPv4) is available, no need to use IPv6 IP
+                pass
+            except NoValidConnectionsError:
+                self._play_context.remote_addr = hostv6
+                # args sample:
+                # ( [b'sshpass', b'-d18', b'ssh', b'-o', b'ControlMaster=auto', b'-o', b'ControlPersist=120s', b'-o', b'UserKnownHostsFile=/dev/null', b'-o', b'StrictHostKeyChecking=no', b'-o', b'StrictHostKeyChecking=no', b'-o', b'User="admin"', b'-o', b'ConnectTimeout=60', b'-o', b'ControlPath="/home/user/.ansible/cp/376bdcc730"', 'fc00:1234:5678:abcd::2', b'/bin/sh -c \'echo PLATFORM; uname; echo FOUND; command -v \'"\'"\'python3.10\'"\'"\'; command -v \'"\'"\'python3.9\'"\'"\'; command -v \'"\'"\'python3.8\'"\'"\'; command -v \'"\'"\'python3.7\'"\'"\'; command -v \'"\'"\'python3.6\'"\'"\'; command -v \'"\'"\'python3.5\'"\'"\'; command -v \'"\'"\'/usr/bin/python3\'"\'"\'; command -v \'"\'"\'/usr/libexec/platform-python\'"\'"\'; command -v \'"\'"\'python2.7\'"\'"\'; command -v \'"\'"\'/usr/bin/python\'"\'"\'; command -v \'"\'"\'python\'"\'"\'; echo ENDFOUND && sleep 0\''], None) # noqa: E501
+                # args[0] are the parameters of ssh connection
+                ssh_args = args[0]
+                # Change the IPv4 host in the ssh_args to IPv6
+                for idx in range(len(ssh_args)):
+                    if type(ssh_args[idx]) == bytes and ssh_args[idx].decode() == self.host:
+                        ssh_args[idx] = hostv6
+                self.host = hostv6
+                self.set_option("host", hostv6)
 
         password = self.get_option("password") or self._play_context.password
         conn_passwords = [password]

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -1,5 +1,6 @@
 from typing import Dict, List
 
+import paramiko
 import pytest
 import logging
 import itertools
@@ -7,6 +8,8 @@ import collections
 import ipaddress
 import time
 import json
+
+from paramiko.ssh_exception import AuthenticationException
 
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert
@@ -639,12 +642,15 @@ def convert_and_restore_config_db_to_ipv6_only(duthosts):
                                      for duthost in duthosts.nodes}
     ipv6_address: Dict[str, List] = {duthost.hostname: []
                                      for duthost in duthosts.nodes}
-    # Check IPv6 mgmt-ip is set, otherwise the DUT will lose control after v4 mgmt-ip is removed
+    # Check IPv6 mgmt-ip is set and available, otherwise the DUT will lose control after v4 mgmt-ip is removed
     for duthost in duthosts.nodes:
         mgmt_interface = json.loads(duthost.shell(f"jq '.MGMT_INTERFACE' {config_db_file}",
                                                   module_ignore_errors=True)["stdout"])
         # Use list() to make a copy of mgmt_interface.keys() to avoid
         # "RuntimeError: dictionary changed size during iteration" error
+        ssh_client = paramiko.SSHClient()
+        ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        has_available_ipv6_addr = False
         for key in list(mgmt_interface):
             ip_addr = key.split("|")[1]
             ip_addr_without_mask = ip_addr.split('/')[0]
@@ -653,8 +659,18 @@ def convert_and_restore_config_db_to_ipv6_only(duthosts):
                 if is_ipv6:
                     logger.info(f"Host[{duthost.hostname}] IPv6[{ip_addr}]")
                     ipv6_address[duthost.hostname].append(ip_addr_without_mask)
+                    try:
+                        ssh_client.connect(ip_addr_without_mask,
+                                           username="WRONG_USER", password="WRONG_PWD", timeout=15)
+                    except AuthenticationException:
+                        has_available_ipv6_addr = has_available_ipv6_addr or True
+                    except BaseException:
+                        pass
+
         pytest_assert(len(ipv6_address[duthost.hostname]) > 0,
                       f"{duthost.hostname} doesn't have IPv6 Management IP address")
+        pytest_assert(has_available_ipv6_addr,
+                      f"{duthost.hostname} doesn't have available IPv6 Management IP address")
 
     # Remove IPv4 mgmt-ip
     for duthost in duthosts.nodes:


### PR DESCRIPTION
 <!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. Enhance IPv6 only conversion fixture to detect the availability of IPv6 addr.
2. Fix a issue that the unavailable IPv4 addr can't be correctly detected.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
1. Enhance IPv6 only conversion fixture to detect the availability of IPv6 addr.
2. Fix a issue that the unavailable IPv4 addr can't be correctly detected.
#### How did you do it?

#### How did you verify/test it?
Test the scenarios: 
1. IPv6 addr is set but not available from sonic-mgmt container, will stop and not remove IPv4, so that the DUT won't lose connection.
2. IPv4 host unreachable with different prompt
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
