### PR TITLE
Add more information log in pfcwd accuracy case for further debug

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -197,8 +197,8 @@ class TestPfcwdAllTimer(object):
         self.all_detect_time.sort()
         self.all_restore_time.sort()
         logger.info("Verify that real detection time is not greater than configured")
-        logger.info("all_detect_time {}".format(self.all_detect_time))
-        logger.info("all_restore_time {}".format(self.all_restore_time))
+        logger.info("all detect time {}".format(self.all_detect_time))
+        logger.info("all restore time {}".format(self.all_restore_time))
         config_detect_time = self.timers['pfc_wd_detect_time'] + self.timers['pfc_wd_poll_time']
         err_msg = ("Real detection time is greater than configured: Real detect time: {} "
                    "Expected: {} (wd_detect_time + wd_poll_time)".format(self.all_detect_time[9],

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -197,6 +197,8 @@ class TestPfcwdAllTimer(object):
         self.all_detect_time.sort()
         self.all_restore_time.sort()
         logger.info("Verify that real detection time is not greater than configured")
+        logger.info("all_detect_time {}".format(self.all_detect_time))
+        logger.info("all_restore_time {}".format(self.all_restore_time))
         config_detect_time = self.timers['pfc_wd_detect_time'] + self.timers['pfc_wd_poll_time']
         err_msg = ("Real detection time is greater than configured: Real detect time: {} "
                    "Expected: {} (wd_detect_time + wd_poll_time)".format(self.all_detect_time[9],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
27262192

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The test_pfcwd_timer_accuracy failed due to "Failed: Real detection time is greater than configured: Real detect time: 1015 Expected: 800 (wd_detect_time + wd_poll_time)"

#### How did you do it?
Add more information in the log, to monitor the status if hit the issue during the nightly build.

#### How did you verify/test it?
Locally run

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
