### PR TITLE
Fix sfp cable tech check in test_tx_disable_channel

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -272,7 +272,7 @@ class TestSfpApi(PlatformApiTestBase):
             spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
             if xcvr_info_dict["type_abbrv_name"] == "SFP":
                 compliance_code = spec_compliance_dict.get("SFP+CableTechnology")
-                if compliance_code == "Passive Cable":
+                if compliance_code == "Passive Cable" or compliance_code == "Unknown":
                     return False
             else:
                 compliance_code = spec_compliance_dict.get("10/40G Ethernet Compliance Code", " ")


### PR DESCRIPTION

### Description of PR
Platform test test_tx_disable_channel fails in the case of some SFP-10G-T xcvrs.   The api does not work on them but the test does not correctly skip over them due to missing logic in is_xcvr_optical. SFP cable tech eeprom field should theoretically either be "Active" or "Passive" but for these particuluar xcvrs it is unknown so we will treat it the same as "Passive".


### Type of change
Treat these unknown xcvrs similar to passive devices.

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Addressing failing SONiC Mgmt test case.

#### How did you do it?
Skip the test case for xcvrs that do not support the API.  This will have no impact on existing test setups where the xcvrs support the api call.

#### How did you verify/test it?
Reran SONiC Mgmt test case to confirm that tests were no longer failing.

#### Any platform specific information?
n/a

#### Supported testbed topology if it's a new test case?
n/a

### Documentation
n/a