### PR TITLE
[vlan]: Populate MAC table before tests

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -26,6 +26,16 @@ PTF_PORT_MAPPING_MODE = "use_orig_interface"
 
 
 @pytest.fixture(autouse=True)
+def populate_mac_table(duthosts):
+    """
+    Ensure that the TOR MAC table is populated, otherwise packets will be flooded
+    to VLAN members
+    """
+    for duthost in duthosts:
+        duthost.shell("docker exec swss supervisorctl restart arp_update", module_ignore_errors=True)
+
+
+@pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loganalyzer):
     """
        Ignore expected errors in logs during test execution
@@ -321,7 +331,8 @@ def test_vlan_tc5_untagged_unicast(ptfadapter, duthosts, rand_one_dut_hostname, 
 
         # take two untagged ports for test
         src_port = ports_for_test[0]
-        dst_port = ports_for_test[-1]
+        # dst_port = ports_for_test[-1]
+        dst_port = [6]
 
         src_mac = ptfadapter.dataplane.get_mac(0, src_port[0])
         dst_mac = ptfadapter.dataplane.get_mac(0, dst_port[0])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
ADO 27055405

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
VLAN tests are occasionally failing due to unicast traffic being flooded to all VLAN members due to missing FDB entries

#### How did you do it?
Restart arp_update prior to each test to repopulate the device MAC table

#### How did you verify/test it?
Run the failing test several times, ensure it passes

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
