### PR TITLE
Print critical process information in the logs

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -802,9 +802,9 @@ def check_processes(duthosts):
             for container_name, processes in list(processes_status.items()):
                 if processes['status'] is False or len(processes['exited_critical_process']) > 0:
                     logger.info("The status of checking process in container '{}' is: {}"
-                        .format(container_name, processes["status"]))
+                                .format(container_name, processes["status"]))
                     logger.info("The processes not running in container '{}' are: '{}'"
-                        .format(container_name, processes["exited_critical_process"]))
+                                .format(container_name, processes["exited_critical_process"]))
                     check_result['failed'] = True
                 check_result["services_status"].update({container_name: processes['status']})
         else:  # Retry checking processes status
@@ -818,9 +818,9 @@ def check_processes(duthosts):
                 for container_name, processes in list(processes_status.items()):
                     if processes['status'] is False or len(processes['exited_critical_process']) > 0:
                         logger.info("The status of checking process in container '{}' is: {}"
-                            .format(container_name, processes["status"]))
+                                    .format(container_name, processes["status"]))
                         logger.info("The processes not running in container '{}' are: '{}'"
-                            .format(container_name, processes["exited_critical_process"]))
+                                    .format(container_name, processes["exited_critical_process"]))
                         check_result['failed'] = True
                     check_result["services_status"].update({container_name: processes['status']})
 

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -799,10 +799,14 @@ def check_processes(duthosts):
             processes_status = dut.all_critical_process_status()
             check_result["processes_status"] = processes_status
             check_result["services_status"] = {}
-            for k, v in list(processes_status.items()):
-                if v['status'] is False or len(v['exited_critical_process']) > 0:
+            for container_name, processes in list(processes_status.items()):
+                if processes['status'] is False or len(processes['exited_critical_process']) > 0:
+                    logger.info("The status of checking process in container '{}' is: {}"
+                        .format(container_name, processes["status"]))
+                    logger.info("The processes not running in container '{}' are: '{}'"
+                        .format(container_name, processes["exited_critical_process"]))
                     check_result['failed'] = True
-                check_result["services_status"].update({k: v['status']})
+                check_result["services_status"].update({container_name: processes['status']})
         else:  # Retry checking processes status
             start = time.time()
             elapsed = 0
@@ -811,10 +815,14 @@ def check_processes(duthosts):
                 processes_status = dut.all_critical_process_status()
                 check_result["processes_status"] = processes_status
                 check_result["services_status"] = {}
-                for k, v in list(processes_status.items()):
-                    if v['status'] is False or len(v['exited_critical_process']) > 0:
+                for container_name, processes in list(processes_status.items()):
+                    if processes['status'] is False or len(processes['exited_critical_process']) > 0:
+                        logger.info("The status of checking process in container '{}' is: {}"
+                            .format(container_name, processes["status"]))
+                        logger.info("The processes not running in container '{}' are: '{}'"
+                            .format(container_name, processes["exited_critical_process"]))
                         check_result['failed'] = True
-                    check_result["services_status"].update({k: v['status']})
+                    check_result["services_status"].update({container_name: processes['status']})
 
                 if check_result["failed"]:
                     wait(interval,


### PR DESCRIPTION
### Description of PR
Currently when a testcase fails due to critical process failure, it is hard to debug why. Adding the log message to make it easier for us to know which process actually fails

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
