### PR TITLE
Revert changes of rename and extract dump file in posttest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,8 +182,6 @@ def pytest_addoption(parser):
     #   collect logs option    #
     ############################
     parser.addoption("--collect_db_data", action="store_true", default=False, help="Collect db info if test failed")
-    parser.addoption("--log_dir", action="store", default=None,
-                     help="Log dir name, can be used to put specific logs in a separate directory")
 
     ############################
     #   macsec options         #

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -1,7 +1,6 @@
 import pytest
 import logging
 import time
-import os
 from tests.common.helpers.assertions import pytest_require
 
 logger = logging.getLogger(__name__)
@@ -14,14 +13,11 @@ pytestmark = [
     pytest.mark.skip_check_dut_health
 ]
 
-LOG_SAVE_PATH = 'logs/'
-
 
 def test_collect_techsupport(request, duthosts, enum_dut_hostname):
     since = request.config.getoption("--posttest_show_tech_since")
     if since == '':
         since = 'yesterday'
-    log_dir = request.config.getoption("--log_dir")
     duthost = duthosts[enum_dut_hostname]
     """
     A util for collecting techsupport after tests.
@@ -33,17 +29,11 @@ def test_collect_techsupport(request, duthosts, enum_dut_hostname):
     # Because Jenkins is configured to save artifacts from tests/logs,
     # and this util is mainly designed for running on Jenkins,
     # save path is fixed to logs for now.
+    TECHSUPPORT_SAVE_PATH = 'logs/'
     out = duthost.command("show techsupport --since {}".format(since), module_ignore_errors=True)
     if out['rc'] == 0:
         tar_file = out['stdout_lines'][-1]
-        tar_file_name = tar_file.split('/')[-1]
-        dump_path = LOG_SAVE_PATH + 'dump/'
-        duthost.fetch(src=tar_file, dest=dump_path, flat=True)
-
-        if not log_dir:
-            log_dir = tar_file.split('/')[-1].split('.tar.gz')[0]
-        tar_file_path = os.path.join(dump_path, tar_file_name)
-        os.rename(tar_file_path, os.path.join(dump_path, log_dir + '.tar.gz'))
+        duthost.fetch(src=tar_file, dest=TECHSUPPORT_SAVE_PATH, flat=True)
 
     assert True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
In PR https://github.com/sonic-net/sonic-mgmt/pull/11993, dump file would be extracted in posttest, but the behavior of extract should not be included in a testcase
#### How did you do it?
Rename and extract in elastictest
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
