### PR TITLE
Fix switch.py for password based login

### DIFF
--- a/ansible/plugins/connection/switch.py
+++ b/ansible/plugins/connection/switch.py
@@ -81,7 +81,7 @@ class Connection(ConnectionBase):
                     client = pexpect.spawn(' '.join(cmd), env={
                                            'TERM': 'dumb'}, timeout=self.timeout)
                     i = client.expect(
-                        ['[Pp]assword:', '>', '#', pexpect.EOF, pexpect.TIMEOUT])
+                        ['>', '#', '[Pp]assword:', pexpect.EOF, pexpect.TIMEOUT])
                     if i in [0, 1, 2]:
                         break
                     else:
@@ -96,7 +96,7 @@ class Connection(ConnectionBase):
                         "Establish connection to server failed after tried %d times." % max_retries)
 
             # if "'>', '#'" means Passwordless login, no need to send password
-            if i in [1, 2]:
+            if i < 2 :
                 self._display.vvv(
                     "Establish connection to server successful without requiring a password.", host=self.host)
                 break

--- a/ansible/plugins/connection/switch.py
+++ b/ansible/plugins/connection/switch.py
@@ -96,7 +96,7 @@ class Connection(ConnectionBase):
                         "Establish connection to server failed after tried %d times." % max_retries)
 
             # if "'>', '#'" means Passwordless login, no need to send password
-            if i < 2 :
+            if i < 2:
                 self._display.vvv(
                     "Establish connection to server successful without requiring a password.", host=self.host)
                 break


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes [#116](https://github.com/aristanetworks/sonic-qual.msft/issues/116)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Tests using tests/scripts/exec_template.yml fail when fanout has a password set. 


Regression introduced by: https://github.com/sonic-net/sonic-mgmt/pull/12318

There is a retry logic in switch.py for different passwords a fanout switch can have in the lab: https://github.com/sonic-net/sonic-mgmt/blob/202305/ansible/group_vars/all/labinfo.json#L21-L25. The issue here is that if the first attenpt fails the value of i being returned is 2 which in the second iteration is being wrongly interpreted as ssh connection being established: https://github.com/sonic-net/sonic-mgmt/blob/202305/ansible/plugins/connection/switch.py#L99-L102. This later results in error when the script tries to run CLI commands on the fanout.




#### How did you do it?
Proposed solution is to make the collection of expected regexes consistent at both of these places:
   1. https://github.com/sonic-net/sonic-mgmt/blob/202305/ansible/plugins/connection/switch.py#L84
   2. https://github.com/sonic-net/sonic-mgmt/blob/202305/ansible/plugins/connection/switch.py#L107

#### How did you verify/test it?
Verified by running the affected pfcwd tests on a testbed where fanouts had password set.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
