### PR TITLE
Remove gnmi cases temporarily in PR test.

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -56,9 +56,9 @@ t0:
   - generic_config_updater/test_portchannel_interface.py
   - generic_config_updater/test_syslog.py
   - generic_config_updater/test_vlan_interface.py
-  - gnmi/test_gnmi.py
-  - gnmi/test_gnmi_appldb.py
-  - gnmi/test_gnmi_configdb.py
+  # - gnmi/test_gnmi.py
+  # - gnmi/test_gnmi_appldb.py
+  # - gnmi/test_gnmi_configdb.py
   - http/test_http_copy.py
   - iface_loopback_action/test_iface_loopback_action.py
   - iface_namingmode/test_iface_namingmode.py

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -56,6 +56,7 @@ t0:
   - generic_config_updater/test_portchannel_interface.py
   - generic_config_updater/test_syslog.py
   - generic_config_updater/test_vlan_interface.py
+  # Temporarily remove these cases because of PR https://github.com/sonic-net/sonic-buildimage/pull/16957
   # - gnmi/test_gnmi.py
   # - gnmi/test_gnmi_appldb.py
   # - gnmi/test_gnmi_configdb.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Due to the image change [#16957](https://github.com/sonic-net/sonic-buildimage/pull/16957), it will cause failure of gnmi cases. And it will block all the test stage of buildimage. So remove the cases under the folder `gnmi` temporarily to unblock the pipeline. After fixing the issue caused by  [#16957](https://github.com/sonic-net/sonic-buildimage/pull/16957), we will add the test cases back. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Due to the image change [#16957](https://github.com/sonic-net/sonic-buildimage/pull/16957), it will cause failure of gnmi cases. And it will block all the test stage of buildimage. So remove the cases under the folder `gnmi` temporarily to unblock the pipeline. After fixing the issue caused by  [#16957](https://github.com/sonic-net/sonic-buildimage/pull/16957), we will add the test cases back. 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
