### PR TITLE
Force root fanout task to use connection "switch"

### DIFF
--- a/ansible/roles/fanout/tasks/rootfanout_connect.yml
+++ b/ansible/roles/fanout/tasks/rootfanout_connect.yml
@@ -35,6 +35,7 @@
 - name: Find the root fanout switch
   set_fact:
     ansible_host: "{{ item.value['mgmtip'] }}"
+    ansible_connection: switch
     root_dev: "{{ item.key }}"
     root_hwsku: "{{ item.value['HwSku'] }}"
   with_dict: "{{ lab_devices }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The task for changing root fanout port vlan must be executed over "switch" connection instead of other ansible connection plugins.

However, when we set "ansible_connection" variable to "multi_passwd_ssh" for lab server, somehow the "connection: switch" for the "Change root fanout port vlan" task is not working. Consequently this task is not executed over the "switch" connection plugin and fails.

#### How did you do it?
To workaround this issue, we can explicitly set "ansible_connection" variable to "switch" in previous steps. This will force the subsequent tasks to use the "switch" connection plugin.

#### How did you verify/test it?
Tested add-topo/remove-topo.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
