### PR TITLE
correct 6100 t0-64 test ports for xon case

### DIFF
--- a/tests/qos/files/qos_params.th.yaml
+++ b/tests/qos/files/qos_params.th.yaml
@@ -508,3 +508,258 @@ qos_params:
                 cell_size: 208
             hdrm_pool_wm_multiplier: 4
             cell_size: 208
+        topo-t0-64:
+            src_port_ids: [22]
+            dst_port_ids: [52,53,54]
+            40000_300m:
+                pkts_num_leak_out: 19
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7063
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7063
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [25, 26, 27, 40, 41]
+                    dst_port_id: 24
+                    pgs_num: 10
+                    pkts_num_trig_pfc: 1194
+                    pkts_num_hdrm_full: 520
+                    pkts_num_hdrm_partial: 361
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7063
+                    cell_size: 208
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 8
+                    pkts_num_trig_ingr_drp: 7063
+                    cell_size: 208
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 6
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7063
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 208
+            50000_300m:
+                pkts_num_leak_out: 23
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7225
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7225
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [1, 2, 3, 4]
+                    dst_port_id: 5
+                    pgs_num: 8
+                    pkts_num_trig_pfc: 1458
+                    pkts_num_hdrm_full: 682
+                    pkts_num_hdrm_partial: 267
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7225
+                    cell_size: 208
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 8
+                    pkts_num_trig_ingr_drp: 7225
+                    cell_size: 208
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 6
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7225
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 208
+            100000_300m:
+                pkts_num_leak_out: 36
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7835
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7835
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [17, 18]
+                    dst_port_id: 16
+                    pgs_num: 4
+                    pkts_num_trig_pfc: 2620
+                    pkts_num_hdrm_full: 1292
+                    pkts_num_hdrm_partial: 1165
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 6
+                    pkts_num_trig_pfc: 6542
+                    cell_size: 208
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7835
+                    cell_size: 208
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 8
+                    pkts_num_trig_ingr_drp: 7835
+                    cell_size: 208
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 6
+                    pkts_num_trig_pfc: 6542
+                    pkts_num_trig_ingr_drp: 7835
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 208
+            xon_1:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 6542
+                pkts_num_dismiss_pfc: 12
+            xon_2:
+                dscp: 4
+                ecn: 1
+                pg: 4
+                pkts_num_trig_pfc: 6542
+                pkts_num_dismiss_pfc: 12
+            ecn_1:
+                dscp: 8
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 208
+            ecn_2:
+                dscp: 8
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 208
+            ecn_3:
+                dscp: 0
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 208
+            ecn_4:
+                dscp: 0
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 208
+            lossy_queue_1:
+                dscp: 8
+                ecn: 1
+                pg: 0
+                pkts_num_trig_egr_drp: 9887
+            wrr:
+                ecn: 1
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                limit: 80
+            wrr_chg:
+                ecn: 1
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                limit: 80
+                lossy_weight: 8
+                lossless_weight: 30
+            wm_pg_shared_lossless:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_fill_min: 6
+                pkts_num_trig_pfc: 6542
+                packet_size: 64
+                cell_size: 208
+            wm_pg_shared_lossy:
+                dscp: 8
+                ecn: 1
+                pg: 0
+                pkts_num_fill_min: 0
+                pkts_num_trig_egr_drp: 9887
+                packet_size: 64
+                cell_size: 208
+            wm_q_shared_lossy:
+                dscp: 8
+                ecn: 1
+                queue: 0
+                pkts_num_fill_min: 8
+                pkts_num_trig_egr_drp: 9887
+                cell_size: 208
+            wm_buf_pool_lossy:
+                dscp: 8
+                ecn: 1
+                pg: 0
+                queue: 0
+                pkts_num_fill_ingr_min: 0
+                pkts_num_trig_egr_drp: 9887
+                pkts_num_fill_egr_min: 8
+                cell_size: 208
+            hdrm_pool_wm_multiplier: 4
+            cell_size: 208


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

xon case failed on 6100 for t0-64 topology

RCA:

original test port ids are as below:
```
dst_port_id=6;
dst_port_2_id=8;
dst_port_3_id=9;
src_port_id=7;
```
but the three dst ports belong different pipe, as below:
```
admin@str3-s6100-acs-6:~$ bcmcmd "show pmap"  | grep -E "xe8 |xe9 |xe6 |xe7 "
             pipe   logical  physical    idb mmu   ucast_Qbase/Numq  mcast_Qbase/Numq  half-pipe
       xe8      1    44        53        20  74       100/10               100/10          0
       xe9      1    45        55        22  75       110/10               110/10          0
       xe6      2    68        65         0 128         0/10                 0/10          0
       xe7      2    69        67         2 129        10/10                10/10          0

```
So it caused xon test failure.


#### How did you do it?

reference other 6100 topology, we choose below test ports:
```
            src_port_ids: [22]
            dst_port_ids: [52,53,54]
```
and all dst ports are in the same pipe.
```
admin@str3-s6100-acs-6:~$ bcmcmd "show pmap"  | grep -E "xe52|xe53|xe54|xe22|pipe"
             pipe   logical  physical    idb mmu   ucast_Qbase/Numq  mcast_Qbase/Numq  half-pipe
      xe52      0     1         1         0   0         0/10                 0/10          0
      xe53      0     2         3         2   1        10/10                10/10          0
      xe54      0     3         5         4   2        20/10                20/10          0
      xe22      1    48        61        28  78       140/10               140/10          0
```

additional, to avoid break other "th" platform's test, copy content of "topo-any" to "topo-t0-64", and just set above recommended test ports into "topo-t0-64" section which is only used by 6100 T0.


#### How did you verify/test it?

pass local full qos sai test, on 6100 for t0-64 topology:

test plan 66177b7ce3f0ed9b4960f1e7

```
qos/test_qos_sai.py::TestQosSai::testParameter[single_asic] PASSED       [  0%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_1] PASSED [  1%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_2] PASSED [  2%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_3] SKIPPED [  3%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_4] SKIPPED [  3%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_asic-xon_1] SKIPPED [  4%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_asic-xon_2] SKIPPED [  5%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_asic-xon_3] SKIPPED [  6%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_asic-xon_4] SKIPPED [  6%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1] PASSED [  7%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2] PASSED [  8%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_3] SKIPPED [  9%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_4] SKIPPED [  9%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_1] SKIPPED [ 10%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_2] SKIPPED [ 11%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_3] SKIPPED [ 12%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_4] SKIPPED [ 12%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[single_asic] PASSED [ 13%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize[single_asic-shared_res_size_1] SKIPPED [ 14%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize[single_asic-shared_res_size_2] SKIPPED [ 15%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark[single_asic] PASSED [ 15%]
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[single_asic-wm_buf_pool_lossless] SKIPPED [ 16%]
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[single_asic-wm_buf_pool_lossy] SKIPPED [ 17%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_asic] PASSED [ 18%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq[single_asic-lossy_queue_voq_1] SKIPPED [ 18%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq[single_asic-lossy_queue_voq_2] SKIPPED [ 19%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_asic] PASSED [ 20%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpQueueMapping[single_asic-downstream] SKIPPED [ 21%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpQueueMapping[single_asic-upstream] SKIPPED [ 21%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping[single_asic] SKIPPED [ 22%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping[single_asic] SKIPPED [ 23%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[single_asic] PASSED      [ 24%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossless] PASSED [ 25%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossy] PASSED [ 25%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark[single_asic] PASSED [ 26%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop[single_asic] SKIPPED   [ 27%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_asic-wm_q_shared_lossless] PASSED [ 28%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_asic-wm_q_shared_lossy] PASSED [ 28%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping[single_asic] SKIPPED [ 29%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpToPgMapping[single_asic-downstream] SKIPPED [ 30%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpToPgMapping[single_asic-upstream] SKIPPED [ 31%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange[single_asic] PASSED [ 31%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts[single_asic-wm_q_wm_all_ports] SKIPPED [ 32%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc[single_asic] SKIPPED [ 33%]


========== 16 passed, 116 skipped, 14 warnings in 3694.26s (1:01:34) ===========

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
