### PR TITLE
Address flakiness in arp/test_unknown_mac.py

### DIFF
--- a/tests/arp/test_unknown_mac.py
+++ b/tests/arp/test_unknown_mac.py
@@ -17,7 +17,7 @@ from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py   # noqa F
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
-from tests.common.utilities import get_intf_by_sub_intf
+from tests.common.utilities import get_intf_by_sub_intf, wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -320,10 +320,14 @@ class TrafficSendVerify(object):
             else:
                 actual_cnt = int(stats[intf]['RX_DRP'])
                 exp_cnt = self.pre_rx_drops[intf] + TEST_PKT_CNT
-                pytest_assert(actual_cnt >= exp_cnt,
-                              "Pkt dropped cnt incorrect for intf {}. Expected: {}, Obtained: {}".format(intf, exp_cnt,
-                                                                                                         actual_cnt))
                 logger.info("Pkt count dropped on interface {}: {}, Expected: {}".format(intf, actual_cnt, exp_cnt))
+                if actual_cnt < exp_cnt:
+                    return False
+         return True
+
+    def verifyIntfCounters(self):
+        exp_cnt = self.pre_rx_drops[intf] + TEST_PKT_CNT
+        pytest_assert(wait_until(10, 2, 0, self._verifyIntfCounters), "Drop counters failed to increment, Expected Drops: {}".format(exp_cnt))
 
     def runTest(self):
         """
@@ -343,7 +347,7 @@ class TrafficSendVerify(object):
             testutils.send(self.ptfadapter, src_port, pkt, count=TEST_PKT_CNT)
             testutils.verify_no_packet_any(self.ptfadapter, exp_pkt, ports=self.ptf_vlan_ports)
         logger.info("Collect and verify drop counters after test run")
-        self._verifyIntfCounters()
+        self.verifyIntfCounters()
 
 
 class TestUnknownMac(object):

--- a/tests/arp/test_unknown_mac.py
+++ b/tests/arp/test_unknown_mac.py
@@ -323,11 +323,11 @@ class TrafficSendVerify(object):
                 logger.info("Pkt count dropped on interface {}: {}, Expected: {}".format(intf, actual_cnt, exp_cnt))
                 if actual_cnt < exp_cnt:
                     return False
-         return True
+        return True
 
     def verifyIntfCounters(self):
-        exp_cnt = self.pre_rx_drops[intf] + TEST_PKT_CNT
-        pytest_assert(wait_until(10, 2, 0, self._verifyIntfCounters), "Drop counters failed to increment, Expected Drops: {}".format(exp_cnt))
+        pytest_assert(wait_until(10, 2, 0, self._verifyIntfCounters),
+                      "Drop counters failed to increment")
 
     def runTest(self):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Use wait_until to verify drop counters in the test `arp/test_unknown_mac.py`
Fixes [#103](https://github.com/aristanetworks/sonic-qual.msft/issues/103)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
`arp/test_unknown_mac.py is flaky` fails occasionally with the following signature.

```
    def _verifyIntfCounters(self, pretest=False):
        """
        Collect counters before and after the test and verify them
    
        Args:
            pretest(bool): collect counters before or after the test run
        """
        stats = self._parseCntrs()
        for key, value in list(self.pkt_map.items()):
            intf = value[1]
            if pretest:
                self.pre_rx_drops[intf] = int(stats[intf]['RX_DRP'])
            else:
                actual_cnt = int(stats[intf]['RX_DRP'])
                exp_cnt = self.pre_rx_drops[intf] + TEST_PKT_CNT
&gt;               pytest_assert(actual_cnt &gt;= exp_cnt,
                              "Pkt dropped cnt incorrect for intf {}. Expected: {}, Obtained: {}".format(intf, exp_cnt,
                                                                                                         actual_cnt))
E               Failed: Pkt dropped cnt incorrect for intf Ethernet112. Expected: 10, Obtained: 0

```

The negative packet check for the packet always passes suggesting that the drops are indeed happening and it's not a product issue. The port counters are just taking some time to get updated.

#### How did you do it?
The proposed solution is to use `wait_until` to check drop counters. This approach is also used in other tests like `drop_counters/test_configurable_drop_counters.py`

#### How did you verify/test it?
Ran the test on Arista-7050CX3 platform with dualtor topology and 202305 image.


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

Signed-off-by: Vivek Verma ([vivekverma@arista.com](mailto:vivekverma@arista.com))
