### PR TITLE
advanced-reboot: Fix Popen.args not being present in Python 2

### DIFF
--- a/ansible/roles/test/files/ptftests/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/advanced-reboot.py
@@ -1767,7 +1767,9 @@ class ReloadTest(BaseTest):
         processes_list = []
         for iface in self.tcpdump_data_ifaces:
             iface_pcap_path = '{}_{}'.format(pcap_path, iface)
-            process = subprocess.Popen(['tcpdump', '-i', iface, tcpdump_filter, '-w', iface_pcap_path])
+            command = ['tcpdump', '-i', iface, tcpdump_filter, '-w', iface_pcap_path]
+            process = subprocess.Popen(command)
+            process.command = command
             self.log('Tcpdump sniffer starting on iface: {}'.format(iface))
             processes_list.append(process)
 
@@ -1792,7 +1794,7 @@ class ReloadTest(BaseTest):
                 wait_timer.cancel()
             # Return code here could be 0, so we need to explicitly check for None
             if process.returncode is not None:
-                self.log("Tcpdump process {} terminated".format(process.args))
+                self.log("Tcpdump process {} terminated".format(' '.join(process.command)))
 
         self.log("Killed all tcpdump processes")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix advanced-reboot ptf py2 incompatibility - Popen.args
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Popen.args is not compatible with py2, where we run testing under py2 ptf container
  File "ptftests/advanced-reboot.py", line 1753, in tcpdump_sniff
    self.start_sniffer(capture_pcap, sniff_filter, wait)
  File "ptftests/advanced-reboot.py", line 1795, in start_sniffer
    self.log("Tcpdump process {} terminated".format(process.args))
AttributeError: 'Popen' object has no attribute 'args'

#### How did you do it?
Replace process.args with process.command

#### How did you verify/test it?
Ran related lines of code in py2 environment and no exception was thrown
```
kellyyeh@kellyyeh:/var/src/sonic-mgmt-int/tests$ python2
Python 2.7.18 (default, Jul  1 2022, 12:27:04) 
[GCC 9.4.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> pcap_path = "pcap_path"
>>> iface = "Vlan1000"
>>> iface_pcap_path = '{}_{}'.format(pcap_path, iface)
>>> import subprocess
>>> tcpdump_filter = ""
>>> command = ['tcpdump', '-i', iface, tcpdump_filter, '-w', iface_pcap_path]
>>> process = subprocess.Popen(command)
>>> tcpdump: Vlan1000: You don't have permission to capture on that device
(socket: Operation not permitted)
>>> process.command = command
>>> print("Tcpdump process {} terminated".format(' '.join(process.command)) )
Tcpdump process tcpdump -i Vlan1000  -w pcap_path_Vlan1000 terminated
```

Ran full advanced-reboot test on lab device and passed
```
2024-03-18 20:21:29 : Tcpdump process tcpdump -i eth0 tcp and tcp dst port 5000 and tcp src port 1234 and not icmp -w /tmp/capture.pcap_eth0 terminated
2024-03-18 20:21:29 : Tcpdump process tcpdump -i eth45 tcp and tcp dst port 5000 and tcp src port 1234 and not icmp -w /tmp/capture.pcap_eth45 terminated
2024-03-18 20:21:29 : Tcpdump process tcpdump -i eth44 tcp and tcp dst port 5000 and tcp src port 1234 and not icmp -w /tmp/capture.pcap_eth44 terminated
2024-03-18 20:21:29 : Tcpdump process tcpdump -i eth22 tcp and tcp dst port 5000 and tcp src port 1234 and not icmp -w /tmp/capture.pcap_eth22 terminated
2024-03-18 20:21:29 : Tcpdump process tcpdump -i eth36 tcp and tcp dst port 5000 and tcp src port 1234 and not icmp -w /tmp/capture.pcap_eth36 terminated
2024-03-18 20:21:29 : Tcpdump process tcpdump -i eth33 tcp and tcp dst port 5000 and tcp src port 1234 and not icmp -w /tmp/capture.pcap_eth33 terminated
2024-03-18 20:21:29 : Tcpdump process tcpdump -i eth55 tcp and tcp dst port 5000 and tcp src port 1234 and not icmp -w /tmp/capture.pcap_eth55 terminated
2024-03-18 20:21:29 : Tcpdump process tcpdump -i eth11 tcp and tcp dst port 5000 and tcp src port 1234 and not icmp -w /tmp/capture.pcap_eth11 terminated
2024-03-18 20:21:29 : Tcpdump process tcpdump -i eth54 tcp and tcp dst port 5000 and tcp src port 1234 and not icmp -w /tmp/capture.pcap_eth54 terminated
2024-03-18 20:21:29 : Tcpdump process tcpdump -i eth5 tcp and tcp dst port 5000 and tcp src port 1234 and not icmp -w /tmp/capture.pcap_eth5 terminated
2024-03-18 20:21:29 : Killed all tcpdump processes
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
