### PR TITLE
Add an option to shutdown bgp in fwutil test

### DIFF
--- a/tests/platform_tests/fwutil/conftest.py
+++ b/tests/platform_tests/fwutil/conftest.py
@@ -17,6 +17,29 @@ FS_MOUNTPOINT_TEMPLATE = "/tmp/image-{}-fs"
 OVERLAY_MOUNTPOINT_TEMPLATE = "/tmp/image-{}-overlay"
 
 
+def pytest_addoption(parser):
+    """
+    Adds pytest options that are used by fwutil tests
+    """
+
+    parser.addoption(
+        "--shutdown_bgp", action="store_true", default=False, help="Shutdown bgp before getting fw image from url"
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def shutdown_bgp(request, duthost):
+    if request.config.getoption('shutdown_bgp'):
+        duthost.command("sudo config bgp shutdown all")
+        duthost.command("sudo config save -y")
+
+    yield
+
+    if request.config.getoption('shutdown_bgp'):
+        duthost.command("sudo config bgp startup all")
+        duthost.command("sudo config save -y")
+
+
 def check_path_exists(duthost, path):
     return duthost.stat(path=path)["stat"]["exists"]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In some lab environment, when the bgp is running, the url of the components is not accessible from the dut.
Add this option so we can shutdown bgp when necessary.
By default, the bgp is not shutdown, same as the current flow.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Please see the description.
#### How did you do it?
Add a pytest option.
#### How did you verify/test it?
Run the test with/without the option set, all passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
