### PR TITLE
Fix IPv6 NTP test case missing an import

### DIFF
--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -7,7 +7,7 @@ from tests.tacacs.utils import check_output
 from tests.bgp.test_bgp_fact import run_bgp_facts
 from tests.test_features import run_show_features
 from tests.tacacs.test_ro_user import ssh_remote_run
-from tests.ntp.test_ntp import run_ntp, setup_ntp
+from tests.ntp.test_ntp import run_ntp, setup_ntp # noqa F401
 from tests.common.helpers.assertions import pytest_require
 from tests.tacacs.conftest import tacacs_creds, check_tacacs_v6 # noqa F401
 from tests.syslog.test_syslog import run_syslog, check_default_route # noqa F401

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -7,7 +7,7 @@ from tests.tacacs.utils import check_output
 from tests.bgp.test_bgp_fact import run_bgp_facts
 from tests.test_features import run_show_features
 from tests.tacacs.test_ro_user import ssh_remote_run
-from tests.ntp.test_ntp import run_ntp
+from tests.ntp.test_ntp import run_ntp, setup_ntp
 from tests.common.helpers.assertions import pytest_require
 from tests.tacacs.conftest import tacacs_creds, check_tacacs_v6 # noqa F401
 from tests.syslog.test_syslog import run_syslog, check_default_route # noqa F401


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Microsoft ADO 27674068

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

Somehow, the import for `setup_ntp` got missed. Add it in.

#### How did you do it?

#### How did you verify/test it?

Verified on physical device

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
