### PR TITLE
Fix test issue in test_bgp_update_timer_session_down

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -8,6 +8,7 @@ import tempfile
 import time
 import six
 
+from datetime import datetime
 from scapy.all import sniff, IP
 from scapy.contrib import bgp
 from tests.common.helpers.bgp import BGPNeighbor
@@ -454,8 +455,8 @@ def test_bgp_update_timer_session_down(
         # close bgp session n0, monitor withdraw info from dut to n1
         bgp_pcap = BGP_DOWN_LOG_TMPL
         with log_bgp_updates(duthost, "any", bgp_pcap, n0.namespace):
-            duthost.shell("config bgp shutdown neighbor {}".format(n0.name))
-            current_time = time.time()
+            result = duthost.shell("config bgp shutdown neighbor {}".format(n0.name))
+            bgp_shutdown_time = datetime.strptime(result['end'], "%Y-%m-%d %H:%M:%S.%f").timestamp()
             time.sleep(constants.sleep_interval)
 
         if constants.log_dir:
@@ -473,7 +474,7 @@ def test_bgp_update_timer_session_down(
                           bgp_update.time, bgp_update.show(dump=True))
             for i, route in enumerate(constants.routes):
                 if match_bgp_update(bgp_update, n1.peer_ip, n1.ip, "withdraw", route):
-                    withdraw_intervals[i] = bgp_update.time - current_time
+                    withdraw_intervals[i] = bgp_update.time - bgp_shutdown_time
 
         for i, route in enumerate(constants.routes):
             if withdraw_intervals[i] >= constants.update_interval_threshold:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test uses the time in sonic-mgmt container as the base time and calculate the bgp withdraw interval against the bgp update packet timestamp which is got from the switch, there are 2 issues in this logic:
1.  There could be time drift in dut or test server.
2.  The time consumed by the ansible path is not calculated. 
To fix this, we can take the end time(which is the ansible command end time form dut) in ansible result as the base time.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fix test issue in test_bgp_update_timer_session_down
#### How did you do it?
Take the end time(which is the ansible command end time form dut) in ansible result as the base time.
#### How did you verify/test it?
Run the test on multiple testbeds, all passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
