### PR TITLE
Fixing a few ACL tests which expect the wrong rule to be hit for counters_sanity_check

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1056,7 +1056,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dport=0x1217)
 
         self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
-        counters_sanity_check.append(5)
+        counters_sanity_check.append(9)
 
     def test_l4_sport_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and forward on L4 source port."""
@@ -1119,7 +1119,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, sport=0x1271)
 
         self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
-        counters_sanity_check.append(10)
+        counters_sanity_check.append(17)
 
     def test_ip_proto_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and drop on the IP protocol."""
@@ -1133,7 +1133,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, flags=0x24)
 
         self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
-        counters_sanity_check.append(5)
+        counters_sanity_check.append(19)
 
     def test_icmp_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
         """Verify that we can match and drop on the TCP flags."""


### PR DESCRIPTION
There are a few ACL tests which are expecting the wrong ACL rule to be hit:
`test_l4_dport_match_forwarded - Expects 5, Actual 9`
```
def test_l4_dport_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
    """Verify that we can match and forward on L4 destination port."""
    pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dport=0x1217)

DATA_INGRESS_IPV4_TEST  RULE_5        9995        FORWARD   ETHER_TYPE: 2048              Active
                                                            IP_PROTOCOL: 126

DATA_INGRESS_IPV4_TEST  RULE_9        9991        FORWARD   ETHER_TYPE: 2048              Active
                                                            L4_DST_PORT: 4631
```

`test_l4_sport_match_dropped - Expects 10, Actual 17`
```
def test_l4_sport_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
    """Verify that we can match and drop on L4 source port."""
    pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, sport=0x1271)

DATA_INGRESS_IPV4_TEST  RULE_10       9990        FORWARD   ETHER_TYPE: 2048              Active
                                                            L4_SRC_PORT_RANGE: 4656-4671

DATA_INGRESS_IPV4_TEST  RULE_17       9983        DROP      ETHER_TYPE: 2048              Active
                                                            L4_SRC_PORT: 4721
```

`test_tcp_flags_match_dropped - Expects 5, Actual 19`
```
def test_tcp_flags_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
    """Verify that we can match and drop on the TCP flags."""
    pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, flags=0x24)

DATA_INGRESS_IPV4_TEST  RULE_5        9995        FORWARD   ETHER_TYPE: 2048              Active
                                                            IP_PROTOCOL: 126

DATA_INGRESS_IPV4_TEST  RULE_19       9981        DROP      ETHER_TYPE: 2048              Active
                                                            TCP_FLAGS: 0x24/0x24
```

The reason this has only started hitting recently is because of https://github.com/sonic-net/sonic-mgmt/issues/12715 which caused the class-level fixtures to be run at a function-level. This caused `counters_sanity_check` to be run between every test instead of once per parametrization.
When it was run at the class-level we'd have other tests which inject packets which hit rules `5 and 10` before we'd run the `counters_sanity_check` fixture
`test_ip_proto_match_forwarded for 5` and `test_l4_sport_range_match_forwarded for 10`.


- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

Which release branch to backport (provide reason below if selected)
- [x] 202205
- [x] 202305
- [x] 202311