### PR TITLE
[PR:11978] [dhcp_relay] Validate DHCPv6 multicast packets can be trapped to CPU

### DIFF
--- a/docs/api_wiki/README.md
+++ b/docs/api_wiki/README.md
@@ -113,6 +113,8 @@ def test_fun(duthosts, rand_one_dut_hostname, ptfhost):
 
 - [active_ip_interfaces](sonichost_methods/active_ip_interfaces.md) - Provides information on all active IP (Ethernet or Portchannel) interfaces given a list of interface names.
 
+- [add_acl_table](sonichost_methods/add_acl_table.md) - Add new acl table via command `sudo config acl add table `
+
 - [all_critical_process_status](sonichost_methods/all_critical_process_status.md) - Provides summary and status of all critical services and their processes
 
 - [check_bgp_session_nsf](sonichost_methods/check_bgp_session_nsf.md) - Checks if BGP neighbor session has entered Nonstop Forwarding(NSF) state
@@ -168,6 +170,8 @@ def test_fun(duthosts, rand_one_dut_hostname, ptfhost):
 - [get_image_info](sonichost_methods/get_image_info.md) - Get list of images installed on the DUT.
 
 - [get_interfaces_status](sonichost_methods/get_interfaces_status.md) - Get interfaces status on the DUT and parse the result into a dict.
+
+- [get_intf_link_local_ipv6_addr](sonichost_methods/get_intf_link_local_ipv6_addr.md) - Get the link local ipv6 address of the interface
 
 - [get_ip_route_info](sonichost_methods/get_ip_route_info.md) - Returns route information for a destionation. The destination could an ip address or ip prefix.
 

--- a/docs/api_wiki/sonichost_methods/add_acl_table.md
+++ b/docs/api_wiki/sonichost_methods/add_acl_table.md
@@ -1,0 +1,50 @@
+# add_acl_table
+
+- [Overview](#overview)
+- [Examples](#examples)
+- [Arguments](#arguments)
+- [Expected Output](#expected-output)
+
+## Overview
+Add new acl table via command `sudo config acl add table `
+
+## Examples
+```
+def test_fun(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+
+    duthost.add_acl_table(table_name="Test_TABLE",
+                          table_type="L3",
+                          acl_stage="ingress",
+                          bind_ports=["Ethernet0", "Ethernet1", "Ethernet3"])
+```
+
+## Arguments
+ - `table_name` - table name of acl table
+    - Required: `True`
+    - Type: `String`
+ - `table_type` - table type of acl table
+    - Required: `True`
+    - Type: `String`
+ - `acl_stage` - acl stage
+    - Required: `False`
+    - Type: `String`
+        - Validate value: "ingress" or "egress"
+    - Default: None
+ - `bind_ports` - ports to bind
+    - Required: `False`
+    - Type option 1: `String`
+        - Format: Ethernet0,Ethernet1,Ethernet3
+    - Type option 2: `List`
+        - Member Type: `String`
+        - Format: ["Ethernet0", "Ethernet1", "Ethernet3"] or ["Vlan100", "Vlan200"]
+        - This list of interfaces will be join to a string
+        - If list of VLAN name provided, acl table will bind to ports binding to those VLAN.
+    - Default: None
+ - `description` - description of acl table
+    - Required: `False`
+    - Type: `String`
+    - Default: None
+
+## Expected Output
+None

--- a/docs/api_wiki/sonichost_methods/get_intf_link_local_ipv6_addr.md
+++ b/docs/api_wiki/sonichost_methods/get_intf_link_local_ipv6_addr.md
@@ -1,0 +1,25 @@
+# get_intf_link_local_ipv6_addr
+
+- [Overview](#overview)
+- [Examples](#examples)
+- [Arguments](#arguments)
+- [Expected Output](#expected-output)
+
+## Overview
+Get the link local ipv6 address of the interface
+
+## Examples
+```
+def test_fun(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+
+    duthost.get_intf_link_local_ipv6_addr("Ethernet0")
+```
+
+## Arguments
+ - `intf` - the interface name
+    - Required: `True`
+    - Type: `String`
+
+## Expected Output
+Link local only IPv6 address like: fe80::2edd:e9ff:fefc:dd58 or empty string if not found.

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1285,6 +1285,23 @@ default nhid 224 proto bgp src fc00:1::32 metric 20 pref medium
         intf_status = self.show_interface(command="status", interfaces=[interface_name])["ansible_facts"]['int_status']
         return intf_status[interface_name]['oper_state'] == 'up'
 
+    def get_intf_link_local_ipv6_addr(self, intf):
+        """
+        Get the link local ipv6 address of the interface
+
+        Args:
+            intf: The SONiC interface name
+
+        Returns:
+            The link local ipv6 address of the interface or empty string if not found
+
+        Sample output:
+            fe80::2edd:e9ff:fefc:dd58
+        """
+        cmd = "ip addr show %s | grep inet6 | grep 'scope link' | awk '{print $2}' | cut -d '/' -f1" % intf
+        addr = self.shell(cmd)["stdout"]
+        return addr
+
     def get_bgp_neighbor_info(self, neighbor_ip):
         """
         @summary: return bgp neighbor info
@@ -2244,6 +2261,34 @@ Totals               6450                 6449
             cli += " -j"
         res = self.shell(cli)['stdout']
         return re.sub(r"Last cached time was.*\d+\n", "", res)
+
+    def add_acl_table(self, table_name, table_type, acl_stage=None, bind_ports=None, description=None):
+        """
+        Add ACL table via 'config acl add table' command.
+        Command sample:
+            config acl add table TEST_TABLE L3 -s ingress -p Ethernet0,Ethernet4 -d "Test ACL table"
+
+        Args:
+            table_name: name of new acl table
+            table_type: type of the acl table
+            acl_stage: acl stage, ingress or egress
+            bind_ports: ports bind to the acl table
+            description: description of the acl table
+        """
+        cmd = "config acl add table {} {}".format(table_name, table_type)
+
+        if acl_stage:
+            cmd += " -s {}".format(acl_stage)
+
+        if bind_ports:
+            if isinstance(bind_ports, list):
+                bind_ports = ",".join(bind_ports)
+            cmd += " -p {}".format(bind_ports)
+
+        if description:
+            cmd += " -d {}".format(description)
+
+        self.command(cmd)
 
     def remove_acl_table(self, acl_table):
         """

--- a/tests/dhcp_relay/acl/dhcpv6_pkt_recv_multicast_accept.json
+++ b/tests/dhcp_relay/acl/dhcpv6_pkt_recv_multicast_accept.json
@@ -1,0 +1,30 @@
+{
+    "acl": {
+        "acl-sets": {
+            "acl-set": {
+                "DHCPV6_PKT_RECV_TEST": {
+                    "acl-entries": {
+                        "acl-entry": {
+                            "9011_ALLOW_DHCPv6": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 9011
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "ff02::1:2/128",
+                                        "protocol": "17"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/dhcp_relay/test_dhcp_pkt_recv.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_recv.py
@@ -1,0 +1,116 @@
+import logging
+import ptf.packet as scapy
+import pytest
+import random
+
+from ptf import testutils
+from scapy.layers.dhcp6 import DHCP6_Solicit
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import capture_and_check_packet_on_dut
+
+pytestmark = [
+    pytest.mark.topology('mx')
+]
+
+ACL_TABLE_NAME_DHCPV6_PKT_RECV_TEST = "DHCPV6_PKT_RECV_TEST"
+ACL_STAGE_INGRESS = "ingress"
+ACL_TABLE_TYPE_L3V6 = "L3V6"
+
+ACL_RULE_FILE_PATH_MULTICAST_ACCEPT = "dhcp_relay/acl/dhcpv6_pkt_recv_multicast_accept.json"
+ACL_RULE_DST_FILE = "/tmp/test_dchp_pkt_acl_rule.json"
+
+DHCP_RELAY_FEATRUE_NAME = "dhcp_relay"
+DHCPV6_MAC_MULTICAST = "33:33:00:01:00:02"
+DHCPV6_IP_MULTICAST = "ff02::1:2"
+DHCPV6_UDP_CLIENT_PORT = 546
+DHCPV6_UDP_SERVER_PORT = 547
+
+
+@pytest.fixture(scope="module", autouse=True)
+def check_dhcp_relay_feature_state(duthost):
+    features_state, _ = duthost.get_feature_status()
+    if "enabled" not in features_state.get(DHCP_RELAY_FEATRUE_NAME, ""):
+        pytest.skip('dhcp relay feature is not enabled, skip the test')
+
+
+class Dhcpv6PktRecvBase:
+
+    @pytest.fixture(scope="class")
+    def setup_teardown(self, duthost, tbinfo):
+        ptf_indices = tbinfo['topo']['properties']['topology']['host_interfaces']
+        dut_intf_ptf_index = duthost.get_extended_minigraph_facts(tbinfo)['minigraph_ptf_indices']
+        yield ptf_indices, dut_intf_ptf_index
+
+    def test_dhcpv6_multicast_recv(self, duthost, ptfadapter, setup_teardown):
+        """
+        Test the DUT can receive DHCPv6 multicast packet
+        """
+        ptf_indices, dut_intf_ptf_index = setup_teardown
+        ptf_index = random.choice(ptf_indices)
+        intf, ptf_port_id = [(intf, id) for intf, id in dut_intf_ptf_index.items() if id == ptf_index][0]
+        logging.info("Start to verify dhcpv6 multicast with infterface=%s and ptf_port_id=%s" % (intf, ptf_port_id))
+
+        def func(pkts):
+            pytest_assert(len([pkt for pkt in pkts if pkt[DHCP6_Solicit].trid == test_trid]) > 0,
+                          "Didn't get packet with expected transaction id")
+        src_mac = ptfadapter.dataplane.get_mac(0, ptf_port_id).decode('utf-8')
+        test_trid = 234
+        pkts_filter = "ether src %s and udp dst port %s" % (src_mac, DHCPV6_UDP_SERVER_PORT)
+        with capture_and_check_packet_on_dut(
+            duthost=duthost,
+            interface=intf,
+            pkts_filter=pkts_filter,
+            pkts_validator=func
+        ):
+            link_local_ipv6_addr = duthost.get_intf_link_local_ipv6_addr(intf)
+            req_pkt = scapy.Ether(dst=DHCPV6_MAC_MULTICAST, src=src_mac) \
+                / scapy.IPv6(src=link_local_ipv6_addr, dst=DHCPV6_IP_MULTICAST)\
+                / scapy.UDP(sport=DHCPV6_UDP_CLIENT_PORT, dport=DHCPV6_UDP_SERVER_PORT)\
+                / DHCP6_Solicit(trid=test_trid)
+            ptfadapter.dataplane.flush()
+            testutils.send_packet(ptfadapter, pkt=req_pkt, port_id=ptf_port_id)
+
+
+class TestDhcpv6WithEmptyAclTable(Dhcpv6PktRecvBase):
+    """
+    Test the DUT with empty ACL table
+    """
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_teardown_acl(self, duthost, setup_teardown):
+        ptf_indices, dut_intf_ptf_index = setup_teardown
+        ptf_intfs = [intf for intf, index in dut_intf_ptf_index.items() if index in ptf_indices]
+        acl_table_name = ACL_TABLE_NAME_DHCPV6_PKT_RECV_TEST
+        duthost.add_acl_table(
+            table_name=acl_table_name,
+            table_type=ACL_TABLE_TYPE_L3V6,
+            acl_stage=ACL_STAGE_INGRESS,
+            bind_ports=ptf_intfs
+        )
+
+        yield
+
+        duthost.remove_acl_table(acl_table_name)
+
+
+class TestDhcpv6WithMulticastAccpectAcl(Dhcpv6PktRecvBase):
+    """
+    Test the DUT with multicast accept ACL rule and default drop all rule.
+    The drop all rule is added by default for L3V6 table type by acl-loader
+    """
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_teardown_acl(self, duthost, setup_teardown):
+        ptf_indices, dut_intf_ptf_index = setup_teardown
+        ptf_intfs = [intf for intf, index in dut_intf_ptf_index.items() if index in ptf_indices]
+        acl_table_name = ACL_TABLE_NAME_DHCPV6_PKT_RECV_TEST
+        duthost.add_acl_table(
+            table_name=acl_table_name,
+            table_type=ACL_TABLE_TYPE_L3V6,
+            acl_stage=ACL_STAGE_INGRESS,
+            bind_ports=ptf_intfs
+        )
+        duthost.copy(src=ACL_RULE_FILE_PATH_MULTICAST_ACCEPT, dest=ACL_RULE_DST_FILE)
+        duthost.shell("acl-loader update full --table_name {} {}".format(acl_table_name, ACL_RULE_DST_FILE))
+
+        yield
+
+        duthost.remove_acl_table(acl_table_name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
To make sure DHCPv6 multicast packets can be received by device, we add a test to send DHCPv6 multicast packet with specific transaction ID from server to device, and check if tcpdump can capture the packet.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
We need to make sure DHCPv6 multicast packets can be received by device.
#### How did you do it?
We add a test to send DHCPv6 multicast packet with specific transaction ID from server to device, and check if tcpdump can capture the packet.


#### How did you verify/test it?
For mx topo, verified on Nokia-7215 testbed with 202305 image and 202205 image.


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
