### PR TITLE
Revert "ACL testcases in A/A setup need additional rules to ALLOW the ICMP keepalives to ensure both TORs don't go in STANDBY mode"

### DIFF
--- a/tests/acl/templates/acltb_test_rules.j2
+++ b/tests/acl/templates/acltb_test_rules.j2
@@ -510,41 +510,7 @@
                                         "destination-ip-address": "192.168.0.122/32"
                                     }
                                 }
-{% if dualtor == True -%}
-                            },
-                            "34": {
-                                "actions": {
-                                    "config": {
-                                        "forwarding-action": "ACCEPT"
-                                    }
-                                },
-                                "config": {
-                                    "sequence-id": 34
-                                },
-                                "ip": {
-                                    "config": {
-                                        "destination-ip-address": "{{Loopback2}}/32"
-                                    }
-                                }
-                            },
-                            "35": {
-                                "actions": {
-                                    "config": {
-                                        "forwarding-action": "ACCEPT"
-                                    }
-                                },
-                                "config": {
-                                    "sequence-id": 35
-                                },
-                                "ip": {
-                                    "config": {
-                                        "destination-ip-address": "{{Loopback3}}/32"
-                                    }
-                                }
                             }
-{%- else -%}
-                            }
-{%- endif %}
                         }
                     }
                 }

--- a/tests/acl/templates/acltb_test_rules_part_1.j2
+++ b/tests/acl/templates/acltb_test_rules_part_1.j2
@@ -125,41 +125,7 @@
                                         "destination-port": "179"
                                     }
                                 }
-{% if dualtor == True -%}
-                            },
-                            "29": {
-                                "actions": {
-                                    "config": {
-                                        "forwarding-action": "ACCEPT"
-                                    }
-                                },
-                                "config": {
-                                    "sequence-id": 29
-                                },
-                                "ip": {
-                                    "config": {
-                                        "destination-ip-address": "{{Loopback2}}/32"
-                                    }
-                                }
-                            },
-                            "30": {
-                                "actions": {
-                                    "config": {
-                                        "forwarding-action": "ACCEPT"
-                                    }
-                                },
-                                "config": {
-                                    "sequence-id": 30
-                                },
-                                "ip": {
-                                    "config": {
-                                        "destination-ip-address": "{{Loopback3}}/32"
-                                    }
-                                }
                             }
-{%- else -%}
-                            }
-{%- endif %}
                         }
                     }
                 }

--- a/tests/acl/templates/acltb_test_rules_part_2.j2
+++ b/tests/acl/templates/acltb_test_rules_part_2.j2
@@ -510,41 +510,7 @@
                                         "destination-ip-address": "192.168.0.122/32"
                                     }
                                 }
-{% if dualtor == True -%}
-                            },
-                            "34": {
-                                "actions": {
-                                    "config": {
-                                        "forwarding-action": "ACCEPT"
-                                    }
-                                },
-                                "config": {
-                                    "sequence-id": 34
-                                },
-                                "ip": {
-                                    "config": {
-                                        "destination-ip-address": "{{Loopback2}}/32"
-                                    }
-                                }
-                            },
-                            "35": {
-                                "actions": {
-                                    "config": {
-                                        "forwarding-action": "ACCEPT"
-                                    }
-                                },
-                                "config": {
-                                    "sequence-id": 35
-                                },
-                                "ip": {
-                                    "config": {
-                                        "destination-ip-address": "{{Loopback3}}/32"
-                                    }
-                                }
                             }
-{%- else -%}
-                            }
-{%- endif %}
                         }
                     }
                 }

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -25,7 +25,6 @@ from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts # noqa F401
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.platform.interface_utils import check_all_interface_information
-from tests.common.utilities import is_ipv4_address
 
 logger = logging.getLogger(__name__)
 
@@ -605,7 +604,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
     ACL_COUNTERS_UPDATE_INTERVAL_SECS = 10
 
     @abstractmethod
-    def setup_rules(self, dut, acl_table, ip_version, tbinfo):
+    def setup_rules(self, dut, acl_table, ip_version):
         """Setup ACL rules for testing.
 
         Args:
@@ -670,7 +669,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
                 # Ignore any other errors to reduce noise
                 loganalyzer.ignore_regex = [r".*"]
                 with loganalyzer:
-                    self.setup_rules(duthost, acl_table, ip_version, tbinfo)
+                    self.setup_rules(duthost, acl_table, ip_version)
                     # Give the dut some time for the ACL rules to be applied and LOG message generated
                     time.sleep(30)
 
@@ -1169,7 +1168,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
 class TestBasicAcl(BaseAclTest):
     """Test Basic functionality of ACL rules (i.e. setup with full update on a running device)."""
 
-    def setup_rules(self, dut, acl_table, ip_version, tbinfo):
+    def setup_rules(self, dut, acl_table, ip_version):
         """Setup ACL rules for testing.
 
         Args:
@@ -1177,23 +1176,6 @@ class TestBasicAcl(BaseAclTest):
             acl_table: Configuration info for the ACL table.
 
         """
-
-        if 'dualtor' in tbinfo['topo']['name']:
-            dut.host.options["variable_manager"].extra_vars.update({"dualtor": True})
-            sonichost = dut.get_asic_or_sonic_host(None)
-            config_facts = sonichost.get_running_config_facts()
-            tor_ipv4_address = [_ for _ in config_facts["LOOPBACK_INTERFACE"]["Loopback2"]
-                                if is_ipv4_address(_.split("/")[0])][0]
-            tor_ipv4_address = tor_ipv4_address.split("/")[0]
-            dut.host.options["variable_manager"].extra_vars.update({"Loopback2": tor_ipv4_address})
-
-            tor_ipv4_address = [_ for _ in config_facts["LOOPBACK_INTERFACE"]["Loopback3"]
-                                if is_ipv4_address(_.split("/")[0])][0]
-            tor_ipv4_address = tor_ipv4_address.split("/")[0]
-            dut.host.options["variable_manager"].extra_vars.update({"Loopback3": tor_ipv4_address})
-        else:
-            dut.host.options["variable_manager"].extra_vars.update({"dualtor": False})
-
         table_name = acl_table["table_name"]
         dut.host.options["variable_manager"].extra_vars.update({"acl_table_name": table_name})
 
@@ -1214,7 +1196,7 @@ class TestIncrementalAcl(BaseAclTest):
     multiple parts.
     """
 
-    def setup_rules(self, dut, acl_table, ip_version, tbinfo):
+    def setup_rules(self, dut, acl_table, ip_version):
         """Setup ACL rules for testing.
 
         Args:
@@ -1222,21 +1204,6 @@ class TestIncrementalAcl(BaseAclTest):
             acl_table: Configuration info for the ACL table.
 
         """
-        if 'dualtor' in tbinfo['topo']['name']:
-            dut.host.options["variable_manager"].extra_vars.update({"dualtor": True})
-            sonichost = dut.get_asic_or_sonic_host(None)
-            config_facts = sonichost.get_running_config_facts()
-            tor_ipv4_address = [_ for _ in config_facts["LOOPBACK_INTERFACE"]["Loopback2"]
-                                if is_ipv4_address(_.split("/")[0])][0]
-            tor_ipv4_address = tor_ipv4_address.split("/")[0]
-            dut.host.options["variable_manager"].extra_vars.update({"Loopback2": tor_ipv4_address})
-            tor_ipv4_address = [_ for _ in config_facts["LOOPBACK_INTERFACE"]["Loopback3"]
-                                if is_ipv4_address(_.split("/")[0])][0]
-            tor_ipv4_address = tor_ipv4_address.split("/")[0]
-            dut.host.options["variable_manager"].extra_vars.update({"Loopback3": tor_ipv4_address})
-        else:
-            dut.host.options["variable_manager"].extra_vars.update({"dualtor": False})
-
         table_name = acl_table["table_name"]
         dut.host.options["variable_manager"].extra_vars.update({"acl_table_name": table_name})
 


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#11892


This test uses acl templates at tests/acl/templates/acltb_test_rules.j2, this change adds “dualtor” in this template, test_techsupport.py does not have this “dualtor”, and then this test is broken.