### PR TITLE
Remove pre-test and GIT_SECRETS from baseline test

### DIFF
--- a/.azure-pipelines/baseline_test/baseline.test.mgmt.public.master.yml
+++ b/.azure-pipelines/baseline_test/baseline.test.mgmt.public.master.yml
@@ -12,21 +12,8 @@ schedules:
     always: true
 
 stages:
-- stage: Pre_test
-  variables:
-  - group: GIT_SECRETS
-  jobs:
-  - job: validate_test_cases
-    displayName: "Validate Test Cases"
-    timeoutInMinutes: 20
-    continueOnError: false
-    pool: ubuntu-20.04
-    steps:
-    - template: ../pytest-collect-only.yml
 
 - stage: Test_round_1
-  dependsOn:
-  - Pre_test
   condition: succeeded('Pre_test')
   variables:
   - group: SONiC-Elastictest
@@ -34,13 +21,11 @@ stages:
     value: veos_vtb
   - name: testbed_file
     value: vtestbed.yaml
-  - group: GIT_SECRETS
   jobs:
   - template: baseline.test.template.yml
 
 - stage: Test_round_2
   dependsOn:
-  - Pre_test
   - Test_round_1
   condition: and(succeeded('Pre_test'), succeededOrFailed('Test_round_1'))
   variables:
@@ -49,13 +34,11 @@ stages:
     value: veos_vtb
   - name: testbed_file
     value: vtestbed.yaml
-  - group: GIT_SECRETS
   jobs:
   - template: baseline.test.template.yml
 
 - stage: Test_round_3
   dependsOn:
-  - Pre_test
   - Test_round_2
   condition: and(succeeded('Pre_test'), succeededOrFailed('Test_round_2'))
   variables:
@@ -64,13 +47,11 @@ stages:
     value: veos_vtb
   - name: testbed_file
     value: vtestbed.yaml
-  - group: GIT_SECRETS
   jobs:
   - template: baseline.test.template.yml
 
 - stage: Test_round_4
   dependsOn:
-  - Pre_test
   - Test_round_3
   condition: and(succeeded('Pre_test'), succeededOrFailed('Test_round_3'))
   variables:
@@ -79,6 +60,5 @@ stages:
     value: veos_vtb
   - name: testbed_file
     value: vtestbed.yaml
-  - group: GIT_SECRETS
   jobs:
   - template: baseline.test.template.yml

--- a/.azure-pipelines/baseline_test/baseline.test.mgmt.public.master.yml
+++ b/.azure-pipelines/baseline_test/baseline.test.mgmt.public.master.yml
@@ -14,7 +14,6 @@ schedules:
 stages:
 
 - stage: Test_round_1
-  condition: succeeded('Pre_test')
   variables:
   - group: SONiC-Elastictest
   - name: inventory
@@ -27,7 +26,7 @@ stages:
 - stage: Test_round_2
   dependsOn:
   - Test_round_1
-  condition: and(succeeded('Pre_test'), succeededOrFailed('Test_round_1'))
+  condition: succeededOrFailed('Test_round_1')
   variables:
   - group: SONiC-Elastictest
   - name: inventory
@@ -40,7 +39,7 @@ stages:
 - stage: Test_round_3
   dependsOn:
   - Test_round_2
-  condition: and(succeeded('Pre_test'), succeededOrFailed('Test_round_2'))
+  condition: succeededOrFailed('Test_round_2')
   variables:
   - group: SONiC-Elastictest
   - name: inventory
@@ -53,7 +52,7 @@ stages:
 - stage: Test_round_4
   dependsOn:
   - Test_round_3
-  condition: and(succeeded('Pre_test'), succeededOrFailed('Test_round_3'))
+  condition: succeededOrFailed('Test_round_3')
   variables:
   - group: SONiC-Elastictest
   - name: inventory


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Baseline test is to run PR tests multiple times to surface flaky issues.
The pre-test step is to find out if there is any importing dependency issue
between test scripts. This dependency issue only could happen with new
PRs. During baseline test, the dependency issue won't happen. It is unnecessary
for baseline test.

The GIT_SECRETS variable is not really used by baseline tests. This change also
deleted the reference to GIT_SECRETS variable group.

#### How did you do it?
* Removed the pre-test stage.
* Removed reference to GIT_SECRETS variable group

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
