### PR TITLE
Increase post-PDU state change delay to allow all PSUs to react

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -206,6 +206,7 @@ def turn_all_outlets_on(pdu_ctrl):
         if not outlet["outlet_on"]:
             pdu_ctrl.turn_on_outlet(outlet)
             time.sleep(5)
+    time.sleep(5)
 
 
 def check_all_psu_on(dut, psu_test_results):
@@ -288,7 +289,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
 
         logging.info("Turn off outlet {}".format(outlet))
         pdu_ctrl.turn_off_outlet(outlet)
-        time.sleep(5)
+        time.sleep(10)
 
         cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
         for line in cli_psu_status["stdout_lines"][2:]:
@@ -302,7 +303,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
 
         logging.info("Turn on outlet {}".format(outlet))
         pdu_ctrl.turn_on_outlet(outlet)
-        time.sleep(5)
+        time.sleep(10)
 
         cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
         for line in cli_psu_status["stdout_lines"][2:]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Increase delay between PDU state change and reading PSU details to 10 seconds (previously 5).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

5 second delay between PDU state change and accessing PSU details is not always enough. The time needed depends on PDU hardware, psud update interval, and PSU hardware. psud update interval of 3s only allows 2s for the PDU to change the power state, which may not always be enough. Increasing to 10 seconds allows at least 7 seconds for the PDU to apply a state change and PSU to reflect it, which MSFT has found sufficient.

#### How did you do it?

Increase post-PDU state change delays to 10 seconds (previously 5 seconds)

#### How did you verify/test it?

MSFT verified by setting the delay to 10 seconds since Cisco was unable to reproduce with our PDU hardware.