### PR TITLE
Add catalinaDD support sonic mgmt in 202305

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -103,6 +103,9 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
                 or hwsku == "Arista-7050CX3-32S-C32":
             for i in range(1, 33):
                 port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
+        elif hwsku == "Arista-7060DX5-64S":
+            for i in range(1, 65):
+                port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 8)
         elif hwsku == "Mellanox-SN2700-D40C8S8":
             # 10G ports
             s10G_ports = range(0, 4) + range(8, 12)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add catalinaDD support sonic mgmt in 202305. This is a back port for the original PR #9305

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

The port_config.ini defines interface names as alias as follows:
Name Alias
Ethernet0 ... Ethernet1/1
Ethernet8 ... Ethernet2/1

The interface names are 0-based and offset by 8 in comparison to the alias name for the interface

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Add support to SONiC Mgmt test to run on Arista-7060DX5-64S in 202305

#### How did you do it?

#### How did you verify/test it?
Verified in local platform setup

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
NA


