### PR TITLE
Enhance the "switch" connection plugin to hand Passwordless Login

### DIFF
--- a/ansible/plugins/connection/switch.py
+++ b/ansible/plugins/connection/switch.py
@@ -97,6 +97,8 @@ class Connection(ConnectionBase):
 
             # if "'>', '#'" means Passwordless login, no need to send password
             if i in [1, 2]:
+                self._display.vvv(
+                    "Establish connection to server successful without requiring a password.", host=self.host)
                 break
 
             self._display.vvv("Try password %s..." %
@@ -104,6 +106,8 @@ class Connection(ConnectionBase):
             client.sendline(login_passwd)
             i = client.expect(['>', '#', '[Pp]assword:', pexpect.EOF])
             if i < 2:
+                self._display.vvv(
+                    "Establish connection to server successful with password.", host=self.host)
                 break
             elif i == 3:
                 last_user = None

--- a/ansible/plugins/connection/switch.py
+++ b/ansible/plugins/connection/switch.py
@@ -94,7 +94,7 @@ class Connection(ConnectionBase):
                 else:
                     raise AnsibleError(
                         "Establish connection to server failed after tried %d times." % max_retries)
-            
+
             # if "'>', '#'" means Passwordless login, no need to send password
             if i in [1, 2]:
                 break

--- a/ansible/plugins/connection/switch.py
+++ b/ansible/plugins/connection/switch.py
@@ -81,8 +81,8 @@ class Connection(ConnectionBase):
                     client = pexpect.spawn(' '.join(cmd), env={
                                            'TERM': 'dumb'}, timeout=self.timeout)
                     i = client.expect(
-                        ['[Pp]assword:', pexpect.EOF, pexpect.TIMEOUT])
-                    if i == 0:
+                        ['[Pp]assword:', '>', '#', pexpect.EOF, pexpect.TIMEOUT])
+                    if i in [0, 1, 2]:
                         break
                     else:
                         self._display.vvv(
@@ -94,6 +94,10 @@ class Connection(ConnectionBase):
                 else:
                     raise AnsibleError(
                         "Establish connection to server failed after tried %d times." % max_retries)
+            
+            # if "'>', '#'" means Passwordless login, no need to send password
+            if i in [1, 2]:
+                break
 
             self._display.vvv("Try password %s..." %
                               login_passwd[0:4], host=self.host)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
27364287

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Case failed with error message "msg": "Establish connection to server failed after tried 3 times."

#### How did you do it?
Ansible uses the option "'ControlPersist=60s'" for SSH connection, it would allow the master connection to remain open after the initial SSH session has been established. This option helps to speed up subsequent SSH connections to the same host by reusing the existing connection. 
But in the current script, the code always waits for the '[Pp]assword:' prompt, causing a timeout in passwordless login.

Break if the prompt is " '>', '#'" to handle the passwordless logdin

#### How did you verify/test it?
Run the original case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
