### PR TITLE
Fixing TypeError: get_RIB_IN_capacity() missing 1 required positional…

### DIFF
--- a/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
@@ -511,7 +511,7 @@ def get_convergence_for_local_link_failover(cvg_api,
             for flow in flows:
                 tx_frate.append(flow.frames_tx_rate)
                 rx_frate.append(flow.frames_rx_rate)
-            assert abs(sum(tx_frate) - sum(rx_frate)) < 500,\
+            assert abs(sum(tx_frate) - sum(rx_frate)) < 500, \
                 "Traffic has not converged after link flap: TxFrameRate:{},RxFrameRate:{}"\
                 .format(sum(tx_frate), sum(rx_frate))
             logger.info("Traffic has converged after link flap")
@@ -608,7 +608,7 @@ def get_convergence_for_remote_link_failover(cvg_api,
             for flow in flows:
                 tx_frate.append(flow.frames_tx_rate)
                 rx_frate.append(flow.frames_rx_rate)
-            assert abs(sum(tx_frate) - sum(rx_frate)) < 500,\
+            assert abs(sum(tx_frate) - sum(rx_frate)) < 500, \
                 "Traffic has not converged after lroute withdraw TxFrameRate:{},RxFrameRate:{}"\
                 .format(sum(tx_frate), sum(rx_frate))
             logger.info("Traffic has converged after route withdraw")
@@ -709,7 +709,7 @@ def get_rib_in_convergence(cvg_api,
         for flow in flows:
             tx_frate.append(flow.frames_tx_rate)
             rx_frate.append(flow.frames_rx_rate)
-        assert abs(sum(tx_frate) - sum(rx_frate)) < 500,\
+        assert abs(sum(tx_frate) - sum(rx_frate)) < 500, \
             "Traffic has not convergedv, TxFrameRate:{},RxFrameRate:{}"\
             .format(sum(tx_frate), sum(rx_frate))
         logger.info("Traffic has converged after route advertisement")
@@ -750,7 +750,6 @@ def get_RIB_IN_capacity(cvg_api,
                         multipath,
                         start_value,
                         step_value,
-                        number_of_routes,
                         route_type,
                         port_speed,):
     """
@@ -828,7 +827,7 @@ def get_RIB_IN_capacity(cvg_api,
                 route_range = bgpv4_peer.v4_routes.add(
                     name="Network_Group%d" % i)
                 route_range.addresses.add(
-                    address='200.1.0.1', prefix=32, count=number_of_routes)
+                    address='200.1.0.1', prefix=32, count=routes)
                 as_path = route_range.as_path
                 as_path_segment = as_path.segments.add()
                 as_path_segment.type = as_path_segment.AS_SEQ
@@ -874,7 +873,7 @@ def get_RIB_IN_capacity(cvg_api,
                 route_range = bgpv6_peer.v6_routes.add(
                     name="Network Group %d" % i)
                 route_range.addresses.add(
-                    address='3000::1', prefix=64, count=number_of_routes)
+                    address='3000::1', prefix=64, count=routes)
                 as_path = route_range.as_path
                 as_path_segment = as_path.segments.add()
                 as_path_segment.type = as_path_segment.AS_SEQ
@@ -918,15 +917,18 @@ def get_RIB_IN_capacity(cvg_api,
 
     try:
         for j in range(start_value, 100000000000, step_value):
+            max_routes = start_value
             tx_frate, rx_frate = [], []
             run_traffic(j)
             flow_stats = get_flow_stats(cvg_api)
+            logger.info('\n')
             logger.info('Loss% : {}'.format(flow_stats[0].loss))
             for flow in flow_stats:
                 tx_frate.append(flow.frames_tx_rate)
                 rx_frate.append(flow.frames_rx_rate)
             logger.info("Tx Frame Rate : {}".format(tx_frate))
             logger.info("Rx Frame Rate : {}".format(rx_frate))
+            logger.info('\n')
             if float(flow_stats[0].loss) > 0.001:
                 if j == start_value:
                     raise Exception(


### PR DESCRIPTION
… argument: ''port_speed

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fixing the exception TypeError: get_RIB_IN_capacity() missing 1 required positional… while running the test_RIB_IN_capacity
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Fixing the exception TypeError: get_RIB_IN_capacity() missing 1 required positional… while running the test_RIB_IN_capacity
#### How did you do it?
Removed the extra argument port_speed 
#### How did you verify/test it?
Tested on arista dut
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
### Output:
AzDevOps@af2e90842c86:~/sonic-mgmt/tests$ py.test --inventory ../ansible/snappi-sonic --host-pattern sonic-s6100-dut --testbed vms-snappi-sonic --testbed_file ../ansible/testbed.csv --show-capture=stdout --log-cli-level info --showlocals -ra --allow_recover --skip_sanity --disable_loganalyzer snappi_tests/bgp/test_bgp_rib_in_capacity.py 
=================================================================== test session starts ===================================================================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.3.0
ansible: 2.13.13
rootdir: /var/AzDevOps/sonic-mgmt/tests
configfile: pytest.ini
plugins: allure-pytest-2.8.22, ansible-4.0.0, forked-1.6.0, html-4.1.0, metadata-3.0.0, repeat-0.9.3, xdist-1.28.0
collecting ... 
------------------------------------------------------------------- live log collection -------------------------------------------------------------------
16:06:51 __init__.pytest_collection_modifyitems   L0581 INFO   | Available basic facts that can be used in conditional skip:
{
  "topo_type": "ptf",
  "topo_name": "ptf64",
  "testbed": "vms-snappi-sonic"
}
collected 1 item                                                                                                                                          

snappi_tests/bgp/test_bgp_rib_in_capacity.py::test_RIB_IN_capacity[speed_100_gbps-IPv4-10000-20000-2] 
--------------------------------------------------------------------- live log setup ----------------------------------------------------------------------
16:06:51 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
16:06:51 __init__.check_test_completeness         L0152 INFO   | Test has no defined levels. Continue without test completeness checks
16:06:57 ptfhost_utils.run_icmp_responder_session L0239 INFO   | Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
16:06:57 conftest.creds_on_dut                    L0723 INFO   | dut sonic-s6100-dut belongs to groups ['snappi-sonic', 'sonic', 'sonic_dell64_40', 'fanout']
16:06:57 conftest.creds_on_dut                    L0747 INFO   | skip empty var file ../ansible/group_vars/all/corefile_uploader.yml
16:06:57 conftest.creds_on_dut                    L0747 INFO   | skip empty var file ../ansible/group_vars/all/env.yml
16:06:58 conftest.nbrhosts                        L0540 INFO   | No VMs exist for this topology: ptf64
16:06:58 conftest.core_dump_and_config_check      L2052 INFO   | Dumping Disk and Memory Space informataion before test on sonic-s6100-dut
16:06:59 conftest.core_dump_and_config_check      L2056 INFO   | Collecting core dumps before test on sonic-s6100-dut
16:06:59 conftest.core_dump_and_config_check      L2065 INFO   | Collecting running config before test on sonic-s6100-dut
16:07:05 __init__.sanity_check                    L0125 INFO   | Skip sanity check according to command line argument
16:07:05 conftest.generate_params_dut_hostname    L1127 INFO   | Using DUTs ['sonic-s6100-dut'] in testbed 'vms-snappi-sonic'
16:07:05 conftest.rand_one_dut_hostname           L0397 INFO   | Randomly select dut sonic-s6100-dut for testing
16:07:05 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture enable_packet_aging_after_test setup starts --------------------
16:07:05 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture enable_packet_aging_after_test setup ends --------------------
16:07:05 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossless_prio setup starts --------------------
16:07:05 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossless_prio setup ends --------------------
16:07:05 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossy_prio setup starts --------------------
16:07:05 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossy_prio setup ends --------------------
16:07:05 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture start_pfcwd_after_test setup starts --------------------
16:07:05 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture start_pfcwd_after_test setup ends --------------------
16:07:05 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_ip setup starts --------------------
16:07:05 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_ip setup ends --------------------
16:07:05 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_port setup starts --------------------
16:07:05 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_port setup ends --------------------
16:07:05 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture cvg_api setup starts --------------------
16:07:05 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture cvg_api setup ends --------------------
16:07:06 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture tgen_ports setup starts --------------------
16:07:07 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture tgen_ports setup ends --------------------
16:07:07 __init__.loganalyzer                     L0051 INFO   | Log analyzer is disabled
---------------------------------------------------------------------- live log call ----------------------------------------------------------------------
16:07:09 bgp_convergence_helper.duthost_bgp_confi L0234 INFO   | Removing configured IP and IPv6 Address from Ethernet0
16:07:12 bgp_convergence_helper.duthost_bgp_confi L0234 INFO   | Removing configured IP and IPv6 Address from Ethernet4
16:07:15 bgp_convergence_helper.duthost_bgp_confi L0234 INFO   | Removing configured IP and IPv6 Address from Ethernet8
16:07:18 bgp_convergence_helper.duthost_bgp_confi L0247 INFO   | Configuring Ethernet0 to PortChannel1 with IPs 21.1.1.1,2000:1::1
16:07:22 bgp_convergence_helper.duthost_bgp_confi L0247 INFO   | Configuring Ethernet4 to PortChannel2 with IPs 22.1.1.1,2000:2::1
16:07:26 bgp_convergence_helper.duthost_bgp_confi L0247 INFO   | Configuring Ethernet8 to PortChannel3 with IPs 23.1.1.1,2000:3::1
16:07:31 bgp_convergence_helper.duthost_bgp_confi L0274 INFO   | Configuring BGP v4 Neighbor 22.1.1.2
16:07:32 bgp_convergence_helper.duthost_bgp_confi L0274 INFO   | Configuring BGP v4 Neighbor 23.1.1.2
16:07:33 bgp_convergence_helper.run_traffic       L0901 INFO   | |-------------------- RIB-IN Capacity test, No.of Routes : 20000 ----|
16:07:33 connection._warn                         L0246 WARNING| Verification of certificates is disabled
16:07:33 connection._info                         L0243 INFO   | Determining the platform and rest_port using the 10.36.77.63 address...
16:07:33 connection._warn                         L0246 WARNING| Unable to connect to http://10.36.77.63:11009.
16:07:33 connection._info                         L0243 INFO   | Connection established to `https://10.36.77.63:11009 on windows`
16:07:33 connection._info                         L0243 INFO   | Using IxNetwork api server version 9.30.2212.5
16:07:33 connection._info                         L0243 INFO   | User info IxNetwork/ST-REG-VM/8010
16:07:33 snappi_api.info                          L1132 INFO   | snappi-0.9.1
16:07:33 snappi_api.info                          L1132 INFO   | snappi_ixnetwork-0.9.1
16:07:33 snappi_api.info                          L1132 INFO   | ixnetwork_restpy-1.0.64
16:07:33 snappi_api.info                          L1132 INFO   | Config validation 0.005s
16:07:33 snappi_api.info                          L1132 INFO   | Ports configuration 0.048s
16:07:33 snappi_api.info                          L1132 INFO   | Captures configuration 0.026s
16:07:40 snappi_api.info                          L1132 INFO   | Location hosts ready [10.36.78.53] 2.058s
16:07:40 snappi_api.info                          L1132 INFO   | Speed conversion is not require for (port.name, speed) : [('Test_Port_1', 'novusHundredGigNonFanOut'), ('Test_Port_2', 'novusHundredGigNonFanOut')]
16:07:40 snappi_api.info                          L1132 INFO   | Aggregation mode speed change 0.284s
16:07:40 snappi_api.info                          L1132 INFO   | Location configuration 6.496s
16:07:40 snappi_api.info                          L1132 INFO   | Layer1 configuration 0.059s
16:07:41 snappi_api.info                          L1132 INFO   | Lag Configuration 1.048s
16:07:41 snappi_api.info                          L1132 INFO   | Lag Ethernet Configuration 0.139s
16:07:42 snappi_api.info                          L1132 INFO   | Lag Protocol Configuration 0.705s
16:07:42 snappi_api.info                          L1132 INFO   | Convert device config : 0.085s
16:07:42 snappi_api.info                          L1132 INFO   | Create IxNetwork device config : 0.000s
16:07:43 snappi_api.info                          L1132 INFO   | Push IxNetwork device config : 0.867s
16:07:43 snappi_api.info                          L1132 INFO   | Devices configuration 0.962s
16:07:44 snappi_api.info                          L1132 INFO   | Flows configuration 1.292s
16:07:45 snappi_api.info                          L1132 INFO   | Start interfaces 0.400s
16:07:45 bgp_convergence_helper.run_traffic       L0906 INFO   | Starting all protocols ...
16:07:57 snappi_api.info                          L1132 INFO   | Setting protocol state 12.441s
16:07:57 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Protocols To start
16:08:28 bgp_convergence_helper.run_traffic       L0912 INFO   | Starting Traffic
16:08:34 snappi_api.info                          L1132 INFO   | Flows generate/apply 6.151s
16:08:47 snappi_api.info                          L1132 INFO   | Flows clear statistics 13.405s
16:08:47 snappi_api.info                          L1132 INFO   | Captures start 0.000s
16:08:50 snappi_api.info                          L1132 INFO   | Flows start 2.983s
16:08:50 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Traffic To start
16:09:21 bgp_convergence_helper.get_RIB_IN_capaci L0924 INFO   | 

16:09:21 bgp_convergence_helper.get_RIB_IN_capaci L0925 INFO   | Loss% : 0.0
16:09:21 bgp_convergence_helper.get_RIB_IN_capaci L0929 INFO   | Tx Frame Rate : [11973180.0]
16:09:21 bgp_convergence_helper.get_RIB_IN_capaci L0930 INFO   | Rx Frame Rate : [11973180.0]
16:09:21 bgp_convergence_helper.get_RIB_IN_capaci L0931 INFO   | 

16:09:21 bgp_convergence_helper.get_RIB_IN_capaci L0945 INFO   | Stopping Traffic
16:09:26 snappi_api.info                          L1132 INFO   | Flows stop 5.399s
16:09:26 utilities.wait                           L0104 INFO   | Pause 10 seconds, reason: For Traffic To stop
16:09:36 bgp_convergence_helper.run_traffic       L0901 INFO   | |-------------------- RIB-IN Capacity test, No.of Routes : 30000 ----|
16:09:36 snappi_api.info                          L1132 INFO   | Config validation 0.005s
16:09:37 snappi_api.info                          L1132 INFO   | Ports configuration 0.046s
16:09:37 snappi_api.info                          L1132 INFO   | Captures configuration 0.027s
16:09:43 snappi_api.info                          L1132 INFO   | Location hosts ready [10.36.78.53] 2.058s
16:09:43 snappi_api.info                          L1132 INFO   | Speed change not require due to redundant Layer1 config
16:09:43 snappi_api.info                          L1132 INFO   | Aggregation mode speed change 0.007s
16:09:43 snappi_api.info                          L1132 INFO   | Location configuration 6.212s
16:09:43 snappi_api.info                          L1132 INFO   | Layer1 configuration 0.058s
16:09:44 snappi_api.info                          L1132 INFO   | Lag Configuration 1.055s
16:09:44 snappi_api.info                          L1132 INFO   | Lag Ethernet Configuration 0.131s
16:09:45 snappi_api.info                          L1132 INFO   | Lag Protocol Configuration 0.580s
16:09:45 snappi_api.info                          L1132 INFO   | Convert device config : 0.086s
16:09:45 snappi_api.info                          L1132 INFO   | Create IxNetwork device config : 0.000s
16:09:46 snappi_api.info                          L1132 INFO   | Push IxNetwork device config : 0.705s
16:09:46 snappi_api.info                          L1132 INFO   | Devices configuration 0.801s
16:09:46 snappi_api.info                          L1132 INFO   | Flows configuration 0.821s
16:09:47 snappi_api.info                          L1132 INFO   | Start interfaces 0.350s
16:09:47 bgp_convergence_helper.run_traffic       L0906 INFO   | Starting all protocols ...
16:09:54 snappi_api.info                          L1132 INFO   | Setting protocol state 6.892s
16:09:54 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Protocols To start
16:10:24 bgp_convergence_helper.run_traffic       L0912 INFO   | Starting Traffic
16:10:30 snappi_api.info                          L1132 INFO   | Flows generate/apply 6.021s
16:10:43 snappi_api.info                          L1132 INFO   | Flows clear statistics 13.284s
16:10:43 snappi_api.info                          L1132 INFO   | Captures start 0.000s
16:10:46 snappi_api.info                          L1132 INFO   | Flows start 2.636s
16:10:46 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Traffic To start
16:11:16 bgp_convergence_helper.get_RIB_IN_capaci L0924 INFO   | 

16:11:16 bgp_convergence_helper.get_RIB_IN_capaci L0925 INFO   | Loss% : 0.0
16:11:16 bgp_convergence_helper.get_RIB_IN_capaci L0929 INFO   | Tx Frame Rate : [11973180.0]
16:11:16 bgp_convergence_helper.get_RIB_IN_capaci L0930 INFO   | Rx Frame Rate : [11973180.0]
16:11:16 bgp_convergence_helper.get_RIB_IN_capaci L0931 INFO   | 

16:11:16 bgp_convergence_helper.get_RIB_IN_capaci L0945 INFO   | Stopping Traffic
16:11:22 snappi_api.info                          L1132 INFO   | Flows stop 5.371s
16:11:22 utilities.wait                           L0104 INFO   | Pause 10 seconds, reason: For Traffic To stop
16:11:32 bgp_convergence_helper.run_traffic       L0901 INFO   | |-------------------- RIB-IN Capacity test, No.of Routes : 40000 ----|
16:11:32 snappi_api.info                          L1132 INFO   | Config validation 0.005s
16:11:33 snappi_api.info                          L1132 INFO   | Ports configuration 0.046s
16:11:33 snappi_api.info                          L1132 INFO   | Captures configuration 0.026s
16:11:39 snappi_api.info                          L1132 INFO   | Location hosts ready [10.36.78.53] 2.057s
16:11:39 snappi_api.info                          L1132 INFO   | Speed change not require due to redundant Layer1 config
16:11:39 snappi_api.info                          L1132 INFO   | Aggregation mode speed change 0.006s
16:11:39 snappi_api.info                          L1132 INFO   | Location configuration 6.210s
16:11:39 snappi_api.info                          L1132 INFO   | Layer1 configuration 0.058s
16:11:40 snappi_api.info                          L1132 INFO   | Lag Configuration 1.059s
16:11:40 snappi_api.info                          L1132 INFO   | Lag Ethernet Configuration 0.124s
16:11:41 snappi_api.info                          L1132 INFO   | Lag Protocol Configuration 0.557s
16:11:41 snappi_api.info                          L1132 INFO   | Convert device config : 0.083s
16:11:41 snappi_api.info                          L1132 INFO   | Create IxNetwork device config : 0.000s
16:11:42 snappi_api.info                          L1132 INFO   | Push IxNetwork device config : 0.795s
16:11:42 snappi_api.info                          L1132 INFO   | Devices configuration 0.888s
16:11:43 snappi_api.info                          L1132 INFO   | Flows configuration 1.272s
16:11:43 snappi_api.info                          L1132 INFO   | Start interfaces 0.376s
16:11:44 bgp_convergence_helper.run_traffic       L0906 INFO   | Starting all protocols ...
16:11:55 snappi_api.info                          L1132 INFO   | Setting protocol state 11.595s
16:11:55 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Protocols To start
16:12:25 bgp_convergence_helper.run_traffic       L0912 INFO   | Starting Traffic
16:12:32 snappi_api.info                          L1132 INFO   | Flows generate/apply 6.261s
16:12:45 snappi_api.info                          L1132 INFO   | Flows clear statistics 13.442s
16:12:45 snappi_api.info                          L1132 INFO   | Captures start 0.000s
16:12:49 snappi_api.info                          L1132 INFO   | Flows start 3.694s
16:12:49 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Traffic To start
16:13:19 bgp_convergence_helper.get_RIB_IN_capaci L0924 INFO   | 

16:13:19 bgp_convergence_helper.get_RIB_IN_capaci L0925 INFO   | Loss% : 0.0
16:13:19 bgp_convergence_helper.get_RIB_IN_capaci L0929 INFO   | Tx Frame Rate : [11973180.0]
16:13:19 bgp_convergence_helper.get_RIB_IN_capaci L0930 INFO   | Rx Frame Rate : [11973180.5]
16:13:19 bgp_convergence_helper.get_RIB_IN_capaci L0931 INFO   | 

16:13:19 bgp_convergence_helper.get_RIB_IN_capaci L0945 INFO   | Stopping Traffic
16:13:24 snappi_api.info                          L1132 INFO   | Flows stop 5.184s
16:13:24 utilities.wait                           L0104 INFO   | Pause 10 seconds, reason: For Traffic To stop
16:13:34 bgp_convergence_helper.run_traffic       L0901 INFO   | |-------------------- RIB-IN Capacity test, No.of Routes : 50000 ----|
16:13:35 snappi_api.info                          L1132 INFO   | Config validation 0.006s
16:13:35 snappi_api.info                          L1132 INFO   | Ports configuration 0.059s
16:13:35 snappi_api.info                          L1132 INFO   | Captures configuration 0.027s
16:13:41 snappi_api.info                          L1132 INFO   | Location hosts ready [10.36.78.53] 2.057s
16:13:41 snappi_api.info                          L1132 INFO   | Speed change not require due to redundant Layer1 config
16:13:41 snappi_api.info                          L1132 INFO   | Aggregation mode speed change 0.006s
16:13:41 snappi_api.info                          L1132 INFO   | Location configuration 6.209s
16:13:42 snappi_api.info                          L1132 INFO   | Layer1 configuration 0.057s
16:13:43 snappi_api.info                          L1132 INFO   | Lag Configuration 1.056s
16:13:43 snappi_api.info                          L1132 INFO   | Lag Ethernet Configuration 0.148s
16:13:43 snappi_api.info                          L1132 INFO   | Lag Protocol Configuration 0.545s
16:13:43 snappi_api.info                          L1132 INFO   | Convert device config : 0.082s
16:13:43 snappi_api.info                          L1132 INFO   | Create IxNetwork device config : 0.000s
16:13:44 snappi_api.info                          L1132 INFO   | Push IxNetwork device config : 0.884s
16:13:44 snappi_api.info                          L1132 INFO   | Devices configuration 0.975s
16:13:45 snappi_api.info                          L1132 INFO   | Flows configuration 0.965s
16:13:46 snappi_api.info                          L1132 INFO   | Start interfaces 0.391s
16:13:46 bgp_convergence_helper.run_traffic       L0906 INFO   | Starting all protocols ...
16:13:59 snappi_api.info                          L1132 INFO   | Setting protocol state 12.737s
16:13:59 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Protocols To start
16:14:29 bgp_convergence_helper.run_traffic       L0912 INFO   | Starting Traffic
16:14:35 snappi_api.info                          L1132 INFO   | Flows generate/apply 6.146s
16:14:48 snappi_api.info                          L1132 INFO   | Flows clear statistics 13.288s
16:14:48 snappi_api.info                          L1132 INFO   | Captures start 0.000s
16:14:51 snappi_api.info                          L1132 INFO   | Flows start 3.242s
16:14:51 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Traffic To start
16:15:22 bgp_convergence_helper.get_RIB_IN_capaci L0924 INFO   | 

16:15:22 bgp_convergence_helper.get_RIB_IN_capaci L0925 INFO   | Loss% : 0.0
16:15:22 bgp_convergence_helper.get_RIB_IN_capaci L0929 INFO   | Tx Frame Rate : [11973180.0]
16:15:22 bgp_convergence_helper.get_RIB_IN_capaci L0930 INFO   | Rx Frame Rate : [11973180.0]
16:15:22 bgp_convergence_helper.get_RIB_IN_capaci L0931 INFO   | 

16:15:22 bgp_convergence_helper.get_RIB_IN_capaci L0945 INFO   | Stopping Traffic
16:15:27 snappi_api.info                          L1132 INFO   | Flows stop 5.352s
16:15:27 utilities.wait                           L0104 INFO   | Pause 10 seconds, reason: For Traffic To stop
16:15:37 bgp_convergence_helper.run_traffic       L0901 INFO   | |-------------------- RIB-IN Capacity test, No.of Routes : 60000 ----|
16:15:37 snappi_api.info                          L1132 INFO   | Config validation 0.005s
16:15:38 snappi_api.info                          L1132 INFO   | Ports configuration 0.046s
16:15:38 snappi_api.info                          L1132 INFO   | Captures configuration 0.028s
16:15:44 snappi_api.info                          L1132 INFO   | Location hosts ready [10.36.78.53] 2.057s
16:15:44 snappi_api.info                          L1132 INFO   | Speed change not require due to redundant Layer1 config
16:15:44 snappi_api.info                          L1132 INFO   | Aggregation mode speed change 0.006s
16:15:44 snappi_api.info                          L1132 INFO   | Location configuration 6.210s
16:15:44 snappi_api.info                          L1132 INFO   | Layer1 configuration 0.057s
16:15:45 snappi_api.info                          L1132 INFO   | Lag Configuration 1.052s
16:15:45 snappi_api.info                          L1132 INFO   | Lag Ethernet Configuration 0.129s
16:15:46 snappi_api.info                          L1132 INFO   | Lag Protocol Configuration 0.555s
16:15:46 snappi_api.info                          L1132 INFO   | Convert device config : 0.080s
16:15:46 snappi_api.info                          L1132 INFO   | Create IxNetwork device config : 0.000s
16:15:47 snappi_api.info                          L1132 INFO   | Push IxNetwork device config : 0.779s
16:15:47 snappi_api.info                          L1132 INFO   | Devices configuration 0.868s
16:15:48 snappi_api.info                          L1132 INFO   | Flows configuration 0.837s
16:15:48 snappi_api.info                          L1132 INFO   | Start interfaces 0.366s
16:15:48 bgp_convergence_helper.run_traffic       L0906 INFO   | Starting all protocols ...
16:16:04 snappi_api.info                          L1132 INFO   | Setting protocol state 15.720s
16:16:04 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Protocols To start
16:16:34 bgp_convergence_helper.run_traffic       L0912 INFO   | Starting Traffic
16:16:40 snappi_api.info                          L1132 INFO   | Flows generate/apply 6.061s
16:16:53 snappi_api.info                          L1132 INFO   | Flows clear statistics 13.180s
16:16:53 snappi_api.info                          L1132 INFO   | Captures start 0.000s
16:16:56 snappi_api.info                          L1132 INFO   | Flows start 2.580s
16:16:56 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Traffic To start
16:17:26 bgp_convergence_helper.get_RIB_IN_capaci L0924 INFO   | 

16:17:26 bgp_convergence_helper.get_RIB_IN_capaci L0925 INFO   | Loss% : 0.0
16:17:26 bgp_convergence_helper.get_RIB_IN_capaci L0929 INFO   | Tx Frame Rate : [11973180.0]
16:17:26 bgp_convergence_helper.get_RIB_IN_capaci L0930 INFO   | Rx Frame Rate : [11973180.0]
16:17:26 bgp_convergence_helper.get_RIB_IN_capaci L0931 INFO   | 

16:17:26 bgp_convergence_helper.get_RIB_IN_capaci L0945 INFO   | Stopping Traffic
16:17:32 snappi_api.info                          L1132 INFO   | Flows stop 5.310s
16:17:32 utilities.wait                           L0104 INFO   | Pause 10 seconds, reason: For Traffic To stop
16:17:42 bgp_convergence_helper.run_traffic       L0901 INFO   | |-------------------- RIB-IN Capacity test, No.of Routes : 70000 ----|
16:17:42 snappi_api.info                          L1132 INFO   | Config validation 0.005s
16:17:43 snappi_api.info                          L1132 INFO   | Ports configuration 0.046s
16:17:43 snappi_api.info                          L1132 INFO   | Captures configuration 0.026s
16:17:49 snappi_api.info                          L1132 INFO   | Location hosts ready [10.36.78.53] 2.063s
16:17:49 snappi_api.info                          L1132 INFO   | Speed change not require due to redundant Layer1 config
16:17:49 snappi_api.info                          L1132 INFO   | Aggregation mode speed change 0.006s
16:17:49 snappi_api.info                          L1132 INFO   | Location configuration 6.215s
16:17:49 snappi_api.info                          L1132 INFO   | Layer1 configuration 0.058s
16:17:50 snappi_api.info                          L1132 INFO   | Lag Configuration 1.067s
16:17:50 snappi_api.info                          L1132 INFO   | Lag Ethernet Configuration 0.120s
16:17:51 snappi_api.info                          L1132 INFO   | Lag Protocol Configuration 0.537s
16:17:51 snappi_api.info                          L1132 INFO   | Convert device config : 0.082s
16:17:51 snappi_api.info                          L1132 INFO   | Create IxNetwork device config : 0.000s
16:17:52 snappi_api.info                          L1132 INFO   | Push IxNetwork device config : 0.870s
16:17:52 snappi_api.info                          L1132 INFO   | Devices configuration 0.961s
16:17:52 snappi_api.info                          L1132 INFO   | Flows configuration 0.696s
16:17:53 snappi_api.info                          L1132 INFO   | Start interfaces 0.370s
16:17:53 bgp_convergence_helper.run_traffic       L0906 INFO   | Starting all protocols ...
16:18:00 snappi_api.info                          L1132 INFO   | Setting protocol state 6.914s
16:18:00 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Protocols To start
16:18:30 bgp_convergence_helper.run_traffic       L0912 INFO   | Starting Traffic
16:18:36 snappi_api.info                          L1132 INFO   | Flows generate/apply 6.212s
16:18:50 snappi_api.info                          L1132 INFO   | Flows clear statistics 13.487s
16:18:50 snappi_api.info                          L1132 INFO   | Captures start 0.000s
16:18:52 snappi_api.info                          L1132 INFO   | Flows start 2.745s
16:18:52 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Traffic To start
16:19:23 bgp_convergence_helper.get_RIB_IN_capaci L0924 INFO   | 

16:19:23 bgp_convergence_helper.get_RIB_IN_capaci L0925 INFO   | Loss% : 0.0
16:19:23 bgp_convergence_helper.get_RIB_IN_capaci L0929 INFO   | Tx Frame Rate : [11973180.0]
16:19:23 bgp_convergence_helper.get_RIB_IN_capaci L0930 INFO   | Rx Frame Rate : [11973180.0]
16:19:23 bgp_convergence_helper.get_RIB_IN_capaci L0931 INFO   | 

16:19:23 bgp_convergence_helper.get_RIB_IN_capaci L0945 INFO   | Stopping Traffic
16:19:28 snappi_api.info                          L1132 INFO   | Flows stop 5.306s
16:19:28 utilities.wait                           L0104 INFO   | Pause 10 seconds, reason: For Traffic To stop
16:19:38 bgp_convergence_helper.run_traffic       L0901 INFO   | |-------------------- RIB-IN Capacity test, No.of Routes : 80000 ----|
16:19:38 snappi_api.info                          L1132 INFO   | Config validation 0.005s
16:19:39 snappi_api.info                          L1132 INFO   | Ports configuration 0.047s
16:19:39 snappi_api.info                          L1132 INFO   | Captures configuration 0.026s
16:19:45 snappi_api.info                          L1132 INFO   | Location hosts ready [10.36.78.53] 2.057s
16:19:45 snappi_api.info                          L1132 INFO   | Speed change not require due to redundant Layer1 config
16:19:45 snappi_api.info                          L1132 INFO   | Aggregation mode speed change 0.006s
16:19:45 snappi_api.info                          L1132 INFO   | Location configuration 6.213s
16:19:45 snappi_api.info                          L1132 INFO   | Layer1 configuration 0.058s
16:19:46 snappi_api.info                          L1132 INFO   | Lag Configuration 1.055s
16:19:46 snappi_api.info                          L1132 INFO   | Lag Ethernet Configuration 0.134s
16:19:47 snappi_api.info                          L1132 INFO   | Lag Protocol Configuration 0.561s
16:19:47 snappi_api.info                          L1132 INFO   | Convert device config : 0.082s
16:19:47 snappi_api.info                          L1132 INFO   | Create IxNetwork device config : 0.000s
16:19:48 snappi_api.info                          L1132 INFO   | Push IxNetwork device config : 0.824s
16:19:48 snappi_api.info                          L1132 INFO   | Devices configuration 0.916s
16:19:49 snappi_api.info                          L1132 INFO   | Flows configuration 1.274s
16:19:50 snappi_api.info                          L1132 INFO   | Start interfaces 0.376s
16:19:50 bgp_convergence_helper.run_traffic       L0906 INFO   | Starting all protocols ...
16:20:02 snappi_api.info                          L1132 INFO   | Setting protocol state 12.575s
16:20:02 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Protocols To start
16:20:32 bgp_convergence_helper.run_traffic       L0912 INFO   | Starting Traffic
16:20:39 snappi_api.info                          L1132 INFO   | Flows generate/apply 6.142s
16:20:52 snappi_api.info                          L1132 INFO   | Flows clear statistics 13.380s
16:20:52 snappi_api.info                          L1132 INFO   | Captures start 0.000s
16:20:55 snappi_api.info                          L1132 INFO   | Flows start 2.979s
16:20:55 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Traffic To start
16:21:25 bgp_convergence_helper.get_RIB_IN_capaci L0924 INFO   | 

16:21:25 bgp_convergence_helper.get_RIB_IN_capaci L0925 INFO   | Loss% : 0.0
16:21:25 bgp_convergence_helper.get_RIB_IN_capaci L0929 INFO   | Tx Frame Rate : [11973180.5]
16:21:25 bgp_convergence_helper.get_RIB_IN_capaci L0930 INFO   | Rx Frame Rate : [11973180.0]
16:21:25 bgp_convergence_helper.get_RIB_IN_capaci L0931 INFO   | 

16:21:25 bgp_convergence_helper.get_RIB_IN_capaci L0945 INFO   | Stopping Traffic
16:21:31 snappi_api.info                          L1132 INFO   | Flows stop 5.160s
16:21:31 utilities.wait                           L0104 INFO   | Pause 10 seconds, reason: For Traffic To stop
16:21:41 bgp_convergence_helper.run_traffic       L0901 INFO   | |-------------------- RIB-IN Capacity test, No.of Routes : 90000 ----|
16:21:41 snappi_api.info                          L1132 INFO   | Config validation 0.004s
16:21:41 snappi_api.info                          L1132 INFO   | Ports configuration 0.047s
16:21:41 snappi_api.info                          L1132 INFO   | Captures configuration 0.027s
16:21:48 snappi_api.info                          L1132 INFO   | Location hosts ready [10.36.78.53] 2.057s
16:21:48 snappi_api.info                          L1132 INFO   | Speed change not require due to redundant Layer1 config
16:21:48 snappi_api.info                          L1132 INFO   | Aggregation mode speed change 0.006s
16:21:48 snappi_api.info                          L1132 INFO   | Location configuration 6.210s
16:21:48 snappi_api.info                          L1132 INFO   | Layer1 configuration 0.059s
16:21:49 snappi_api.info                          L1132 INFO   | Lag Configuration 1.054s
16:21:49 snappi_api.info                          L1132 INFO   | Lag Ethernet Configuration 0.135s
16:21:50 snappi_api.info                          L1132 INFO   | Lag Protocol Configuration 0.543s
16:21:50 snappi_api.info                          L1132 INFO   | Convert device config : 0.086s
16:21:50 snappi_api.info                          L1132 INFO   | Create IxNetwork device config : 0.000s
16:21:50 snappi_api.info                          L1132 INFO   | Push IxNetwork device config : 0.861s
16:21:50 snappi_api.info                          L1132 INFO   | Devices configuration 0.956s
16:21:52 snappi_api.info                          L1132 INFO   | Flows configuration 1.324s
16:21:52 snappi_api.info                          L1132 INFO   | Start interfaces 0.380s
16:21:52 bgp_convergence_helper.run_traffic       L0906 INFO   | Starting all protocols ...
16:21:59 snappi_api.info                          L1132 INFO   | Setting protocol state 6.807s
16:21:59 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Protocols To start
16:22:29 bgp_convergence_helper.run_traffic       L0912 INFO   | Starting Traffic
16:22:36 snappi_api.info                          L1132 INFO   | Flows generate/apply 6.520s
16:22:49 snappi_api.info                          L1132 INFO   | Flows clear statistics 13.189s
16:22:49 snappi_api.info                          L1132 INFO   | Captures start 0.000s
16:22:52 snappi_api.info                          L1132 INFO   | Flows start 2.742s
16:22:52 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Traffic To start
16:23:22 bgp_convergence_helper.get_RIB_IN_capaci L0924 INFO   | 

16:23:22 bgp_convergence_helper.get_RIB_IN_capaci L0925 INFO   | Loss% : 2.959
16:23:22 bgp_convergence_helper.get_RIB_IN_capaci L0929 INFO   | Tx Frame Rate : [11973180.5]
16:23:22 bgp_convergence_helper.get_RIB_IN_capaci L0930 INFO   | Rx Frame Rate : [11973180.0]
16:23:22 bgp_convergence_helper.get_RIB_IN_capaci L0931 INFO   | 

16:23:22 bgp_convergence_helper.get_RIB_IN_capaci L0936 INFO   | Loss greater than 0.001 occured
16:23:22 bgp_convergence_helper.get_RIB_IN_capaci L0937 INFO   | Reducing the routes and running test
16:23:22 bgp_convergence_helper.get_RIB_IN_capaci L0939 INFO   | Stopping Traffic
16:23:28 snappi_api.info                          L1132 INFO   | Flows stop 5.329s
16:23:28 utilities.wait                           L0104 INFO   | Pause 10 seconds, reason: For Traffic To stop
16:23:38 bgp_convergence_helper.run_traffic       L0901 INFO   | |-------------------- RIB-IN Capacity test, No.of Routes : 81250 ----|
16:23:38 snappi_api.info                          L1132 INFO   | Config validation 0.006s
16:23:38 snappi_api.info                          L1132 INFO   | Ports configuration 0.047s
16:23:38 snappi_api.info                          L1132 INFO   | Captures configuration 0.026s
16:23:45 snappi_api.info                          L1132 INFO   | Location hosts ready [10.36.78.53] 2.056s
16:23:45 snappi_api.info                          L1132 INFO   | Speed change not require due to redundant Layer1 config
16:23:45 snappi_api.info                          L1132 INFO   | Aggregation mode speed change 0.006s
16:23:45 snappi_api.info                          L1132 INFO   | Location configuration 6.208s
16:23:45 snappi_api.info                          L1132 INFO   | Layer1 configuration 0.058s
16:23:46 snappi_api.info                          L1132 INFO   | Lag Configuration 1.051s
16:23:46 snappi_api.info                          L1132 INFO   | Lag Ethernet Configuration 0.130s
16:23:46 snappi_api.info                          L1132 INFO   | Lag Protocol Configuration 0.540s
16:23:47 snappi_api.info                          L1132 INFO   | Convert device config : 0.085s
16:23:47 snappi_api.info                          L1132 INFO   | Create IxNetwork device config : 0.001s
16:23:47 snappi_api.info                          L1132 INFO   | Push IxNetwork device config : 0.829s
16:23:47 snappi_api.info                          L1132 INFO   | Devices configuration 0.924s
16:23:49 snappi_api.info                          L1132 INFO   | Flows configuration 1.527s
16:23:49 snappi_api.info                          L1132 INFO   | Start interfaces 0.388s
16:23:49 bgp_convergence_helper.run_traffic       L0906 INFO   | Starting all protocols ...
16:24:02 snappi_api.info                          L1132 INFO   | Setting protocol state 12.576s
16:24:02 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Protocols To start
16:24:32 bgp_convergence_helper.run_traffic       L0912 INFO   | Starting Traffic
16:24:38 snappi_api.info                          L1132 INFO   | Flows generate/apply 6.155s
16:24:52 snappi_api.info                          L1132 INFO   | Flows clear statistics 13.275s
16:24:52 snappi_api.info                          L1132 INFO   | Captures start 0.000s
16:24:55 snappi_api.info                          L1132 INFO   | Flows start 2.835s
16:24:55 utilities.wait                           L0104 INFO   | Pause 30 seconds, reason: For Traffic To start
16:25:25 bgp_convergence_helper.get_RIB_IN_capaci L0959 INFO   | Loss% : 0.921
16:25:25 bgp_convergence_helper.get_RIB_IN_capaci L0981 INFO   | 
+----------------------+-------------------------+
| Test Name            |   Maximum no. of Routes |
|----------------------+-------------------------|
| RIB-IN Capacity Test |                   80000 |
+----------------------+-------------------------+
16:25:57 bgp_convergence_helper.cleanup_config    L0995 INFO   | Wait until all critical services are fully started
16:26:19 bgp_convergence_helper.cleanup_config    L0998 INFO   | Convergence Test Completed
PASSED                                                                                                                                              [100%]
-------------------------------------------------------------------- live log teardown --------------------------------------------------------------------
16:26:19 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture cvg_api teardown starts --------------------
16:26:19 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture cvg_api teardown ends --------------------
16:26:19 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture start_pfcwd_after_test teardown starts --------------------
16:26:22 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture start_pfcwd_after_test teardown ends --------------------
16:26:22 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossy_prio teardown starts --------------------
16:26:22 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossy_prio teardown ends --------------------
16:26:22 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossless_prio teardown starts --------------------
16:26:22 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossless_prio teardown ends --------------------
16:26:22 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture enable_packet_aging_after_test teardown starts --------------------
16:26:22 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture enable_packet_aging_after_test teardown ends --------------------
16:26:23 conftest.core_dump_and_config_check      L2093 INFO   | Dumping Disk and Memory Space informataion after test on sonic-s6100-dut
16:26:25 conftest.core_dump_and_config_check      L2097 INFO   | Collecting core dumps after test on sonic-s6100-dut
16:26:26 conftest.core_dump_and_config_check      L2114 INFO   | Collecting running config after test on sonic-s6100-dut
16:26:27 conftest.core_dump_and_config_check      L2243 INFO   | Core dump and config check passed for test_bgp_rib_in_capacity.py


==================================================================== warnings summary =====================================================================
../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.loganalyzer
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.sanity_check
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.test_completeness
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:471
  /usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:471: CryptographyDeprecationWarning: Blowfish has been deprecated
    cipher=algorithms.Blowfish,

../../../../usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:485
  /usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:485: CryptographyDeprecationWarning: CAST5 has been deprecated
    cipher=algorithms.CAST5,

../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

snappi_tests/bgp/test_bgp_rib_in_capacity.py::test_RIB_IN_capacity[speed_100_gbps-IPv4-10000-20000-2]
snappi_tests/bgp/test_bgp_rib_in_capacity.py::test_RIB_IN_capacity[speed_100_gbps-IPv4-10000-20000-2]
snappi_tests/bgp/test_bgp_rib_in_capacity.py::test_RIB_IN_capacity[speed_100_gbps-IPv4-10000-20000-2]
snappi_tests/bgp/test_bgp_rib_in_capacity.py::test_RIB_IN_capacity[speed_100_gbps-IPv4-10000-20000-2]
  /usr/local/lib/python3.8/dist-packages/pytest_ansible/module_dispatcher/v213.py:100: UserWarning: provided hosts list is empty, only localhost is available
    warnings.warn("provided hosts list is empty, only localhost is available")

snappi_tests/bgp/test_bgp_rib_in_capacity.py::test_RIB_IN_capacity[speed_100_gbps-IPv4-10000-20000-2]
  /var/AzDevOps/.local/lib/python3.8/site-packages/snappi_ixnetwork/device/utils.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import namedtuple, Mapping

snappi_tests/bgp/test_bgp_rib_in_capacity.py::test_RIB_IN_capacity[speed_100_gbps-IPv4-10000-20000-2]
snappi_tests/bgp/test_bgp_rib_in_capacity.py::test_RIB_IN_capacity[speed_100_gbps-IPv4-10000-20000-2]
  /usr/local/lib/python3.8/dist-packages/ixnetwork_restpy/testplatform/sessions/sessions.py:59: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    elif LooseVersion(build_number) < LooseVersion('8.52'):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
----------------------------------------------------------------- live log sessionfinish ------------------------------------------------------------------
16:26:27 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
======================================================= 1 passed, 14 warnings in 1177.05s (0:19:37) =======================================================
INFO:root:Can not get Allure report URL. Please check logs