### PR TITLE
Improve IPV6 debug information for debug reachability issue

### DIFF
--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -103,12 +103,12 @@ def do_setup_tacacs(ptfhost, duthost, tacacs_creds):
     logger.info('Upon reboot: setup tacacs_creds')
     tacacs_server_ip = ptfhost.mgmt_ip
     tacacs_server_passkey = tacacs_creds[duthost.hostname]['tacacs_passkey']
-    setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip, tacacs_server_passkey)
+    setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip, tacacs_server_passkey, ptfhost)
 
     ptfhost_vars = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars
     if 'ansible_hostv6' in ptfhost_vars:
         tacacs_server_ip = ptfhost_vars['ansible_hostv6']
-        setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip, tacacs_server_passkey)
+        setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip, tacacs_server_passkey, ptfhost)
     logger.info('Upon reboot: complete: setup tacacs_creds')
 
 

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -72,13 +72,18 @@ def setup_local_user(duthost, tacacs_creds):
 
 
 def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip,
-                        tacacs_server_passkey, authorization="local"):
+                        tacacs_server_passkey, ptfhost, authorization="local"):
     """setup tacacs client"""
 
     # UT should failed when set reachable TACACS server with this setup_tacacs_client
     ping_result = duthost.shell("ping {} -c 1 -W 3".format(tacacs_server_ip))['stdout']
     logger.info("TACACS server ping result: {}".format(ping_result))
     if "100% packet loss" in ping_result:
+        # collect more information for debug testbed network issue
+        duthost_interface = duthost.shell("sudo ifconfig eth0")['stdout']
+        ptfhost_interface = ptfhost.shell("ifconfig mgmt")['stdout']
+        logger.debug("PTF IPV6 address not reachable, dut interfaces: {}, ptfhost interfaces:{}"
+                        .format(ping_result, duthost_interface, ptfhost_interface))
         pytest_assert(False, "TACACS server not reachable: {}".format(ping_result))
 
     # configure tacacs client


### PR DESCRIPTION
Improve IPV6 debug information for debug reachability issue.

#### Why I did it
There are random IPV6 ptfhost address unreachable issue, need add debug information for investigation.

##### Work item tracking
- Microsoft ADO: 26544335

#### How I did it
Improve IPV6 debug information for debug reachability issue.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Improve IPV6 debug information for debug reachability issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

