### PR TITLE
[pretest] Testcase to validate backend acl load

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -375,8 +375,8 @@ def test_backend_acl_load(duthosts, enum_dut_hostname, tbinfo):
         if "DATAACL" not in rule["table"]:
             continue
         if ((rule["rule"].startswith("RULE") and rule["action"] != "FORWARD")
-            or (rule["rule"].startswith("DEFAULT") and rule["action"] != "DROP")
-            or rule["status"] != "Active"):
+                or (rule["rule"].startswith("DEFAULT") and rule["action"] != "DROP")
+                or rule["status"] != "Active"):
             pytest.fail("Backend acl not installed succesfully: {}".format(rule))
 
 

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -364,6 +364,22 @@ def prepare_autonegtest_params(duthosts, fanouthosts):
 """
 
 
+def test_backend_acl_load(duthosts, enum_dut_hostname, tbinfo):
+    duthost = duthosts[enum_dut_hostname]
+    pytest_require("t0-backend" in tbinfo["topo"]["name"],
+                   "Skip 'test_backend_acl_load' on non t0-backend testbeds.")
+    out = duthost.command("systemctl restart backend-acl.service")
+    pytest_assert(out["rc"] == 0, "Failed to load backend acl: {}".format(out["stderr"]))
+    rules = duthost.show_and_parse("show acl rule DATAACL")
+    for rule in rules:
+        if "DATAACL" not in rule["table"]:
+            continue
+        if ((rule["rule"].startswith("RULE") and rule["action"] != "FORWARD")
+            or (rule["rule"].startswith("DEFAULT") and rule["action"] != "DROP")
+            or rule["status"] != "Active"):
+            pytest.fail("Backend acl not installed succesfully: {}".format(rule))
+
+
 # This one is special. It is public, but we need to ensure that it is the last one executed in pre-test.
 def test_generate_running_golden_config(duthosts):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #12048

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Add an explicit testcase to validate that acl is loaded successfully on the backend T0 testbed. Without this case, acl load failure was determined by examining the nighly run failures on the backend testbed

#### How did you verify/test it?
Ran the test against a backend T0 testbed with the fix to load acl correctly and it passed
Ran the test against a non backend T0 testbed and it is skipped
```
test_pretest.py::test_features_state[str2-7050qx-32s-acs-02] PASSED                                                                    [  7%]
test_pretest.py::test_cleanup_testbed[str2-7050qx-32s-acs-02] PASSED                                                                   [ 14%]
test_pretest.py::test_disable_container_autorestart[str2-7050qx-32s-acs-02] PASSED                                                     [ 21%]
test_pretest.py::test_disable_rsyslog_rate_limit[str2-7050qx-32s-acs-02] PASSED                                                        [ 28%]
test_pretest.py::test_connect_to_internal_nameserver[str2-7050qx-32s-acs-02] PASSED                                                    [ 35%]
test_pretest.py::test_update_buffer_template[str2-7050qx-32s-acs-02] PASSED                                                            [ 42%]
test_pretest.py::test_backend_acl_load[str2-7050qx-32s-acs-02] PASSED                                                                  [ 50%]
test_pretest.py::test_cleanup_cache PASSED                                                                                             [ 57%]
test_pretest.py::test_update_testbed_metadata 
--------------------------------------------------------------- live log call ----------------------------------------------------------------
19:55:47 test_pretest.prepare_autonegtest_params  L0358 WARNING| skipped to create autoneg test datafile because of no ports selected
PASSED                                                                                                                                 [ 64%]
test_pretest.py::test_collect_testbed_prio PASSED                                                                                      [ 71%]
test_pretest.py::test_collect_pfc_pause_delay_params PASSED                                                                            [ 78%]
test_pretest.py::test_update_saithrift_ptf SKIPPED (No URL specified for python saithrift package)                                     [ 85%]
test_pretest.py::test_conn_graph_valid PASSED                                                                                          [ 92%]
test_pretest.py::test_generate_running_golden_config PASSED                                                                            [100%]


test_pretest.py::test_backend_acl_load[str2-7050qx-32s-acs-03] SKIPPED (Skip 'test_backend_acl_load' on non t0-backend testbeds.)      [100%]
```

#### Supported testbed topology if it's a new test case?
t0-backend
