### PR TITLE
Remove fail for syslog rate limit test

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1398,7 +1398,7 @@ syslog/test_syslog_source_ip.py:
   skip:
     reason: "Testcase consistent failed, raised issue to track"
     conditions:
-      - https://github.com/sonic-net/sonic-mgmt/issues/6479
+      - https://github.com/sonic-net/sonic-mgmt/issues/6479 
 
 #######################################
 #####         system_health       #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1398,7 +1398,7 @@ syslog/test_syslog_source_ip.py:
   skip:
     reason: "Testcase consistent failed, raised issue to track"
     conditions:
-      - https://github.com/sonic-net/sonic-mgmt/issues/6479 
+      - https://github.com/sonic-net/sonic-mgmt/issues/6479
 
 #######################################
 #####         system_health       #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1394,12 +1394,6 @@ syslog/test_syslog.py:
       - "branch in ['internal-202012']"
       - "build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 33"
 
-syslog/test_syslog_rate_limit.py:
-  xfail:
-    reason: "Testcase xfail, raised issue to track"
-    conditions:
-      - https://github.com/sonic-net/sonic-mgmt/issues/11181
-
 syslog/test_syslog_source_ip.py:
   skip:
     reason: "Testcase consistent failed, raised issue to track"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR


Summary:
Fixes # (issue)
the TC syslog/test_syslog_rate_limit.py was made to XPASS - i.e. it was set such that it is not expected to pass owing to this issue - https://github.com/sonic-net/sonic-mgmt/issues/11181 - which has now been closed. Therefore, we no longer need to make this a fail test case, and can continue to expect it to pass.

### Type of change
- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [X] 202205
- [X] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/issues/11181 is resolved, and the below TC is no longer expected to fail, therefore need not be marked as an fail TC.

#### How did you do it?

#### How did you verify/test it?
Initiated runs on local testbeds with the latest image.
[syslog_rate_limit.log](https://github.com/sonic-net/sonic-mgmt/files/14936960/syslog_rate_limit.log)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
