### PR TITLE
Add test_advanced_reboot.py into PR test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -87,6 +87,7 @@ t0:
   - platform_tests/mellanox/test_psu_power_threshold.py
   - platform_tests/mellanox/test_reboot_cause.py
   - platform_tests/sfp/test_sfpshow.py
+  - platform_tests/test_advanced_reboot.py
   - platform_tests/test_auto_negotiation.py
   - platform_tests/test_cont_warm_reboot.py
   - platform_tests/test_cpu_memory_usage.py

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -353,8 +353,8 @@ def run_garp_service(duthost, ptfhost, tbinfo, change_mac_addresses, request):
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     if tbinfo['topo']['type'] == 't0':
         garp_config = {}
-        vlans = config_facts['VLAN']
-        vlan_intfs = config_facts['VLAN_INTERFACE']
+        vlans = config_facts.get('VLAN', {})
+        vlan_intfs = config_facts.get('VLAN_INTERFACE', {})
         dut_mac = ''
         for vlan_details in list(vlans.values()):
             if 'dualtor' in tbinfo['topo']['name']:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Previously, `test_advanced_reboot.py` fails to run on kvm testbed because of the failure of `KeyError:"VLAN"`. There is no vlan config on kvm testbed, so in this PR, we fix this issue. If the key "VLAN" doesn't exist, we will set default value `{}` to it, and add module `test_advanced_reboot.py` into PR test.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Previously, `test_advanced_reboot.py` fails to run on kvm testbed because of the failure of `KeyError:"VLAN"`. There is no vlan config on kvm testbed, so in this PR, we fix this issue. If the key "VLAN" doesn't exist, we will set default value `{}` to it, and add module `test_advanced_reboot.py` into PR test.

#### How did you do it?
Use `get` to get the value of key `VLAN`. If the key "VLAN" doesn't exist, we will set default value `{}` to it. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
