### PR TITLE
fix cisco lossyQueueVoq failure

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -696,6 +696,10 @@ class QosSaiBase(QosBase):
         dstPorts = request.config.getoption("--qos_dst_ports")
         srcPorts = request.config.getoption("--qos_src_ports")
 
+        logging.debug("__buildTestPorts testPortIds: {}, testPortIps: {}, src_port_ids: {}, \
+                      dst_port_ids: {}, get_src_dst_asic_and_duts: {}, uplinkPortIds: {}".format(
+                      testPortIds, testPortIps, src_port_ids, dst_port_ids, get_src_dst_asic_and_duts, uplinkPortIds))
+
         src_dut_port_ids = testPortIds[get_src_dst_asic_and_duts['src_dut_index']]
         src_test_port_ids = src_dut_port_ids[get_src_dst_asic_and_duts['src_asic_index']]
         dst_dut_port_ids = testPortIds[get_src_dst_asic_and_duts['dst_dut_index']]
@@ -1170,6 +1174,8 @@ class QosSaiBase(QosBase):
             "downlink_port_ips": downlinkPortIps,
             "downlink_port_names": downlinkPortNames
         })
+        logging.debug("testPorts: {}".format(testPorts))
+
         dutinterfaces = {}
         uplinkPortIds = testPorts.get('uplink_port_ids', [])
 


### PR DESCRIPTION
…leshooting capability

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

consistently hit LossyQueueVoq failure on cisco platform

# RCA:

## symptom 1 : dst port ip is incorrect, and get_multiple_flows failed

```
dst_port_id=0;
dst_port_ip="10.0.0.33";     >>>>> wrong ptf parameter: dst port id 0's IP is 10.0.0.1 instead of 10.0.0.33
... omitted ...
src_port_id=4;
src_port_ip="10.0.0.5";
... omitted ... 
uplink_port_ids=[0, 4, 16, 20];
downlink_port_ids=[34, 36, 37, 38, 39, 42, 44, 45, 46, 47, 50, 52, 53, 54, 55, 58, 60, 61, 62, 63];
... omitted ...
testPortIps={0: {0: {
0: {"peer_addr": "10.0.0.1"},    >>>>> here, dutconfig's parameter is correct instead.
4: {"peer_addr": "10.0.0.5"}, 
16: {"peer_addr": "10.0.0.9"}, 
20: {"peer_addr": "10.0.0.13"}, 
34: {"peer_addr": "10.0.0.33"}, 
... omitted ...
```

## symptom 2: flaky failure casued by LAG session aging

```
... omittd ....
dst_port_id=0;
dst_port_ip="10.0.0.1";
... omitted ...
src_port_id=4;
src_port_ip="10.0.0.5";
... omitted ...
uplink_port_ids=[0, 4, 16, 20];
... omitted ...
======================================================================
ERROR: sai_qos_tests.LossyQueueVoqTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"saitests/py3/sai_qos_tests.py\", line 3749, in runTest
    int(self.test_params['pg']), self.asic_type), \\
  File \"saitests/py3/sai_qos_tests.py\", line 399, in fill_leakout_plus_one
    src_port_id, dst_port_id, pkt.__repr__()[0:180], queue))
RuntimeError: fill_leakout_plus_one: Fail: src_port_id:4 dst_port_id:0, pkt:<Ether  dst=9C:54:16:4E:29:F0 src=4a:71:a4:fd:3b:04 type=IPv4 |<IP  ihl=None tos=0x21 id=1 frag=0 ttl=64 proto=tcp src=192.0.0.2 dst=10.0.0.1 |<TCP  sport=1234 dport=1244 flags=S |, queue:0
```

## rootcause

in testQosSaiLossyQueueVoq case,
- dst_port_id was unexpectedly assigned port index rather than port id.
- always supose src_port_id is in downstream ports, but sometimes src_port is in upstream ports, need to pick up donwstream port for src port as well.

```
        if separated_dscp_to_tc_map_on_uplink(dut_qos_maps):
            # We need to choose only the downlink port ids, which are associated
            # with AZURE dscp_to_tc mapping. The uplink ports have a
            # different mapping.
            for index in range(len(dutConfig['testPorts']['downlink_port_ids'])):
                if dutConfig["testPorts"]["src_port_id"] != \                 >>>> here, always consider src port as downstream port
                        dutConfig['testPorts']['downlink_port_ids'][index]:
                    dst_port_id = index   >>> here, should change to port id instead of port index
                    dst_port_ip = dutConfig['testPorts']['downlink_port_ips'][index]
                    break
```

#### How did you do it?

- fixed issues mentioned above
- additionally, add more debug message to enhance port selection's  troubleshooting capability

#### How did you verify/test it?

- Cisco-8102-C64, t0-64:  **pass**
```
test plan id: 66124cf9547d049f1bfc47d4
...
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq[single_asic-lossy_queue_voq_1] PASSED [ 16%]
```

- Cisco-8102-C64, t1-64-lag:  **pass**

```
test plan id: 66124cfb547d049f1bfc47d6
... ...
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq[single_asic-lossy_queue_voq_1] PASSED [ 16%]
```

- Cisco-8101-O8C48, t1-56-lag topology: **pass**
```
test plan id: 66124cffe3f0ed9b4960a7ba
... 
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq[single_asic-lossy_queue_voq_1] PASSED [ 16%]
```

- Cisco-8111-O32, t1-lag topology:  **pass**
```
test plan id: 66124d01547d049f1bfc47da
... ...
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq[single_asic-lossy_queue_voq_1] PASSED [ 16%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
