### PR TITLE
Fix testQosSaiHeadroomPoolSize on Mellanox T1 in dualtor deployment

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -790,7 +790,8 @@ class TestQosSai(QosSaiBase):
         if not qosConfig['hdrm_pool_size'].get('src_port_ids', None):
             pytest.skip("No enough test ports on this DUT")
 
-        if not dutConfig['dualTor']:
+        # run 4 pgs and 4 dscps test for dualtor and T1 dualtor scenario
+        if not dutConfig['dualTor'] and not dutConfig['dualTorScenario']:
             qosConfig['hdrm_pool_size']['pgs'] = qosConfig['hdrm_pool_size']['pgs'][:2]
             qosConfig['hdrm_pool_size']['dscps'] = qosConfig['hdrm_pool_size']['dscps'][:2]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The PR is to fix `testQosSaiHeadroomPoolSize` on Mellanox T1 in dualtor deployment.
The test was failing because the 4 lossless pgs/queues are enabled on Mellanox-SN4600 T1 platform, but the test is still running in 2 lossless pgs/queues mode as `qos_dual_tor` option is set.
To workaroud, we checked the `tunnel_qos_remap` flag in the DUT, and enable 4 loss_less pgs/queues test on Mellanox T1 platform.  

Summary:
Fixes  `testQosSaiHeadroomPoolSize` on Mellanox T1 in dualtor deployment.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
The PR is to fix `testQosSaiHeadroomPoolSize` on Mellanox T1 in dualtor deployment.

#### How did you do it?
Check the `tunnel_qos_remap` flag in the DUT, and enable 4 loss_less pgs/queues test on Mellanox T1 platform.  

#### How did you verify/test it?
Verified on a physical testbed, with `tunnel_qos_remap` enabled.
```
collecting 3 items                                                                                                                                                                                    
collected 3 items                                                                                                                                                                                     

qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[single_asic]  ^H ^H ^H ^H^[PASSED                                                                                                                 [ 33%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[single_dut_multi_asic]  ^HSKIPPED (single_dut_multi_asic is not supported on T0 topologies)                                            [ 66%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[multi_dut] SKIPPED (multi-dut is not supported on T0 topologies)                                                                    [100%]
```
#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
