### PR TITLE
Fixing AttributeError: 'LagPort' object has no attribute 'protocol'

### DIFF
--- a/tests/snappi_tests/lacp/files/lacp_dut_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_dut_helper.py
@@ -149,8 +149,8 @@ def __tgen_bgp_config(api,
                           i, location=temp_tg_port[i-1]['location'])
 
     lag0 = config.lags.lag(name="lag0")[-1]
+    lag0.protocol.lacp.actor_system_id = "00:10:00:00:11:11"
     lp = lag0.ports.port(port_name='Test_Port_1')[-1]
-    lp.protocol.lacp.actor_system_id = "00:10:00:00:11:11"
     lp.ethernet.name = "eth0"
     lp.ethernet.mac = "00:11:02:00:10:01"
     lag1 = config.lags.lag(name="lag1")[-1]
@@ -160,7 +160,7 @@ def __tgen_bgp_config(api,
             m = '0'+hex(i).split('0x')[1]
         else:
             m = hex(i).split('0x')[1]
-        lagport.protocol.lacp.actor_system_id = "00:10:00:00:00:11"
+        lag1.protocol.lacp.actor_system_id = "00:10:00:00:00:%s" % m
         lagport.ethernet.name = "eth%d" % i
         lagport.ethernet.mac = "00:10:04:00:00:%s" % m
 

--- a/tests/snappi_tests/lacp/files/lacp_physical_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_physical_helper.py
@@ -205,12 +205,14 @@ def __tgen_bgp_config(cvg_api,
                           i, location=temp_tg_port[i-1]['location'])
 
     lag0 = config.lags.lag(name="lag0")[-1]
+    lag0.protocol.lacp.actor_system_id = "00:10:00:00:11:11"
+
     lp = lag0.ports.port(port_name='Test_Port_1')[-1]
-    lp.protocol.lacp.actor_system_id = "00:10:00:00:11:11"
-    lp.protocol.lacp.lacpdu_periodic_time_interval = lacpdu_interval_period
-    lp.protocol.lacp.lacpdu_timeout = lacpdu_timeout
     lp.ethernet.name = "eth0"
     lp.ethernet.mac = "00:11:02:00:10:01"
+    lp.lacp.lacpdu_periodic_time_interval = lacpdu_interval_period
+    lp.lacp.lacpdu_timeout = lacpdu_timeout
+
     lag1 = config.lags.lag(name="lag1")[-1]
     for i in range(2, port_count+1):
         lagport = lag1.ports.port(port_name='Test_Port_%d' % i)[-1]
@@ -218,11 +220,11 @@ def __tgen_bgp_config(cvg_api,
             m = '0'+hex(i).split('0x')[1]
         else:
             m = hex(i).split('0x')[1]
-        lagport.protocol.lacp.actor_system_id = "00:10:00:00:00:11"
-        #
-        lagport.protocol.lacp.lacpdu_periodic_time_interval = lacpdu_interval_period
-        lagport.protocol.lacp.lacpdu_timeout = lacpdu_timeout
-        #
+        lag1.protocol.lacp.actor_system_id = "00:10:00:00:00:%s" % m
+
+        lagport.lacp.lacpdu_periodic_time_interval = lacpdu_interval_period
+        lagport.lacp.lacpdu_timeout = lacpdu_timeout
+
         lagport.ethernet.name = "eth%d" % i
         lagport.ethernet.mac = "00:10:04:00:00:%s" % m
     logger.info('|-------------- LACP Timers --------------|')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Providing fix for AttributeError: 'LagPort' object has no attribute 'protocol' since snappi-convergence verison has been upgraded
Fixes # (issue)https://github.com/sonic-net/sonic-mgmt/issues/12262

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Providing fix for AttributeError: 'LagPort' object has no attribute 'protocol' since snappi-convergence verison has been upgraded
#### How did you do it?
Modified the protocol attribute to be added to lag config object
#### How did you verify/test it?
Tested on Arista dut
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
