### PR TITLE
Revert "Fix qos/test_qos_sai.py teardown. (#11934)"

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1224,7 +1224,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class')
     def stopServices(
-        self, duthosts, get_src_dst_asic_and_duts, dut_disable_ipv6,
+        self, duthosts, get_src_dst_asic_and_duts,
         swapSyncd_on_selected_duts, enable_container_autorestart, disable_container_autorestart, get_mux_status, # noqa F811
         tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports):  # noqa F811
         """


### PR DESCRIPTION
This reverts commit 66751e52d2a59c3bae6cc00d1b8150ed543f9617.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

#11934  caused SNMP critical process crash issue in qos test

```
11:15:47 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture swapSyncd_on_selected_duts setup starts --------------------
11:16:43 sonic.is_container_running               L0450 INFO   | container syncd is not running
11:16:43 sonic.is_container_running               L0450 INFO   | container swss is not running
11:17:32 docker.swap_syncd                        L0169 INFO   | Reloading config and restarting swss...
11:17:32 config_reload.config_reload              L0092 INFO   | reloading config_db
11:19:13 processes_utils.wait_critical_processes  L0070 INFO   | Wait until all critical processes are healthy in 300 sec
11:19:13 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
11:19:38 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
11:20:02 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
11:20:27 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
11:20:52 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
11:21:17 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
11:21:41 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
11:22:06 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
11:22:31 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
11:22:55 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
11:23:21 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
11:23:46 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
11:24:10 processes_utils._all_critical_processes_ L0039 INFO   | Check critical processes status
11:25:25 docker.restore_default_syncd             L0206 INFO   | Reloading config and restarting swss...
11:25:25 config_reload.config_reload              L0092 INFO   | reloading config_db
ERROR                                                                    [ 33%]

... omitted ...


    def wait_critical_processes(dut):
        """
        @summary: wait until all critical processes are healthy.
        @param dut: The AnsibleHost object of DUT. For interacting with DUT.
        """
        timeout = reset_timeout(dut)
        # No matter what we set in inventory file, we always set sup timeout to 900
        # because most SUPs have 10+ dockers that need to come up
        if dut.is_supervisor_node():
            timeout = 900
        logging.info("Wait until all critical processes are healthy in {} sec"
                     .format(timeout))
>       pytest_assert(wait_until(timeout, 20, 0, _all_critical_processes_healthy, dut),
                      "Not all critical processes are healthy")
E       Failed: Not all critical processes are healthy

dut        = <MultiAsicSonicHost str3-8111-01>
timeout    = 300
```

snmp's critical process hit issue:

```
$ docker exec snmp     bash -c "[ -f /etc/supervisor/critical_processes ] && cat /etc/supervisor/critical_processes" 
program:snmpd
program:snmp-subagent

$ docker exec snmp     supervisorctl status ;
dependent-startup                RUNNING   pid 8, uptime 0:00:31
rsyslogd                         RUNNING   pid 19, uptime 0:00:30
snmp-subagent                    STOPPED   Not started
snmpd                            FATAL     Exited too quickly (process log may have details)
start                            EXITED    Mar 22 10:20 AM
supervisor-proc-exit-listener    RUNNING   pid 9, uptime 0:00:31
```


#### How did you do it?

revert #11934 can help

#### How did you verify/test it?

after rever #11934, not see snmp crash in local qos test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
