### PR TITLE
Ignore ansible log message when check TACACS accounting syslog.

### DIFF
--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -85,13 +85,17 @@ def check_tacacs_server_no_other_user_log(ptfhost, tacacs_creds):
 
 def check_local_log_exist(duthost, tacacs_creds, command):
     """
+        Remove all ansible command log with /D command,
+        which will match following format:
+            "ansible.legacy.command Invoked"
+
         Find logs run by tacacs_rw_user from syslog:
             Find logs match following format:
                 "INFO audisp-tacplus: Accounting: user: tacacs_rw_user,.*, command: .*command,"
             Print matched logs with /P command.
     """
     username = tacacs_creds['tacacs_rw_user']
-    log_pattern = "/INFO audisp-tacplus.+Accounting: user: {0},.*, command: .*{1},/P" \
+    log_pattern = "/ansible.legacy.command Invoked/D;/INFO audisp-tacplus.+Accounting: user: {0},.*, command: .*{1},/P" \
                   .format(username, command)
     logs = wait_for_log(duthost, "/var/log/syslog", log_pattern)
     pytest_assert(len(logs) > 0)
@@ -106,6 +110,9 @@ def check_local_log_exist(duthost, tacacs_creds, command):
 def check_local_no_other_user_log(duthost, tacacs_creds):
     """
         Find logs not run by tacacs_rw_user from syslog:
+            Remove all ansible command log with /D command,
+            which will match following format:
+                "ansible.legacy.command Invoked"
 
             Remove all tacacs_rw_user's log with /D command,
             which will match following format:
@@ -117,7 +124,7 @@ def check_local_no_other_user_log(duthost, tacacs_creds):
             Print matched logs with /P command, which are not run by tacacs_rw_user.
     """
     username = tacacs_creds['tacacs_rw_user']
-    log_pattern = "/INFO audisp-tacplus: Accounting: user: {0},/D;/INFO audisp-tacplus: Accounting: user:/P" \
+    log_pattern = "/ansible.legacy.command Invoked/D;/INFO audisp-tacplus: Accounting: user: {0},/D;/INFO audisp-tacplus: Accounting: user:/P" \
                   .format(username)
     logs = wait_for_log(duthost, "/var/log/syslog", log_pattern)
 

--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -95,7 +95,8 @@ def check_local_log_exist(duthost, tacacs_creds, command):
             Print matched logs with /P command.
     """
     username = tacacs_creds['tacacs_rw_user']
-    log_pattern = "/ansible.legacy.command Invoked/D;/INFO audisp-tacplus.+Accounting: user: {0},.*, command: .*{1},/P" \
+    log_pattern = "/ansible.legacy.command Invoked/D;\
+                  /INFO audisp-tacplus.+Accounting: user: {0},.*, command: .*{1},/P" \
                   .format(username, command)
     logs = wait_for_log(duthost, "/var/log/syslog", log_pattern)
     pytest_assert(len(logs) > 0)
@@ -124,7 +125,9 @@ def check_local_no_other_user_log(duthost, tacacs_creds):
             Print matched logs with /P command, which are not run by tacacs_rw_user.
     """
     username = tacacs_creds['tacacs_rw_user']
-    log_pattern = "/ansible.legacy.command Invoked/D;/INFO audisp-tacplus: Accounting: user: {0},/D;/INFO audisp-tacplus: Accounting: user:/P" \
+    log_pattern = "/ansible.legacy.command Invoked/D;\
+                  /INFO audisp-tacplus: Accounting: user: {0},/D;\
+                  /INFO audisp-tacplus: Accounting: user:/P" \
                   .format(username)
     logs = wait_for_log(duthost, "/var/log/syslog", log_pattern)
 


### PR DESCRIPTION
Ignore ansible log message when check TACACS accounting syslog.

#### Why I did it
Every ansible command will generate a syslog, when check TACACS accounting with sed command, the sed query will match the ansible log, this will make test case can't find regression. 

##### Work item tracking
- Microsoft ADO: 25270078

#### How I did it
Ignore ansible log message when check TACACS accounting syslog.

#### How to verify it
Pass all test case.
Fix TACACS accounting test case to prevent regression.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

will updated with this PR image later.
- [] SONiC.master-16482.360728-2c8b4066f

#### Description for the changelog
Ignore ansible log message when check TACACS accounting syslog.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

