### PR TITLE
Update test_tagged_arp script to do a PTF interface reset after test

### DIFF
--- a/tests/arp/test_tagged_arp.py
+++ b/tests/arp/test_tagged_arp.py
@@ -12,9 +12,10 @@ from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_add       
 from tests.common.helpers.backend_acl import apply_acl_rules, bind_acl_table        # noqa F401
 from tests.common.fixtures.duthost_utils import ports_list   # noqa F401
 from tests.common.helpers.portchannel_to_vlan import setup_acl_table  # noqa F401
-from tests.common.helpers.portchannel_to_vlan import acl_rule_cleanup # noqa F401
+from tests.common.helpers.portchannel_to_vlan import acl_rule_cleanup  # noqa F401
 from tests.common.helpers.portchannel_to_vlan import vlan_intfs_dict  # noqa F401
 from tests.common.helpers.portchannel_to_vlan import setup_po2vlan    # noqa F401
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses   # noqa F401
 from tests.common.helpers.portchannel_to_vlan import running_vlan_ports_list
 
 logger = logging.getLogger(__name__)
@@ -61,7 +62,7 @@ def arp_cleanup(duthost):
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_arp(duthosts, rand_one_dut_hostname, ptfhost, rand_selected_dut, ptfadapter,
-                ports_list, tbinfo, vlan_intfs_dict, setup_acl_table, setup_po2vlan, cfg_facts): # noqa F811
+                ports_list, tbinfo, vlan_intfs_dict, setup_acl_table, setup_po2vlan, cfg_facts):  # noqa F811
     duthost = duthosts[rand_one_dut_hostname]
     # --------------------- Setup -----------------------
     try:
@@ -90,7 +91,7 @@ def build_arp_packet(vlan_id, neighbor_mac, dst_mac, neighbor_ip):
 @pytest.mark.bsl
 @pytest.mark.po2vlan
 def test_tagged_arp_pkt(ptfadapter, duthosts, rand_one_dut_hostname,
-                        rand_selected_dut, tbinfo, ports_list): # noqa F811
+                        rand_selected_dut, tbinfo, ports_list):  # noqa F811
     """
     Send tagged GARP packets from each port.
     Verify packets egress without tag from ports whose PVID same with ingress port.
@@ -105,9 +106,9 @@ def test_tagged_arp_pkt(ptfadapter, duthosts, rand_one_dut_hostname,
         # Send GARP packets to switch to populate the arp table with dummy MACs for each port
         # Totally 10 dummy MACs for each port, send 1 packet for each dummy MAC
         # ARP table will be cleaned up before each iteration, so there won't be any conflict MAC and IP
-        dummy_macs = ['{}:{:02x}:{:02x}'.format(DUMMY_MAC_PREFIX, port_index & 0xFF, i+1)
+        dummy_macs = ['{}:{:02x}:{:02x}'.format(DUMMY_MAC_PREFIX, port_index & 0xFF, i + 1)
                       for i in range(DUMMY_ARP_COUNT)]
-        dummy_ips = ['{}.{:d}.{:d}'.format(DUMMY_IP_PREFIX, port_index & 0xFF, i+1)
+        dummy_ips = ['{}.{:d}.{:d}'.format(DUMMY_IP_PREFIX, port_index & 0xFF, i + 1)
                      for i in range(DUMMY_ARP_COUNT)]
         for permit_vlanid in map(int, vlan_port["permit_vlanid"]):
             logger.info('Test ARP: interface %s, VLAN %u' % (vlan_port["dev"], permit_vlanid))


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1. There is a module level autoused fixture setup_po2vlan, it is invoked in tests/arp/test_tagged_arp.py. It would created a lag interface at PTF called bond1.

2. The lag interface bond1 have 2 members, eth0 and eth5. And it shared the same ipv6 address with eth0:

```
bond1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.8.2  netmask 255.255.255.0  broadcast 0.0.0.0
        inet6 fe80::1e34:daff:fe73:8000  prefixlen 64  scopeid 0x20<link>
        ether 1c:34:da:73:80:00  txqueuelen 1000  (Ethernet)
        RX packets 15  bytes 3008 (2.9 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 11  bytes 866 (866.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet6 fe80::1e34:daff:fe73:8000  prefixlen 64  scopeid 0x20<link>
        ether 1c:34:da:73:80:00  txqueuelen 1000  (Ethernet)
        RX packets 1203  bytes 149531 (146.0 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 336  bytes 27764 (27.1 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```

3. In the tear down step. the fixture would remove the lag members and then remove the lag interface bond1. But it did not flap the eth0 in the final. It lead to the nd entry for fe80::1e34:daff:fe73:8000 not back to eth0.

And this situation happens with around 30% percentage. Then the eth0 would not respond to the ND request for this address.
Then if the test script running after test_tagged_arp is depending ND learning from PTF eth0, then the case would failure due to no ND reply from PTF eth0.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Test enhancement for script test_tagged_arp.
#### How did you do it?
Invoke a existing fixture to do a PTF interface reset.
#### How did you verify/test it?
Internal regression
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
