### PR TITLE
Fix snmp_pdu_controllers.py cannot handle outlet power null string

### DIFF
--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -231,7 +231,8 @@ class snmpPduController(PduControllerBase):
             current_val = str(val)
             port_oid = current_oid.replace(self.PORT_POWER_BASE_OID, '')
             if port_oid == port_id:
-                status['output_watts'] = 0 if current_val == "" else current_val
+                if current_val != "":
+                    status['output_watts'] = current_val
                 return
 
     def _get_one_outlet_status(self, cmdGen, snmp_auth, port_id):

--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -231,7 +231,7 @@ class snmpPduController(PduControllerBase):
             current_val = str(val)
             port_oid = current_oid.replace(self.PORT_POWER_BASE_OID, '')
             if port_oid == port_id:
-                status['output_watts'] = current_val
+                status['output_watts'] = 0 if current_val == "" else current_val
                 return
 
     def _get_one_outlet_status(self, cmdGen, snmp_auth, port_id):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes snmp_pdu_controolers.py cannot handle outlet power null string

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Testcase will fail if outlet power string is null.

#### How did you do it?
Do NOT return output_watts if outlet power string is null.

#### How did you verify/test it?
By running devutils, if the PDU cannot provide watts value, snmp_pdu_controllers.py return items without output_watts.
```
[
    {
        "Host": "strtk5-s6100-acs-5",
        "PSU status": {
            "PSU1": {
                "power_on": true,
                "output_watts": "N/A"
            },
            "PSU2": {
                "power_on": true,
                "output_watts": "N/A"
            }
        },
        "PDU status": [
            {
                "outlet_id": ".1.1.37",
                "outlet_on": true,
                "pdu_name": "pdu-229",
                "psu_name": "PSU1",
                "feed_name": "N/A"
            },
            {
                "outlet_id": ".1.1.36",
                "outlet_on": true,
                "pdu_name": "pdu-230",
                "psu_name": "PSU2",
                "feed_name": "N/A"
            }
        ],
        "Summary": [],
        "Action": "status"
    }
]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
