### PR TITLE
Fix dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default for dualtor.

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -16,6 +16,7 @@ from tests.common.utilities import skip_release
 from tests.common import config_reload
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
+from tests.common.dualtor.dual_tor_common import active_active_ports   # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0'),
@@ -306,6 +307,7 @@ def start_dhcp_monitor_debug_counter(duthost):
 
 
 def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
+                            active_active_ports,                                                         # noqa F811
                             rand_unselected_dut, toggle_all_simulator_ports_to_rand_selected_tor_m):     # noqa F811
     """Test DHCP relay functionality on T0 topology.
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
@@ -325,11 +327,17 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                 if testing_mode == DUAL_TOR_MODE:
                     standby_duthost = rand_unselected_dut
                     start_dhcp_monitor_debug_counter(standby_duthost)
+                    client_iface = str(dhcp_relay['client_iface']['name'])
+                    # In case of active-standby ports northbound  trafic is duplicated
+                    # to both ToRs by the y-cable whereas is case of active-active
+                    # ports the traffic is ECMPd, therefore only one ToR receives
+                    # northbound packets
+                    discReqCount = 0 if client_iface in active_active_ports else 1
                     expected_standby_agg_counter_message = (
                         r".*dhcp_relay#dhcpmon\[[0-9]+\]: "
                         r"\[\s*Agg-%s\s*-[\sA-Za-z0-9]+\s*rx/tx\] "
-                        r"Discover: +1/ +0, Offer: +0/ +0, Request: +1/ +0, ACK: +0/ +0+"
-                    ) % (dhcp_relay['downlink_vlan_iface']['name'])
+                        r"Discover: +%d/ +0, Offer: +0/ +0, Request: +%d/ +0, ACK: +0/ +0+"
+                    ) % (dhcp_relay['downlink_vlan_iface']['name'], discReqCount, discReqCount)
                     loganalyzer_standby = LogAnalyzer(ansible_host=standby_duthost, marker_prefix="dhcpmon counter")
                     marker_standby = loganalyzer_standby.init()
                     loganalyzer_standby.expect_regex = [expected_standby_agg_counter_message]

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -328,7 +328,7 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                     expected_standby_agg_counter_message = (
                         r".*dhcp_relay#dhcpmon\[[0-9]+\]: "
                         r"\[\s*Agg-%s\s*-[\sA-Za-z0-9]+\s*rx/tx\] "
-                        r"Discover: +0/ +0, Offer: +0/ +0, Request: +0/ +0, ACK: +0/ +0+"
+                        r"Discover: +1/ +0, Offer: +0/ +0, Request: +1/ +0, ACK: +0/ +0+"
                     ) % (dhcp_relay['downlink_vlan_iface']['name'])
                     loganalyzer_standby = LogAnalyzer(ansible_host=standby_duthost, marker_prefix="dhcpmon counter")
                     marker_standby = loganalyzer_standby.init()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default for dualtor.
Fixes # (issue): https://github.com/aristanetworks/sonic-qual.msft/issues/64

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default  fails on dualtor/dualtor-aa

```
Expected Messages that are missing:
.dhcp_relay#dhcpmon[[0-9]+]: [\sAgg-Vlan1000\s*-[\sA-Za-z0-9]+\s*rx/tx] Discover: +0/ +0, Offer: +0/ +0, Request: +0/ +0, ACK: +0/ +0+
```
First issue is that packets go to unselected ToR in case of dualtor-aa which is being addressed by #11921.
Second issue is related to dualtor which is addressed in this pull request and is as follows -

The y-cable duplicates all the northbound traffic to both ToRs. The data plane traffic is dropped by the standby ToR through MUX-ACL, but the control plane traffic still ends up in the CPU and therefore in this case discover/request RX counters account for these packets on the standby Tor. The standby ToR however does not relay these packets further to the DHCP server(s) and neither offer nor ack go through the standby ToR. However the test is expecting the RX count of discover and request as 0.

#### How did you do it?
The proposed solution is to modify the regex and expect RX count of `Discover` and `Request` as 1 on standby ToR while other counters should be 0 in case of active-standby port. For active-active ports the regex remains the same as only one ToR receives northbound traffic in that case.

#### How did you verify/test it?
Verified on Arista 7050 platform with dualtor topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
