### PR TITLE
Cisco: Adding watchdog timeout values for MtFuji platform

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -150,6 +150,13 @@ x86_64-8101_32fh_o-r0:
     greater_timeout: 6553
     too_big_timeout: 6554
 
+# Cisco-Mtfuji watchdog
+x86_64-8102_28fh_dpu_o-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554
+
 x86_64-8111_32eh_o-r0:
   default:
     valid_timeout: 10


### PR DESCRIPTION
Description of PR
Adding watchdog timeout values for Cisco MtFuji platform.
Dependencies: tests/platform_tests/api/test_watchdog.

Approach
What is the motivation for this PR?
Adding watchdog timeout values for Cisco MtFuji platform..

How did you verify/test it?
Verified this on Cisco MtFuji platform (T1 profile)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ X] 202311

