### PR TITLE
remove low speed port from test port list for breakout test scenario

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -138,8 +138,6 @@ class TestQosSai(QosSaiBase):
         'Arista-7050CX3-32S-D48C8'
     ]
 
-    BREAKOUT_SKUS = ['Arista-7050-QX-32S']
-
     @pytest.fixture(scope='function')
     def change_port_speed(
             self, request, ptfhost, duthosts, dutTestParams, fanouthosts, dutConfig, tbinfo,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

Regarding to 7050qx's  QoS SAI test for topo t0:

test port select result is as below:
 testPortIds={0: {0:
 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]}};

and  1,2,3 are low speed breakout port. as below:

admin@bjw-can-7050qx-3:~$ show int st                                                                
     Interface            Lanes    Speed    MTU    FEC         Alias            Vlan    Oper    Admin                                      Type    Asym PFC
--------------  ---------------  -------  -----  -----  ------------  --------------  ------  -------  ----------------------------------------  ----------
     Ethernet0                9      10G   9100    N/A     Ethernet1          routed      up     down                            SFP/SFP+/SFP28         off
     Ethernet1               10      10G   9100    N/A     Ethernet2           trunk      up       up                            SFP/SFP+/SFP28         off
     Ethernet2               11      10G   9100    N/A     Ethernet3           trunk      up       up                            SFP/SFP+/SFP28         off
     Ethernet3               12       1G   9100    N/A     Ethernet4           trunk      up       up                            SFP/SFP+/SFP28         off
     Ethernet4      13,14,15,16      40G   9100    N/A   Ethernet6/1           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off

it cause two issue:

- caused using wrong test target porfile for qos sai test. as below:


        profileName = ingressLosslessProfile["profileName"]      >>>>> [Xu]: just get profile of first test port, in this function.
        logger.info(
            "Lossless Buffer profile selected is {}".format(profileName))

        if self.isBufferInApplDb(dut_asic):
            profile_pattern = "^BUFFER_PROFILE_TABLE\\:pg_lossless_(.*)_profile$"
        else:
            profile_pattern = "^BUFFER_PROFILE\\|pg_lossless_(.*)_profile"
        m = re.search(profile_pattern, profileName)
        pytest_assert(m.group(1), "Cannot find port speed/cable length")

        # portSpeedCableLength = m.group(1)
        portSpeedCableLength = "40000_300m"     >>>> [Xu]: according to above sample result of test port selection, first port' id is 1 (it's Etherent1), the corresponding PG lossless porfile is "pg_lossless_10000_300m_profile". so we can never get expected pg_lossless_40000_300m_profile profile.



- cause qos sai test traffic go through low speed breakout port rather than high speed 40G port
and eventually, caused Xon case failure.


#### How did you do it?

remove low speed port out of test port list

#### How did you verify/test it?

pass UT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
