### PR TITLE
[202205] Remove pretest and posttest from all run tests scripts

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -130,10 +130,17 @@ function setup_test_options()
     # for the scenario of specifying test scripts using pattern like `subfolder/test_*.py`. The pattern will be
     # expanded to matched test scripts by bash. Among the expanded scripts, we may want to skip a few. Then we can
     # explicitly specify the script to be skipped.
+    ignore_files=("test_pretest.py" "test_posttest.py")
+    ignore_conditions=""
+    for file in "${ignore_files[@]}"; do
+        ignore_conditions+=('!' -name "$file" -a)
+    done
+    ignore_conditions[${#ignore_conditions[@]}-1]=''
+
     ignores=$(python2 -c "print('|'.join('''$SKIP_FOLDERS'''.split()))")
     if [[ -z ${TEST_CASES} ]]; then
         # When TEST_CASES is not specified, find all the possible scripts, ignore the scripts under $SKIP_FOLDERS
-        all_scripts=$(find ./ -name 'test_*.py' | sed s:^./:: | grep -vE "^(${ignores})")
+        all_scripts=$(find ./ -name 'test_*.py' ${ignore_conditions[@]} | sed s:^./:: | grep -vE "^(${ignores})")
     else
         # When TEST_CASES is specified, ignore the scripts under $SKIP_FOLDERS
         all_scripts=""

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -130,17 +130,18 @@ function setup_test_options()
     # for the scenario of specifying test scripts using pattern like `subfolder/test_*.py`. The pattern will be
     # expanded to matched test scripts by bash. Among the expanded scripts, we may want to skip a few. Then we can
     # explicitly specify the script to be skipped.
-    ignore_files=("test_pretest.py" "test_posttest.py")
-    ignore_conditions=""
-    for file in "${ignore_files[@]}"; do
-        ignore_conditions+=('!' -name "$file" -a)
-    done
-    ignore_conditions[${#ignore_conditions[@]}-1]=''
-
     ignores=$(python2 -c "print('|'.join('''$SKIP_FOLDERS'''.split()))")
     if [[ -z ${TEST_CASES} ]]; then
         # When TEST_CASES is not specified, find all the possible scripts, ignore the scripts under $SKIP_FOLDERS
-        all_scripts=$(find ./ -name 'test_*.py' ${ignore_conditions[@]} | sed s:^./:: | grep -vE "^(${ignores})")
+        all_scripts=$(find ./ -name 'test_*.py' | sed s:^./:: | grep -vE "^(${ignores})")
+        ignore_files=("test_pretest.py" "test_posttest.py")
+        for ((i=${#all_scripts[@]}-1; i>=0; i--)); do
+            # Check if the current element is in the sub array
+            if [[ " ${ignore_files[@]} " =~ " ${all_scripts[i]} " ]]; then
+                # Remove the element from the main array
+                unset 'all_scripts[i]'
+            fi
+        done
     else
         # When TEST_CASES is specified, ignore the scripts under $SKIP_FOLDERS
         all_scripts=""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Currently in run_tests.sh, pretest and posttest are running separately with other scripts, but when we gathering other pytest scripts, pretest and posttest would be collected, so they would run twice, which would waste time
Cherry pick of PR https://github.com/sonic-net/sonic-mgmt/pull/11497
#### How did you do it?
when gathering pytest scripts without specific testcases, remove pretest and posttest from all test scripts
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
