### PR TITLE
Unify console access to use account from group vars

### DIFF
--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -35,7 +35,7 @@ If console fails, do power cycle
 
 def recover_via_console(sonichost, conn_graph_facts, localhost, mgmt_ip, image_url, hwsku):
     try:
-        dut_console = duthost_console(sonichost, conn_graph_facts, localhost)
+        dut_console = duthost_console(sonichost, conn_graph_facts)
 
         do_power_cycle(sonichost, conn_graph_facts, localhost)
 

--- a/.azure-pipelines/recover_testbed/testbed_status.py
+++ b/.azure-pipelines/recover_testbed/testbed_status.py
@@ -1,6 +1,6 @@
 import logging
 import ipaddress
-from dut_connection import duthost_ssh, duthost_console # noqa E402
+from dut_connection import duthost_console, get_alt_passwords, get_ssh_info # noqa E402
 
 logger = logging.getLogger(__name__)
 
@@ -8,19 +8,32 @@ logger = logging.getLogger(__name__)
 def dut_lose_management_ip(sonichost, conn_graph_facts, localhost, mgmt_ip):
     # Recover DUTs
     logger.info("=====Recover start=====")
-    dut_console = duthost_console(sonichost, conn_graph_facts, localhost)
+
+    # Set the minimum log level due to the security
+    netmiko_logger = logging.getLogger("netmiko")
+    default_netmiko_logger_level = netmiko_logger.getEffectiveLevel()
+    netmiko_logger.setLevel(logging.INFO)
+
+    dut_console = duthost_console(sonichost, conn_graph_facts)
     gw_ip = list(ipaddress.ip_interface(mgmt_ip).network.hosts())[0]
     brd_ip = ipaddress.ip_interface(mgmt_ip).network.broadcast_address
     try:
+        sonic_username, _, _ = get_ssh_info(sonichost)
+        sonicadmin_alt_passwords = get_alt_passwords(sonichost)
+        dut_console.send_command("echo '{}:{}' | sudo chpasswd".format(sonic_username, sonicadmin_alt_passwords[0]))
+        netmiko_logger.setLevel(default_netmiko_logger_level)
+
         dut_console.send_command("sudo mv /etc/sonic/config_db.json /etc/sonic/config_db.json.bak")
 
         dut_console.send_command("sudo ip addr add {} brd {} dev eth0".format(mgmt_ip, brd_ip))
         dut_console.send_command("sudo ip route add default via {}".format(gw_ip))
 
         dut_console.send_command("sudo config save -y")
+
     except Exception as e:
-        logging.info(e)
+        logger.info(e)
     finally:
         logger.info("=====Recover finish=====")
+        netmiko_logger.setLevel(default_netmiko_logger_level)
         localhost.pause(seconds=120, prompt="Wait for SONiC initialization")
         dut_console.disconnect()

--- a/ansible/devutil/devices/ansible_hosts.py
+++ b/ansible/devutil/devices/ansible_hosts.py
@@ -35,6 +35,7 @@ from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
 from ansible.vars.manager import VariableManager
+from ansible.vars.hostvars import HostVars
 from ansible.playbook.play import Play
 
 from ansible.plugins.callback import CallbackBase
@@ -237,6 +238,12 @@ class AnsibleHostsBase(object):
             self.vm = variable_manager
         else:
             self.vm = VariableManager(loader=self.loader, inventory=self.im)
+
+        # Trigger ansible to load and render host variables
+        # After this operation, self.vm._hostvars will be populated with content
+        # self.vm._hostvars["example_hostname"] will return all variables visible by "example_hostname"
+        # The best part is that if the variable is a template, it is automatically rendered with correct data type
+        HostVars(inventory=self.im, variable_manager=self.vm, loader=self.loader)
 
         self.options = {
             "forks": 6,

--- a/ansible/devutil/inv_helpers.py
+++ b/ansible/devutil/inv_helpers.py
@@ -5,6 +5,7 @@ try:
     from ansible.parsing.dataloader import DataLoader
     from ansible.vars.manager import VariableManager
     from ansible.inventory.manager import InventoryManager
+    from ansible.vars.hostvars import HostVars
     has_ansible = True
 except ImportError:
     # ToDo: Support running without Ansible
@@ -56,6 +57,7 @@ class HostManager():
             loader=self._dataloader, sources=inventory_files)
         self._var_mgr = VariableManager(
             loader=self._dataloader, inventory=self._inv_mgr)
+        HostVars(inventory=self._inv_mgr, variable_manager=self._var_mgr, loader=self._dataloader)
 
     def get_host_vars(self, hostname):
         """
@@ -105,7 +107,7 @@ class HostManager():
         """
         res = {}
         host = self._inv_mgr.get_host(hostname)
-        vars = self._var_mgr.get_vars(host=host)
+        vars = self._var_mgr._hostvars[hostname]
         groups = [group.name for group in host.groups]
         k_v = {
             'fanout': {'alias': 'fanout',

--- a/ansible/files/sonic_lab_console_links.csv
+++ b/ansible/files/sonic_lab_console_links.csv
@@ -1,5 +1,5 @@
 StartDevice,StartPort,EndDevice,Console_type,Proxy,BaudRate
-console-1,10,str-msn2700-01,ssh,root,9600
-console-2,11,str-7260-10,ssh,root,9600
-console-1,12,str-7260-11,ssh,root,
-management-1,13,str-acs-serv-01,ssh,root,9600
+console-1,10,str-msn2700-01,ssh,,9600
+console-2,11,str-7260-10,ssh,,9600
+console-1,12,str-7260-11,ssh,,
+management-1,13,str-acs-serv-01,ssh,,9600


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In this PR, we streamlined the process of retrieving console usernames by consolidating the source to a single location: the group vars. This change simplifies our codebase and enhances maintainability. The field 'proxy'  in console link CSV under the ansible/files folder is no longer in use for this purpose.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
In this PR, we streamlined the process of retrieving console usernames by consolidating the source to a single location: the group vars. This change simplifies our codebase and enhances maintainability. The field 'proxy'  in console link CSV under the ansible/files folder is no longer in use for this purpose.

#### How did you do it?
Streamlined the process of retrieving console usernames by consolidating the source to a single location: the group vars.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
