### PR TITLE
[IPv6 only]Fixture to convert DUT mgmt-ip to IPv6 only

### DIFF
--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -1,10 +1,13 @@
 import imp
+import logging
 import os
 
 from functools import wraps
 from ansible.errors import AnsibleAuthenticationFailure
 from ansible.plugins import connection
 
+
+logger = logging.getLogger(__name__)
 
 # HACK: workaround to import the SSH connection plugin
 _ssh_mod = os.path.join(os.path.dirname(connection.__file__), "ssh.py")
@@ -26,17 +29,20 @@ DOCUMENTATION += """
           vars:
               - name: ansible_altpasswords
               - name: ansible_ssh_altpasswords
+      hostv6:
+          description: IPv6 address
+          vars:
+              - name: ansible_hostv6
 """.lstrip("\n")
 
 
 def _password_retry(func):
     """
     Decorator to retry ssh/scp/sftp in the case of invalid password
-
+    Will retry with IPv6 addr if IPv4 addr is unavailable
     Will retry for password in (ansible_password, ansible_altpassword, ansible_altpasswords):
     """
-    @wraps(func)
-    def wrapped(self, *args, **kwargs):
+    def _conn_with_multi_pwd(self, *args, **kwargs):
         password = self.get_option("password") or self._play_context.password
         conn_passwords = [password]
         altpassword = self.get_option("altpassword")
@@ -45,7 +51,6 @@ def _password_retry(func):
         altpasswds = self.get_option("altpasswords")
         if altpasswds:
             conn_passwords.extend(altpasswds)
-
         while conn_passwords:
             conn_password = conn_passwords.pop(0)
             # temporarily replace `password` for this trial
@@ -61,8 +66,39 @@ def _password_retry(func):
                 # reset `password` to its original state
                 self.set_option("password", password)
                 self._play_context.password = password
-            # retry here, need create a new pipe for sshpass
+            # This is a retry, so the fd/pipe for sshpass is closed, and we need a new one
             self.sshpass_pipe = os.pipe()
+
+    @wraps(func)
+    def wrapped(self, *args, **kwargs):
+        try:
+            # First, try with original host(generally IPv4) with multi-password
+            return _conn_with_multi_pwd(self, *args, **kwargs)
+        except BaseException as e:
+            # If a non-authentication related exception is raised and IPv6 host is set,
+            # Retry with IPv6 host with multi-password
+            try:
+                hostv6 = self.get_option("hostv6")
+            except KeyError:
+                hostv6 = None
+            if (type(e) != AnsibleAuthenticationFailure) and hostv6:
+                # This is a retry, so the fd/pipe for sshpass is closed, and we need a new one
+                self.sshpass_pipe = os.pipe()
+                self._play_context.remote_addr = hostv6
+                # args sample:
+                # ( [b'sshpass', b'-d18', b'ssh', b'-o', b'ControlMaster=auto', b'-o', b'ControlPersist=120s', b'-o', b'UserKnownHostsFile=/dev/null', b'-o', b'StrictHostKeyChecking=no', b'-o', b'StrictHostKeyChecking=no', b'-o', b'User="admin"', b'-o', b'ConnectTimeout=60', b'-o', b'ControlPath="/home/user/.ansible/cp/376bdcc730"', 'fc00:1234:5678:abcd::2', b'/bin/sh -c \'echo PLATFORM; uname; echo FOUND; command -v \'"\'"\'python3.10\'"\'"\'; command -v \'"\'"\'python3.9\'"\'"\'; command -v \'"\'"\'python3.8\'"\'"\'; command -v \'"\'"\'python3.7\'"\'"\'; command -v \'"\'"\'python3.6\'"\'"\'; command -v \'"\'"\'python3.5\'"\'"\'; command -v \'"\'"\'/usr/bin/python3\'"\'"\'; command -v \'"\'"\'/usr/libexec/platform-python\'"\'"\'; command -v \'"\'"\'python2.7\'"\'"\'; command -v \'"\'"\'/usr/bin/python\'"\'"\'; command -v \'"\'"\'python\'"\'"\'; echo ENDFOUND && sleep 0\''], None) # noqa: E501
+                # args[0] are the parameters of ssh connection
+                ssh_args = args[0]
+                # Change the IPv4 host in the ssh_args to IPv6
+                for idx in range(len(ssh_args)):
+                    if type(ssh_args[idx]) == bytes and ssh_args[idx].decode() == self.host:
+                        ssh_args[idx] = hostv6
+                self.host = hostv6
+                self.set_option("host", hostv6)
+                return _conn_with_multi_pwd(self, *args, **kwargs)
+            else:
+                raise e
+
     return wrapped
 
 

--- a/tests/common/devices/duthosts.py
+++ b/tests/common/devices/duthosts.py
@@ -54,9 +54,15 @@ class DutHosts(object):
                    DUTs in the testbed should be used
 
         """
+        self.ansible_adhoc = ansible_adhoc
+        self.tbinfo = tbinfo
+        self.duts = duts
+        self.__initialize_nodes()
+
+    def __initialize_nodes(self):
         # TODO: Initialize the nodes in parallel using multi-threads?
-        self.nodes = self._Nodes([MultiAsicSonicHost(ansible_adhoc, hostname, self, tbinfo['topo']['type'])
-                                  for hostname in tbinfo["duts"] if hostname in duts])
+        self.nodes = self._Nodes([MultiAsicSonicHost(self.ansible_adhoc, hostname, self, self.tbinfo['topo']['type'])
+                                  for hostname in self.tbinfo["duts"] if hostname in self.duts])
         self.supervisor_nodes = self._Nodes([node for node in self.nodes if node.is_supervisor_node()])
         self.frontend_nodes = self._Nodes([node for node in self.nodes if node.is_frontend_node()])
 
@@ -125,3 +131,6 @@ class DutHosts(object):
             complex_args['host'] = node.hostname
             result[node.hostname] = node.config_facts(*module_args, **complex_args)['ansible_facts']
         return result
+
+    def reset(self):
+        self.__initialize_nodes()

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -759,6 +759,12 @@ ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_to
     conditions:
       - "asic_type in ['mellanox'] or asic_subtype in ['broadcom-dnx']"
 
+ip/test_mgmt_ipv6_only.py::test_image_download_ipv6_only:
+  skip:
+    reason: "Skipping mgmt ipv6 test for mgmt topo"
+    conditions:
+      - "topo_type in ['m0', 'mx']"
+
 #######################################
 #####            ipfwd            #####
 #######################################

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -1,0 +1,80 @@
+import pytest
+
+from tests.common.fixtures.duthost_utils import convert_and_restore_config_db_to_ipv6_only  # noqa F401
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
+]
+
+
+def test_bgp_facts_ipv6_only(duthosts, enum_frontend_dut_hostname, enum_asic_index,
+                             convert_and_restore_config_db_to_ipv6_only): # noqa F811
+    """compare the bgp facts between observed states and target state"""
+
+    duthost = duthosts[enum_frontend_dut_hostname]
+
+    bgp_facts = duthost.bgp_facts(instance_id=enum_asic_index)['ansible_facts']
+    namespace = duthost.get_namespace_from_asic_id(enum_asic_index)
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running", namespace=namespace)['ansible_facts']
+    sonic_db_cmd = "sonic-db-cli {}".format("-n " + namespace if namespace else "")
+    for k, v in list(bgp_facts['bgp_neighbors'].items()):
+        # Verify bgp sessions are established
+        assert v['state'] == 'established'
+        # Verify local ASNs in bgp sessions
+        assert v['local AS'] == int(config_facts['DEVICE_METADATA']['localhost']['bgp_asn'].encode().decode("utf-8"))
+        # Check bgpmon functionality by validate STATE DB contains this neighbor as well
+        state_fact = duthost.shell('{} STATE_DB HGET "NEIGH_STATE_TABLE|{}" "state"'
+                                   .format(sonic_db_cmd, k), module_ignore_errors=False)['stdout_lines']
+        peer_type = duthost.shell('{} STATE_DB HGET "NEIGH_STATE_TABLE|{}" "peerType"'
+                                  .format(sonic_db_cmd, k),
+                                  module_ignore_errors=False)['stdout_lines']
+        assert state_fact[0] == "Established"
+        assert peer_type[0] == "i-BGP" if v['remote AS'] == v['local AS'] else "e-BGP"
+
+    # In multi-asic, would have 'BGP_INTERNAL_NEIGHBORS' and possibly no 'BGP_NEIGHBOR' (ebgp) neighbors.
+    nbrs_in_cfg_facts = {}
+    nbrs_in_cfg_facts.update(config_facts.get('BGP_NEIGHBOR', {}))
+    nbrs_in_cfg_facts.update(config_facts.get('BGP_INTERNAL_NEIGHBOR', {}))
+    # In VoQ Chassis, we would have BGP_VOQ_CHASSIS_NEIGHBOR as well.
+    nbrs_in_cfg_facts.update(config_facts.get('BGP_VOQ_CHASSIS_NEIGHBOR', {}))
+    for k, v in list(nbrs_in_cfg_facts.items()):
+        # Compare the bgp neighbors name with config db bgp neighbors name
+        assert v['name'] == bgp_facts['bgp_neighbors'][k]['description']
+        # Compare the bgp neighbors ASN with config db
+        assert int(v['asn'].encode().decode("utf-8")) == bgp_facts['bgp_neighbors'][k]['remote AS']
+
+
+def test_show_features_ipv6_only(duthosts, enum_dut_hostname, convert_and_restore_config_db_to_ipv6_only): # noqa F811
+    """Verify show features command output against CONFIG_DB
+    """
+
+    duthost = duthosts[enum_dut_hostname]
+    features_dict, succeeded = duthost.get_feature_status()
+    pytest_assert(succeeded, "failed to obtain feature status")
+    for cmd_key, cmd_value in list(features_dict.items()):
+        redis_value = duthost.shell('/usr/bin/redis-cli -n 4 --raw hget "FEATURE|{}" "state"'
+                                    .format(cmd_key), module_ignore_errors=False)['stdout']
+        pytest_assert(redis_value.lower() == cmd_value.lower(),
+                      "'{}' is '{}' which does not match with config_db".format(cmd_key, cmd_value))
+
+
+def test_image_download_ipv6_only(creds, duthosts, enum_dut_hostname,
+                                  convert_and_restore_config_db_to_ipv6_only): # noqa F811
+    """
+    Test image download in mgmt ipv6 only scenario
+    """
+    duthost = duthosts[enum_dut_hostname]
+    image_url = creds.get("test_image_url", {}).get("ipv6", "")
+    pytest_require(len(image_url) != 0, "Cannot get image url")
+    cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    mgmt_interfaces = cfg_facts.get("MGMT_INTERFACE", {}).keys()
+    for mgmt_interface in mgmt_interfaces:
+        output = duthost.shell("curl --fail --interface {} {}".format(mgmt_interface, image_url),
+                               module_ignore_errors=True)
+        if output["rc"] == 0:
+            break
+    else:
+        pytest.fail("Failed to download image from image_url {} via any of {}"
+                    .format(image_url, list(mgmt_interfaces)))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

1. Add a fixture to convert the DUT to IPv6 only(only mgmt-ip)
2. Enhance the connection plugin to re-connect with the IPv6 address if the IPv4 address is unavailable
3. Add a new test module with examples to test the IPv6-only scenario.
4. Fix the performance issue introduced by IPv6 detecting.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Support test mgmt-ip IPv6 only scenario.

#### How did you do it?
Remove the IPv4 mgmt address before the test module starts, and restore after the test module is finished.
Enhance the connection plugging to first connect with the IPv4 address, and retry with the IPv6 address if IPv4 is unavailable.
Add a new test module with examples to test the IPv6-only scenario.
Try with IPv4 first, only when IPv4 fails with unavailable, try IPv6 addr

#### How did you verify/test it?

Run on physical testbeds, with dual-stack mgmt-ip addresses testbed and only with IPv6/IPv4 mgmt-ip address testbed.

ip/test_mgmt_ipv6_only.py::test_bgp_facts_ipv6_only[-] PASSED                                                                                                                                                               [ 33%]
ip/test_mgmt_ipv6_only.py::test_show_features_ipv6_only[-] PASSED                                                                                                                                                                [ 66%]
ip/test_mgmt_ipv6_only.py::test_image_download_ipv6_only[-] SKIPPED (Cannot get image url)                                                                                                                                       [100%]
================================ short test summary info ================================================================================================================
SKIPPED [1] common/helpers/assertions.py:16: Cannot get image url
================================================================================================= 2 passed, 1 skipped, 3 warnings in 657.76s (0:10:57) ==================================================================================================
INFO:root:Can not get Allure report URL. Please check logs
jianquanye@sonic-mgmt-jianquanye:/var/src/sonic-mgmt-int/tests$ 

#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
All topologies.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
