### PR TITLE
[202305] [TACACS] Fix TACACS authorization test case random failure.

### DIFF
--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -544,13 +544,11 @@ def test_tacacs_authorization_wildcard(
                                     ptfhost,
                                     duthosts,
                                     enum_rand_one_per_hwsku_hostname,
+                                    setup_authorization_tacacs,
                                     tacacs_creds,
                                     check_tacacs,
                                     remote_user_client,
                                     remote_rw_user_client):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    change_and_wait_aaa_config_update(duthost, "sudo config aaa authorization tacacs+")
-
     # Create files for command with wildcards
     create_test_files(remote_user_client)
 
@@ -594,8 +592,12 @@ def test_tacacs_authorization_wildcard(
 
 
 def test_stop_request_next_server_after_reject(
-        duthosts, enum_rand_one_per_hwsku_hostname,
-        tacacs_creds, ptfhost, check_tacacs, remote_user_client, local_user_client):
+                                            duthosts,
+                                            enum_rand_one_per_hwsku_hostname,
+                                            setup_authorization_tacacs,
+                                            tacacs_creds,
+                                            ptfhost,
+                                            check_tacacs):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     # not ignore on version >= 202305


### PR DESCRIPTION
Fix TACACS authorization test case random failure.

### Description of PR
Fix TACACS authorization test case random failure.
Cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/12256 from master branch.

##### Work item tracking
- Microsoft ADO: 27322278

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205

### Approach
#### What is the motivation for this PR?
Test case test_stop_request_next_server_after_reject randomly failed with some test device.
This is because test case test_tacacs_authorization_wildcard doesn't not set TACACS authorization config back and test_stop_request_next_server_after_reject continue use it config. however on some test device the first test take too much time and make the ansible connection drop, and the TACACS authorization config blocked the ansible login again.

#### How did you do it?
Reset TACACS authorization config to local after every test case.

#### How did you verify/test it?
Pass all test cases

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
