### PR TITLE
Fix copp test for bookworm upgrade in SwSS/SyncD/Syncd RPC/PMON

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -222,7 +222,23 @@ def _install_nano(dut, creds,  syncd_docker_name):
         https_proxy = creds.get('proxy_env', {}).get('https_proxy', '')
         check_cmd = "docker exec -i {} bash -c 'cat /etc/os-release'".format(syncd_docker_name)
         # Change the permission of /tmp to 777 to workaround issue #16034
-        if "bullseye" in dut.shell(check_cmd)['stdout'].lower():
+        if "bookworm" in dut.shell(check_cmd)['stdout'].lower():
+            cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
+                    chmod 777 /tmp \
+                    && rm -rf /var/lib/apt/lists/* \
+                    && apt-get update \
+                    && apt-get install -y python3-pip build-essential libssl-dev libffi-dev \
+                    python3-dev wget cmake python-is-python3 \
+                    && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+                    && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
+                    && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
+                    && rm -f 1.0.0.tar.gz && pip3 install cffi && pip3 install --upgrade cffi && pip3 install nnpy \
+                    && mkdir -p /opt && cd /opt && wget \
+                    https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
+                    && mkdir ptf && cd ptf && wget \
+                    https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
+                    " '''.format(http_proxy, https_proxy, syncd_docker_name)
+        elif "bullseye" in dut.shell(check_cmd)['stdout'].lower():
             cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
                     chmod 777 /tmp \
                     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
There is the PR to upgrade the Lunix to bookworm in SwSS/SyncD/Syncd RPC/PMON containers.
When running the test tests/copp/test_copp.py, it failed to install python-setuptools.
I removed the python-setuptools from the package list and run the test, they all passed.
Looks like python-setuptools is not necessary.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Fix copp test for bookworm upgrade in SwSS/SyncD/Syncd RPC/PMON
#### How did you do it?
Removed the python-setuptools from the package list.
#### How did you verify/test it?
Run the test cases in tests/copp/test_copp.py, all passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
