### PR TITLE
[dhcp_relay] Update dhcpv6_relay_test for dualtor

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
@@ -298,8 +298,9 @@ class DHCPTest(DataplaneBaseTest):
 
     def create_dhcp_relay_relay_reply_packet(self):
         relay_relay_reply_packet = packet.Ether(dst=self.uplink_mac)
+        dst_ip = self.loopback_ipv6 if self.is_dualtor else self.relay_iface_ip
         relay_relay_reply_packet /= IPv6(src=self.server_ip,
-                                         dst=self.relay_iface_ip)
+                                         dst=dst_ip)
         relay_relay_reply_packet /= packet.UDP(
             sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
         relay_relay_reply_packet /= DHCP6_RelayReply(msgtype=13, hopcount=1, linkaddr=self.vlan_ip,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
The dst ip address of packets come from upstream in dualtor should be loopback ip rather than vlan ip.

#### How did you do it?
Use loopback ip as dst ip in dualtor

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
