### PR TITLE
[cacl] Update acl template to remove IN_PORTS

### DIFF
--- a/tests/common/templates/default_acl_rules.json
+++ b/tests/common/templates/default_acl_rules.json
@@ -19,14 +19,6 @@
                                         "ethertype": "2048",
                                         "vlan_id": "1000"
                                     }
-                                },
-                                "input_interface": {
-                                    "interface_ref":
-                                    {
-                                        "config": {
-                                            "interface": "Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet4,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet8"
-                                        }
-                                    }
                                 }
                             }
                         }

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -983,7 +983,6 @@ def recover_acl_rule(duthost, data_acl):
             acl_entry_config[seq_id]["config"]["sequence-id"] = seq_id
             acl_entry_config[seq_id]["l2"]["config"]["ethertype"] = value["ETHER_TYPE"]
             acl_entry_config[seq_id]["l2"]["config"]["vlan_id"] = value["VLAN_ID"]
-            acl_entry_config[seq_id]["input_interface"]["interface_ref"]["config"]["interface"] = value["IN_PORTS"]
 
     with tempfile.NamedTemporaryFile(suffix=".json", prefix="acl_config", mode="w") as fp:
         json.dump(acl_config, fp)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
DATAACL does not allow IN_PORTS qualifier from 202305 and above. Hence updating the templates used for cacl test to remove the usage of input_interfaces during acl entry creation

#### How did you verify/test it?
Tested against 202305 on t0-backend which has DATAACL along with rules and it passed. Ran the test against a non-backend device which has the DATAACL table and it passed
![image](https://github.com/sonic-net/sonic-mgmt/assets/48968228/d563ee1a-de35-48eb-a46a-e6a3fa02128e)
![image](https://github.com/sonic-net/sonic-mgmt/assets/48968228/4594528f-dfb1-4805-a283-cb6363b7b182)
