### PR TITLE
Add check of dut type and kvm support flag in ptf_runner

### DIFF
--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -32,6 +32,14 @@ def ptf_collect(host, log_file, skip_pcap=False):
         allure.attach.file(filename_pcap, 'ptf_pcap: ' + filename_pcap, allure.attachment_type.PCAP)
 
 
+def get_dut_type(host):
+    dut_type_exists = host.stat(path="/sonic/dut_type.txt")
+    if dut_type_exists["stat"]["exists"]:
+        dut_type = host.shell("cat /sonic/dut_type.txt")["stdout"]
+        logger.info("DUT type is {}".format(dut_type))
+        return dut_type.lower()
+
+
 def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                platform="remote", qlen=0, relax=True, debug_level="info",
                socket_recv_size=None, log_file=None, device_sockets=[], timeout=0, custom_options="",
@@ -39,6 +47,11 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
     # Call virtual env ptf for migrated py3 scripts.
     # ptf will load all scripts under ptftests, it will throw error for py2 scripts.
     # So move migrated scripts to seperated py3 folder avoid impacting py2 scripts.
+    dut_type = get_dut_type(host)
+    if dut_type == "kvm" and params.get("kvm_support") is not True:
+        logger.info("Skip test case {} for not support on KVM DUT".format(testname))
+        return True
+
     if is_python3:
         path_exists = host.stat(path="/root/env-python3/bin/ptf")
         if path_exists["stat"]["exists"]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
We are adding more data plane test scripts to PR test, but some traffic test using ptf_runner can't be tested on KVM platform, we need to test configuration and skip ptf_runner test if needed
It's a better approach to get dut type in ptf_runner and use a flag to decide whether the case could be run on KVM dut, and dut type already stored in ptf with PR https://github.com/sonic-net/sonic-mgmt/pull/12588
#### How did you do it?
Get dut_type and kvm_support flag at the beginning of ptf runner, if dut is kvm and kvm_support is false, return True to skip ptf_runner test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
