### PR TITLE
[dualtor-aa] Fix set_drop issue with mux_simulator

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -232,14 +232,19 @@ def set_drop_all(url, recover_directions_all):
     A helper function is returned to make fixture accept arguments
     """
     def _set_drop_all(directions):
+        nonlocal is_dropped
         server_url = url(action=DROP)
         data = {"out_sides": directions}
         logger.info("Dropping all packets to {}".format(directions))
         pytest_assert(_post(server_url, data), "Failed to set drop all on {}".format(directions))
+        is_dropped = True
+
+    is_dropped = False
 
     yield _set_drop_all
 
-    recover_directions_all()
+    if is_dropped:
+        recover_directions_all()
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fix  the following `test_link_drop` issue on `dualtor-aa`:
```
def _recover_directions_all():
"""
Function to recover all traffic on all directions on a certain port
Args:
interface_name: a str, the name of interface to control
Returns:
None.
"""
server_url = url(action=OUTPUT)
data = {"out_sides": [UPPER_TOR, LOWER_TOR, NIC]}
>       pytest_assert(_post(server_url, data),
"Failed to set output on all directions for all interfaces")
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As there is no active-standby mux ports on `dualtor-aa`, the drop helper fixture for active-standby mux ports `set_drop_all` is never called. So let's skip the recovery step in `set_drop_all` if `set_drop_all` is not called.

#### How did you verify/test it?
```
dualtor_io/test_link_drop.py::test_active_link_drop_upstream[active-active-lab-****-acs-1] PASSED                                                                                                                                                                  [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
