### PR TITLE
Improve test_start_pfcwd to support 4 lossless queues

### DIFF
--- a/tests/generic_config_updater/test_pfcwd_status.py
+++ b/tests/generic_config_updater/test_pfcwd_status.py
@@ -128,9 +128,6 @@ def extract_pfcwd_config(duthost, start_pfcwd):
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     port_qos_map = config_facts.get("PORT_QOS_MAP", {})
 
-    if len(list(port_qos_map.keys())) == 0:
-        return []
-
     pfcwd_config = defaultdict()
     for line in output['stdout_lines']:
         if line.strip().startswith('Ethernet'):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR is to improve test case `test_start_pfcwd` to support 4-lossless queues.
The test is failing on some testbed. The error message is as below.
```
>       pytest_assert(
            wait_until(READ_FLEXDB_TIMEOUT, READ_FLEXDB_INTERVAL, 0, _confirm_value_in_flex_db, duthost, expected_count),
            "FLEX DB does not properly reflect Pfcwd status: Expected number of entries {}"
            .format(expected_count)
        )
E       Failed: FLEX DB does not properly reflect Pfcwd status: Expected number of entries 84
```
The actual number of entries in FLEX_COUNTER_DB is more than the expected number because there are 4 lossless queues in some ports, and then there will be more DB entries.

This PR fixed the issue by counting the lossless priorities on each port and then calculate the expected DB entry number.

Summary:
Fixes # (issue)
This PR is to improve test case `test_start_pfcwd` to support 4-lossless queues.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR is to improve test case `test_start_pfcwd` to support 4-lossless queues.

#### How did you do it?
This PR fixed the issue by counting the lossless priorities on each port and then calculate the expected DB entry number.

#### How did you verify/test it?
The change is verified on a T1 testbed.
```
collected 2 items                                                                                                                                                                                                                  

generic_config_updater/test_pfcwd_status.py::test_start_pfcwd[single] PASSED                                                                                                                                                 [ 50%]
generic_config_updater/test_pfcwd_status.py::test_start_pfcwd[all] PASSED                                                                                                                                                    [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
