### PR TITLE
Revert "[CI/CD]Add topology and device type argument for PR test"

### DIFF
--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -223,21 +223,6 @@ class TestPlanManager(object):
 
         common_extra_params = common_extra_params + " --completeness_level=confident --allow_recover"
 
-        # Add topo and device type args for PR test
-        if test_plan_type == "PR":
-            # Add topo arg
-            if topology in ["t0", "t0-64-32"]:
-                common_extra_params = common_extra_params + " --topology=t0,any"
-            elif topology in ["t1-lag", "t1-8-lag"]:
-                common_extra_params = common_extra_params + " --topology=t1,any"
-            elif topology == "dualtor":
-                common_extra_params = common_extra_params + " --topology=t0,dualtor,any"
-            elif topology == "dpu":
-                common_extra_params = common_extra_params + " --topology=dpu,any"
-
-            # Add device type arg
-            common_extra_params = common_extra_params + " --device_type=vs"
-
         # If triggered by the internal repos, use internal sonic-mgmt repo as the code base
         sonic_mgmt_repo_url = GITHUB_SONIC_MGMT_REPO
         if kwargs.get("source_repo") in INTERNAL_REPO_LIST:


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#12483 because some test scripts were skipped if no device_type mark.