### PR TITLE
Fix platform_tests/api/test_fan_drawer_fans.py

### DIFF
--- a/tests/platform_tests/api/test_fan_drawer_fans.py
+++ b/tests/platform_tests/api/test_fan_drawer_fans.py
@@ -45,7 +45,8 @@ class TestFanDrawerFans(PlatformApiTestBase):
     # level, so we must do the same here to prevent a scope mismatch.
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, platform_api_conn, duthost):
+    def setup(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         if self.num_fan_drawers is None:
             try:
                 self.num_fan_drawers = chassis.get_num_fan_drawers(platform_api_conn)


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  Fix flaky test platform_tests/api/test_fan_drawer_fans.py
Fixes # [aristanetworks/sonic-qual.msft#106](https://github.com/aristanetworks/sonic-qual.msft/issues/106)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
`setup` fixture in the test class has `duthost` parameter which always points to first ToR device. Thus `stop_thermal_control_daemon(duthost)` which needs for test to pass, is always stopping `thermalctld` for the first ToR device and thus leads to flakiness of the test when runs on second ToR.

#### How did you do it?
Fix: Derive the duthost name based on the test selected ToR (duthosts[enum_rand_one_per_hwsku_hostname]).

#### How did you verify/test it?
Test is consistently passing with the fix (verified on Arista-7260CX3-C64).

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
