### PR TITLE
[dualtor] Fix dualtor bgp update delay due to precision loss in conversion

### DIFF
--- a/tests/dualtor_mgmt/test_dualtor_bgp_update_delay.py
+++ b/tests/dualtor_mgmt/test_dualtor_bgp_update_delay.py
@@ -157,6 +157,8 @@ def test_dualtor_bgp_update_delay(duthost, ip_version, select_bgp_neighbor):
 
     first_update_to_peer_time = datetime.fromtimestamp(float(first_update_to_peer.time))
     first_update_from_peer_time = datetime.fromtimestamp(float(first_update_from_peer.time))
+    logging.debug("The BGP update to peer is sent at %s", first_update_to_peer_time)
+    logging.debug("The BGP update from peer is received at %s", first_update_from_peer_time)
     pytest_assert(
         (first_update_to_peer_time - bgp_startup_time).total_seconds() >= 10,
         "There should be at least 10 seconds of delay between startup BGP session and the first out BGP update"

--- a/tests/dualtor_mgmt/test_dualtor_bgp_update_delay.py
+++ b/tests/dualtor_mgmt/test_dualtor_bgp_update_delay.py
@@ -155,8 +155,8 @@ def test_dualtor_bgp_update_delay(duthost, ip_version, select_bgp_neighbor):
         "Could not find any BGP updates to %s" % bgp_neighbor
     )
 
-    first_update_to_peer_time = datetime.fromtimestamp(first_update_to_peer.time)
-    first_update_from_peer_time = datetime.fromtimestamp(first_update_from_peer.time)
+    first_update_to_peer_time = datetime.fromtimestamp(float(first_update_to_peer.time))
+    first_update_from_peer_time = datetime.fromtimestamp(float(first_update_from_peer.time))
     pytest_assert(
         (first_update_to_peer_time - bgp_startup_time).total_seconds() >= 10,
         "There should be at least 10 seconds of delay between startup BGP session and the first out BGP update"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fix the issue that, when converting packet receive time(`Decimal`) to `datetime` object, the `Decimal` is converted to an integer first, the fraction is lost, which could result in the test failure due to insufficient bgp update delay.

```
>>> from decimal import Decimal
>>> from datetime import datetime
>>> n = 1092.898980
>>> nd = Decimal(n)
>>> datetime.fromtimestamp(n)
datetime.datetime(1970, 1, 1, 0, 18, 12, 898980)
>>> datetime.fromtimestamp(nd)
<stdin>:1: DeprecationWarning: an integer is required (got type decimal.Decimal).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
datetime.datetime(1970, 1, 1, 0, 18, 12)
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Converting to `float` first to keep the factional part.

#### How did you verify/test it?
```
dualtor_mgmt/test_dualtor_bgp_update_delay.py::test_dualtor_bgp_update_delay[ipv4-1-10] PASSED                                                                                                                                                                         [ 10%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
