### PR TITLE
Adding Marvell(innovium) specific change for PFCWD tests

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -786,7 +786,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
 
     def set_traffic_action(self, duthost, action):
         action = action if action != "dontcare" else "drop"
-        if duthost.facts["asic_type"] in ["mellanox", "cisco-8000"] or is_tunnel_qos_remap_enabled(duthost):
+        if duthost.facts["asic_type"] in ["mellanox", "cisco-8000", "innovium"] or is_tunnel_qos_remap_enabled(duthost):
             self.rx_action = "forward"
         else:
             self.rx_action = action

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -298,7 +298,7 @@ class SendVerifyTraffic(object):
             tx_action = "forward"
             wd_action = "forward"
 
-        if dut.facts['asic_type'] in ['mellanox', 'cisco-8000']:
+        if dut.facts['asic_type'] in ['mellanox', 'cisco-8000', 'innovium']:
             rx_action = "forward"
 
         logger.info("--- Verify PFCwd function for pfcwd action {}, Tx traffic {}, Rx traffic {} ---"


### PR DESCRIPTION

Modifying rx_action to forward for Marvell(innovium) chip type in PFCWD tests.

### Description of PR

With changes done in ingress zero buffer pool/profile, need to add rx_action to forward for Marvell(innovium) chip type to pass PFCWD cases


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [*] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [*] 202205
- [*] 202305
- [*] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
