### PR TITLE
copp/test_copp.py extend timeout for bgp trap install and uninstall

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -163,7 +163,7 @@ class TestCOPP(object):
 
         logger.info("Verify {} trap status is uninstalled by sending traffic".format(self.trap_id))
         pytest_assert(
-            wait_until(100, 20, 0, _copp_runner, duthost, ptfhost, self.trap_id.upper(),
+            wait_until(300, 20, 0, _copp_runner, duthost, ptfhost, self.trap_id.upper(),
                        copp_testbed, dut_type, has_trap=False),
             "uninstalling {} trap fail".format(self.trap_id))
 
@@ -487,7 +487,7 @@ def pre_condition_install_trap(ptfhost, duthost, copp_testbed, trap_id, feature_
 
     logger.info("Verify {} trap status is installed by sending traffic in pre_condition".format(trap_id))
     pytest_assert(
-        wait_until(100, 20, 0, _copp_runner, duthost, ptfhost, trap_id.upper(), copp_testbed, dut_type),
+        wait_until(300, 20, 0, _copp_runner, duthost, ptfhost, trap_id.upper(), copp_testbed, dut_type),
         "Installing {} trap fail".format(trap_id))
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test_copp.py can fail because some devices take longer than the 100 second default timeout

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
copp/test_copp.py was flakey due to short timeout

#### How did you do it?
Increased the timeout

#### How did you verify/test it?
reproduced the issue on an Arista platform and ensured the test passed with changes.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
