### PR TITLE
Fixing snappi_api_serv_port return

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -43,7 +43,7 @@ def snappi_api_serv_port(duthosts, rand_one_dut_hostname):
     """
     duthost = duthosts[rand_one_dut_hostname]
     return (duthost.host.options['variable_manager'].
-            _hostvars[duthost.hostname]['snappi_api_server']['rest_port'])
+            _hostvars[duthost.hostname]['secret_group_vars']['snappi_api_server']['rest_port'])
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fixing snappi api server port return
Fixes # (issue)

### Type of change
The change fixes the return value of the snappi_api_serv_port value. Previously it was throwing keyerror: snappi_api_server . Currently its fixed, it takes the port number from ansible/group_vars/snappi_sonic/snappi-sonic.yml
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
To fix the snappi_api_serv_port fixture
#### How did you do it?
Previously the 'secret_group_vars' key was missing, now this has been added
#### How did you verify/test it?
This was tested on a linux api server
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
