### PR TITLE
Skip available route check for mellanox platforms

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -499,7 +499,7 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
         duthost.command(route_add)
 
     check_available_counters = True
-    if duthost.facts['asic_type'] == 'broadcom':
+    if duthost.facts['asic_type'] in ['broadcom', 'mellanox']:
         check_available_counters = False
 
     # Make sure CRM counters updated


### PR DESCRIPTION
 * Per a recent release note by Nvidia, CRM available entries for a specific object reflect the momentarily availability and may 
   change even if no entries of that object are created / removed due to the background computation done by the internal 
   processes, therefore skip available route counter checks which cause crm test failures.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # 27685893

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
To avoid CRM test failures due to available counter mismatch
#### How did you do it?
Skip available counter verification for CRM route test.
#### How did you verify/test it?
By running the test locally on mellanox testbeds
#### Any platform specific information?
Mellanox-specific change
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
