### PR TITLE
Fix in regex to accomodate serial number with '-'

### DIFF
--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -28,7 +28,7 @@ pytestmark = [
 ]
 
 REGEX_MAC_ADDRESS = r'^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$'
-REGEX_SERIAL_NUMBER = r'^[A-Za-z0-9]+$'
+REGEX_SERIAL_NUMBER = r'^[A-Za-z0-9\-]+$'
 REGEX_IP_ADDRESS = r'^(?:[0-9]{1,3}\.){3}([0-9]{1,3})$'
 
 MODULE_TYPE = ['SUPERVISOR', 'LINE-CARD', 'FABRIC-CARD']


### PR DESCRIPTION
#### What is the motivation for this PR?
Failing testcase test_get_system_eeprom_info[str2-xxxx-lc2-1], where the eeprom serial number was having a '-' in the string.

So now the 

#### How did you do it?
Updated the REGEX_SERIAL_NUMBER  in test_module.py. There was a similar definition of REGEX_SERIAL_NUMBER in test_chassis.py which is correct.

#### How did you verify/test it?
Verified the test passes

```
jujoseph@c0248bf93d0e:/var/src/sonic-mgmt-int/tests$ ./run_tests.sh -c platform_tests/api/test_module.py::TestModuleApi::test_get_system_eeprom_info    -d str2-xxxx-lc2-1   -i '../ansible/str2,../ansible/veos' -n vms29-t2-xxxx-1  -t 't2,any' -u -e "--skip_sanity --disable_loganalyzer"
=== Running tests in groups ===
Running: python2 -m pytest platform_tests/api/test_module.py::TestModuleApi::test_get_system_eeprom_info --inventory ../ansible/str2,../ansible/veos --host-pattern str2-xxxx-lc2-1 --testbed vms29-t2-xxxx-1 --testbed_file /var/src/sonic-mgmt-int/ansible/testbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/tr.xml --log-file=logs/test.log --topology t2,any --skip_sanity --disable_loganalyzer
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
===================================================================================================================== test session starts ======================================================================================================================
platform linux2 -- Python 2.7.18, pytest-4.6.11, py-1.11.0, pluggy-0.13.1
ansible: 2.8.20
rootdir: /var/src/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: allure-pytest-2.8.22, metadata-1.11.0, celery-4.4.7, repeat-0.9.1, forked-1.3.0, ansible-2.2.4, html-1.22.1, xdist-1.28.0
collecting ... 
--------------------------------------------------------------------------------------------------------------------- live log collection ----------------------------------------------------------------------------------------------------------------------

PASSED                                                                                                                                                    [100%]

------------------------------------------------------------------------------------------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------------------------
================================================================================================================== 1 passed in 156.59 seconds ==================================================================================================================


jujoseph@c0248bf93d0e:/var/src/sonic-mgmt-int/tests$ ./run_tests.sh -c  platform_tests/api/test_module.py::TestModuleApi::test_get_system_eeprom_info -i '../ansible/str2,../ansible/veos' -n vms21-t0-dx010-7   -t 't0,any' -u -e "--skip_sanity --disable_loganalyzer"
=== Running tests in groups ===
Running: python2 -m pytest platform_tests/api/test_module.py::TestModuleApi::test_get_system_eeprom_info --inventory ../ansible/str2,../ansible/veos --host-pattern str2-dx010-acs-7 --testbed vms21-t0-dx010-7 --testbed_file /var/src/sonic-mgmt-int/ansible/testbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/tr.xml --log-file=logs/test.log --topology t0,any --skip_sanity --disable_loganalyzer
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
============================================================================================ test session starts =============================================================================================
platform linux2 -- Python 2.7.18, pytest-4.6.11, py-1.11.0, pluggy-0.13.1
ansible: 2.8.20
rootdir: /var/src/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: allure-pytest-2.8.22, metadata-1.11.0, celery-4.4.7, repeat-0.9.1, forked-1.3.0, ansible-2.2.4, html-1.22.1, xdist-1.28.0
collecting ... 
-------------------------------------------------------------------------------------------- live log collection ---------------------------------------------------------------------------------------------
03:15:57 testbed.get_testbed_type                 L0261 WARNING| Unsupported testbed type - dpu
03:15:57 testbed.get_testbed_type                 L0261 WARNING| Unsupported testbed type - dpu
03:15:57 testbed.get_testbed_type                 L0261 WARNING| Unsupported testbed type - dpu
03:16:32 testbed.get_testbed_type                 L0261 WARNING| Unsupported testbed type - dpu
03:16:32 testbed.get_testbed_type                 L0261 WARNING| Unsupported testbed type - dpu
03:16:32 testbed.get_testbed_type                 L0261 WARNING| Unsupported testbed type - dpu
SKIPPED                                                                                                [100%]

----------------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml ------------------------------------------------------------------------
========================================================================================== short test summary info ===========================================================================================
SKIPPED [1] platform_tests/api/test_module.py: Only support T2
========================================================================================= 1 skipped in 49.74 seconds =========================================================================================
INFO:root:Can not get Allure report URL. Please check logs

```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
