### PR TITLE
Fix unreachable DUT mgmt_ip in IPv6 only test case

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1170,7 +1170,7 @@ def paramiko_ssh(ip_address, username, passwords):
 def get_dut_current_passwd(ipv4_address, ipv6_address, username, passwords):
     try:
         return _paramiko_ssh(ipv4_address, username, passwords)
-    except (AuthenticationException, NoValidConnectionsError, socket.timeout) as e:
-        if not ipv6_address:
-            raise e
+    except AuthenticationException:
+        raise
+    except Exception:
         return _paramiko_ssh(ipv6_address, username, passwords)

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -467,14 +467,6 @@ def get_test_server_visible_vars(inv_files, server):
     return vm.get_vars(host=test_server_host)
 
 
-def is_ip_reachable(duthost, ip_address):
-    ping_result = duthost.command("ping {} -c 1 -W 3".format(ip_address), module_ignore_errors=True)['stdout']
-    logger.info("IP ping result: {}".format(ping_result))
-    if "100% packet loss" in ping_result:
-        return False
-    return True
-
-
 def is_ipv4_address(ip_address):
     """Check if ip address is ipv4."""
     ip_address = ip_address.encode().decode()

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -18,12 +18,11 @@ import traceback
 import copy
 import tempfile
 import uuid
-import socket
 import paramiko
 from io import StringIO
 from ast import literal_eval
 from scapy.all import sniff as scapy_sniff
-from paramiko.ssh_exception import AuthenticationException, NoValidConnectionsError
+from paramiko.ssh_exception import AuthenticationException
 
 import pytest
 from ansible.parsing.dataloader import DataLoader

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -467,6 +467,14 @@ def get_test_server_visible_vars(inv_files, server):
     return vm.get_vars(host=test_server_host)
 
 
+def is_ip_reachable(duthost, ip_address):
+    ping_result = duthost.command("ping {} -c 1 -W 3".format(ip_address), module_ignore_errors=True)['stdout']
+    logger.info("IP ping result: {}".format(ping_result))
+    if "100% packet loss" in ping_result:
+        return False
+    return True
+
+
 def is_ipv4_address(ip_address):
     """Check if ip address is ipv4."""
     ip_address = ip_address.encode().decode()

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1168,8 +1168,9 @@ def paramiko_ssh(ip_address, username, passwords):
 
 def get_dut_current_passwd(ipv4_address, ipv6_address, username, passwords):
     try:
-        return _paramiko_ssh(ipv4_address, username, passwords)
+        _, passwd = _paramiko_ssh(ipv4_address, username, passwords)
     except AuthenticationException:
         raise
     except Exception:
-        return _paramiko_ssh(ipv6_address, username, passwords)
+        _, passwd = _paramiko_ssh(ipv6_address, username, passwords)
+    return passwd

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -765,7 +765,7 @@ def creds_on_dut(duthost):
     creds["ansible_altpasswords"] = []
 
     passwords = creds["ansible_altpasswords"] + [creds["sonicadmin_password"]]
-    creds['sonicadmin_password'] = get_dut_current_passwd(duthost.mgmt_ip, creds['sonicadmin_user'], passwords)
+    creds['sonicadmin_password'] = get_dut_current_passwd(duthost.mgmt_ip, duthost.mgmt_ipv6, creds['sonicadmin_user'], passwords)
 
     for k, v in list(console_login_creds.items()):
         creds["console_user"][k] = v["user"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -765,7 +765,12 @@ def creds_on_dut(duthost):
     creds["ansible_altpasswords"] = []
 
     passwords = creds["ansible_altpasswords"] + [creds["sonicadmin_password"]]
-    creds['sonicadmin_password'] = get_dut_current_passwd(duthost.mgmt_ip, duthost.mgmt_ipv6, creds['sonicadmin_user'], passwords)
+    creds['sonicadmin_password'] = get_dut_current_passwd(
+        duthost.mgmt_ip,
+        duthost.mgmt_ipv6,
+        creds['sonicadmin_user'],
+        passwords
+    )
 
     for k, v in list(console_login_creds.items()):
         creds["console_user"][k] = v["user"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ from tests.common.helpers.dut_ports import encode_dut_port_name
 from tests.common.helpers.dut_utils import encode_dut_and_container_name
 from tests.common.system_utils import docker
 from tests.common.testbed import TestbedInfo
+from tests.common.utilities import is_ip_reachable
 from tests.common.utilities import get_inventory_files
 from tests.common.utilities import get_host_vars
 from tests.common.utilities import get_host_visible_vars
@@ -764,8 +765,13 @@ def creds_on_dut(duthost):
 
     creds["ansible_altpasswords"] = []
 
+    if is_ip_reachable(duthost, duthost.mgmt_ip):
+        dutip = duthost.mgmt_ip
+    else:
+        dutip = duthost.mgmt_ipv6
+
     passwords = creds["ansible_altpasswords"] + [creds["sonicadmin_password"]]
-    creds['sonicadmin_password'] = get_dut_current_passwd(duthost.mgmt_ip, creds['sonicadmin_user'], passwords)
+    creds['sonicadmin_password'] = get_dut_current_passwd(dutip, creds['sonicadmin_user'], passwords)
 
     for k, v in list(console_login_creds.items()):
         creds["console_user"][k] = v["user"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,6 @@ from tests.common.helpers.dut_ports import encode_dut_port_name
 from tests.common.helpers.dut_utils import encode_dut_and_container_name
 from tests.common.system_utils import docker
 from tests.common.testbed import TestbedInfo
-from tests.common.utilities import is_ip_reachable
 from tests.common.utilities import get_inventory_files
 from tests.common.utilities import get_host_vars
 from tests.common.utilities import get_host_visible_vars
@@ -765,13 +764,8 @@ def creds_on_dut(duthost):
 
     creds["ansible_altpasswords"] = []
 
-    if is_ip_reachable(duthost, duthost.mgmt_ip):
-        dutip = duthost.mgmt_ip
-    else:
-        dutip = duthost.mgmt_ipv6
-
     passwords = creds["ansible_altpasswords"] + [creds["sonicadmin_password"]]
-    creds['sonicadmin_password'] = get_dut_current_passwd(dutip, creds['sonicadmin_user'], passwords)
+    creds['sonicadmin_password'] = get_dut_current_passwd(duthost.mgmt_ip, creds['sonicadmin_user'], passwords)
 
     for k, v in list(console_login_creds.items()):
         creds["console_user"][k] = v["user"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix unreachable DUT mgmt_ip in IPv6 only test case
Fixes # (issue)

Microsoft ADO 27674168, 27674176
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/pull/12303 introduced a bug that DUT mgmt_ipv4 is unreachable in a IPv6 only test case, causing test_rw_user_ipv6_only, test_ro_user_ipv6_only, test_snmp_ipv6_only failed with `paramiko.ssh_exception.NoValidConnectionsError` or `socket.timeout: timed out`
#### How did you do it?
If mgmt_ip is unreachable, try mgmt_ipv6
#### How did you verify/test it?
Verified on internal and 202305 branch on physical DUT
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
