### PR TITLE
Make test_vlan_ping stable

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -160,7 +160,13 @@ def verify_icmp_packet(dut_mac, src_port, dst_port, ptfadapter):
                                              ip_dst=str(dst_port['ipv4']), ip_ttl=63)
     for i in range(5):
         testutils.send_packet(ptfadapter, src_port['port_index_list'][0], pkt)
-        testutils.verify_packet_any_port(ptfadapter, exptd_pkt, dst_port['port_index_list'])
+        try:
+            testutils.verify_packet_any_port(ptfadapter, exptd_pkt, dst_port['port_index_list'])
+            # if verification succeeds, break the loop
+            break
+        except Exception as e:
+            if i >= 4:
+                raise e # If it fails on the last attempt, raise the exception
 
 
 def test_vlan_ping(vlan_ping_setup, duthosts, rand_one_dut_hostname, ptfadapter):

--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -166,7 +166,7 @@ def verify_icmp_packet(dut_mac, src_port, dst_port, ptfadapter):
             break
         except Exception as e:
             if i >= 4:
-                raise e # If it fails on the last attempt, raise the exception
+                raise e  # If it fails on the last attempt, raise the exception
 
 
 def test_vlan_ping(vlan_ping_setup, duthosts, rand_one_dut_hostname, ptfadapter):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Make test_vlan_ping stable

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
test_vlan_ping is not stable due to ptf not receiving packet.

#### How did you do it?
Change from receiving packet for 5 times to receiving packet for 1 time.

#### How did you verify/test it?
Run with t0-8111 physical testbed.
```
03:41:22 conftest.rand_one_dut_hostname           L0393 INFO   | Randomly select dut str3-8111-04 for testing
03:41:22 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture vlan_ping_setup setup starts --------------------
03:41:22 facts_cache.read                         L0092 INFO   | Load cache file "/var/src/sonic-mgmt-int/tests/_cache/str3-8111-04/mg_facts.pickle" failed with exception: FileNotFoundError(2, 'No such file or directory')
03:41:23 facts_cache.write                        L0120 INFO   | Cached facts "str3-8111-04.mg_facts" to /var/src/sonic-mgmt-int/tests/_cache/str3-8111-04/mg_facts.pickle
03:41:26 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture vlan_ping_setup setup ends --------------------
03:41:40 __init__.loganalyzer                     L0045 INFO   | Log analyzer is disabled
---------------------------------------------------------------------- live log call ----------------------------------------------------------------------
03:41:40 test_vlan_ping.test_vlan_ping            L0183 INFO   | initializing setup for ipv4 and ipv6
03:41:43 test_vlan_ping.test_vlan_ping            L0185 INFO   | Checking connectivity to ptf ports
03:41:47 test_vlan_ping.test_vlan_ping            L0203 INFO   | Check connectivity to both ptfhost
PASSED                                                                                                                                              [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
