### PR TITLE
Add module `platform_tests/test_kdump.py` into PR test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -87,6 +87,7 @@ t0:
   - platform_tests/mellanox/test_psu_power_threshold.py
   - platform_tests/mellanox/test_reboot_cause.py
   - platform_tests/sfp/test_sfpshow.py
+  - platform_tests/test_kdump.py
   - platform_tests/test_auto_negotiation.py
   #  Temporarily remove for blocking builimage and take too much time to complete on KVM
   # - platform_tests/test_cont_warm_reboot.py

--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -1,20 +1,9 @@
 import logging
 
 import pytest
-import os
-import sys
 from .pdu_manager import pdu_manager_factory
 from tests.common.utilities import get_host_visible_vars, get_sup_node_or_random_node
 
-SELF_DIR = os.path.dirname(os.path.abspath(__file__))
-BASE_DIR = os.path.realpath(os.path.join(SELF_DIR, ".."))
-if BASE_DIR not in sys.path:
-    sys.path.append(BASE_DIR)
-ANSIBLE_DIR = os.path.realpath(os.path.join(SELF_DIR, "../../../../ansible"))
-if ANSIBLE_DIR not in sys.path:
-    sys.path.append(ANSIBLE_DIR)
-
-from devutil.inv_helpers import HostManager            # noqa E402
 
 logger = logging.getLogger(__name__)
 
@@ -50,9 +39,6 @@ def _get_pdu_controller(duthost, conn_graph_facts, tbinfo):
         inv_mgr = duthost.host.options["inventory_manager"]
         pdu_host = inv_mgr.get_host(duthost.hostname).get_vars().get("pdu_host")
 
-        hostmgr = HostManager(os.path.join(ANSIBLE_DIR, tbinfo['inv_name']))
-        hosts = hostmgr.get_host_list('all', pdu_host)
-
         pdu_links = {}
         pdu_info = {}
         pdu_vars = {}
@@ -62,23 +48,22 @@ def _get_pdu_controller(duthost, conn_graph_facts, tbinfo):
 
         index = 1
         for ph in pdu_host.split(','):
-            if ph in hosts:
-                host_vars = hosts[ph]
-                pdu_links['PSU{}'.format(index)] = {
-                    'N/A': {
-                        'peerdevice': ph,
-                        'peerport': 'probing',
-                        'feed': 'N/A',
-                    }
+            host_vars = inv_mgr.get_host(ph).get_vars()
+            pdu_links['PSU{}'.format(index)] = {
+                'N/A': {
+                    'peerdevice': ph,
+                    'peerport': 'probing',
+                    'feed': 'N/A',
                 }
-                pdu_info[ph] = {
-                    'Hostname': ph,
-                    'Protocol': host_vars['protocol'],
-                    'ManagementIp': host_vars['ansible_host'],
-                    'Type': 'Pdu',
-                }
-                pdu_vars[ph] = host_vars
-                index = index + 1
+            }
+            pdu_info[ph] = {
+                'Hostname': ph,
+                'Protocol': host_vars['protocol'],
+                'ManagementIp': host_vars['ansible_host'],
+                'Type': 'Pdu',
+            }
+            pdu_vars[ph] = host_vars
+            index = index + 1
     else:
         pdu_links = device_pdu_links[hostname]
         pdu_info = device_pdu_info[hostname]

--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -32,6 +32,8 @@ def get_pdu_visible_vars(inventories, pdu_hostnames):
 
 def _get_pdu_controller(duthost, conn_graph_facts):
     hostname = duthost.hostname
+    # To adapt to the kvm testbed, conn_graph_facts is None for kvm.
+    # So we give the default value `{}` to kvm.
     device_pdu_links = conn_graph_facts.get('device_pdu_links', {})
     device_pdu_info = conn_graph_facts.get('device_pdu_info', {})
 

--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -30,7 +30,7 @@ def get_pdu_visible_vars(inventories, pdu_hostnames):
     return pdu_hosts_vars
 
 
-def _get_pdu_controller(duthost, conn_graph_facts, tbinfo):
+def _get_pdu_controller(duthost, conn_graph_facts):
     hostname = duthost.hostname
     device_pdu_links = conn_graph_facts.get('device_pdu_links', {})
     device_pdu_info = conn_graph_facts.get('device_pdu_info', {})
@@ -43,7 +43,7 @@ def _get_pdu_controller(duthost, conn_graph_facts, tbinfo):
 
 
 @pytest.fixture(scope="module")
-def pdu_controller(duthosts, conn_graph_facts, tbinfo):
+def pdu_controller(duthosts, conn_graph_facts):
     """
     @summary: Fixture for controlling power supply to PSUs of DUT
     @param duthost: Fixture duthost defined in sonic-mgmt/tests/conftest.py
@@ -51,7 +51,7 @@ def pdu_controller(duthosts, conn_graph_facts, tbinfo):
               controller_base.py.
     """
     duthost = get_sup_node_or_random_node(duthosts)
-    controller = _get_pdu_controller(duthost, conn_graph_facts, tbinfo)
+    controller = _get_pdu_controller(duthost, conn_graph_facts)
 
     yield controller
 
@@ -62,12 +62,12 @@ def pdu_controller(duthosts, conn_graph_facts, tbinfo):
 
 
 @pytest.fixture(scope="module")
-def get_pdu_controller(conn_graph_facts, tbinfo):
+def get_pdu_controller(conn_graph_facts):
     controller_map = {}
 
     def pdu_controller_helper(duthost):
         if duthost.hostname not in controller_map:
-            controller = _get_pdu_controller(duthost, conn_graph_facts, tbinfo)
+            controller = _get_pdu_controller(duthost, conn_graph_facts)
             controller_map[duthost.hostname] = controller
 
         return controller_map[duthost.hostname]

--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -33,6 +33,10 @@ def get_pdu_visible_vars(inventories, pdu_hostnames):
 def _get_pdu_controller(duthost, conn_graph_facts):
     hostname = duthost.hostname
     # To adapt to the kvm testbed, conn_graph_facts is None for kvm.
+    # Unfortunately, for most DUTs
+    # we will get None because there is no key pdu_host under most of the hosts in iventory.
+    # And although we can get the pdu hosts list of a DUT from inventory
+    # we can not get the hwsku and os of pdu host from inventory.
     # So we give the default value `{}` to kvm.
     device_pdu_links = conn_graph_facts.get('device_pdu_links', {})
     device_pdu_info = conn_graph_facts.get('device_pdu_info', {})

--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -43,8 +43,8 @@ def get_pdu_visible_vars(inventories, pdu_hostnames):
 
 def _get_pdu_controller(duthost, conn_graph_facts, tbinfo):
     hostname = duthost.hostname
-    device_pdu_links = conn_graph_facts['device_pdu_links']
-    device_pdu_info = conn_graph_facts['device_pdu_info']
+    device_pdu_links = conn_graph_facts.get('device_pdu_links', {})
+    device_pdu_info = conn_graph_facts.get('device_pdu_info', {})
     if hostname not in device_pdu_links or hostname not in device_pdu_info:
         # fall back to using inventory
         inv_mgr = duthost.host.options["inventory_manager"]

--- a/tests/common/plugins/pdu_controller/__init__.py
+++ b/tests/common/plugins/pdu_controller/__init__.py
@@ -34,40 +34,10 @@ def _get_pdu_controller(duthost, conn_graph_facts, tbinfo):
     hostname = duthost.hostname
     device_pdu_links = conn_graph_facts.get('device_pdu_links', {})
     device_pdu_info = conn_graph_facts.get('device_pdu_info', {})
-    if hostname not in device_pdu_links or hostname not in device_pdu_info:
-        # fall back to using inventory
-        inv_mgr = duthost.host.options["inventory_manager"]
-        pdu_host = inv_mgr.get_host(duthost.hostname).get_vars().get("pdu_host")
 
-        pdu_links = {}
-        pdu_info = {}
-        pdu_vars = {}
-
-        if pdu_host is None:
-            return pdu_manager_factory(duthost.hostname, pdu_links, pdu_info, pdu_vars)
-
-        index = 1
-        for ph in pdu_host.split(','):
-            host_vars = inv_mgr.get_host(ph).get_vars()
-            pdu_links['PSU{}'.format(index)] = {
-                'N/A': {
-                    'peerdevice': ph,
-                    'peerport': 'probing',
-                    'feed': 'N/A',
-                }
-            }
-            pdu_info[ph] = {
-                'Hostname': ph,
-                'Protocol': host_vars['protocol'],
-                'ManagementIp': host_vars['ansible_host'],
-                'Type': 'Pdu',
-            }
-            pdu_vars[ph] = host_vars
-            index = index + 1
-    else:
-        pdu_links = device_pdu_links[hostname]
-        pdu_info = device_pdu_info[hostname]
-        pdu_vars = get_pdu_visible_vars(duthost.host.options["inventory_manager"]._sources, pdu_info.keys())
+    pdu_links = device_pdu_links.get(hostname, {})
+    pdu_info = device_pdu_info.get(hostname, {})
+    pdu_vars = get_pdu_visible_vars(duthost.host.options["inventory_manager"]._sources, pdu_info.keys())
 
     return pdu_manager_factory(duthost.hostname, pdu_links, pdu_info, pdu_vars)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
To adapt to kvm testbed, there are two isssues in previous pdu_controller __init__.py script:
- conn_graph_facts is None on kvm testbed, and it will generate KeyError when trying to get the value using method `conn_graph_facts["xxx"]`. 
- inv_mgr has no function called `get_host_list`

So in this PR, I fix these issues 
- Use method `get` to get the value in dict `conn_graph_facts` to avoid KeyError and set it `{}` if the key not exists in the dict. 
- The code in branch `if hostname not in device_pdu_links or hostname not in device_pdu_info` is unnecessary here. Because, we use conn_graph_facts to get pdu links and pdu info first. if the hostname not in device_pdu_links or hostname not in device_pdu_info here means the host doesn't not exist in the csv file, so we don't have to get info from inventory. So remove the code in this branch in this PR. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
To adapt to kvm testbed, there are two isssues in previous pdu_controller __init__.py script:
- conn_graph_facts is None on kvm testbed, and it will generate KeyError when trying to get the value using method `conn_graph_facts["xxx"]`. 
- inv_mgr has no function called `get_host_list`

So in this PR, I fix these issues 
- Use method `get` to get the value in dict `conn_graph_facts` to avoid KeyError and set it `{}` if the key not exists in the dict. 
- The code in branch `if hostname not in device_pdu_links or hostname not in device_pdu_info` is unnecessary here. Because, we use conn_graph_facts to get pdu links and pdu info first. if the hostname not in device_pdu_links or hostname not in device_pdu_info here means the host doesn't not exist in the csv file, so we don't have to get info from inventory. So remove the code in this branch in this PR. 

#### How did you do it?
- Use method `get` to get the value in dict `conn_graph_facts` to avoid KeyError and set it `{}` if the key not exists in the dict. 
- Remove the code in branch `if hostname not in device_pdu_links or hostname not in device_pdu_info` in this PR. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
