### PR TITLE
[platform][cli] PSU Status Tests: Permit Daemons Some Time to enter RUNNING State

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -231,7 +231,7 @@ def test_show_platform_psustatus(duthosts, enum_supervisor_dut_hostname):
     duthost = duthosts[enum_supervisor_dut_hostname]
     logging.info("Check pmon daemon status on dut '{}'".format(duthost.hostname))
     pytest_assert(
-        check_pmon_daemon_status(duthost),
+        wait_until(60, 5, 0, check_pmon_daemon_status, duthost),
         "Not all pmon daemons running on '{}'".format(duthost.hostname)
     )
     cmd = " ".join([CMD_SHOW_PLATFORM, "psustatus"])
@@ -264,7 +264,9 @@ def test_show_platform_psustatus_json(duthosts, enum_supervisor_dut_hostname):
         pytest.skip("JSON output not available in this version")
 
     logging.info("Check pmon daemon status")
-    pytest_assert(check_pmon_daemon_status(duthost), "Not all pmon daemons running.")
+    pytest_assert(
+        wait_until(60, 5, 0, check_pmon_daemon_status, duthost),
+        "Not all pmon daemons running.")
 
     cmd = " ".join([CMD_SHOW_PLATFORM, "psustatus", "--json"])
 


### PR DESCRIPTION
### Description of PR
This patch adds a 60-second window to the psustatus tests to allow time for the relevant daemons to reach the RUNNING state, should they be found in the STARTING state when the daemon status check occurs.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

Encountered an instance where the psustatus tests failed because the pmon daemon status check caught the applicable daemons in the STARTING state as opposed to the RUNNING state. This was seen one time; despite a few dozen attempts, have not been able to recreate the issue. This change will help guard against such potential race conditions.

#### How did you do it?

Added a 60 second wait (5 second interval, 0 delay) on `check_pmon_daemon_status` in each of the psustatus tests.

#### How did you verify/test it?

Ran the tests with the fixes applied and they passed.