### PR TITLE
[dualtor][active-standby] Improve the toggle by checking on both sides

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -559,12 +559,10 @@ def _toggle_all_simulator_ports_to_target_dut(target_dut_hostname, duthosts, mux
             probe_ports = set(inactive_ports.keys()) | set(not_standby_ports.keys())
             _probe_mux_ports(duthosts, probe_ports)
 
-        logger.info(
-            'Found muxcables not active on {}: {}'.format(active_duthost.hostname, json.dumps(list(inactive_ports.keys())))
-        )
-        logger.info(
-            'Found muxcables not standby on {}: {}'.format(standby_duthost.hostname, json.dumps(list(not_standby_ports.keys())))
-        )
+        logger.info('Found muxcables not active on {}: {}'.format(
+            active_duthost.hostname, json.dumps(list(inactive_ports.keys()))))
+        logger.info('Found muxcables not standby on {}: {}'.format(
+            standby_duthost.hostname, json.dumps(list(not_standby_ports.keys()))))
         return False
 
     logging.info("Toggling mux cable to {}".format(target_dut_hostname))

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -544,19 +544,26 @@ def _toggle_all_simulator_ports_to_target_dut(target_dut_hostname, duthosts, mux
     """Helper function to toggle all ports to active on the target DUT."""
 
     def _check_toggle_done(duthosts, target_dut_hostname, probe=False):
-        duthost = duthosts[target_dut_hostname]
-        inactive_ports = _get_mux_ports(duthost, exclude_status="active")
-        if not inactive_ports:
+        active_duthost = duthosts[target_dut_hostname]
+        standby_duthost = [_ for _ in duthosts if _.hostname != target_dut_hostname][0]
+        inactive_ports = _get_mux_ports(active_duthost, exclude_status="active")
+        not_standby_ports = _get_mux_ports(standby_duthost, exclude_status="standby")
+
+        if not inactive_ports and not not_standby_ports:
             return True
 
         # NOTE: if ICMP responder is not running, linkmgrd is stuck in waiting for heartbeats and
         # the mux probe interval is backed off. Adding a probe here to notify linkmgrd to shorten
         # the wait for linkmgrd's sync with the mux.
         if probe:
-            _probe_mux_ports(duthosts, list(inactive_ports.keys()))
+            probe_ports = set(inactive_ports.keys()) | set(not_standby_ports.keys())
+            _probe_mux_ports(duthosts, probe_ports)
 
         logger.info(
-            'Found muxcables not active on {}: {}'.format(duthost.hostname, json.dumps(list(inactive_ports.keys())))
+            'Found muxcables not active on {}: {}'.format(active_duthost.hostname, json.dumps(list(inactive_ports.keys())))
+        )
+        logger.info(
+            'Found muxcables not standby on {}: {}'.format(standby_duthost.hostname, json.dumps(list(not_standby_ports.keys())))
         )
         return False
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Improve the toggle fixture check by validate toggle outcome on both ToRs.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Validate the ports are all in standby on the peer side.

#### How did you verify/test it?
```
dualtor_io/test_normal_op.py::test_normal_op_upstream[active-standby] PASSED                                                                                                                                                                                           [ 50%]
dualtor_io/test_normal_op.py::test_normal_op_upstream[active-active] SKIPPED (Skip as no mux ports of 'active-active' cable type)
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
