### PR TITLE
Fix IndexError in test_no_pfc

### DIFF
--- a/tests/qos/test_pfc_pause.py
+++ b/tests/qos/test_pfc_pause.py
@@ -313,7 +313,7 @@ def test_no_pfc(pfc_test_setup, fanouthosts, rand_selected_dut, ptfhost, conn_gr
     setup = pfc_test_setup
     prio = int(enum_dut_lossless_prio.split('|')[-1])
     # Skip the extra lossless priority test if 4 lossless prio is not enabled on testing port
-    if prio not in lossless_prio_dscp_map:
+    if prio not in lossless_prio_dscp_map or len(lossless_prio_dscp_map[prio]) == 0:
         pytest.skip("lossless prio {} not enabled on testing port".format(prio))
 
     dscp = lossless_prio_dscp_map[prio]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The PR is to fix `IndexError` in test case `test_no_pfc`.
The error is because the fixture `lossless_prio_dscp_map` always selects the first port in `PORT_QOS_MAP` table as the testing port, and selects the first profile in `DSCP_TO_TC_MAP` to get the DSCP to TC map. So on some particular topo, we saw the `IndexError` because the selected profile is not applied to the testing port.
```
>           traffic_params = {'dscp': dscp[0], 'dscp_bg': dscp_bg}
E           IndexError: list index out of range
```
This PR fixed the issue by checking the lossless priority and `lossless_prio_dscp_map` as well. The test case will be skipped if the extra lossless queue is not enabled on this port or the map `lossless_prio_dscp_map` for a particular priority is empty.

Summary:
Fixes `IndexError` in test case `test_no_pfc`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR is to address `IndexError` in `test_no_pfc`.

#### How did you do it?
This PR fixed the issue by checking the lossless priority and `lossless_prio_dscp_map` as well. The test case will be skipped if the extra lossless queue is not enabled on this port or the map `lossless_prio_dscp_map` for a particular priority is empty.

#### How did you verify/test it?
Verified on a dualtor testbed where I saw the new failure. Test can pass now.
```
collected 8 items                                                                                                                                                                                     

qos/test_pfc_pause.py::test_no_pfc[svcstr-7050-acs-3|2] SKIPPED (lossless prio 2 not enabled on testing port)                                                                                   [ 12%]
qos/test_pfc_pause.py::test_no_pfc[svcstr-7050-acs-3|3]  ^HPASSED                                                                                                                                  [ 25%]
qos/test_pfc_pause.py::test_no_pfc[svcstr-7050-acs-3|4] PASSED                                                                                                                                  [ 37%]
qos/test_pfc_pause.py::test_no_pfc[svcstr-7050-acs-3|6] SKIPPED (lossless prio 6 not enabled on testing port)                                                                                   [ 50%]
qos/test_pfc_pause.py::test_no_pfc[svcstr-7050-acs-4|2] SKIPPED (lossless prio 2 not enabled on testing port)                                                                                   [ 62%]
qos/test_pfc_pause.py::test_no_pfc[svcstr-7050-acs-4|3]  ^HPASSED                                                                                                                                  [ 75%]
qos/test_pfc_pause.py::test_no_pfc[svcstr-7050-acs-4|4] PASSED                                                                                                                                  [ 87%]
qos/test_pfc_pause.py::test_no_pfc[svcstr-7050-acs-4|6] SKIPPED (lossless prio 6 not enabled on testing port)                                                                                   [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
