### PR TITLE
Change the mark in module `test_link_flap.py`. 

### DIFF
--- a/tests/platform_tests/link_flap/test_link_flap.py
+++ b/tests/platform_tests/link_flap/test_link_flap.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 
@@ -23,7 +24,6 @@ def get_port_list(duthost, tbinfo):
 
 
 @pytest.mark.usefixtures("bgp_sessions_config")
-@pytest.mark.platform('physical')
 def test_link_flap(request, duthosts, rand_one_dut_hostname, tbinfo, fanouthosts, get_loop_times):
     """
     Validates that link flap works as expected


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The module `test_link_flap.py` can support physical testbeds only， and it uses `pytest.mark.platform('physical')` before to identify. But usually, we use mark `pytest.mark.device_type('physical')` to identify, and in Elastictest, we will also use the mark `device_type` to collect and filter cases. So in this PR, we change this mark. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The module `test_link_flap.py` can support physical testbeds only， and it uses `pytest.mark.platform('physical')` before to identify. But usually, we use mark `pytest.mark.device_type('physical')` to identify, and in Elastictest, we will also use the mark `device_type` to collect and filter cases. So in this PR, we change this mark. 

#### How did you do it?
Change the mark `pytest.mark.platform('physical')` to `pytest.mark.device_type('physical')`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
