### PR TITLE
Fix jinja2 templating delimiters in ansible conditional statements

### DIFF
--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -50,7 +50,7 @@
 
   - name: Check for a single host
     fail: msg="Please use -l server_X to limit this playbook to one host"
-    when: "{{ play_hosts|length }} != 1"
+    when: play_hosts|length != 1
 
   - name: Check that variable testbed_name is defined
     fail: msg="Define testbed_name variable with -e testbed_name=something"

--- a/ansible/testbed_connect_topo.yml
+++ b/ansible/testbed_connect_topo.yml
@@ -5,7 +5,7 @@
   pre_tasks:
   - name: Check for a single host
     fail: msg="Please use -l server_X to limit this playbook to one host"
-    when: "{{ play_hosts|length }} != 1"
+    when: play_hosts|length != 1
 
   - name: Check that variable vm_set_name is defined
     fail: msg="Define vm_set_name variable with -e vm_set_name=something"

--- a/ansible/testbed_connect_vms.yml
+++ b/ansible/testbed_connect_vms.yml
@@ -20,7 +20,7 @@
   pre_tasks:
   - name: Check for a single host
     fail: msg="Please use -l server_X to limit this playbook to one host"
-    when: "{{ play_hosts|length }} != 1"
+    when: play_hosts|length != 1
 
   - name: Check that variable vm_set_name is defined
     fail: msg="Define vm_set_name variable with -e vm_set_name=something"

--- a/ansible/testbed_disconnect_vms.yml
+++ b/ansible/testbed_disconnect_vms.yml
@@ -20,7 +20,7 @@
   pre_tasks:
   - name: Check for a single host
     fail: msg="Please use -l server_X to limit this playbook to one host"
-    when: "{{ play_hosts|length }} != 1"
+    when: play_hosts|length != 1
 
   - name: Check that variable vm_set_name is defined
     fail: msg="Define vm_set_name variable with -e vm_set_name=something"

--- a/ansible/testbed_remove_vm_topology.yml
+++ b/ansible/testbed_remove_vm_topology.yml
@@ -36,7 +36,7 @@
 
   - name: Check for a single host
     fail: msg="Please use -l server_X to limit this playbook to one host"
-    when: "{{ play_hosts|length }} != 1"
+    when: play_hosts|length != 1
 
   - name: Check that variable testbed_name is defined
     fail: msg="Define testbed_name variable with -e testbed_name=something"

--- a/ansible/testbed_renumber_vm_topology.yml
+++ b/ansible/testbed_renumber_vm_topology.yml
@@ -35,7 +35,7 @@
 
   - name: Check for a single host
     fail: msg="Please use -l server_X to limit this playbook to one host"
-    when: "{{ play_hosts|length }} != 1"
+    when: play_hosts|length != 1
 
   - name: Check that variable testbed_name is defined
     fail: msg="Define testbed_name variable with -e testbed_name=something"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
In ansible's conditional statements, jinja2 templating delimiters should not be used. Otherwise ansible will give warnings.

#### How did you do it?
This fix removed the jinja2 templating delimiters to avoid warnings.

#### How did you verify/test it?
Test run the updated playbooks.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
