### PR TITLE
fix: add t2 VMs to veos_vtb

### DIFF
--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -65,6 +65,9 @@ all:
         vlab-11:
         vlab-12:
         vlab-8k-01:
+        vlab-t2-01:
+        vlab-t2-02:
+        vlab-t2-sup:
     ptf:
       hosts:
         ptf-01:

--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -213,7 +213,7 @@ foo ALL=(ALL) NOPASSWD:ALL
 
 4. Verify that you can login into the **host** (e.g. `ssh foo@172.17.0.1`, if the default docker bridge IP is `172.18.0.1/16`, follow https://docs.docker.com/network/bridge/#configure-the-default-bridge-network to change it to `172.17.0.1/16`, delete the current `sonic-mgmt` docker using command `docker rm -f <sonic-mgmt_container_name>`, then start over from step 1 of section **Setup sonic-mgmt docker** ) from the `sonic-mgmt` **container** without any password prompt.
 
-5. (Required for IPv6 test cases) Verify that you can login into the **host** via IPv6 (e.g. `ssh foo@fd00:1::1` if the default docker bridge is `fd00:1::1/64`) from the `sonic-mgmt` **container** without any password prompt. 
+5. (Required for IPv6 test cases) Verify that you can login into the **host** via IPv6 (e.g. `ssh foo@fd00:1::1` if the default docker bridge is `fd00:1::1/64`) from the `sonic-mgmt` **container** without any password prompt.
 
 6. Verify that you can use `sudo` without a password prompt inside the **host** (e.g. `sudo bash`).
 

--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -101,18 +101,15 @@ cd sonic-mgmt
 ./setup-container.sh -n <container name> -d /data
 ```
 
-2. (Required for IPv6 test cases): Follow the steps [IPv6 for docker default bridge](https://docs.docker.com/config/daemon/ipv6/#use-ipv6-for-the-default-bridge-network) to enable IPv6 for container. Here is an example which uses ULA address to setup `/etc/docker/daemon.json` if no special requirement or no local docker configuration. Then restart docker daemon to take effect.
+2. (Required for IPv6 test cases): Follow the steps [IPv6 for docker default bridge](https://docs.docker.com/config/daemon/ipv6/#use-ipv6-for-the-default-bridge-network) to enable IPv6 for container. For example, edit the Docker daemon configuration file located at `/etc/docker/daemon.json` with the following parameters to use ULA address if no special requirement. Then restart docker daemon by running `sudo systemctl restart docker` to take effect.
 
-```
-$ sudo bash -c 'cat <<EOF > /etc/docker/daemon.json 
+```json
 {
     "ipv6": true,
     "fixed-cidr-v6": "fd00:1::1/64",
     "experimental": true,
     "ip6tables": true
 }
-EOF'
-$ sudo systemctl restart docker
 ```
 
 3. From now on, **all steps are running inside the sonic-mgmt docker**, unless otherwise specified.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add T2 VMs to `veos_vtb` file to avoid having the following error when running `deploy-mg` for T2 KVM Testbed.

```
TASK [create new minigraph file for SONiC device] ********************************
fatal: [vlab-t2-sup]: FAILED! => {"changed": false, "msg": "Ansible Undefined Variable: 'syslog_servers' is undefined"}
fatal: [vlab-t2-01]: FAILED! => {"changed": false, "msg": "Ansible Undefined Variable: 'syslog_servers' is undefined"}
fatal: [vlab-t2-02]: FAILED! => {"changed": false, "msg": "Ansible Undefined Variable: 'syslog_servers' is undefined"}
```

Besides, this PR also includes a small improvement to the `docs/testbed/README.testbed.VsSetup.md` wording.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
