### PR TITLE
Add log for exited critical process in common function `get_critical_processes_status`

### DIFF
--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -9,6 +9,8 @@ import time
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until, get_plt_reboot_ctrl
 
+logger = logging.getLogger(__name__)
+
 
 def reset_timeout(duthost):
     """
@@ -28,8 +30,12 @@ def reset_timeout(duthost):
 
 def get_critical_processes_status(dut):
     processes_status = dut.all_critical_process_status()
-    for k, v in list(processes_status.items()):
-        if v['status'] is False or len(v['exited_critical_process']) > 0:
+    for container_name, processes in list(processes_status.items()):
+        if processes['status'] is False or len(processes['exited_critical_process']) > 0:
+            logger.info("The status of checking process in container '{}' is: {}"
+                        .format(container_name, processes["status"]))
+            logger.info("The processes not running in container '{}' are: '{}'"
+                        .format(container_name, processes["exited_critical_process"]))
             return False, processes_status
 
     return True, processes_status


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
For some testcase (e.g., `platform_tests/test_sequential_restart.py::test_restart_swss`), we cannot easily determine which process is exited when check critical process status failed. So I add log for exited critical process in common function `get_critical_processes_status`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Add log for exited critical process in common function `get_critical_processes_status`


#### How did you do it?
Add log for exited critical process in common function `get_critical_processes_status`

#### How did you verify/test it?
Verified by run testcase `platform_tests/test_sequential_restart.py::test_restart_swss` on physical testbed. I can see below message in the log file:
```
08/04/2024 08:23:44 processes_utils.get_critical_processes_s L0035 INFO   | The status of checking process in container 'swss' is: False
08/04/2024 08:23:44 processes_utils.get_critical_processes_s L0037 INFO   | The processes not running in container 'swss' are: '['orchagent']'
08/04/2024 08:23:44 utilities.wait_until                     L0148 DEBUG  | _all_critical_processes_healthy is False, wait 20 seconds and check again
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
