### PR TITLE
[platform_tests] add wait time for e1031 devices

### DIFF
--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -129,7 +129,11 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list,
                 dut, asic_index, interfaces_per_asic, xcvr_skip_list)
 
         logging.info("Check pmon daemon status")
-        assert check_pmon_daemon_status(dut), "Not all pmon daemons running."
+        if dut.facts["platform"] == "x86_64-cel_e1031-r0":
+            result = wait_until(300, 20, 0, check_pmon_daemon_status, dut)
+        else:
+            result = check_pmon_daemon_status(dut)
+        assert result, "Not all pmon daemons running."
 
     if dut.facts["asic_type"] in ["mellanox"]:
 

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -71,7 +71,7 @@ def test_reload_configuration(duthosts, enum_rand_one_per_hwsku_hostname,
     logging.info("Wait some time for all the transceivers to be detected")
     max_wait_time_for_transceivers = 300
     if duthost.facts["platform"] == "x86_64-cel_e1031-r0":
-        max_wait_time_for_transceivers = 600
+        max_wait_time_for_transceivers = 900
     assert wait_until(max_wait_time_for_transceivers, 20, 0, check_all_interface_information,
                       duthost, interfaces, xcvr_skip_list), "Not all transceivers are detected \
     in {} seconds".format(max_wait_time_for_transceivers)

--- a/tests/platform_tests/test_sequential_restart.py
+++ b/tests/platform_tests/test_sequential_restart.py
@@ -70,9 +70,12 @@ def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service,
     wait_critical_processes(dut)
 
     logging.info("Wait some time for all the transceivers to be detected")
-    pytest_assert(wait_until(300, 20, 0, check_interface_information, dut,
+    interface_wait_time = 300
+    if dut.facts["platform"] == "x86_64-cel_e1031-r0":
+        interface_wait_time = 900
+    pytest_assert(wait_until(interface_wait_time, 20, 0, check_interface_information, dut,
                   enum_frontend_asic_index, interfaces, xcvr_skip_list),
-                  "Not all interface information are detected within 300 seconds")
+                  "Not all interface information are detected within {} seconds".format(interface_wait_time))
 
     logging.info("Check transceiver status on asic %s" % enum_frontend_asic_index)
     check_transceiver_basic(dut, enum_frontend_asic_index, interfaces, xcvr_skip_list)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
E1031 is weak and requires more wait time in many tests

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Many tests cannot pass because wait time is not enough

#### How did you do it?
Add wait time

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
