### PR TITLE
Kill process causing CPU spike

### DIFF
--- a/tests/snmp/test_snmp_cpu.py
+++ b/tests/snmp/test_snmp_cpu.py
@@ -75,7 +75,7 @@ def test_snmp_cpu(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_a
             pytest.fail("cpu diff large than 5%%, %d, %d" % (
                 int(snmp_facts['ansible_ChStackUnitCpuUtil5sec']), int(output['stdout'])))
 
-        duthost.shell("killall yes")
     except Exception:
-        duthost.shell("killall yes")
         raise
+    finally:
+        duthost.shell("killall yes")


### PR DESCRIPTION
### Description of PR
Moved the killall yes process to finally section so that the process will always get killed at the end of the testcase. We were seeing cases wherein they were left behind.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
In some cases we were seeing the yes process being left behind causing other testcases to fail due to high CPU. 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
