### PR TITLE
Optimize pfc_storm_eos and make it compatible with the latest EOS version.

### DIFF
--- a/tests/common/templates/pfc_storm_eos.j2
+++ b/tests/common/templates/pfc_storm_eos.j2
@@ -1,9 +1,9 @@
 bash
 cd /mnt/flash
 {% if (pfc_asym  is defined) and (pfc_asym == True) %}
-{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} &
+{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo chrt 98 python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} > /dev/null 2>&1 &
 {% else %}
-{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}} &
+{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo chrt 98 python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}}  > /dev/null 2>&1 &
 {% endif %}
 exit
 exit

--- a/tests/common/templates/pfc_storm_stop_eos.j2
+++ b/tests/common/templates/pfc_storm_stop_eos.j2
@@ -1,9 +1,9 @@
 bash
 cd /mnt/flash
 {% if (pfc_asym  is defined) and (pfc_asym == True) %}
-{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo pkill -f "sudo python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}}" {{'&' if pfc_storm_stop_defer_time is defined else ''}}
+{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo chrt 99 pkill -f "sudo chrt 98 python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}}" {{'&' if pfc_storm_stop_defer_time is defined else ''}}
 {% else %}
-{% if pfc_storm_stop_defer_time is defined %} sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f "sudo python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}}" {{'&' if pfc_storm_stop_defer_time is defined else ''}}
+{% if pfc_storm_stop_defer_time is defined %} sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo chrt 99 pkill -f "sudo chrt 98 python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}}" {{'&' if pfc_storm_stop_defer_time is defined else ''}}
 {% endif %}
 exit
 exit


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Optimize pfc_storm_eos and make it compatible with the latest EOS version.
Fixes https://github.com/aristanetworks/sonic-qual.msft/issues/73

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
The pfc_gen.py is a CPU traffic generator that may not reliably send minimum fps needed to fully block an egress port. 

This is causing the following tests to fail on dualtor topology :-
```
qos/test_tunnel_qos_remap.py::test_pfc_pause_extra_lossless_standby
qos/test_tunnel_qos_remap.py::test_pfc_pause_extra_lossless_active
```

with the following signature

```
The queue 2 for port Ethernet116 counter increased unexpectedly
```

#### How did you do it?
1. Modified the `pfc_storm_eos.j2` template to run `pfc_gen.py` with higher real time priority.
2. Redirection `> /dev/null 2>&1 &` is introduced to make the template compatible with the latest EOS version.

#### How did you verify/test it?
Verified on Arista 7260 platform with dualtor topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
