### PR TITLE
platform: daemon: chassisd: Sort keys in data_dict

### DIFF
--- a/tests/platform_tests/daemon/test_chassisd.py
+++ b/tests/platform_tests/daemon/test_chassisd.py
@@ -85,7 +85,7 @@ def collect_data(duthost):
         data = duthost.shell('sonic-db-cli STATE_DB HGETALL "{}"'.format(k))['stdout']
         data = compose_dict_from_cli(data)
         dev_data[k] = data
-    data_dict = {'keys': keys, 'data': dev_data}
+    data_dict = {'keys': sorted(keys), 'data': dev_data}
     return OrderedDict(sorted(data_dict.items()))
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Sort keys in data_dict in test_chassisd.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

The list of keys is taken unsorted from redis and is thus subject to potential re-ordering based on how the keys are inserted during chassisd startup. Ultimately it should not matter what order the keys are in as long as all are present, so sort the list so that we can compare them correctly.

#### How did you do it?

I sorted the list of keys in data_dict that `collect_data` returns.

#### How did you verify/test it?

The sonic-mgmt suite was run multiple times with this patch applied and the test failure was not observed.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A