### PR TITLE
miss t0-8-lag topo support in qos test

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -36,7 +36,7 @@ class QosBase:
     Common APIs
     """
     SUPPORTED_T0_TOPOS = ["t0", "t0-56-po2vlan", "t0-64", "t0-116", "t0-35", "dualtor-56", "dualtor-64", "dualtor-120",
-                          "dualtor", "t0-120", "t0-80", "t0-backend", "t0-56-o8v48"]
+                          "dualtor", "t0-120", "t0-80", "t0-backend", "t0-56-o8v48", "t0-8-lag"]
     SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-56-lag", "t1-backend", "t1-28-lag"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
     SUPPORTED_ASIC_LIST = ["pac", "gr", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "td3", "th3",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

2700 t0-8-lag nightly test always failed , because of keyerror, as below:
```
18/04/2024 09:46:32 __init__._fixture_generator_decorator    L0088 ERROR  | 
KeyError(0)
Traceback (most recent call last):
  File "/var/src/sonic-mgmt_tbtk5-t0-2700-4_65a9f3c0abd5cba890cf2070/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/var/src/sonic-mgmt_tbtk5-t0-2700-4_65a9f3c0abd5cba890cf2070/tests/qos/qos_sai_base.py", line 1059, in dutConfig
    testPorts = self.__buildTestPorts(request, testPortIds, testPortIps,
  File "/var/src/sonic-mgmt_tbtk5-t0-2700-4_65a9f3c0abd5cba890cf2070/tests/qos/qos_sai_base.py", line 683, in __buildTestPorts
    src_dut_port_ids = testPortIds[get_src_dst_asic_and_duts['src_dut_index']]
KeyError: 0
```

RCA:

SUPPORTED_T0_TOPOS  miss "t0-8-lag" topo, so failed to prepare qos test parameter in dutConfig().
```
     SUPPORTED_T0_TOPOS = ["t0", "t0-56-po2vlan", "t0-64", "t0-116", "t0-35", "dualtor-56", "dualtor-64", "dualtor-120",
-                          "dualtor", "t0-120", "t0-80", "t0-backend", "t0-56-o8v48"]
+                          "dualtor", "t0-120", "t0-80", "t0-backend", "t0-56-o8v48", "t0-8-lag"]
```

#### How did you do it?

append t0-8-lag to SUPPORTED_T0_TOPOS

#### How did you verify/test it?

All qos sai case pass, except one xfail case. Check testplan id: 66210dc5e3f0ed9b496106bf in detail:
===== 17 passed, 114 skipped, 1 xfailed, 3 warnings in 4085.87s (1:08:05) ======

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
