### PR TITLE
sonic-mgmt: Use yaml.safe_load

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -999,7 +999,7 @@ def main():
     # Load Data
     print("LOADING PROCESS STARTED")
     print("LOADING: " + args.i)
-    doc = yaml.load(open(args.i, 'r'))
+    doc = yaml.safe_load(open(args.i, 'r'))
     # dictionary contains information about devices
     devices = dict()
     generateDictionary(doc, devices, "devices")             # load devices


### PR DESCRIPTION
### Description of PR
Summary:
Fixes deprecation of yaml.load. In python3 yaml.load is deprecated and requires a new Loader parameter. In python2 this script was able to run and just printed a deprecation warning.

Fix is to switch to use yaml.safe_load.

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?
In python3 yaml.load is deprecated and requires a new Loader parameter. In python2 this script was able to run and just printed a deprecation warning.

#### How did you do it?
Fix is to switch to use yaml.safe_load.

#### How did you verify/test it?
Ran full test runs internally with this fix applied

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA