### PR TITLE
Add IPV6 only testcase for telemetry

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -33,6 +33,7 @@ from tests.common.cache import cached
 from tests.common.cache import FactsCache
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
 from tests.common.helpers.assertions import pytest_assert
+from netaddr import valid_ipv6
 
 logger = logging.getLogger(__name__)
 cache = FactsCache()
@@ -474,6 +475,19 @@ def is_ipv4_address(ip_address):
         return True
     except ipaddress.AddressValueError:
         return False
+
+
+def get_mgmt_ipv6(duthost):
+    config_facts = duthost.get_running_config_facts()
+    mgmt_interfaces = config_facts.get("MGMT_INTERFACE", {})
+    mgmt_ipv6 = None
+
+    for mgmt_interface, ip_configs in mgmt_interfaces.items():
+        for ip_addr_with_prefix in ip_configs.keys():
+            ip_addr = ip_addr_with_prefix.split("/")[0]
+            if valid_ipv6(ip_addr):
+                mgmt_ipv6 = ip_addr
+    return mgmt_ipv6
 
 
 def compare_crm_facts(left, right):

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -1,6 +1,8 @@
 import pytest
+import re
 
-from netaddr import valid_ipv6
+from tests.common.utilities import get_mgmt_ipv6
+from tests.common.helpers.assertions import pytest_assert
 from tests.tacacs.utils import check_output
 from tests.bgp.test_bgp_fact import run_bgp_facts
 from tests.test_features import run_show_features
@@ -9,6 +11,8 @@ from tests.common.helpers.assertions import pytest_require
 from tests.tacacs.conftest import tacacs_creds, check_tacacs_v6 # noqa F401
 from tests.syslog.test_syslog import run_syslog, check_default_route # noqa F401
 from tests.common.fixtures.duthost_utils import convert_and_restore_config_db_to_ipv6_only  # noqa F401
+from tests.common.helpers.gnmi_utils import GNMIEnvironment
+from tests.telemetry.conftest import setup_streaming_telemetry_ipv6
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -44,17 +48,22 @@ def ignore_expected_loganalyzer_exception(loganalyzer):
             loganalyzer[hostname].ignore_regex.extend(ignore_regex)
 
 
-def get_mgmt_ipv6(duthost):
-    config_facts = duthost.get_running_config_facts()
-    mgmt_interfaces = config_facts.get("MGMT_INTERFACE", {})
-    mgmt_ipv6 = None
-
-    for mgmt_interface, ip_configs in mgmt_interfaces.items():
-        for ip_addr_with_prefix in ip_configs.keys():
-            ip_addr = ip_addr_with_prefix.split("/")[0]
-            if valid_ipv6(ip_addr):
-                mgmt_ipv6 = ip_addr
-    return mgmt_ipv6
+def test_telemetry_output_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname,
+                                    localhost, setup_streaming_telemetry_ipv6,
+                                    convert_and_restore_config_db_to_ipv6_only):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
+    if duthost.is_supervisor_node():
+        pytest.skip(
+            "Skipping test as no Ethernet0 frontpanel port on supervisor")
+    dut_ip = get_mgmt_ipv6(duthost)
+    cmd = "~/gnmi_get -xpath_target COUNTERS_DB -xpath COUNTERS/Ethernet0 -target_addr \
+          [%s]:%s -logtostderr -insecure" % (dut_ip, env.gnmi_port)
+    show_gnmi_out = duthost.shell(cmd)['stdout']
+    result = str(show_gnmi_out)
+    inerrors_match = re.search("SAI_PORT_STAT_IF_IN_ERRORS", result)
+    pytest_assert(inerrors_match is not None,
+                  "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi output")
 
 
 def test_bgp_facts_ipv6_only(duthosts, enum_frontend_dut_hostname, enum_asic_index,

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -12,7 +12,7 @@ from tests.tacacs.conftest import tacacs_creds, check_tacacs_v6 # noqa F401
 from tests.syslog.test_syslog import run_syslog, check_default_route # noqa F401
 from tests.common.fixtures.duthost_utils import convert_and_restore_config_db_to_ipv6_only  # noqa F401
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
-from tests.telemetry.conftest import setup_streaming_telemetry_ipv6 # noqa F401
+from tests.telemetry.conftest import setup_streaming_telemetry # noqa F401
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -105,8 +105,9 @@ def test_rw_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname
     check_output(res, 'testadmin', 'remote_user_su')
 
 
+@pytest.mark.parametrize('setup_streaming_telemetry', [True], indirect=True)
 def test_telemetry_output_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname,
-                                    localhost, setup_streaming_telemetry_ipv6, # noqa F811
+                                    setup_streaming_telemetry, # noqa F811
                                     convert_and_restore_config_db_to_ipv6_only): # noqa F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -150,4 +150,3 @@ def test_telemetry_output_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname,
 def test_ntp_ipv6_only(duthosts, rand_one_dut_hostname,
                                   convert_and_restore_config_db_to_ipv6_only, setup_ntp): # noqa F811
     run_ntp(duthosts, rand_one_dut_hostname, setup_ntp)
-

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -48,24 +48,6 @@ def ignore_expected_loganalyzer_exception(loganalyzer):
             loganalyzer[hostname].ignore_regex.extend(ignore_regex)
 
 
-def test_telemetry_output_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname,
-                                    localhost, setup_streaming_telemetry_ipv6,
-                                    convert_and_restore_config_db_to_ipv6_only):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
-    if duthost.is_supervisor_node():
-        pytest.skip(
-            "Skipping test as no Ethernet0 frontpanel port on supervisor")
-    dut_ip = get_mgmt_ipv6(duthost)
-    cmd = "~/gnmi_get -xpath_target COUNTERS_DB -xpath COUNTERS/Ethernet0 -target_addr \
-          [%s]:%s -logtostderr -insecure" % (dut_ip, env.gnmi_port)
-    show_gnmi_out = duthost.shell(cmd)['stdout']
-    result = str(show_gnmi_out)
-    inerrors_match = re.search("SAI_PORT_STAT_IF_IN_ERRORS", result)
-    pytest_assert(inerrors_match is not None,
-                  "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi output")
-
-
 def test_bgp_facts_ipv6_only(duthosts, enum_frontend_dut_hostname, enum_asic_index,
                              convert_and_restore_config_db_to_ipv6_only): # noqa F811
     run_bgp_facts(duthosts, enum_frontend_dut_hostname, enum_asic_index)
@@ -121,3 +103,21 @@ def test_rw_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname
     res = ssh_remote_run(localhost, dutipv6, tacacs_creds['tacacs_rw_user'],
                          tacacs_creds['tacacs_rw_user_passwd'], "cat /etc/passwd")
     check_output(res, 'testadmin', 'remote_user_su')
+
+
+def test_telemetry_output_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname,
+                                    localhost, setup_streaming_telemetry_ipv6,
+                                    convert_and_restore_config_db_to_ipv6_only): # noqa F811
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
+    if duthost.is_supervisor_node():
+        pytest.skip(
+            "Skipping test as no Ethernet0 frontpanel port on supervisor")
+    dut_ip = get_mgmt_ipv6(duthost)
+    cmd = "~/gnmi_get -xpath_target COUNTERS_DB -xpath COUNTERS/Ethernet0 -target_addr \
+          [%s]:%s -logtostderr -insecure" % (dut_ip, env.gnmi_port)
+    show_gnmi_out = duthost.shell(cmd)['stdout']
+    result = str(show_gnmi_out)
+    inerrors_match = re.search("SAI_PORT_STAT_IF_IN_ERRORS", result)
+    pytest_assert(inerrors_match is not None,
+                  "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi output")

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -12,7 +12,7 @@ from tests.tacacs.conftest import tacacs_creds, check_tacacs_v6 # noqa F401
 from tests.syslog.test_syslog import run_syslog, check_default_route # noqa F401
 from tests.common.fixtures.duthost_utils import convert_and_restore_config_db_to_ipv6_only  # noqa F401
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
-from tests.telemetry.conftest import setup_streaming_telemetry_ipv6
+from tests.telemetry.conftest import setup_streaming_telemetry_ipv6 # noqa F401
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -106,7 +106,7 @@ def test_rw_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname
 
 
 def test_telemetry_output_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname,
-                                    localhost, setup_streaming_telemetry_ipv6,
+                                    localhost, setup_streaming_telemetry_ipv6, # noqa F811
                                     convert_and_restore_config_db_to_ipv6_only): # noqa F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -153,7 +153,7 @@ def setup_streaming_telemetry_ipv6(duthosts, enum_rand_one_per_hwsku_hostname, l
         # Wait until telemetry was restarted
         py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, env.gnmi_container),
                   "%s not started." % (env.gnmi_container))
-        logger.info("telemetry process restarted. Now run pyclient on ptfdocker")
+        logger.info("telemetry process started")
 
         # Wait until the TCP port was opened
         dut_ip = get_mgmt_ipv6(duthost)

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -86,10 +86,11 @@ def delete_gnmi_config(duthost):
 
 
 @pytest.fixture(scope="module")
-def setup_streaming_telemetry(duthosts, enum_rand_one_per_hwsku_hostname, localhost,  ptfhost, gnxi_path):
+def setup_streaming_telemetry(request, duthosts, enum_rand_one_per_hwsku_hostname, localhost, ptfhost, gnxi_path):
     """
     @summary: Post setting up the streaming telemetry before running the test.
     """
+    is_ipv6 = request.param
     try:
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         has_gnmi_config = check_gnmi_config(duthost)
@@ -113,56 +114,18 @@ def setup_streaming_telemetry(duthosts, enum_rand_one_per_hwsku_hostname, localh
 
         # Wait until the TCP port was opened
         dut_ip = duthost.mgmt_ip
+        if is_ipv6:
+            dut_ip = get_mgmt_ipv6(duthost)
         wait_tcp_connection(localhost, dut_ip, env.gnmi_port, timeout_s=60)
 
         # pyclient should be available on ptfhost. If it was not available, then fail pytest.
-        file_exists = ptfhost.stat(path=gnxi_path + "gnmi_cli_py/py_gnmicli.py")
-        py_assert(file_exists["stat"]["exists"] is True)
-    except RunAnsibleModuleFail as e:
-        logger.info("Error happens in the setup period of setup_streaming_telemetry, recover the telemetry.")
-        restore_telemetry_forpyclient(duthost, default_client_auth)
-        raise e
-
-    yield
-    restore_telemetry_forpyclient(duthost, default_client_auth)
-    if not has_gnmi_config:
-        delete_gnmi_config(duthost)
-
-
-@pytest.fixture(scope="module")
-def setup_streaming_telemetry_ipv6(duthosts, enum_rand_one_per_hwsku_hostname, localhost):
-    """
-    @summary: Post setting up the streaming telemetry before running the test.
-    """
-    try:
-        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        has_gnmi_config = check_gnmi_config(duthost)
-        if not has_gnmi_config:
-            create_gnmi_config(duthost)
-        env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
-        default_client_auth = setup_telemetry_forpyclient(duthost)
-
-        if default_client_auth == "true":
-            duthost.shell('sonic-db-cli CONFIG_DB HSET "%s|gnmi" "client_auth" "false"' % (env.gnmi_config_table),
-                          module_ignore_errors=False)
-            duthost.shell("systemctl reset-failed %s" % (env.gnmi_container))
-            duthost.service(name=env.gnmi_container, state="restarted")
+        if is_ipv6:
+            cmd = "docker cp %s:/usr/sbin/gnmi_get ~/" % (env.gnmi_container)
+            ret = duthost.shell(cmd)['rc']
+            py_assert(ret == 0)
         else:
-            logger.info('client auth is false. No need to restart telemetry')
-
-        # Wait until telemetry was restarted
-        py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, env.gnmi_container),
-                  "%s not started." % (env.gnmi_container))
-        logger.info("telemetry process started")
-
-        # Wait until the TCP port was opened
-        dut_ip = get_mgmt_ipv6(duthost)
-        wait_tcp_connection(localhost, dut_ip, env.gnmi_port, timeout_s=60)
-
-        # Copy gnmi_get from container to host
-        cmd = "docker cp %s:/usr/sbin/gnmi_get ~/" % (env.gnmi_container)
-        ret = duthost.shell(cmd)['rc']
-        py_assert(ret == 0)
+            file_exists = ptfhost.stat(path=gnxi_path + "gnmi_cli_py/py_gnmicli.py")
+            py_assert(file_exists["stat"]["exists"] is True)
     except RunAnsibleModuleFail as e:
         logger.info("Error happens in the setup period of setup_streaming_telemetry, recover the telemetry.")
         restore_telemetry_forpyclient(duthost, default_client_auth)

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -112,7 +112,7 @@ def setup_streaming_telemetry(duthosts, enum_rand_one_per_hwsku_hostname, localh
         logger.info("telemetry process restarted. Now run pyclient on ptfdocker")
 
         # Wait until the TCP port was opened
-        dut_ip = get_mgmt_ipv6(duthost)
+        dut_ip = duthost.mgmt_ip
         wait_tcp_connection(localhost, dut_ip, env.gnmi_port, timeout_s=60)
 
         # pyclient should be available on ptfhost. If it was not available, then fail pytest.
@@ -156,7 +156,7 @@ def setup_streaming_telemetry_ipv6(duthosts, enum_rand_one_per_hwsku_hostname, l
         logger.info("telemetry process restarted. Now run pyclient on ptfdocker")
 
         # Wait until the TCP port was opened
-        dut_ip = duthost.mgmt_ip
+        dut_ip = get_mgmt_ipv6(duthost)
         wait_tcp_connection(localhost, dut_ip, env.gnmi_port, timeout_s=60)
 
         # Copy gnmi_get from container to host

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -35,8 +35,9 @@ def validate_yang(duthost, op_file="", yang_file=""):
     assert ret["rc"] == 0, "Yang validation failed for {}".format(yang_file)
 
 
+@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 @pytest.mark.disable_loganalyzer
-def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, localhost, gnxi_path,
+def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, gnxi_path,
                 test_eventd_healthy):
     """ Run series of events inside duthost and validate that output is correct
     and conforms to YANG schema"""
@@ -53,6 +54,7 @@ def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_strea
             logger.info("Completed test file: {}".format(os.path.join(EVENTS_TESTS_PATH, file)))
 
 
+@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 @pytest.mark.disable_loganalyzer
 def test_events_cache(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, gnxi_path):
     """Create expected o/p file of events with N events. Call event-publisher tool to publish M events (M<N). Publish
@@ -91,6 +93,7 @@ def test_events_cache(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup
     verify_counter_increase(duthost, current_published_counter, N, PUBLISHED)
 
 
+@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 @pytest.mark.disable_loganalyzer
 def test_events_cache_overflow(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry,
                                gnxi_path):

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -80,8 +80,9 @@ def test_telemetry_enabledbydefault(duthosts, enum_rand_one_per_hwsku_hostname):
                           "Telemetry feature is not enabled")
 
 
+@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                         setup_streaming_telemetry, localhost, gnxi_path):
+                         setup_streaming_telemetry, gnxi_path):
     """Run pyclient from ptfdocker and show gnmi server outputself.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -102,7 +103,7 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
                   "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi_output")
 
 
-def test_osbuild_version(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, localhost, gnxi_path):
+def test_osbuild_version(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
     """ Test osbuild/version query.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -118,7 +119,7 @@ def test_osbuild_version(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, lo
                  0, "invalid build_version value at {0}".format(result))
 
 
-def test_sysuptime(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, localhost, gnxi_path):
+def test_sysuptime(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
     """
     @summary: Run pyclient from ptfdocker and test the dataset 'system uptime' to check
               whether the value of 'system uptime' was float number and whether the value was
@@ -167,7 +168,7 @@ def test_sysuptime(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, localhos
         pytest.fail("The value of system uptime was not updated correctly.")
 
 
-def test_virtualdb_table_streaming(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, localhost, gnxi_path):
+def test_virtualdb_table_streaming(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
     """Run pyclient from ptfdocker to stream a virtual-db query multiple times.
     """
     logger.info('start virtual db sample streaming testing')
@@ -196,7 +197,7 @@ def invoke_py_cli_from_ptf(ptfhost, cmd, callback):
     callback(ret["stdout"])
 
 
-def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, localhost, gnxi_path):
+def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
     logger.info("Testing on change update notifications")
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 26660292

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

Add testcase for telemetry using mgmt ipv6

#### How did you do it?

Use ipv6 mgmt port for target ip with fixture to make dut ipv6 only

#### How did you verify/test it?


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
