### PR TITLE
Fix the log rotate test for issue#11179

### DIFF
--- a/tests/syslog/test_logrotate.py
+++ b/tests/syslog/test_logrotate.py
@@ -64,7 +64,7 @@ def simulate_small_var_log_partition(rand_selected_dut, localhost):
         config_reload(duthost, safe_reload=True)
 
         logger.info('Start logrotate-config service')
-        duthost.shell('sudo service logrotate-config start')
+        duthost.shell('sudo service logrotate-config restart')
 
     yield
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # ([issue](https://github.com/sonic-net/sonic-mgmt/issues/11179))
The root cause of the test failure is that there is one change adding dependency to logrotate config https://github.com/sonic-net/sonic-buildimage/pull/17312
There they have added this line RemainAfterExit=yes
With this change the command "sudo service logrotate-config start" cannot start the logrotate with new configuration. 
In any case, "restart" is the correct way to start a service to avoid such issues.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
To fix issue https://github.com/sonic-net/sonic-mgmt/issues/11179
#### How did you do it?
Chage the command "sudo service logrotate-config **start**" to "sudo service logrotate-config **restart**" 
#### How did you verify/test it?
Run the test and it passed on master image.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
