### PR TITLE
test_show_platform.py: match 'N/A' for led_status in show platform psustatus

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -47,7 +47,7 @@ def get_dut_psu_line_pattern(dut):
             PSU 2  N/A      N/A               12.01           4.12        49.50  OK        green
 
         """
-        psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(green|amber|red|off)")
+        psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(green|amber|red|off|N/A)")
     return psu_line_pattern
 
 

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -276,7 +276,7 @@ def test_show_platform_psustatus_json(duthosts, enum_supervisor_dut_hostname):
     if duthost.facts["platform"] == "x86_64-dellemc_z9332f_d1508-r0":
         led_status_list = ["N/A"]
     else:
-        led_status_list = ["green", "amber", "red", "off"]
+        led_status_list = ["green", "amber", "red", "off", "N/A"]
     for psu_info in psu_info_list:
         expected_keys = ["index", "name", "presence", "status", "led_status", "model", "serial", "voltage", "current",
                          "power"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Test cases `test_show_platform.py::test_show_platform_psustatus` and `test_show_platform.py::test_show_platform_psustatus_json` are expecting PSU LED state to be red/green/amber/off even if PSU is not present. Fix is required to expect “N/A” also which is appropriate if PSU is not present.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

Verified with running the testcases in the case of PSUs not present on certain locations. 
```
$ show plat psustatus
PSU    Model            Serial       HW Rev    Voltage (V)    Current (A)    Power (W)    Status       LED
-----  ---------------  -----------  --------  -------------  -------------  -----------  -----------  -----
PSU 1  PSU6.3KW-20A-HV  DTM25030246  1.0       54.582         15.259         834.008      OK           green
PSU 2  PSU6.3KW-20A-HV  DTM245200J4  1.0       54.426         15.396         837.527      OK           green
PSU 3  PSU6.3KW-20A-HV  DTM24510345  1.0       54.661         14.986         819.932      OK           green
PSU 4  PSU6.3KW-20A-HV  DTM24520096  1.0       54.739         14.78          809.375      OK           green
PSU 5  N/A              N/A          N/A       N/A            N/A            N/A          NOT PRESENT  N/A
PSU 6  N/A              N/A          N/A       N/A            N/A            N/A          NOT PRESENT  N/A
PSU 7  N/A              N/A          N/A       N/A            N/A            N/A          NOT PRESENT  N/A
PSU 8  PSU6.3KW-20A-HV  DTM245200EK  1.0       54.582         15.67          855.122      OK           green
PSU 9  N/A              N/A          N/A       N/A            N/A            N/A          NOT PRESENT  N/A

=============================== warnings summary ===============================
../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================== PASSES ====================================
________________ test_show_platform_psustatus_json[sfd-lt2-sup] ________________
- generated xml file: /data/tests/logs/platform_tests/cli/test_show_platform.py::test_show_platform_psustatus_json_2024-04-02-23-39-08.xml -
---------------------------- live log sessionfinish ----------------------------
23:40:40 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
=========================== short test summary info ============================
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_psustatus_json[sfd-lt2-sup]
=================== 1 passed, 1 warning in 89.86s (0:01:29) ====================


=============================== warnings summary ===============================
../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================== PASSES ====================================
__________________ test_show_platform_psustatus[sfd-lt2-sup] ___________________
- generated xml file: /data/tests/logs/platform_tests/cli/test_show_platform.py::test_show_platform_psustatus_2024-04-02-23-48-55.xml -
---------------------------- live log sessionfinish ----------------------------
23:50:24 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
=========================== short test summary info ============================
PASSED platform_tests/cli/test_show_platform.py::test_show_platform_psustatus[sfd-lt2-sup]
=================== 1 passed, 1 warning in 86.78s (0:01:26) ====================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
