### PR TITLE
Fix incorrect expected OFFSET_ECMP for Arista-7050-QX-32S and add safe_reboot

### DIFF
--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -163,7 +163,7 @@ def check_ecmp_offset_value(duthost, asic_name, topo_type, hwsku):
                           Expected {}, but got {}.".format(392, offset_count))
     elif topo_type == "t1":
         offset_count = offset_list.count('0xa')
-        if hwsku in ["Arista-7060CX-32S-C32", "Arista-7050QX32S-Q32"]:
+        if hwsku in ["Arista-7060CX-32S-C32", "Arista-7050QX32S-Q32", "Arista-7050-QX-32S"]:
             pytest_assert(offset_count >= 33, "the count of 0xa OFFSET_ECMP is not correct. \
                           Expected >= 33, but got {}.".format(offset_count))
         else:

--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -211,11 +211,13 @@ def test_ecmp_hash_seed_value(localhost, duthosts, tbinfo, enum_rand_one_per_hws
         check_hash_seed_value(duthost, asic_name, topo_type)
     elif parameter == "reboot":
         logging.info("Run cold reboot on DUT")
-        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_COLD, reboot_helper=None, reboot_kwargs=None)
+        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_COLD, reboot_helper=None,
+               reboot_kwargs=None, safe_reboot=True)
         check_hash_seed_value(duthost, asic_name, topo_type)
     elif parameter == "warm-reboot" and topo_type == "t0":
         logging.info("Run warm reboot on DUT")
-        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_WARM, reboot_helper=None, reboot_kwargs=None)
+        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_WARM, reboot_helper=None,
+               reboot_kwargs=None, safe_reboot=True)
         check_hash_seed_value(duthost, asic_name, topo_type)
 
 
@@ -257,9 +259,11 @@ def test_ecmp_offset_value(localhost, duthosts, tbinfo, enum_rand_one_per_hwsku_
         check_hash_seed_value(duthost, asic_name, topo_type)
     elif parameter == "reboot":
         logging.info("Run cold reboot on DUT")
-        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_COLD, reboot_helper=None, reboot_kwargs=None)
+        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_COLD, reboot_helper=None,
+               reboot_kwargs=None, safe_reboot=True)
         check_ecmp_offset_value(duthost, asic_name, topo_type, hwsku)
     elif parameter == "warm-reboot" and topo_type == "t0":
         logging.info("Run warm reboot on DUT")
-        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_WARM, reboot_helper=None, reboot_kwargs=None)
+        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_WARM, reboot_helper=None,
+               reboot_kwargs=None, safe_reboot=True)
         check_ecmp_offset_value(duthost, asic_name, topo_type, hwsku)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix unexpected OFFSET_ECMP value for Arista-7050-QX-32S

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Fix incorrect expected OFFSET_ECMP for Arista-7050-QX-32S.
The expected 0xa OFFSET_ECMP for Arista-7050-QX-32S is 33, not 67.
Add safe check for reboot, if not all critical services are booting up, will not check OFFSET_ECMP value,
ensure the failed summary is accurate.

#### How did you do it?
Change Arista-7050-QX-32S's expected number of 0xa OFFSET_ECMP to 33.
Add safe_reboot=True for reboot

#### How did you verify/test it?
Run tests/ecmp/test_ecmp_sai_value.py on 7050qx and other testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
