### PR TITLE
debug: add temporary eth0 interface debug logs

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -672,6 +672,9 @@ def convert_and_restore_config_db_to_ipv6_only(duthosts):
                     logger.info(f"Host[{duthost.hostname}] IPv6[{ip_addr}]")
                     ipv6_address[duthost.hostname].append(ip_addr_without_mask)
                     try:
+                        # Add a temporary debug log to see if the DUT is reachable via IPv6 mgmt-ip. Will remove later
+                        duthost_interface = duthost.shell("sudo ifconfig eth0")['stdout']
+                        logging.debug(f"Checking host[{duthost.hostname}] ifconfig eth0:[{duthost_interface}]")
                         ssh_client.connect(ip_addr_without_mask,
                                            username="WRONG_USER", password="WRONG_PWD", timeout=15)
                     except AuthenticationException:

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 import re
 
@@ -54,12 +56,22 @@ def ignore_expected_loganalyzer_exception(loganalyzer):
             loganalyzer[hostname].ignore_regex.extend(ignore_regex)
 
 
+def log_eth0_interface_info(duthosts):
+    for duthost in duthosts:
+        duthost_interface = duthost.shell("sudo ifconfig eth0")['stdout']
+        logging.debug(f"Checking host[{duthost.hostname}] ifconfig eth0:[{duthost_interface}] after fixture")
+
+
 def test_bgp_facts_ipv6_only(duthosts, enum_frontend_dut_hostname, enum_asic_index,
                              convert_and_restore_config_db_to_ipv6_only): # noqa F811
+    # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
+    log_eth0_interface_info(duthosts)
     run_bgp_facts(duthosts, enum_frontend_dut_hostname, enum_asic_index)
 
 
 def test_show_features_ipv6_only(duthosts, enum_dut_hostname, convert_and_restore_config_db_to_ipv6_only): # noqa F811
+    # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
+    log_eth0_interface_info(duthosts)
     run_show_features(duthosts, enum_dut_hostname)
 
 
@@ -68,6 +80,8 @@ def test_image_download_ipv6_only(creds, duthosts, enum_dut_hostname,
     """
     Test image download in mgmt ipv6 only scenario
     """
+    # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
+    log_eth0_interface_info(duthosts)
     duthost = duthosts[enum_dut_hostname]
     image_url = creds.get("test_image_url", {}).get("ipv6", "")
     pytest_require(len(image_url) != 0, "Cannot get image url")
@@ -88,11 +102,15 @@ def test_image_download_ipv6_only(creds, duthosts, enum_dut_hostname,
                           ("fd82:b34f:cc99::100", "fd82:b34f:cc99::200")])
 def test_syslog_ipv6_only(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b,
                           check_default_route, convert_and_restore_config_db_to_ipv6_only): # noqa F811
+    # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
+    log_eth0_interface_info(duthosts)
     run_syslog(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b, check_default_route)
 
 
 def test_snmp_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_all_duts,
                         convert_and_restore_config_db_to_ipv6_only): # noqa F811
+    # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
+    log_eth0_interface_info(duthosts)
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     hostipv6 = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_hostv6']
@@ -110,6 +128,8 @@ def test_snmp_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname, localhost, c
 
 def test_ro_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname,
                            tacacs_creds, check_tacacs_v6, convert_and_restore_config_db_to_ipv6_only): # noqa F811
+    # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
+    log_eth0_interface_info(duthosts)
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutipv6 = get_mgmt_ipv6(duthost)
 
@@ -120,6 +140,8 @@ def test_ro_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname
 
 def test_rw_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname,
                            tacacs_creds, check_tacacs_v6, convert_and_restore_config_db_to_ipv6_only): # noqa F811
+    # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
+    log_eth0_interface_info(duthosts)
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutipv6 = get_mgmt_ipv6(duthost)
 
@@ -132,6 +154,8 @@ def test_rw_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname
 def test_telemetry_output_ipv6_only(convert_and_restore_config_db_to_ipv6_only, # noqa F811
                                     duthosts, enum_rand_one_per_hwsku_hostname,
                                     setup_streaming_telemetry): # noqa F811
+    # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
+    log_eth0_interface_info(duthosts)
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
     if duthost.is_supervisor_node():
@@ -149,4 +173,6 @@ def test_telemetry_output_ipv6_only(convert_and_restore_config_db_to_ipv6_only, 
 
 def test_ntp_ipv6_only(duthosts, rand_one_dut_hostname,
                                   convert_and_restore_config_db_to_ipv6_only, setup_ntp): # noqa F811
+    # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
+    log_eth0_interface_info(duthosts)
     run_ntp(duthosts, rand_one_dut_hostname, setup_ntp)

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -100,7 +100,7 @@ def test_image_download_ipv6_only(creds, duthosts, enum_dut_hostname,
 @pytest.mark.parametrize("dummy_syslog_server_ip_a, dummy_syslog_server_ip_b",
                          [("fd82:b34f:cc99::100", None),
                           ("fd82:b34f:cc99::100", "fd82:b34f:cc99::200")])
-def test_syslog_ipv6_only(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b,
+def test_syslog_ipv6_only(duthosts, rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b,
                           check_default_route, convert_and_restore_config_db_to_ipv6_only): # noqa F811
     # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
     log_eth0_interface_info(duthosts)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add temporary eth0 interface debug logs for IPv6 tests, which could be useful for debugging the test failures in `ip/test_mgmt_ipv6_only`

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
