### PR TITLE
fdb aging time expired

### DIFF
--- a/tests/fdb/test_fdb_mac_expire.py
+++ b/tests/fdb/test_fdb_mac_expire.py
@@ -228,7 +228,7 @@ class TestFdbMacExpire:
 
         logger.info("wait for FDB aging time of '{0}' secs".format(fdbAgingTime))
         time.sleep(fdbAgingTime)
-        #increasing the polling interval for cisco devices
+        # increasing the polling interval for cisco devices
         time.sleep(20)
 
         count = 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
name="testFdbMacExpire[disable_refresh]"
failure message="Failed: Failed! MAC did not expire after expected FDB aging time expired"
name="testFdbMacExpire[refresh_with_dest_mac]"
failure message="Failed: Failed! MAC did not expire after expected FDB aging time expired"
Logs: /auto/sonic-logs/crocodile-T0/6266/t0_croc_6266_nightly/fdb

Summary:
Fixes # (issue)
The test updates fdb_aging_time value, restarts swssconfig in order to pickup the new value, populated the FDB table with dummy MAC entry, and then waits for fdb_aging_time and makes sure FDB entry with dummy MAC is cleared.

Found by multiple test performed, that the aging time is not sufficient to clear the dummy MAC entries. So, increasing the polling interval for Cisco devices

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
