### PR TITLE
Update gnmi test to support DUT which all interfaces are routed

### DIFF
--- a/tests/gnmi/test_gnmi_configdb.py
+++ b/tests/gnmi/test_gnmi_configdb.py
@@ -23,14 +23,19 @@ def get_first_interface(duthost):
     status_data = output["stdout_lines"]
     if 'Admin' not in status_data[0]:
         return None
+    if 'Lanes' not in status_data[0]:
+        return None
     admin_index = status_data[0].split().index('Admin')
+    lanes_index = status_data[0].split().index('Lanes')
     for line in status_data:
-        if "routed" not in line:
-            interface_status = line.strip()
-            assert len(interface_status) > 0, "Failed to read interface properties"
-            sl = interface_status.split()
-            if sl[admin_index] == 'up':
-                return sl[0]
+        interface_status = line.strip()
+        assert len(interface_status) > 0, "Failed to read interface properties"
+        sl = interface_status.split()
+        # Skip portchannel
+        if sl[lanes_index] == 'N/A':
+            continue
+        if sl[admin_index] == 'up':
+            return sl[0]
     return None
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix gnmi test for DUT which all interfaces are routed.
Fixes # (issue)
Microsoft ADO: 27150366

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
GNMI test failed on DUT which all interfaces are routed.
Some DUT do not have portchannel and all the interface type are "routed".
I was using "routed" as key to detect portchannel, but this logic does not work for t1 backend topology.


#### How did you do it?
I use lanes to detect portchannel, if lanes is "N/A", this is portchannel or other unwanted port.

#### How did you verify/test it?
Run gnmi end to end test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
