### PR TITLE
cisco qos param calc hardening

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -99,12 +99,12 @@ class QosParamCisco(object):
         found = False
         exp = 1
         mantissa = 0
-        reduced_thr = thr >> 4
-        further_reduced_thr = thr >> 5
+        reduced_thr = int(thr) >> 4
+        further_reduced_thr = int(thr) >> 5
         for i in range(32):
             ith_bit = 1 << i
             if further_reduced_thr < ith_bit <= reduced_thr:
-                mantissa = thr // ith_bit
+                mantissa = int(thr) // ith_bit
                 exp = i
                 found = True
                 break


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

in corner case,  cisco qos param calculating code hit syntax error:

```
11:50:04 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture dutQosConfig setup starts --------------------
11:50:04 qos_sai_base.dutQosConfig                L1369 INFO   | Lossless Buffer profile selected is BUFFER_PROFILE_TABLE:pg_lossless_100000_300m_profile
11:50:04 qos_sai_base.dutArpProxyConfig           L1317 INFO   | Failed to read vlan interface config. Excpetion Expecting value: line 1 column 1 (char 0)
11:50:07 __init__._fixture_generator_decorator    L0088 ERROR  | 
TypeError("unsupported operand type(s) for >>: 'float' and 'int'")
Traceback (most recent call last):
  File "/var/src/sonic-mgmt-int/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/var/src/sonic-mgmt-int/tests/qos/qos_sai_base.py", line 1468, in dutQosConfig
    qpm = qos_param_generator.QosParamCisco(
  File "/var/src/sonic-mgmt-int/tests/qos/files/cisco/qos_param_generator.py", line 61, in __init__
    refined_pause_thr = self.gr_get_hw_thr_buffs(pre_pad_pause // self.buffer_size) * self.buffer_size
  File "/var/src/sonic-mgmt-int/tests/qos/files/cisco/qos_param_generator.py", line 117, in gr_get_hw_thr_buffs
    mantissa, exp = self.gr_get_mantissa_exp(thr)
  File "/var/src/sonic-mgmt-int/tests/qos/files/cisco/qos_param_generator.py", line 102, in gr_get_mantissa_exp
    reduced_thr = thr >> 4
TypeError: unsupported operand type(s) for >>: 'float' and 'int'
11:50:07 __init__._fixture_generator_decorator    L0089 INFO   | -------------------- fixture dutQosConfig setup ends --------------------
ERROR                                                                    [ 33%]
```


#### How did you do it?

force convert "thr" type to int

#### How did you verify/test it?

pass local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
