### PR TITLE
Adding background traffic to all-port-storm.

### DIFF
--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pytest
 import time
+import random
 
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts      # noqa F401
 from tests.common.helpers.pfc_storm import PFCMultiStorm
@@ -111,6 +112,108 @@ def set_storm_params(duthost, fanout_graph, fanouthosts, peer_params):
     storm_hndle = PFCMultiStorm(duthost, fanout_graph, fanouthosts, peer_params)
     storm_hndle.set_storm_params()
     return storm_hndle
+
+
+@pytest.fixture(scope='class', autouse=True)
+def start_background_traffic(
+        duthosts,
+        enum_rand_one_per_hwsku_frontend_hostname,
+        setup_pfc_test,
+        copy_ptftests_directory,
+        ptfhost,
+        tbinfo
+        ):
+    """
+       This fixutre is to start a background traffic during
+       the test. This will start a continuous traffic flow from PTF
+       exiting the test port.
+    """
+    if duthosts[enum_rand_one_per_hwsku_frontend_hostname].facts['asic_type'] != "cisco-8000":
+        yield
+        return
+
+    # This is needed only for cisco-8000
+    program_name = "pfcwd_background_traffic"
+    dut = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    dst_dut_intf = list(setup_pfc_test['test_ports'].keys())[0]
+    mg_facts = dut.get_extended_minigraph_facts(tbinfo)
+    vlan_ports = []
+    for vlan in mg_facts['minigraph_vlans'].keys():
+        vlan_ports.extend(mg_facts['minigraph_vlans'][vlan]['members'])
+    all_ip_intfs = mg_facts['minigraph_interfaces'] + mg_facts['minigraph_portchannel_interfaces']
+    non_vlan_ports = set(list(setup_pfc_test['test_ports'])) - set(vlan_ports) - set([dst_dut_intf])
+    src_dut_intf = random.choice(list(non_vlan_ports))
+    dest_mac = dut.get_dut_iface_mac(src_dut_intf)
+    # Find out if the selected port is a lag member
+    # If so, we need to use the neighbor address of the portchannel.
+    # else, we need the neighbor address of the interface itself.
+    required_intf = dst_dut_intf
+    for intf in mg_facts['minigraph_portchannels']:
+        if dst_dut_intf in mg_facts['minigraph_portchannels'][intf]['members']:
+            required_intf = intf
+            break
+    # At this point, required_intf is either a portchannel or Ethernet port.
+    # It should have a neibhor address or it is an error.
+    dst_ip_addr = None
+    for intf_obj in all_ip_intfs:
+        if intf_obj['attachto'] == required_intf:
+            dst_ip_addr = intf_obj['peer_addr']
+            break
+    if dst_ip_addr is None:
+        raise RuntimeError("Couldnot find the neighbor address for intf:{}".format(required_intf))
+    ptf_src_port = mg_facts['minigraph_ptf_indices'][src_dut_intf]
+    ptf_dst_port = mg_facts['minigraph_ptf_indices'][dst_dut_intf]
+    extra_vars = {
+        f'{program_name}_args':
+            'dest_mac=u"{}";dst_ip_addr={};ptf_src_port={};ptf_dst_port={};pfc_queue_idx={}'.format(
+                dest_mac,
+                dst_ip_addr,
+                ptf_src_port,
+                ptf_dst_port,
+                3   # Hardcoded in the testcase as well.
+                )}
+    try:
+        ptfhost.command('supervisorctl stop {}'.format(program_name))
+    except BaseException:
+        pass
+
+    ptfhost.host.options["variable_manager"].extra_vars.update(extra_vars)
+    script_args = \
+        '''dest_mac=u"{}";dst_ip_addr="{}";ptf_src_port={};ptf_dst_port={};pfc_queue_idx={}'''.format(
+                dest_mac,
+                dst_ip_addr,
+                ptf_src_port,
+                ptf_dst_port,
+                3)
+    supervisor_conf_content = ('''
+[program:{program_name}]
+command=/root/env-python3/bin/ptf --test-dir /root/ptftests/py3 {program_name}.BG_pkt_sender'''
+                               ''' --platform-dir /root/ptftests/ -t'''
+                               ''' '{script_args}' --relax  --platform remote
+process_name={program_name}
+stdout_logfile=/tmp/{program_name}.out.log
+stderr_logfile=/tmp/{program_name}.err.log
+redirect_stderr=false
+autostart=false
+autorestart=true
+startsecs=1
+numprocs=1
+'''.format(script_args=script_args, program_name=program_name))
+    ptfhost.copy(
+        content=supervisor_conf_content,
+        dest=f'/etc/supervisor/conf.d/{program_name}.conf')
+
+    ptfhost.command('supervisorctl reread')
+    ptfhost.command('supervisorctl update')
+    ptfhost.command(f'supervisorctl start {program_name}')
+
+    yield
+
+    try:
+        ptfhost.command(f'supervisorctl stop {program_name}')
+    except BaseException:
+        pass
+    ptfhost.command(f'supervisorctl remove {program_name}')
 
 
 @pytest.mark.usefixtures('stop_pfcwd', 'storm_test_setup_restore')

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -2,12 +2,11 @@ import logging
 import os
 import pytest
 import time
-import random
 
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts      # noqa F401
 from tests.common.helpers.pfc_storm import PFCMultiStorm
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
-from .files.pfcwd_helper import start_wd_on_ports
+from .files.pfcwd_helper import start_wd_on_ports, start_background_traffic     # noqa F401
 from .files.pfcwd_helper import EXPECT_PFC_WD_DETECT_RE, EXPECT_PFC_WD_RESTORE_RE, fetch_vendor_specific_diagnosis_re
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
@@ -18,6 +17,12 @@ pytestmark = [
 ]
 
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="class")
+def pfc_queue_idx():
+    # Needed for start_background_traffic
+    yield 3   # Hardcoded in the testcase as well.
 
 
 @pytest.fixture(scope='class', autouse=True)
@@ -114,109 +119,7 @@ def set_storm_params(duthost, fanout_graph, fanouthosts, peer_params):
     return storm_hndle
 
 
-@pytest.fixture(scope='class', autouse=True)
-def start_background_traffic(
-        duthosts,
-        enum_rand_one_per_hwsku_frontend_hostname,
-        setup_pfc_test,
-        copy_ptftests_directory,
-        ptfhost,
-        tbinfo
-        ):
-    """
-       This fixutre is to start a background traffic during
-       the test. This will start a continuous traffic flow from PTF
-       exiting the test port.
-    """
-    if duthosts[enum_rand_one_per_hwsku_frontend_hostname].facts['asic_type'] != "cisco-8000":
-        yield
-        return
-
-    # This is needed only for cisco-8000
-    program_name = "pfcwd_background_traffic"
-    dut = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    dst_dut_intf = list(setup_pfc_test['test_ports'].keys())[0]
-    mg_facts = dut.get_extended_minigraph_facts(tbinfo)
-    vlan_ports = []
-    for vlan in mg_facts['minigraph_vlans'].keys():
-        vlan_ports.extend(mg_facts['minigraph_vlans'][vlan]['members'])
-    all_ip_intfs = mg_facts['minigraph_interfaces'] + mg_facts['minigraph_portchannel_interfaces']
-    non_vlan_ports = set(list(setup_pfc_test['test_ports'])) - set(vlan_ports) - set([dst_dut_intf])
-    src_dut_intf = random.choice(list(non_vlan_ports))
-    dest_mac = dut.get_dut_iface_mac(src_dut_intf)
-    # Find out if the selected port is a lag member
-    # If so, we need to use the neighbor address of the portchannel.
-    # else, we need the neighbor address of the interface itself.
-    required_intf = dst_dut_intf
-    for intf in mg_facts['minigraph_portchannels']:
-        if dst_dut_intf in mg_facts['minigraph_portchannels'][intf]['members']:
-            required_intf = intf
-            break
-    # At this point, required_intf is either a portchannel or Ethernet port.
-    # It should have a neibhor address or it is an error.
-    dst_ip_addr = None
-    for intf_obj in all_ip_intfs:
-        if intf_obj['attachto'] == required_intf:
-            dst_ip_addr = intf_obj['peer_addr']
-            break
-    if dst_ip_addr is None:
-        raise RuntimeError("Couldnot find the neighbor address for intf:{}".format(required_intf))
-    ptf_src_port = mg_facts['minigraph_ptf_indices'][src_dut_intf]
-    ptf_dst_port = mg_facts['minigraph_ptf_indices'][dst_dut_intf]
-    extra_vars = {
-        f'{program_name}_args':
-            'dest_mac=u"{}";dst_ip_addr={};ptf_src_port={};ptf_dst_port={};pfc_queue_idx={}'.format(
-                dest_mac,
-                dst_ip_addr,
-                ptf_src_port,
-                ptf_dst_port,
-                3   # Hardcoded in the testcase as well.
-                )}
-    try:
-        ptfhost.command('supervisorctl stop {}'.format(program_name))
-    except BaseException:
-        pass
-
-    ptfhost.host.options["variable_manager"].extra_vars.update(extra_vars)
-    script_args = \
-        '''dest_mac=u"{}";dst_ip_addr="{}";ptf_src_port={};ptf_dst_port={};pfc_queue_idx={}'''.format(
-                dest_mac,
-                dst_ip_addr,
-                ptf_src_port,
-                ptf_dst_port,
-                3)
-    supervisor_conf_content = ('''
-[program:{program_name}]
-command=/root/env-python3/bin/ptf --test-dir /root/ptftests/py3 {program_name}.BG_pkt_sender'''
-                               ''' --platform-dir /root/ptftests/ -t'''
-                               ''' '{script_args}' --relax  --platform remote
-process_name={program_name}
-stdout_logfile=/tmp/{program_name}.out.log
-stderr_logfile=/tmp/{program_name}.err.log
-redirect_stderr=false
-autostart=false
-autorestart=true
-startsecs=1
-numprocs=1
-'''.format(script_args=script_args, program_name=program_name))
-    ptfhost.copy(
-        content=supervisor_conf_content,
-        dest=f'/etc/supervisor/conf.d/{program_name}.conf')
-
-    ptfhost.command('supervisorctl reread')
-    ptfhost.command('supervisorctl update')
-    ptfhost.command(f'supervisorctl start {program_name}')
-
-    yield
-
-    try:
-        ptfhost.command(f'supervisorctl stop {program_name}')
-    except BaseException:
-        pass
-    ptfhost.command(f'supervisorctl remove {program_name}')
-
-
-@pytest.mark.usefixtures('stop_pfcwd', 'storm_test_setup_restore')
+@pytest.mark.usefixtures('stop_pfcwd', 'storm_test_setup_restore', 'start_background_traffic')
 class TestPfcwdAllPortStorm(object):
     """ PFC storm test class """
     def run_test(self, duthost, storm_hndle, expect_regex, syslog_marker, action):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

### Summary:
Recently cisco-8000 pfcwd was changed to not trigger watchdog when there is no traffic. So the pfcwd_timer_accuracy script fails, since there is no watchdog triggered during the test. So in this PR a new fixture is added for cisco-8000 only, that will run a background traffic on the selected port when the timer accuracy test is run.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [X] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?
The pfcwd feature was updated not to trigger watchdog when no traffic is present. So we need a background traffic to make the timer accuracy script to work.
#### How did you do it?
Added a background traffic fixture function, that uses supervisor in the PTF container.

#### How did you verify/test it?
Ran on T0 TB with sonic fanout:
`=============================================================================================== PASSES ===============================================================================================
____________________________________________________________________ TestPfcwdAllPortStorm.test_all_port_storm_restore[mth-t0-64] ____________________________________________________________________
--------------------------------------------- generated xml file: /run_logs/2024-03-25-20-11-56/pfcwd/test_pfcwd_all_port_storm_2024-03-25-20-11-56.xml ----------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
--------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------
20:17:04 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
====================================================================================== short test summary info =======================================================================================
PASSED pfcwd/test_pfcwd_all_port_storm.py::TestPfcwdAllPortStorm::test_all_port_storm_restore[mth-t0-64]
============================================================================== 1 passed, 1 warning in 306.27s (0:05:06) ==============================================================================
sonic@3852cf4ada95:/data/tests$ 
`
#### Any platform specific information?
Specific to cisco-8000 only.