### PR TITLE
Revert "Fix dhcpv6 testcase failures in Dual TOR Setups"

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
@@ -63,7 +63,6 @@ class DHCPCounterTest(DataplaneBaseTest):
     def __init__(self):
         self.test_params = testutils.test_params_get()
         self.client_port_index = int(self.test_params['client_port_index'])
-        self.is_dualtor = True if self.test_params['is_dualtor'] == 'True' else False
         self.client_link_local = self.generate_client_interace_ipv6_link_local_address(
             self.client_port_index)
 
@@ -86,19 +85,18 @@ class DHCPCounterTest(DataplaneBaseTest):
         self.vlan_ip = self.test_params['vlan_ip']
         self.client_mac = self.dataplane.get_mac(0, self.client_port_index)
         self.loopback_ipv6 = self.test_params['loopback_ipv6']
+        self.is_dualtor = True if self.test_params['is_dualtor'] == 'True' else False
         self.reference = 0
 
     def generate_client_interace_ipv6_link_local_address(self, client_port_index):
-        # For DUALTOR Setup, flapping the link will disrupt ICMP HB communication and link health is impacted.
-        # Skip this for DUALTOR.
-        if not self.is_dualtor:
-            # Shutdown and startup the client interface to generate a proper IPv6 link-local address
-            command = "ifconfig eth{} down".format(client_port_index)
-            proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
-            proc.communicate()
-            command = "ifconfig eth{} up".format(client_port_index)
-            proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
-            proc.communicate()
+        # Shutdown and startup the client interface to generate a proper IPv6 link-local address
+        command = "ifconfig eth{} down".format(client_port_index)
+        proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+        proc.communicate()
+
+        command = "ifconfig eth{} up".format(client_port_index)
+        proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+        proc.communicate()
 
         command = "ip addr show eth{} | grep inet6 | grep 'scope link' | awk '{{print $2}}' | cut -d '/' -f1"\
                   .format(client_port_index)

--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
@@ -101,7 +101,6 @@ class DHCPTest(DataplaneBaseTest):
     def __init__(self):
         self.test_params = testutils.test_params_get()
         self.client_port_index = int(self.test_params['client_port_index'])
-        self.is_dualtor = True if self.test_params['is_dualtor'] == 'True' else False
         self.client_link_local = self.generate_client_interace_ipv6_link_local_address(
             self.client_port_index)
 
@@ -129,18 +128,17 @@ class DHCPTest(DataplaneBaseTest):
         self.client_mac = self.dataplane.get_mac(0, self.client_port_index)
         self.uplink_mac = self.test_params['uplink_mac']
         self.loopback_ipv6 = self.test_params['loopback_ipv6']
+        self.is_dualtor = True if self.test_params['is_dualtor'] == 'True' else False
 
     def generate_client_interace_ipv6_link_local_address(self, client_port_index):
-        # For DUALTOR Setup, flapping the link will disrupt ICMP HB communication and link health is impacted.
-        # Skip this for DUALTOR.
-        if not self.is_dualtor:
-            # Shutdown and startup the client interface to generate a proper IPv6 link-local address
-            command = "ifconfig eth{} down".format(client_port_index)
-            proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
-            proc.communicate()
-            command = "ifconfig eth{} up".format(client_port_index)
-            proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
-            proc.communicate()
+        # Shutdown and startup the client interface to generate a proper IPv6 link-local address
+        command = "ifconfig eth{} down".format(client_port_index)
+        proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+        proc.communicate()
+
+        command = "ifconfig eth{} up".format(client_port_index)
+        proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+        proc.communicate()
 
         command = "ip addr show eth{} | grep inet6 | grep 'scope link' | awk '{{print $2}}' | cut -d '/' -f1".\
                   format(client_port_index)

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -13,9 +13,7 @@ from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m  # noqa F401
-from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby                 # noqa F401
-from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup                        # noqa F401
-from tests.common.dualtor.dual_tor_common import active_active_ports                                        # noqa F401
+
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0', 'mx'),
@@ -241,27 +239,8 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data)
                ("*:*" in output, "dhcp6relay socket is not properly binded")
 
 
-@pytest.fixture
-def setup_active_active_as_active_standby(
-    active_active_ports, rand_selected_dut, rand_unselected_dut, tbinfo,                # noqa F811
-    config_active_active_dualtor_active_standby, validate_active_active_dualtor_setup): # noqa F811
-    if 'dualtor' not in tbinfo['topo']['name']:
-        logger.info("Skipping toggle on non-dualtor testbed")
-
-    if active_active_ports:
-        # The traffic from active-active mux ports are ECMPed so the DHCP6 Request
-        # May land to any TOR.
-        # So let's configure the active-active mux ports, to let them work in active-standby mode.
-        logger.info("Configuring {} as active".format(rand_selected_dut.hostname))
-        logger.info("Configuring {} as standby".format(rand_unselected_dut.hostname))
-        config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, active_active_ports)
-
-    return
-
-
 def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
-                              toggle_all_simulator_ports_to_rand_selected_tor_m, # noqa F811
-                              setup_active_active_as_active_standby):            # noqa F811
+                              toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
     """ Test DHCPv6 Counter """
     duthost = duthosts[rand_one_dut_hostname]
     skip_release(duthost, ["201911", "202106"])
@@ -270,6 +249,7 @@ def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp
                      "Decline", "Reconfigure", "Information-Request", "Relay-Forward", "Relay-Reply", "Malformed"]
 
     for dhcp_relay in dut_dhcp_relay_data:
+
         init_counter(duthost, dhcp_relay['client_iface']['name'], message_types)
         init_counter(duthost, dhcp_relay['downlink_vlan_iface']['name'], message_types)
         if dhcp_relay['is_dualtor']:
@@ -326,8 +306,7 @@ def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp
 
 
 def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
-                            toggle_all_simulator_ports_to_rand_selected_tor_m, # noqa F811
-                            setup_active_active_as_active_standby):            # noqa F811
+                            toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
     """Test DHCP relay functionality on T0 topology.
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
     """


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#11695

Standby side should have the counter as zero, no increase.