### PR TITLE
[multi-password] Add action plugin to get the hash of currently used password

### DIFF
--- a/ansible/plugins/action/current_password.py
+++ b/ansible/plugins/action/current_password.py
@@ -9,6 +9,7 @@ import sys
 if sys.version_info[0] >= 3:
     unicode = str
 
+
 class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):

--- a/ansible/plugins/action/current_password.py
+++ b/ansible/plugins/action/current_password.py
@@ -1,0 +1,27 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+
+import sys
+
+# If the version of the Python interpreter is greater or equal to 3, set the unicode variable to the str class.
+if sys.version_info[0] >= 3:
+    unicode = str
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = {}
+        super(ActionModule, self).run(tmp, task_vars)
+        module_args = self._task.args.copy()
+        self._connection.reset()
+        module_return = self._execute_module(
+            module_name='command',
+            module_args=module_args,
+            task_vars=task_vars,
+            tmp=tmp
+        )
+        module_return["current_password_hash"] = self._connection.get_option("current_password_hash")
+        return module_return

--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -1,3 +1,4 @@
+import hashlib
 import imp
 import logging
 import os
@@ -63,7 +64,11 @@ def _password_retry(func):
             self.set_option("password", conn_password)
             self._play_context.password = conn_password
             try:
-                return func(self, *args, **kwargs)
+                results = func(self, *args, **kwargs)
+                if not self.has_option("current_password_hash"):
+                    digest = hashlib.sha256(conn_password.encode()).hexdigest()
+                    self.set_option("current_password_hash", digest)
+                return results
             except AnsibleAuthenticationFailure:
                 # if there is no more altpassword to try, raise
                 if not conn_passwords:

--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -65,7 +65,7 @@ def _password_retry(func):
             self._play_context.password = conn_password
             try:
                 results = func(self, *args, **kwargs)
-                if not self.has_option("current_password_hash"):
+                if "current_password_hash" not in self._options:
                     digest = hashlib.sha256(conn_password.encode()).hexdigest()
                     self.set_option("current_password_hash", digest)
                 return results


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The multi_password_ssh plugin enhanced the ansible ssh plugin to support trying multiple passwords.
In case we need to know which password is used, some enhancement is required.

#### How did you do it?
This change enhanced the multi_password_ssh plugin to store the hash of current password in its options. 
A new action plugin "current_password" is added to run a command module and try to get the stored hash 
of current password. The hash of current password will be added to the module's result.

#### How did you verify/test it?
Tested with playbook like below:
```
- hosts: sonic
  gather_facts: no
  tasks:

  - name: Run command
    action: current_password
    args:
      argv: ["whoami"]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
