### PR TITLE
Add skip to test_device_checker

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1399,6 +1399,12 @@ syslog/test_syslog_source_ip.py:
 #######################################
 #####         system_health       #####
 #######################################
+system_health/test_system_health.py::test_device_checker:
+  skip:
+    reason: "Test not supported on Mellanox platforms"
+    conditions:
+      - "asic_type in ['mellanox']"
+
 system_health/test_system_health.py::test_service_checker_with_process_exit:
   xfail:
     strict: True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
On Mellanox basic we read asic temperature from sdk sysfs rather than /run/hw-management/thermal/asic

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [X] 202311

### Approach

#### What is the motivation for this PR?
Test is no longer supported on mellanox asic because asic temperature is read from sdk sysfs rather than /run/hw-management/thermal/asic

#### How did you do it?
Added a skip

#### How did you verify/test it?
Check test is skipped

#### Any platform specific information?
no
