### PR TITLE
Adding background traffic for pfcwd_timer_Accuracy for cisco-8000.

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/pfcwd_background_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/pfcwd_background_traffic.py
@@ -55,7 +55,7 @@ class BG_pkt_sender(BaseTest):
                 'pktlen': 1024}
 
             pkt = simple_udp_packet(**pkt_args)
-            exp_pkt = Mask(simple_udp_packet(**pkt_args))
+            exp_pkt = Mask(pkt.copy())
             exp_pkt.exp_pkt[scapy.Ether].dst = pkt[scapy.Ether].src
             exp_pkt.exp_pkt[scapy.Ether].src = self.test_params['dest_mac']
             exp_pkt.exp_pkt[scapy.IP].ttl = pkt[scapy.IP].ttl - 1

--- a/ansible/roles/test/files/ptftests/py3/pfcwd_background_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/pfcwd_background_traffic.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+'''
+    Script to drive a continuous background traffic for pfcwd scripts.
+
+    It takes the following arguments:
+    dest_mac : The DUT Src port's mac address.
+    dst_ip_addr : The packet destination IP address.
+    ptf_src_port: The src port index in the ptf.
+    ptf_dst_port: The dst port index in the ptf.
+    pfc_queue_idx: The DSCP queue vaue to be used for packets.
+
+    The script tries out 100 UDP packets, each with different src IP address
+    and finds out one packet that goes through the given dest port. Once
+    that packet is calculated, it keeps sending that packet until it is
+    stopped by the supervisor.
+
+    CMD:
+    /root/env-python3/bin/python3 /root/env-python3/bin/ptf --test-dir \
+        /root/ptftests/py3 pfcwd_background_traffic.BG_pkt_sender \
+        --platform-dir /root/ptftests/ -t \
+        'dest_mac=u"80:27:6c:47:8c:cc";dst_ip_addr="10.0.0.5";\
+        ptf_src_port=5;ptf_dst_port=4;pfc_queue_idx=4' \
+        --relax --platform remote
+'''
 
 from ptf.testutils import test_params_get, verify_packet, simple_udp_packet
 from ptf.base_tests import BaseTest

--- a/ansible/roles/test/files/ptftests/py3/pfcwd_background_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/pfcwd_background_traffic.py
@@ -7,7 +7,7 @@
     dst_ip_addr : The packet destination IP address.
     ptf_src_port: The src port index in the ptf.
     ptf_dst_port: The dst port index in the ptf.
-    pfc_queue_idx: The DSCP queue vaue to be used for packets.
+    pfc_queue_idx: The DSCP queue value to be used for packets.
 
     The script tries out 100 UDP packets, each with different src IP address
     and finds out one packet that goes through the given dest port. Once

--- a/ansible/roles/test/files/ptftests/py3/pfcwd_background_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/pfcwd_background_traffic.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+from ptf.testutils import test_params_get, verify_packet, simple_udp_packet
+from ptf.base_tests import BaseTest
+from scapy.all import sendp
+import ptf.packet as scapy
+from ptf.mask import Mask
+import ptf
+
+
+class BG_pkt_sender(BaseTest):
+    def __init__(self):
+        BaseTest.__init__(self)
+        self.dataplane = ptf.dataplane_instance
+        self.test_params = test_params_get()
+        params = ['dest_mac', 'dst_ip_addr', 'ptf_src_port', 'ptf_dst_port', 'pfc_queue_idx']
+        for param in params:
+            if self.test_params.get(param, None) is None:
+                raise RuntimeError("Need all these args:{}".format(params))
+
+    def setUp(self):
+        self.dataplane = ptf.dataplane_instance
+
+    def runTest(self):
+        required_pkt = None
+        for ip_count in range(100):
+            pkt_args = {
+                'eth_dst': self.test_params['dest_mac'],
+                'ip_src': '100.4.{}.4'.format(ip_count),
+                'ip_dst': self.test_params['dst_ip_addr'],
+                'ip_tos': (int(self.test_params['pfc_queue_idx']) << 2) | 1,
+                'pktlen': 1024}
+
+            pkt = simple_udp_packet(**pkt_args)
+            exp_pkt = Mask(simple_udp_packet(**pkt_args))
+            exp_pkt.exp_pkt[scapy.Ether].dst = pkt[scapy.Ether].src
+            exp_pkt.exp_pkt[scapy.Ether].src = self.test_params['dest_mac']
+            exp_pkt.exp_pkt[scapy.IP].ttl = pkt[scapy.IP].ttl - 1
+            exp_pkt.set_do_not_care_scapy(scapy.Ether, 'src')
+            exp_pkt.set_do_not_care_scapy(scapy.Ether, 'dst')
+            exp_pkt.set_do_not_care_scapy(scapy.IP, 'ttl')
+            sendp(pkt, iface="eth"+str(int(self.test_params['ptf_src_port'])), count=1, verbose=False)
+            try:
+                verify_packet(self, exp_pkt, int(self.test_params['ptf_dst_port']), timeout=1)
+                required_pkt = pkt
+                break
+            except AssertionError:
+                print("Pkt didn't come back, or not received on the required dst port.")
+        if required_pkt is None:
+            raise RuntimeError("Couldn't identify the required packet, exiting.")
+        while True:
+            sendp(required_pkt, iface="eth"+str(int(self.test_params['ptf_src_port'])), count=1000000, verbose=False)

--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -1,5 +1,7 @@
 import ipaddress
 import sys
+import random
+import pytest
 
 from tests.common import constants
 
@@ -366,3 +368,109 @@ def fetch_vendor_specific_diagnosis_re(duthost):
         return ""
 
     return VENDOR_SPEC_ADDITIONAL_INFO_RE.get(duthost.facts["asic_type"], "")
+
+
+@pytest.fixture(scope='class', autouse=False)
+def start_background_traffic(
+        duthosts,
+        enum_rand_one_per_hwsku_frontend_hostname,
+        pfc_queue_idx,
+        setup_pfc_test,
+        copy_ptftests_directory,
+        ptfhost,
+        tbinfo
+        ):
+    """
+       This fixutre is to start a background traffic during
+       the test. This will start a continuous traffic flow from PTF
+       exiting the test port.
+
+       This uses a fixture pfc_queue_idx: which *must* be defined in the
+       test script before using this fixture.
+    """
+    if duthosts[enum_rand_one_per_hwsku_frontend_hostname].facts['asic_type'] != "cisco-8000":
+        yield
+        return
+
+    # This is needed only for cisco-8000
+    program_name = "pfcwd_background_traffic"
+    dut = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    dst_dut_intf = list(setup_pfc_test['test_ports'].keys())[0]
+    mg_facts = dut.get_extended_minigraph_facts(tbinfo)
+    vlan_ports = []
+    for vlan in mg_facts['minigraph_vlans'].keys():
+        vlan_ports.extend(mg_facts['minigraph_vlans'][vlan]['members'])
+    all_ip_intfs = mg_facts['minigraph_interfaces'] + mg_facts['minigraph_portchannel_interfaces']
+    non_vlan_ports = set(list(setup_pfc_test['test_ports'])) - set(vlan_ports) - set([dst_dut_intf])
+    src_dut_intf = random.choice(list(non_vlan_ports))
+    dest_mac = dut.get_dut_iface_mac(src_dut_intf)
+    # Find out if the selected port is a lag member
+    # If so, we need to use the neighbor address of the portchannel.
+    # else, we need the neighbor address of the interface itself.
+    required_intf = dst_dut_intf
+    for intf in mg_facts['minigraph_portchannels']:
+        if dst_dut_intf in mg_facts['minigraph_portchannels'][intf]['members']:
+            required_intf = intf
+            break
+    # At this point, required_intf is either a portchannel or Ethernet port.
+    # It should have a neibhor address or it is an error.
+    dst_ip_addr = None
+    for intf_obj in all_ip_intfs:
+        if intf_obj['attachto'] == required_intf:
+            dst_ip_addr = intf_obj['peer_addr']
+            break
+    if dst_ip_addr is None:
+        raise RuntimeError("Couldnot find the neighbor address for intf:{}".format(required_intf))
+    ptf_src_port = mg_facts['minigraph_ptf_indices'][src_dut_intf]
+    ptf_dst_port = mg_facts['minigraph_ptf_indices'][dst_dut_intf]
+    extra_vars = {
+        f'{program_name}_args':
+            'dest_mac=u"{}";dst_ip_addr={};ptf_src_port={};ptf_dst_port={};pfc_queue_idx={}'.format(
+                dest_mac,
+                dst_ip_addr,
+                ptf_src_port,
+                ptf_dst_port,
+                pfc_queue_idx
+                )}
+    try:
+        ptfhost.command('supervisorctl stop {}'.format(program_name))
+    except BaseException:
+        pass
+
+    ptfhost.host.options["variable_manager"].extra_vars.update(extra_vars)
+    script_args = \
+        '''dest_mac=u"{}";dst_ip_addr="{}";ptf_src_port={};ptf_dst_port={};pfc_queue_idx={}'''.format(
+                dest_mac,
+                dst_ip_addr,
+                ptf_src_port,
+                ptf_dst_port,
+                pfc_queue_idx)
+    supervisor_conf_content = ('''
+[program:{program_name}]
+command=/root/env-python3/bin/ptf --test-dir /root/ptftests/py3 {program_name}.BG_pkt_sender'''
+                               ''' --platform-dir /root/ptftests/ -t'''
+                               ''' '{script_args}' --relax  --platform remote
+process_name={program_name}
+stdout_logfile=/tmp/{program_name}.out.log
+stderr_logfile=/tmp/{program_name}.err.log
+redirect_stderr=false
+autostart=false
+autorestart=true
+startsecs=1
+numprocs=1
+'''.format(script_args=script_args, program_name=program_name))
+    ptfhost.copy(
+        content=supervisor_conf_content,
+        dest=f'/etc/supervisor/conf.d/{program_name}.conf')
+
+    ptfhost.command('supervisorctl reread')
+    ptfhost.command('supervisorctl update')
+    ptfhost.command(f'supervisorctl start {program_name}')
+
+    yield
+
+    try:
+        ptfhost.command(f'supervisorctl stop {program_name}')
+    except BaseException:
+        pass
+    ptfhost.command(f'supervisorctl remove {program_name}')

--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -381,7 +381,7 @@ def start_background_traffic(
         tbinfo
         ):
     """
-       This fixutre is to start a background traffic during
+       This fixutre starts a background traffic during
        the test. This will start a continuous traffic flow from PTF
        exiting the test port.
 
@@ -413,14 +413,14 @@ def start_background_traffic(
             required_intf = intf
             break
     # At this point, required_intf is either a portchannel or Ethernet port.
-    # It should have a neibhor address or it is an error.
+    # It should have a neighbor address or it is an error.
     dst_ip_addr = None
     for intf_obj in all_ip_intfs:
         if intf_obj['attachto'] == required_intf:
             dst_ip_addr = intf_obj['peer_addr']
             break
     if dst_ip_addr is None:
-        raise RuntimeError("Couldnot find the neighbor address for intf:{}".format(required_intf))
+        raise RuntimeError("Could not find the neighbor address for intf:{}".format(required_intf))
     ptf_src_port = mg_facts['minigraph_ptf_indices'][src_dut_intf]
     ptf_dst_port = mg_facts['minigraph_ptf_indices'][dst_dut_intf]
     extra_vars = {

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 import time
+import random
 
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts      # noqa F401
 from tests.common.helpers.assertions import pytest_assert
@@ -157,6 +158,110 @@ def set_storm_params(dut, fanout_info, fanout, peer_params):
 @pytest.mark.usefixtures('pfcwd_timer_setup_restore')
 class TestPfcwdAllTimer(object):
     """ PFCwd timer test class """
+
+    @pytest.fixture(scope='class', autouse=True)
+    def start_background_traffic(
+            self,
+            duthosts,
+            enum_rand_one_per_hwsku_frontend_hostname,
+            pfcwd_timer_setup_restore,
+            setup_pfc_test,
+            copy_ptftests_directory,
+            ptfhost,
+            tbinfo
+            ):
+        """
+           This fixutre is to start a background traffic during
+           the test. This will start a continuous traffic flow from PTF
+           exiting the test port.
+        """
+        if duthosts[enum_rand_one_per_hwsku_frontend_hostname].facts['asic_type'] != "cisco-8000":
+            yield
+            return
+
+        # This is needed only for cisco-8000
+        program_name = "pfcwd_background_traffic"
+        dut = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        dst_dut_intf = list(setup_pfc_test['test_ports'].keys())[0]
+        mg_facts = dut.get_extended_minigraph_facts(tbinfo)
+        vlan_ports = []
+        for vlan in mg_facts['minigraph_vlans'].keys():
+            vlan_ports.extend(mg_facts['minigraph_vlans'][vlan]['members'])
+        all_ip_intfs = mg_facts['minigraph_interfaces'] + mg_facts['minigraph_portchannel_interfaces']
+        non_vlan_ports = set(list(setup_pfc_test['test_ports'])) - set(vlan_ports) - set([dst_dut_intf])
+        src_dut_intf = random.choice(list(non_vlan_ports))
+        dest_mac = dut.get_dut_iface_mac(src_dut_intf)
+        # Find out if the selected port is a lag member
+        # If so, we need to use the neighbor address of the portchannel.
+        # else, we need the neighbor address of the interface itself.
+        required_intf = dst_dut_intf
+        for intf in mg_facts['minigraph_portchannels']:
+            if dst_dut_intf in mg_facts['minigraph_portchannels'][intf]['members']:
+                required_intf = intf
+                break
+        # At this point, required_intf is either a portchannel or Ethernet port.
+        # It should have a neibhor address or it is an error.
+        dst_ip_addr = None
+        for intf_obj in all_ip_intfs:
+            if intf_obj['attachto'] == required_intf:
+                dst_ip_addr = intf_obj['peer_addr']
+                break
+        if dst_ip_addr is None:
+            raise RuntimeError("Couldnot find the neighbor address for intf:{}".format(required_intf))
+        ptf_src_port = mg_facts['minigraph_ptf_indices'][src_dut_intf]
+        ptf_dst_port = mg_facts['minigraph_ptf_indices'][dst_dut_intf]
+        extra_vars = {
+            f'{program_name}_args':
+                'dest_mac=u"{}";dst_ip_addr={};ptf_src_port={};ptf_dst_port={};pfc_queue_idx={}'.format(
+                    dest_mac,
+                    dst_ip_addr,
+                    ptf_src_port,
+                    ptf_dst_port,
+                    pfcwd_timer_setup_restore['storm_handle'].pfc_queue_idx
+                    )}
+        try:
+            ptfhost.command('supervisorctl stop {}'.format(program_name))
+        except BaseException:
+            pass
+
+        ptfhost.host.options["variable_manager"].extra_vars.update(extra_vars)
+        script_args = \
+            '''dest_mac=u"{}";dst_ip_addr="{}";ptf_src_port={};ptf_dst_port={};pfc_queue_idx={}'''.format(
+                    dest_mac,
+                    dst_ip_addr,
+                    ptf_src_port,
+                    ptf_dst_port,
+                    pfcwd_timer_setup_restore['storm_handle'].pfc_queue_idx)
+        supervisor_conf_content = ('''
+[program:{program_name}]
+command=/root/env-python3/bin/ptf --test-dir /root/ptftests/py3 {program_name}.BG_pkt_sender'''
+                                   ''' --platform-dir /root/ptftests/ -t'''
+                                   ''' '{script_args}' --relax  --platform remote
+process_name={program_name}
+stdout_logfile=/tmp/{program_name}.out.log
+stderr_logfile=/tmp/{program_name}.err.log
+redirect_stderr=false
+autostart=false
+autorestart=true
+startsecs=1
+numprocs=1
+'''.format(script_args=script_args, program_name=program_name))
+        ptfhost.copy(
+            content=supervisor_conf_content,
+            dest=f'/etc/supervisor/conf.d/{program_name}.conf')
+
+        ptfhost.command('supervisorctl reread')
+        ptfhost.command('supervisorctl update')
+        ptfhost.command(f'supervisorctl start {program_name}')
+
+        yield
+
+        try:
+            ptfhost.command(f'supervisorctl stop {program_name}')
+        except BaseException:
+            pass
+        ptfhost.command(f'supervisorctl remove {program_name}')
+
     def run_test(self):
         """
         Test execution

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -1,12 +1,12 @@
 import logging
 import pytest
 import time
-import random
 
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts      # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.pfc_storm import PFCStorm
-from .files.pfcwd_helper import start_wd_on_ports
+from .files.pfcwd_helper import start_wd_on_ports, start_background_traffic     # noqa F401
+
 from tests.common.plugins.loganalyzer import DisableLogrotateCronContext
 
 
@@ -15,6 +15,13 @@ pytestmark = [
 ]
 
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="class")
+def pfc_queue_idx(pfcwd_timer_setup_restore):
+    # This is used by the common code, this needs to be defined
+    # before using start_background_traffic() fixture.
+    yield pfcwd_timer_setup_restore['storm_handle'].pfc_queue_idx
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -155,110 +162,7 @@ def set_storm_params(dut, fanout_info, fanout, peer_params):
     return storm_handle
 
 
-@pytest.fixture(scope='class', autouse=True)
-def start_background_traffic(
-        duthosts,
-        enum_rand_one_per_hwsku_frontend_hostname,
-        pfcwd_timer_setup_restore,
-        setup_pfc_test,
-        copy_ptftests_directory,
-        ptfhost,
-        tbinfo
-        ):
-    """
-       This fixutre is to start a background traffic during
-       the test. This will start a continuous traffic flow from PTF
-       exiting the test port.
-    """
-    if duthosts[enum_rand_one_per_hwsku_frontend_hostname].facts['asic_type'] != "cisco-8000":
-        yield
-        return
-
-    # This is needed only for cisco-8000
-    program_name = "pfcwd_background_traffic"
-    dut = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    dst_dut_intf = list(setup_pfc_test['test_ports'].keys())[0]
-    mg_facts = dut.get_extended_minigraph_facts(tbinfo)
-    vlan_ports = []
-    for vlan in mg_facts['minigraph_vlans'].keys():
-        vlan_ports.extend(mg_facts['minigraph_vlans'][vlan]['members'])
-    all_ip_intfs = mg_facts['minigraph_interfaces'] + mg_facts['minigraph_portchannel_interfaces']
-    non_vlan_ports = set(list(setup_pfc_test['test_ports'])) - set(vlan_ports) - set([dst_dut_intf])
-    src_dut_intf = random.choice(list(non_vlan_ports))
-    dest_mac = dut.get_dut_iface_mac(src_dut_intf)
-    # Find out if the selected port is a lag member
-    # If so, we need to use the neighbor address of the portchannel.
-    # else, we need the neighbor address of the interface itself.
-    required_intf = dst_dut_intf
-    for intf in mg_facts['minigraph_portchannels']:
-        if dst_dut_intf in mg_facts['minigraph_portchannels'][intf]['members']:
-            required_intf = intf
-            break
-    # At this point, required_intf is either a portchannel or Ethernet port.
-    # It should have a neibhor address or it is an error.
-    dst_ip_addr = None
-    for intf_obj in all_ip_intfs:
-        if intf_obj['attachto'] == required_intf:
-            dst_ip_addr = intf_obj['peer_addr']
-            break
-    if dst_ip_addr is None:
-        raise RuntimeError("Couldnot find the neighbor address for intf:{}".format(required_intf))
-    ptf_src_port = mg_facts['minigraph_ptf_indices'][src_dut_intf]
-    ptf_dst_port = mg_facts['minigraph_ptf_indices'][dst_dut_intf]
-    extra_vars = {
-        f'{program_name}_args':
-            'dest_mac=u"{}";dst_ip_addr={};ptf_src_port={};ptf_dst_port={};pfc_queue_idx={}'.format(
-                dest_mac,
-                dst_ip_addr,
-                ptf_src_port,
-                ptf_dst_port,
-                pfcwd_timer_setup_restore['storm_handle'].pfc_queue_idx
-                )}
-    try:
-        ptfhost.command('supervisorctl stop {}'.format(program_name))
-    except BaseException:
-        pass
-
-    ptfhost.host.options["variable_manager"].extra_vars.update(extra_vars)
-    script_args = \
-        '''dest_mac=u"{}";dst_ip_addr="{}";ptf_src_port={};ptf_dst_port={};pfc_queue_idx={}'''.format(
-                dest_mac,
-                dst_ip_addr,
-                ptf_src_port,
-                ptf_dst_port,
-                pfcwd_timer_setup_restore['storm_handle'].pfc_queue_idx)
-    supervisor_conf_content = ('''
-[program:{program_name}]
-command=/root/env-python3/bin/ptf --test-dir /root/ptftests/py3 {program_name}.BG_pkt_sender'''
-                               ''' --platform-dir /root/ptftests/ -t'''
-                               ''' '{script_args}' --relax  --platform remote
-process_name={program_name}
-stdout_logfile=/tmp/{program_name}.out.log
-stderr_logfile=/tmp/{program_name}.err.log
-redirect_stderr=false
-autostart=false
-autorestart=true
-startsecs=1
-numprocs=1
-'''.format(script_args=script_args, program_name=program_name))
-    ptfhost.copy(
-        content=supervisor_conf_content,
-        dest=f'/etc/supervisor/conf.d/{program_name}.conf')
-
-    ptfhost.command('supervisorctl reread')
-    ptfhost.command('supervisorctl update')
-    ptfhost.command(f'supervisorctl start {program_name}')
-
-    yield
-
-    try:
-        ptfhost.command(f'supervisorctl stop {program_name}')
-    except BaseException:
-        pass
-    ptfhost.command(f'supervisorctl remove {program_name}')
-
-
-@pytest.mark.usefixtures('pfcwd_timer_setup_restore')
+@pytest.mark.usefixtures('pfcwd_timer_setup_restore', 'start_background_traffic')
 class TestPfcwdAllTimer(object):
     """ PFCwd timer test class """
     def run_test(self):

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -155,88 +155,83 @@ def set_storm_params(dut, fanout_info, fanout, peer_params):
     return storm_handle
 
 
-@pytest.mark.usefixtures('pfcwd_timer_setup_restore')
-class TestPfcwdAllTimer(object):
-    """ PFCwd timer test class """
+@pytest.fixture(scope='class', autouse=True)
+def start_background_traffic(
+        duthosts,
+        enum_rand_one_per_hwsku_frontend_hostname,
+        pfcwd_timer_setup_restore,
+        setup_pfc_test,
+        copy_ptftests_directory,
+        ptfhost,
+        tbinfo
+        ):
+    """
+       This fixutre is to start a background traffic during
+       the test. This will start a continuous traffic flow from PTF
+       exiting the test port.
+    """
+    if duthosts[enum_rand_one_per_hwsku_frontend_hostname].facts['asic_type'] != "cisco-8000":
+        yield
+        return
 
-    @pytest.fixture(scope='class', autouse=True)
-    def start_background_traffic(
-            self,
-            duthosts,
-            enum_rand_one_per_hwsku_frontend_hostname,
-            pfcwd_timer_setup_restore,
-            setup_pfc_test,
-            copy_ptftests_directory,
-            ptfhost,
-            tbinfo
-            ):
-        """
-           This fixutre is to start a background traffic during
-           the test. This will start a continuous traffic flow from PTF
-           exiting the test port.
-        """
-        if duthosts[enum_rand_one_per_hwsku_frontend_hostname].facts['asic_type'] != "cisco-8000":
-            yield
-            return
+    # This is needed only for cisco-8000
+    program_name = "pfcwd_background_traffic"
+    dut = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    dst_dut_intf = list(setup_pfc_test['test_ports'].keys())[0]
+    mg_facts = dut.get_extended_minigraph_facts(tbinfo)
+    vlan_ports = []
+    for vlan in mg_facts['minigraph_vlans'].keys():
+        vlan_ports.extend(mg_facts['minigraph_vlans'][vlan]['members'])
+    all_ip_intfs = mg_facts['minigraph_interfaces'] + mg_facts['minigraph_portchannel_interfaces']
+    non_vlan_ports = set(list(setup_pfc_test['test_ports'])) - set(vlan_ports) - set([dst_dut_intf])
+    src_dut_intf = random.choice(list(non_vlan_ports))
+    dest_mac = dut.get_dut_iface_mac(src_dut_intf)
+    # Find out if the selected port is a lag member
+    # If so, we need to use the neighbor address of the portchannel.
+    # else, we need the neighbor address of the interface itself.
+    required_intf = dst_dut_intf
+    for intf in mg_facts['minigraph_portchannels']:
+        if dst_dut_intf in mg_facts['minigraph_portchannels'][intf]['members']:
+            required_intf = intf
+            break
+    # At this point, required_intf is either a portchannel or Ethernet port.
+    # It should have a neibhor address or it is an error.
+    dst_ip_addr = None
+    for intf_obj in all_ip_intfs:
+        if intf_obj['attachto'] == required_intf:
+            dst_ip_addr = intf_obj['peer_addr']
+            break
+    if dst_ip_addr is None:
+        raise RuntimeError("Couldnot find the neighbor address for intf:{}".format(required_intf))
+    ptf_src_port = mg_facts['minigraph_ptf_indices'][src_dut_intf]
+    ptf_dst_port = mg_facts['minigraph_ptf_indices'][dst_dut_intf]
+    extra_vars = {
+        f'{program_name}_args':
+            'dest_mac=u"{}";dst_ip_addr={};ptf_src_port={};ptf_dst_port={};pfc_queue_idx={}'.format(
+                dest_mac,
+                dst_ip_addr,
+                ptf_src_port,
+                ptf_dst_port,
+                pfcwd_timer_setup_restore['storm_handle'].pfc_queue_idx
+                )}
+    try:
+        ptfhost.command('supervisorctl stop {}'.format(program_name))
+    except BaseException:
+        pass
 
-        # This is needed only for cisco-8000
-        program_name = "pfcwd_background_traffic"
-        dut = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        dst_dut_intf = list(setup_pfc_test['test_ports'].keys())[0]
-        mg_facts = dut.get_extended_minigraph_facts(tbinfo)
-        vlan_ports = []
-        for vlan in mg_facts['minigraph_vlans'].keys():
-            vlan_ports.extend(mg_facts['minigraph_vlans'][vlan]['members'])
-        all_ip_intfs = mg_facts['minigraph_interfaces'] + mg_facts['minigraph_portchannel_interfaces']
-        non_vlan_ports = set(list(setup_pfc_test['test_ports'])) - set(vlan_ports) - set([dst_dut_intf])
-        src_dut_intf = random.choice(list(non_vlan_ports))
-        dest_mac = dut.get_dut_iface_mac(src_dut_intf)
-        # Find out if the selected port is a lag member
-        # If so, we need to use the neighbor address of the portchannel.
-        # else, we need the neighbor address of the interface itself.
-        required_intf = dst_dut_intf
-        for intf in mg_facts['minigraph_portchannels']:
-            if dst_dut_intf in mg_facts['minigraph_portchannels'][intf]['members']:
-                required_intf = intf
-                break
-        # At this point, required_intf is either a portchannel or Ethernet port.
-        # It should have a neibhor address or it is an error.
-        dst_ip_addr = None
-        for intf_obj in all_ip_intfs:
-            if intf_obj['attachto'] == required_intf:
-                dst_ip_addr = intf_obj['peer_addr']
-                break
-        if dst_ip_addr is None:
-            raise RuntimeError("Couldnot find the neighbor address for intf:{}".format(required_intf))
-        ptf_src_port = mg_facts['minigraph_ptf_indices'][src_dut_intf]
-        ptf_dst_port = mg_facts['minigraph_ptf_indices'][dst_dut_intf]
-        extra_vars = {
-            f'{program_name}_args':
-                'dest_mac=u"{}";dst_ip_addr={};ptf_src_port={};ptf_dst_port={};pfc_queue_idx={}'.format(
-                    dest_mac,
-                    dst_ip_addr,
-                    ptf_src_port,
-                    ptf_dst_port,
-                    pfcwd_timer_setup_restore['storm_handle'].pfc_queue_idx
-                    )}
-        try:
-            ptfhost.command('supervisorctl stop {}'.format(program_name))
-        except BaseException:
-            pass
-
-        ptfhost.host.options["variable_manager"].extra_vars.update(extra_vars)
-        script_args = \
-            '''dest_mac=u"{}";dst_ip_addr="{}";ptf_src_port={};ptf_dst_port={};pfc_queue_idx={}'''.format(
-                    dest_mac,
-                    dst_ip_addr,
-                    ptf_src_port,
-                    ptf_dst_port,
-                    pfcwd_timer_setup_restore['storm_handle'].pfc_queue_idx)
-        supervisor_conf_content = ('''
+    ptfhost.host.options["variable_manager"].extra_vars.update(extra_vars)
+    script_args = \
+        '''dest_mac=u"{}";dst_ip_addr="{}";ptf_src_port={};ptf_dst_port={};pfc_queue_idx={}'''.format(
+                dest_mac,
+                dst_ip_addr,
+                ptf_src_port,
+                ptf_dst_port,
+                pfcwd_timer_setup_restore['storm_handle'].pfc_queue_idx)
+    supervisor_conf_content = ('''
 [program:{program_name}]
 command=/root/env-python3/bin/ptf --test-dir /root/ptftests/py3 {program_name}.BG_pkt_sender'''
-                                   ''' --platform-dir /root/ptftests/ -t'''
-                                   ''' '{script_args}' --relax  --platform remote
+                               ''' --platform-dir /root/ptftests/ -t'''
+                               ''' '{script_args}' --relax  --platform remote
 process_name={program_name}
 stdout_logfile=/tmp/{program_name}.out.log
 stderr_logfile=/tmp/{program_name}.err.log
@@ -246,22 +241,26 @@ autorestart=true
 startsecs=1
 numprocs=1
 '''.format(script_args=script_args, program_name=program_name))
-        ptfhost.copy(
-            content=supervisor_conf_content,
-            dest=f'/etc/supervisor/conf.d/{program_name}.conf')
+    ptfhost.copy(
+        content=supervisor_conf_content,
+        dest=f'/etc/supervisor/conf.d/{program_name}.conf')
 
-        ptfhost.command('supervisorctl reread')
-        ptfhost.command('supervisorctl update')
-        ptfhost.command(f'supervisorctl start {program_name}')
+    ptfhost.command('supervisorctl reread')
+    ptfhost.command('supervisorctl update')
+    ptfhost.command(f'supervisorctl start {program_name}')
 
-        yield
+    yield
 
-        try:
-            ptfhost.command(f'supervisorctl stop {program_name}')
-        except BaseException:
-            pass
-        ptfhost.command(f'supervisorctl remove {program_name}')
+    try:
+        ptfhost.command(f'supervisorctl stop {program_name}')
+    except BaseException:
+        pass
+    ptfhost.command(f'supervisorctl remove {program_name}')
 
+
+@pytest.mark.usefixtures('pfcwd_timer_setup_restore')
+class TestPfcwdAllTimer(object):
+    """ PFCwd timer test class """
     def run_test(self):
         """
         Test execution


### PR DESCRIPTION
### Description of PR
Summary:
Recently cisco-8000 pfcwd was changed to not trigger watchdog when there is no traffic. So the pfcwd_timer_accuracy script fails, since there is no watchdog triggered during the test. So in this PR a new fixture is added for cisco-8000 only, that will run a background traffic on the selected port when the timer accuracy test is run.
### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [X] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?
The pfcwd feature was updated not to trigger watchdog when no traffic is present. So we need a background traffic to make the timer accuracy script to work.

#### How did you do it?
Added a background traffic fixture function, that uses supervisor in the PTF container.

#### How did you verify/test it?
Ran on T0 testbed with a sonic fanout:
`=============================================================================================== PASSES ===============================================================================================
_______________________________________________________________________ TestPfcwdAllTimer.test_pfcwd_timer_accuracy[mth-t0-64] _______________________________________________________________________
--------------------------------------------- generated xml file: /run_logs/2024-03-25-04-22-06/pfcwd/test_pfcwd_timer_accuracy_2024-03-25-04-22-06.xml ----------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
--------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------
04:39:24 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
====================================================================================== short test summary info =======================================================================================
PASSED pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy[mth-t0-64]
============================================================================= 1 passed, 1 warning in 1036.69s (0:17:16) ==============================================================================
sonic@3852cf4ada95:/data/tests$ 
`
#### Any platform specific information?
Specific to cisco-8000 only.