### PR TITLE
[backend] Skip po2vlan scenarios and modify acl usage for backend

### DIFF
--- a/tests/common/helpers/portchannel_to_vlan.py
+++ b/tests/common/helpers/portchannel_to_vlan.py
@@ -11,7 +11,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses    # noqa F
 from tests.common.fixtures.duthost_utils import ports_list   # noqa F401
 from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_orig          # noqa F401
 from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_add
-from tests.common.helpers.backend_acl import apply_acl_rules, bind_acl_table
+from tests.common.helpers.backend_acl import bind_acl_table
 from tests.common.checkpoint import create_checkpoint, rollback
 from tests.common.utilities import check_skip_release
 
@@ -361,7 +361,7 @@ def acl_rule_cleanup(duthost, tbinfo):
     """Cleanup all the existing DATAACL rules"""
     # remove all rules under the ACL_RULE table
     if "t0-backend" in tbinfo["topo"]["name"]:
-        duthost.shell('acl-loader delete')
+        duthost.shell('acl-loader delete DATAACL')
 
     yield
 
@@ -375,7 +375,6 @@ def setup_acl_table(duthost, tbinfo, acl_rule_cleanup):
     yield
 
     if "t0-backend" in tbinfo["topo"]["name"]:
-        duthost.command('config acl remove table DATAACL')
         # rebind with new set of ports
         bind_acl_table(duthost, tbinfo)
 
@@ -384,7 +383,7 @@ def setup_acl_table(duthost, tbinfo, acl_rule_cleanup):
 def setup_po2vlan(duthosts, ptfhost, rand_one_dut_hostname, rand_selected_dut, ptfadapter,
                ports_list, tbinfo, vlan_intfs_dict, setup_acl_table, fanouthosts):  # noqa F811
 
-    if "dualtor" in tbinfo["topo"]["name"]:
+    if any(topo in tbinfo["topo"]["name"] for topo in ["dualtor", "t0-backend"]):
         yield
         return
 
@@ -417,8 +416,6 @@ def setup_po2vlan(duthosts, ptfhost, rand_one_dut_hostname, rand_selected_dut, p
 
         vp_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)
         populate_fdb(ptfadapter, vp_list, vlan_intfs_dict)
-        bind_acl_table(duthost, tbinfo)
-        apply_acl_rules(duthost, tbinfo)
     # --------------------- Testing -----------------------
         yield
     # --------------------- Teardown -----------------------


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR contains the following changes
 * skip testcases that use the po2vlan scenario since that is not applicable to backend 
 * modify the acl usage to account for the fact that IN_PORTs qualifier is no longer applicable from 202305 and above

#### How did you verify/test it?
Ran all the testcases with 'pytest.mark.po2vlan' on 202305 and verified that they passed with the existing scenarios
```
collected 13 items                                                                                                                           

arp/test_tagged_arp.py::test_tagged_arp_pkt[str2-7050qx-32s-acs-02] PASSED                                                             [  7%]
fdb/test_fdb.py::test_fdb[ethernet-str2-7050qx-32s-acs-02] PASSED                                                                      [ 15%]
fdb/test_fdb.py::test_fdb[arp_request-str2-7050qx-32s-acs-02] PASSED                                                                   [ 23%]
fdb/test_fdb.py::test_fdb[arp_reply-str2-7050qx-32s-acs-02] PASSED                                                                     [ 30%]
fdb/test_fdb.py::test_fdb[cleanup-str2-7050qx-32s-acs-02] PASSED                                                                       [ 38%]
snmp/test_snmp_fdb.py::test_snmp_fdb_send_tagged[str2-7050qx-32s-acs-02] PASSED                                                        [ 46%]
vlan/test_vlan.py::test_vlan_tc1_send_untagged[str2-7050qx-32s-acs-02] PASSED                                                          [ 53%]
vlan/test_vlan.py::test_vlan_tc2_send_tagged[str2-7050qx-32s-acs-02] PASSED                                                            [ 61%]
vlan/test_vlan.py::test_vlan_tc3_send_invalid_vid[str2-7050qx-32s-acs-02] PASSED                                                       [ 69%]
vlan/test_vlan.py::test_vlan_tc4_tagged_unicast[str2-7050qx-32s-acs-02] PASSED                                                         [ 76%]
vlan/test_vlan.py::test_vlan_tc5_untagged_unicast[str2-7050qx-32s-acs-02] PASSED                                                       [ 84%]
vlan/test_vlan.py::test_vlan_tc6_tagged_untagged_unicast[str2-7050qx-32s-acs-02] PASSED                                                [ 92%]
vlan/test_vlan.py::test_vlan_tc7_tagged_qinq_switch_on_outer_tag[str2-7050qx-32s-acs-02] SKIPPED (Unsupported platform.)               [100%]
```
