### PR TITLE
[macsec]: Add a sleep at the link flap retry for the flaky failure

### DIFF
--- a/tests/macsec/test_fault_handling.py
+++ b/tests/macsec/test_fault_handling.py
@@ -48,6 +48,9 @@ class TestFaultHandling():
                 except AssertionError as e:
                     if retry == 0:
                         raise e
+                    # This test may fail due to the lag of DUT exceeding MKA_TIMEOUT that triggers a rekey.
+                    # To mitigate this, retry the test after a while with a few seconds of idle time.
+                    sleep(30)
                 dut_egress_sa_table_orig, dut_ingress_sa_table_orig = dut_egress_sa_table_new, dut_ingress_sa_table_new
 
         # Flap > 6 seconds but < 90 seconds


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 27459603

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
There is a flaky failure on the macsec_test_fault_handling. It's due to the lag of DUT exceeding MKA_TIMEOUT that triggers a rekey.

#### How did you do it?
To mitigate this, retry the test after a while with a few seconds of idle time.

#### How did you verify/test it?
Check Azp

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
