### PR TITLE
[CI/CD]Add topology and device type argument for PR test

### DIFF
--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -223,6 +223,20 @@ class TestPlanManager(object):
 
         common_extra_params = common_extra_params + " --completeness_level=confident --allow_recover"
 
+        t0_topos = ["t0", "t0-64-32", "dualtor"]
+        t1_topos = ["t1-lag", "t1-8-lag"]
+
+        # Add topo args and device type for PR test
+        if test_plan_type == "PR":
+            # Add topo args
+            if topology in t0_topos:
+                common_extra_params = common_extra_params + " --topology=t0,any"
+            elif topology in t1_topos:
+                common_extra_params = common_extra_params + " --topology=t1,any"
+
+            # Add device type
+            common_extra_params = common_extra_params + " --device_type=vs"
+
         # If triggered by the internal repos, use internal sonic-mgmt repo as the code base
         sonic_mgmt_repo_url = GITHUB_SONIC_MGMT_REPO
         if kwargs.get("source_repo") in INTERNAL_REPO_LIST:

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -223,16 +223,15 @@ class TestPlanManager(object):
 
         common_extra_params = common_extra_params + " --completeness_level=confident --allow_recover"
 
-        t0_topos = ["t0", "t0-64-32", "dualtor"]
-        t1_topos = ["t1-lag", "t1-8-lag"]
-
         # Add topo and device type args for PR test
         if test_plan_type == "PR":
             # Add topo arg
-            if topology in t0_topos:
+            if topology in ["t0", "t0-64-32"]:
                 common_extra_params = common_extra_params + " --topology=t0,any"
-            elif topology in t1_topos:
+            elif topology in ["t1-lag", "t1-8-lag"]:
                 common_extra_params = common_extra_params + " --topology=t1,any"
+            elif topology == "dualtor":
+                common_extra_params = common_extra_params + " --topology=t0,dualtor,any"
             elif topology == "dpu":
                 common_extra_params = common_extra_params + " --topology=dpu,any"
 

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -226,15 +226,15 @@ class TestPlanManager(object):
         t0_topos = ["t0", "t0-64-32", "dualtor"]
         t1_topos = ["t1-lag", "t1-8-lag"]
 
-        # Add topo args and device type for PR test
+        # Add topo and device type args for PR test
         if test_plan_type == "PR":
-            # Add topo args
+            # Add topo arg
             if topology in t0_topos:
                 common_extra_params = common_extra_params + " --topology=t0,any"
             elif topology in t1_topos:
                 common_extra_params = common_extra_params + " --topology=t1,any"
 
-            # Add device type
+            # Add device type arg
             common_extra_params = common_extra_params + " --device_type=vs"
 
         # If triggered by the internal repos, use internal sonic-mgmt repo as the code base

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -233,6 +233,8 @@ class TestPlanManager(object):
                 common_extra_params = common_extra_params + " --topology=t0,any"
             elif topology in t1_topos:
                 common_extra_params = common_extra_params + " --topology=t1,any"
+            elif topology == "dpu":
+                common_extra_params = common_extra_params + " --topology=dpu,any"
 
             # Add device type arg
             common_extra_params = common_extra_params + " --device_type=vs"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

[CI/CD]Add topology and device type argument for PR test. 
If PR test, add argument `--topology=t0,any` for `t0`, `t0-64-32`, and `dualtor` topologies. And add `--topolog=t1,any` for `t1-lag` and `t1-8-lag` topologies. Add `--device_type=vs` argument for all PR test scritps.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
