### PR TITLE
Update script to enable dynamic buffer on all generic SKU

### DIFF
--- a/tests/common/helpers/enable-dynamic-buffer.py
+++ b/tests/common/helpers/enable-dynamic-buffer.py
@@ -218,7 +218,7 @@ config_db.db_connect('CONFIG_DB')
 
 # Don't enable dynamic buffer calculation if it is not a default SKU
 metadata = config_db.get_entry('DEVICE_METADATA', 'localhost')
-if 'ACS-MSN' not in metadata['hwsku']:
+if 'ACS-MSN' not in metadata['hwsku'] and 'ACS-SN' not in metadata['hwsku']:
     print("Don't enable dynamic buffer calculation for non-default SKUs")
     exit(0)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The reason why dynamic buffers are not enabled on **ACS-SN**5600 is because on deploy minigraph, the script that enables dynamic buffers, has this condition:
if 'ACS-MSN' not in metadata['hwsku']:
    print("Don't enable dynamic buffer calculation for non-default SKUs")
    exit(0)

Instead, it should be this condition:
if 'ACS-MSN' not in metadata['hwsku'] and '**ACS-SN**' not in metadata['hwsku']:

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach

#### What is the motivation for this PR?
For generic SKUs, we always use dynamic buffer model

#### How did you do it?
fixed the condition and tested dynamic buffer model enabled on ACS-SN5600 hwsku

#### How did you verify/test it?
run deploy with the change

#### Any platform specific information?
ACS-SN5600

#### Supported testbed topology if it's a new test case?
no 