### PR TITLE
Revert "[dhcp_relay] Skip test_dhcpv6_relay for dualtor-aa (#12046)"

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -312,20 +312,6 @@ dhcp_relay/test_dhcpv6_relay.py:
     conditions:
       - "platform in ['x86_64-8111_32eh_o-r0']"
 
-dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default:
-  skip:
-    reason: "Test is not supported in dualtor-aa"
-    conditions:
-      - https://github.com/sonic-net/sonic-mgmt/issues/12045
-      - "'dualtor-aa' in topo_name"
-
-dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter:
-  skip:
-    reason: "Test is not supported in dualtor-aa"
-    conditions:
-      - https://github.com/sonic-net/sonic-mgmt/issues/12045
-      - "'dualtor-aa' in topo_name"
-
 #######################################
 #####         drop_packets        #####
 #######################################


### PR DESCRIPTION
This reverts commit dbed546b15d226daae4fc9307a2ebf0df35ad755.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
dhcpv6 relay failure in dualtor-aa was fixed by https://github.com/sonic-net/sonic-mgmt/pull/11695
Hence remove skip condition

#### How did you do it?
Remove skip test_dhcpv6_relay in dualtor-aa

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
