### PR TITLE
[test_bgp_update_timer] to support delta in DUT and mgmt docker time

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -487,7 +487,9 @@ def test_bgp_update_timer_session_down(
         bgp_pcap = BGP_DOWN_LOG_TMPL
         with log_bgp_updates(duthost, "any", bgp_pcap, n0.namespace):
             duthost.shell("config bgp shutdown neighbor {}".format(n0.name))
-            current_time = time.time()
+            # use dut time to avoid delta in dut and mgmt docker time
+            cmd_dut_time = duthost.shell("date +%s.%6N", module_ignore_errors=True)
+            current_time = cmd_dut_time.get('stdout', None)
             time.sleep(constants.sleep_interval)
 
         if constants.log_dir:


### PR DESCRIPTION
### Description of PR
Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/10840
bgp/test_bgp_update_timer.py::test_bgp_update_timer_session_down run into failure with delta in dut and mgmt docker time. if there is a delta, test will calculate the wrong bgp update interval, which would be greater than the threshold.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
To fix the issue for bgp/test_bgp_update_timer.py::test_bgp_update_timer_session_down on testbed with delta in dut and mgmt docker time.

#### How did you do it?
Used dut time to deduce the update interval instead of mgmt docker time

#### How did you verify/test it?
run local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
