### PR TITLE
Add mark file for end to end test

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -49,7 +49,12 @@ def analyze_logs(analyzers, markers, node=None, results=None, fail_test=True, st
 def loganalyzer(duthosts, request):
     if request.config.getoption("--disable_loganalyzer") or "disable_loganalyzer" in request.keywords:
         logging.info("Log analyzer is disabled")
+        mark_file = "/etc/sonic/disable_loganalyzer_mark"
+        for duthost in duthosts:
+            duthost.shell("touch %s" % mark_file, module_ignore_errors=True)
         yield
+        for duthost in duthosts:
+            duthost.shell("rm -f %s" % mark_file, module_ignore_errors=True)
         return
 
     # Analyze all the duts

--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ansible.errors import AnsibleConnectionFailure
+from pytest_ansible.errors import AnsibleConnectionFailure
 from .loganalyzer import LogAnalyzer, DisableLogrotateCronContext
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
@@ -53,14 +53,14 @@ def loganalyzer(duthosts, request):
         mark_file = "/etc/sonic/disable_loganalyzer_mark"
         for duthost in duthosts:
             try:
-                duthost.shell("touch %s" % mark_file)
-            except (RunAnsibleModuleFail, AnsibleConnectionFailure) as e:
+                duthost.shell("touch %s" % mark_file, module_ignore_errors=True)
+            except AnsibleConnectionFailure as e:
                 logging.warning("command failed: {}".format(repr(e)))
         yield
         for duthost in duthosts:
             try:
-                duthost.shell("rm -f %s" % mark_file)
-            except (RunAnsibleModuleFail, AnsibleConnectionFailure) as e:
+                duthost.shell("rm -f %s" % mark_file, module_ignore_errors=True)
+            except AnsibleConnectionFailure as e:
                 logging.warning("command failed: {}".format(repr(e)))
         return
 

--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -55,13 +55,13 @@ def loganalyzer(duthosts, request):
             try:
                 duthost.shell("touch %s" % mark_file)
             except (RunAnsibleModuleFail, AnsibleConnectionFailure) as e:
-                logging.warning("command failed: \n", str(e))
+                logging.warning("command failed: {}".format(repr(e)))
         yield
         for duthost in duthosts:
             try:
                 duthost.shell("rm -f %s" % mark_file)
             except (RunAnsibleModuleFail, AnsibleConnectionFailure) as e:
-                logging.warning("command failed: \n", str(e))
+                logging.warning("command failed: {}".format(repr(e)))
         return
 
     # Analyze all the duts

--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ansible.errors import AnsibleConnectionFailure
 from .loganalyzer import LogAnalyzer, DisableLogrotateCronContext
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
@@ -52,17 +53,15 @@ def loganalyzer(duthosts, request):
         mark_file = "/etc/sonic/disable_loganalyzer_mark"
         for duthost in duthosts:
             try:
-                duthost.shell("touch %s" % mark_file, module_ignore_errors=True)
-            except RunAnsibleModuleFail:
-                # Ignore possible ansible error
-                pass
+                duthost.shell("touch %s" % mark_file)
+            except RunAnsibleModuleFail, AnsibleConnectionFailure as e:
+                logging.warning("command failed: \n", str(e))
         yield
         for duthost in duthosts:
             try:
-                duthost.shell("rm -f %s" % mark_file, module_ignore_errors=True)
-            except RunAnsibleModuleFail:
-                # Ignore possible ansible error
-                pass
+                duthost.shell("rm -f %s" % mark_file)
+            except RunAnsibleModuleFail, AnsibleConnectionFailure as e:
+                logging.warning("command failed: \n", str(e))
         return
 
     # Analyze all the duts

--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -51,10 +51,18 @@ def loganalyzer(duthosts, request):
         logging.info("Log analyzer is disabled")
         mark_file = "/etc/sonic/disable_loganalyzer_mark"
         for duthost in duthosts:
-            duthost.shell("touch %s" % mark_file, module_ignore_errors=True)
+            try:
+                duthost.shell("touch %s" % mark_file, module_ignore_errors=True)
+            except RunAnsibleModuleFail:
+                # Ignore possible ansible error
+                pass
         yield
         for duthost in duthosts:
-            duthost.shell("rm -f %s" % mark_file, module_ignore_errors=True)
+            try:
+                duthost.shell("rm -f %s" % mark_file, module_ignore_errors=True)
+            except RunAnsibleModuleFail:
+                # Ignore possible ansible error
+                pass
         return
 
     # Analyze all the duts

--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -54,13 +54,13 @@ def loganalyzer(duthosts, request):
         for duthost in duthosts:
             try:
                 duthost.shell("touch %s" % mark_file)
-            except RunAnsibleModuleFail, AnsibleConnectionFailure as e:
+            except (RunAnsibleModuleFail, AnsibleConnectionFailure) as e:
                 logging.warning("command failed: \n", str(e))
         yield
         for duthost in duthosts:
             try:
                 duthost.shell("rm -f %s" % mark_file)
-            except RunAnsibleModuleFail, AnsibleConnectionFailure as e:
+            except (RunAnsibleModuleFail, AnsibleConnectionFailure) as e:
                 logging.warning("command failed: \n", str(e))
         return
 

--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -1,7 +1,6 @@
 import logging
 import pytest
 
-from pytest_ansible.errors import AnsibleConnectionFailure
 from .loganalyzer import LogAnalyzer, DisableLogrotateCronContext
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
@@ -50,18 +49,7 @@ def analyze_logs(analyzers, markers, node=None, results=None, fail_test=True, st
 def loganalyzer(duthosts, request):
     if request.config.getoption("--disable_loganalyzer") or "disable_loganalyzer" in request.keywords:
         logging.info("Log analyzer is disabled")
-        mark_file = "/etc/sonic/disable_loganalyzer_mark"
-        for duthost in duthosts:
-            try:
-                duthost.shell("touch %s" % mark_file, module_ignore_errors=True)
-            except AnsibleConnectionFailure as e:
-                logging.warning("command failed: {}".format(repr(e)))
         yield
-        for duthost in duthosts:
-            try:
-                duthost.shell("rm -f %s" % mark_file, module_ignore_errors=True)
-            except AnsibleConnectionFailure as e:
-                logging.warning("command failed: {}".format(repr(e)))
         return
 
     # Analyze all the duts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,6 @@ from tests.platform_tests.args.cont_warm_reboot_args import add_cont_warm_reboot
 from tests.platform_tests.args.normal_reboot_args import add_normal_reboot_args
 from ptf import testutils
 from ptf.mask import Mask
-from pytest_ansible.errors import AnsibleConnectionFailure
 
 logger = logging.getLogger(__name__)
 cache = FactsCache()
@@ -2282,11 +2281,7 @@ def add_mgmt_test_mark(duthosts):
     @param duthosts: fixture to get DUT hosts
     '''
     mark_file = "/etc/sonic/mgmt_test_mark"
-    for duthost in duthosts:
-        try:
-            duthost.shell("touch %s" % mark_file, module_ignore_errors=True)
-        except AnsibleConnectionFailure as e:
-            logging.info("Failed to create mark: {}".format(repr(e)))
+    duthosts.shell("touch %s" % mark_file, module_ignore_errors=True)
 
 
 def verify_packets_any_fixed(test, pkt, ports=[], device_number=0, timeout=None):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add mark file for mgmt test.
Fixes # (issue)
Microsoft ADO: 24657445

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
We need a flag to mark that DUT is under end to end test.
https://github.com/sonic-net/sonic-utilities/pull/3102
db migrator needs to detect DUT is running in end to end test.

#### How did you do it?
Create /etc/sonic/mgmt_test_mark with fixture.

#### How did you verify/test it?
Run end to end test, and check /etc/sonic/mgmt_test_mark.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
