### PR TITLE
[dut_console] Fix test_console_baud_rate use dut passwd/admin to login console

### DIFF
--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -54,7 +54,7 @@ def console_client_setup_teardown(duthost, conn_graph_facts, creds):
         try:
             client = create_ssh_client(console_host, "{}:{}".format(console_user, console_port), console_password)
             ensure_console_session_up(client, console_port)
-        except Exception as _:
+        except Exception:
             client = None
         else:
             break

--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -47,7 +47,7 @@ def console_client_setup_teardown(duthost, conn_graph_facts, creds):
     pytest_require(is_sonic_console(conn_graph_facts, dut_hostname), "Unsupport non-sonic console swith.")
     console_port = conn_graph_facts['device_console_link'][dut_hostname]['ConsolePort']['peerport']
     console_user = creds['console_user']['console_ssh']
-    console_passwords=creds['console_password']['console_ssh']
+    console_passwords = creds['console_password']['console_ssh']
 
     client = None
     for console_password in console_passwords:

--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -53,12 +53,13 @@ def console_client_setup_teardown(duthost, conn_graph_facts, creds):
     for console_password in console_passwords:
         try:
             client = create_ssh_client(console_host, "{}:{}".format(console_user, console_port), console_password)
-        except Exception as err:
-            pytest.fail("Not connect console ssh, error: {}".format(err))
+            ensure_console_session_up(client, console_port)
+        except Exception as _:
+            client = None
         else:
             break
 
-    ensure_console_session_up(client, console_port)
+    pytest_assert(client is not None, "Cannot connect to console device")
     client.sendline()
     yield client, console_port
 

--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -46,14 +46,17 @@ def console_client_setup_teardown(duthost, conn_graph_facts, creds):
     pytest_require(console_type == "ssh", "Unsupported console type: {}".format(console_type))
     pytest_require(is_sonic_console(conn_graph_facts, dut_hostname), "Unsupport non-sonic console swith.")
     console_port = conn_graph_facts['device_console_link'][dut_hostname]['ConsolePort']['peerport']
-    dutuser = creds['sonicadmin_user']
-    dutpass = creds['sonicadmin_password']
+    console_user = creds['console_user']['console_ssh']
+    console_passwords=creds['console_password']['console_ssh']
 
     client = None
-    try:
-        client = create_ssh_client(console_host, "{}:{}".format(dutuser, console_port), dutpass)
-    except Exception as err:
-        pytest.fail("Not connect console ssh, error: {}".format(err))
+    for console_password in console_passwords:
+        try:
+            client = create_ssh_client(console_host, "{}:{}".format(console_user, console_port), console_password)
+        except Exception as err:
+            pytest.fail("Not connect console ssh, error: {}".format(err))
+        else:
+            break
 
     ensure_console_session_up(client, console_port)
     client.sendline()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
In this test case, dut passwd/username are used to login console, which is incorrect.

#### How did you do it?
Use console admin/passwd to login console.

#### How did you verify/test it?
Run tests.
```
collected 3 items                                                                                                                                                                                                                                          

dut_console/test_console_baud_rate.py::test_console_baud_rate_config PASSED                                                                                                                                                                          [ 33%]
dut_console/test_console_baud_rate.py::test_baud_rate_sonic_connect PASSED                                                                                                                                                                           [ 66%]
dut_console/test_console_baud_rate.py::test_baud_rate_boot_connect PASSED                                                                                                                                                                            [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
