### PR TITLE
[Fix] Catch no mgmt-ipv4 in testbed health check

### DIFF
--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -15,6 +15,7 @@ import os
 import sys
 import json
 from datetime import datetime
+from netaddr import valid_ipv4
 
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, ".."))
@@ -123,9 +124,37 @@ class TestbedHealthChecker:
         conn_graph_facts = self.localhost.conn_graph_facts(hosts=self.sonichosts.hostnames,
                                                            filepath=os.path.join(ansible_path, "files"))
 
-        hosts_reachable = True
+        # Verify mgmt-ipv4 address exists
+        config_db_file = "/etc/sonic/config_db.json"
+        ipv4_not_exists_hosts = []
+
+        for sonichost in self.sonichosts:
+            mgmt_interface = json.loads(sonichost.shell(f"jq '.MGMT_INTERFACE' {config_db_file}",
+                                                        module_ignore_errors=True)["stdout"])
+
+            ipv4_exists = False
+
+            # Use list() to make a copy of mgmt_interface.keys() to avoid
+            for key in list(mgmt_interface):
+                ip_addr = key.split("|")[1]
+                ip_addr_without_mask = ip_addr.split('/')[0]
+                if ip_addr:
+                    is_ipv4 = valid_ipv4(ip_addr_without_mask)
+                    if is_ipv4:
+                        ipv4_exists = True
+                        break
+
+            if not ipv4_exists:
+                ipv4_not_exists_hosts.append(sonichost.hostname)
+                logger.info("{} deos not have mgmt-ipv4 address.".format(sonichost.hostname))
+                self.check_result.errmsg.append("{} deos not have mgmt-ipv4 address.".format(sonichost.hostname))
+
+        if len(ipv4_not_exists_hosts) > 0:
+            raise HostsUnreachable(self.check_result.errmsg)
 
         # Check hosts reachability
+        hosts_reachable = True
+
         for sonichost in self.sonichosts:
 
             # Check sonichost reachability


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

[Fix] Catch no mgmt-ipv4 in testbed health check.

If a device lacks a management IPv4 address but has an enabled management IPv6, Ansible's reachability check may still pass. However, users will not be able to access the device using its management IPv4 address, potentially blocking certain tests. 

This PR introduces an extra check within the `testbed_health_check` script to detect the absence of a management IPv4 address. If a device does not have a management IPv4, it will be marked as Unhealthy to avoid confusion.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

If a device lacks a management IPv4 address but has an enabled management IPv6, Ansible's reachability check may still pass. However, users will not be able to access the device using its management IPv4 address, potentially blocking certain tests. 

This PR introduces an extra check within the `testbed_health_check` script to detect the absence of a management IPv4 address. If a device does not have a management IPv4, it will be marked as Unhealthy to avoid confusion.

#### How did you do it?

Check mgmt-ipv4 configuration in sonic config_db.json.

#### How did you verify/test it?

Test the device without mgmt-ipv4(others were normal), the health check failed.
Test the device with mgmt-ipv4(others were normal), the health check passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
