### PR TITLE
Adding new pfcwd test with no traffic, no WD.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -950,6 +950,12 @@ pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg:
      conditions:
         - "asic_type in ['cisco-8000']"
 
+pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic:
+   skip:
+     reason: "This test is applicable only for cisco-8000"
+     conditions:
+        - "asic_type != 'cisco-8000'"
+
 pfcwd/test_pfcwd_warm_reboot.py:
    skip:
      reason: "Warm Reboot is not supported in T2."

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -784,6 +784,37 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             logger.info("--- Verify PFCwd counters for port {} ---".format(port))
             self.stats.verify_pkt_cnts(self.pfc_wd['port_type'], self.pfc_wd['test_pkt_count'])
 
+    def run_no_traffic_test(self, dut, port):
+        """
+        No Storm detection with no traffic.
+
+        Args:
+            dut(AnsibleHost) : DUT instance
+            port(string) : DUT port
+
+        Returns:
+            loganalyzer(Loganalyzer) : instance
+        """
+
+        loganalyzer = LogAnalyzer(ansible_host=self.dut,
+                                  marker_prefix="pfc_function_no_storm_detect_port_{}".format(port))
+        marker = loganalyzer.init()
+        ignore_file = os.path.join(TEMPLATES_DIR, "ignore_pfc_wd_messages")
+        reg_exp = loganalyzer.parse_regexp_file(src=ignore_file)
+        loganalyzer.ignore_regex.extend(reg_exp)
+        loganalyzer.expect_regex = []
+        loganalyzer.match_regex = []
+        loganalyzer.match_regex.extend([EXPECT_PFC_WD_DETECT_RE + fetch_vendor_specific_diagnosis_re(dut)])
+
+        restore_time = self.timers['pfc_wd_restore_time_large']
+        detect_time = self.timers['pfc_wd_detect_time']
+        start_wd_on_ports(dut, port, restore_time, detect_time, "drop")
+        self.storm_hndle.start_storm()
+
+        logger.info("Verify if PFC storm is not detected on port {}".format(port))
+        loganalyzer.analyze(marker)
+        return loganalyzer
+
     def set_traffic_action(self, duthost, action):
         action = action if action != "dontcare" else "drop"
         if duthost.facts["asic_type"] in ["mellanox", "cisco-8000"] or is_tunnel_qos_remap_enabled(duthost):
@@ -1136,4 +1167,55 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                     logger.info("--- Disabling fake storm on port {} queue {}".format(port, self.queue_oid))
                     PfcCmd.set_storm_status(self.dut, self.queue_oid, "disabled")
                 logger.info("--- Stop PFCWD ---")
+                self.dut.command("pfcwd stop")
+
+    def test_pfcwd_no_traffic(
+            self, request, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
+            ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+        """
+        Verify the pfcwd is not triggered when no traffic is sent, even when pfc storm is active.
+        Args:
+            request(object) : pytest request object
+            setup_pfc_test(fixture) : Module scoped autouse fixture for PFCwd
+            enum_fanout_graph_facts(fixture) : fanout graph info
+            ptfhost(AnsibleHost) : ptf host instance
+            duthost(AnsibleHost) : DUT instance
+            fanouthosts(AnsibleHost): fanout instance
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        setup_info = setup_pfc_test
+        setup_dut_info = setup_dut_test_params
+        self.fanout_info = enum_fanout_graph_facts
+        self.ptf = ptfhost
+        self.dut = duthost
+        self.fanout = fanouthosts
+        self.timers = setup_info['pfc_timers']
+        self.ports = setup_info['selected_test_ports']
+        self.test_ports_info = setup_info['test_ports']
+        if self.dut.topo_type == 't2':
+            key, value = list(self.ports.items())[0]
+            self.ports = {key: value}
+        self.neighbors = setup_info['neighbors']
+        self.peer_dev_list = dict()
+        self.storm_hndle = None
+        self.rx_action = None
+        self.tx_action = None
+        self.is_dualtor = setup_dut_info['basicParams']['is_dualtor']
+        self.fake_storm = False  # Not needed for this test.
+
+        for idx, port in enumerate(self.ports):
+            logger.info("")
+            logger.info("--- Testing non-Trafific Pfcwd actions on {} ---".format(port))
+            self.setup_test_params(port, setup_info['vlan'], init=not idx)
+
+            pfc_wd_restore_time_large = request.config.getoption("--restore-time")
+            # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.
+            self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)
+            try:
+                self.run_no_traffic_test(self.dut, port)
+            finally:
+                if self.storm_hndle:
+                    logger.info("--- Stop pfc storm on port {}".format(port))
+                    self.storm_hndle.stop_storm()
+                logger.info("--- Stop PFC WD ---")
                 self.dut.command("pfcwd stop")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Recently cisco-8000 PFCWD behaviour was modified - to not trigger the WD when there is no traffic, even when there is a PFC storm. The current tests in pfcwd_function don't cover this case, so we are adding a new test to cover this case.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test gap, where there is no traffic but there is a pfc storm, and WD is not triggered.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [X] 202311

### Approach
#### What is the motivation for this PR?
The new behaviour of pfcwd in cisco-8000 requires a new test.

#### How did you do it?
Added a new test, which verifies that the WD is not triggered, and no syslog is present when there is no traffic.

#### How did you verify/test it?
Ran it on my testbed:
                                                          

pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[mth-t0-64] PASSED                                                                          [ 20%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[mth-t0-64] PASSED                                                                       [ 40%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[mth-t0-64] PASSED                                                                       [ 60%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[mth-t0-64] PASSED                                                                      [ 80%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[mth-t0-64] PASSED                                                                       [100%]
----------------------------------------------------------------------- live log teardown ------------------------------------------------------------------------
18:32:35 conftest.core_dump_and_config_check      L2229 WARNING| Core dump or config check failed for test_pfcwd_function.py, results: {"core_dump_check": {"pass": true, "new_core_dumps": {"mth-t0-64": []}}, "config_db_check": {"pass": false, "pre_only_config": {"mth-t0-64": {"null": {}}}, "cur_only_config": {"mth-t0-64": {"null": {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "400"}}}}}, "inconsistent_config": {"mth-t0-64": {"null": {}}}}}


======================================================================== warnings summary ========================================================================
../../usr/local/lib/python3.8/dist-packages/_yaml/__init__.py:18
  /usr/local/lib/python3.8/dist-packages/_yaml/__init__.py:18: DeprecationWarning: The _yaml extension module is now located at yaml._yaml and its location is subject to change.  To use the LibYAML-based parser and emitter, import from `yaml`: `from yaml import CLoader as Loader, CDumper as Dumper`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
---------------------------------------------- generated xml file: /run_logs/pfcwd-func/tr_2024-05-01-18-09-02.xml -----------------------------------------------
=========================================================== 5 passed, 1 warning in 1574.55s (0:26:14) ============================================================
INFO:root:Can not get Allure report URL. Please check logs

#### Any platform specific information?
Specific to cisco-8000 only.

#### Supported testbed topology if it's a new test case?
Any T0/T1/T2 should work.
