### PR TITLE
[override] Extend support for backend testbed

### DIFF
--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -75,6 +75,21 @@ def setup_env(duthosts, golden_config_exists_on_dut, tbinfo, enum_rand_one_per_h
     config_reload(duthost)
 
 
+def compare_dicts_ignore_list_order(dict1, dict2):
+    def normalize(data):
+        if isinstance(data, list):
+            return set(data)
+        elif isinstance(data, dict):
+            return {k: normalize(v) for k, v in data.items()}
+        else:
+            return data
+
+    dict1_normalized = normalize(dict1)
+    dict2_normalized = normalize(dict2)
+
+    return dict1_normalized == dict2_normalized
+
+
 def load_minigraph_with_golden_empty_input(duthost):
     """Test Golden Config with empty input
     """
@@ -87,10 +102,17 @@ def load_minigraph_with_golden_empty_input(duthost):
     for table in initial_config:
         if table in NON_USER_CONFIG_TABLES:
             continue
-        pytest_assert(
-            initial_config[table] == current_config[table],
-            "empty input compare fail! {}".format(table)
-        )
+
+        if table == "ACL_TABLE":
+            pytest_assert(
+                compare_dicts_ignore_list_order(initial_config[table], current_config[table]),
+                "empty input ACL_TABLE compare fail!"
+            )
+        else:
+            pytest_assert(
+                initial_config[table] == current_config[table],
+                "empty input compare fail! {}".format(table)
+            )
 
 
 def load_minigraph_with_golden_partial_config(duthost):
@@ -144,10 +166,17 @@ def load_minigraph_with_golden_full_config(duthost, full_config):
     for table in full_config:
         if table in NON_USER_CONFIG_TABLES:
             continue
-        pytest_assert(
-            full_config[table] == current_config[table],
-            "full config override fail! {}".format(table)
-        )
+
+        if table == "ACL_TABLE":
+            pytest_assert(
+                compare_dicts_ignore_list_order(full_config[table], current_config[table]),
+                "full config ACL_TABLE compare fail!"
+            )
+        else:
+            pytest_assert(
+                full_config[table] == current_config[table],
+                "full config override fail! {}".format(table)
+            )
 
 
 def load_minigraph_with_golden_empty_table_removal(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
ADO: 27963882
Summary: Extend support for backend test
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
override test fail in backend testbed for ACL_TABLE comparison failure. This is because DATAACL ports are in random order.
[sonic-buildimage/src/sonic-config-engine/minigraph.py at master · sonic-net/sonic-buildimage (github.com)](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-config-engine/minigraph.py#L1344)
#### How did you do it?
Compare the set of ports in ACL_TABLE
#### How did you verify/test it?
E2E test in backend testbed
```
PASSED                                                                                                                                                                                               [100%]
-------------------------------------------------------------------------------------------- live log teardown ---------------------------------------------------------------------------------------------
07:31:20 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture setup_env teardown starts --------------------
07:31:20 utilities.restore_config                 L0016 INFO   | Restore /etc/sonic/config_db.json with /etc/sonic/config_db.json_before_override on str2-7050qx-32s-acs-02
07:31:21 utilities.restore_config                 L0016 INFO   | Restore /etc/sonic/golden_config_db.json with /etc/sonic/golden_config_db.json_before_override on str2-7050qx-32s-acs-02
07:31:22 config_reload.config_reload              L0092 INFO   | reloading config_db
07:34:01 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture setup_env teardown ends --------------------
07:34:08 conftest.core_dump_and_config_check      L2098 INFO   | Dumping Disk and Memory Space informataion after test on str2-7050qx-32s-acs-02
07:34:10 conftest.core_dump_and_config_check      L2102 INFO   | Collecting core dumps after test on str2-7050qx-32s-acs-02
07:34:10 conftest.core_dump_and_config_check      L2119 INFO   | Collecting running config after test on str2-7050qx-32s-acs-02
07:34:12 conftest.core_dump_and_config_check      L2248 INFO   | Core dump and config check passed for override_config_table/test_override_config_table.py
---------------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -----------------------------------------------------------------------
------------------------------------------------------------------------------------------ live log sessionfinish ------------------------------------------------------------------------------------------
07:34:12 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
================================================================================ 1 passed, 1 warning in 1047.69s (0:17:27) =================================================================================
INFO:root:Can not get Allure report URL. Please check logs
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
