### PR TITLE
Fix the module `test_sfpshow.py` and add it in PR test. 

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -92,6 +92,7 @@ t0:
   - platform_tests/mellanox/test_hw_management_service.py
   - platform_tests/mellanox/test_psu_power_threshold.py
   - platform_tests/mellanox/test_reboot_cause.py
+  - platform_tests/sfp/test_sfpshow.py
   - platform_tests/test_auto_negotiation.py
   - platform_tests/test_cont_warm_reboot.py
   - platform_tests/test_cpu_memory_usage.py

--- a/tests/platform_tests/sfp/util.py
+++ b/tests/platform_tests/sfp/util.py
@@ -33,7 +33,7 @@ def parse_eeprom(output_lines):
 
 
 def get_dev_conn(duthost, conn_graph_facts, asic_index):
-    dev_conn = conn_graph_facts["device_conn"][duthost.hostname]
+    dev_conn = conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {})
 
     # Get the interface pertaining to that asic
     portmap = get_port_map(duthost, asic_index)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The module `test_sfpshow.py` will fail on kvm testbed because of the failure 
```
  File "/var/src/sonic-mgmt/tests/platform_tests/sfp/util.py", line 36, in get_dev_conn
    dev_conn = conn_graph_facts["device_conn"][duthost.hostname]
KeyError: 'vlab-01'
```
In this PR, we fix this issue, and add it into PR test. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The module `test_sfpshow.py` will fail on kvm testbed because of the failure 
```
  File "/var/src/sonic-mgmt/tests/platform_tests/sfp/util.py", line 36, in get_dev_conn
    dev_conn = conn_graph_facts["device_conn"][duthost.hostname]
KeyError: 'vlab-01'
```
In this PR, we fix this issue, and add it into PR test. 

#### How did you do it?
Use method `get` to get the value from a python dict. And set it `{}` if there is no such key. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
