### PR TITLE
Change hardcoded PFC_STORM_TEST_PORT to choose from available interfaces

### DIFF
--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -7,6 +7,7 @@ import time
 
 from run_events_test import run_test
 
+random.seed(10)
 logger = logging.getLogger(__name__)
 tag = "sonic-events-swss"
 

--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python3
 
 import logging
+import random
+import re
 import time
 
 from run_events_test import run_test
@@ -8,8 +10,6 @@ from run_events_test import run_test
 logger = logging.getLogger(__name__)
 tag = "sonic-events-swss"
 
-IF_STATE_TEST_PORT = "Ethernet0"
-PFC_STORM_TEST_PORT = "Ethernet4"
 PFC_STORM_TEST_QUEUE = "4"
 PFC_STORM_DETECTION_TIME = 100
 PFC_STORM_RESTORATION_TIME = 100
@@ -35,6 +35,14 @@ def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
 
 def shutdown_interface(duthost):
     logger.info("Shutting down an interface")
+    interfaces = duthost.get_interfaces_status()
+    pattern = re.compile(r'^Ethernet[0-9]{1,2}$')
+    interface_list = []
+    for interface, status in interfaces.items():
+        if pattern.match(interface) and status["oper"] == "up" and status["admin"] == "up":
+            interface_list.append(interface)
+    IF_STATE_TEST_PORT = random.choice(interface_list)
+    assert IF_STATE_TEST_PORT is not None, "Unable to find valid interface for test"
     ret = duthost.shell("config interface startup {}".format(IF_STATE_TEST_PORT))
     assert ret["rc"] == 0, "Failing to startup interface {}".format(IF_STATE_TEST_PORT)
 
@@ -47,6 +55,15 @@ def shutdown_interface(duthost):
 
 def generate_pfc_storm(duthost):
     logger.info("Generating pfc storm")
+    interfaces = duthost.get_interfaces_status()
+    pattern = re.compile(r'^Ethernet[0-9]{1,2}$')
+    interface_list = []
+    for interface, status in interfaces.items():
+        if pattern.match(interface) and status["oper"] == "up" and status["admin"] == "up":
+            interface_list.append(interface)
+    PFC_STORM_TEST_PORT = random.choice(interface_list)
+    assert PFC_STORM_TEST_PORT is not None, "Unable to find valid interface for test"
+
     queue_oid = duthost.get_queue_oid(PFC_STORM_TEST_PORT, PFC_STORM_TEST_QUEUE)
     duthost.shell("sonic-db-cli COUNTERS_DB HSET \"COUNTERS:{}\" \"DEBUG_STORM\" \"enabled\"".
                   format(queue_oid))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Move logic that chooses PFC_STORM_TEST_PORT dynamically from 202311 to 202305

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
In 202305's `tests/telemetry/events/swss_events.py`, `PFC_STORM_TEST_PORT` is hardcoded to use `Ethernet4`, which may not be available for testing on some configurations.

#### How did you do it?
There already is logic on 202305 and master that dynamically selects the port for testing. Backporting that logic back to 202305.

#### How did you verify/test it?
Test machine without `Ethernet4` can now continue running the test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
