### PR TITLE
Set the RTC from the system time after NTP sync during deploy-mg

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -556,6 +556,11 @@
             async: 60
             poll: 10
 
+          - name: Set the RTC from the system time
+            become: true
+            command: hwclock --systohc
+            ignore_errors: true
+
           - name: Start ntp.service on DUT
             become: true
             service: name=ntp state=restarted enabled=true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
SONiC currently does not support NTP long jump. In case there is a big difference between RTC and NTP server's time, the NTP service may long time to have system time synched with NTP server.

During deploy-mg, there are steps to force sync DUT's system time to NTP server. However, during tests, the DUT may be power-cycled. After power cycle, RTC time will be used as system time. In case the difference between RTC and NTP server is too big, the system time of DUT may be inaccurate because NTP long jump is not supported yet.

#### How did you do it?
This change added a step to set system time to RTC after system time is force synched with NTP server during deploy minigraph.

With this change, the time difference between DUT and NTP server won't be too big after DUT is power-cycled.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
