### PR TITLE
[cherry-pick] [202311]Skip service warm restart test on Mellanox platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -915,6 +915,15 @@ platform_tests/test_sequential_restart.py::test_restart_syncd:
     reason: "Restarting syncd is not supported yet"
 
 #######################################
+##### test_service_warm_restart.py ####
+#######################################
+platform_tests/test_service_warm_restart.py:
+  skip:
+    reason: "Skip test_service_warm_restart on mellanox platform"
+    conditions:
+      - "asic_type in ['mellanox']"
+
+#######################################
 #####   test_xcvr_info_in_db.py   #####
 #######################################
 platform_tests/test_xcvr_info_in_db.py::test_xcvr_info_in_db:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip service warm restart test on Mellanox platform as it's not required.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR is to skip service warm restart test on Mellanox platform as it's not required.

#### How did you do it?
Update `tests_mark_conditions_platform_tests.yaml`

#### How did you verify/test it?
The change is verified by yaml file syntax check.

#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
