### PR TITLE
[docs/testbed]: Fix typo in VM instances

### DIFF
--- a/docs/testbed/README.testbed.Overview.md
+++ b/docs/testbed/README.testbed.Overview.md
@@ -133,7 +133,7 @@ Like the T0 type topology, the T1 type topology also has variations:
 
 * The DUT has 32 ports.
 * Requires 24 VMs.
-* 16 of the ports are connected to 16 VMs simulating upstream T2 neighbors. Each VM has 2 links connected. The connection to each upstream T2 is configured as a port-channel with 2 links.
+* 16 of the ports are connected to 8 VMs simulating upstream T2 neighbors. Each VM has 2 links connected. The connection to each upstream T2 is configured as a port-channel with 2 links.
 * 16 of the ports are connected to another 16 VMs simulating downstream T0 neighbors. No port-channel is configured for the links between DUT and T0 neighbors.
 
 ### T2 type topology


### PR DESCRIPTION
### Fix typo in README.testbed.Overview.md

- Testbed configuration for `t1-lag` mentions number of T2 VM instances as 16 while the actual value must have been 8.

Summary:
Fixes # Not applicable

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

Fix a minor error in the README documentation.

#### How did you do it?

Fix typo.

#### How did you verify/test it?

Not applicable

#### Any platform specific information?

Not applicable.

#### Supported testbed topology if it's a new test case?

Not applicable.

### Documentation

Updated README.