### PR TITLE
sonic-mgmt: Add FEC check test case.

### DIFF
--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -21,7 +21,7 @@ def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     @Summary: Check the FEC operational mode, if links are up using 'show interface status'
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
- 
+
     if any(platform in duthost.facts['platform'] for platform in SUPPORTED_PLATFORMS):
         # Not supported on 202305 and older releases
         skip_release(duthost, ['201811', '201911', '202012', '202205', '202211', '202305'])

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -1,0 +1,33 @@
+import logging
+import pytest
+
+from tests.common.utilities import skip_release
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
+    pytest.mark.topology('any')
+]
+
+SUPPORTED_PLATFORMS = [
+    "mlnx_msn4700"
+]
+
+def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts):
+    """
+    @Summary: Check the FEC operational mode, if links are up using 'show interface status'
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    
+    if any(platform in duthost.facts['platform'] for platform in SUPPORTED_PLATFORMS):
+        #Not supported on 202305 and older releases
+        skip_release(duthost, ['201811', '201911', '202012', '202205', '202211', '202305'])
+    else:
+        pytest.skip("DUT has platform {}, test is not supported".format(duthost.facts['platform']))
+
+    logging.info("Get output of '{}'".format("show interface status"))
+    intf_status = duthost.show_and_parse("show interface status")
+
+    for intf in intf_status:
+        if intf['oper'].lower() == "up":
+            if intf['fec'].lower() == "n/a":
+                pytest.fail("FEC status is N/A for interface {}".format(intf['interface']))

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -9,17 +9,21 @@ pytestmark = [
 ]
 
 SUPPORTED_PLATFORMS = [
-    "mlnx_msn4700"
+    "mlnx_msn",
+    "8101",
+    "8111"
 ]
 
-def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index, conn_graph_facts):
+
+def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                              enum_frontend_asic_index, conn_graph_facts):
     """
     @Summary: Check the FEC operational mode, if links are up using 'show interface status'
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    
+  
     if any(platform in duthost.facts['platform'] for platform in SUPPORTED_PLATFORMS):
-        #Not supported on 202305 and older releases
+        # Not supported on 202305 and older releases
         skip_release(duthost, ['201811', '201911', '202012', '202205', '202211', '202305'])
     else:
         pytest.skip("DUT has platform {}, test is not supported".format(duthost.facts['platform']))

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -14,11 +14,16 @@ SUPPORTED_PLATFORMS = [
     "8111_32eh"
 ]
 
+SUPPORTED_SPEEDS = [
+    "100G", "200G", "400G", "800G", "1600G"
+]
+
 
 def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                               enum_frontend_asic_index, conn_graph_facts):
     """
-    @Summary: Check the FEC operational mode, if links are up using 'show interface status'
+    @Summary: Verify the FEC operational mode is valid, for all the interfaces with
+    SFP present, supported speeds and link is up using 'show interface status'
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
@@ -32,6 +37,14 @@ def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     intf_status = duthost.show_and_parse("show interface status")
 
     for intf in intf_status:
-        if intf['oper'].lower() == "up":
-            if intf['fec'].lower() == "n/a":
-                pytest.fail("FEC status is N/A for interface {}".format(intf['interface']))
+        sfp_presence = duthost.show_and_parse("sudo sfpshow presence -p {}"
+                                              .format(intf['interface']))
+        if sfp_presence:
+            presence = sfp_presence[0].get('presence', '').lower()
+            oper = intf.get('oper', '').lower()
+            speed = intf.get('speed', '')
+            fec = intf.get('fec', '').lower()
+
+            if presence == "present" and oper == "up" and speed in SUPPORTED_SPEEDS:
+                if fec == "n/a":
+                    pytest.fail("FEC status is N/A for interface {}".format(intf['interface']))

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -10,8 +10,8 @@ pytestmark = [
 
 SUPPORTED_PLATFORMS = [
     "mlnx_msn",
-    "8101",
-    "8111"
+    "8101_32fh",
+    "8111_32eh"
 ]
 
 
@@ -21,7 +21,7 @@ def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     @Summary: Check the FEC operational mode, if links are up using 'show interface status'
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-  
+ 
     if any(platform in duthost.facts['platform'] for platform in SUPPORTED_PLATFORMS):
         # Not supported on 202305 and older releases
         skip_release(duthost, ['201811', '201911', '202012', '202205', '202211', '202305'])


### PR DESCRIPTION
### Description of PR

sonic-mgmt: Adding a test case to verify FEC mode is valid for all the interfaces with link is "UP".
Also adding a test case to configure FEC mode and verify the FEC operation mode after that.

Summary:
Add new test cases.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

1. Check FEC operational mode from "show interfaces fec status".
2. Configure FEC mode using "sudo config interface fec <interface> <fec mode>

#### How did you verify/test it?

Verified in the lab device on Mellanox 2700, Mellanox 4700, Cisco 8101 and Cisco 8111 devices with latest 202311 SONiC version.

Additionally, verified a negative test case of SONiC version 202305 on Mellanox 4700 platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
