### PR TITLE
port_alias.py: Handle port_config.ini header change

### DIFF
--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -47,7 +47,7 @@ RETURN = '''
 FILE_PATH = '/usr/share/sonic/device'
 PORTMAP_FILE = 'port_config.ini'
 ALLOWED_HEADER = ['name', 'lanes', 'alias', 'index', 'asic_port_name', 'role', 'speed',
-                  'coreid', 'coreportid', 'numvoq']
+                  'core_id', 'core_port_id', 'num_voq']
 
 MACHINE_CONF = '/host/machine.conf'
 ONIE_PLATFORM_KEY = 'onie_platform'
@@ -143,11 +143,11 @@ class SonicPortAliasMap():
                             role_index = index
                         if 'asic_port_name' in text:
                             asic_name_index = index
-                        if 'coreid' in text:
+                        if 'core_id' in text:
                             port_coreid_index = index
-                        if 'coreportid' in text:
+                        if 'core_port_id' in text:
                             port_core_portid_index = index
-                        if 'numvoq' in text:
+                        if 'num_voq' in text:
                             num_voq_index = index
                         if 'index' in text:
                             port_index = index


### PR DESCRIPTION
In https://github.com/sonic-net/sonic-buildimage/pull/18704 the header of port_config.ini was changed:
```
- # name              lanes     alias               index  role   speed    asic_port_name     coreId     corePortId     numVoq
+ # name              lanes     alias               index  role   speed    asic_port_name     core_id     core_port_id     num_voq
```

But port_alias.py depends on the header names and wasn't updated:
```
ALLOWED_HEADER = ['name', 'lanes', 'alias', 'index', 'asic_port_name', 'role', 'speed',
                  'coreid', 'coreportid', 'numvoq']
```

This PR updates port_alias.py to account for the port_config.ini change.

Summary:
Fixes #12718 

### Type of change
[x] Bug fix
