### PR TITLE
assign correct test ports for th platflorm's t1-64-lag topology

### DIFF
--- a/tests/qos/files/qos_params.th.yaml
+++ b/tests/qos/files/qos_params.th.yaml
@@ -1,5 +1,260 @@
 qos_params:
     th:
+        topo-t1-64-lag:
+            src_port_ids: [20,50]
+            dst_port_ids: [52,53,54]
+            40000_300m:
+                pkts_num_leak_out: 19
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7063
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7063
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [25, 26, 27, 40, 41]
+                    dst_port_id: 24
+                    pgs_num: 10
+                    pkts_num_trig_pfc: 1194
+                    pkts_num_hdrm_full: 520
+                    pkts_num_hdrm_partial: 361
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7063
+                    cell_size: 208
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 8
+                    pkts_num_trig_ingr_drp: 7063
+                    cell_size: 208
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 6
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7063
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 208
+            50000_300m:
+                pkts_num_leak_out: 23
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7225
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7225
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [1, 2, 3, 4]
+                    dst_port_id: 5
+                    pgs_num: 8
+                    pkts_num_trig_pfc: 1458
+                    pkts_num_hdrm_full: 682
+                    pkts_num_hdrm_partial: 267
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7225
+                    cell_size: 208
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 8
+                    pkts_num_trig_ingr_drp: 7225
+                    cell_size: 208
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 6
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7225
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 208
+            100000_300m:
+                pkts_num_leak_out: 36
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7835
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7835
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [17, 18]
+                    dst_port_id: 16
+                    pgs_num: 4
+                    pkts_num_trig_pfc: 2620
+                    pkts_num_hdrm_full: 1292
+                    pkts_num_hdrm_partial: 1165
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 6
+                    pkts_num_trig_pfc: 6542
+                    cell_size: 208
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7835
+                    cell_size: 208
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 8
+                    pkts_num_trig_ingr_drp: 7835
+                    cell_size: 208
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 6
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7835
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 208
+            xon_1:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 6542
+                pkts_num_dismiss_pfc: 12
+            xon_2:
+                dscp: 4
+                ecn: 1
+                pg: 4
+                pkts_num_trig_pfc: 6542
+                pkts_num_dismiss_pfc: 12
+            ecn_1:
+                dscp: 8
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 208
+            ecn_2:
+                dscp: 8
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 208
+            ecn_3:
+                dscp: 0
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 208
+            ecn_4:
+                dscp: 0
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 208
+            lossy_queue_1:
+                dscp: 8
+                ecn: 1
+                pg: 0
+                pkts_num_trig_egr_drp: 9887
+            wrr:
+                ecn: 1
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                limit: 80
+            wrr_chg:
+                ecn: 1
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                limit: 80
+                lossy_weight: 8
+                lossless_weight: 30
+            wm_pg_shared_lossless:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_fill_min: 6
+                pkts_num_trig_pfc: 6542
+                packet_size: 64
+                cell_size: 208
+            wm_pg_shared_lossy:
+                dscp: 8
+                ecn: 1
+                pg: 0
+                pkts_num_fill_min: 0
+                pkts_num_trig_egr_drp: 9887
+                packet_size: 64
+                cell_size: 208
+            wm_q_shared_lossy:
+                dscp: 8
+                ecn: 1
+                queue: 0
+                pkts_num_fill_min: 8
+                pkts_num_trig_egr_drp: 9887
+                cell_size: 208
+            wm_buf_pool_lossy:
+                dscp: 8
+                ecn: 1
+                pg: 0
+                queue: 0
+                pkts_num_fill_ingr_min: 0
+                pkts_num_trig_egr_drp: 9887
+                pkts_num_fill_egr_min: 8
+                cell_size: 208
+            hdrm_pool_wm_multiplier: 4
+            cell_size: 208
         topo-any:
             40000_300m:
                 pkts_num_leak_out: 19


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

testQosSaiPfcXonLimit case fail on "th" platform for t1-64-lag topology

Failed test log indicate cannot find out the actual dst port in phase of running get_rx_port(). as below,  flush on many port:
![image](https://github.com/sonic-net/sonic-mgmt/assets/112069142/a86979d5-5519-4211-9d82-70c8e86bfdb3)


and the incorrect test ports are:
```
dst_port_2_id=16;
dst_port_3_id=20;
dst_port_id=0;
src_port_id=4;
```

compare with other working platform using same topology t1-64-lag:
the correct test ports are:
```
dst_port_2_id=53;
dst_port_3_id=54;
dst_port_id=52;
src_port_id=20;

```

#### How did you do it?

assign correct test ports in "tests/qos/files/qos_params.th.yaml::qos_params::th::topo-t1-64-lag"

```
index da942b387..b4444527d 100644
--- a/tests/qos/files/qos_params.th.yaml
+++ b/tests/qos/files/qos_params.th.yaml
@@ -1,5 +1,260 @@
 qos_params:
     th:
+        topo-t1-64-lag:
+            src_port_ids: [20,50]
+            dst_port_ids: [52,53,54]
```

notice: in above changes,  value of "src_port_ids" and "dst_port_ids" is important, it force test code select test port from these two list,
and other qos parameter is only template, and copy from "th" platform's "topo-any" section. Reviewer don't need to check if those value is correct. Eventually, test code will dynamically caculate and update those parameter in template.




#### How did you verify/test it?

manually run qos sai test, xon and lossyQueue passed, as below:
```
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_asic] PASSED [ 18%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1] PASSED [  7%]                                              
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2] PASSED [  8%]     
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
