### PR TITLE
Check TACACS login performance by check how many commands run during login.

### DIFF
--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -5,8 +5,7 @@ from tests.common.devices.ptf import PTFHost
 from tests.common.helpers.tacacs.tacacs_helper import stop_tacacs_server, start_tacacs_server, \
     per_command_accounting_skip_versions, remove_all_tacacs_server
 from .utils import check_server_received, change_and_wait_aaa_config_update, get_auditd_config_reload_line_count, \
-    ensure_tacacs_server_running_after_ut, ssh_connect_remote_retry, ssh_run_command    # noqa: F401
-from tests.common.errors import RunAnsibleModuleFail
+    ensure_tacacs_server_running_after_ut, ssh_connect_remote_retry, ssh_run_command, cleanup_tacacs_log # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release
 
@@ -18,18 +17,6 @@ pytestmark = [
 ]
 
 logger = logging.getLogger(__name__)
-
-
-def cleanup_tacacs_log(ptfhost, rw_user_client):
-    try:
-        ptfhost.command('rm /var/log/tac_plus.acct')
-    except RunAnsibleModuleFail:
-        logger.info("/var/log/tac_plus.acct does not exist.")
-
-    res = ptfhost.command('touch /var/log/tac_plus.acct')
-    logger.info(res["stdout_lines"])
-
-    ssh_run_command(rw_user_client, 'sudo truncate -s 0 /var/log/syslog')
 
 
 def host_run_command(host, command):

--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -5,7 +5,7 @@ from tests.common.devices.ptf import PTFHost
 from tests.common.helpers.tacacs.tacacs_helper import stop_tacacs_server, start_tacacs_server, \
     per_command_accounting_skip_versions, remove_all_tacacs_server
 from .utils import check_server_received, change_and_wait_aaa_config_update, get_auditd_config_reload_line_count, \
-    ensure_tacacs_server_running_after_ut, ssh_connect_remote_retry, ssh_run_command, cleanup_tacacs_log # noqa: F401
+    ensure_tacacs_server_running_after_ut, ssh_connect_remote_retry, ssh_run_command, cleanup_tacacs_log  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release
 

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -7,7 +7,8 @@ import time
 from tests.common.helpers.tacacs.tacacs_helper import stop_tacacs_server, start_tacacs_server, \
     per_command_authorization_skip_versions, remove_all_tacacs_server, get_ld_path
 from tests.tacacs.utils import change_and_wait_aaa_config_update, ensure_tacacs_server_running_after_ut, \
-    ssh_connect_remote_retry, ssh_run_command, TIMEOUT_LIMIT       # noqa: F401
+    ssh_connect_remote_retry, ssh_run_command, TIMEOUT_LIMIT, \
+    cleanup_tacacs_log, count_authorization_request       # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release, wait_until, paramiko_ssh
 from .utils import check_server_received
@@ -643,3 +644,64 @@ def test_fallback_to_local_authorization_with_config_reload(
     finally:
         #  Restore config after test finish
         restore_config(duthost, CONFIG_DB, CONFIG_DB_BACKUP)
+
+
+def test_tacacs_authorization_commands_during_login(
+                                                ptfhost,
+                                                duthosts,
+                                                enum_rand_one_per_hwsku_hostname,
+                                                setup_authorization_tacacs,
+                                                tacacs_creds,
+                                                check_tacacs,
+                                                remote_rw_user_client):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    duthost.shell("sudo config aaa authentication debug disable")
+    duthost.shell("sudo service auditd stop")
+    duthost.shell("sudo service auditd start")
+    change_and_wait_aaa_config_update(duthost, "sudo config aaa accounting local")
+
+    # Clean tacacs log
+    cleanup_tacacs_log(ptfhost, remote_rw_user_client)
+
+    # Create a new SSH session
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+    test_user = tacacs_creds['tacacs_authorization_user']
+    with ssh_connect_remote_retry(
+        dutip,
+        test_user,
+        tacacs_creds['tacacs_authorization_user_passwd'],
+        duthost
+    ) as ssh_client:
+        ssh_client.exec_command("grep")
+        ssh_client.exec_command("/usr/bin/run-parts")
+        ssh_client.exec_command("grep")
+        # get authorization command count during user login
+        count = count_authorization_request(ptfhost)
+        if count > 10:
+            """
+                Get local accounting log for debug
+                Remove all ansible command log with /D command,
+                which will match following format:
+                    "ansible.legacy.command Invoked"
+                Remove all usermod command with /D command,
+                which will match following format:
+                    "usermod"
+                Remove all command exit log with /D command,
+                which will match following format:
+                    "exit=.*"
+                Find logs run by test user from syslog:
+                    Find logs match following format:
+                        "INFO audisp-tacplus: Accounting: user: ,.*, command: .*command,"
+                    Print matched logs with /P command.
+            """
+            log_pattern = "/ansible.legacy.command Invoked/D;\
+                            /usermod/D;\
+                            /exit=.*/D;\
+                            /INFO audisp-tacplus.+Accounting: user: {0},.*, command: .*,/P" \
+                        .format(test_user)
+
+            res = duthost.shell("sed -nE '{0}' /var/log/syslog".format(log_pattern))["stdout"]
+            logger.warning("Found {} commands during login, local accounting log: {}".format(count, res))
+            pytest_assert(False, "Device execute {} commands during login,\
+                           please check and remove unecessary login commands: {}".format(count, res))

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -673,7 +673,7 @@ def test_tacacs_authorization_commands_during_login(
         tacacs_creds['tacacs_authorization_user_passwd'],
         duthost
     ) as ssh_client:
-        ssh_client.exec_command("grep")
+        # run some command to make sure login finish
         ssh_client.exec_command("/usr/bin/run-parts")
         ssh_client.exec_command("grep")
         # get authorization command count during user login

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 import paramiko
 import time
+from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.tacacs.tacacs_helper import start_tacacs_server
 from tests.common.utilities import wait_until, paramiko_ssh
@@ -125,3 +126,23 @@ def duthost_shell_with_unreachable_retry(duthost, command):
                            .format(e, retries, DEVICE_UNREACHABLE_MAX_RETRIES))
             if retries > DEVICE_UNREACHABLE_MAX_RETRIES:
                 raise e
+
+
+def cleanup_tacacs_log(ptfhost, rw_user_client):
+    try:
+        ptfhost.command('rm /var/log/tac_plus.acct')
+    except RunAnsibleModuleFail:
+        logger.info("/var/log/tac_plus.acct does not exist.")
+
+    res = ptfhost.command('touch /var/log/tac_plus.acct')
+    logger.info(res["stdout_lines"])
+
+    ssh_run_command(rw_user_client, 'sudo truncate -s 0 /var/log/syslog')
+
+
+def count_authorization_request(ptfhost):
+    hex_string = binascii.hexlify("cmd=/".encode('ascii')).decode()
+    sed_command = "sed -n 's/.*-> 0x\(..\).*/\\1/p'  /var/log/tac_plus.log | sed ':a; N; $!ba; s/\\n//g'"  # noqa W605 E501
+    res = ptfhost.shell(sed_command)["stdout"]
+    logger.warning("TACACS authorization request hex: {}".format(res))
+    return res.count(hex_string)

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -138,6 +138,7 @@ def cleanup_tacacs_log(ptfhost, rw_user_client):
     logger.info(res["stdout_lines"])
 
     ssh_run_command(rw_user_client, 'sudo truncate -s 0 /var/log/syslog')
+    ptfhost.command('truncate -s 0 /var/log/tac_plus.log')
 
 
 def count_authorization_request(ptfhost):


### PR DESCRIPTION
Check TACACS login performance by check how many commands run during login.

#### Why I did it
When TACACS enabled, If some hardware SKU run too many commands during user login, it will cause login performance issue. Add new test case to check and prevent this happen.

##### Work item tracking
- Microsoft ADO: 25504697

#### How I did it
Check how many commands run during user login.

#### How to verify it
Pass all test case.
Add new test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

will updated with this PR image later.
- [] SONiC.master-16482.360728-2c8b4066f

#### Description for the changelog
Check TACACS login performance by check how many commands run during login.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

