### PR TITLE
[kdump] Fix function definition in kdump test case teardown module

### DIFF
--- a/tests/platform_tests/test_kdump.py
+++ b/tests/platform_tests/test_kdump.py
@@ -36,7 +36,7 @@ class TestKernelPanic:
 
     @pytest.fixture(autouse=True)
     def tearDown(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                 localhost, pdu_controller):
+                 localhost, pdu_controller, conn_graph_facts, xcvr_skip_list):
         yield
         # If the SSH connection is not established, or any critical process is exited,
         # try to recover the DUT by PDU reboot.
@@ -53,7 +53,7 @@ class TestKernelPanic:
                           'Recover {} by PDU reboot failed'.format(hostname))
             # Wait until all critical processes are healthy.
             wait_critical_processes(duthost)
-            self.wait_lc_healthy_if_sup(duthost, duthosts, localhost)
+            self.wait_lc_healthy_if_sup(duthost, duthosts, localhost, conn_graph_facts, xcvr_skip_list)
 
     def test_kernel_panic(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
                           conn_graph_facts, xcvr_skip_list):


### PR DESCRIPTION
### Description of PR

Fix function definition in teardown module in test_kdump.py causing below error in cases of test failure
```
failed on teardown with "TypeError: wait_lc_healthy_if_sup() missing 2 required positional arguments: 'conn_graph_facts' and 'xcvr_skip_list'"
```
Issue: https://migsonic.atlassian.net/browse/MIGSMSFT-430


#### How did you do it?
Fix the function definition to pass the required arguments

### Type of change

- [x] Bug fix

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

#### How did you verify/test it?
Run test case with the change

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

