### PR TITLE
Modify DeviceConnection to accept multiple passwords

### DIFF
--- a/ansible/roles/test/files/ptftests/device_connection.py
+++ b/ansible/roles/test/files/ptftests/device_connection.py
@@ -34,9 +34,10 @@ class DeviceConnection:
         self.username = username
         self.password = password
         self.alt_password = alt_password
+        self.alt_password_index = 0
 
     @retry(
-        stop_max_attempt_number=2,
+        stop_max_attempt_number=4,
         retry_on_exception=lambda e: isinstance(e, AuthenticationException)
     )
     def execCommand(self, cmd, timeout=DEFAULT_CMD_EXECUTION_TIMEOUT_SEC):
@@ -69,9 +70,10 @@ class DeviceConnection:
         except AuthenticationException as authenticationException:
             logger.error('SSH Authentication failure with message: %s' %
                          authenticationException)
-            if self.alt_password is not None:
+            if self.alt_password is not None and self.alt_password_index < len(self.alt_password):
                 # attempt retry with alt_password
-                self.password = self.alt_password
+                self.password = self.alt_password[self.alt_password_index]
+                self.alt_password_index += 1
                 raise AuthenticationException
         except SSHException as sshException:
             logger.error('SSH Command failed with message: %s' % sshException)

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -256,7 +256,7 @@ class TestWrArp:
 
         logger.info('Warm-Reboot Control-Plane assist feature')
         sonicadmin_alt_password = duthost.host.options['variable_manager'].\
-            _hostvars[duthost.hostname].get("ansible_altpassword")
+            _hostvars[duthost.hostname]['sonic_default_passwords']
         ptf_runner(
             ptfhost,
             'ptftests',
@@ -285,7 +285,7 @@ class TestWrArp:
 
         logger.info('Warm-Reboot Control-Plane assist feature')
         sonicadmin_alt_password = duthost.host.options['variable_manager'].\
-            _hostvars[duthost.hostname].get("ansible_altpassword")
+            _hostvars[duthost.hostname]['sonic_default_passwords']
         ptf_runner(
             ptfhost,
             'ptftests',

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -688,6 +688,9 @@ class AdvancedReboot:
         """
         logger.info("Running PTF runner on PTF host: {0}".format(self.ptfhost))
 
+        passwords = self.duthost.host.options['variable_manager'].\
+            _hostvars[self.duthost.hostname]['sonic_default_passwords']
+
         params = {
             "dut_username": self.rebootData['dut_username'],
             "dut_password": self.rebootData['dut_password'],
@@ -715,8 +718,7 @@ class AdvancedReboot:
             "asic_type": self.duthost.facts["asic_type"],
             "allow_mac_jumping": self.allowMacJump,
             "preboot_files": self.prebootFiles,
-            "alt_password": self.duthost.host.options['variable_manager']
-                            ._hostvars[self.duthost.hostname].get("ansible_altpassword"),
+            "alt_password": passwords,
             "service_list": None if self.rebootType != 'service-warm-restart' else self.service_list,
             "service_data": None if self.rebootType != 'service-warm-restart' else self.service_data,
             "neighbor_type": self.neighborType,

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -187,8 +187,8 @@ def test_vxlan_decap(setup, vxlan_status, duthosts, rand_one_dut_hostname, tbinf
                      ptfhost, creds, toggle_all_simulator_ports_to_rand_selected_tor_m):    # noqa F811
     duthost = duthosts[rand_one_dut_hostname]
 
-    sonic_admin_alt_password = duthost.host.options[
-        'variable_manager']._hostvars[duthost.hostname].get("ansible_altpassword")
+    sonic_admin_alt_password = duthost.host.options['variable_manager'].\
+        _hostvars[duthost.hostname]['sonic_default_passwords']
 
     vxlan_enabled, scenario = vxlan_status
     is_active_active_dualtor = False


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

Currently, DeviceConnection only accepts one alternate passwords. It's possible to have some scenario where multiple alternate passwords need to be present (such as multiple sources of images, or multiple environments).

#### How did you do it?

Modify the class to use multiple alternate passwords. Also, modify the calling code to use sonic_default_passwords instead, which does have both of the default passwords that may be present in a SONiC image.

#### How did you verify/test it?

From the t0-sonic run, for testing warm reboot:

```
09/04/2024 01:35:26 base._run                                L0071 DEBUG  | /var/src/sonic-mgmt/tests/ptf_runner.py::ptf_runner#95: [ptf-01] AnsibleModule::shell, args=["/root/env-python3/bin/ptf --test-dir ptftests/py3 advanced-reboot.ReloadTest --platform-dir ptftests --qlen=1000 --platform remote -t 'dut_username='\"'\"'admin'\"'\"';dut_password='\"'\"'password'\"'\"';dut_hostname='\"'\"'10.250.0.114'\"'\"';reboot_limit_in_seconds=215;reboot_type='\"'\"'warm-reboot'\"'\"';other_vendor_flag=False;portchannel_ports_file='\"'\"'/tmp/portchannel_interfaces.json'\"'\"';vlan_ports_file='\"'\"'/tmp/vlan_interfaces.json'\"'\"';ports_file='\"'\"'/tmp/ports.json'\"'\"';dut_mac='\"'\"'52:54:00:5d:b4:63'\"'\"';vlan_mac='\"'\"'52:54:00:5d:b4:63'\"'\"';lo_prefix='\"'\"'10.1.0.32/32'\"'\"';default_ip_range='\"'\"'192.168.64.0/18'\"'\"';vlan_ip_range='\"'\"'{\"Vlan1000\": \"192.168.0.0/21\"}'\"'\"';lo_v6_prefix='\"'\"'fc00:1::/64'\"'\"';arista_vms=['\"'\"'10.250.0.54'\"'\"', '\"'\"'10.250.0.53'\"'\"', '\"'\"'10.250.0.52'\"'\"', '\"'\"'10.250.0.51'\"'\"'];nexthop_ips=None;allow_vlan_flooding=False;sniff_time_incr=300;setup_fdb_before_test=True;vnet=False;vnet_pkts='\"'\"''\"'\"';bgp_v4_v6_time_diff=40;asic_type='\"'\"'vs'\"'\"';allow_mac_jumping=False;preboot_files='\"'\"'peer_dev_info,neigh_port_info'\"'\"';alt_password=['\"'\"'YourPaSsWoRd'\"'\"', '\"'\"'password'\"'\"'];service_list=None;service_data=None;neighbor_type='\"'\"'sonic'\"'\"';preboot_oper=None;inboot_oper=None' --relax --debug info --log-file /tmp/advanced-reboot.ReloadTest.log --test-case-timeout 2100"], kwargs={"chdir": "/root", "module_ignore_errors": false}
```

Specifically, `alt_password=['\"'\"'YourPaSsWoRd'\"'\"', '\"'\"'password'\"'\"']` is now an array of two (or more) passwords.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
