### PR TITLE
Add 18 data plane test to t1-lag PR checker

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -179,6 +179,8 @@ dualtor:
   - arp/test_arp_extended.py
 
 t1-lag:
+  - arp/test_arpall.py
+  - arp/test_neighbor_mac_noptf.py
   - bgp/test_bgp_allow_list.py
   - bgp/test_bgp_bbr.py
   - bgp/test_bgp_bounce.py
@@ -189,19 +191,35 @@ t1-lag:
   - bgp/test_traffic_shift.py
   - configlet/test_add_rack.py
   - container_checker/test_container_checker.py
+  - dhcp_relay/test_dhcp_pkt_fwd.py
+  - fdb/test_fdb_flush.py
   - generic_config_updater/test_mmu_dynamic_threshold_config_update.py
   - http/test_http_copy.py
   - iface_namingmode/test_iface_namingmode.py
+  - ipfwd/test_dip_sip.py
   - ipfwd/test_mtu.py
   - lldp/test_lldp.py
   - monit/test_monit_status.py
   - override_config_table/test_override_config_table.py
   - pc/test_lag_2.py
+  - pc/test_po_update.py
   - platform_tests/test_cpu_memory_usage.py
   - process_monitoring/test_critical_process_monitoring.py
+  - qos/test_buffer.py
   - route/test_default_route.py
+  - route/test_route_perf.py
   - scp/test_scp_copy.py
+  - snmp/test_snmp_cpu.py
+  - snmp/test_snmp_default_route.py
+  - snmp/test_snmp_interfaces.py
+  - snmp/test_snmp_lldp.py
+  - snmp/test_snmp_loopback.py
+  - snmp/test_snmp_memory.py
+  - snmp/test_snmp_pfc_counters.py
+  - snmp/test_snmp_queue.py
+  - snmp/test_snmp_v2mib.py
   - test_interfaces.py
+  - voq/test_voq_ipfwd.py
 
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker
#### How did you do it?
Add 18 data plane test to t1-lag PR checker and sort from A to Z
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
