### PR TITLE
Add retry logic for fanout to ToR interface shutdown

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -484,14 +484,14 @@ def _oper_up_dut_intfs(tor_host, dut_intfs):
     are shutdown.
     """
 
-    logger.info("zhangjing: dut_intfs: {}".format(dut_intfs))
+    logger.debug("dut_intfs: {}".format(dut_intfs))
 
     intfs_status = tor_host.show_and_parse("show interface status")
-    logger.info("zhangjing: show interface status: {}".format(intfs_status))
+    logger.debug("show interface status: {}".format(intfs_status))
 
     up_dut_intfs = [intf['interface'] for intf in intfs_status
                     if intf['interface'] in dut_intfs and intf['oper'] == 'up']
-    logger.info("zhangjing: up_dut_intfs: {}".format(up_dut_intfs))
+    logger.debug("up_dut_intfs: {}".format(up_dut_intfs))
 
     return up_dut_intfs
 

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -489,7 +489,8 @@ def _oper_up_dut_intfs(tor_host, dut_intfs):
     intfs_status = tor_host.show_and_parse("show interface status")
     logger.info("zhangjing: show interface status: {}".format(intfs_status))
 
-    up_dut_intfs = [intf for intf in intfs_status if intf['interface'] in dut_intfs and intf['oper'] == 'up']
+    up_dut_intfs = [intf['interface'] for intf in intfs_status
+                    if intf['interface'] in dut_intfs and intf['oper'] == 'up']
     logger.info("zhangjing: up_dut_intfs: {}".format(up_dut_intfs))
 
     return up_dut_intfs

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -58,6 +58,9 @@ ARP_RESPONDER_PY = "arp_responder.py"
 SCRIPTS_SRC_DIR = "scripts/"
 OPT_DIR = "/opt"
 
+EOS_RETRY_MAX = 3
+RETRY_TIMEOUT_SECONDS = 5
+
 
 def get_tor_mux_intfs(duthost):
     return sorted(duthost.get_vlan_intfs(), key=lambda intf: int(intf.replace('Ethernet', '')))
@@ -451,7 +454,45 @@ def _shutdown_fanout_tor_intfs(tor_host, tor_fanouthosts, tbinfo, dut_intfs=None
         fanout_host.shutdown(intf_list)
         fanout_intfs_to_recover[fanout_host].extend(intf_list)
 
+    oper_up_dut_intf = _oper_up_dut_intfs(tor_host, dut_intfs)
+    retry_cnt = 0
+
+    while oper_up_dut_intf and retry_cnt < EOS_RETRY_MAX:
+
+        retry_fanout_shut_intfs = defaultdict(list)
+        for dut_intf in oper_up_dut_intf:
+            encoded_dut_intf = encode_dut_port_name(tor_host.hostname, dut_intf)
+            if encoded_dut_intf in full_dut_fanout_port_map:
+                fanout_host = full_dut_fanout_port_map[encoded_dut_intf]['fanout_host']
+                fanout_intf = full_dut_fanout_port_map[encoded_dut_intf]['fanout_intf']
+                retry_fanout_shut_intfs[fanout_host].append(fanout_intf)
+
+        for fanout_host, intf_list in list(retry_fanout_shut_intfs.items()):
+            fanout_host.shutdown(intf_list)
+            fanout_intfs_to_recover[fanout_host].extend(intf_list)
+
+        retry_cnt += 1
+        time.sleep(RETRY_TIMEOUT_SECONDS)
+
+        oper_up_dut_intf = _oper_up_dut_intfs(tor_host, dut_intfs)
+
     return fanout_shut_intfs
+
+
+def _oper_up_dut_intfs(tor_host, dut_intfs):
+    """Helper function for checking if fanout interfaces that are connected to specified DUT
+    are shutdown.
+    """
+
+    logger.info("zhangjing: dut_intfs: {}".format(dut_intfs))
+
+    intfs_status = tor_host.show_and_parse("show interface status")
+    logger.info("zhangjing: show interface status: {}".format(intfs_status))
+
+    up_dut_intfs = [intf for intf in intfs_status if intf['interface'] in dut_intfs and intf['oper'] == 'up']
+    logger.info("zhangjing: up_dut_intfs: {}".format(up_dut_intfs))
+
+    return up_dut_intfs
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Noticed `test_link_flap` and `dualtor_io/test_link_failure` failures due to unsuccessful fanout link shutdown, adding a retry logic to address.   

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
* Ran test case "dualtor_io/test_link_failure.py::test_active_link_down_upstream", hard coded interface list to have only one intf at the attempt to shutdown 
```
22:41:07 eos.shutdown                             L0087 INFO   | Shut interface [Ethernet34/1]
22:41:10 dual_tor_utils._oper_up_dut_intfs        L0486 INFO   | up_dut_intfs: ['Ethernet8', 'Ethernet12', 'Ethernet16', 'Ethernet20', 'Ethernet24', 'Ethernet28', 'Ethernet32', 'Ethernet36', 'Ethernet40', 'Ethernet44', 'Ethernet48', 'Ethernet52', 'Ethernet56', 'Ethernet60', 'Ethernet64', 'Ethernet68', 'Ethernet72', 'Ethernet76', 'Ethernet80', 'Ethernet84', 'Ethernet88', 'Ethernet92', 'Ethernet96']
```
Triggered retry:
```
22:41:16 eos.shutdown                             L0087 INFO   | Shut interface [Ethernet35/1,Ethernet36/1,Ethernet37/1,Ethernet38/1,Ethernet39/1,Ethernet40/1,Ethernet41/1,Ethernet42/1,Ethernet43/1,Ethernet44/1,Ethernet45/1,Ethernet46/1,Ethernet47/1,Ethernet48/1,Ethernet49/1,Ethernet50/1,Ethernet51/1,Ethernet52/1,Ethernet53/1,Ethernet54/1,Ethernet55/1,Ethernet56/1,Ethernet57/1]
22:41:25 dual_tor_utils._oper_up_dut_intfs        L0486 INFO   | zhangjing: up_dut_intfs: []
```
Test passed: 
```
============= 1 passed, 1 skipped, 3 warnings in 571.74s (0:09:31) =============
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
