### PR TITLE
Add fixture to detect NTP issue

### DIFF
--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -1,11 +1,13 @@
 import pytest
 import shutil
+import logging
 
 from tests.common.helpers.assertions import pytest_require as pyrequire
 from tests.common.helpers.dut_utils import check_container_state
-from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config, create_ext_conf
+from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config, create_ext_conf, GNMI_SERVER_START_WAIT_TIME
 from tests.generic_config_updater.gu_utils import create_checkpoint, rollback
 
+logger = logging.getLogger(__name__)
 SETUP_ENV_CP = "test_setup_checkpoint"
 
 
@@ -129,3 +131,18 @@ def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost):
     # Rollback configuration
     rollback(duthost, SETUP_ENV_CP)
     recover_cert_config(duthost)
+
+@pytest.fixture(scope="module", autouse=True)
+def check_dut_timestamp(duthosts, rand_one_dut_hostname, localhost):
+    '''
+    Check DUT time to detect NTP issue
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    # Seconds since 1970-01-01 00:00:00 UTC
+    time_cmd = "date +%s"
+    dut_res = duthost.shell(time_cmd, module_ignore_errors=True)
+    local_res = localhost.shell(time_cmd, module_ignore_errors=True)
+    local_time = int(local_res["stdout"])
+    dut_time = int(dut_res["stdout"])
+    logger.info("Local time %d, DUT time %d" % (local_time, dut_time))
+    assert (local_time - dut_time < GNMI_SERVER_START_WAIT_TIME), "DUT time is wrong (%d), please check NTP" % (dut_time - local_time)

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -4,7 +4,8 @@ import logging
 
 from tests.common.helpers.assertions import pytest_require as pyrequire
 from tests.common.helpers.dut_utils import check_container_state
-from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config, create_ext_conf, GNMI_SERVER_START_WAIT_TIME
+from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config, create_ext_conf
+from tests.gnmi.helper import GNMI_SERVER_START_WAIT_TIME
 from tests.generic_config_updater.gu_utils import create_checkpoint, rollback
 
 logger = logging.getLogger(__name__)
@@ -132,6 +133,7 @@ def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost):
     rollback(duthost, SETUP_ENV_CP)
     recover_cert_config(duthost)
 
+
 @pytest.fixture(scope="module", autouse=True)
 def check_dut_timestamp(duthosts, rand_one_dut_hostname, localhost):
     '''
@@ -145,4 +147,5 @@ def check_dut_timestamp(duthosts, rand_one_dut_hostname, localhost):
     local_time = int(local_res["stdout"])
     dut_time = int(dut_res["stdout"])
     logger.info("Local time %d, DUT time %d" % (local_time, dut_time))
-    assert (local_time - dut_time < GNMI_SERVER_START_WAIT_TIME), "DUT time is wrong (%d), please check NTP" % (dut_time - local_time)
+    time_diff = local_time - dut_time
+    assert (time_diff < GNMI_SERVER_START_WAIT_TIME), "DUT time is wrong (%d), please check NTP" % (-time_diff)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
We received a lots of tickets for gnmi end to end test failure, and the root cause is NTP issue and system time is wrong.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
We received a lots of tickets for gnmi end to end test failure, and the root cause is NTP issue and system time is wrong.

#### How did you do it?
Add fixture to check DUT time, and then we don't need to spend time to identify NTP issue.

#### How did you verify/test it?
Run GNMI end to end test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
