### PR TITLE
Fixing global_pause attribute and speed typecasting

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -549,7 +549,7 @@ def snappi_dut_base_config(duthost_list,
                         for i, sp in enumerate(snappi_ports) if sp['location'] in tgen_ports]
     pytest_assert(len(set([sp['speed'] for sp in new_snappi_ports])) == 1, 'Ports have different link speeds')
     [config.ports.port(name='Port {}'.format(sp['port_id']), location=sp['location']) for sp in new_snappi_ports]
-    speed_gbps = int(new_snappi_ports[0]['speed'])/1000
+    speed_gbps = int(int(new_snappi_ports[0]['speed'])/1000)
 
     config.options.port_options.location_preemption = True
     l1_config = config.layer1.layer1()[-1]

--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -225,13 +225,14 @@ def run_pfc_test(api,
     time.sleep(1)
 
     """ Run traffic """
-    tgen_flow_stats, switch_flow_stats = run_traffic(duthost=duthost,
-                                                     api=api,
-                                                     config=testbed_config,
-                                                     data_flow_names=data_flow_names,
-                                                     all_flow_names=all_flow_names,
-                                                     exp_dur_sec=DATA_FLOW_DURATION_SEC + data_flow_delay_sec,
-                                                     snappi_extra_params=snappi_extra_params)
+    tgen_flow_stats, switch_flow_stats, in_flight_flow_metrics = run_traffic(duthost=duthost,
+                                                                             api=api,
+                                                                             config=testbed_config,
+                                                                             data_flow_names=data_flow_names,
+                                                                             all_flow_names=all_flow_names,
+                                                                             exp_dur_sec=DATA_FLOW_DURATION_SEC +
+                                                                             data_flow_delay_sec,
+                                                                             snappi_extra_params=snappi_extra_params)
 
     # Reset pfc delay parameter
     pfc = testbed_config.layer1[0].flow_control.ieee_802_1qbb
@@ -239,8 +240,8 @@ def run_pfc_test(api,
 
     # Verify PFC pause frames
     if valid_pfc_frame_test:
-        is_valid_pfc_frame = validate_pfc_frame(snappi_extra_params.packet_capture_file + ".pcapng")
-        pytest_assert(is_valid_pfc_frame, "PFC frames invalid")
+        is_valid_pfc_frame, error_msg = validate_pfc_frame(snappi_extra_params.packet_capture_file + ".pcapng")
+        pytest_assert(is_valid_pfc_frame, error_msg)
         return
 
     # Verify pause flows
@@ -277,7 +278,7 @@ def run_pfc_test(api,
     if test_traffic_pause:
         # Verify in flight TX packets count relative to switch buffer size
         verify_in_flight_buffer_pkts(duthost=duthost,
-                                     flow_metrics=tgen_flow_stats,
+                                     flow_metrics=in_flight_flow_metrics,
                                      snappi_extra_params=snappi_extra_params)
     else:
         # Verify zero pause frames are counted when the PFC class enable vector is not set

--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -103,7 +103,7 @@ def run_pfc_test(api,
                                                                      port_id=port_id)
 
     speed_str = testbed_config.layer1[0].speed
-    speed_gbps = int(speed_str.split('_')[1])
+    speed_gbps = int(float(speed_str.split('_')[1]))
 
     if snappi_extra_params.headroom_test_params is not None:
         DATA_FLOW_DURATION_SEC += 10
@@ -264,6 +264,7 @@ def run_pfc_test(api,
     # Verify PFC pause frame count on the DUT
     verify_pause_frame_count_dut(duthost=duthost,
                                  test_traffic_pause=test_traffic_pause,
+                                 global_pause=global_pause,
                                  snappi_extra_params=snappi_extra_params)
 
     # Verify in flight TX lossless packets do not leave the DUT when traffic is expected


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fixing the collateral caused by https://github.com/sonic-net/sonic-mgmt/pull/11400 and the speed mode typecasting to int
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Fixing the collateral caused by https://github.com/sonic-net/sonic-mgmt/pull/11400 and the speed mode typecasting to int
#### How did you do it?

#### How did you verify/test it?
added the global_pause attribute to verify_pause_frame_count_dut fixture in multidut_helper file
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
