### PR TITLE
[GCU] Improve debug print for cacl test

### DIFF
--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 import time
+import difflib
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_res_success, expect_op_failure
@@ -64,20 +65,28 @@ def setup_env(duthosts, rand_one_dut_hostname):
         logger.info("original iptable rules: {}, current iptable rules: {}".format(
             original_iptable_rules, current_iptable_rules)
         )
+        iptable_rules_diff = [
+            li for li in difflib.ndiff(original_iptable_rules, current_iptable_rules) if li[0] != ' '
+        ]
+        logger.info("iptable_rules_diff {}".format(iptable_rules_diff))
         pytest_assert(
             set(original_iptable_rules) == set(current_iptable_rules),
-            "iptable rules are not suppose to change after test. org:{} cur:{}".format(
-                original_iptable_rules, current_iptable_rules)
+            "iptable rules are not suppose to change after test. diff: {}".format(
+                iptable_rules_diff)
         )
 
         current_cacl_tables = get_cacl_tables(duthost)
         logger.info("original cacl tables: {}, current cacl tables: {}".format(
             original_cacl_tables, current_cacl_tables)
         )
+        cacl_tables_diff = [
+            li for li in difflib.ndiff(original_cacl_tables, current_cacl_tables) if li[0] != ' '
+        ]
+        logger.info("cacl_tables_diff {}".format(iptable_rules_diff))
         pytest_assert(
             set(original_cacl_tables) == set(current_cacl_tables),
-            "cacl tables are not suppose to change after test, org:{} cur:{}".format(
-                original_cacl_tables, current_cacl_tables)
+            "cacl tables are not suppose to change after test. diff: {}".format(
+                cacl_tables_diff)
         )
     finally:
         delete_checkpoint(duthost)

--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -22,8 +22,6 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
-T0_CACL_TABLE = ["NTP_ACL", "SNMP_ACL", "SSH_ONLY"]
-
 
 def get_cacl_tables(duthost):
     """Get acl control palne tables
@@ -53,6 +51,7 @@ def setup_env(duthosts, rand_one_dut_hostname):
     """
     duthost = duthosts[rand_one_dut_hostname]
     original_iptable_rules = get_iptable_rules(duthost)
+    original_cacl_tables = get_cacl_tables(duthost)
     create_checkpoint(duthost)
 
     yield
@@ -62,12 +61,18 @@ def setup_env(duthosts, rand_one_dut_hostname):
         rollback_or_reload(duthost)
 
         current_iptable_rules = get_iptable_rules(duthost)
-        pytest_assert(set(original_iptable_rules) == set(current_iptable_rules),
-                      "iptable rules are not suppose to change after test")
+        pytest_assert(
+            set(original_iptable_rules) == set(current_iptable_rules),
+            "iptable rules are not suppose to change after test. org:{} cur:{}".format(
+                original_iptable_rules, current_iptable_rules)
+        )
 
         current_cacl_tables = get_cacl_tables(duthost)
-        pytest_assert(set(T0_CACL_TABLE) == set(current_cacl_tables),
-                      "iptable rules are not suppose to change after test")
+        pytest_assert(
+            set(original_cacl_tables) == set(current_cacl_tables),
+            "cacl tables are not suppose to change after test, org:{} cur:{}".format(
+                original_cacl_tables, current_cacl_tables)
+        )
     finally:
         delete_checkpoint(duthost)
 

--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -61,6 +61,9 @@ def setup_env(duthosts, rand_one_dut_hostname):
         rollback_or_reload(duthost)
 
         current_iptable_rules = get_iptable_rules(duthost)
+        logger.info("original iptable rules: {}, current iptable rules: {}".format(
+            original_iptable_rules, current_iptable_rules)
+        )
         pytest_assert(
             set(original_iptable_rules) == set(current_iptable_rules),
             "iptable rules are not suppose to change after test. org:{} cur:{}".format(
@@ -68,6 +71,9 @@ def setup_env(duthosts, rand_one_dut_hostname):
         )
 
         current_cacl_tables = get_cacl_tables(duthost)
+        logger.info("original cacl tables: {}, current cacl tables: {}".format(
+            original_cacl_tables, current_cacl_tables)
+        )
         pytest_assert(
             set(original_cacl_tables) == set(current_cacl_tables),
             "cacl tables are not suppose to change after test, org:{} cur:{}".format(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
ADO: 27980127
Summary: Improve debug print for cacl test as requested
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Improve debug print
#### How did you do it?
Show more print
#### How did you verify/test it?
E2E test
```
07:46:39 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture setup_env teardown starts --------------------
......
07:46:51 test_cacl.setup_env                      L0066 INFO   | original iptable rules: ['-P INPUT ACCEPT', '-P FORWARD ACCEPT', '-P OUTPUT ACCEPT', '-A INPUT -s 127.0.0.1/32 -i lo -j ACCEPT', '-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT', '-A INPUT -p icmp -m icmp --icmp-type 8 -j ACCEPT', '-A INPUT -p icmp -m icmp --icmp-type 0 -j ACCEPT', '-A INPUT -p icmp -m icmp --icmp-type 3 -j ACCEPT', '-A INPUT -p icmp -m icmp --icmp-type 11 -j ACCEPT', '-A INPUT -p udp -m udp --dport 67:68 -j ACCEPT', '-A INPUT -p udp -m udp --dport 546:547 -j ACCEPT', '-A INPUT -p tcp -m tcp --dport 179 -j ACCEPT', '-A INPUT -s 20.44.16.64/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 13.66.141.96/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 13.69.229.128/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 52.162.110.128/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 52.231.147.224/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 40.74.146.224/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 40.78.203.96/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 20.150.171.224/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 52.162.110.128/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -d 10.20.8.199/32 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -d 10.212.64.1/32 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -d 10.212.64.2/32 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 20.44.16.64/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 13.66.141.96/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 13.69.229.128/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 52.162.110.128/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 52.231.147.224/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 40.74.146.224/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 40.78.203.96/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 20.150.171.224/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 52.162.110.128/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -d 10.20.8.199/32 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -d 10.212.64.1/32 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -d 10.212.64.2/32 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -d 10.1.0.32/32 -j DROP', '-A INPUT -d 192.168.0.1/32 -j DROP', '-A INPUT -d 10.0.0.32/32 -j DROP', '-A INPUT -d 10.0.0.34/32 -j DROP', '-A INPUT -d 10.0.0.36/32 -j DROP', '-A INPUT -d 10.0.0.38/32 -j DROP', '-A INPUT -m ttl --ttl-lt 2 -j ACCEPT'], current iptable rules:['-P FORWARD ACCEPT', '-P OUTPUT ACCEPT', '-A INPUT -s 127.0.0.1/32 -i lo -j ACCEPT', '-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT', '-A INPUT -p icmp -m icmp --icmp-type 8 -j ACCEPT', '-A INPUT -p icmp -m icmp --icmp-type 0 -j ACCEPT', '-A INPUT -p icmp -m icmp --icmp-type 3 -j ACCEPT', '-A INPUT -p icmp -m icmp --icmp-type 11 -j ACCEPT', '-A INPUT -p udp -m udp --dport 67:68 -j ACCEPT', '-A INPUT -p udp -m udp --dport 546:547 -j ACCEPT', '-A INPUT -p tcp -m tcp --dport 179 -j ACCEPT', '-A INPUT -s 20.44.16.64/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 13.66.141.96/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 13.69.229.128/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 52.162.110.128/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 52.231.147.224/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 40.74.146.224/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 40.78.203.96/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 20.150.171.224/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 52.162.110.128/27 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -d 10.20.8.199/32 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -d 10.212.64.1/32 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -d 10.212.64.2/32 -p tcp -m tcp --dport 8081 -j ACCEPT', '-A INPUT -s 20.44.16.64/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 13.66.141.96/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 13.69.229.128/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 52.162.110.128/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 52.231.147.224/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 40.74.146.224/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 40.78.203.96/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 20.150.171.224/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -s 52.162.110.128/27 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -d 10.20.8.199/32 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -d 10.212.64.1/32 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -d 10.212.64.2/32 -p tcp -m tcp --dport 8090 -j ACCEPT', '-A INPUT -d 10.1.0.32/32 -j DROP', '-A INPUT -d 192.168.0.1/32 -j DROP', '-A INPUT -d 10.0.0.32/32 -j DROP', '-A INPUT -d 10.0.0.34/32 -j DROP', '-A INPUT -d 10.0.0.36/32 -j DROP', '-A INPUT -d 10.0.0.38/32 -j DROP', '-A INPUT -m ttl --ttl-lt 2 -j ACCEPT']
07:46:51 test_cacl.setup_env                      L0070 INFO   | iptable_rules_diff:['- -P INPUT ACCEPT']
......
            iptable_rules_diff = [li for li in difflib.ndiff(original_iptable_rules, current_iptable_rules) if li[0] != ' ']
            logger.info("iptable_rules_diff:{}".format(iptable_rules_diff))

>           pytest_assert(set(original_iptable_rules) == set(current_iptable_rules),
                          "iptable rules are not suppose to change after test. diff {}".format(iptable_rules_diff))
E                         Failed: iptable rules are not suppose to change after test. diff ['- -P INPUT ACCEPT']
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
