### PR TITLE
[Mellanox] Fix test_secure_upgrade.py and disable on systems who does not support it

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1011,12 +1011,6 @@ platform_tests/sfp/test_sfputil.py::test_check_sfputil_low_power_mode:
       - "platform in ['x86_64-cel_e1031-r0']"
       - "asic_type in ['nvidia-bluefield']"
 
-platform_tests/test_secure_upgrade.py:
-  skip:
-    reason: "platform does not support secure upgrade"
-    conditions:
-      - "'sn2' in platform or 'sn3' in platform or 'sn4' in platform"
-
 platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset:
   skip:
     reason: "platform does not support sfp reset"
@@ -1047,6 +1041,12 @@ platform_tests/test_reboot.py::test_warm_reboot:
     reason: "Warm reboot is broken on dualtor topology. Skipping for now."
     conditions:
       - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-buildimage/issues/16502"
+
+platform_tests/test_secure_upgrade.py:
+  skip:
+    reason: "platform does not support secure upgrade"
+    conditions:
+      - "'sn2' in platform or 'sn3' in platform or 'sn4' in platform"
 
 #######################################
 #####           qos               #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1011,6 +1011,12 @@ platform_tests/sfp/test_sfputil.py::test_check_sfputil_low_power_mode:
       - "platform in ['x86_64-cel_e1031-r0']"
       - "asic_type in ['nvidia-bluefield']"
 
+platform_tests/test_secure_upgrade.py:
+  skip:
+    reason: "platform does not support secure upgrade"
+    conditions:
+      - "'sn2' in platform or 'sn3' in platform or 'sn4' in platform"
+
 platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset:
   skip:
     reason: "platform does not support sfp reset"

--- a/tests/platform_tests/test_secure_upgrade.py
+++ b/tests/platform_tests/test_secure_upgrade.py
@@ -67,11 +67,10 @@ def test_non_secure_boot_upgrade_failure(duthost, non_secure_image_path, tbinfo)
         # in case of success result will take the target image name
         result = install_sonic(duthost, non_secure_image_path, tbinfo)
     except RunAnsibleModuleFail as err:
-        output_msg = str(err.results._check_key("module_stdout"))
         err_msg = str(err.results._check_key("msg"))
-        logger.info("Expected fail, err msg is : {}\n\noutput_msg is {}".format(err_msg, output_msg))
+        logger.info("Expected fail, err msg is : {}".format(err_msg))
         pytest_assert(
-            "Failure: CMS signature verification failed" in str(output_msg),
+            "Failure: CMS signature Verification Failed" in str(err_msg),
             "failure was not due to security limitations")
     finally:
         pytest_assert(result == "image install failure", "non-secure image was successfully installed")


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Test failed for 2 reasons:
1. When assigning value to "output_msg"(line 70), there is no "module_output" key in the err.result, the message needed in the check is in "msg", which is assigned to "err_msg"in line 71.
2. There are 2 letters should be upper case(Failure: CMS signature **V**erification **F**ailed)

(Pdb) l
 69  	    except RunAnsibleModuleFail as err:
 70  	        **output_msg = str(err.results._check_key("module_stdout"))**
 71  	        err_msg = str(err.results._check_key("msg"))
 72  	        import pdb
 73  	        pdb.set_trace()
 74  ->	        logger.info("Expected fail, err msg is : {}\n\noutput_msg is {}".format(err_msg, output_msg))
 75  	        pytest_assert(
 76  	            "Failure: CMS signature Verification Failed" in str(err_msg),
 77  	            "failure was not due to security limitations")
 78  	    finally:
 79  	        pytest_assert(result == "image install failure", "non-secure image was successfully installed")
(Pdb) err
run module reduce_and_add_sonic_images failed, Ansible Results =>
{"changed": false, "failed": true, "msg": "Image installation failed: rc=1, out=\nVerifing image SONiC-OS-202211_SPC4_ES2.1-f8737c490_Internal signature...\nVerifying image signature\nFailure: CMS signature Verification Failed: \n\n, err=Warning: 'sonic_installer' command is deprecated and will be removed in the future\nPlease use 'sonic-installer' instead\nError: Failed verify image signature\nAborted!\n"}
(Pdb) err.results
{'failed': True, 'msg': "Image installation failed: rc=1, out=\nVerifing image SONiC-OS-202211_SPC4_ES2.1-f8737c490_Internal signature...\nVerifying image signature\nFailure: CMS signature **Verification Failed**: \n\n, err=Warning: 'sonic_installer' command is deprecated and will be removed in the future\nPlease use 'sonic-installer' instead\nError: Failed verify image signature\nAborted!\n", 'invocation': {'module_args': {'new_image_url': 'http://nbu-nfs.mellanox.com/auto/sw_regression/system/SONIC/security/secure_boot/sig_mismatch_image/sonic-mellanox.bin', 'disk_used_pcent': 8, 'required_space': 1600, 'save_as': None}}, '_ansible_no_log': False, 'changed': False}  **- No key module_stdout in the  err.results**

And add the skip condition for Nvidia platforms which don't support secure upgrade.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fix test_secure_upgrade.py test issue
#### How did you do it?
1. Fix the test by checking the information in "err_msg = str(err.results._check_key("msg"))"
2. Fix the lowercase letters.
3. Add skip condition.
#### How did you verify/test it?
Run the test on 5600 platform, it passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
