### PR TITLE
Add ipv6 only mgmt TACACS test case

### DIFF
--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -6,6 +6,7 @@ from tests.bgp.test_bgp_fact import run_bgp_facts
 from tests.test_features import run_show_features
 from tests.tacacs.test_ro_user import ssh_remote_run
 from tests.common.helpers.assertions import pytest_require
+from tests.tacacs.conftest import tacacs_creds, check_tacacs_v6 # noqa F401
 from tests.syslog.test_syslog import run_syslog, check_default_route # noqa F401
 from tests.common.fixtures.duthost_utils import convert_and_restore_config_db_to_ipv6_only  # noqa F401
 
@@ -98,9 +99,6 @@ def test_ro_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutipv6 = get_mgmt_ipv6(duthost)
 
-    if not dutipv6:
-        pytest.skip("Skip IPv6 only test, DUT has no mgmt IPv6.")
-
     res = ssh_remote_run(localhost, dutipv6, tacacs_creds['tacacs_ro_user'],
                          tacacs_creds['tacacs_ro_user_passwd'], 'cat /etc/passwd')
     check_output(res, 'test', 'remote_user')
@@ -110,9 +108,6 @@ def test_rw_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname
                            convert_and_restore_config_db_to_ipv6_only): # noqa F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutipv6 = get_mgmt_ipv6(duthost)
-
-    if not dutipv6:
-        pytest.skip("Skip IPv6 only test, DUT has no mgmt IPv6.")
 
     res = ssh_remote_run(localhost, dutipv6, tacacs_creds['tacacs_rw_user'],
                          tacacs_creds['tacacs_rw_user_passwd'], "cat /etc/passwd")

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -1,15 +1,32 @@
 import pytest
 
+from netaddr import valid_ipv6
+from tests.tacacs.utils import check_output
 from tests.bgp.test_bgp_fact import run_bgp_facts
 from tests.test_features import run_show_features
+from tests.tacacs.test_ro_user import ssh_remote_run
 from tests.common.helpers.assertions import pytest_require
 from tests.syslog.test_syslog import run_syslog, check_default_route # noqa F401
 from tests.common.fixtures.duthost_utils import convert_and_restore_config_db_to_ipv6_only  # noqa F401
 
 pytestmark = [
+    pytest.mark.disable_loganalyzer,
     pytest.mark.topology('any'),
     pytest.mark.device_type('vs')
 ]
+
+
+def get_mgmt_ipv6(duthost):
+    config_facts = duthost.get_running_config_facts()
+    mgmt_interfaces = config_facts.get("MGMT_INTERFACE", {})
+    mgmt_ipv6 = None
+
+    for mgmt_interface, ip_configs in mgmt_interfaces.items():
+        for ip_addr_with_prefix in ip_configs.keys():
+            ip_addr = ip_addr_with_prefix.split("/")[0]
+            if valid_ipv6(ip_addr):
+                mgmt_ipv6 = ip_addr
+    return mgmt_ipv6
 
 
 def test_bgp_facts_ipv6_only(duthosts, enum_frontend_dut_hostname, enum_asic_index,
@@ -47,3 +64,29 @@ def test_image_download_ipv6_only(creds, duthosts, enum_dut_hostname,
 def test_syslog_ipv6_only(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b,
                           check_default_route, convert_and_restore_config_db_to_ipv6_only): # noqa F811
     run_syslog(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b, check_default_route)
+
+
+def test_ro_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs_v6,
+                           convert_and_restore_config_db_to_ipv6_only): # noqa F811
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutipv6 = get_mgmt_ipv6(duthost)
+
+    if not dutipv6:
+        pytest.skip("Skip IPv6 only test, DUT has no mgmt IPv6.")
+
+    res = ssh_remote_run(localhost, dutipv6, tacacs_creds['tacacs_ro_user'],
+                         tacacs_creds['tacacs_ro_user_passwd'], 'cat /etc/passwd')
+    check_output(res, 'test', 'remote_user')
+
+
+def test_rw_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs_v6,
+                           convert_and_restore_config_db_to_ipv6_only): # noqa F811
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutipv6 = get_mgmt_ipv6(duthost)
+
+    if not dutipv6:
+        pytest.skip("Skip IPv6 only test, DUT has no mgmt IPv6.")
+
+    res = ssh_remote_run(localhost, dutipv6, tacacs_creds['tacacs_rw_user'],
+                         tacacs_creds['tacacs_rw_user_passwd'], "cat /etc/passwd")
+    check_output(res, 'testadmin', 'remote_user_su')

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -94,8 +94,8 @@ def test_syslog_ipv6_only(rand_selected_dut, dummy_syslog_server_ip_a, dummy_sys
     run_syslog(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b, check_default_route)
 
 
-def test_ro_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs_v6,
-                           convert_and_restore_config_db_to_ipv6_only): # noqa F811
+def test_ro_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname,
+                           tacacs_creds, check_tacacs_v6, convert_and_restore_config_db_to_ipv6_only): # noqa F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutipv6 = get_mgmt_ipv6(duthost)
 
@@ -104,8 +104,8 @@ def test_ro_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname
     check_output(res, 'test', 'remote_user')
 
 
-def test_rw_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs_v6,
-                           convert_and_restore_config_db_to_ipv6_only): # noqa F811
+def test_rw_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname,
+                           tacacs_creds, check_tacacs_v6, convert_and_restore_config_db_to_ipv6_only): # noqa F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutipv6 = get_mgmt_ipv6(duthost)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
ADO 27109592
Summary: Add ipv6 only mgmt TACACS test case
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
