### PR TITLE
Fix for the test telemetry/test_events.py (#12472)

### DIFF
--- a/tests/telemetry/events/run_events_test.py
+++ b/tests/telemetry/events/run_events_test.py
@@ -13,10 +13,8 @@ logger = logging.getLogger(__name__)
 def run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, trigger, json_file,
              filter_event_regex, tag, heartbeat=False, thread_timeout=30):
     op_file = os.path.join(data_dir, json_file)
-    if trigger is not None:  # no trigger for heartbeat
-        trigger(duthost)  # add events to cache
     listen_for_events(duthost, gnxi_path, ptfhost, filter_event_regex, op_file,
-                      thread_timeout)  # listen from cache
+                      thread_timeout, trigger=trigger)  # listen from cache
     data = {}
     with open(op_file, "r") as f:
         data = json.load(f)


### PR DESCRIPTION
Triggering events after the event thread to listen to the events is started, and waiting for sometime after detecting the event for the heartbeat to stop.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The test telemetry/test_events.py fails.
```
assert results[0] != "", "No output from PTF docker, thread timed out after {} seconds".format(thread_timeout)
AssertionError: No output from PTF docker, thread timed out after 30 seconds
FAILED
```
#### How did you do it?
When events are triggered before we start the event thread, the events are not always being detected. So trigger the events after starting the event thread.
Also, there is a race condition for the heartbeat to be stopped (after an event is detected) and the heartbeat to be started (after another event thread is started). So wait for some time for the heartbeat to stop before triggering and detecting another event.
#### How did you verify/test it?
Ran telemetry/test_events.py on Arista-7260CX3 platform with dualtor topology.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
