### PR TITLE
[test_dhcp_pkt_recv] Exclude disabled interfaces in test case

### DIFF
--- a/tests/dhcp_relay/test_dhcp_pkt_recv.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_recv.py
@@ -37,7 +37,9 @@ class Dhcpv6PktRecvBase:
 
     @pytest.fixture(scope="class")
     def setup_teardown(self, duthost, tbinfo):
-        ptf_indices = tbinfo['topo']['properties']['topology']['host_interfaces']
+        disabled_host_interfaces = tbinfo['topo']['properties']['topology']['disabled_host_interfaces']
+        ptf_indices = [interface for interface in tbinfo['topo']['properties']['topology']['host_interfaces']
+                       if interface not in disabled_host_interfaces]
         dut_intf_ptf_index = duthost.get_extended_minigraph_facts(tbinfo)['minigraph_ptf_indices']
         yield ptf_indices, dut_intf_ptf_index
 

--- a/tests/dhcp_relay/test_dhcp_pkt_recv.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_recv.py
@@ -37,8 +37,8 @@ class Dhcpv6PktRecvBase:
 
     @pytest.fixture(scope="class")
     def setup_teardown(self, duthost, tbinfo):
-        disabled_host_interfaces = tbinfo['topo']['properties']['topology']['disabled_host_interfaces']
-        ptf_indices = [interface for interface in tbinfo['topo']['properties']['topology']['host_interfaces']
+        disabled_host_interfaces = tbinfo['topo']['properties']['topology'].get('disabled_host_interfaces', [])
+        ptf_indices = [interface for interface in tbinfo['topo']['properties']['topology'].get('host_interfaces', [])
                        if interface not in disabled_host_interfaces]
         dut_intf_ptf_index = duthost.get_extended_minigraph_facts(tbinfo)['minigraph_ptf_indices']
         yield ptf_indices, dut_intf_ptf_index


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
When randomly choice a ptf interface, we didn't exclude disabled interfaces, so the test case may failed on connection issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Test case randomly failed.
#### How did you do it?
Excluded disabled intefaces
#### How did you verify/test it?
Run test cases on DUT
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
