### PR TITLE
[dualtor-io] Collect syslog for tor failure testcases

### DIFF
--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -154,7 +154,8 @@ def test_standby_tor_reboot_downstream_active(
     Send downstream traffic to the active ToR and reboot the standby ToR.
     Confirm no switchover occurred and no disruption
     """
-    with LogAnalyzer(ansible_host=upper_tor_host,marker_prefix="test_standby_tor_reboot_downstream_active"):
+    with LogAnalyzer(ansible_host=upper_tor_host,
+                     marker_prefix="test_standby_tor_reboot_downstream_active"):
         send_t1_to_server_with_action(
             upper_tor_host, verify=True,
             action=toggle_lower_tor_pdu, stop_after=60

--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -67,26 +67,28 @@ def test_active_tor_reboot_upstream(
     Send upstream traffic and reboot the active ToR. Confirm switchover
     occurred and disruption lasts < 1 second
     """
-    send_server_to_t1_with_action(
-        upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=toggle_upper_tor_pdu, stop_after=60
-    )
-    wait_for_device_reachable(upper_tor_host)
-    wait_for_mux_container(upper_tor_host)
-    wait_for_pmon_container(upper_tor_host)
+    with LogAnalyzer(ansible_host=lower_tor_host,
+                     marker_prefix="test_active_tor_reboot_upstream"):
+        send_server_to_t1_with_action(
+            upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+            action=toggle_upper_tor_pdu, stop_after=60
+        )
+        wait_for_device_reachable(upper_tor_host)
+        wait_for_mux_container(upper_tor_host)
+        wait_for_pmon_container(upper_tor_host)
 
-    if cable_type == CableType.active_standby:
-        verify_tor_states(
-            expected_active_host=lower_tor_host,
-            expected_standby_host=upper_tor_host
-        )
-    elif cable_type == CableType.active_active:
-        verify_tor_states(
-            expected_active_host=[upper_tor_host, lower_tor_host],
-            expected_standby_host=None,
-            cable_type=cable_type,
-            verify_db_timeout=60
-        )
+        if cable_type == CableType.active_standby:
+            verify_tor_states(
+                expected_active_host=lower_tor_host,
+                expected_standby_host=upper_tor_host
+            )
+        elif cable_type == CableType.active_active:
+            verify_tor_states(
+                expected_active_host=[upper_tor_host, lower_tor_host],
+                expected_standby_host=None,
+                cable_type=cable_type,
+                verify_db_timeout=60
+            )
 
 
 @pytest.mark.disable_loganalyzer
@@ -100,17 +102,19 @@ def test_active_tor_reboot_downstream_standby(
     Send downstream traffic to the standby ToR and reboot the active ToR.
     Confirm switchover occurred and disruption lasts < 1 second
     """
-    send_t1_to_server_with_action(
-        lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=toggle_upper_tor_pdu, stop_after=60
-    )
-    wait_for_device_reachable(upper_tor_host)
-    wait_for_mux_container(upper_tor_host)
-    wait_for_pmon_container(upper_tor_host)
-    verify_tor_states(
-        expected_active_host=lower_tor_host,
-        expected_standby_host=upper_tor_host
-    )
+    with LogAnalyzer(ansible_host=lower_tor_host,
+                     marker_prefix="test_active_tor_reboot_downstream_standby"):
+        send_t1_to_server_with_action(
+            lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+            action=toggle_upper_tor_pdu, stop_after=60
+        )
+        wait_for_device_reachable(upper_tor_host)
+        wait_for_mux_container(upper_tor_host)
+        wait_for_pmon_container(upper_tor_host)
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host
+        )
 
 
 @pytest.mark.disable_loganalyzer
@@ -124,17 +128,19 @@ def test_standby_tor_reboot_upstream(
     Send upstream traffic and reboot the standby ToR. Confirm no switchover
     occurred and no disruption
     """
-    send_server_to_t1_with_action(
-        upper_tor_host, verify=True,
-        action=toggle_lower_tor_pdu, stop_after=60
-    )
-    wait_for_device_reachable(lower_tor_host)
-    wait_for_mux_container(lower_tor_host)
-    wait_for_pmon_container(lower_tor_host)
-    verify_tor_states(
-        expected_active_host=upper_tor_host,
-        expected_standby_host=lower_tor_host
-    )
+    with LogAnalyzer(ansible_host=upper_tor_host,
+                     marker_prefix="test_standby_tor_reboot_upstream"):
+        send_server_to_t1_with_action(
+            upper_tor_host, verify=True,
+            action=toggle_lower_tor_pdu, stop_after=60
+        )
+        wait_for_device_reachable(lower_tor_host)
+        wait_for_mux_container(lower_tor_host)
+        wait_for_pmon_container(lower_tor_host)
+        verify_tor_states(
+            expected_active_host=upper_tor_host,
+            expected_standby_host=lower_tor_host
+        )
 
 
 @pytest.mark.disable_loganalyzer
@@ -148,17 +154,18 @@ def test_standby_tor_reboot_downstream_active(
     Send downstream traffic to the active ToR and reboot the standby ToR.
     Confirm no switchover occurred and no disruption
     """
-    send_t1_to_server_with_action(
-        upper_tor_host, verify=True,
-        action=toggle_lower_tor_pdu, stop_after=60
-    )
-    wait_for_device_reachable(lower_tor_host)
-    wait_for_mux_container(lower_tor_host)
-    wait_for_pmon_container(lower_tor_host)
-    verify_tor_states(
-        expected_active_host=upper_tor_host,
-        expected_standby_host=lower_tor_host
-    )
+    with LogAnalyzer(ansible_host=upper_tor_host,marker_prefix="test_standby_tor_reboot_downstream_active"):
+        send_t1_to_server_with_action(
+            upper_tor_host, verify=True,
+            action=toggle_lower_tor_pdu, stop_after=60
+        )
+        wait_for_device_reachable(lower_tor_host)
+        wait_for_mux_container(lower_tor_host)
+        wait_for_pmon_container(lower_tor_host)
+        verify_tor_states(
+            expected_active_host=upper_tor_host,
+            expected_standby_host=lower_tor_host
+        )
 
 
 @pytest.mark.enable_active_active


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
As `loganalyzer` is disabled for tor failure dualtor IO testcases, there is no syslog for debug purpose.
Let's collect syslog to help debug.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Collect syslog in tor failure dualtor IO testcases.

#### How did you verify/test it?
```
dualtor_io/test_tor_failure.py::test_active_tor_reboot_downstream_standby[active-standby-str2-7260cx3-acs-12] PASSED                                                                                                                                                   [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
