### PR TITLE
Add device type mark in module test_copp.py. 

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -43,7 +43,8 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", "t2", "m0", "mx")
+    pytest.mark.topology("t0", "t1", "t2", "m0", "mx"),
+    pytest.mark.device_type('physical')
 ]
 
 _COPPTestParameters = namedtuple("_COPPTestParameters",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In order to run this module, we need a special RPC syncd image but this image doesn't suppot vs testbed. So I add the pytest mark `pytest.mark.device_type('physical')` in this module to make it clearly. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
In order to run this module, we need a special RPC syncd image but this image doesn't suppot vs testbed. So I add the pytest mark `pytest.mark.device_type('physical')` in this module to make it clearly. 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
