### PR TITLE
[tests/stress]: Fix loganalyzer checks for stress test

### DIFF
--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -37,10 +37,13 @@ def announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name):
     logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
 
 
-def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conpleteness_level,
-                                 withdraw_and_announce_existing_routes, loganalyzer):
+def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_conpleteness_level,
+                                 withdraw_and_announce_existing_routes, loganalyzer,
+                                 enum_rand_one_per_hwsku_frontend_hostname):
     ptf_ip = tbinfo["ptf_ip"]
     topo_name = tbinfo["topo"]["name"]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+
     if loganalyzer:
         ignoreRegex = [
             ".*ERR route_check.py:.*",
@@ -54,7 +57,10 @@ def test_announce_withdraw_route(duthost, localhost, tbinfo, get_function_conple
             ignoreRegex.append(".*ERR memory_threshold_check:.*")
             ignoreRegex.append(".*ERR monit.*memory_check.*")
             ignoreRegex.append(".*ERR monit.*mem usage of.*matches resource limit.*")
-        loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
+
+        # Ignore errors in ignoreRegex for *all* DUTs
+        for dut in duthosts:
+            loganalyzer[dut.hostname].ignore_regex.extend(ignoreRegex)
 
     normalized_level = get_function_conpleteness_level
     if normalized_level is None:

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -47,7 +47,7 @@ def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_conpl
     if loganalyzer:
         ignoreRegex = [
             ".*ERR route_check.py:.*",
-            ".*ERR.* \'routeCheck\' status failed.*",
+            ".*ERR.* 'routeCheck' status failed.*",
             ".*Process \'orchagent\' is stuck in namespace \'host\'.*",
             ".*ERR rsyslogd: .*"
         ]


### PR DESCRIPTION
* In dual TOR testbeds, loganalyzer analyzes both DUTs for errors, so errors need to be ignored on both or else it can cause tests to error out.
* Fix regex expression for routeCheck failures as the current regex still doesn't ignore loganalyzer failures

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fix log analyzer errors on dualtor testbeds
#### How did you do it?
By making sure loganalyzer ignore_regex is ignored for all DUTs in duthosts
#### How did you verify/test it?
By running the test locally and via nightly test pipeline
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
