### PR TITLE
Adding fixes for dualtor in test_pfcwd_function.py

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -511,7 +511,7 @@ class SendVerifyTraffic():
         if is_dualtor:
             self.vlan_mac = "00:aa:bb:cc:dd:ee"
         else:
-            self.vlan_mac = router_mac
+            self.vlan_mac = self.tx_mac
         # Verify traffic before pfc storm
         self.verify_rx_ingress("forward")
 
@@ -559,7 +559,7 @@ class SendVerifyTraffic():
         else:
             dst_port = "[ " + str(self.pfc_wd_rx_port_id) + " ]"
         ptf_params = {'router_mac': self.tx_mac,
-                      'vlan_mac': self.tx_mac,
+                      'vlan_mac': self.vlan_mac,
                       'queue_index': self.pfc_queue_index,
                       'pkt_count': self.pfc_wd_test_pkt_count,
                       'port_src': self.pfc_wd_test_port_id,
@@ -625,7 +625,7 @@ class SendVerifyTraffic():
             other_pg = self.pfc_queue_index + 1
 
         ptf_params = {'router_mac': self.tx_mac,
-                      'vlan_mac': self.tx_mac,
+                      'vlan_mac': self.vlan_mac,
                       'queue_index': other_pg,
                       'pkt_count': self.pfc_wd_test_pkt_count,
                       'port_src': self.pfc_wd_test_port_id,


### PR DESCRIPTION
### Description of PR
After updating the tests/pfcwd/test_pfcwd_function.py for multi-asic, the script started failing in dualtor, due to miscalculating vlan_mac. This PR is to address this failure.

Summary:
Pls see above.

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [] 202012
- [X] 202205
- [X] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Changed the vlan_mac calculation back to original form.

#### How did you verify/test it?
```
------------------------------------------------------------------------------- generated xml file: /run_logs/rraghav-pfcwd/pfcwd/test_pfcwd_function_2024-03-14-21-29-10.xml --------------------------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------------------------------
21:46:34 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
================================================================================================================== short test summary info ===================================================================================================================
SKIPPED [1] common/helpers/assertions.py:14: Pfcwd multi port test needs at least 2 ports
=================================================================================================== 3 passed, 1 skipped, 5 warnings in 1042.88s (0:17:22) ====================================================================================================
sonic@sonic-ucs-m6-5:/data/tests$ 
```

Pls see https://github.com/sonic-net/sonic-mgmt/pull/11966/files as well.
Pls see https://github.com/sonic-net/sonic-mgmt/pull/10198 for discussion on the failure.
@lipxu : FYI.
