### PR TITLE
Skip passw_hardening script due to Issue #13582

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -881,7 +881,7 @@ ntp/test_ntp.py::test_ntp_long_jump_disabled:
 #####      passw_hardening        #####
 #######################################
 passw_hardening/test_passw_hardening.py:
-  skip:
+  xfail:
     reason: "Skip the script due to Issue #13582. Command currently not supported multi-asic platforms"
     conditions:
       - "is_multi_asic==True"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -881,8 +881,8 @@ ntp/test_ntp.py::test_ntp_long_jump_disabled:
 #####      passw_hardening        #####
 #######################################
 passw_hardening/test_passw_hardening.py:
-  xfail:
-    reason: "Test fails due to Issue #13582 on multi-asic platforms"
+  skip:
+    reason: "Skip the script due to Issue #13582. Command currently not supported multi-asic platforms"
     conditions:
       - "is_multi_asic==True"
       - https://github.com/sonic-net/sonic-buildimage/issues/13582

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -878,6 +878,16 @@ ntp/test_ntp.py::test_ntp_long_jump_disabled:
     reason: "Known NTP bug"
 
 #######################################
+#####      passw_hardening        #####
+#######################################
+passw_hardening/test_passw_hardening.py:
+  xfail:
+    reason: "Test fails due to Issue #13582 on multi-asic platforms"
+    conditions:
+      - "is_multi_asic==True"
+      - https://github.com/sonic-net/sonic-buildimage/issues/13582
+
+#######################################
 #####           pc               #####
 #######################################
 pc/test_lag_2.py::test_lag_db_status_with_po_update:


### PR DESCRIPTION
### Description of PR
Skip the script due to Issue #13582. Command currently not supported multi-asic platforms
https://github.com/sonic-net/sonic-buildimage/issues/13582.  Another tracker for this: https://github.com/sonic-net/sonic-buildimage/issues/18417

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Script fails due to https://github.com/sonic-net/sonic-buildimage/issues/13582

#### How did you do it?

#### How did you verify/test it?
Verified it on a multi-asic platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
