### PR TITLE
fixing bgp/test_traffic_shift_sup.py harcoded for admin user. issue#12195

### DIFF
--- a/tests/bgp/test_traffic_shift_sup.py
+++ b/tests/bgp/test_traffic_shift_sup.py
@@ -58,9 +58,9 @@ class TestTrafficShiftOnSup:
                      "ssh {}@{} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'".format(
                          self.dutuser, self.dutip),
                      timeout=300)
-            client.expect(["admin@{}'s password:".format(self.dutip)])
+            client.expect(["{}@{}'s password:".format(self.dutuser, self.dutip)])
             client.sendline(self.dutpass)
-            client.expect("admin*")
+            client.expect("{}*".format(self.dutuser))
             client.sendline(cmd)
             client.expect("Password .*")
             client.sendline(self.dutpass)


### PR DESCRIPTION

### Description of PR
bgp/test_traffic_shift_sup.py harcoded for admin user, does not work for non admin sonic_admin_user

client.expect(["admin@{}'s password:".format(self.dutip)]) <<<<< hardcoded as admin
client.sendline(self.dutpass)
client.expect("admin*") <<<<< hardcoded as admin
client.sendline(cmd)
client.expect("Password .*")
client.sendline(self.dutpass)

Summary:
Fixes # 12195

### Type of change
Fix is to use sonic_admin_user creds in expect expression match.

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [X] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?
Fix is failing sonic-mgmt tests where user is not admin.

#### How did you verify/test it?
Ran sonic-mgmt test  bgp/test_traffic_shift_sup.py  to validate

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
N/A