### PR TITLE
[dhcp_relay] Skip test_dhcpv6_relay ffor dualtor-aa

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -312,6 +312,20 @@ dhcp_relay/test_dhcpv6_relay.py:
     conditions:
       - "platform in ['x86_64-8111_32eh_o-r0']"
 
+dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default:
+  skip:
+    reason: "Test is not supported in dualtor-aa"
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/12045
+      - "'dualtor-aa' in topo_name"
+
+dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter:
+  skip:
+    reason: "Test is not supported in dualtor-aa"
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/12045
+      - "'dualtor-aa' in topo_name"
+
 #######################################
 #####         drop_packets        #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
dhcpv6 relay packets verify test cases are not supported in dualtor-aa currently.

#### How did you do it?
Skip test.

#### How did you verify/test it?
Run tests.
```
collected 5 items                                                                                                                                                                                                                                          

dhcp_relay/test_dhcpv6_relay.py::test_interface_binding PASSED                                                                                                                                                                                       [ 20%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter SKIPPED (Test is not supported in dualtor-aa)                                                                                                                                             [ 40%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default SKIPPED (Test is not supported in dualtor-aa)                                                                                                                                               [ 60%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap SKIPPED (skip the link flap testcase on dual tor testbeds)                                                                                                                          [ 80%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_start_with_uplinks_down SKIPPED (skip the uplinks down testcase on dual tor testbeds)                                                                                                               [100%]

===================================================================================================================== warnings summary =====================================================================================================================
../../../usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:471
  /usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:471: CryptographyDeprecationWarning: Blowfish has been deprecated
    cipher=algorithms.Blowfish,

../../../usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:485
  /usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:485: CryptographyDeprecationWarning: CAST5 has been deprecated
    cipher=algorithms.CAST5,

../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:219
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:219: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
----------------------------------------------------------------------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/dhcp_relay/test_dhcpv6_relay.xml -----------------------------------------------------------------------------------
================================================================================================================= short test summary info ==================================================================================================================
SKIPPED [2] dhcp_relay/test_dhcpv6_relay.py: Test is not supported in dualtor-aa
SKIPPED [1] dhcp_relay/test_dhcpv6_relay.py:347: skip the link flap testcase on dual tor testbeds
SKIPPED [1] dhcp_relay/test_dhcpv6_relay.py:394: skip the uplinks down testcase on dual tor testbeds
=================================================================================================== 1 passed, 4 skipped, 3 warnings in 246.82s (0:04:06) ==================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
