### PR TITLE
[dhcp_server] test ip assignment with single and range ip configuration

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1081,6 +1081,8 @@ def capture_and_check_packet_on_dut(
     interface='any',
     pkts_filter='',
     pkts_validator=lambda pkts: pytest_assert(len(pkts) > 0, "No packets captured"),
+    pkts_validator_args=[],
+    pkts_validator_kwargs={},
     wait_time=1
 ):
     """
@@ -1090,6 +1092,9 @@ def capture_and_check_packet_on_dut(
         interface: the interface to capture packets on, default is 'any'
         pkts_filter: the PCAP-FILTER to apply to the captured packets, default is '' means no filter
         pkts_validator: the function to validate the captured packets, default is to check if any packet is captured
+        pkts_validator_args: ther args to pass to the pkts_validator function
+        pkts_validator_kwargs: the kwargs to pass to the pkts_validator function
+        wait_time: the time to wait before stopping the packet capture, default is 1 second
     """
     pcap_save_path = "/tmp/func_capture_and_check_packet_on_dut_%s.pcap" % (str(uuid.uuid4()))
     cmd_capture_pkts = "sudo nohup tcpdump --immediate-mode -U -i %s -w %s >/dev/null 2>&1 %s & echo $!" \
@@ -1106,6 +1111,6 @@ def capture_and_check_packet_on_dut(
         duthost.shell("kill -s 2 %s" % tcpdump_pid)
         with tempfile.NamedTemporaryFile() as temp_pcap:
             duthost.fetch(src=pcap_save_path, dest=temp_pcap.name, flat=True)
-            pkts_validator(scapy_sniff(offline=temp_pcap.name))
+            pkts_validator(scapy_sniff(offline=temp_pcap.name), *pkts_validator_args, **pkts_validator_kwargs)
     finally:
         duthost.file(path=pcap_save_path, state="absent")

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert as py_assert
+from tests.common.helpers.assertions import pytest_require as py_require
 
 DHCP_SERVER_CONTAINER_NAME = "dhcp_server"
 DHCP_SERVER_FEATRUE_NAME = "dhcp_server"
@@ -8,15 +10,14 @@ DHCP_SERVER_FEATRUE_NAME = "dhcp_server"
 @pytest.fixture(scope="module", autouse=True)
 def dhcp_server_setup_teardown(duthost):
     features_state, _ = duthost.get_feature_status()
-    if DHCP_SERVER_FEATRUE_NAME not in features_state:
-        pytest.fail('There is no dhcp server feature in the DUT')
+    py_require(DHCP_SERVER_FEATRUE_NAME in features_state, "Skip on vs testbed without dhcp server feature")
     restore_state_flag = True
     if "enabled" not in features_state.get(DHCP_SERVER_FEATRUE_NAME, ""):
         duthost.shell("config feature state dhcp_server enabled")
     else:
         restore_state_flag = False
-    if not wait_until(10, 1, 1, duthost.is_container_running, DHCP_SERVER_CONTAINER_NAME):
-        pytest.fail('feature dhcp_server is enabled but container is not running')
+    py_assert(wait_until(10, 1, 1, duthost.is_container_running, DHCP_SERVER_CONTAINER_NAME),
+              'feature dhcp_server is enabled but container is not running')
 
     yield
 

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -8,14 +8,11 @@ DHCP_SERVER_FEATRUE_NAME = "dhcp_server"
 @pytest.fixture(scope="module", autouse=True)
 def dhcp_server_setup_teardown(duthost):
     features_state, _ = duthost.get_feature_status()
-    if DHCP_SERVER_FEATRUE_NAME not in DHCP_SERVER_FEATRUE_NAME:
+    if DHCP_SERVER_FEATRUE_NAME not in features_state:
         pytest.fail('There is no dhcp server feature in the DUT')
     restore_state_flag = True
     if "enabled" not in features_state.get(DHCP_SERVER_FEATRUE_NAME, ""):
         duthost.shell("config feature state dhcp_server enabled")
-        features_state, _ = duthost.get_feature_status()
-        if "enabled" not in features_state.get(DHCP_SERVER_FEATRUE_NAME, ""):
-            pytest.fail('Enabling dhcp server feature failed')
     else:
         restore_state_flag = False
     if not wait_until(10, 1, 1, duthost.is_container_running, DHCP_SERVER_CONTAINER_NAME):
@@ -25,3 +22,4 @@ def dhcp_server_setup_teardown(duthost):
 
     if restore_state_flag:
         duthost.shell("config feature state dhcp_server disabled", module_ignore_errors=True)
+        duthost.shell("docker rm dhcp_server", module_ignore_errors=True)

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -3,6 +3,7 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.helpers.assertions import pytest_require as py_require
 
+DHCP_RELAY_CONTAINER_NAME = "dhcp_relay"
 DHCP_SERVER_CONTAINER_NAME = "dhcp_server"
 DHCP_SERVER_FEATRUE_NAME = "dhcp_server"
 
@@ -11,16 +12,34 @@ DHCP_SERVER_FEATRUE_NAME = "dhcp_server"
 def dhcp_server_setup_teardown(duthost):
     features_state, _ = duthost.get_feature_status()
     py_require(DHCP_SERVER_FEATRUE_NAME in features_state, "Skip on vs testbed without dhcp server feature")
-    restore_state_flag = True
+    restore_state_flag = False
     if "enabled" not in features_state.get(DHCP_SERVER_FEATRUE_NAME, ""):
+        restore_state_flag = True
         duthost.shell("config feature state dhcp_server enabled")
-    else:
-        restore_state_flag = False
-    py_assert(wait_until(10, 1, 1, duthost.is_container_running, DHCP_SERVER_CONTAINER_NAME),
-              'feature dhcp_server is enabled but container is not running')
+        duthost.shell("sudo systemctl restart dhcp_relay.service")
+
+    def is_supervisor_subprocess_running(duthost, container_name, app_name):
+        return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {app_name}")["stdout"]
+    py_assert(
+        wait_until(20, 1, 1,
+                   is_supervisor_subprocess_running,
+                   duthost,
+                   DHCP_SERVER_CONTAINER_NAME,
+                   "dhcp-server-ipv4:kea-dhcp4"),
+        'feature dhcp_server is enabled but container is not running'
+    )
+    py_assert(
+        wait_until(30, 1, 1,
+                   is_supervisor_subprocess_running,
+                   duthost,
+                   DHCP_RELAY_CONTAINER_NAME,
+                   "dhcp-relay:dhcprelayd"),
+        'dhcprelayd in container dhcp_relay is not running'
+    )
 
     yield
 
     if restore_state_flag:
         duthost.shell("config feature state dhcp_server disabled", module_ignore_errors=True)
+        duthost.shell("sudo systemctl restart dhcp_relay.service")
         duthost.shell("docker rm dhcp_server", module_ignore_errors=True)

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+from tests.common.utilities import wait_until
+
+DHCP_SERVER_CONTAINER_NAME = "dhcp_server"
+DHCP_SERVER_FEATRUE_NAME = "dhcp_server"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def dhcp_server_setup_teardown(duthost):
+    features_state, _ = duthost.get_feature_status()
+    if DHCP_SERVER_FEATRUE_NAME not in DHCP_SERVER_FEATRUE_NAME:
+        pytest.fail('There is no dhcp server feature in the DUT')
+    restore_state_flag = True
+    if "enabled" not in features_state.get(DHCP_SERVER_FEATRUE_NAME, ""):
+        duthost.shell("config feature state dhcp_server enabled")
+        features_state, _ = duthost.get_feature_status()
+        if "enabled" not in features_state.get(DHCP_SERVER_FEATRUE_NAME, ""):
+            pytest.fail('Enabling dhcp server feature failed')
+    else:
+        restore_state_flag = False
+    if not wait_until(10, 1, 1, duthost.is_container_running, DHCP_SERVER_CONTAINER_NAME):
+        pytest.fail('feature dhcp_server is enabled but container is not running')
+
+    yield
+
+    if restore_state_flag:
+        duthost.shell("config feature state dhcp_server disabled", module_ignore_errors=True)

--- a/tests/dhcp_server/test_dhcp_server.py
+++ b/tests/dhcp_server/test_dhcp_server.py
@@ -1,6 +1,7 @@
 import binascii
 import contextlib
 from datetime import datetime
+import json
 import logging
 import ipaddress
 import pytest

--- a/tests/dhcp_server/test_dhcp_server.py
+++ b/tests/dhcp_server/test_dhcp_server.py
@@ -1,0 +1,337 @@
+import binascii
+import logging
+import pytest
+import ptf.packet as scapy
+import ptf.testutils as testutils
+from tests.common.utilities import capture_and_check_packet_on_dut
+from tests.common.helpers.assertions import pytest_assert
+
+
+pytestmark = [
+    pytest.mark.topology('m0', 'mx'),
+]
+
+
+VLAN_GATE_WAY = '192.168.0.1'
+VLAN_SUBNET_MASK = '255.255.255.0'
+DHCP_DEFAULT_LEASE_TIME = 300
+DHCP_DEFAULT_CUSTOM_OPTION_VALUE = 'hello_from_sonic'
+DHCP_MAC_BROADCAST = "ff:ff:ff:ff:ff:ff"
+DHCP_IP_DEFAULT_ROUTE = "0.0.0.0"
+DHCP_IP_BROADCAST = "255.255.255.255"
+DHCP_UDP_CLIENT_PORT = 68
+DHCP_UDP_SERVER_PORT = 67
+DHCP_MESSAGE_TYPE_DISCOVER_NUM = 1
+DHCP_MESSAGE_TYPE_OFFER_NUM = 2
+DHCP_MESSAGE_TYPE_REQUEST_NUM = 3
+DHCP_MESSAGE_TYPE_ACK_NUM = 5
+DHCP_MESSAGE_TYPE_NAK_NUM = 6
+
+
+def clean_fdb_table(duthost):
+    duthost.shell("sonic-clear fdb all")
+
+
+def ping_dut_refresh_fdb(ptfhost, interface, vlan_ip):
+    ptfhost.shell("timeout 1 ping -c 1 -w 1 -I {} {}".format(interface, vlan_ip), module_ignore_errors=True)
+
+
+def clean_dhcp_server_config(duthost):
+    keys = duthost.shell("sonic-db-cli CONFIG_DB KEYS DHCP_SERVER_IPV4*")
+    for key in keys["stdout_lines"]:
+        duthost.shell("sonic-db-cli CONFIG_DB DEL '{}'".format(key))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def dhcp_server_config_setup_and_teardown(duthost):
+    clean_dhcp_server_config(duthost)
+    config_commands = [
+                        'config dhcp_server ipv4 add --mode PORT --lease_time %s ' % DHCP_DEFAULT_LEASE_TIME +
+                        '--gateway %s --netmask 255.255.255.0 Vlan1000' % VLAN_GATE_WAY,
+                        'config dhcp_server ipv4 enable Vlan1000',
+                        # config part 1: for single ip assignment test
+                        'config dhcp_server ipv4 range add test_single_0 192.168.0.10',
+                        'config dhcp_server ipv4 bind Vlan1000 Ethernet0 --range test_single_0',
+                        'config dhcp_server ipv4 range add test_single_1 192.168.0.11',
+                        'config dhcp_server ipv4 bind Vlan1000 Ethernet1 --range test_single_1',
+                        'config dhcp_server ipv4 range add test_single_2 192.168.0.12',
+                        'config dhcp_server ipv4 bind Vlan1000 Ethernet2 --range test_single_2',
+                        # config part 2: for range assignment test
+                        'config dhcp_server ipv4 range add test_range_5 192.168.0.20 192.168.0.24',
+                        'config dhcp_server ipv4 bind Vlan1000 Ethernet5 --range test_range_5',
+                        # config part 3: for customize options test
+                        'config dhcp_server ipv4 option add ' +
+                        'sonic_test_option 147 string %s' % DHCP_DEFAULT_CUSTOM_OPTION_VALUE,
+                        'config dhcp_server ipv4 option bind Vlan1000 sonic_test_option'
+                    ]
+    for cmd in config_commands:
+        duthost.shell(cmd)
+
+    yield
+
+    clean_dhcp_server_config(duthost)
+
+
+def match_expected_dhcp_options(pkt_dhcp_options, option_name, expected_value):
+    for option in pkt_dhcp_options:
+        if option[0] == option_name:
+            return option[1] == expected_value
+    return False
+
+
+def convert_mac_to_chaddr(mac):
+    return binascii.unhexlify(mac.replace(":", "")) + b'\x00' * 10
+
+
+def create_dhcp_client_packet(src_mac, message_type, client_options=[], xid=123):
+    dhcp_options = [("message-type", message_type)] + client_options + ["end"]
+    pkt = scapy.Ether(dst=DHCP_MAC_BROADCAST, src=src_mac)
+    pkt /= scapy.IP(src=DHCP_IP_DEFAULT_ROUTE, dst=DHCP_IP_BROADCAST)
+    pkt /= scapy.UDP(sport=DHCP_UDP_CLIENT_PORT, dport=DHCP_UDP_SERVER_PORT)
+    pkt /= scapy.BOOTP(chaddr=convert_mac_to_chaddr(src_mac), xid=xid)
+    pkt /= scapy.DHCP(options=dhcp_options)
+    return pkt
+
+
+def send_and_verify(
+    duthost,
+    ptfhost,
+    ptfadapter,
+    senario_context,
+    test_pkt,
+    pkts_validator,
+    pkts_validator_args=[],
+    pkts_validator_kwargs={}
+):
+    dut_port_to_capture_pkt = senario_context['dut_port_to_capture_pkt']
+    pkts_filter = "udp dst port %s" % (DHCP_UDP_CLIENT_PORT)
+    with capture_and_check_packet_on_dut(
+        duthost=duthost,
+        interface=dut_port_to_capture_pkt,
+        pkts_filter=pkts_filter,
+        pkts_validator=pkts_validator,
+        pkts_validator_args=pkts_validator_args,
+        pkts_validator_kwargs=pkts_validator_kwargs,
+        wait_time=3
+    ):
+        clean_fdb_table(duthost)
+        if 'refresh_fdb_ptf_port' in senario_context:
+            ping_dut_refresh_fdb(ptfhost, senario_context['refresh_fdb_ptf_port'], VLAN_GATE_WAY)
+        ptf_port_index = senario_context['ptf_port_index']
+        testutils.send_packet(ptfadapter, ptf_port_index, test_pkt)
+
+
+def validate_dhcp_server_pkts(pkts, test_xid, expected_ip, expected_msg_type):
+    def is_expected_pkt(pkt):
+        logging.info("validate_dhcp_server_pkts: %s" % repr(pkt))
+        pkt_dhcp_options = pkt[scapy.DHCP].options
+        if pkt[scapy.BOOTP].xid != test_xid:
+            return False
+        elif pkt[scapy.BOOTP].yiaddr != expected_ip:
+            return False
+        elif not match_expected_dhcp_options(pkt_dhcp_options, "subnet_mask", VLAN_SUBNET_MASK):
+            return False
+        elif not match_expected_dhcp_options(pkt_dhcp_options, "server_id", VLAN_GATE_WAY):
+            return False
+        elif not match_expected_dhcp_options(pkt_dhcp_options, "lease_time", DHCP_DEFAULT_LEASE_TIME):
+            return False
+        elif not match_expected_dhcp_options(pkt_dhcp_options, "message-type", expected_msg_type):
+            return False
+        return True
+    pytest_assert(len([pkt for pkt in pkts if is_expected_pkt(pkt)]) == 1,
+                  "Didn't got dhcp packet with expected ip and xid")
+
+
+def validate_no_dhcp_server_pkts(pkts, test_xid):
+    def is_expected_pkt(pkt):
+        logging.info("validate_no_dhcp_server_pkts: %s" % repr(pkt))
+        pkt_dhcp_options = pkt[scapy.DHCP].options
+        if pkt[scapy.BOOTP].xid != test_xid:
+            return False
+        elif match_expected_dhcp_options(pkt_dhcp_options, "message-type", DHCP_MESSAGE_TYPE_NAK_NUM):
+            return False
+        return True
+    pytest_assert(len([pkt for pkt in pkts if is_expected_pkt(pkt)]) == 0,
+                  "Got unexpected dhcp packet")
+
+
+def validate_dhcp_server_pkts_custom_option(pkts, test_xid, **options):
+    def has_custom_option(pkt):
+        logging.info("validate_dhcp_server_pkts_custom_option: %s" % repr(pkt))
+        if pkt[scapy.BOOTP].xid != test_xid:
+            return False
+        pkt_dhcp_options = pkt[scapy.DHCP].options
+        for option_type, expected_value in options.items():
+            if not match_expected_dhcp_options(pkt_dhcp_options, int(option_type), expected_value):
+                return False
+        return True
+    pytest_assert(len([pkt for pkt in pkts if has_custom_option(pkt)]) == 1,
+                  "Didn't got dhcp packet with expected custom option")
+
+
+# dhcp_server/test_dhcp_server.py::test_dhcp_server_port_based_assignment_single_ip
+@pytest.mark.parametrize('senario_context', [
+    {
+        'description': 'Verify configured interface with \
+                        client mac not in FDB table can successfully get IP',
+        'dut_port_to_capture_pkt': 'Ethernet0',
+        'expected_assigned_ip': '192.168.0.10',
+        'ptf_port_index': 0,
+        "test_xid": 11
+    },
+    {
+        'description': 'Verify configured interface with \
+                        client mac in FDB table can successfully get IP',
+        'dut_port_to_capture_pkt': 'Ethernet1',
+        'expected_assigned_ip': '192.168.0.11',
+        'ptf_port_index': 1,
+        'refresh_fdb_ptf_port': 'eth1',
+        "test_xid": 12
+    },
+    {
+        'description': 'Verify configured interface with \
+                        client mac in FDB table but mac was learnt \
+                        from another interface can successfully get IP.',
+        'dut_port_to_capture_pkt': 'Ethernet2',
+        'expected_assigned_ip': '192.168.0.12',
+        'ptf_mac_port_index': 3,
+        'ptf_port_index': 2,
+        'refresh_fdb_ptf_port': 'eth3',
+        "test_xid": 13
+    },
+    {
+        'description': 'Verify no-configured interface cannot get IP',
+        'dut_port_to_capture_pkt': 'any',
+        "expected_assigned_ip": None,
+        'ptf_port_index': 4,
+        'refresh_fdb_ptf_port': 'eth4',
+        "test_xid": 14
+    }
+])
+def test_dhcp_server_port_based_assignment_single_ip(duthost, ptfhost, ptfadapter, senario_context):
+    """
+       Test single ip assignment with different senarios, each senario has a description in senario_context.
+    """
+    test_xid = senario_context['test_xid']
+    ptf_mac_port_index = senario_context.get('ptf_mac_port_index', senario_context['ptf_port_index'])
+    client_mac = ptfadapter.dataplane.get_mac(0, ptf_mac_port_index).decode('utf-8')
+    expected_ip = senario_context['expected_assigned_ip']
+    pkts_validator = validate_dhcp_server_pkts if expected_ip else validate_no_dhcp_server_pkts
+    pkts_validator_args = [test_xid, expected_ip, DHCP_MESSAGE_TYPE_OFFER_NUM] if expected_ip else [test_xid]
+    discover_pkt = create_dhcp_client_packet(
+        src_mac=client_mac,
+        message_type=DHCP_MESSAGE_TYPE_DISCOVER_NUM,
+        client_options=[],
+        xid=test_xid
+    )
+    send_and_verify(
+        duthost=duthost,
+        ptfhost=ptfhost,
+        ptfadapter=ptfadapter,
+        senario_context=senario_context,
+        test_pkt=discover_pkt,
+        pkts_validator=pkts_validator,
+        pkts_validator_args=pkts_validator_args
+    )
+    request_pkt = create_dhcp_client_packet(
+        src_mac=client_mac,
+        message_type=DHCP_MESSAGE_TYPE_REQUEST_NUM,
+        client_options=[("requested_addr", expected_ip), ("server_id", VLAN_GATE_WAY)],
+        xid=test_xid
+    )
+    pkts_validator_args = [test_xid, expected_ip, DHCP_MESSAGE_TYPE_ACK_NUM] if expected_ip else [test_xid]
+    send_and_verify(
+        duthost=duthost,
+        ptfhost=ptfhost,
+        ptfadapter=ptfadapter,
+        senario_context=senario_context,
+        test_pkt=request_pkt,
+        pkts_validator=pkts_validator,
+        pkts_validator_args=pkts_validator_args
+    )
+
+
+@pytest.mark.parametrize('senario_context', [
+    {
+        'dut_port_to_capture_pkt': 'Ethernet5',
+        'expected_assigned_ip': '192.168.0.20',
+        'ptf_port_index': 5,
+        "test_xid": 15
+    }
+])
+def test_dhcp_server_port_based_assignment_range(duthost, ptfhost, ptfadapter, senario_context):
+    """
+       Test range ip assignment
+    """
+    test_xid = senario_context['test_xid']
+    ptf_mac_port_index = senario_context.get('ptf_mac_port_index', senario_context['ptf_port_index'])
+    client_mac = ptfadapter.dataplane.get_mac(0, ptf_mac_port_index).decode('utf-8')
+    expected_ip = senario_context['expected_assigned_ip']
+    pkts_validator = validate_dhcp_server_pkts if expected_ip else validate_no_dhcp_server_pkts
+    pkts_validator_args = [test_xid, expected_ip, DHCP_MESSAGE_TYPE_OFFER_NUM] if expected_ip else [test_xid]
+    discover_pkt = create_dhcp_client_packet(
+        src_mac=client_mac,
+        message_type=DHCP_MESSAGE_TYPE_DISCOVER_NUM,
+        client_options=[],
+        xid=test_xid
+    )
+    send_and_verify(
+        duthost=duthost,
+        ptfhost=ptfhost,
+        ptfadapter=ptfadapter,
+        senario_context=senario_context,
+        test_pkt=discover_pkt,
+        pkts_validator=pkts_validator,
+        pkts_validator_args=pkts_validator_args
+    )
+    request_pkt = create_dhcp_client_packet(
+        src_mac=client_mac,
+        message_type=DHCP_MESSAGE_TYPE_REQUEST_NUM,
+        client_options=[("requested_addr", expected_ip), ("server_id", VLAN_GATE_WAY)],
+        xid=test_xid
+    )
+    pkts_validator_args = [test_xid, expected_ip, DHCP_MESSAGE_TYPE_ACK_NUM] if expected_ip else [test_xid]
+    send_and_verify(
+        duthost=duthost,
+        ptfhost=ptfhost,
+        ptfadapter=ptfadapter,
+        senario_context=senario_context,
+        test_pkt=request_pkt,
+        pkts_validator=pkts_validator,
+        pkts_validator_args=pkts_validator_args
+    )
+
+
+@pytest.mark.parametrize('senario_context', [
+    {
+        'dut_port_to_capture_pkt': 'Ethernet5',
+        'ptf_port_index': 5,
+        "test_xid": 16
+    }
+])
+def test_dhcp_server_port_based_customize_options(duthost, ptfhost, ptfadapter, senario_context):
+    """
+        Test dhcp server packets if carry the customized options as expected
+    """
+    test_xid = senario_context['test_xid']
+    ptf_mac_port_index = senario_context['ptf_port_index']
+    client_mac = ptfadapter.dataplane.get_mac(0, ptf_mac_port_index).decode('utf-8')
+    pkts_validator = validate_dhcp_server_pkts_custom_option
+    pkts_validator_args = [test_xid]
+    pkts_validator_kwargs = {"147": DHCP_DEFAULT_CUSTOM_OPTION_VALUE.encode('ascii')}
+    discover_pkt = create_dhcp_client_packet(
+        src_mac=client_mac,
+        message_type=DHCP_MESSAGE_TYPE_DISCOVER_NUM,
+        client_options=[],
+        xid=test_xid
+    )
+    send_and_verify(
+        duthost=duthost,
+        ptfhost=ptfhost,
+        ptfadapter=ptfadapter,
+        senario_context=senario_context,
+        test_pkt=discover_pkt,
+        pkts_validator=pkts_validator,
+        pkts_validator_args=pkts_validator_args,
+        pkts_validator_kwargs=pkts_validator_kwargs
+    )

--- a/tests/dhcp_server/test_dhcp_server.py
+++ b/tests/dhcp_server/test_dhcp_server.py
@@ -269,8 +269,8 @@ def test_dhcp_server_port_based_assignment_single_ip_s1(
         'config dhcp_server ipv4 add --mode PORT --lease_time %s ' % DHCP_DEFAULT_LEASE_TIME +
         '--gateway %s --netmask %s %s' % (gate_way, net_mask, vlan_name),
         'config dhcp_server ipv4 enable %s' % vlan_name,
-        'config dhcp_server ipv4 range add test_single_0_ip %s' % expected_assigned_ip,
-        'config dhcp_server ipv4 bind %s %s --range test_single_0_ip' % (vlan_name, dut_port)
+        'config dhcp_server ipv4 range add test_single_ip %s' % expected_assigned_ip,
+        'config dhcp_server ipv4 bind %s %s --range test_single_ip' % (vlan_name, dut_port)
     ]
     with dhcp_server_config(duthost, config_commands):
         verify_discover_and_request_then_release(
@@ -304,8 +304,8 @@ def test_dhcp_server_port_based_assignment_single_ip_s2(
         'config dhcp_server ipv4 add --mode PORT --lease_time %s ' % DHCP_DEFAULT_LEASE_TIME +
         '--gateway %s --netmask %s %s' % (gate_way, net_mask, vlan_name),
         'config dhcp_server ipv4 enable %s' % vlan_name,
-        'config dhcp_server ipv4 range add test_single_0_ip %s' % expected_assigned_ip,
-        'config dhcp_server ipv4 bind %s %s --range test_single_0_ip' % (vlan_name, dut_port)
+        'config dhcp_server ipv4 range add test_single_ip %s' % expected_assigned_ip,
+        'config dhcp_server ipv4 bind %s %s --range test_single_ip' % (vlan_name, dut_port)
     ]
     ptf_port_index = int(dut_port.replace('Ethernet', ''))
     with dhcp_server_config(duthost, config_commands):
@@ -342,8 +342,8 @@ def test_dhcp_server_port_based_assignment_single_ip_s3(
         'config dhcp_server ipv4 add --mode PORT --lease_time %s ' % DHCP_DEFAULT_LEASE_TIME +
         '--gateway %s --netmask %s %s' % (gate_way, net_mask, vlan_name),
         'config dhcp_server ipv4 enable %s' % vlan_name,
-        'config dhcp_server ipv4 range add test_single_0_ip %s' % expected_assigned_ip,
-        'config dhcp_server ipv4 bind %s %s --range test_single_0_ip' % (vlan_name, dut_port)
+        'config dhcp_server ipv4 range add test_single_ip %s' % expected_assigned_ip,
+        'config dhcp_server ipv4 bind %s %s --range test_single_ip' % (vlan_name, dut_port)
     ]
     _, ptf_mac_port_index = random.choice([m for m in vlan_members_with_ptf_idx if m[0] != dut_port])
     with dhcp_server_config(duthost, config_commands):
@@ -379,7 +379,7 @@ def test_dhcp_server_port_based_assignment_single_ip_s4(
         'config dhcp_server ipv4 add --mode PORT --lease_time %s ' % DHCP_DEFAULT_LEASE_TIME +
         '--gateway %s --netmask %s %s' % (gate_way, net_mask, vlan_name),
         'config dhcp_server ipv4 enable %s' % vlan_name,
-        'config dhcp_server ipv4 range add test_single_0_ip %s' % expected_assigned_ip
+        'config dhcp_server ipv4 range add test_single_ip %s' % expected_assigned_ip
     ]
     with dhcp_server_config(duthost, config_commands):
         verify_discover_and_request_then_release(
@@ -415,8 +415,8 @@ def test_dhcp_server_port_based_assignment_range_ip(
         'config dhcp_server ipv4 add --mode PORT --lease_time %s ' % DHCP_DEFAULT_LEASE_TIME +
         '--gateway %s --netmask %s %s' % (gate_way, net_mask, vlan_name),
         'config dhcp_server ipv4 enable %s' % vlan_name,
-        'config dhcp_server ipv4 range add test_single_0_ip %s %s' % (expected_assigned_ip, last_ip_in_range),
-        'config dhcp_server ipv4 bind %s %s --range test_single_0_ip' % (vlan_name, dut_port),
+        'config dhcp_server ipv4 range add test_range_ip %s %s' % (expected_assigned_ip, last_ip_in_range),
+        'config dhcp_server ipv4 bind %s %s --range test_range_ip' % (vlan_name, dut_port),
     ]
     with dhcp_server_config(duthost, config_commands):
         verify_discover_and_request_then_release(
@@ -447,8 +447,8 @@ def test_dhcp_server_port_based_customize_options(duthost, ptfhost, ptfadapter, 
         'config dhcp_server ipv4 add --mode PORT --lease_time %s ' % DHCP_DEFAULT_LEASE_TIME +
         '--gateway %s --netmask %s %s' % (gate_way, net_mask, vlan_name),
         'config dhcp_server ipv4 enable %s' % vlan_name,
-        'config dhcp_server ipv4 range add test_option_0_ip %s' % expected_assigned_ip,
-        'config dhcp_server ipv4 bind %s %s --range test_option_0_ip' % (vlan_name, dut_port),
+        'config dhcp_server ipv4 range add test_option_ip %s' % expected_assigned_ip,
+        'config dhcp_server ipv4 bind %s %s --range test_option_ip' % (vlan_name, dut_port),
         'config dhcp_server ipv4 option add ' +
         'sonic_test_option 147 string %s' % DHCP_DEFAULT_CUSTOM_OPTION_VALUE,
         'config dhcp_server ipv4 option bind %s sonic_test_option' % vlan_name
@@ -492,4 +492,130 @@ def test_dhcp_server_port_based_customize_options(duthost, ptfhost, ptfadapter, 
             pkts_validator_args=pkts_validator_args,
             pkts_validator_kwargs=pkts_validator_kwargs,
             refresh_fdb_ptf_port='eth'+str(ptf_port_index)
+        )
+
+
+def test_dhcp_server_port_based_assigenment_single_ip_mac_move(
+    duthost,
+    ptfhost,
+    ptfadapter,
+    parse_vlan_setting_from_running_config
+):
+    """
+        To test port based single ip assignment with client move to an interface has free IP to assign.
+    """
+    test_xid = 7
+    vlan_name, gate_way, net_mask, vlan_hosts, vlan_members_with_ptf_idx = parse_vlan_setting_from_running_config
+    expected_assigned_ip_0 = random.choice(vlan_hosts)
+    dut_port_0, ptf_port_index_0 = random.choice(vlan_members_with_ptf_idx)
+    expected_assigned_ip_1 = random.choice([v for v in vlan_hosts if v != expected_assigned_ip_0])
+    dut_port_1, ptf_port_index_1 = random.choice([m for m in vlan_members_with_ptf_idx if m[0] != dut_port_0])
+    config_commands = [
+        'config dhcp_server ipv4 add --mode PORT --lease_time %s ' % DHCP_DEFAULT_LEASE_TIME +
+        '--gateway %s --netmask %s %s' % (gate_way, net_mask, vlan_name),
+        'config dhcp_server ipv4 enable %s' % vlan_name,
+        'config dhcp_server ipv4 range add test_single_ip_0 %s' % expected_assigned_ip_0,
+        'config dhcp_server ipv4 bind %s %s --range test_single_ip_0' % (vlan_name, dut_port_0),
+        'config dhcp_server ipv4 range add test_single_ip_1 %s' % expected_assigned_ip_1,
+        'config dhcp_server ipv4 bind %s %s --range test_single_ip_1' % (vlan_name, dut_port_1)
+    ]
+    with dhcp_server_config(duthost, config_commands):
+        verify_discover_and_request_then_release(
+            duthost=duthost,
+            ptfhost=ptfhost,
+            ptfadapter=ptfadapter,
+            dut_port_to_capture_pkt=dut_port_0,
+            ptf_port_index=ptf_port_index_0,
+            ptf_mac_port_index=ptf_port_index_0,
+            test_xid=test_xid,
+            expected_assigned_ip=expected_assigned_ip_0,
+            exp_server_ip=gate_way,
+            net_mask=net_mask
+        )
+        verify_discover_and_request_then_release(
+            duthost=duthost,
+            ptfhost=ptfhost,
+            ptfadapter=ptfadapter,
+            dut_port_to_capture_pkt=dut_port_1,
+            ptf_port_index=ptf_port_index_1,
+            ptf_mac_port_index=ptf_port_index_0,
+            test_xid=test_xid,
+            expected_assigned_ip=expected_assigned_ip_1,
+            exp_server_ip=gate_way,
+            net_mask=net_mask
+        )
+
+
+def test_dhcp_server_port_based_assigenment_single_ip_mac_swap(
+    duthost,
+    ptfhost,
+    ptfadapter,
+    parse_vlan_setting_from_running_config
+):
+    """
+        To test port based single ip assignment with two clients swap their interfaces.
+    """
+    test_xid = 8
+    vlan_name, gate_way, net_mask, vlan_hosts, vlan_members_with_ptf_idx = parse_vlan_setting_from_running_config
+    expected_assigned_ip_0 = random.choice(vlan_hosts)
+    dut_port_0, ptf_port_index_0 = random.choice(vlan_members_with_ptf_idx)
+    expected_assigned_ip_1 = random.choice([v for v in vlan_hosts if v != expected_assigned_ip_0])
+    dut_port_1, ptf_port_index_1 = random.choice([m for m in vlan_members_with_ptf_idx if m[0] != dut_port_0])
+    config_commands = [
+        'config dhcp_server ipv4 add --mode PORT --lease_time %s ' % DHCP_DEFAULT_LEASE_TIME +
+        '--gateway %s --netmask %s %s' % (gate_way, net_mask, vlan_name),
+        'config dhcp_server ipv4 enable %s' % vlan_name,
+        'config dhcp_server ipv4 range add test_single_ip_0 %s' % expected_assigned_ip_0,
+        'config dhcp_server ipv4 bind %s %s --range test_single_ip_0' % (vlan_name, dut_port_0),
+        'config dhcp_server ipv4 range add test_single_ip_1 %s' % expected_assigned_ip_1,
+        'config dhcp_server ipv4 bind %s %s --range test_single_ip_1' % (vlan_name, dut_port_1)
+    ]
+    with dhcp_server_config(duthost, config_commands):
+        verify_discover_and_request_then_release(
+            duthost=duthost,
+            ptfhost=ptfhost,
+            ptfadapter=ptfadapter,
+            dut_port_to_capture_pkt=dut_port_0,
+            ptf_port_index=ptf_port_index_0,
+            ptf_mac_port_index=ptf_port_index_0,
+            test_xid=test_xid,
+            expected_assigned_ip=expected_assigned_ip_0,
+            exp_server_ip=gate_way,
+            net_mask=net_mask
+        )
+        verify_discover_and_request_then_release(
+            duthost=duthost,
+            ptfhost=ptfhost,
+            ptfadapter=ptfadapter,
+            dut_port_to_capture_pkt=dut_port_1,
+            ptf_port_index=ptf_port_index_1,
+            ptf_mac_port_index=ptf_port_index_1,
+            test_xid=test_xid,
+            expected_assigned_ip=expected_assigned_ip_1,
+            exp_server_ip=gate_way,
+            net_mask=net_mask
+        )
+        verify_discover_and_request_then_release(
+            duthost=duthost,
+            ptfhost=ptfhost,
+            ptfadapter=ptfadapter,
+            dut_port_to_capture_pkt=dut_port_1,
+            ptf_port_index=ptf_port_index_1,
+            ptf_mac_port_index=ptf_port_index_0,
+            test_xid=test_xid,
+            expected_assigned_ip=expected_assigned_ip_1,
+            exp_server_ip=gate_way,
+            net_mask=net_mask
+        )
+        verify_discover_and_request_then_release(
+            duthost=duthost,
+            ptfhost=ptfhost,
+            ptfadapter=ptfadapter,
+            dut_port_to_capture_pkt=dut_port_0,
+            ptf_port_index=ptf_port_index_0,
+            ptf_mac_port_index=ptf_port_index_1,
+            test_xid=test_xid,
+            expected_assigned_ip=expected_assigned_ip_0,
+            exp_server_ip=gate_way,
+            net_mask=net_mask
         )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is part of [test plan](https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/IPv4-Port-Based-DHCP-Server-test-plan.md) #11348 implementation

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
To make sure dhcp server has the capability for usage.
#### How did you do it?
In this PR,
first, we write common function to construct DHCP packet, parse VLAN configuration, parse port mapping and send packet and verify packet.
second, we add cases for ip assignment with single ip configuration.
last, we add case for ip assignment with range ip configuration.

#### How did you verify/test it?
Run tests on Arista-720DT-G48S4 and Nokia-7215 mx topo.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
