### PR TITLE
[Recover via console] Raise exception when something error happened during recovering. 

### DIFF
--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -51,13 +51,12 @@ def recover_via_console(sonichost, conn_graph_facts, localhost, mgmt_ip, image_u
         elif device_type in ["nokia"]:
             posix_shell_onie(dut_console, mgmt_ip, image_url, is_nokia=True)
         else:
-            return
+            raise Exception("We don't support this type of testbed.")
 
         dut_lose_management_ip(sonichost, conn_graph_facts, localhost, mgmt_ip)
     except Exception as e:
-        logger.info(e)
         traceback.print_exc()
-        return
+        raise Exception(e)
 
 
 def recover_testbed(sonichosts, conn_graph_facts, localhost, image_url, hwsku):
@@ -111,8 +110,7 @@ def recover_testbed(sonichosts, conn_graph_facts, localhost, image_url, hwsku):
                 # Do power cycle
                 need_to_recover = True
             else:
-                logger.info("Authentication failed. Passwords are incorrect.")
-                return
+                raise Exception("Authentication failed. Passwords are incorrect.")
 
             if need_to_recover:
                 recover_via_console(sonichost, conn_graph_facts, localhost, mgmt_ip, image_url, hwsku)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When an error occurs during recovery, the previous script would simply log the error and return, which Elastictest interprets as a successful operation. However, in this PR, we have implemented a change where if the script encounters a failure, it will now raise an Exception instead.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
When an error occurs during recovery, the previous script would simply log the error and return, which Elastictest interprets as a successful operation. However, in this PR, we have implemented a change where if the script encounters a failure, it will now raise an Exception instead.

#### How did you do it?
Raise an exception instead of simply log the error 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
