### PR TITLE
T2-VOQ-VS: Add command to loganalyzer ignore

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -49,7 +49,7 @@ r, ".* ERR syncd\d*#syncd.*translateVidToRid: unable to get RID for VID.*"
 r, ".* ERR dhcp_relay.*setsockopt.*No such device.*"
 r, ".* ERR syncd\d*#syncd.*Failed to get attr of SAI_OBJECT_TYPE_ACL_COUNTER.*"
 r, ".* ERR syncd\d*#syncd.*Failed to get (stats|attr) of .*(MACSEC|MACsec).*"
-r, ".* Metadata file \/etc\/sonic\/vs_chassis_metadata.json not found"
+r, ".* Metadata file \/etc\/sonic\/vs_chassis_metadata.json not found.*"
 
 ##### White list below messages found on physical devices for now. Need to address them later.
 

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -49,6 +49,7 @@ r, ".* ERR syncd\d*#syncd.*translateVidToRid: unable to get RID for VID.*"
 r, ".* ERR dhcp_relay.*setsockopt.*No such device.*"
 r, ".* ERR syncd\d*#syncd.*Failed to get attr of SAI_OBJECT_TYPE_ACL_COUNTER.*"
 r, ".* ERR syncd\d*#syncd.*Failed to get (stats|attr) of .*(MACSEC|MACsec).*"
+r, ".* Metadata file \/etc\/sonic\/vs_chassis_metadata.json not found"
 
 ##### White list below messages found on physical devices for now. Need to address them later.
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
As part of T2-VS Support changes(https://github.com/sonic-net/sonic-buildimage/pull/18512), sonic_platform package will be available now on VS platforms. 
sfputil script was getting exited earlier due to module not found. But now, the module will be found, and next it invokes load_platform_chassis(). For non-chassis VS platforms, the metadata file will not be present, and hence it throws an exception with a syslog.
ERR sfputil: Failed to instantiate Chassis due to FileNotFoundError('Metadata file /etc/sonic/vs_chassis_metadata.json not found')

The sonic-mgmt tests on VS which invoke sfputil commands are failing with loganalyzer caching this message.

Fix: Adding the above to loganalyzer ignore messages. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
As part of T2-VS Support changes, sonic_platform package will be available now on VS platforms. 
sfputil script was getting exited earlier due to module not found. But now, the module will be found, and next it invokes load_platform_chassis(). For non-chassis VS platforms, the metadata file will not be present, and hence it throws an exception with a syslog.
ERR sfputil: Failed to instantiate Chassis due to FileNotFoundError('Metadata file /etc/sonic/vs_chassis_metadata.json not found')

#### How did you do it?
Added the above to loganalyzer ignore messages. 

#### How did you verify/test it?

#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?
None
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
