### PR TITLE
Revert rename and extract dump in posttest in 202012

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,12 +171,6 @@ def pytest_addoption(parser):
     parser.addoption("--loop_times", metavar="LOOP_TIMES", action="store", default=1, type=int,
                      help="Define the loop times of the test")
 
-    ############################
-    #   collect logs option    #
-    ############################
-    parser.addoption("--log_dir", action="store", default=None,
-                     help="Log dir name, can be used to put specific logs in a separate directory")
-
 
 @pytest.fixture(scope="session", autouse=True)
 def enhance_inventory(request):

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -1,10 +1,6 @@
 import pytest
 import logging
 import time
-import os
-import glob
-import tarfile
-import gzip
 from tests.common.helpers.assertions import pytest_require
 
 logger = logging.getLogger(__name__)
@@ -17,51 +13,11 @@ pytestmark = [
     pytest.mark.skip_check_dut_health
 ]
 
-LOG_SAVE_PATH = 'logs/'
-
-
-def extract_tar_gz_file(tar_file_path, extract_path):
-    logger.info("Extracting {} to {}".format(tar_file_path, extract_path))
-    with tarfile.open(tar_file_path, 'r') as tar:
-        members = tar.getmembers()
-        for member in members:
-            try:
-                logger.info("Extract {}".format(member.name))
-                tar.extract(member, path=extract_path)
-            except Exception as e:
-                logger.info("Error extracting {}: {}".format(member.name, e))
-
-
-def extract_gz_file(gz_file_path):
-    extracted_file_path = os.path.splitext(gz_file_path)[0]
-    logger.info("Extracting {} to {}".format(gz_file_path, extracted_file_path))
-    with gzip.open(gz_file_path, 'rb') as f_in:
-        with open(extracted_file_path, 'wb') as f_out:
-            f_out.write(f_in.read())
-    os.remove(gz_file_path)
-
-
-def extract_dump_and_syslog(tar_file_path, dump_path, dir_name):
-    logger.info("Extracting tar.gz dump file {}".format(tar_file_path))
-    extract_tar_gz_file(tar_file_path, dump_path)
-    # rename dump folder
-    os.rename(tar_file_path.split('.tar.gz')[0], os.path.join(dump_path, dir_name))
-    # renmae .tar.gz dump file
-    os.rename(tar_file_path, os.path.join(dump_path, dir_name + '.tar.gz'))
-
-    syslog_path = dump_path + dir_name + '/log/'
-    syslog_gz_files = glob.glob(os.path.join(syslog_path, 'syslog*.gz'))
-    logger.info("Extracting syslog gz files: {}".format(syslog_gz_files))
-    if len(syslog_gz_files) > 0:
-        for syslog_gz in syslog_gz_files:
-            extract_gz_file(syslog_gz)
-
 
 def test_collect_techsupport(request, duthosts, enum_dut_hostname):
     since = request.config.getoption("--posttest_show_tech_since")
     if since == '':
         since = 'yesterday'
-    log_dir = request.config.getoption("--log_dir")
     duthost = duthosts[enum_dut_hostname]
     """
     A util for collecting techsupport after tests.
@@ -73,18 +29,11 @@ def test_collect_techsupport(request, duthosts, enum_dut_hostname):
     # Because Jenkins is configured to save artifacts from tests/logs,
     # and this util is mainly designed for running on Jenkins,
     # save path is fixed to logs for now.
+    TECHSUPPORT_SAVE_PATH = 'logs/'
     out = duthost.command("show techsupport --since {}".format(since), module_ignore_errors=True)
     if out['rc'] == 0:
         tar_file = out['stdout_lines'][-1]
-        tar_file_name = tar_file.split('/')[-1]
-        dump_path = LOG_SAVE_PATH + 'dump/'
-        duthost.fetch(src=tar_file, dest=dump_path, flat=True)
-
-        if not log_dir:
-            log_dir = tar_file.split('/')[-1].split('.tar.gz')[0]
-        tar_file_path = os.path.join(dump_path, tar_file_name)
-        logger.info("tar_file_path: {}, dump_path: {}".format(tar_file_path, dump_path))
-        extract_dump_and_syslog(tar_file_path, dump_path, log_dir)
+        duthost.fetch(src=tar_file, dest=TECHSUPPORT_SAVE_PATH, flat=True)
 
     assert True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
In PR https://github.com/sonic-net/sonic-mgmt/pull/12193, dump file would be extracted in posttest, but the behavior of extract should not be included in a testcase
#### How did you do it?
Rename and extract in elastictest
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
