### PR TITLE
[BGP suppress fib] Use safe config reload in test case test_bgp_route_with_suppress

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -315,7 +315,7 @@ def setup_vrf_cfg(duthost, cfg_facts, nbrhosts, tbinfo):
     duthost.template(src="bgp/vrf_config_db.j2", dest="/tmp/config_db_vrf.json")
     duthost.shell("cp -f /tmp/config_db_vrf.json /etc/sonic/config_db.json")
 
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True)
 
 
 def setup_vrf(duthost, nbrhosts, tbinfo):
@@ -797,7 +797,7 @@ def test_bgp_route_with_suppress(duthost, tbinfo, nbrhosts, ptfadapter, localhos
         if vrf_type == USER_DEFINED_VRF:
             with allure.step("Clean user defined vrf"):
                 duthost.shell("cp -f /etc/sonic/config_db.json.bak /etc/sonic/config_db.json")
-                config_reload(duthost)
+                config_reload(duthost, safe_reload=True)
 
 
 def test_bgp_route_without_suppress(duthost, tbinfo, nbrhosts, ptfadapter, prepare_param, restore_bgp_suppress_fib,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test reloads config in setup stage to configure VRF. In test body it applys the suppress fib config and do random reload/reboot.
It is possible that the system is not ready for warm/fast reboot after the first reload.
Use safe reload to avoid this.
And also use safe reload in the teardown to avoid any possible affection to the next test.

Test log of such a failure:
```
INFO     test_bgp_suppress_fib:test_bgp_suppress_fib.py:625 Randomly choose fast from reload, cold, warm, fast
DEBUG    tests.common.cache.facts_cache:facts_cache.py:82 Read cached facts "arc-switch1025.host_visible_vars"
DEBUG    tests.common.devices.base:base.py:67 /root/mars/workspace/sonic-mgmt/tests/common/devices/sonic.py::get_now_time#1059: [arc-switch1025] AnsibleModule::command, args=["date +\"%Y-%m-%d %H:%M:%S\" -u"], kwargs={}
DEBUG    tests.common.devices.base:base.py:104 /root/mars/workspace/sonic-mgmt/tests/common/devices/sonic.py::get_now_time#1059: [arc-switch1025] AnsibleModule::command Result => {"cmd": ["date", "+%Y-%m-%d %H:%M:%S", "-u"], "stdout": "2024-04-10 12:15:57", "stderr": "", "rc": 0, "start": "2024-04-10 15:15:57.935912", "end": "2024-04-10 15:15:57.943586", "delta": "0:00:00.007674", "changed": true, "invocation": {"module_args": {"_raw_params": "date +\"%Y-%m-%d %H:%M:%S\" -u", "warn": true, "_uses_shell": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["2024-04-10 12:15:57"], "stderr_lines": [], "_ansible_no_log": false, "failed": false}
INFO     tests.common.reboot:reboot.py:143 waiting for ssh to drop on arc-switch1025
INFO     tests.common.reboot:reboot.py:183 rebooting arc-switch1025 with command "fast-reboot"
DEBUG    tests.common.devices.base:base.py:67 /root/mars/workspace/sonic-mgmt/tests/common/devices/multi_asic.py::_run_on_asics#129: [arc-switch1025] AnsibleModule::command, args=["fast-reboot"], kwargs={}
DEBUG    tests.common.devices.base:base.py:67 /root/mars/workspace/sonic-mgmt/tests/common/reboot.py::wait_for_shutdown#144: [localhost] AnsibleModule::wait_for, args=[], kwargs={"host": "10.210.25.45", "port": 22, "state": "absent", "search_regex": "OpenSSH_[\\w\\.]+ Debian", "delay": 10, "timeout": 180, "module_ignore_errors": true}
DEBUG    tests.common.devices.base:base.py:104 /root/mars/workspace/sonic-mgmt/tests/common/devices/multi_asic.py::_run_on_asics#129: [arc-switch1025] AnsibleModule::command Result => {"failed": true, "msg": "non-zero return code", "cmd": ["fast-reboot"], "stdout": "", "stderr": "RESTARTCHECK failed", "rc": 10, "start": "2024-04-10 15:15:58.926237", "end": "2024-04-10 15:16:33.247360", "delta": "0:00:34.321123", "changed": true, "invocation": {"module_args": {"_raw_params": "fast-reboot", "warn": true, "_uses_shell": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": [], "stderr_lines": ["RESTARTCHECK failed"], "_ansible_no_log": false}
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
To fix test issue of test_bgp_route_with_suppress
#### How did you do it?
Use safe config reload in test case test_bgp_route_with_suppress
#### How did you verify/test it?
Run the fixed test on the same testbed serveral times, all passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
