### PR TITLE
Enhance the reboot method

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -285,7 +285,6 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     # successful reboot
     file_check = duthost.stat(path="/dev/shm/test_reboot")
     if file_check['stat']['exists']:
-        duthost.command("sudo rm /dev/shm/test_reboot")
         raise Exception('DUT {} did not reboot'.format(hostname))
 
     DUT_ACTIVE.set()

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -241,6 +241,10 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     except KeyError:
         raise ValueError('invalid reboot type: "{} for {}"'.format(reboot_type, hostname))
 
+    # Create a temporary file in tmpfs before reboot
+    logger.info('DUT {} create a file /dev/shm/test_reboot before rebooting'.format(hostname))
+    duthost.command('sudo touch /dev/shm/test_reboot')
+
     reboot_res, dut_datetime = perform_reboot(duthost, pool, reboot_command, reboot_helper, reboot_kwargs, reboot_type)
 
     wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res)
@@ -276,6 +280,12 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         ret = wait_until(warmboot_finalizer_timeout, 5, 0, check_warmboot_finalizer_inactive, duthost)
         if not ret:
             raise Exception('warmboot-finalizer service timeout on DUT {}'.format(hostname))
+
+    # Verify if the temporary file created in tmpfs is deleted after reboot, to determine a
+    # successful reboot
+    file_check = duthost.command('find /dev/shm/test_reboot', module_ignore_errors=True)['rc']
+    if not file_check:
+        raise Exception('DUT {} reboot did not finish successfully'.format(hostname))
 
     DUT_ACTIVE.set()
     logger.info('{} reboot finished on {}'.format(reboot_type, hostname))

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -285,7 +285,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     # successful reboot
     file_check = duthost.command('find /dev/shm/test_reboot', module_ignore_errors=True)['rc']
     if not file_check:
-        raise Exception('DUT {} reboot did not finish successfully'.format(hostname))
+        raise Exception('DUT {} did not reboot'.format(hostname))
 
     DUT_ACTIVE.set()
     logger.info('{} reboot finished on {}'.format(reboot_type, hostname))

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -283,8 +283,9 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
 
     # Verify if the temporary file created in tmpfs is deleted after reboot, to determine a
     # successful reboot
-    file_check = duthost.command('find /dev/shm/test_reboot', module_ignore_errors=True)['rc']
-    if not file_check:
+    file_check = duthost.stat(path="/dev/shm/test_reboot")
+    if file_check['stat']['exists']:
+        duthost.command("sudo rm /dev/shm/test_reboot")
         raise Exception('DUT {} did not reboot'.format(hostname))
 
     DUT_ACTIVE.set()


### PR DESCRIPTION
### Description of PR
Implement a clear method to determine conclusively whether the device has been rebooted.

Summary:
Enhance reboot test

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
To confirm that the device has been rebooted without encountering any platform or PDU controller issues.

#### How did you do it?
Created a test file in RAM filesystem, which should be deleted after the device is rebooted successfully.

#### How did you verify/test it?
Verified all the tests in tests/platform_tests/test_reboot.py in the lab testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

