### PR TITLE
[E1031] Update the command for restart swss/syncd container in testcase

### DIFF
--- a/tests/platform_tests/test_sequential_restart.py
+++ b/tests/platform_tests/test_sequential_restart.py
@@ -58,7 +58,10 @@ def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service,
 
     asichost = dut.asic_instance(enum_frontend_asic_index)
     service_name = asichost.get_service_name(service)
-    dut.command("sudo systemctl restart {}".format(service_name))
+    if dut.facts["platform"] == "x86_64-cel_e1031-r0":
+        dut.shell("sudo systemctl stop {} && sleep 30 && sudo systemctl start {}".format(service_name, service_name))
+    else:
+        dut.command("sudo systemctl restart {}".format(service_name))
 
     for container in dut.get_default_critical_services_list():
         if is_service_hiting_start_limit(dut, container) is True:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
On Celestica-E1031 platform, issue `sudo systemctl restart swss` sometimes cause orchagent process exited with below error:
```
Apr  8 08:21:54.574827 e1031-1 NOTICE swss#orchagent: :- allocateNewSwitchObjectId: created SWITCH VID oid:0x21000000000000 for hwinfo: ''
Apr  8 08:22:54.655366 e1031-1 ERR swss#orchagent: :- wait: SELECT operation result: TIMEOUT on getresponse
Apr  8 08:22:54.655843 e1031-1 ERR swss#orchagent: :- wait: failed to get response for getresponse
Apr  8 08:22:54.659878 e1031-1 ERR swss#orchagent: :- create: create status: SAI_STATUS_FAILURE
Apr  8 08:22:54.666990 e1031-1 ERR swss#orchagent: :- main: Failed to create a switch, rv:-1
Apr  8 08:22:57.939530 e1031-1 INFO swss#supervisord 2024-04-08 08:22:57,929 INFO exited: orchagent (terminated by SIGABRT (core dumped); not expected)
```

To avoid this issue, I updated the command to:
* `sudo systemctl stop swss`
* `sleep 30`
* `sudo systemctl start swss`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
On Celestica-E1031 platform, issue `sudo systemctl restart swss` sometimes cause orchagent process exited with below error:
```
Apr  8 08:21:54.574827 e1031-1 NOTICE swss#orchagent: :- allocateNewSwitchObjectId: created SWITCH VID oid:0x21000000000000 for hwinfo: ''
Apr  8 08:22:54.655366 e1031-1 ERR swss#orchagent: :- wait: SELECT operation result: TIMEOUT on getresponse
Apr  8 08:22:54.655843 e1031-1 ERR swss#orchagent: :- wait: failed to get response for getresponse
Apr  8 08:22:54.659878 e1031-1 ERR swss#orchagent: :- create: create status: SAI_STATUS_FAILURE
Apr  8 08:22:54.666990 e1031-1 ERR swss#orchagent: :- main: Failed to create a switch, rv:-1
Apr  8 08:22:57.939530 e1031-1 INFO swss#supervisord 2024-04-08 08:22:57,929 INFO exited: orchagent (terminated by SIGABRT (core dumped); not expected)
```

#### How did you do it?

To avoid this issue, I updated the command to:
* `sudo systemctl stop swss`
* `sleep 30`
* `sudo systemctl start swss`

#### How did you verify/test it?

Verified on Celestica-E1031 M0 testbed. Run the testcase more than 10 times and all passed:

```
platform_tests/test_sequential_restart.py::test_restart_swss[e1031-1-None] PASSED                                              [ 50%]
platform_tests/test_sequential_restart.py::test_restart_syncd[e1031-1-None] SKIPPED (Restarting syncd is not supported yet)    [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
