### PR TITLE
Updated SFP error description test cases to skip SFP which return 'Not supported' message

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -849,6 +849,10 @@ class TestSfpApi(PlatformApiTestBase):
                            "Unable to retrieve transceiver {} error description".format(i)):
                 if "Not implemented" in error_description:
                     pytest.skip("get_error_description isn't implemented. Skip the test")
+                if "Not supported" in error_description:
+                    logger.warning("test_get_error_description: Skipping transceiver {} as error description not "
+                                   "supported on this port)".format(i))
+                    continue
                 if self.expect(isinstance(error_description, str) or isinstance(error_description, str),
                                "Transceiver {} error description appears incorrect".format(i)):
                     self.expect(error_description == "OK", "Transceiver {} is not present".format(i))

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -22,6 +22,8 @@ cmd_sfp_reset = "sudo sfputil reset"
 cmd_sfp_show_lpmode = "sudo sfputil show lpmode"
 cmd_sfp_set_lpmode = "sudo sfputil lpmode"
 
+logger = logging.getLogger(__name__)
+
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
     pytest.mark.topology('any')
@@ -69,6 +71,10 @@ def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_h
     parsed_presence = parse_output(sfp_error_status["stdout_lines"][2:])
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
+            if "Not supported" in sfp_error_status['stdout']:
+                logger.warning("test_check_sfputil_error_status: Skipping transceiver {} as error status not "
+                               "supported on this port)".format(intf))
+                continue
             assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
             assert parsed_presence[intf] == "OK", "Interface error status is not 'OK'"
 
@@ -233,7 +239,7 @@ def test_check_sfputil_low_power_mode(duthosts, enum_rand_one_per_hwsku_frontend
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
             assert intf in parsed_lpmode, "Interface is not in output of '{}'".format(cmd_sfp_show_lpmode)
-            assert parsed_lpmode[intf].lower() == original_lpmode[intf].lower(),\
+            assert parsed_lpmode[intf].lower() == original_lpmode[intf].lower(), \
                 "Unexpected SFP lpmode. actual:{}, expected:{}".format(
                     parsed_lpmode[intf].lower(), original_lpmode[intf].lower())
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When Software control module is enabled in sai.profile, when call SFP API for getting error description or using sfputil tool "Not supported" will be returned

Updates covers this scenario and print warning.
 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Make TC passing
#### How did you do it?
Added handler for "Not supported" 
#### How did you verify/test it?
Run TC, TC passed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
