### PR TITLE
Add topology mark in the module already in PR test

### DIFF
--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -7,7 +7,7 @@ from tests.common.helpers.assertions import pytest_assert
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('ptf')
+    pytest.mark.topology('t0', 'ptf')
 ]
 
 

--- a/tests/generic_config_updater/test_bgp_prefix.py
+++ b/tests/generic_config_updater/test_bgp_prefix.py
@@ -8,7 +8,7 @@ from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfi
 from tests.generic_config_updater.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1'),     # It is a t1 only feature
+    pytest.mark.topology('t0', 't1')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/generic_config_updater/test_bgp_prefix.py
+++ b/tests/generic_config_updater/test_bgp_prefix.py
@@ -8,7 +8,7 @@ from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfi
 from tests.generic_config_updater.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
 
 pytestmark = [
-    pytest.mark.topology('t1'),     # It is a t1 only feature
+    pytest.mark.topology('t0', 't1'),     # It is a t1 only feature
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -12,8 +12,7 @@ from tests.common.helpers.assertions import pytest_assert
 
 
 pytestmark = [
-    pytest.mark.topology('any'),
-    pytest.mark.device_type('physical'),
+    pytest.mark.topology('any')
 ]
 
 

--- a/tests/test_vs_chassis_setup.py
+++ b/tests/test_vs_chassis_setup.py
@@ -10,6 +10,7 @@ from tests.common.utilities import check_qos_db_fv_reference_with_table
 logger = logging.getLogger(__name__)
 
 pytestmark = [
+    pytest.mark.topology("t2"),
     pytest.mark.disable_loganalyzer
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In our pytest, it's crucial to have proper markers for different test topologies to ensure that tests are run in the correct testbeds. It seems that some modules, despite having passed the PR tests, lack the necessary topology markers. In this PR, we add the missing markers, which will enhance the clarity and efficiency of the testing process and ensure that each module is tested on the appropriate testbeds. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
In our pytest, it's crucial to have proper markers for different test topologies to ensure that tests are run in the correct testbeds. It seems that some modules, despite having passed the PR tests, lack the necessary topology markers. In this PR, we add the missing markers, which will enhance the clarity and efficiency of the testing process and ensure that each module is tested on the appropriate testbeds. 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
