### PR TITLE
Temporary fix for Dynamic ACL via GCU ACL rule replacement test

### DIFF
--- a/tests/generic_config_updater/templates/create_secondary_forward_rules.j2
+++ b/tests/generic_config_updater/templates/create_secondary_forward_rules.j2
@@ -1,0 +1,20 @@
+[
+    {
+        "op": "add",
+        "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_1",
+        "value": {
+            "DST_IP": "{{ ipv4_subnet }}",
+            "PRIORITY": "9999",
+            "PACKET_ACTION": "FORWARD"
+        }
+    },
+    {
+        "op": "add",
+        "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_2",
+        "value": {
+            "DST_IPV6": "{{ ipv6_subnet }}",
+            "PRIORITY": "9998",
+            "PACKET_ACTION": "FORWARD"
+        }
+    }
+]

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -879,37 +879,6 @@ def dynamic_acl_replace_rules(duthost):
     REPLACEMENT_IPV4_SUBNET = DST_IP_FORWARDED_REPLACEMENT + "/32"
     REPLACEMENT_IPV6_SUBNET = DST_IPV6_FORWARDED_REPLACEMENT + "/128"
 
-    remove_patch = [
-    {
-        "op": "remove",
-        "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_1"
-    },
-    {
-        "op": "remove",
-        "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_2"
-    }
-    ]
-
-    add_patch = [
-        {
-            "op": "replace",
-            "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_1",
-            "value": {
-                "DST_IP": REPLACEMENT_IPV4_SUBNET,
-                "PRIORITY": "9999",
-                "PACKET_ACTION": "FORWARD"
-            }
-        },
-        {
-        "op": "replace",
-        "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_2",
-            "value": {
-                "DST_IPV6": REPLACEMENT_IPV6_SUBNET,
-                "PRIORITY": "9998",
-                "PACKET_ACTION": "FORWARD"
-            }
-        }
-    ]
 
     extra_vars = {
         'ipv4_subnet': REPLACEMENT_IPV4_SUBNET,
@@ -929,15 +898,14 @@ def dynamic_acl_replace_rules(duthost):
                                "DST_IPV6: " + REPLACEMENT_IPV6_SUBNET,
                                "Active"]
 
-    #output = format_and_apply_template(duthost, REPLACE_RULES_TEMPLATE, extra_vars)
+    #replacing an ACL rule causing error logs to get flooded because of a SONiC bug currently - temporary fix
 
-    output = apply_patch(duthost, remove_patch)
-
-    expect_op_success(duthost, output)
+    dynamic_acl_remove_ip_forward_rule(duthost, "IPV4")
+    dynamic_acl_remove_ip_forward_rule(duthost, "IPV6")
 
     time.sleep(2)
 
-    output = apply_patch(duthost, add_patch)
+    output = format_and_apply_template(duthost, CREATE_FORWARD_RULES_TEMPLATE, extra_vars)
 
     expect_op_success(duthost, output)
 

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -880,7 +880,6 @@ def dynamic_acl_replace_rules(duthost):
     REPLACEMENT_IPV4_SUBNET = DST_IP_FORWARDED_REPLACEMENT + "/32"
     REPLACEMENT_IPV6_SUBNET = DST_IPV6_FORWARDED_REPLACEMENT + "/128"
 
-
     extra_vars = {
         'ipv4_subnet': REPLACEMENT_IPV4_SUBNET,
         'ipv6_subnet': REPLACEMENT_IPV6_SUBNET
@@ -899,7 +898,7 @@ def dynamic_acl_replace_rules(duthost):
                                "DST_IPV6: " + REPLACEMENT_IPV6_SUBNET,
                                "Active"]
 
-    #replacing an ACL rule causing error logs to get flooded because of a SONiC bug currently - temporary fix
+    # replacing an ACL rule causing error logs to get flooded because of a SONiC bug currently - temporary fix
 
     dynamic_acl_remove_ip_forward_rule(duthost, "IPV4")
     dynamic_acl_remove_ip_forward_rule(duthost, "IPV6")

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -879,6 +879,38 @@ def dynamic_acl_replace_rules(duthost):
     REPLACEMENT_IPV4_SUBNET = DST_IP_FORWARDED_REPLACEMENT + "/32"
     REPLACEMENT_IPV6_SUBNET = DST_IPV6_FORWARDED_REPLACEMENT + "/128"
 
+    remove_patch = [
+    {
+        "op": "remove",
+        "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_1"
+    },
+    {
+        "op": "remove",
+        "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_2"
+    }
+    ]
+
+    add_patch = [
+        {
+            "op": "replace",
+            "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_1",
+            "value": {
+                "DST_IP": REPLACEMENT_IPV4_SUBNET,
+                "PRIORITY": "9999",
+                "PACKET_ACTION": "FORWARD"
+            }
+        },
+        {
+        "op": "replace",
+        "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_2",
+            "value": {
+                "DST_IPV6": REPLACEMENT_IPV6_SUBNET,
+                "PRIORITY": "9998",
+                "PACKET_ACTION": "FORWARD"
+            }
+        }
+    ]
+
     extra_vars = {
         'ipv4_subnet': REPLACEMENT_IPV4_SUBNET,
         'ipv6_subnet': REPLACEMENT_IPV6_SUBNET
@@ -897,7 +929,15 @@ def dynamic_acl_replace_rules(duthost):
                                "DST_IPV6: " + REPLACEMENT_IPV6_SUBNET,
                                "Active"]
 
-    output = format_and_apply_template(duthost, REPLACE_RULES_TEMPLATE, extra_vars)
+    #output = format_and_apply_template(duthost, REPLACE_RULES_TEMPLATE, extra_vars)
+
+    output = apply_patch(duthost, remove_patch)
+
+    expect_op_success(duthost, output)
+
+    time.sleep(2)
+
+    output = apply_patch(duthost, add_patch)
 
     expect_op_success(duthost, output)
 

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 CREATE_CUSTOM_TABLE_TYPE_FILE = "create_custom_table_type.json"
 CREATE_CUSTOM_TABLE_TEMPLATE = "create_custom_table.j2"
 CREATE_FORWARD_RULES_TEMPLATE = "create_forward_rules.j2"
+CREATE_SECONDARY_FORWARD_RULES_TEMPLATE = "create_secondary_forward_rules.j2"
 CREATE_INITIAL_DROP_RULE_TEMPLATE = "create_initial_drop_rule.j2"
 CREATE_SECONDARY_DROP_RULE_TEMPLATE = "create_secondary_drop_rule.j2"
 CREATE_THREE_DROP_RULES_TEMPLATE = "create_three_drop_rules.j2"
@@ -905,7 +906,7 @@ def dynamic_acl_replace_rules(duthost):
 
     time.sleep(2)
 
-    output = format_and_apply_template(duthost, CREATE_FORWARD_RULES_TEMPLATE, extra_vars)
+    output = format_and_apply_template(duthost, CREATE_SECONDARY_FORWARD_RULES_TEMPLATE, extra_vars)
 
     expect_op_success(duthost, output)
 


### PR DESCRIPTION

### Description of PR
Summary:

Changes test_gcu_acl_forward_rule_replacement to separate the replacement operation into two separate delete and add operations.  This is to address test failures caused by a SONiC OS bug that floods error logs after a ACL rule is directly replaced in configDB, despite ACL functionality working as intended - https://github.com/sonic-net/sonic-buildimage/issues/18719

Test working on testbed that it previously failed on:

![image](https://github.com/sonic-net/sonic-mgmt/assets/156464693/f05b735a-39bc-4fbf-88e4-90c1aa5e2071)


### Type of change


- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Temporarily fix test case to get rid of errors in nightly testing suite pending bug fix in SONiC OS
#### How did you do it?
Changed the replace operation into two separate delete and add operations
#### How did you verify/test it?
Tested it on a testbed that had previously been failing
