### PR TITLE
Fix the Keyerror issue caused by none `conn_graph_fact` in VS set-up

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -94,13 +94,9 @@ t0:
   - platform_tests/test_cpu_memory_usage.py
   - platform_tests/test_first_time_boot_password_change/test_first_time_boot_password_change.py
   - platform_tests/test_port_toggle.py
-  - platform_tests/test_power_off_reboot.py
-  - platform_tests/test_reboot.py
   - platform_tests/test_secure_upgrade.py
   - platform_tests/test_sensors.py
-  - platform_tests/test_sequential_restart.py
   - platform_tests/test_service_warm_restart.py
-  - platform_tests/test_xcvr_info_in_db.py
   - portstat/test_portstat.py
   - process_monitoring/test_critical_process_monitoring.py
   - qos/test_buffer.py
@@ -272,6 +268,10 @@ dpu:
 
 onboarding_t0:
   - console/test_console_availability.py
+  - platform_tests/test_power_off_reboot.py
+  - platform_tests/test_reboot.py
+  - platform_tests/test_sequential_restart.py
+  - platform_tests/test_xcvr_info_in_db.py
 
 
 specific_param:

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -97,6 +97,7 @@ t0:
   - platform_tests/test_reboot.py
   - platform_tests/test_secure_upgrade.py
   - platform_tests/test_sensors.py
+  - platform_tests/test_sequential_restart.py
   - platform_tests/test_service_warm_restart.py
   - portstat/test_portstat.py
   - process_monitoring/test_critical_process_monitoring.py

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -94,6 +94,7 @@ t0:
   - platform_tests/test_first_time_boot_password_change/test_first_time_boot_password_change.py
   - platform_tests/test_port_toggle.py
   - platform_tests/test_power_off_reboot.py
+  - platform_tests/test_reboot.py
   - platform_tests/test_secure_upgrade.py
   - platform_tests/test_sensors.py
   - platform_tests/test_service_warm_restart.py

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -93,6 +93,7 @@ t0:
   - platform_tests/test_cpu_memory_usage.py
   - platform_tests/test_first_time_boot_password_change/test_first_time_boot_password_change.py
   - platform_tests/test_port_toggle.py
+  - platform_tests/test_power_off_reboot.py
   - platform_tests/test_secure_upgrade.py
   - platform_tests/test_sensors.py
   - platform_tests/test_service_warm_restart.py

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -269,7 +269,6 @@ dpu:
 onboarding_t0:
   - console/test_console_availability.py
   - platform_tests/test_power_off_reboot.py
-  - platform_tests/test_reboot.py
   - platform_tests/test_sequential_restart.py
   - platform_tests/test_xcvr_info_in_db.py
 

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -99,6 +99,7 @@ t0:
   - platform_tests/test_sensors.py
   - platform_tests/test_sequential_restart.py
   - platform_tests/test_service_warm_restart.py
+  - platform_tests/test_xcvr_info_in_db.py
   - portstat/test_portstat.py
   - process_monitoring/test_critical_process_monitoring.py
   - qos/test_buffer.py

--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -34,7 +34,7 @@ def teardown_module(duthosts, enum_supervisor_dut_hostname, conn_graph_facts, xc
     yield
 
     logging.info("Tearing down: to make sure all the critical services, interfaces and transceivers are good")
-    interfaces = conn_graph_facts["device_conn"][duthost.hostname]
+    interfaces = conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {})
     check_critical_processes(duthost, watch_secs=10)
     check_interfaces_and_services(duthost, interfaces, xcvr_skip_list, INTERFACE_WAIT_TIME)
 
@@ -117,7 +117,7 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
             poweroff_reboot_kwargs["all_outlets"] = all_outlets
             poweroff_reboot_kwargs["power_on_seq"] = power_on_seq
             poweroff_reboot_kwargs["delay_time"] = power_off_delay
-            reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
+            reboot_and_check(localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
                              xcvr_skip_list, REBOOT_TYPE_POWEROFF,
                              _power_off_reboot_helper, poweroff_reboot_kwargs)
     except Exception as e:

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -52,7 +52,7 @@ def teardown_module(duthosts, enum_rand_one_per_hwsku_hostname,
 
     logging.info(
         "Tearing down: to make sure all the critical services, interfaces and transceivers are good")
-    interfaces = conn_graph_facts["device_conn"][duthost.hostname]
+    interfaces = conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {})
     wait_for_startup(duthost, localhost, delay=10, timeout=300)
     check_critical_processes(duthost, watch_secs=10)
     check_interfaces_and_services(duthost, interfaces, xcvr_skip_list)
@@ -171,7 +171,7 @@ def test_cold_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
     @summary: This test case is to perform cold reboot and check platform status
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
+    reboot_and_check(localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
                      xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD, duthosts=duthosts)
 
 
@@ -192,7 +192,7 @@ def test_soft_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
     if duthost.is_multi_asic:
         pytest.skip("Multi-ASIC devices not supporting soft reboot")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
+    reboot_and_check(localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
                      xcvr_skip_list, reboot_type=REBOOT_TYPE_SOFT, duthosts=duthosts)
 
 
@@ -207,7 +207,7 @@ def test_fast_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
     if duthost.is_multi_asic:
         pytest.skip("Multi-ASIC devices not supporting fast reboot")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
+    reboot_and_check(localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
                      xcvr_skip_list, reboot_type=REBOOT_TYPE_FAST, duthosts=duthosts)
 
 
@@ -230,7 +230,7 @@ def test_warm_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
             pytest.skip(
                 "ISSU is not supported on this DUT, skip this test case")
 
-    reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
+    reboot_and_check(localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
                      xcvr_skip_list, reboot_type=REBOOT_TYPE_WARM, duthosts=duthosts)
 
 
@@ -260,7 +260,7 @@ def test_watchdog_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
             # reboot on the DUT.
             duthost.shell("sudo systemctl stop cpu_wdt", module_ignore_errors=True)
 
-        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
+        reboot_and_check(localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
                          xcvr_skip_list, REBOOT_TYPE_WATCHDOG, duthosts=duthosts)
     finally:
         if "x86_64-cel_e1031-r0" in duthost.facts['platform']:
@@ -277,7 +277,7 @@ def test_continuous_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
     ls_starting_out = set(duthost.shell(
         "ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())
     for i in range(3):
-        reboot_and_check(localhost, duthost, conn_graph_facts["device_conn"][duthost.hostname],
+        reboot_and_check(localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
                          xcvr_skip_list, reboot_type=REBOOT_TYPE_COLD, duthosts=duthosts)
     ls_ending_out = set(duthost.shell(
         "ls /dev/C0-*", module_ignore_errors=True)["stdout"].split())

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -56,7 +56,7 @@ def test_reload_configuration(duthosts, enum_rand_one_per_hwsku_hostname,
     @summary: This test case is to reload the configuration and check platform status
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    interfaces = conn_graph_facts["device_conn"][duthost.hostname]
+    interfaces = conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {})
     asic_type = duthost.facts["asic_type"]
 
     if config_force_option_supported(duthost):

--- a/tests/platform_tests/test_sequential_restart.py
+++ b/tests/platform_tests/test_sequential_restart.py
@@ -104,7 +104,7 @@ def test_restart_swss(duthosts, enum_rand_one_per_hwsku_hostname, enum_frontend_
     @summary: This test case is to restart the swss service and check platform status
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    all_interfaces = conn_graph_facts["device_conn"][duthost.hostname]
+    all_interfaces = conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {})
 
     if enum_frontend_asic_index is not None:
         # Get the interface pertaining to that asic
@@ -124,5 +124,5 @@ def test_restart_syncd(duthosts, enum_rand_one_per_hwsku_hostname, enum_frontend
     @summary: This test case is to restart the syncd service and check platform status
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    restart_service_and_check(localhost, duthost, enum_frontend_asic_index,
-                              "syncd", conn_graph_facts["device_conn"][duthost.hostname], xcvr_skip_list)
+    restart_service_and_check(localhost, duthost, enum_frontend_asic_index, "syncd",
+                              conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}), xcvr_skip_list)

--- a/tests/platform_tests/test_xcvr_info_in_db.py
+++ b/tests/platform_tests/test_xcvr_info_in_db.py
@@ -22,7 +22,7 @@ def test_xcvr_info_in_db(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     logging.info("Check transceiver status")
-    all_interfaces = conn_graph_facts["device_conn"][duthost.hostname]
+    all_interfaces = conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {})
 
     if enum_frontend_asic_index is not None:
         # Get the interface pertaining to that asic
@@ -30,7 +30,7 @@ def test_xcvr_info_in_db(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
 
         # Check if the interfaces of this AISC is present in conn_graph_facts
         all_interfaces = {k: v for k, v in list(interface_list.items())
-                          if k in conn_graph_facts["device_conn"][duthost.hostname]}
+                          if k in conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {})}
         logging.info("ASIC {} interface_list {}".format(
             enum_frontend_asic_index, all_interfaces))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
To adapt to kvm testbed, we need to fix the issue -- `conn_graph_fact` is none in VS set-up. 
In this PR, we use method `get` of a dict to get the value instead of `[]` to avoid key error when getting value from an empty dict `conn_graph_fact`. 

Also, in this PR, after fixing this issue, we can add three platform tests into PR test. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
To adapt to kvm testbed, we need to fix the issue -- `conn_graph_fact` is none in VS set-up. 
In this PR, we use method `get` of a dict to get the value instead of `[]` to avoid key error when getting value from an empty dict `conn_graph_fact`. 

Also, in this PR, after fixing this issue, we can add three platform tests into PR test. 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
