### PR TITLE
Fix the test fail with NoneType in test_voq_chassis_app_db_consistency

### DIFF
--- a/tests/voq/test_voq_chassis_app_db_consistency.py
+++ b/tests/voq/test_voq_chassis_app_db_consistency.py
@@ -166,12 +166,12 @@ def test_voq_chassis_app_db_consistency(duthosts, enum_rand_one_per_hwsku_fronte
         if test_case == "config_reload_no_config_save":
             logging.info("Reloading config")
             config_reload(duthost, safe_reload=True)
-            pytest_assert(wait_until(180, 30, 0, check_db_consistency, duthosts, duthost, init_dump),
+            pytest_assert(wait_until(600, 30, 0, check_db_consistency, duthosts, duthost, init_dump),
                           "DB_Consistency Failed")
         elif test_case == "config_reload_with_config_save":
             duthost.shell('sudo config save -y')
             config_reload(duthost, safe_reload=True)
-            pytest_assert(wait_until(180, 30, 0, check_db_consistency, duthosts, duthost, post_change_db_dump),
+            pytest_assert(wait_until(600, 30, 0, check_db_consistency, duthosts, duthost, post_change_db_dump),
                           "DB_Consistency Failed")
         else:
             logging.info("Rebooting dut {}".format(duthost))
@@ -182,7 +182,7 @@ def test_voq_chassis_app_db_consistency(duthosts, enum_rand_one_per_hwsku_fronte
             localhost.wait_for(host=duthost.mgmt_ip, port=22, state="started", delay=10, timeout=300)
             pytest_assert(wait_until(330, 20, 0, duthost.critical_services_fully_started),
                           "All critical services should fully started!")
-            pytest_assert(wait_until(380, 30, 0, check_db_consistency, duthosts, duthost, init_dump),
+            pytest_assert(wait_until(600, 30, 0, check_db_consistency, duthosts, duthost, init_dump),
                           "DB_Consistency Failed After Reboot")
 
     finally:
@@ -253,7 +253,9 @@ def get_db_dump(duthosts, duthost):
 
     chassis_app_db_sysparams = {}
     key = "*SYSTEM*|*" + duthost.sonichost.hostname + "*"
-    chassis_app_db_sysparams["CHASSIS_APP_DB"] = redis_get_keys(duthosts.supervisor_nodes[0], "CHASSIS_APP_DB", key)
+    chassis_app_db_result = redis_get_keys(duthosts.supervisor_nodes[0], "CHASSIS_APP_DB", key)
+    if chassis_app_db_result is not None:
+        chassis_app_db_sysparams["CHASSIS_APP_DB"] = chassis_app_db_result
     voqdb = VoqDbCli(duthosts.supervisor_nodes[0])
     chassis_app_db_sysparams["SYSTEM_LAG_ID_TABLE"] = voqdb.dump("SYSTEM_LAG_ID_TABLE")["SYSTEM_LAG_ID_TABLE"]['value']
     chassis_app_db_sysparams["SYSTEM_LAG_ID_SET"] = voqdb.dump("SYSTEM_LAG_ID_SET")["SYSTEM_LAG_ID_SET"]['value']


### PR DESCRIPTION
#### What is the motivation for this PR?
Fix the test fail with NoneType in test_voq_chassis_app_db_consistency. This test used to fail with error 

```
/azp/_work/8/s/tests/common/helpers/sonic_db.py::dump#169: [svcstr-xxxx-sup-1] AnsibleModule::command, args=["sonic-db-dump -n CHASSIS_APP_DB -y -k *SYSTEM_LAG_ID_SET*"], kwargs={}
12/01/2024 21:22:18 base._run                                L0082 DEBUG  | /azp/_work/8/s/tests/common/helpers/sonic_db.py::dump#169: [svcstr-xxxx-sup-1] AnsibleModule::command Result => {"stderr_lines": [], "cmd": ["sonic-db-dump", "-n", "CHASSIS_APP_DB", "-y", "-k", "*SYSTEM_LAG_ID_SET*"], "end": "2024-01-12 21:22:19.633679", "_ansible_no_log": false, "stdout": "{\n  \"SYSTEM_LAG_ID_SET\": {\n    \"expireat\": 1705094539.5715408,\n    \"ttl\": -0.001,\n    \"type\": \"set\",\n    \"value\": [\n      \"1\",\n      \"10\",\n      \"11\",\n      \"12\",\n      \"13\",\n      \"14\",\n      \"15\",\n      \"16\",\n      \"17\",\n      \"18\",\n      \"19\",\n      \"2\",\n      \"20\",\n      \"21\",\n      \"22\",\n      \"23\",\n      \"24\",\n      \"25\",\n      \"3\",\n      \"4\",\n      \"5\",\n      \"6\",\n      \"7\",\n      \"8\",\n      \"9\"\n    ]\n  }\n}", "changed": true, "rc": 0, "start": "2024-01-12 21:22:19.403027", "stderr": "", "delta": "0:00:00.230652", "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": false, "strip_empty_ends": true, "_raw_params": "sonic-db-dump -n CHASSIS_APP_DB -y -k *SYSTEM_LAG_ID_SET*", "removes": null, "argv": null, "warn": true, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["{", "  \"SYSTEM_LAG_ID_SET\": {", "    \"expireat\": 1705094539.5715408,", "    \"ttl\": -0.001,", "    \"type\": \"set\",", "    \"value\": [", "      \"1\",", "      \"10\",", "      \"11\",", "      \"12\",", "      \"13\",", "      \"14\",", "      \"15\",", "      \"16\",", "      \"17\",", "      \"18\",", "      \"19\",", "      \"2\",", "      \"20\",", "      \"21\",", "      \"22\",", "      \"23\",", "      \"24\",", "      \"25\",", "      \"3\",", "      \"4\",", "      \"5\",", "      \"6\",", "      \"7\",", "      \"8\",", "      \"9\"", "    ]", "  }", "}"], "failed": false}
12/01/2024 21:22:18 utilities.wait_until                     L0134 ERROR  | Exception caught while checking check_db_consistency:Traceback (most recent call last):
  File "/azp/_work/8/s/tests/common/utilities.py", line 128, in wait_until
    check_result = condition(*args, **kwargs)
  File "/azp/_work/8/s/tests/voq/test_voq_chassis_app_db_consistency.py", line 228, in check_db_consistency
    curr_dump = get_db_dump(duthosts, duthost)
  File "/azp/_work/8/s/tests/voq/test_voq_chassis_app_db_consistency.py", line 260, in get_db_dump
    return {k: sorted(v) for k, v in chassis_app_db_sysparams.items()}
  File "/azp/_work/8/s/tests/voq/test_voq_chassis_app_db_consistency.py", line 260, in <dictcomp>
    return {k: sorted(v) for k, v in chassis_app_db_sysparams.items()}
TypeError: 'NoneType' object is not iterable
, error:'NoneType' object is not iterable```
```

#### How did you do it?
Check for chassis_ap_db_result before adding to chassis_app_db_sysparams. What I found was that, it could take more time for CHASSIS_APP_DB is populated with SYSTEM_NEIGH/SYSTEM_INTERFACE after reboot/config reload of an LC. Hence when we poll for data repeatedly, there could be a case when get we get back is empty and we blindly add "None" to dictionary which fails with above error.

I have also increased the max time we wait from 180 to 600.

#### How did you verify/test it?

So the current fix is to skip adding to chassis_app_db_sysparams["CHASSIS_APP_DB"] if the chassis_app_db_result is None. I have added the logs below where we see the multiple iterations where we check for check_db_consistency() and finally becomes true when both the expected and current db_dumps are same.

```
10/04/2024 03:48:41 test_voq_chassis_app_db_consistency.chec L0234 INFO   | The Difference between the initial DB_DUMP and Current DB_DUMP : {'SYSTEM_LAG_ID_TABLE': ([u'str2-xxxx-lc1-1|asic0|PortChannel102', u'str2-xxxx-lc1-1|asic1|PortChannel106', u'str2-xxxx-lc2-1|asic0|PortChannel101', u'str2-xxxx-lc2-1|asic1|PortChannel105'], [u'str2-xxxx-lc2-1|asic0|PortChannel101', u'str2-xxxx-lc2-1|asic1|PortChannel105']), 'SYSTEM_LAG_ID_SET': ([u'1', u'2', u'3', u'4'], [u'3', u'4']), 'CHASSIS_APP_DB': ([u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic0|Ethernet-IB0', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic0|Ethernet-Rec0', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic0|Ethernet128', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic0|PortChannel102', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic1|Ethernet-IB1', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic1|Ethernet-Rec1', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic1|Ethernet184', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic1|PortChannel106', u'SYSTEM_LAG_MEMBER_TABLE|str2-xxxx-lc1-1|asic0|PortChannel102:str2-xxxx-lc1-1|asic0|Ethernet32', u'SYSTEM_LAG_MEMBER_TABLE|str2-xxxx-lc1-1|asic0|PortChannel102:str2-xxxx-lc1-1|asic0|Ethernet40', u'SYSTEM_LAG_MEMBER_TABLE|str2-xxxx-lc1-1|asic1|PortChannel106:str2-xxxx-lc1-1|asic1|Ethernet208', u'SYSTEM_LAG_MEMBER_TABLE|str2-xxxx-lc1-1|asic1|PortChannel106:str2-xxxx-lc1-1|asic1|Ethernet216', u'SYSTEM_LAG_TABLE|str2-xxxx-lc1-1|asic0|PortChannel102', u'SYSTEM_LAG_TABLE|str2-xxxx-lc1-1|asic1|PortChannel106', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic0|Ethernet-IB0|3.3.3.1', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic0|Ethernet-IB0|3333::3:1', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic0|Ethernet128|10.0.0.5', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic0|Ethernet128|fc00::a', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic0|PortChannel102|10.0.0.1', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic0|PortChannel102|fc00::2', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|Ethernet-IB1|3.3.3.2', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|Ethernet-IB1|3333::3:2', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|Ethernet184|10.0.0.11', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|Ethernet184|fc00::16', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|PortChannel106|10.0.0.7', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|PortChannel106|fc00::e'], None)}
10/04/2024 03:48:41 utilities.wait_until                     L0143 DEBUG  | check_db_consistency is False, wait 30 seconds and check again

10/04/2024 03:49:11 sonic_db.redis_get_keys                  L0553 DEBUG  | Getting keys from redis by command: sonic-db-cli CHASSIS_APP_DB KEYS "*SYSTEM*|*str2-xxxx-lc1-1*"
10/04/2024 03:49:11 base._run                                L0063 DEBUG  | /var/src/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#122: [str2-xxxx-sup-1] AnsibleModule::shell, args=["sonic-db-cli CHASSIS_APP_DB KEYS \"*SYSTEM*|*str2-xxxx-lc1-1*\""], kwargs={}

10/04/2024 03:49:16 base._run                                L0082 DEBUG  | /var/src/sonic-mgmt-int/tests/common/helpers/sonic_db.py::dump#169: [str2-xxxx-sup-1] AnsibleModule::command Result => {"stderr_lines": [], "cmd": ["sonic-db-dump", "-n", "CHASSIS_APP_DB", "-y", "-k", "*SYSTEM_LAG_ID_SET*"], "end": "2024-04-10 03:49:15.964264", "_ansible_no_log": false, "stdout": "{\n  \"SYSTEM_LAG_ID_SET\": {\n    \"expireat\": 1712720955.9446938,\n    \"ttl\": -0.001,\n    \"type\": \"set\",\n    \"value\": [\n      \"1\",\n      \"2\",\n      \"3\",\n      \"4\"\n    ]\n  }\n}", "changed": true, "rc": 0, "start": "2024-04-10 03:49:15.775029", "stderr": "", "delta": "0:00:00.189235", "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": false, "strip_empty_ends": true, "_raw_params": "sonic-db-dump -n CHASSIS_APP_DB -y -k *SYSTEM_LAG_ID_SET*", "removes": null, "argv": null, "warn": true, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["{", "  \"SYSTEM_LAG_ID_SET\": {", "    \"expireat\": 1712720955.9446938,", "    \"ttl\": -0.001,", "    \"type\": \"set\",", "    \"value\": [", "      \"1\",", "      \"2\",", "      \"3\",", "      \"4\"", "    ]", "  }", "}"], "failed": false}
10/04/2024 03:49:16 test_voq_chassis_app_db_consistency.chec L0234 INFO   | The Difference between the initial DB_DUMP and Current DB_DUMP : {'CHASSIS_APP_DB': ([u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic0|Ethernet-IB0', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic0|Ethernet-Rec0', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic0|Ethernet128', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic0|PortChannel102', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic1|Ethernet-IB1', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic1|Ethernet-Rec1', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic1|Ethernet184', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic1|PortChannel106', u'SYSTEM_LAG_MEMBER_TABLE|str2-xxxx-lc1-1|asic0|PortChannel102:str2-xxxx-lc1-1|asic0|Ethernet32', u'SYSTEM_LAG_MEMBER_TABLE|str2-xxxx-lc1-1|asic0|PortChannel102:str2-xxxx-lc1-1|asic0|Ethernet40', u'SYSTEM_LAG_MEMBER_TABLE|str2-xxxx-lc1-1|asic1|PortChannel106:str2-xxxx-lc1-1|asic1|Ethernet208', u'SYSTEM_LAG_MEMBER_TABLE|str2-xxxx-lc1-1|asic1|PortChannel106:str2-xxxx-lc1-1|asic1|Ethernet216', u'SYSTEM_LAG_TABLE|str2-xxxx-lc1-1|asic0|PortChannel102', u'SYSTEM_LAG_TABLE|str2-xxxx-lc1-1|asic1|PortChannel106', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic0|Ethernet-IB0|3.3.3.1', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic0|Ethernet-IB0|3333::3:1', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic0|Ethernet128|10.0.0.5', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic0|Ethernet128|fc00::a', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic0|PortChannel102|10.0.0.1', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic0|PortChannel102|fc00::2', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|Ethernet-IB1|3.3.3.2', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|Ethernet-IB1|3333::3:2', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|Ethernet184|10.0.0.11', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|Ethernet184|fc00::16', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|PortChannel106|10.0.0.7', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|PortChannel106|fc00::e'], [u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic0|Ethernet-IB0', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic0|Ethernet-Rec0', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic0|Ethernet128', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic0|PortChannel102', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic1|Ethernet-IB1', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic1|Ethernet-Rec1', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic1|Ethernet184', u'SYSTEM_INTERFACE|str2-xxxx-lc1-1|asic1|PortChannel106', u'SYSTEM_LAG_MEMBER_TABLE|str2-xxxx-lc1-1|asic0|PortChannel102:str2-xxxx-lc1-1|asic0|Ethernet32', u'SYSTEM_LAG_MEMBER_TABLE|str2-xxxx-lc1-1|asic0|PortChannel102:str2-xxxx-lc1-1|asic0|Ethernet40', u'SYSTEM_LAG_MEMBER_TABLE|str2-xxxx-lc1-1|asic1|PortChannel106:str2-xxxx-lc1-1|asic1|Ethernet208', u'SYSTEM_LAG_MEMBER_TABLE|str2-xxxx-lc1-1|asic1|PortChannel106:str2-xxxx-lc1-1|asic1|Ethernet216', u'SYSTEM_LAG_TABLE|str2-xxxx-lc1-1|asic0|PortChannel102', u'SYSTEM_LAG_TABLE|str2-xxxx-lc1-1|asic1|PortChannel106', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic0|Ethernet-IB0|3.3.3.1', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic0|Ethernet-IB0|3333::3:1', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|Ethernet-IB1|3.3.3.2', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|Ethernet-IB1|3333::3:2', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|Ethernet184|10.0.0.11', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|Ethernet184|fc00::16', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|PortChannel106|10.0.0.7', u'SYSTEM_NEIGH|str2-xxxx-lc1-1|asic1|PortChannel106|fc00::e'])}
10/04/2024 03:49:16 utilities.wait_until                     L0143 DEBUG  | check_db_consistency is False, wait 30 seconds and check again

10/04/2024 03:49:46 sonic_db.redis_get_keys                  L0553 DEBUG  | Getting keys from redis by command: sonic-db-cli CHASSIS_APP_DB KEYS "*SYSTEM*|*str2-xxxx-lc1-1*"
10/04/2024 03:49:46 base._run                                L0063 DEBUG  | /var/src/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#122: [str2-xxxx-sup-1] AnsibleModule::shell, args=["sonic-db-cli CHASSIS_APP_DB KEYS \"*SYSTEM*|*str2-xxxx-lc1-1*\""], kwargs={}

10/04/2024 03:49:49 utilities.wait_until                     L0140 DEBUG  | check_db_consistency is True, exit early with True
```




```

voq/test_voq_chassis_app_db_consistency.py::test_voq_chassis_app_db_consistency[str2-xxxx-lc1-1-1-dut_reboot]   PASSED                                                                                                                                     [ 33%]
voq/test_voq_chassis_app_db_consistency.py::test_voq_chassis_app_db_consistency[str2-xxxx-lc1-1-1-config_reload_with_config_save]  PASSED                                                                                                                 [ 66%]
voq/test_voq_chassis_app_db_consistency.py::test_voq_chassis_app_db_consistency[str2-xxxx-lc1-1-1-config_reload_no_config_save]  PASSED                                                                                                                   [100%] 

------------------------------------------------------------------------------------------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------------------------
================================================================================================================= 3 passed in 1537.12 seconds ==================================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
