### PR TITLE
[cherry-pick] [202311] Skip test_bgp_queues test on Mellanox platform with t1-lag topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -116,9 +116,9 @@ bgp/test_bgp_multipath_relax.py:
 
 bgp/test_bgp_queue.py:
   skip:
-    reason: "Unsupported topology or mellanox T1-LAG asic"
+    reason: "1. Not support on mgmt device 2. Known issue on Mellanox platform with T1-LAG topology"
     conditions:
-      - "topo_type in ['m0', 'mx'] or ((topo_type in ['t1-lag']) and (asic_type in ['mellanox']))"
+      - "topo_type in ['m0', 'mx'] or ((topo_name in ['t1-lag']) and (asic_type in ['mellanox']))"
 
 bgp/test_bgp_slb.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This is a cherry-pick of PR https://github.com/sonic-net/sonic-mgmt/pull/12738
The test case `test_bgp_queues` is failing on Mellanox platform with t1-lag topology because of known issue on router interface.
Earlier there was a PR https://github.com/sonic-net/sonic-mgmt/pull/11705 to skip it, but that didn't work as expected as `topo_type` was used, which should be `topo_name`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
The test case `test_bgp_queues` is failing on Mellanox platform with t1-lag topology. 

#### How did you do it?
Update `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`

#### How did you verify/test it?
The change is verified by running on a Mellanox testbed with t1-lag topo.
```
collected 1 item                                                                                                                                                                                      

bgp/test_bgp_queue.py::test_bgp_queues[str2-msn2700-spy-2-None] SKIPPED (Unsupported topology or mellanox T1-LAG asic)                                                                          [100%]
```

#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
