### PR TITLE
[dualtor] adapting `test_mac_move_during_switchover` to dualtor_aa

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -807,7 +807,7 @@ def simulator_flap_counter(url):
     def _simulator_flap_counter(interface_name):
         server_url = url(interface_name, FLAP_COUNTER)
         counter = _get(server_url)
-        assert(counter and len(counter) == 1)
+        assert (counter and len(counter) == 1)
         return list(counter.values())[0]
 
     return _simulator_flap_counter

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -609,7 +609,9 @@ def toggle_all_simulator_ports_to_rand_selected_tor(duthosts, mux_server_url,
 
 
 @pytest.fixture
-def toggle_all_simulator_ports_to_rand_unselected_tor(duthosts, rand_unselected_dut, mux_server_url, tbinfo):
+def toggle_all_simulator_ports_to_rand_unselected_tor(duthosts, rand_unselected_dut,
+                                                      mux_server_url, tbinfo,
+                                                      active_standby_ports):
     """
     A function level fixture to toggle all ports to randomly unselected tor
 
@@ -617,7 +619,7 @@ def toggle_all_simulator_ports_to_rand_unselected_tor(duthosts, rand_unselected_
     is imported in test script. The run_icmp_responder fixture is defined in tests.common.fixtures.ptfhost_utils
     """
     # Skip on non dualtor testbed
-    if 'dualtor' not in tbinfo['topo']['name']:
+    if 'dualtor' not in tbinfo['topo']['name'] or not active_standby_ports:
         return
 
     _toggle_all_simulator_ports_to_target_dut(rand_unselected_dut.hostname, duthosts, mux_server_url, tbinfo)

--- a/tests/dualtor/test_switchover_failure.py
+++ b/tests/dualtor/test_switchover_failure.py
@@ -145,9 +145,6 @@ def common_setup_teardown(
         wait_until(60, 5, 0, rand_selected_dut.critical_services_fully_started)
         wait_until(60, 5, 0, rand_selected_dut.critical_processes_running, "swss")
         wait_until(60, 5, 0, rand_selected_dut.critical_processes_running, "mux")
-        verify_tor_states(
-            rand_unselected_dut, rand_selected_dut, "unhealthy", verify_db_timeout=60
-        )
 
 
 @pytest.mark.enable_active_active
@@ -201,3 +198,6 @@ def test_mac_move_during_switchover(
             intf_names=[common_setup_teardown["intf1"]],
             cable_type=cable_type
         )
+
+    # recover mux conifg
+    rand_selected_dut.shell("config mux mode auto all")

--- a/tests/dualtor/test_switchover_failure.py
+++ b/tests/dualtor/test_switchover_failure.py
@@ -10,6 +10,8 @@ from tests.common.dualtor.mux_simulator_control import (  # noqa: F401
 )
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service  # noqa: F401
 from tests.common.utilities import wait_until
+from tests.common.dualtor.dual_tor_common import cable_type, CableType                                     # noqa F401
+
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +150,7 @@ def common_setup_teardown(
         )
 
 
+@pytest.mark.enable_active_active
 def test_mac_move_during_switchover(
     common_setup_teardown,
     toggle_all_simulator_ports_to_rand_unselected_tor,  # noqa: F811
@@ -156,6 +159,7 @@ def test_mac_move_during_switchover(
     ptfadapter,
     neigh_learn_pkt,
     ip_pkt,
+    cable_type,                                         # noqa: F811
 ):
     """
     Trigger a MAC move during a switchover and verify that the switchover still completes successfully
@@ -166,9 +170,14 @@ def test_mac_move_during_switchover(
     # Pause syncd and trigger a switchover. Since syncd is paused, orchagent will hang (if the bug is present)
     # which allows us to pause orchagent mid-switchover
     rand_selected_dut.control_process("syncd", pause=True)
-    rand_selected_dut.shell(
-        "config mux mode active {}".format(common_setup_teardown["intf1"])
-    )
+    if cable_type == CableType.active_standby:
+        rand_selected_dut.shell(
+            "config mux mode active {}".format(common_setup_teardown["intf1"])
+        )
+    if cable_type == CableType.active_active:
+        rand_selected_dut.shell(
+            "config mux mode standby {}".format(common_setup_teardown["intf1"])
+        )
     rand_selected_dut.control_process("orchagent", pause=True)
 
     # Unpause syncd to process the MAC move
@@ -177,8 +186,18 @@ def test_mac_move_during_switchover(
 
     rand_selected_dut.control_process("orchagent", pause=False)
 
-    verify_tor_states(
-        rand_selected_dut,
-        rand_unselected_dut,
-        intf_names=[common_setup_teardown["intf1"]],
-    )
+    if cable_type == CableType.active_standby:
+        verify_tor_states(
+            rand_selected_dut,
+            rand_unselected_dut,
+            intf_names=[common_setup_teardown["intf1"]],
+            cable_type=cable_type
+        )
+
+    if cable_type == CableType.active_active:
+        verify_tor_states(
+            expected_active_host=rand_unselected_dut,
+            expected_standby_host=rand_selected_dut,
+            intf_names=[common_setup_teardown["intf1"]],
+            cable_type=cable_type
+        )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Adapting `test_mac_move_during_switchover` to dualtor_aa topology.

sign-off: zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?
1. skip `mux_simulator` actions if this is dualtor-aa topo
2. remove `verify_tor_states` in recover step, to avoid flakiness
3. recover mux config after test completes
#### How did you verify/test it?
tested on dualtor-aa topology
```
---------------------------- live log sessionfinish ----------------------------
20:31:29 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
=========================== short test summary info ============================
SKIPPED [2] dualtor/test_switchover_failure.py:152: Skip as no mux ports of 'active-standby' cable type
============= 2 passed, 2 skipped, 2 warnings in 398.90s (0:06:38) =============
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
