### PR TITLE
Fix ptf can't ssh dut issue due to password rotation

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1163,3 +1163,8 @@ def _paramiko_ssh(ip_address, username, passwords):
 def paramiko_ssh(ip_address, username, passwords):
     ssh, pwd = _paramiko_ssh(ip_address, username, passwords)
     return ssh
+
+
+def get_dut_current_passwd(ip_address, username, passwords):
+    _, pwd = _paramiko_ssh(ip_address, username, passwords)
+    return pwd

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,7 @@ from tests.common.utilities import get_host_visible_vars
 from tests.common.utilities import get_test_server_host
 from tests.common.utilities import str2bool
 from tests.common.utilities import safe_filename
+from tests.common.utilities import get_dut_current_passwd
 from tests.common.helpers.dut_utils import is_supervisor_node, is_frontend_node
 from tests.common.cache import FactsCache
 from tests.common.config_reload import config_reload
@@ -767,6 +768,9 @@ def creds_on_dut(duthost):
     creds["console_password"] = {}
 
     creds["ansible_altpasswords"] = []
+
+    passwords = creds["ansible_altpasswords"] + [creds["sonicadmin_password"]]
+    creds['sonicadmin_password'] = get_dut_current_passwd(duthost.mgmt_ip, creds['sonicadmin_user'], passwords)
 
     for k, v in list(console_login_creds.items()):
         creds["console_user"][k] = v["user"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Some testcases failed for ptf can't login ssh dut due to password rotation
#### How did you do it?
Get dut current password and overwrite default one in creds
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
