### PR TITLE
Add buffer queue counters test case to telemetry test

### DIFF
--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -43,7 +43,6 @@ def get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, gnmi_port):
             '.format(dut_ip, gnmi_port, i)
         
         cmd_output = ptfhost.shell(cmd, module_ignore_errors=True)
-        stdout_output = cmd_output["stdout"]
         
         if not cmd_output["failed"]:
             cnt += 1
@@ -119,8 +118,8 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
             "Skipping test as no Ethernet0 frontpanel port on supervisor")
     logger.info('start telemetry output testing')
     dut_ip = duthost.mgmt_ip
-    cmd = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m get -x COUNTERS/Ethernet0 -xt COUNTERS_DB \
-           -o "ndastreamingservertest"'.format(dut_ip, env.gnmi_port)
+    cmd = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m get -x COUNTERS/Ethernet0 -xt \
+        COUNTERS_DB -o "ndastreamingservertest"'.format(dut_ip, env.gnmi_port)
     show_gnmi_out = ptfhost.shell(cmd)['stdout']
     logger.info("GNMI Server output")
     logger.info(show_gnmi_out)
@@ -132,7 +131,7 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                         setup_streaming_telemetry, gnxi_path):
+                                    setup_streaming_telemetry, gnxi_path):
     """
     Run pyclient from ptfdocker and check number of queue counters to check
     correctness of the feature of polling only configured port buffer queues.

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -165,7 +165,7 @@ def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, 
     pre_del_cnt = get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, env.gnmi_port)
 
     # Remove buffer queue and reload and get new number of queue counters
-    buffer_queues = data['BUFFER_QUEUE'].keys()
+    buffer_queues = list(data['BUFFER_QUEUE'].keys())
     del data['BUFFER_QUEUE'][buffer_queues[0]]
     load_new_cfg(duthost, data)
     post_del_cnt = get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, env.gnmi_port)

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -166,7 +166,9 @@ def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, 
 
     # Remove buffer queue and reload and get new number of queue counters
     buffer_queues = list(data['BUFFER_QUEUE'].keys())
-    del data['BUFFER_QUEUE'][buffer_queues[0]]
+    eth0 = "Ethernet0"
+    eth0_buffer_queues = [bq for bq in buffer_queues if eth0 in bq]
+    del data['BUFFER_QUEUE'][eth0_buffer_queues[0]]
     load_new_cfg(duthost, data)
     post_del_cnt = get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, env.gnmi_port)
 

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -162,6 +162,7 @@ def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, 
     # to removing buffer queues
     data['DEVICE_METADATA']["localhost"]["create_only_config_db_buffers"] \
         = "true"
+    data['BUFFER_QUEUE']["Ethernet0|3-4"]["profile"] = "egress_lossless_profile"
     load_new_cfg(duthost, data)
     pre_del_cnt = get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, env.gnmi_port)
 

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -165,7 +165,8 @@ def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, 
     pre_del_cnt = get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, env.gnmi_port)
 
     # Remove buffer queue and reload and get new number of queue counters
-    del data['BUFFER_QUEUE'][0]
+    buffer_queues = data['BUFFER_QUEUE'].keys()
+    del data['BUFFER_QUEUE'][buffer_queues[0]]
     load_new_cfg(duthost, data)
     post_del_cnt = get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, env.gnmi_port)
 

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -167,7 +167,7 @@ def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, 
     # Remove buffer queue and reload and get new number of queue counters
     buffer_queues = list(data['BUFFER_QUEUE'].keys())
     eth0 = "Ethernet0"
-    eth0_buffer_queues = [bq for bq in buffer_queues if eth0 in bq]
+    eth0_buffer_queues = [bq for bq in buffer_queues if any(val in eth0 for val in bq.split('|'))]
     del data['BUFFER_QUEUE'][eth0_buffer_queues[0]]
     load_new_cfg(duthost, data)
     post_del_cnt = get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, env.gnmi_port)

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -41,12 +41,12 @@ def get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, gnmi_port):
             -p {1} -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:{2} \
             -xt COUNTERS_DB -o "ndastreamingservertest" \
             '.format(dut_ip, gnmi_port, i)
-        
+
         cmd_output = ptfhost.shell(cmd, module_ignore_errors=True)
-        
+
         if not cmd_output["failed"]:
             cnt += 1
-            
+
     return cnt
 
 
@@ -156,7 +156,7 @@ def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, 
     duthost.shell("sonic-cfggen -d --print-data > {}".format(ORIG_CFG_DB))
     data = json.loads(duthost.shell("cat {}".format(ORIG_CFG_DB),
                                     verbose=False)['stdout'])
-    
+
     # Add create_only_config_db_buffers entry to device metadata to enable
     # counters optimization and get number of queue counters of Ethernet0 prior
     # to removing buffer queues

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -4,12 +4,13 @@ import logging
 import re
 import pytest
 import random
-
+import json
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from telemetry_utils import assert_equal, get_list_stdout, get_dict_stdout, skip_201911_and_older
 from telemetry_utils import generate_client_cli, parse_gnmi_output, check_gnmi_cli_running
+from tests.common import config_reload
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -22,6 +23,32 @@ METHOD_GET = "get"
 MEMORY_CHECKER_WAIT = 1
 MEMORY_CHECKER_CYCLES = 60
 SUBMODE_ONCHANGE = 1
+CFG_DB_PATH = "/etc/sonic/config_db.json"
+ORIG_CFG_DB = "/etc/sonic/orig_config_db.json"
+MAX_UC_CNT = 7
+BUFFER_QUEUES_REMOVED = 2
+
+
+def load_new_cfg(duthost, data):
+    duthost.copy(content=json.dumps(data, indent=4), dest=CFG_DB_PATH)
+    config_reload(duthost, config_source='config_db', safe_reload=True)
+
+
+def get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, gnmi_port):
+    cnt = 0
+    for i in range(MAX_UC_CNT):
+        cmd = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} \
+            -p {1} -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:{2} \
+            -xt COUNTERS_DB -o "ndastreamingservertest" \
+            '.format(dut_ip, gnmi_port, i)
+        
+        cmd_output = ptfhost.shell(cmd, module_ignore_errors=True)
+        stdout_output = cmd_output["stdout"]
+        
+        if not cmd_output["failed"]:
+            cnt += 1
+            
+    return cnt
 
 
 def test_config_db_parameters(duthosts, enum_rand_one_per_hwsku_hostname):
@@ -101,6 +128,52 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
     inerrors_match = re.search("SAI_PORT_STAT_IF_IN_ERRORS", result)
     pytest_assert(inerrors_match is not None,
                   "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi_output")
+
+
+@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
+def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
+                         setup_streaming_telemetry, gnxi_path):
+    """
+    Run pyclient from ptfdocker and check number of queue counters to check
+    correctness of the feature of polling only configured port buffer queues.
+        - Set "create_only_config_db_buffers" to true in config db, to create
+      only relevant counters
+        - Remove one of the buffer queues, Ethernet0|3-4 is chosen arbitrary
+        - Using gnmi to query COUNTERS_QUEUE_NAME_MAP for Ethernet0 compare
+        number of queue counters on Ethernet0. It is expected that it will
+        decrease by the number of deleted queue buffers.
+    This test covers the issue: 'The feature "polling only configured ports
+    buffer queue" will break SNMP'
+    https://github.com/sonic-net/sonic-buildimage/issues/17448
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
+    if duthost.is_supervisor_node():
+        pytest.skip(
+            "Skipping test as no Ethernet0 frontpanel port on supervisor")
+    logger.info('start telemetry output testing')
+    dut_ip = duthost.mgmt_ip
+
+    duthost.shell("sonic-cfggen -d --print-data > {}".format(ORIG_CFG_DB))
+    data = json.loads(duthost.shell("cat {}".format(ORIG_CFG_DB),
+                                    verbose=False)['stdout'])
+    
+    # Add create_only_config_db_buffers entry to device metadata to enable
+    # counters optimization and get number of queue counters of Ethernet0 prior
+    # to removing buffer queues
+    data['DEVICE_METADATA']["localhost"]["create_only_config_db_buffers"] \
+        = "true"
+    load_new_cfg(duthost, data)
+    pre_del_cnt = get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, env.gnmi_port)
+
+    # Remove buffer queue and reload and get number of queue counters of
+    # Ethernet0 after removing two buffer queues
+    del data['BUFFER_QUEUE']["Ethernet0|3-4"]
+    load_new_cfg(duthost, data)
+    post_del_cnt = get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, env.gnmi_port)
+
+    pytest_assert((pre_del_cnt - post_del_cnt) == BUFFER_QUEUES_REMOVED,
+                  "Number of queue counters count differs from expected")
 
 
 def test_osbuild_version(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):


### PR DESCRIPTION
### Description of PR
This test is checking that the number of buffer queue counters from telemetry point of view is inline when using create_only_config_db_counters optimization.

Summary:
Accompanies "Fix SNMP dropping some of the queue counter when create_only_config_db_buffers is set to true" (https://github.com/sonic-net/sonic-snmpagent/pull/303) which fixes the issue: "The feature "polling only configured ports buffer queue" will break SNMP" (https://github.com/sonic-net/sonic-buildimage/issues/17448).
Accompanies "Test polling only configured buffer queue counters" https://github.com/sonic-net/sonic-mgmt/pull/11941


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
To enhance the bug fix mentioned above, solving an issue with buffer queue counters optimization.
#### How did you do it?

- Set "create_only_config_db_buffers" to true in config db, to create only relevant counters
- Remove one of the buffer queues, Ethernet0|3-4 is chosen arbitrary
- Using gnmi to query COUNTERS_QUEUE_NAME_MAP for Ethernet0 compare number of queue counters on Ethernet0. It is expected that it will decrease by the number of deleted queue buffers.
#### How did you verify/test it?
Run the test multiple times on various setups.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Any
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
