### PR TITLE
[202311] Add IPv6-only test case for NTP (#12258)

### DIFF
--- a/ansible/lab
+++ b/ansible/lab
@@ -121,6 +121,7 @@ sonic_s6100:
       ansible_host: 10.251.0.190
     vlab-02:
       ansible_host: 10.250.0.114
+      ansible_hostv6: fec0::ffff:afa:e
 
 sonic_a7260:
   vars:

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -111,7 +111,7 @@ all:
           ansible_user: admin
         vlab-02:
           ansible_host: 10.250.0.114
-          ansible_hostv6: fec0::ffff:afa:2
+          ansible_hostv6: fec0::ffff:afa:e
           type: kvm
           hwsku: Force10-S6100
           serial_port: 9095

--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -44,6 +44,10 @@ class AnsibleHostBase(object):
         else:
             self.host = ansible_adhoc(become=True, *args, **kwargs)[hostname]
             self.mgmt_ip = self.host.options["inventory_manager"].get_host(hostname).vars["ansible_host"]
+            if "ansible_hostv6" in self.host.options["inventory_manager"].get_host(hostname).vars:
+                self.mgmt_ipv6 = self.host.options["inventory_manager"].get_host(hostname).vars["ansible_hostv6"]
+            else:
+                self.mgmt_ipv6 = None
         self.hostname = hostname
 
     def __getattr__(self, module_name):

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -9,6 +9,7 @@ from tests.tacacs.utils import check_output
 from tests.bgp.test_bgp_fact import run_bgp_facts
 from tests.test_features import run_show_features
 from tests.tacacs.test_ro_user import ssh_remote_run
+from tests.ntp.test_ntp import run_ntp, setup_ntp  # noqa F401
 from tests.common.helpers.assertions import pytest_require
 from tests.tacacs.conftest import tacacs_creds, check_tacacs_v6 # noqa F401
 from tests.syslog.test_syslog import run_syslog, check_default_route # noqa F401
@@ -21,6 +22,11 @@ pytestmark = [
     pytest.mark.topology('any'),
     pytest.mark.device_type('vs')
 ]
+
+
+def pytest_generate_tests(metafunc):
+    if "ptf_use_ipv6" in metafunc.fixturenames:
+        metafunc.parametrize("ptf_use_ipv6", [True], scope="module")
 
 
 @pytest.fixture(autouse=True)
@@ -163,3 +169,8 @@ def test_telemetry_output_ipv6_only(convert_and_restore_config_db_to_ipv6_only, 
     inerrors_match = re.search("SAI_PORT_STAT_IF_IN_ERRORS", result)
     pytest_assert(inerrors_match is not None,
                   "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi output")
+
+
+def test_ntp_ipv6_only(duthosts, rand_one_dut_hostname,
+                                  convert_and_restore_config_db_to_ipv6_only, setup_ntp): # noqa F811
+    run_ntp(duthosts, rand_one_dut_hostname, setup_ntp)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Backport of #12258

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

Add support for testing NTP over IPv6. Additionally, test NTP when running with an IPv6-only network.

Also, this fixes the IPv6 address assignment for vlab-02 and makes sure it's given an address on the same subnet as the PTF container.

#### How did you do it?

#### How did you verify/test it?

Tested on KVM and physical DUT with IPv6-only mgmt address.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
