### PR TITLE
Upgrade flake8 in pre-commit from 4.0.1 to 6.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: check-ast
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
     -   id: flake8
         args: ["--max-line-length=120"]


### PR DESCRIPTION
### Description of PR

* Flake8 4.0.1 is an old release that depends on Python >3.6 <3.8.1 and has importlib-metadata incompatabilities with Python >3.12. Hence updating Flake8 to a later release so it can be used with later Python releases.

Summary:
Fixes # Not applicable

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Git pre-commit hook uses Flake8 4.0.1 (2021 release) which works with Python >3.6 <3.8 and has specific version dependencies to importlib-metadata. The tool and pre-commit breaks when using later versions of Python (> 3.12). Hence updating pre-commit to use a later version of flake8.

#### How did you do it?
Update pre-commit config

#### How did you verify/test it?
Tested it by running `pre-commit` on changed files.

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
Not applicable.

### Documentation
Not applicable