### PR TITLE
Fix snmp_pdu_controller cannot handle secrets vars in snmp_rwcommunity

### DIFF
--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -4,6 +4,7 @@ This module contains classes for PDU controllers that supports the SNMP manageme
 The classes must implement the PduControllerBase interface defined in controller_base.py.
 """
 import logging
+import jinja2
 
 from .controller_base import PduControllerBase
 
@@ -146,7 +147,11 @@ class snmpPduController(PduControllerBase):
         PduControllerBase.__init__(self)
         self.controller = controller
         self.snmp_rocommunity = pdu['snmp_rocommunity']
-        self.snmp_rwcommunity = pdu.get('creds', {}).get('snmp_rwcommunity', pdu.get('snmp_rwcommunity'))
+        if 'secret_group_vars' in pdu['snmp_rwcommunity']:
+            context = {'secret_group_vars': pdu['secret_group_vars']}
+            self.snmp_rwcommunity = jinja2.Template(pdu['snmp_rwcommunity']).render(context)
+        else:
+            self.snmp_rwcommunity = pdu['snmp_rwcommunity']
         self.pduType = 'Sentry4' if hwsku == 'Sentry' and psu_peer_type == 'Pdu' else hwsku
         self.port_oid_dict = {}
         self.port_label_dict = {}

--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -146,7 +146,7 @@ class snmpPduController(PduControllerBase):
         PduControllerBase.__init__(self)
         self.controller = controller
         self.snmp_rocommunity = pdu['snmp_rocommunity']
-        self.snmp_rwcommunity = pdu['snmp_rwcommunity']
+        self.snmp_rwcommunity = pdu.get('creds', {}).get('snmp_rwcommunity', pdu.get('snmp_rwcommunity'))
         self.pduType = 'Sentry4' if hwsku == 'Sentry' and psu_peer_type == 'Pdu' else hwsku
         self.port_oid_dict = {}
         self.port_label_dict = {}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes snmp_pdu_controller cannot handle secrets vars in snmp_rwcommunity

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
snmp_pdu_controller cannot handle SNMP rwcommunity is stored as secrets vars.

#### How did you do it?
Use jinja2 to render snmp secret if it is a secret vars.

#### How did you verify/test it?
Test with physical testbed with following cases:
platform_tests/test_power_off_reboot.py::test_power_off_reboot

```
05:41:07 reboot.check_reboot_cause_history        L0435 INFO   | index:  4, reboot cause: Power Loss, reboot cause from DUT: Power Loss
05:41:07 reboot.check_reboot_cause_history        L0435 INFO   | index:  5, reboot cause: Power Loss, reboot cause from DUT: Power Loss
05:41:07 reboot.check_reboot_cause_history        L0435 INFO   | index:  6, reboot cause: Power Loss, reboot cause from DUT: Power Loss
05:41:07 reboot.check_reboot_cause_history        L0435 INFO   | index:  7, reboot cause: Power Loss, reboot cause from DUT: Power Loss
05:41:07 reboot.check_reboot_cause_history        L0435 INFO   | index:  8, reboot cause: Power Loss, reboot cause from DUT: Power Loss
05:41:07 reboot.check_reboot_cause_history        L0435 INFO   | index:  9, reboot cause: Power Loss, reboot cause from DUT: Power Loss
05:41:07 test_reboot.check_interfaces_and_service L0163 INFO   | Further checking skipped for power off test which intends to verify reboot-cause only
PASSED                                                                                                                                    [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
