### PR TITLE
Fix qos/test_pfc_pause.py for dualtor-aa

### DIFF
--- a/tests/qos/test_pfc_pause.py
+++ b/tests/qos/test_pfc_pause.py
@@ -293,6 +293,7 @@ def test_pfc_pause_lossless(pfc_test_setup, fanouthosts, duthost, ptfhost,
 
 def test_no_pfc(pfc_test_setup, fanouthosts, rand_selected_dut, ptfhost, conn_graph_facts,        # noqa F811
                 fanout_graph_facts, lossless_prio_dscp_map, enum_dut_lossless_prio, # noqa F811
+                setup_standby_ports_on_rand_unselected_tor,       # noqa F811
                 toggle_all_simulator_ports_to_rand_selected_tor): # noqa F811
     """
     Test if lossless and lossy priorities can forward packets in the absence of PFC pause frames


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix qos/test_pfc_pause.py for dualtor-aa
Fixes: [#100](https://github.com/aristanetworks/sonic-qual.msft/issues/100)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
`qos/test_pfc_pause.py` fails on dualtor-aa

```
            errors = dict()
            for intf in results:
                if len(results[intf]) != 2:
                    continue
    
                pass_count = results[intf][0]
                total_count = results[intf][1]
    
                if total_count == 0:
                    continue
    
                if pass_count &lt; total_count * PTF_PASS_RATIO_THRESH:
                    errors[intf] = results[intf]
    
            if len(errors) &gt; 0:
                test_errors += "Dscp: {}, Background Dscp: {}, errors occured: {}\n"\
                               .format(dscp, dscp_bg, " ".join(["{}:{}".format(k, v) for k, v in list(errors.items())]))
    
&gt;       pytest_assert(len(test_errors) == 0, test_errors)
E       Failed: Dscp: [3], Background Dscp: 4, errors occured: Ethernet12:[0, 20]
E       Dscp: [3], Background Dscp: 0, errors occured: Ethernet12:[0, 20]
E       Dscp: [3], Background Dscp: 1, errors occured: Ethernet12:[0, 20]
```

```
            errors = dict()
            for intf in results:
                if len(results[intf]) != 2:
                    continue
    
                pass_count = results[intf][0]
                total_count = results[intf][1]
    
                if total_count == 0:
                    continue
    
                if pass_count &lt; total_count * PTF_PASS_RATIO_THRESH:
                    errors[intf] = results[intf]
    
            if len(errors) &gt; 0:
                test_errors += "Dscp: {}, Background Dscp: {}, errors occured: {}\n"\
                               .format(dscp, dscp_bg, " ".join(["{}:{}".format(k, v) for k, v in list(errors.items())]))
    
&gt;       pytest_assert(len(test_errors) == 0, test_errors)
E       Failed: Dscp: [4], Background Dscp: 3, errors occured: Ethernet12:[0, 20]
E       Dscp: [4], Background Dscp: 0, errors occured: Ethernet12:[0, 20]
E       Dscp: [4], Background Dscp: 1, errors occured: Ethernet12:[0, 20]
```

This happens because the packets go to unselected ToR.

#### How did you do it?
Follow the same approach as in [#11921](https://github.com/sonic-net/sonic-mgmt/pull/11921)

#### How did you verify/test it?
Verified on Arista-7260 platform with both dualtor-aa and dualtor topology.

```
qos/test_pfc_pause.py::test_pfc_pause_lossless[gd377|2] SKIPPED (Fanout needs to send PFC fra...) [  6%]
qos/test_pfc_pause.py::test_pfc_pause_lossless[gd377|3] SKIPPED (Fanout needs to send PFC fra...) [ 12%]
qos/test_pfc_pause.py::test_pfc_pause_lossless[gd377|4] SKIPPED (Fanout needs to send PFC fra...) [ 18%]
qos/test_pfc_pause.py::test_pfc_pause_lossless[gd377|6] SKIPPED (Fanout needs to send PFC fra...) [ 25%]
qos/test_pfc_pause.py::test_pfc_pause_lossless[gd426|2] SKIPPED (Fanout needs to send PFC fra...) [ 31%]
qos/test_pfc_pause.py::test_pfc_pause_lossless[gd426|3] SKIPPED (Fanout needs to send PFC fra...) [ 37%]
qos/test_pfc_pause.py::test_pfc_pause_lossless[gd426|4] SKIPPED (Fanout needs to send PFC fra...) [ 43%]
qos/test_pfc_pause.py::test_pfc_pause_lossless[gd426|6] SKIPPED (Fanout needs to send PFC fra...) [ 50%]
qos/test_pfc_pause.py::test_no_pfc[gd377|2] SKIPPED (No DSCP found for priority 2.)               [ 56%]
qos/test_pfc_pause.py::test_no_pfc[gd377|3] PASSED                                                [ 62%]
qos/test_pfc_pause.py::test_no_pfc[gd377|4] PASSED                                                [ 68%]
qos/test_pfc_pause.py::test_no_pfc[gd377|6] SKIPPED (No DSCP found for priority 6.)               [ 75%]
qos/test_pfc_pause.py::test_no_pfc[gd426|2] SKIPPED (No DSCP found for priority 2.)               [ 81%]
qos/test_pfc_pause.py::test_no_pfc[gd426|3] PASSED                                                [ 87%]
qos/test_pfc_pause.py::test_no_pfc[gd426|4] PASSED                                                [ 93%]
qos/test_pfc_pause.py::test_no_pfc[gd426|6] SKIPPED (No DSCP found for priority 6.)               [100%]

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
