### PR TITLE
[Baseline] Disable dpu test to support multiple databases for smartswitch

### DIFF
--- a/.azure-pipelines/baseline_test/baseline.test.template.yml
+++ b/.azure-pipelines/baseline_test/baseline.test.template.yml
@@ -115,20 +115,20 @@ jobs:
         STOP_ON_FAILURE: "False"
         TEST_PLAN_NUM: $(BASELINE_MGMT_PUBLIC_MASTER_TEST_NUM)
 
-- job: dpu_elastictest
-  displayName: "kvmtest-dpu by Elastictest"
-  timeoutInMinutes: 240
-  continueOnError: false
-  pool: ubuntu-20.04
-  steps:
-    - template: ../run-test-elastictest-template.yml
-      parameters:
-        TOPOLOGY: dpu
-        MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
-        MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
-        KVM_IMAGE_BRANCH: "master"
-        MGMT_BRANCH: "master"
-        BUILD_REASON: "BaselineTest"
-        RETRY_TIMES: "0"
-        STOP_ON_FAILURE: "False"
-        TEST_PLAN_NUM: $(BASELINE_MGMT_PUBLIC_MASTER_TEST_NUM)
+# - job: dpu_elastictest
+#   displayName: "kvmtest-dpu by Elastictest"
+#   timeoutInMinutes: 240
+#   continueOnError: false
+#   pool: ubuntu-20.04
+#   steps:
+#     - template: ../run-test-elastictest-template.yml
+#       parameters:
+#         TOPOLOGY: dpu
+#         MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
+#         MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
+#         KVM_IMAGE_BRANCH: "master"
+#         MGMT_BRANCH: "master"
+#         BUILD_REASON: "BaselineTest"
+#         RETRY_TIMES: "0"
+#         STOP_ON_FAILURE: "False"
+#         TEST_PLAN_NUM: $(BASELINE_MGMT_PUBLIC_MASTER_TEST_NUM)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
According to https://github.com/sonic-net/sonic-mgmt/pull/11780, need to disable dpu kvm test to support multiple databases for smartswitch
#### How did you do it?
Disable dpu for now
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
