### PR TITLE
Revert PR#11967 - Fix 9332 fanout TX_DROP

### DIFF
--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202012.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202012.yml
@@ -50,8 +50,3 @@
       shell: "bcmcmd 'fp detach' && bcmcmd 'fp init'"
       become: yes
   when: "'broadcom' in fanout_sonic_version.asic_type"
-
-- name: Run config qos reload command to load qos settings in order to fix 9332 Wdrr testcase failure
-  shell: config qos reload
-  become: yes
-  when: "'DellEMC-Z9332f-O32' in device_info[inventory_hostname]['HwSku']"


### PR DESCRIPTION
This reverts commit 234a7ecd24946186505886e75f60f7945653e91e.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Original PR#11967 will cause DUT portchannel down. No workaround is found currently. No RCA.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
