### PR TITLE
Adding skip for warm and fast reboot cases.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1318,6 +1318,36 @@ snappi_tests/ecn/test_red_accuracy_with_snappi:
     conditions:
       - "topo_type in ['tgen']"
 
+snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot[fast]:
+  skip:
+    reason: "Cisco-8000 supports only cold reboot."
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
+snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot[warm]:
+  skip:
+    reason: "Cisco-8000 supports only cold reboot."
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
+snappi_tests/reboot/test_fast_reboot.py:
+  skip:
+    reason: "Cisco-8000 supports only cold reboot."
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
+snappi_tests/reboot/test_soft_reboot.py:
+  skip:
+    reason: "Cisco-8000 supports only cold reboot."
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
+snappi_tests/reboot/test_warm_reboot.py:
+  skip:
+    reason: "Cisco-8000 supports only cold reboot."
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
 #######################################
 #####            snmp             #####
 #######################################


### PR DESCRIPTION
cisco-8000 doesn't support warm or fast reboots. We need to skip these cases.