### PR TITLE
T2 Chassis - BGP FIB Suppress Pending Testplan

### DIFF
--- a/docs/testplan/BGP-Suppress-FIB-Pending-test-plan-T2-Chassis.md
+++ b/docs/testplan/BGP-Suppress-FIB-Pending-test-plan-T2-Chassis.md
@@ -7,11 +7,12 @@
     + [Supported Topology](#supported-topology)
   * [Test cases](#test-cases)
     + [Test case # 1 - BGPv4 route suppress test](#test-case---1---bgpv4-route-suppress-test)
-    + [Test case # 2 - Test BGP route without suppress](#test-case---2---test-bgp-route-without-suppress)
-    + [Test case # 3 - Test BGP route suppress under negative operation](#test-case---3---test-bgp-route-suppress-under-negative-operation)
-    + [Test case # 4 - Test BGP route suppress in credit loops scenario](#test-case---4---test-bgp-route-suppress-in-credit-loops-scenario)
-    + [Test case # 5 - Test BGP route suppress under stress](#test-case---5---test-bgp-route-suppress-under-stress)
-    + [Test case # 6 - Test BGP route suppress performance](#test-case---6---test-bgp-route-suppress-performance)
+    + [Test case # 2 - BGPv6 route suppress test](#test-case---2---bgpv6-route-suppress-test)    
+    + [Test case # 3 - Test BGP route without suppress](#test-case---3---test-bgp-route-without-suppress)
+    + [Test case # 4 - Test BGP route suppress under negative operation](#test-case---4---test-bgp-route-suppress-under-negative-operation)
+    + [Test case # 5 - Test BGP route suppress in credit loops scenario](#test-case---5---test-bgp-route-suppress-in-credit-loops-scenario)
+    + [Test case # 6 - Test BGP route suppress under stress](#test-case---6---test-bgp-route-suppress-under-stress)
+    + [Test case # 7 - Test BGP route suppress performance](#test-case---7---test-bgp-route-suppress-performance)
 	
 	
 # T2-Chassis: BGP Suppress FIB Pending Test Plan
@@ -72,7 +73,7 @@ kill -SIGSTOP $(pidof orchagent)
 8. Verify packets are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
 9. Suspend orchagent process on both asics to simulate a delay on upstream DUT.
 ```
-kill -SIGCONT $(pidof orchagent)
+kill -SIGSTOP $(pidof orchagent)
 ```
 10. Restore orchagent process on both asics of the downstream dut,
 ```
@@ -88,27 +89,62 @@ kill -SIGCONT $(pidof orchagent)
 ```
 16. Make sure announced BGP routes are __not__ in __queued__ state in the upstream DUT routing table.
 17. Make sure the routes are programmed in FIB by checking offloaded flag value in the upstream DUT routing table.
-18. Verify the routes are announced to all T3 peer neighbors on the upstream linecard.
+18. Verify the routes are announced to all T3 peer neighbors on the upstream DUT.
 19. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
 
-### Test case # 2 - Test BGP route without suppress
+### Test case # 2 - BGPv6 route suppress test
+1. Enable BGP suppress-fib-pending function on all DUTs in multi-dut scenario.
+2. Save configuration and do config reload on DUTs.
+3. Suspend orchagent process on both asics to simulate a delay on downstream DUT.
+```
+kill -SIGSTOP $(pidof orchagent)
+```
+4. Announce BGP ipv6 prefixes to downstream DUT from one of T1 peer using exabgp.
+5. Make sure announced BGP routes are in __queued__ state in the downstream DUT routing table for the specific asic.
+6. Verify the routes are not announced via __IBGP__ or __EBGP__ to any of the peers.
+7. Send traffic matching the prefixes from one of T3 peer.
+8. Verify packets are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
+9. Suspend orchagent process on both asics to simulate a delay on upstream DUT.
+```
+kill -SIGSTOP $(pidof orchagent)
+```
+10. Restore orchagent process on both asics of the downstream dut,
+```
+kill -SIGCONT $(pidof orchagent)
+```
+11. Make sure announced BGP routes are __not__ in __queued__ state in the downstream DUT routing table.
+12. Make sure the routes are programmed in FIB by checking offloaded flag value in the downstream DUT routing table.
+13. Make sure announced BGP routes are in __queued__ state in the upstream DUT routing table for the specific asic.
+14. Verify the routes are not announced via __IBGP__ or __EBGP__ to any of the T3 peers.
+15. Restore orchagent process on both asics of the upstream dut,
+```
+kill -SIGCONT $(pidof orchagent)
+```
+16. Make sure announced BGP routes are __not__ in __queued__ state in the upstream DUT routing table.
+17. Make sure the routes are programmed in FIB by checking offloaded flag value in the upstream DUT routing table.
+18. Verify the routes are announced to all T3 peer neighbors on the upstream DUT.
+19. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
+
+### Test case # 3 - Test BGP route without suppress
 
 1. Disable BGP suppress-fib-pending function at both upstream and downstream DUT(Default configuration).
 2. Suspend orchagent process on both asics to simulate a delay on both upstream and downstream DUTs.
 ```
 kill -SIGSTOP $(pidof orchagent)
 ```
-3. Announce BGP ipv4 prefixes to DUT from one of T1 peer using exabgp.
+3. Announce BGP prefixes to DUT from one of T1 peer using exabgp.
 4. Make sure announced BGP routes are __not__ in __queued__ state on both DUT's routing table.
-5. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
-6.  Restore orchagent process on both asics for both DUTs,
+5. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream DUT.
+6. Send traffic matching the prefixes from one of T3 peer.
+7. Verify packets are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
+8.  Restore orchagent process on both asics for both DUTs,
 ```
 kill -SIGCONT $(pidof orchagent)
 ```
-7. Make sure the routes are programmed in FIB by checking offloaded flag in the upstream and downstream DUT routing table.
-8. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
+9. Make sure the routes are programmed in FIB by checking offloaded flag in the upstream and downstream DUT routing table.
+10. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
 
-### Test case # 3 - Test BGP route suppress under negative operation
+### Test case # 4 - Test BGP route suppress under negative operation
 
 1. Enable BGP suppress-fib-pending function on all DUTs in multi-dut scenario.
 2. Save configuration and do config reload on DUTs.
@@ -116,69 +152,71 @@ kill -SIGCONT $(pidof orchagent)
 ```
 kill -SIGSTOP $(pidof orchagent)
 ```
-4. Announce BGP ipv4 prefixes to downstream DUT from one of T1 peer using exabgp.
+4. Announce BGP prefixes to downstream DUT from one of T1 peer using exabgp.
 5. Execute BGP session restart by restarting all BGP sessions on the downstream DUT.
 6. Verify BGP neighborships are re-established.
 7. Make sure announced BGP routes are in __queued__ state in the downstream DUT routing table
 8. Verify the routes are not announced via __IBGP__ or __EBGP__ to any of the peers. 
-9. Configure static routes then redistribute to BGP.
+9. Configure static route with nexthop as downstream DUT and then redistribute to BGP.
 10. Verify the redistributed routes are in the DUT routing table.
-11. Verify the static routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
-12. Send traffic matching the prefixes from one of T3 peer .
-13. Verify packets are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
-14. Suspend orchagent process on both asics to simulate a delay on upstream DUT.
+11. Verify the static routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream DUT.
+12. Send traffic matching the initial prefixes from one of T3 peer .
+13. Verify packets with intial prefixes are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
+14. Then, send traffic matching the static route prefix from one of the T3 peer.
+15. Make sure traffic with static route prefix are forwarded via downstream DUT as expected.
+16. Suspend orchagent process on both asics to simulate a delay on upstream DUT.
+```
+kill -SIGSTOP $(pidof orchagent)
+```
+17. Restore orchagent process on both asics of the downstream dut,
 ```
 kill -SIGCONT $(pidof orchagent)
 ```
-15. Restore orchagent process on both asics of the downstream dut,
+18. Make sure announced BGP routes are __not__ in __queued__ state in the downstream DUT routing table.
+19. Make sure the routes are programmed in FIB by checking offloaded flag value in the downstream DUT routing table.
+20. Make sure announced BGP routes are in __queued__ state in the upstream DUT routing table for the specific asic.
+21. Verify the routes are not announced via __IBGP__ or __EBGP__ to any of the T3 peers.
+22. Restore orchagent process on both asics of the upstream dut,
 ```
 kill -SIGCONT $(pidof orchagent)
 ```
-16. Make sure announced BGP routes are __not__ in __queued__ state in the downstream DUT routing table.
-17. Make sure the routes are programmed in FIB by checking offloaded flag value in the downstream DUT routing table.
-18. Make sure announced BGP routes are in __queued__ state in the upstream DUT routing table for the specific asic.
-19. Verify the routes are not announced via __IBGP__ or __EBGP__ to any of the T3 peers.
-20. Restore orchagent process on both asics of the upstream dut,
-```
-kill -SIGCONT $(pidof orchagent)
-```
-21. Make sure announced BGP routes are __not__ in __queued__ state in the upstream DUT routing table.
-22. Make sure the routes are programmed in FIB by checking offloaded flag value in the upstream DUT routing table.
-23. Verify the routes are announced to all T3 peer neighbors on the upstream linecard.
-24. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
+23. Make sure announced BGP routes are __not__ in __queued__ state in the upstream DUT routing table.
+24. Make sure the routes are programmed in FIB by checking offloaded flag value in the upstream DUT routing table.
+25. Verify the routes are announced to all T3 peer neighbors on the upstream DUT.
+26. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
 
-### Test case # 4 - Test BGP route suppress in credit loops scenario
+### Test case # 5 - Test BGP route suppress in credit loops scenario
 
 1. Disable BGP suppress-fib-pending function at both upstream and downstream DUT(Default configuration).
-2. Suspend orchagent process on both asics to simulate a delay on the upstream DUT.
+2. Suspend orchagent process on both asics to simulate a delay on the downstream DUT.
 ```
 kill -SIGSTOP $(pidof orchagent)
 ```
 3. Announce BGP prefixes to downstream DUT from one of T1 peer using exabgp.
-4. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
+4. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream DUT.
 5. Send traffic matching the prefixes from the T3 peer and verify packets are forwarded back to the same T3 peer.
 6. Enable BGP suppress-fib-pending function on the downstream DUT.
-7. Restore orchagent process on both asics on the upstream DUT now,
+7. Restore orchagent process on both asics on the downstream DUT now,
 ```
 kill -SIGCONT $(pidof orchagent)
 ```
 8. Make sure the routes are programmed in FIB by checking offloaded flag in the downstream DUT routing table.
 9. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
 
-### Test case # 5 - Test BGP route suppress under stress
+### Test case # 6 - Test BGP route suppress under stress
 
 1. Do BGP route flap 5 times - Announce/Withdraw BGP prefixes from one of T1 peer using exabgp.
 2. Disable BGP suppress-fib-pending function on both upstream and downstream DUT
 3. Send traffic matching the prefixes in the BGP route flap from one of T3 peer and verify packets are forwarded back to the same T3 peer.
-4. Suspend orchagent process to simulate a delay on both asics of the upstream DUT.
+4. Suspend orchagent process to simulate a delay on both asics of the downstream DUT.
 ```
 kill -SIGSTOP $(pidof orchagent)
 ```
 5. Announce 33K BGP prefixes to DUT from T1 peer by exabgp
-6. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
+6. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream DUT.
 7. Send traffic matching the prefixes in the BGP route flap from one of T3 VM and verify packets are forwarded back to the same T3 VM.
 8. Enable BGP suppress-fib-pending function at downstream DUT.
-9. Restore orchagent process on both asics on the upstream DUT now,
+9. Restore orchagent process on both asics on the downstream DUT now,
 ```
 kill -SIGCONT $(pidof orchagent)
 ```
@@ -186,13 +224,19 @@ kill -SIGCONT $(pidof orchagent)
 11. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
 
 
-### Test case # 6 - Test BGP route suppress performance
+### Test case # 7 - Test BGP route suppress performance
 
-1. Enable BGP suppress-fib-pending function at the downstream DUT.
-2. Start tcpdump capture at the ingress and egress port at DUTs
-3. Announce 33K BGP prefixes to DUT from T1 VM by exabgp
-4. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
+1. Enable BGP suppress-fib-pending function on upstream and downstream DUTs.
+2. Start tcpdump capture at the ingress and egress ports of both the DUTs.
+3. Announce 33K BGP prefixes to downstream DUT from T1 VM by exabgp
+4. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream DUT.
 5. Withdraw 33K BGP prefixes to DUT from the same T1 VM using exabgp
 6. Verify the BGP routes are withdrawn from all T3 VM peer neighbors.
-7. Stop tcpdump capture on the DUTs' ingress and egress ports.
-8. Verify the average as well as middle route process time is under threshold.
+7. Stop tcpdump capture on both the DUTs' ingress and egress ports.
+8. Calculate the average and middle route processing time for each of the ipv4 and ipv6 route prefixes announced and withdrawn.
+9. Verify the average as well as middle route process time are under the threshold processing time ~ 3 seconds(T2 Chassis) for each route.
+```
+Note:
+Average route processing time (announced or withdrawn) = Sum of total processing time taken for each route (announced or withdrawn) / Total number of routes (announced or withdrawn)
+Middle route processing time (announced or withdrawn)  = Middle data value(time) in the sorted list of all route processing times data set (either announced or withdrawn)
+```

--- a/docs/testplan/BGP-Suppress-FIB-Pending-test-plan-T2-Chassis.md
+++ b/docs/testplan/BGP-Suppress-FIB-Pending-test-plan-T2-Chassis.md
@@ -48,6 +48,7 @@ Command to disable the feature:
 ```
 admin@sonic:~$ sudo config suppress-fib-pending disabled
 ```
+Note: Issue raised for the above command not working on multi-asic environment globally, https://github.com/sonic-net/sonic-buildimage/issues/19022 . Currently it works only as specific asic commands.
 
 ### Supported Topology
 The tests will be supported on t1 as well as on t2 topo.
@@ -65,8 +66,8 @@ As part of test changes for T2, to be consistent with existing T1 test cases, we
 kill -SIGSTOP $(pidof orchagent)
 ```
 4. Announce BGP ipv4 prefixes to DUT from one of T1 peer using exabgp.
-5. Make sure announced BGP routes are in __queued__ state in the DUT routing table
-6. Verify the routes are not announced via __IBGP__ or __EBGP__ to any of the peers. * (IBGP verification and on both upstream T3, downstream T1 neighbors)
+5. Make sure announced BGP routes are in __queued__ state in the DUT routing table for the specific asic.
+6. Verify the routes are not announced via __IBGP__ or __EBGP__ to any of the peers.
 7. Send traffic matching the prefixes from one of T3 peer .
 8. Verify packets are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
 9. Restore orchagent process on both asics by,
@@ -75,7 +76,7 @@ kill -SIGSTOP $(pidof orchagent)
 ```
 10. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table.
 11. Make sure the routes are programmed in FIB by checking offloaded flag value in the DUT routing table.
-12. Verify the routes are announced to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
+12. Verify the routes are announced to all T3 peer neighbors on the upstream linecard.
 13. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
 
 ### Test case # 2 - Test BGP route without suppress
@@ -86,8 +87,8 @@ kill -SIGSTOP $(pidof orchagent)
 kill -SIGSTOP $(pidof orchagent)
 ```
 3. Announce BGP ipv4 prefixes to DUT from one of T1 peer using exabgp.
-4. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table.
-5. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
+4. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table for the specific asic.
+5. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
 6.  Restore orchagent process on both asics by,
 ```
 kill -SIGSTOP $(pidof orchagent)
@@ -105,12 +106,12 @@ kill -SIGSTOP $(pidof orchagent)
 ```
 4. Announce BGP prefixes to DUT from one of T1 peer using exabgp.
 5. Execute BGP session restart by restarting all BGP sessions on the DUT.
-6. Verify BGP neighborships are reestablished.
+6. Verify BGP neighborships are re-established.
 7. Make sure announced BGP routes are in __queued__ state in the DUT routing table
 8. Verify the routes are not announced via __IBGP__ or __EBGP__ to any of the peers. 
 9. Configure static routes then redistribute to BGP.
 10. Verify the redistributed routes are in the DUT routing table.
-11. Verify the static routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
+11. Verify the static routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
 12. Send traffic matching the prefixes from one of T3 peer .
 13. Verify packets are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
 14. Restore orchagent process on both asics by,
@@ -119,7 +120,7 @@ kill -SIGSTOP $(pidof orchagent)
 ```
 14. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table.
 15. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
-16. Verify the routes are announced to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
+16. Verify the routes are announced to all T3 peer neighbors on the upstream linecard.
 17. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
 
 ### Test case # 4 - Test BGP route suppress in credit loops scenario
@@ -129,18 +130,17 @@ kill -SIGSTOP $(pidof orchagent)
 ```
 kill -SIGSTOP $(pidof orchagent)
 ```
-3. Announce a default route to DUT from one of T3 peer.
-4. Announce BGP prefixes to DUT from one of T1 peer using exabgp.
-5. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
-6. Send traffic matching the prefixes from the T3 peer and verify packets are forwarded back to the same T3 peer.
-7. Enable BGP suppress-fib-pending function on the same DUT
-8. Save configuration and do config reload on DUT.
-9. Restore orchagent process on both asics by,
+3. Announce BGP prefixes to DUT from one of T1 peer using exabgp.
+4. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
+5. Send traffic matching the prefixes from the T3 peer and verify packets are forwarded back to the same T3 peer.
+6. Enable BGP suppress-fib-pending function on the same DUT
+7. Save configuration and do config reload on DUT.
+8. Restore orchagent process on both asics by,
 ```
 kill -SIGSTOP $(pidof orchagent)
 ```
-10. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
-11. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
+9. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
+10. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
 
 ### Test case # 5 - Test BGP route suppress under stress
 
@@ -152,7 +152,7 @@ kill -SIGSTOP $(pidof orchagent)
 kill -SIGSTOP $(pidof orchagent)
 ```
 5. Announce 1K BGP prefixes to DUT from T1 peer by exabgp
-6. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
+6. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
 7. Send traffic matching the prefixes in the BGP route flap from one of T3 VM and verify packets are forwarded back to the same T3 VM.
 8. Enable BGP suppress-fib-pending function at DUT
 9. Restore orchagent process on both asics by,
@@ -169,8 +169,8 @@ kill -SIGSTOP $(pidof orchagent)
 2. Save configuration and do config reload on DUT.
 3. Start tcpdump capture at the ingress and egress port at DUT
 4. Announce 1K BGP prefixes to DUT from T1 VM by exabgp
-5. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
+5. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
 6. Withdraw 1K BGP prefixes to DUT from the same T1 VM using exabgp
-7. Verify the BGP routes are withdrawn from all T3/T1 VM peer neighbors across linecards.
+7. Verify the BGP routes are withdrawn from all T3 VM peer neighbors.
 8. Stop tcpdump capture on the DUT ingress and egress ports.
 9. Verify the average as well as middle route process time is under threshold.

--- a/docs/testplan/BGP-Suppress-FIB-Pending-test-plan-T2-Chassis.md
+++ b/docs/testplan/BGP-Suppress-FIB-Pending-test-plan-T2-Chassis.md
@@ -1,0 +1,186 @@
+- [T2-Chassis: BGP Suppress FIB Pending Test Plan](#t2-chassis--bgp-suppress-fib-pending-test-plan)
+  * [Related documents](#related-documents)
+  * [Overview](#overview)
+    + [Scope](#scope)
+    + [Scale / Performance](#scale---performance)
+    + [Related **DUT** CLI commands](#related---dut---cli-commands)
+    + [Supported Topology](#supported-topology)
+  * [Test cases](#test-cases)
+    + [Test case # 1 - BGPv4 route suppress test](#test-case---1---bgpv4-route-suppress-test)
+    + [Test case # 2 - Test BGP route without suppress](#test-case---2---test-bgp-route-without-suppress)
+    + [Test case # 3 - Test BGP route suppress under negative operation](#test-case---3---test-bgp-route-suppress-under-negative-operation)
+    + [Test case # 4 - Test BGP route suppress in credit loops scenario](#test-case---4---test-bgp-route-suppress-in-credit-loops-scenario)
+    + [Test case # 5 - Test BGP route suppress under stress](#test-case---5---test-bgp-route-suppress-under-stress)
+    + [Test case # 6 - Test BGP route suppress performance](#test-case---6---test-bgp-route-suppress-performance)
+	
+	
+# T2-Chassis: BGP Suppress FIB Pending Test Plan
+
+## Related documents
+
+| **Document Name** | **Link** |
+|-------------------|----------|
+| BGP Suppress FIB Pending HLD | [https://github.com/stepanblyschak/SONiC/blob/bgp-suppress-fib-pending/doc/BGP/BGP-supress-fib-pending.md]|
+| T1 - BGP Suppress FIB Pending| [https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/BGP-Suppress-FIB-Pending-test-plan.md]|
+
+## Overview
+
+This test plan is an extension of the __BGP Suppress FIB Pending Test Plan__ added for T1 DUT at [https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/BGP-Suppress-FIB-Pending-test-plan.md]. 
+
+As of today, SONiC BGP advertises learnt prefixes regardless of whether these prefixes were successfully programmed into ASIC.
+While route programming failure is followed by orchagent crash and all services restart, even for successfully created routes there is a short period of time when the peer will be black holing traffic.
+
+### Scope
+
+The test is to verify the mechanism that allows BGP not to advertise routes that haven't been installed into ASIC yet.
+
+
+### Scale / Performance
+
+No scale/performance test involved in this test plan
+
+### Related **DUT** CLI commands
+Command to enable the feature:
+```
+admin@sonic:~$ sudo config suppress-fib-pending enabled
+```
+Command to disable the feature:
+```
+admin@sonic:~$ sudo config suppress-fib-pending disabled
+```
+
+### Supported Topology
+The tests will be supported on t1 as well as on t2 topo.
+
+
+## Test cases
+
+As part of test changes for T2, to be consistent with existing T1 test cases, we will choose DUT which is connected to downstream T1 neighbors. This is because, on the other line card connected to upstream neighbors, it is not possible to verify traffic not being sent to the neighbor advertising the prefix since there is already a default route pointing to it.
+
+### Test case # 1 - BGPv4 route suppress test
+1. Enable BGP suppress-fib-pending function at DUT.
+2. Save configuration and do config reload on DUT.
+3. Suspend orchagent process on both asics to simulate a delay.
+```
+ docker exec -it swss0 bash -c "supervisorctl stop orchagent"
+ docker exec -it swss1 bash -c "supervisorctl stop orchagent"
+```
+4. Announce BGP ipv4 prefixes to DUT from one of T1 peer using exabgp.
+5. Make sure announced BGP routes are in __queued__ state in the DUT routing table
+6. Verify the routes are not announced via __IBGP__ or __EBGP__ to any of the peers. * (IBGP verification and on both upstream T3, downstream T1 neighbors)
+7. Send traffic matching the prefixes from one of T3 peer .
+8. Verify packets are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
+9. Restore orchagent process on both asics by,
+```
+ docker exec -it swss0 bash -c "supervisorctl start orchagent"
+ docker exec -it swss1 bash -c "supervisorctl start orchagent"
+```
+10. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table.
+11. Make sure the routes are programmed in FIB by checking offloaded flag value in the DUT routing table.
+12. Verify the routes are announced to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
+13. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
+
+### Test case # 2 - Test BGP route without suppress
+
+1. Disable BGP suppress-fib-pending function at DUT.
+2. Suspend orchagent process on both asics to simulate a delay.
+```
+ docker exec -it swss0 bash -c "supervisorctl stop orchagent"
+ docker exec -it swss1 bash -c "supervisorctl stop orchagent"
+```
+3. Announce BGP ipv4 prefixes to DUT from one of T1 peer using exabgp.
+4. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table.
+5. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
+6.  Restore orchagent process on both asics by,
+```
+ docker exec -it swss0 bash -c "supervisorctl start orchagent"
+ docker exec -it swss1 bash -c "supervisorctl start orchagent"
+```
+7. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
+8. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
+
+### Test case # 3 - Test BGP route suppress under negative operation
+
+1. Enable BGP suppress-fib-pending function at DUT.
+2. Save configuration and do config reload on DUT.
+3. Suspend orchagent process on both asics to simulate a delay.
+```
+ docker exec -it swss0 bash -c "supervisorctl stop orchagent"
+ docker exec -it swss1 bash -c "supervisorctl stop orchagent"
+```
+4. Announce BGP prefixes to DUT from one of T1 peer using exabgp.
+5. Execute BGP session restart by restarting all BGP sessions on the DUT.
+6. Verify BGP neighborships are reestablished.
+7. Make sure announced BGP routes are in __queued__ state in the DUT routing table
+8. Verify the routes are not announced via __IBGP__ or __EBGP__ to any of the peers. 
+9. Configure static routes then redistribute to BGP.
+10. Verify the redistributed routes are in the DUT routing table.
+11. Verify the static routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
+12. Send traffic matching the prefixes from one of T3 peer .
+13. Verify packets are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
+14. Restore orchagent process on both asics by,
+```
+ docker exec -it swss0 bash -c "supervisorctl start orchagent"
+ docker exec -it swss1 bash -c "supervisorctl start orchagent"
+```
+14. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table.
+15. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
+16. Verify the routes are announced to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
+17. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
+
+### Test case # 4 - Test BGP route suppress in credit loops scenario
+
+1. Disable BGP suppress-fib-pending function at DUT.
+2. Suspend orchagent process on both asics to simulate a delay.
+```
+ docker exec -it swss0 bash -c "supervisorctl stop orchagent"
+ docker exec -it swss1 bash -c "supervisorctl stop orchagent"
+```
+3. Announce a default route to DUT from one of T3 peer.
+4. Announce BGP prefixes to DUT from one of T1 peer using exabgp.
+5. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
+6. Send traffic matching the prefixes from the T3 peer and verify packets are forwarded back to the same T3 peer.
+7. Enable BGP suppress-fib-pending function on the same DUT
+8. Save configuration and do config reload on DUT.
+9. Restore orchagent process on both asics by,
+```
+ docker exec -it swss0 bash -c "supervisorctl start orchagent"
+ docker exec -it swss1 bash -c "supervisorctl start orchagent"
+```
+10. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
+11. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
+
+### Test case # 5 - Test BGP route suppress under stress
+
+1. Do BGP route flap 5 times - Announce/Withdraw BGP prefixes from one of T1 peer using exabgp.
+2. Disable BGP suppress-fib-pending function on DUT
+3. Send traffic matching the prefixes in the BGP route flap from one of T3 peer and verify packets are forwarded back to the same T3 peer.
+4. Suspend orchagent process to simulate a delay on both asics.
+```
+ docker exec -it swss0 bash -c "supervisorctl stop orchagent"
+ docker exec -it swss1 bash -c "supervisorctl stop orchagent"
+```
+5. Announce 1K BGP prefixes to DUT from T1 peer by exabgp
+6. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
+7. Send traffic matching the prefixes in the BGP route flap from one of T3 VM and verify packets are forwarded back to the same T3 VM.
+8. Enable BGP suppress-fib-pending function at DUT
+9. Restore orchagent process
+```
+ docker exec -it swss0 bash -c "supervisorctl start orchagent"
+ docker exec -it swss1 bash -c "supervisorctl start orchagent"
+```
+10. Verify the routes are programmed in FIB by checking offloaded flag in the DUT routing table
+11. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
+
+
+### Test case # 6 - Test BGP route suppress performance
+
+1. Enable BGP suppress-fib-pending function at DUT.
+2. Save configuration and do config reload on DUT.
+3. Start tcpdump capture at the ingress and egress port at DUT
+4. Announce 1K BGP prefixes to DUT from T1 VM by exabgp
+5. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
+6. Withdraw 1K BGP prefixes to DUT from the same T1 VM using exabgp
+7. Verify the BGP routes are withdrawn from all T3/T1 VM peer neighbors across linecards.
+8. Stop tcpdump capture on the DUT ingress and egress ports.
+9. Verify the average as well as middle route process time is under threshold.

--- a/docs/testplan/BGP-Suppress-FIB-Pending-test-plan-T2-Chassis.md
+++ b/docs/testplan/BGP-Suppress-FIB-Pending-test-plan-T2-Chassis.md
@@ -174,7 +174,7 @@ kill -SIGCONT $(pidof orchagent)
 ```
 kill -SIGSTOP $(pidof orchagent)
 ```
-5. Announce 1K BGP prefixes to DUT from T1 peer by exabgp
+5. Announce 33K BGP prefixes to DUT from T1 peer by exabgp
 6. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
 7. Send traffic matching the prefixes in the BGP route flap from one of T3 VM and verify packets are forwarded back to the same T3 VM.
 8. Enable BGP suppress-fib-pending function at downstream DUT.
@@ -190,9 +190,9 @@ kill -SIGCONT $(pidof orchagent)
 
 1. Enable BGP suppress-fib-pending function at the downstream DUT.
 2. Start tcpdump capture at the ingress and egress port at DUTs
-3. Announce 1K BGP prefixes to DUT from T1 VM by exabgp
+3. Announce 33K BGP prefixes to DUT from T1 VM by exabgp
 4. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
-5. Withdraw 1K BGP prefixes to DUT from the same T1 VM using exabgp
+5. Withdraw 33K BGP prefixes to DUT from the same T1 VM using exabgp
 6. Verify the BGP routes are withdrawn from all T3 VM peer neighbors.
 7. Stop tcpdump capture on the DUTs' ingress and egress ports.
 8. Verify the average as well as middle route process time is under threshold.

--- a/docs/testplan/BGP-Suppress-FIB-Pending-test-plan-T2-Chassis.md
+++ b/docs/testplan/BGP-Suppress-FIB-Pending-test-plan-T2-Chassis.md
@@ -59,118 +59,140 @@ The tests will be supported on t1 as well as on t2 topo.
 As part of test changes for T2, to be consistent with existing T1 test cases, we will choose DUT which is connected to downstream T1 neighbors. This is because, on the other line card connected to upstream neighbors, it is not possible to verify traffic not being sent to the neighbor advertising the prefix since there is already a default route pointing to it.
 
 ### Test case # 1 - BGPv4 route suppress test
-1. Enable BGP suppress-fib-pending function at DUT.
-2. Save configuration and do config reload on DUT.
-3. Suspend orchagent process on both asics to simulate a delay.
+1. Enable BGP suppress-fib-pending function on all DUTs in multi-dut scenario.
+2. Save configuration and do config reload on DUTs.
+3. Suspend orchagent process on both asics to simulate a delay on downstream DUT.
 ```
 kill -SIGSTOP $(pidof orchagent)
 ```
-4. Announce BGP ipv4 prefixes to DUT from one of T1 peer using exabgp.
-5. Make sure announced BGP routes are in __queued__ state in the DUT routing table for the specific asic.
+4. Announce BGP ipv4 prefixes to downstream DUT from one of T1 peer using exabgp.
+5. Make sure announced BGP routes are in __queued__ state in the downstream DUT routing table for the specific asic.
 6. Verify the routes are not announced via __IBGP__ or __EBGP__ to any of the peers.
-7. Send traffic matching the prefixes from one of T3 peer .
+7. Send traffic matching the prefixes from one of T3 peer.
 8. Verify packets are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
-9. Restore orchagent process on both asics by,
+9. Suspend orchagent process on both asics to simulate a delay on upstream DUT.
 ```
 kill -SIGCONT $(pidof orchagent)
 ```
-10. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table.
-11. Make sure the routes are programmed in FIB by checking offloaded flag value in the DUT routing table.
-12. Verify the routes are announced to all T3 peer neighbors on the upstream linecard.
-13. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
+10. Restore orchagent process on both asics of the downstream dut,
+```
+kill -SIGCONT $(pidof orchagent)
+```
+11. Make sure announced BGP routes are __not__ in __queued__ state in the downstream DUT routing table.
+12. Make sure the routes are programmed in FIB by checking offloaded flag value in the downstream DUT routing table.
+13. Make sure announced BGP routes are in __queued__ state in the upstream DUT routing table for the specific asic.
+14. Verify the routes are not announced via __IBGP__ or __EBGP__ to any of the T3 peers.
+15. Restore orchagent process on both asics of the upstream dut,
+```
+kill -SIGCONT $(pidof orchagent)
+```
+16. Make sure announced BGP routes are __not__ in __queued__ state in the upstream DUT routing table.
+17. Make sure the routes are programmed in FIB by checking offloaded flag value in the upstream DUT routing table.
+18. Verify the routes are announced to all T3 peer neighbors on the upstream linecard.
+19. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
 
 ### Test case # 2 - Test BGP route without suppress
 
-1. Disable BGP suppress-fib-pending function at DUT.
-2. Suspend orchagent process on both asics to simulate a delay.
+1. Disable BGP suppress-fib-pending function at both upstream and downstream DUT(Default configuration).
+2. Suspend orchagent process on both asics to simulate a delay on both upstream and downstream DUTs.
 ```
 kill -SIGSTOP $(pidof orchagent)
 ```
 3. Announce BGP ipv4 prefixes to DUT from one of T1 peer using exabgp.
-4. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table for the specific asic.
+4. Make sure announced BGP routes are __not__ in __queued__ state on both DUT's routing table.
 5. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
-6.  Restore orchagent process on both asics by,
+6.  Restore orchagent process on both asics for both DUTs,
 ```
 kill -SIGCONT $(pidof orchagent)
 ```
-7. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
+7. Make sure the routes are programmed in FIB by checking offloaded flag in the upstream and downstream DUT routing table.
 8. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
 
 ### Test case # 3 - Test BGP route suppress under negative operation
 
-1. Enable BGP suppress-fib-pending function at DUT.
-2. Save configuration and do config reload on DUT.
-3. Suspend orchagent process on both asics to simulate a delay.
+1. Enable BGP suppress-fib-pending function on all DUTs in multi-dut scenario.
+2. Save configuration and do config reload on DUTs.
+3. Suspend orchagent process on both asics to simulate a delay on downstream DUT.
 ```
 kill -SIGSTOP $(pidof orchagent)
 ```
-4. Announce BGP prefixes to DUT from one of T1 peer using exabgp.
-5. Execute BGP session restart by restarting all BGP sessions on the DUT.
+4. Announce BGP ipv4 prefixes to downstream DUT from one of T1 peer using exabgp.
+5. Execute BGP session restart by restarting all BGP sessions on the downstream DUT.
 6. Verify BGP neighborships are re-established.
-7. Make sure announced BGP routes are in __queued__ state in the DUT routing table
+7. Make sure announced BGP routes are in __queued__ state in the downstream DUT routing table
 8. Verify the routes are not announced via __IBGP__ or __EBGP__ to any of the peers. 
 9. Configure static routes then redistribute to BGP.
 10. Verify the redistributed routes are in the DUT routing table.
 11. Verify the static routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
 12. Send traffic matching the prefixes from one of T3 peer .
 13. Verify packets are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
-14. Restore orchagent process on both asics by,
+14. Suspend orchagent process on both asics to simulate a delay on upstream DUT.
 ```
 kill -SIGCONT $(pidof orchagent)
 ```
-14. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table.
-15. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
-16. Verify the routes are announced to all T3 peer neighbors on the upstream linecard.
-17. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
+15. Restore orchagent process on both asics of the downstream dut,
+```
+kill -SIGCONT $(pidof orchagent)
+```
+16. Make sure announced BGP routes are __not__ in __queued__ state in the downstream DUT routing table.
+17. Make sure the routes are programmed in FIB by checking offloaded flag value in the downstream DUT routing table.
+18. Make sure announced BGP routes are in __queued__ state in the upstream DUT routing table for the specific asic.
+19. Verify the routes are not announced via __IBGP__ or __EBGP__ to any of the T3 peers.
+20. Restore orchagent process on both asics of the upstream dut,
+```
+kill -SIGCONT $(pidof orchagent)
+```
+21. Make sure announced BGP routes are __not__ in __queued__ state in the upstream DUT routing table.
+22. Make sure the routes are programmed in FIB by checking offloaded flag value in the upstream DUT routing table.
+23. Verify the routes are announced to all T3 peer neighbors on the upstream linecard.
+24. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
 
 ### Test case # 4 - Test BGP route suppress in credit loops scenario
 
-1. Disable BGP suppress-fib-pending function at DUT.
-2. Suspend orchagent process on both asics to simulate a delay.
+1. Disable BGP suppress-fib-pending function at both upstream and downstream DUT(Default configuration).
+2. Suspend orchagent process on both asics to simulate a delay on the upstream DUT.
 ```
 kill -SIGSTOP $(pidof orchagent)
 ```
-3. Announce BGP prefixes to DUT from one of T1 peer using exabgp.
+3. Announce BGP prefixes to downstream DUT from one of T1 peer using exabgp.
 4. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
 5. Send traffic matching the prefixes from the T3 peer and verify packets are forwarded back to the same T3 peer.
-6. Enable BGP suppress-fib-pending function on the same DUT
-7. Save configuration and do config reload on DUT.
-8. Restore orchagent process on both asics by,
+6. Enable BGP suppress-fib-pending function on the downstream DUT.
+7. Restore orchagent process on both asics on the upstream DUT now,
 ```
 kill -SIGCONT $(pidof orchagent)
 ```
-9. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
-10. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
+8. Make sure the routes are programmed in FIB by checking offloaded flag in the downstream DUT routing table.
+9. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
 
 ### Test case # 5 - Test BGP route suppress under stress
 
 1. Do BGP route flap 5 times - Announce/Withdraw BGP prefixes from one of T1 peer using exabgp.
-2. Disable BGP suppress-fib-pending function on DUT
+2. Disable BGP suppress-fib-pending function on both upstream and downstream DUT
 3. Send traffic matching the prefixes in the BGP route flap from one of T3 peer and verify packets are forwarded back to the same T3 peer.
-4. Suspend orchagent process to simulate a delay on both asics.
+4. Suspend orchagent process to simulate a delay on both asics of the upstream DUT.
 ```
 kill -SIGSTOP $(pidof orchagent)
 ```
 5. Announce 1K BGP prefixes to DUT from T1 peer by exabgp
 6. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
 7. Send traffic matching the prefixes in the BGP route flap from one of T3 VM and verify packets are forwarded back to the same T3 VM.
-8. Enable BGP suppress-fib-pending function at DUT
-9. Restore orchagent process on both asics by,
+8. Enable BGP suppress-fib-pending function at downstream DUT.
+9. Restore orchagent process on both asics on the upstream DUT now,
 ```
 kill -SIGCONT $(pidof orchagent)
 ```
-10. Verify the routes are programmed in FIB by checking offloaded flag in the DUT routing table
+10. Verify the routes are programmed in FIB by checking offloaded flag in the downstream DUT routing table
 11. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
 
 
 ### Test case # 6 - Test BGP route suppress performance
 
-1. Enable BGP suppress-fib-pending function at DUT.
-2. Save configuration and do config reload on DUT.
-3. Start tcpdump capture at the ingress and egress port at DUT
-4. Announce 1K BGP prefixes to DUT from T1 VM by exabgp
-5. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
-6. Withdraw 1K BGP prefixes to DUT from the same T1 VM using exabgp
-7. Verify the BGP routes are withdrawn from all T3 VM peer neighbors.
-8. Stop tcpdump capture on the DUT ingress and egress ports.
-9. Verify the average as well as middle route process time is under threshold.
+1. Enable BGP suppress-fib-pending function at the downstream DUT.
+2. Start tcpdump capture at the ingress and egress port at DUTs
+3. Announce 1K BGP prefixes to DUT from T1 VM by exabgp
+4. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
+5. Withdraw 1K BGP prefixes to DUT from the same T1 VM using exabgp
+6. Verify the BGP routes are withdrawn from all T3 VM peer neighbors.
+7. Stop tcpdump capture on the DUTs' ingress and egress ports.
+8. Verify the average as well as middle route process time is under threshold.

--- a/docs/testplan/BGP-Suppress-FIB-Pending-test-plan-T2-Chassis.md
+++ b/docs/testplan/BGP-Suppress-FIB-Pending-test-plan-T2-Chassis.md
@@ -72,7 +72,7 @@ kill -SIGSTOP $(pidof orchagent)
 8. Verify packets are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
 9. Restore orchagent process on both asics by,
 ```
-kill -SIGSTOP $(pidof orchagent)
+kill -SIGCONT $(pidof orchagent)
 ```
 10. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table.
 11. Make sure the routes are programmed in FIB by checking offloaded flag value in the DUT routing table.
@@ -91,7 +91,7 @@ kill -SIGSTOP $(pidof orchagent)
 5. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard.
 6.  Restore orchagent process on both asics by,
 ```
-kill -SIGSTOP $(pidof orchagent)
+kill -SIGCONT $(pidof orchagent)
 ```
 7. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
 8. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
@@ -116,7 +116,7 @@ kill -SIGSTOP $(pidof orchagent)
 13. Verify packets are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
 14. Restore orchagent process on both asics by,
 ```
-kill -SIGSTOP $(pidof orchagent)
+kill -SIGCONT $(pidof orchagent)
 ```
 14. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table.
 15. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
@@ -137,7 +137,7 @@ kill -SIGSTOP $(pidof orchagent)
 7. Save configuration and do config reload on DUT.
 8. Restore orchagent process on both asics by,
 ```
-kill -SIGSTOP $(pidof orchagent)
+kill -SIGCONT $(pidof orchagent)
 ```
 9. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
 10. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
@@ -157,7 +157,7 @@ kill -SIGSTOP $(pidof orchagent)
 8. Enable BGP suppress-fib-pending function at DUT
 9. Restore orchagent process on both asics by,
 ```
-kill -SIGSTOP $(pidof orchagent)
+kill -SIGCONT $(pidof orchagent)
 ```
 10. Verify the routes are programmed in FIB by checking offloaded flag in the DUT routing table
 11. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.

--- a/docs/testplan/BGP-Suppress-FIB-Pending-test-plan-T2-Chassis.md
+++ b/docs/testplan/BGP-Suppress-FIB-Pending-test-plan-T2-Chassis.md
@@ -62,8 +62,7 @@ As part of test changes for T2, to be consistent with existing T1 test cases, we
 2. Save configuration and do config reload on DUT.
 3. Suspend orchagent process on both asics to simulate a delay.
 ```
- docker exec -it swss0 bash -c "supervisorctl stop orchagent"
- docker exec -it swss1 bash -c "supervisorctl stop orchagent"
+kill -SIGSTOP $(pidof orchagent)
 ```
 4. Announce BGP ipv4 prefixes to DUT from one of T1 peer using exabgp.
 5. Make sure announced BGP routes are in __queued__ state in the DUT routing table
@@ -72,8 +71,7 @@ As part of test changes for T2, to be consistent with existing T1 test cases, we
 8. Verify packets are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
 9. Restore orchagent process on both asics by,
 ```
- docker exec -it swss0 bash -c "supervisorctl start orchagent"
- docker exec -it swss1 bash -c "supervisorctl start orchagent"
+kill -SIGSTOP $(pidof orchagent)
 ```
 10. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table.
 11. Make sure the routes are programmed in FIB by checking offloaded flag value in the DUT routing table.
@@ -85,16 +83,14 @@ As part of test changes for T2, to be consistent with existing T1 test cases, we
 1. Disable BGP suppress-fib-pending function at DUT.
 2. Suspend orchagent process on both asics to simulate a delay.
 ```
- docker exec -it swss0 bash -c "supervisorctl stop orchagent"
- docker exec -it swss1 bash -c "supervisorctl stop orchagent"
+kill -SIGSTOP $(pidof orchagent)
 ```
 3. Announce BGP ipv4 prefixes to DUT from one of T1 peer using exabgp.
 4. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table.
 5. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
 6.  Restore orchagent process on both asics by,
 ```
- docker exec -it swss0 bash -c "supervisorctl start orchagent"
- docker exec -it swss1 bash -c "supervisorctl start orchagent"
+kill -SIGSTOP $(pidof orchagent)
 ```
 7. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
 8. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
@@ -105,8 +101,7 @@ As part of test changes for T2, to be consistent with existing T1 test cases, we
 2. Save configuration and do config reload on DUT.
 3. Suspend orchagent process on both asics to simulate a delay.
 ```
- docker exec -it swss0 bash -c "supervisorctl stop orchagent"
- docker exec -it swss1 bash -c "supervisorctl stop orchagent"
+kill -SIGSTOP $(pidof orchagent)
 ```
 4. Announce BGP prefixes to DUT from one of T1 peer using exabgp.
 5. Execute BGP session restart by restarting all BGP sessions on the DUT.
@@ -120,8 +115,7 @@ As part of test changes for T2, to be consistent with existing T1 test cases, we
 13. Verify packets are not forwarded to any T1 peers of downstream line cards. And also make sure packets are forwarded to other T3 peers because of default route.
 14. Restore orchagent process on both asics by,
 ```
- docker exec -it swss0 bash -c "supervisorctl start orchagent"
- docker exec -it swss1 bash -c "supervisorctl start orchagent"
+kill -SIGSTOP $(pidof orchagent)
 ```
 14. Make sure announced BGP routes are __not__ in __queued__ state in the DUT routing table.
 15. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
@@ -133,8 +127,7 @@ As part of test changes for T2, to be consistent with existing T1 test cases, we
 1. Disable BGP suppress-fib-pending function at DUT.
 2. Suspend orchagent process on both asics to simulate a delay.
 ```
- docker exec -it swss0 bash -c "supervisorctl stop orchagent"
- docker exec -it swss1 bash -c "supervisorctl stop orchagent"
+kill -SIGSTOP $(pidof orchagent)
 ```
 3. Announce a default route to DUT from one of T3 peer.
 4. Announce BGP prefixes to DUT from one of T1 peer using exabgp.
@@ -144,8 +137,7 @@ As part of test changes for T2, to be consistent with existing T1 test cases, we
 8. Save configuration and do config reload on DUT.
 9. Restore orchagent process on both asics by,
 ```
- docker exec -it swss0 bash -c "supervisorctl start orchagent"
- docker exec -it swss1 bash -c "supervisorctl start orchagent"
+kill -SIGSTOP $(pidof orchagent)
 ```
 10. Make sure the routes are programmed in FIB by checking offloaded flag in the DUT routing table.
 11. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.
@@ -157,17 +149,15 @@ As part of test changes for T2, to be consistent with existing T1 test cases, we
 3. Send traffic matching the prefixes in the BGP route flap from one of T3 peer and verify packets are forwarded back to the same T3 peer.
 4. Suspend orchagent process to simulate a delay on both asics.
 ```
- docker exec -it swss0 bash -c "supervisorctl stop orchagent"
- docker exec -it swss1 bash -c "supervisorctl stop orchagent"
+kill -SIGSTOP $(pidof orchagent)
 ```
 5. Announce 1K BGP prefixes to DUT from T1 peer by exabgp
 6. Verify the routes are announced via __IBGP__ and __EBGP__ to all T3 peer neighbors on the upstream linecard as well as to all other T1 peers on the downstream linecards including DUT.
 7. Send traffic matching the prefixes in the BGP route flap from one of T3 VM and verify packets are forwarded back to the same T3 VM.
 8. Enable BGP suppress-fib-pending function at DUT
-9. Restore orchagent process
+9. Restore orchagent process on both asics by,
 ```
- docker exec -it swss0 bash -c "supervisorctl start orchagent"
- docker exec -it swss1 bash -c "supervisorctl start orchagent"
+kill -SIGSTOP $(pidof orchagent)
 ```
 10. Verify the routes are programmed in FIB by checking offloaded flag in the DUT routing table
 11. Send traffic matching the prefixes from one of T3 peer and verify packets are forwarded to expected T1 peer only.


### PR DESCRIPTION
**T2 Chassis - BGP FIB Suppress Pending Test Plan**

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This T2 Chassis test plan for BGP FIB suppress pending feature is an extension of the BGP Suppress FIB Pending Test Plan added for T1 DUT at [plan](https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/BGP-Suppress-FIB-Pending-test-plan.md)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The test plan is created to verify the BGP suppress FIB pending feature functionality on a T2 Chassis line card that allows BGP not to advertise routes that haven't been installed into ASIC yet.

#### How did you do it?
Consistent to the existing T1 FIB suppress pending test cases, adapt the tests to verify the functionality on a T2 chassis. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
