### PR TITLE
Add skip to the test when buffer model is the dynamic model

### DIFF
--- a/tests/generic_config_updater/test_pg_headroom_update.py
+++ b/tests/generic_config_updater/test_pg_headroom_update.py
@@ -25,7 +25,7 @@ def skip_when_buffer_is_dynamic_model(duthost):
     buffer_model = duthost.shell(
         'redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model')['stdout']
     if buffer_model == 'dynamic':
-        pytest.skip("Skip the test, because dynamic buffer config cannot be updated")
+        pytest.skip("Skip the test, because dynamic buffer config cannot be updated using generic config updater")
 
 
 @pytest.fixture(scope="function")

--- a/tests/generic_config_updater/test_pg_headroom_update.py
+++ b/tests/generic_config_updater/test_pg_headroom_update.py
@@ -20,6 +20,14 @@ READ_ASICDB_TIMEOUT = 20
 READ_ASICDB_INTERVAL = 5
 
 
+@pytest.fixture(scope='module', autouse=True)
+def skip_when_buffer_is_dynamic_model(duthost):
+    buffer_model = duthost.shell(
+        'redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model')['stdout']
+    if buffer_model == 'dynamic':
+        pytest.skip("Skip the test, because dynamic buffer config cannot be updated")
+
+
 @pytest.fixture(scope="function")
 def ensure_dut_readiness(duthost):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

The test flow to update "xoff" in dynamic buffer model is wrong.

The test logic;
1. Fetch a buffer profile of lossless headroom from the CONFIG_DB
2. Compose a json file containing the buffer profile with the new dynamic_th
3. Apply the json file as a patch
4. Expect the dynamic_th to be updated

However, there is no lossless profile in the CONFIG_DB when the buffer model is dynamic. All such profiles are generated by the buffer manager and pushed into APPL_DB which is the design from day one.
As a result, the test fails due to "APPL DB or ASIC DB does not properly reflect newly configured value(s) for xoff"

As a result, test should be skipped when the buffer model is dynamic.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
skip the test when buffer model is the dynamic model

#### How did you do it?
added a skip, with same logic as in previous similar PR https://github.com/sonic-net/sonic-mgmt/pull/10393

#### How did you verify/test it?
Run the test and see it was skipped

