### PR TITLE
Add test case to verify snmp over mgmt IPv6 with ipv6 only config

### DIFF
--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -74,3 +74,19 @@ def test_image_download_ipv6_only(creds, duthosts, enum_dut_hostname,
 def test_syslog_ipv6_only(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b,
                           check_default_route, convert_and_restore_config_db_to_ipv6_only): # noqa F811
     run_syslog(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b, check_default_route)
+
+
+def test_snmp_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_all_duts,
+                        convert_and_restore_config_db_to_ipv6_only): # noqa F811
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    hostipv6 = duthost.host.options['inventory_manager'].get_host(
+        duthost.hostname).vars['ansible_hostv6']
+
+    sysDescr_oid = ".1.3.6.1.2.1.1.1.0"
+    snmpget = "snmpget -v2c -c {} {} {}".format(
+        creds_all_duts[duthost.hostname]['snmp_rocommunity'], hostipv6, sysDescr_oid)
+    result = localhost.shell(snmpget)['stdout_lines']
+
+    assert result is not None, "Failed to get snmp result from localhost"
+    assert result[0] is not None, "Failed to get snmp result from DUT IPv6 {}".format(hostipv6)
+    assert "SONiC Software Version" in result[0], "Sysdescr not found in SNMP result from DUT IPv6 {}".format(hostipv6)

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -110,6 +110,7 @@ def test_snmp_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname, localhost, c
     assert result[0] is not None, "Failed to get snmp result from DUT IPv6 {}".format(hostipv6)
     assert "SONiC Software Version" in result[0], "Sysdescr not found in SNMP result from DUT IPv6 {}".format(hostipv6)
 
+
 def test_ro_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname,
                            tacacs_creds, check_tacacs_v6, convert_and_restore_config_db_to_ipv6_only): # noqa F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -128,4 +129,3 @@ def test_rw_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname
     res = ssh_remote_run(localhost, dutipv6, tacacs_creds['tacacs_rw_user'],
                          tacacs_creds['tacacs_rw_user_passwd'], "cat /etc/passwd")
     check_output(res, 'testadmin', 'remote_user_su')
-

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -83,7 +83,7 @@ def test_snmp_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname, localhost, c
         duthost.hostname).vars['ansible_hostv6']
 
     sysDescr_oid = ".1.3.6.1.2.1.1.1.0"
-    snmpget = "snmpget -v2c -c {} {} {}".format(
+    snmpget = "snmpget -v2c -c {} udp6:[{}] {}".format(
         creds_all_duts[duthost.hostname]['snmp_rocommunity'], hostipv6, sysDescr_oid)
     result = localhost.shell(snmpget)['stdout_lines']
 

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -83,6 +83,7 @@ def test_snmp_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname, localhost, c
         duthost.hostname).vars['ansible_hostv6']
 
     sysDescr_oid = ".1.3.6.1.2.1.1.1.0"
+    # Query by specifying udp6 protocol along with host IPv6
     snmpget = "snmpget -v2c -c {} udp6:[{}] {}".format(
         creds_all_duts[duthost.hostname]['snmp_rocommunity'], hostipv6, sysDescr_oid)
     result = localhost.shell(snmpget)['stdout_lines']


### PR DESCRIPTION
configuration

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
MSFT ADO: 26660281

Add test case to verify SNMP Over mgmt IPv6 with IPv6 only configuration.
#### How did you do it?
Get SNMP result over mgmt IPv6 address and verify if the expected result is obtained for sysDescr OID.
#### How did you verify/test it?
Verified on 202305 OS version.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
