### PR TITLE
Fix _backup_and_restore_config_db to properly restore config_db.json after upgrade

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -38,13 +38,13 @@ def _backup_and_restore_config_db(duts, scope='function'):
 
     for duthost in duthosts:
         logger.info("Backup {} to {} on {}".format(CONFIG_DB, CONFIG_DB_BAK, duthost.hostname))
-        duthost.shell("cp {} {}".format(CONFIG_DB, CONFIG_DB_BAK))
+        duthost.fetch(src=CONFIG_DB, dest="/tmp/{}{}".format(duthost.hostname, CONFIG_DB_BAK), flat=True)
 
     yield
 
     for duthost in duthosts:
         logger.info("Restore {} with {} on {}".format(CONFIG_DB, CONFIG_DB_BAK, duthost.hostname))
-        duthost.shell("mv {} {}".format(CONFIG_DB_BAK, CONFIG_DB))
+        duthost.copy(src="/tmp/{}{}".format(duthost.hostname, CONFIG_DB_BAK), dest=CONFIG_DB)
 
 
 @pytest.fixture(scope="module")

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -29,7 +29,7 @@ def _backup_and_restore_config_db(duts, scope='function'):
     the test starts and then restore it after the test ends.
     """
     CONFIG_DB = "/etc/sonic/config_db.json"
-    CONFIG_DB_BAK = "/etc/sonic/config_db.json.before_test_{}".format(scope)
+    CONFIG_DB_BAK = "/host/config_db.json.before_test_{}".format(scope)
 
     if type(duts) is not list:
         duthosts = [duts]
@@ -38,13 +38,13 @@ def _backup_and_restore_config_db(duts, scope='function'):
 
     for duthost in duthosts:
         logger.info("Backup {} to {} on {}".format(CONFIG_DB, CONFIG_DB_BAK, duthost.hostname))
-        duthost.fetch(src=CONFIG_DB, dest="/tmp/{}{}".format(duthost.hostname, CONFIG_DB_BAK), flat=True)
+        duthost.shell("cp {} {}".format(CONFIG_DB, CONFIG_DB_BAK))
 
     yield
 
     for duthost in duthosts:
         logger.info("Restore {} with {} on {}".format(CONFIG_DB, CONFIG_DB_BAK, duthost.hostname))
-        duthost.copy(src="/tmp/{}{}".format(duthost.hostname, CONFIG_DB_BAK), dest=CONFIG_DB)
+        duthost.shell("mv {} {}".format(CONFIG_DB_BAK, CONFIG_DB))
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
test_warm_upgrade_sad_path fails in teardown because it is unable to restore config_db. This is because in the event of an upgrade, config_db backup is deleted if stored in /etc/sonic/.

#### How did you do it?
Instead of storing config_db backup in /etc/sonic/, store in /host instead.

#### How did you verify/test it?
Ran test_warm_upgrade_sad_path and verified it passes

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
