### PR TITLE
fix function parse_service_status_and_critical_process didn't get critical process correctly

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -740,11 +740,11 @@ class SonicHost(AnsibleHostBase):
             # 2. Check status is not running
             elif status != 'RUNNING':
                 # 3. Check process is critical
-                if pname in critical_group_list or pname in critical_process_list:
+                if pname.split(':')[0] in critical_group_list or pname in critical_process_list:
                     service_critical_process['exited_critical_process'].append(pname)
                     service_critical_process['status'] = False
             else:
-                if pname in critical_group_list or pname in critical_process_list:
+                if pname.split(':')[0] in critical_group_list or pname in critical_process_list:
                     service_critical_process['running_critical_process'].append(pname)
 
         return service_critical_process

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1968,7 +1968,7 @@ Totals               6450                 6449
             logging.warning("CRM counters are not ready yet, will retry after 10 seconds")
             time.sleep(10)
             timeout -= 10
-        assert(timeout >= 0)
+        assert timeout >= 0
 
         return crm_facts
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
When using command supervisorctl status, program name will be printed with the prefix \<group\>:, so the function parse_service_status_and_critical_process won't miss process under group.

For example:

```
root@bjw-can-720dt-2:/# cat /etc/supervisor/critical_processes
group:dhcp-server-ipv4

Supervisor config:

[group:dhcp-server-ipv4]
programs=dhcpservd

[program:dhcpservd]
.....

Supercisorctl status output:
admin@bjw-can-720dt-2:~$ docker exec dhcp_server supervisorctl status
dhcp-server-ipv4:dhcpservd       RUNNING   pid 29, uptime 3:54:51
....
```


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
When using command supervisorctl status, program name will be printed with the prefix <group>:, so the function parse_service_status_and_critical_process won't miss process under group.

#### How did you do it?
parse the group name from the command line output for matching.

#### How did you verify/test it?
Run unit test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
