### PR TITLE
[Fix] Fix issue of testbed health check key error and print Exception type and message

### DIFF
--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -180,7 +180,8 @@ class TestbedHealthChecker:
 
         for sonichost in self.sonichosts:
 
-            rst = sonichost.shell(f"jq '.MGMT_INTERFACE' {config_db_file}", module_ignore_errors=True).get("stdout", None)
+            rst = sonichost.shell(f"jq '.MGMT_INTERFACE' {config_db_file}", module_ignore_errors=True).get("stdout",
+                                                                                                           None)
 
             # If valid stdout
             if rst is not None and rst.strip() != "":

--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -280,7 +280,7 @@ class TestbedHealthChecker:
             # catch other exceptions
             logger.info("{}: {}".format(type(e).__name__, e))
             self.check_result.code = 4
-            self.check_result.errmsg = ["An error occurred."]
+            self.check_result.errmsg = [type(e).__name__]
             self.check_result.data = str(e)
 
         finally:

--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -180,7 +180,7 @@ class TestbedHealthChecker:
 
         for sonichost in self.sonichosts:
 
-            rst = sonichost.shell(f"jq '.MGMT_INTERFACE' {config_db_file}", module_ignore_errors=True)["stdout"]
+            rst = sonichost.shell(f"jq '.MGMT_INTERFACE' {config_db_file}", module_ignore_errors=True).get("stdout", None)
 
             # If valid stdout
             if rst is not None and rst.strip() != "":
@@ -277,7 +277,7 @@ class TestbedHealthChecker:
 
         except Exception as e:
             # catch other exceptions
-            logger.info("An error occurred: {}".format(e))
+            logger.info("{}: {}".format(type(e).__name__, e))
             self.check_result.code = 4
             self.check_result.errmsg = ["An error occurred."]
             self.check_result.data = str(e)

--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -278,10 +278,10 @@ class TestbedHealthChecker:
 
         except Exception as e:
             # catch other exceptions
-            logger.info("{}: {}".format(type(e).__name__, e))
+            logger.info(repr(e))
             self.check_result.code = 4
-            self.check_result.errmsg = [type(e).__name__]
-            self.check_result.data = str(e)
+            self.check_result.errmsg = [repr(e)]
+            self.check_result.data = None
 
         finally:
             # If output file is specified, write result to it.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

[Fix] Fix issue of testbed health check key error and print Exception type and message.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

Fix issue of testbed health check key error and print Exception type and message.

#### How did you do it?
- Use `dict.get(key, None)` method instead of direct reference `dict[key]`
- Add exception type in log

#### How did you verify/test it?
Test on both healthy and unhealthy testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
