### PR TITLE
Adding GRE ERSPAN type-2 for Marvell platform

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -216,7 +216,7 @@ class EverflowPolicerTest(BaseTest):
         if self.asic_type in ["mellanox"]:
             import binascii
             payload = binascii.unhexlify("0"*44) + str(payload)     # Add the padding
-        elif self.asic_type in ["innovium"]:
+        elif self.asic_type in ["innovium"] or self.hwsku in ["rd98DX35xx_cn9131" , "rd98DX35xx"]:
             import binascii
             payload = binascii.unhexlify("0"*24) + str(payload)     # Add the padding
 
@@ -252,6 +252,7 @@ class EverflowPolicerTest(BaseTest):
             masked_exp_pkt.set_do_not_care_scapy(scapy.GRE, "seqnum_present")
         if self.asic_type in ["marvell"]:
             masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "id")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.GRE, "seqnum_present")
 
         if exp_pkt.haslayer(scapy.ERSPAN_III):
             masked_exp_pkt.set_do_not_care_scapy(scapy.ERSPAN_III, "span_id")
@@ -269,7 +270,7 @@ class EverflowPolicerTest(BaseTest):
                 pkt = scapy.Ether(pkt).load
                 pkt = pkt[22:]  # Mask the Mellanox specific inner header
                 pkt = scapy.Ether(pkt)
-            elif self.asic_type in ["innovium"]:
+            elif self.asic_type in ["innovium"] or self.hwsku in ["rd98DX35xx_cn9131" , "rd98DX35xx"]:
                 pkt = scapy.Ether(pkt)[scapy.GRE].payload
                 pkt_str = str(pkt)
                 pkt = scapy.Ether(pkt_str[8:])

--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -216,7 +216,7 @@ class EverflowPolicerTest(BaseTest):
         if self.asic_type in ["mellanox"]:
             import binascii
             payload = binascii.unhexlify("0"*44) + str(payload)     # Add the padding
-        elif self.asic_type in ["innovium"] or self.hwsku in ["rd98DX35xx_cn9131" , "rd98DX35xx"]:
+        elif self.asic_type in ["innovium"] or self.hwsku in ["rd98DX35xx_cn9131", "rd98DX35xx"]:
             import binascii
             payload = binascii.unhexlify("0"*24) + str(payload)     # Add the padding
 
@@ -270,7 +270,7 @@ class EverflowPolicerTest(BaseTest):
                 pkt = scapy.Ether(pkt).load
                 pkt = pkt[22:]  # Mask the Mellanox specific inner header
                 pkt = scapy.Ether(pkt)
-            elif self.asic_type in ["innovium"] or self.hwsku in ["rd98DX35xx_cn9131" , "rd98DX35xx"]:
+            elif self.asic_type in ["innovium"] or self.hwsku in ["rd98DX35xx_cn9131", "rd98DX35xx"]:
                 pkt = scapy.Ether(pkt)[scapy.GRE].payload
                 pkt_str = str(pkt)
                 pkt = scapy.Ether(pkt_str[8:])

--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -216,7 +216,7 @@ class EverflowPolicerTest(BaseTest):
         if self.asic_type in ["mellanox"]:
             import binascii
             payload = binascii.unhexlify("0"*44) + str(payload)     # Add the padding
-        elif self.asic_type in ["innovium"] or self.hwsku in ["rd98DX35xx_cn9131", "rd98DX35xx"]:
+        elif self.asic_type in ["innovium"] or self.hwsku in ["rd98DX35xx_cn9131", "rd98DX35xx", "Nokia-7215-A1"]:
             import binascii
             payload = binascii.unhexlify("0"*24) + str(payload)     # Add the padding
 
@@ -270,7 +270,7 @@ class EverflowPolicerTest(BaseTest):
                 pkt = scapy.Ether(pkt).load
                 pkt = pkt[22:]  # Mask the Mellanox specific inner header
                 pkt = scapy.Ether(pkt)
-            elif self.asic_type in ["innovium"] or self.hwsku in ["rd98DX35xx_cn9131", "rd98DX35xx"]:
+            elif self.asic_type in ["innovium"] or self.hwsku in ["rd98DX35xx_cn9131", "rd98DX35xx", "Nokia-7215-A1"]:
                 pkt = scapy.Ether(pkt)[scapy.GRE].payload
                 pkt_str = str(pkt)
                 pkt = scapy.Ether(pkt_str[8:])

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -856,9 +856,12 @@ class BaseEverflowTest(object):
                 payload = binascii.unhexlify("0" * 44) + str(payload)
             else:
                 payload = binascii.unhexlify("0" * 44) + bytes(payload)
-
-        if duthost.facts["asic_type"] in ["barefoot", "cisco-8000", "innovium"] or duthost.facts.get(
-                "platform_asic") in ["broadcom-dnx"] or duthost.facts["hwsku"] in ["rd98DX35xx", "rd98DX35xx_cn9131"]:
+        if (
+            duthost.facts["asic_type"] in ["barefoot", "cisco-8000", "innovium"]
+            or duthost.facts.get("platform_asic") in ["broadcom-dnx"]
+            or duthost.facts["hwsku"]
+            in ["rd98DX35xx", "rd98DX35xx_cn9131", "Nokia-7215-A1"]
+        ):
             if six.PY2:
                 payload = binascii.unhexlify("0" * 24) + str(payload)
             else:

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -858,7 +858,7 @@ class BaseEverflowTest(object):
                 payload = binascii.unhexlify("0" * 44) + bytes(payload)
 
         if duthost.facts["asic_type"] in ["barefoot", "cisco-8000", "innovium"] or duthost.facts.get(
-                "platform_asic") in ["broadcom-dnx"]:
+                "platform_asic") in ["broadcom-dnx"] or duthost.facts["hwsku"] in ["rd98DX35xx", "rd98DX35xx_cn9131"]:
             if six.PY2:
                 payload = binascii.unhexlify("0" * 24) + str(payload)
             else:
@@ -884,6 +884,7 @@ class BaseEverflowTest(object):
         expected_packet.set_do_not_care_scapy(packet.IP, "chksum")
         if duthost.facts["asic_type"] == 'marvell':
             expected_packet.set_do_not_care_scapy(packet.IP, "id")
+            expected_packet.set_do_not_care_scapy(packet.GRE, "seqnum_present")
         if duthost.facts["asic_type"] in ["cisco-8000", "innovium"] or \
                 duthost.facts.get("platform_asic") in ["broadcom-dnx"]:
             expected_packet.set_do_not_care_scapy(packet.GRE, "seqnum_present")


### PR DESCRIPTION
Summary:
Fixes # (issue)
Adding GRE ERSPAN type-2 for Marvell platform

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [X ] 202305
- [ X] 202311

### Approach
#### What is the motivation for this PR?
Added GRE ERSPAN type-2 for Marvell platform 

#### How did you do it?
Added GRE ERSPAN type-2 for Marvell platform and changed the ethertype.

#### How did you verify/test it?
Verified on Marvell platform.

#### Any platform specific information?
Yes

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
