### PR TITLE
Fix the shell command when setting up ipv6 docker daemon

### DIFF
--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -104,14 +104,14 @@ cd sonic-mgmt
 2. (Required for IPv6 test cases): Follow the steps [IPv6 for docker default bridge](https://docs.docker.com/config/daemon/ipv6/#use-ipv6-for-the-default-bridge-network) to enable IPv6 for container. Here is an example which uses ULA address to setup `/etc/docker/daemon.json` if no special requirement or no local docker configuration. Then restart docker daemon to take effect.
 
 ```
-$ sudo bash -c "cat <<EOF > /etc/docker/daemon.json 
+$ sudo bash -c 'cat <<EOF > /etc/docker/daemon.json 
 {
     "ipv6": true,
     "fixed-cidr-v6": "fd00:1::1/64",
     "experimental": true,
     "ip6tables": true
 }
-EOF"
+EOF'
 $ sudo systemctl restart docker
 ```
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #12522 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The shell command for enabling docker ipv6 in the README.testbed.VsSetup.md won't run correctly, and generated a malformed json file.

Expected json file:
```
{
    "ipv6": true,
    "fixed-cidr-v6": "fd00:1::1/64",
    "experimental": true,
    "ip6tables": true
}
```
malformed json file:
```
{
    ipv6: true,
    fixed-cidr-v6: fd00:1::1/64,
    experimental: true,
    ip6tables: true
}
```
#### How did you do it?
use single quote ' to keep valid json format.

#### How did you verify/test it?
Run the command locally and restarted docker. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
