### PR TITLE
Fix qos/test_qos_sai.py

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -777,25 +777,31 @@ class QosSaiBase(QosBase):
                             if sysMap['port_type'] == sysPorts[port_id]['port_type'] and sport != port_id:
                                 dst_all_sys_port.update({sport: sysMap['system_port']})
 
-        return {
-            "dst_port_id": dstPort,
-            "dst_port_ip": dst_test_port_ips[dstPort]['peer_addr'],
-            "dst_port_ipv6": dst_test_port_ips[dstPort]['peer_addr_ipv6'],
-            "dst_port_vlan": dstVlan,
-            "dst_port_2_id": dstPort2,
-            "dst_port_2_ip": dst_test_port_ips[dstPort2]['peer_addr'],
-            "dst_port_2_ipv6": dst_test_port_ips[dstPort2]['peer_addr_ipv6'],
-            "dst_port_2_vlan": dstVlan2,
-            'dst_port_3_id': dstPort3,
-            "dst_port_3_ip": dst_test_port_ips[dstPort3]['peer_addr'],
-            "dst_port_3_ipv6": dst_test_port_ips[dstPort3]['peer_addr_ipv6'],
-            "dst_port_3_vlan": dstVlan3,
-            "src_port_id": srcPort,
-            "src_port_ip": src_port_ip["peer_addr"],
-            "src_port_ipv6": src_port_ip["peer_addr_ipv6"],
-            "src_port_vlan": srcVlan,
-            "dst_sys_ports": dst_all_sys_port
+        testPorts = {
+             "dst_port_id": dstPort,
+             "dst_port_ip": dst_test_port_ips[dstPort]['peer_addr'],
+             "dst_port_vlan": dstVlan,
+             "dst_port_2_id": dstPort2,
+             "dst_port_2_ip": dst_test_port_ips[dstPort2]['peer_addr'],
+             "dst_port_2_vlan": dstVlan2,
+             'dst_port_3_id': dstPort3,
+             "dst_port_3_ip": dst_test_port_ips[dstPort3]['peer_addr'],
+             "dst_port_3_vlan": dstVlan3,
+             "src_port_id": srcPort,
+             "src_port_ip": src_port_ip["peer_addr"],
+             "src_port_vlan": srcVlan
         }
+
+        if 'peer_addr_ipv6' in dst_test_port_ips[dstPort]:
+            testPorts.update({"dst_port_ipv6": dst_test_port_ips[dstPort]['peer_addr_ipv6']})
+        if 'peer_addr_ipv6' in dst_test_port_ips[dstPort2]:
+            testPorts.update({"dst_port_2_ipv6": dst_test_port_ips[dstPort2]['peer_addr_ipv6']})
+        if 'peer_addr_ipv6' in dst_test_port_ips[dstPort3]:
+            testPorts.update({"dst_port_3_ipv6": dst_test_port_ips[dstPort3]['peer_addr_ipv6']})
+        if 'peer_addr_ipv6' in src_port_ip["peer_addr"]:
+            testPorts.update({"src_port_ip": src_port_ip["peer_addr"]})
+        return testPorts
+
 
     def __buildPortSpeeds(self, config_facts):
         port_speeds = collections.defaultdict(list)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix qos/test_qos_sai.py
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Regression introduced by #12088 

`qos/test_qos_sai.py` fails with the following traceback -

```
14:44:01 __init__._fixture_generator_decorator    L0088 ERROR  | 
KeyError('peer_addr_ipv6')
Traceback (most recent call last):
  File "/var/src/sonic-mgmt_vms21-t0-2700_646f1402735219c3e5444094/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/var/src/sonic-mgmt_vms21-t0-2700_646f1402735219c3e5444094/tests/qos/qos_sai_base.py", line 1089, in dutConfig
    testPorts = self.__buildTestPorts(request, testPortIds, testPortIps,
  File "/var/src/sonic-mgmt_vms21-t0-2700_646f1402735219c3e5444094/tests/qos/qos_sai_base.py", line 766, in __buildTestPorts
    "dst_port_ipv6": dst_test_port_ips[dstPort]['peer_addr_ipv6'],
KeyError: 'peer_addr_ipv6'
```

#### How did you do it?
Downlink ports don't have BGP neighbors in case of T0, hence the above change is causing the key error.

The proposed fix is to modify the testPorts dictionary with peer_addr_ipv6 only if it is defined.

#### How did you verify/test it?
Verified on Arista-7260 with dualtor topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
