### PR TITLE
Enable SSH keep-alive when connecting via Ansible

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -190,7 +190,7 @@ become_method='sudo'
 # ssh arguments to use
 # Leaving off ControlPersist will result in poor performance, so use
 # paramiko on older platforms rather than removing it
-ssh_args = -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+ssh_args = -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=4
 
 
 # The path to use for the ControlPath sockets. This defaults to


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

Some test cases use `ptf_runner` to run a script on the PTF container and then get the results. Those scripts may take an extended amount of time to run, and may also have no output generated for some time. This means that there would be no packets sent by either side during this time.

Depending on the network setup, if there is some NAT happening or some firewall configuration between the sonic-mgmt container and the PTF container, that extended period of time with no output may result in NAT/firewall thinking the connection has been dropped/closed, removing the connection entry, and thus causing packets from the PTF back to the sonic-mgmt container to get dropped. (Our internal lab connectivity is one such setup.)

#### How did you do it?

To fix this, in ansible.cfg, enable SSH keep-alive by sending a packet every 30 seconds to make sure the server is still reachable and to make sure the connection entry is preserved.

#### How did you verify/test it?

Verified in our internal environment that a warm upgrade test succeeds, when the network path between the sonic-mgmt container and the PTF container involves NAT (which requires an active TCP connection with traffic to keep the NAT entry alive).

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
