### PR TITLE
[202205] Ignore apply pathch error in gcu test

### DIFF
--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -142,5 +142,6 @@ def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loga
 
             # sonic-sairedis/vslib/HostInterfaceInfo.cpp: Need investigation
             ".*ERR syncd[0-9]*#syncd.*tap2veth_fun: failed to write to socket.*", # test_portchannel_interface tc2
+            ".*ERR.*'apply-patch' executed failed.*",  # negative cases that are expected to fail
         ]
         loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
In sonic-mgmt E2E test, there are negative cases that are expected to fail, so we just fail apply-patch and didn't record the error in log.err in negative case
But a log.error https://github.com/sonic-net/sonic-utilities/blob/master/config/main.py#L1171 was added in recent change, which cause many failures in GCU test
Cherry pick of PR https://github.com/sonic-net/sonic-mgmt/pull/12656
#### How did you do it?
Ignore apply-patch in GCU test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
