### PR TITLE
imporve qos log readability

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -363,6 +363,7 @@ class TestQosSai(QosSaiBase):
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
+        testParams.update({"test_port_ids": dutConfig["testPortIds"]})
         testParams.update({
             "dscp": qosConfig[xoffProfile]["dscp"],
             "ecn": qosConfig[xoffProfile]["ecn"],
@@ -635,6 +636,7 @@ class TestQosSai(QosSaiBase):
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
+        testParams.update({"test_port_ids": dutConfig["testPortIds"]})
         testParams.update({
             "dscp": qosConfig[xonProfile]["dscp"],
             "ecn": qosConfig[xonProfile]["ecn"],
@@ -1163,6 +1165,7 @@ class TestQosSai(QosSaiBase):
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
+        testParams.update({"test_port_ids": dutConfig["testPortIds"]})
         testParams.update({
             "dscp": qosConfig["lossy_queue_1"]["dscp"],
             "ecn": qosConfig["lossy_queue_1"]["ecn"],

--- a/tests/saitests/py3/texttable.py
+++ b/tests/saitests/py3/texttable.py
@@ -1,10 +1,15 @@
 #!python
 
+from itertools import zip_longest
+
+
 class TextTable():
 
-    def __init__(self, field_names=None):
+    def __init__(self, field_names=None, attr_name=None, attr_value=None):
         self.widths = []
         self.table = []
+        self.attr_name = attr_name
+        self.attr_value = attr_value
         self._field_names = None
         if field_names:
             self._field_names = field_names
@@ -60,6 +65,31 @@ class TextTable():
             buf += '\n' + line
 
         return buf
+
+    def get_rows(self):
+        return self.table
+
+    @staticmethod
+    def merge_table(current, base=None):
+        if base is None:
+            return current
+
+        if len(current._field_names) != len(base._field_names) or \
+           any(cf != bf for cf, bf in zip(current._field_names, base._field_names)):
+            return current
+
+        if (current.attr_name or base.attr_name) and current.attr_name != base.attr_name:
+            return current
+
+        new_fields = [current.attr_name] + current._field_names if current.attr_name else current._field_names
+
+        merged = TextTable(new_fields)
+        for cr, br in zip_longest(current.get_rows(), base.get_rows(), fillvalue=[]):
+            if br:
+                merged.add_row([base.attr_value] + br if base.attr_value else br)
+            if cr:
+                merged.add_row([current.attr_value] + cr if current.attr_value else cr)
+        return merged
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

improve qos log readability and troubleshoot capability

#### How did you do it?

implement:

# Log message wrapper:
All the messages were outputted to PTF logging by default, and can set flag to output to stderr of PTF console for specific message.
so it can avoid lots of message flush on console and "test summary", easy to identify failure when triage.
and also can check PTF logging which include all the message when rootcause failure.

# CounterCollector Class
provide general interface for counter collecting, comparing, and displaying.

# Diagnostic Counter Wrapper

so far, we can read 8 kinds of counter:
port_counter, queue_counter_counter, queue_share_wm_counter, pg_share_wm_counter, pg_headroom_wm_counter, pg_counter_couner, pg_drop_counter and ptf_tx_rx_counter

Although CounterCollector provides a common API to collect, compare and display these counters, if you use countercollect directly, the code of the test case will still become confusing. After all, at least one line of code for each counter.
If the types of counter queries are subsequently increased, more code unrelated to the test steps will be exposed in the testcase.

Therefore, the diag coutner wrapper is used to include all types of counter activities, so that the code in the test case is more inclined to reflect the test steps and logic rather than these diagnostic codes.

# assert wrapper

By default, we will display the counter difference between the first and last step of this case on both normal and abnormal exits.
but using python build-in assert instruction make it difficult to show counter diff.
so we implement a assert wrapper to show counter diff when assert exception occur.

# TextTable Class

This is not newly added class, in befor, it help to output counters in table format like well-known python library prettytable.
in this PR, add a new class static method "merge_table())" to merge two table which need to show their difference.

# example case:

not applied this feature to all qos testcase.
only applied above changes to xoff, xon, lossyqueue cases as a example first.  Monitor for long time to collect the feedback, and then enhance.

# already cover various sku/topo

see below test record table

# skip chassis device

since test have not covered chassis yet, skip chassis device support so far.


#### How did you verify/test it?

pass verification in lab testbed

| testbedv                   | testplan id               | test result |
| -------------------------- | ------------------------- | ----------- |
| testbed-bjw-can-t1-7260-12 | 66221bb2547d049f1bfc7327  | pass        |
| tbtk5-t0-7260-7            | 662223a7547d049f1bfc733f  | pass        |
| tbtk5-t0-7260-01           | 66223b92547d049f1bfc7383  | pass        |
| testbed-bjw-can-t0-7260-11 | 662223d9baaf1d86b8992e09  | pass        |
| testbed-bjw-can-t1-7260-8  | 662223f8547d049f1bfc7343  | pass        |
| vms1-t1-2700               | 66224f7e547d049f1bfc73b6  | pass        |
| vms21-t1-2700-2            | 662236e3547d049f1bfc7380  | pass        |
| testbed-bjw-can-2700-4     | 66223cd3e3f0ed9b49610956  | paSS        |
| vms18-t1-msn4600c-acs-1    | 66222cfae3f0ed9b4961092e  | pass        |
| vms18-t1-7050qx-acs-03     | 662271c2e3f0ed9b496109a5  | pass        |
| vms63-t0-7060-1            | 66227256baaf1d86b8992ea7  | pass        |
| vms6-t1-7060               | 66227269baaf1d86b8992ea9  | pass        |
| vms11-t0-7050qx-acs-4      | 66227238e3f0ed9b496109a9  | pass        |
| vms64-t0-s6100-1           | 662275c9547d049f1bfc73ff  | pass        |
| tbtk5-t0-s6100-2           | 1662275db547d049f1bfc7401 | pass        |
| tbtk5-t1-s6100-5           | 6622aec8547d049f1bfc747e  | pass        |
| vms68-t1-s6100-1           | 6622a06e547d049f1bfc745c  | pass        |

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
