### PR TITLE
Update the pfcwd test cases according to the new implement of the pfcwd.

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/pfc_wd_background_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/pfc_wd_background_traffic.py
@@ -1,0 +1,77 @@
+import ptf
+import logging
+from ptf.base_tests import BaseTest
+import time
+from ptf.testutils import test_params_get, simple_ip_packet, send_packet
+
+
+class PfcWdBackgroundTrafficTest(BaseTest):
+    def __init__(self):
+        BaseTest.__init__(self)
+        self.test_params = test_params_get()
+
+    def setUp(self):
+        self.dataplane = ptf.dataplane_instance
+        self.router_mac = self.test_params['router_mac']
+        self.pkt_count = int(self.test_params['pkt_count'])
+        self.src_ports = self.test_params['src_ports']
+        self.dst_ports = self.test_params['dst_ports']
+        self.src_ips = self.test_params['src_ips']
+        self.dst_ips = self.test_params['dst_ips']
+        self.queues = self.test_params['queues'] if 'queues' in self.test_params else [3, 4]
+        self.bidirection = self.test_params['bidirection'] if 'bidirection' in self.test_params else True
+
+    def runTest(self):
+        ttl = 64
+        pkts_dict = {}
+        if len(self.dst_ports) > len(self.src_ports):
+            self.src_ports.append(self.src_ports[0])
+            self.src_ips.append(self.src_ips[0])
+        for i in range(len(self.src_ports)):
+            src_port = int(self.src_ports[i])
+            dst_port = int(self.dst_ports[i])
+            if src_port not in pkts_dict:
+                pkts_dict[src_port] = []
+            if dst_port not in pkts_dict:
+                pkts_dict[dst_port] = []
+            src_mac = self.dataplane.get_mac(0, src_port)
+            dst_mac = self.dataplane.get_mac(0, dst_port)
+            for queue in self.queues:
+                print(f"traffic from {src_port} to {dst_port}: {queue} ")
+                logging.info(f"traffic from {src_port} to {dst_port}: {queue} ")
+                pkt = simple_ip_packet(
+                    eth_src=src_mac,
+                    eth_dst=self.router_mac,
+                    ip_src=self.src_ips[i],
+                    ip_dst=self.dst_ips[i],
+                    ip_dscp=queue,
+                    ip_ecn=0,
+                    ip_ttl=ttl
+                )
+                pkts_dict[src_port].append(pkt)
+                if self.bidirection:
+                    print(f"traffic from {dst_port} to {src_port}: {queue} ")
+                    logging.info(f"traffic from {dst_port} to {src_port}: {queue} ")
+                    pkt = simple_ip_packet(
+                        eth_src=dst_mac,
+                        eth_dst=self.router_mac,
+                        ip_src=self.dst_ips[i],
+                        ip_dst=self.src_ips[i],
+                        ip_dscp=queue,
+                        ip_ecn=0,
+                        ip_ttl=ttl
+                    )
+                    pkts_dict[dst_port].append(pkt)
+
+        start = time.time()
+        logging.info("Start to send the background traffic")
+        print("Start to send the background traffic")
+        timeout = 500
+        while True:
+            for port, pkts in pkts_dict.items():
+                for pkt in pkts:
+                    send_packet(self, port, pkt, self.pkt_count)
+
+            now = time.time()
+            if now - start > timeout:
+                break

--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -1,9 +1,13 @@
+import datetime
 import ipaddress
 import sys
 import random
 import pytest
+import contextlib
 
+from tests.ptf_runner import ptf_runner
 from tests.common import constants
+from tests.common.mellanox_data import is_mellanox_device
 
 # If the version of the Python interpreter is greater or equal to 3, set the unicode variable to the str class.
 if sys.version_info[0] >= 3:
@@ -14,8 +18,9 @@ VENDOR_SPEC_ADDITIONAL_INFO_RE = {
     "mellanox":
         r"additional info: occupancy:[0-9]+\|packets:[0-9]+\|packets_last:[0-9]+\|pfc_rx_packets:[0-9]+\|"
         r"pfc_rx_packets_last:[0-9]+\|pfc_duration:[0-9]+\|pfc_duration_last:[0-9]+\|timestamp:[0-9]+\.[0-9]+\|"
-        r"timestamp_last:[0-9]+\.[0-9]+\|real_poll_time:[0-9]+"
+        r"timestamp_last:[0-9]+\.[0-9]+\|(effective|real)_poll_time:[0-9]+"
     }
+
 EXPECT_PFC_WD_RESTORE_RE = ".*storm restored.*"
 
 
@@ -474,3 +479,61 @@ numprocs=1
     except BaseException:
         pass
     ptfhost.command(f'supervisorctl remove {program_name}')
+
+
+@contextlib.contextmanager
+def send_background_traffic(duthost, ptfhost, storm_hndle, selected_test_ports, test_ports_info):
+    """Send background traffic, stop the background traffic when the context finish """
+    if is_mellanox_device(duthost):
+        background_traffic_params = _prepare_background_traffic_params(duthost, storm_hndle,
+                                                                       selected_test_ports,
+                                                                       test_ports_info)
+        background_traffic_log = _send_background_traffic(ptfhost, background_traffic_params)
+    yield
+    if is_mellanox_device(duthost):
+        _stop_background_traffic(ptfhost, background_traffic_log)
+
+
+def _prepare_background_traffic_params(duthost, queues, selected_test_ports, test_ports_info):
+    src_ports = []
+    dst_ports = []
+    src_ips = []
+    dst_ips = []
+    for selected_test_port in selected_test_ports:
+        selected_test_port_info = test_ports_info[selected_test_port]
+        if type(selected_test_port_info["rx_port_id"]) == list:
+            src_ports.append(selected_test_port_info["rx_port_id"][0])
+        else:
+            src_ports.append(selected_test_port_info["rx_port_id"])
+        dst_ports.append(selected_test_port_info["test_port_id"])
+        dst_ips.append(selected_test_port_info["test_neighbor_addr"])
+        src_ips.append(selected_test_port_info["rx_neighbor_addr"])
+
+    router_mac = duthost.get_dut_iface_mac(selected_test_ports[0])
+    pkt_count = 1000
+
+    ptf_params = {'router_mac': router_mac,
+                  'src_ports': src_ports,
+                  'dst_ports': dst_ports,
+                  'src_ips': src_ips,
+                  'dst_ips': dst_ips,
+                  'queues': queues,
+                  'bidirection': False,
+                  'pkt_count': pkt_count}
+
+    return ptf_params
+
+
+def _send_background_traffic(ptfhost, ptf_params):
+    timestamp = datetime.datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+    log_file = "/tmp/pfc_wd_background_traffic.PfcWdBackgroundTrafficTest.{}.log".format(timestamp)
+    ptf_runner(ptfhost, "ptftests", "pfc_wd_background_traffic.PfcWdBackgroundTrafficTest", "/root/ptftests",
+               params=ptf_params, log_file=log_file, is_python3=True, async_mode=True)
+
+    return log_file
+
+
+def _stop_background_traffic(ptfhost, background_traffic_log):
+    pids = ptfhost.shell(f"pgrep -f {background_traffic_log}")["stdout_lines"]
+    for pid in pids:
+        ptfhost.shell(f"kill -9 {pid}", module_ignore_errors=True)

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -17,6 +17,7 @@ from tests.common import port_toggle
 from tests.common import constants
 from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled, dualtor_ports # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m # noqa F401, E501
+from .files.pfcwd_helper import send_background_traffic
 
 
 PTF_PORT_MAPPING_MODE = 'use_orig_interface'
@@ -707,22 +708,27 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         loganalyzer.expect_regex.extend([EXPECT_PFC_WD_DETECT_RE + fetch_vendor_specific_diagnosis_re(dut)])
         loganalyzer.match_regex = []
 
-        if action != "dontcare":
-            start_wd_on_ports(dut, port, restore_time, detect_time, action)
+        selected_test_ports = [self.pfc_wd['rx_port'][0]]
+        test_ports_info = {self.pfc_wd['rx_port'][0]: self.pfc_wd}
+        queues = [self.storm_hndle.pfc_queue_idx]
 
-        if not self.pfc_wd['fake_storm']:
-            self.storm_hndle.start_storm()
+        with send_background_traffic(dut, self.ptf, queues, selected_test_ports, test_ports_info):
+            if action != "dontcare":
+                start_wd_on_ports(dut, port, restore_time, detect_time, action)
 
-        if action == "dontcare":
-            self.traffic_inst.fill_buffer()
-            start_wd_on_ports(dut, port, restore_time, detect_time, "drop")
+            if not self.pfc_wd['fake_storm']:
+                self.storm_hndle.start_storm()
 
-        # placing this here to cover all action types. for 'dontcare' action,
-        # wd is started much later after the pfc storm is started
-        if self.pfc_wd['fake_storm']:
-            PfcCmd.set_storm_status(dut, self.queue_oid, "enabled")
+            if action == "dontcare":
+                self.traffic_inst.fill_buffer()
+                start_wd_on_ports(dut, port, restore_time, detect_time, "drop")
 
-        time.sleep(5)
+            # placing this here to cover all action types. for 'dontcare' action,
+            # wd is started much later after the pfc storm is started
+            if self.pfc_wd['fake_storm']:
+                PfcCmd.set_storm_status(dut, self.queue_oid, "enabled")
+
+            time.sleep(5)
 
         # storm detect
         logger.info("Verify if PFC storm is detected on port {}".format(port))


### PR DESCRIPTION
Update the pfcwd test cases according to the new implement of the pfcwd
After the feature is completed, it criteria to trigger the pfcwd is much more strict than previous on Nvidia platform, So adjust the test case to properly trigger the pfcwd. The solution is to send background traffic during the pfc frame is sent from the fanout.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
To make the pfcwd test case could pass after the new implement of the pfcwd.

#### How did you do it?
Add the logic of sending the background traffic to make the test case could pass after the new implement of the pfcwd

#### How did you verify/test it?
All pfcwd test case could pass
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
