### PR TITLE
[Mellanox] Update qos_params.spc3.yaml to support 400000_40m for dualtor pcbb xoff test on Nvidia platform

### DIFF
--- a/tests/qos/files/qos_params.spc3.yaml
+++ b/tests/qos/files/qos_params.spc3.yaml
@@ -34,6 +34,38 @@ qos_params:
                     pkts_num_trig_pfc: 176064
                     pkts_num_trig_ingr_drp: 177916
                     pkts_num_margin: 4
+            400000_40m:
+                pkts_num_leak_out: 0
+                pcbb_xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 167524
+                    pkts_num_trig_ingr_drp: 171535
+                    pkts_num_margin: 4
+                pcbb_xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 167524
+                    pkts_num_trig_ingr_drp: 171535
+                    pkts_num_margin: 4
+                pcbb_xoff_3:
+                    outer_dscp: 2
+                    dscp: 3
+                    ecn: 1
+                    pg: 2
+                    pkts_num_trig_pfc: 167524
+                    pkts_num_trig_ingr_drp: 171535
+                    pkts_num_margin: 4
+                pcbb_xoff_4:
+                    outer_dscp: 6
+                    dscp: 4
+                    ecn: 1
+                    pg: 6
+                    pkts_num_trig_pfc: 167524
+                    pkts_num_trig_ingr_drp: 171535
+                    pkts_num_margin: 4
         topo-dualtor-64:
             100000_40m:
                 pkts_num_leak_out: 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Update qos_params.spc3.yaml to support 400000_40m for dualtor pcbb xoff test on Nvidia platform
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Support 400000_40m for dualtor pcbb xoff test on Nvidia platform
#### How did you do it?
Compute and set proper values for 400000_40m 
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?
Add coverage for x86_64-mlnx_msn4700-r0
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
