### PR TITLE
Fix test_nbr_health.py

### DIFF
--- a/ansible/library/snmp_facts.py
+++ b/ansible/library/snmp_facts.py
@@ -495,6 +495,9 @@ def main():
         for oid, val in varBinds:
             current_oid = oid.prettyPrint()
             current_val = val.prettyPrint()
+            if 'No more variables left in this MIB View' in current_val:
+                continue
+
             if v.ifIndex in current_oid:
                 ifIndex = int(current_oid.rsplit('.', 1)[-1])
                 results['snmp_interfaces'][ifIndex]['ifindex'] = current_val

--- a/tests/test_nbr_health.py
+++ b/tests/test_nbr_health.py
@@ -27,7 +27,7 @@ def check_snmp(hostname, mgmt_addr, localhost, community, is_eos):
 
 def check_eos_facts(hostname, mgmt_addr, host):
     logger.info("Check neighbor {} eos facts".format(hostname))
-    res = host.eos_facts()
+    res = host.eos_facts(gather_subset=["!config"])
     logger.info("facts: {}".format(json.dumps(res, indent=4)))
     try:
         eos_facts = res['ansible_facts']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix test_nbr_health.py
Fixes https://github.com/sonic-net/sonic-mgmt/issues/7883

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
test_nbr_health.py fails as

```
No more variables left in this MIB View
```

On addressing that another error is seen due to Ansible version 

```
KeyError: 'ansible_net_interfaces'
```
#### How did you do it?
Fixed both these errors by modifying the test.

#### How did you verify/test it?
Tested on Arista 7050 platform with dualtor topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
