### PR TITLE
[test_po_cleanup] Do a safe config reload

### DIFF
--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -58,7 +58,7 @@ def test_po_cleanup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_as
             fail_msg = "PortChannel interface still exists in kernel"
             pytest.fail(fail_msg)
     # Restore config services
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True, wait_for_bgp=True)
 
 
 def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
@@ -94,7 +94,7 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
 
         with loganalyzer:
             logging.info("Reloading config..")
-            config_reload(duthost)
+            config_reload(duthost, safe_reload=True, wait_for_bgp=True)
 
         duthost.shell("killall yes")
     except Exception:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

For test_po_cleanup and test_po_cleanup_after_reload, do a safe reload and wait for BGP to come up. This makes sure that the next test case that runs gets the testbed in a good, stable state.

This is particularly needed on slow-CPU devices where a proper config reload will take some time to run.

#### How did you do it?

#### How did you verify/test it?

Verified that two runs of `pc/test_po_cleanup.py` on MSN2700 passed. This doesn't necessarily guarantee it won't ever fail because of this error, though, since it seems to be somewhat flaky.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
