### PR TITLE
[backend] Use regular interfaces on ptf for backend and handle default acl

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -29,6 +29,8 @@ pytestmark = [
 
 logger = logging.getLogger(__name__)
 
+PTF_PORT_MAPPING_MODE = 'use_orig_interface'
+
 PKT_NUMBER = 1000
 
 # CLI commands to obtain drop counters.
@@ -98,6 +100,20 @@ def parse_combined_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname)
                 if re.match(item, duthost.facts["platform"]):
                     COMBINED_ACL_DROP_COUNTER = True
                     break
+
+
+@pytest.fixture(scope='module', autouse=True)
+def handle_backend_acl(duthost, tbinfo):
+    """
+    Cleanup/Recreate all the existing DATAACL rules
+    """
+    if "t0-backend" in tbinfo["topo"]["name"]:
+        duthost.shell('acl-loader delete DATAACL')
+
+    yield
+
+    if "t0-backend" in tbinfo["topo"]["name"]:
+        duthost.shell('systemctl restart backend-acl')
 
 
 def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info,   # noqa F811


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
- Backend has tagged members in vlan and this results in double tagged packets sent from the ptf for some cases where vlan tagged packets are sent from the ptf. Hence regular interface mode will ensure that packets are not sent out of subintf.
- Also the default acl on backend will not allow proper testing of functionality since certain testcases expect rx drops but that will get accounted as acl drops. To avoid that, the default acl is cleaned up before the testing begins and restored back at the end.

#### How did you verify/test it?
Ran the test on 202305 against t0-backend and it passed
```
collected 102 items                                                                                                                          

drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port_channe...) [  0%]
drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop[vlan_members-str2-7050qx-32s-acs-02] SKIPPED (Test case requires exp...) [  1%]
drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members available)   [  2%]
drop_packets/test_drop_counters.py::test_multicast_smac_drop[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port_channel...) [  3%]
drop_packets/test_drop_counters.py::test_multicast_smac_drop[vlan_members-str2-7050qx-32s-acs-02] SKIPPED (Test case requires expl...) [  4%]
drop_packets/test_drop_counters.py::test_multicast_smac_drop[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members available)    [  5%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port_...) [  6%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[vlan_members-str2-7050qx-32s-acs-02] PASSED                        [  7%]
drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members av...) [  8%]
drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port_cha...) [  9%]
drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[vlan_members-str2-7050qx-32s-acs-02] PASSED                           [ 10%]
drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members avail...) [ 11%]
drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port_cha...) [ 12%]
drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[vlan_members-str2-7050qx-32s-acs-02] PASSED                           [ 13%]
drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members avail...) [ 14%]
drop_packets/test_drop_counters.py::test_dst_ip_absent[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port_channel_membe...) [ 15%]
drop_packets/test_drop_counters.py::test_dst_ip_absent[vlan_members-str2-7050qx-32s-acs-02] PASSED                                     [ 16%]
drop_packets/test_drop_counters.py::test_dst_ip_absent[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members available)          [ 17%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[port_channel_members-str2-7050qx-32s-acs-02-ipv4] SKIPPED (No po...) [ 18%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[port_channel_members-str2-7050qx-32s-acs-02-ipv6] SKIPPED (No po...) [ 19%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[vlan_members-str2-7050qx-32s-acs-02-ipv4] PASSED                     [ 20%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[vlan_members-str2-7050qx-32s-acs-02-ipv6] PASSED                     [ 21%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[rif_members-str2-7050qx-32s-acs-02-ipv4] SKIPPED (No rif_members...) [ 22%]
drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[rif_members-str2-7050qx-32s-acs-02-ipv6] SKIPPED (No rif_members...) [ 23%]
drop_packets/test_drop_counters.py::test_src_ip_is_class_e[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port_channel_m...) [ 24%]
drop_packets/test_drop_counters.py::test_src_ip_is_class_e[vlan_members-str2-7050qx-32s-acs-02] SKIPPED (BRCM does not drop SIP cl...) [ 25%]
drop_packets/test_drop_counters.py::test_src_ip_is_class_e[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members available)      [ 26%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-str2-7050qx-32s-acs-02-ipv4-src] SKIPPED (No port_ch...) [ 27%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-str2-7050qx-32s-acs-02-ipv6-src] SKIPPED (No port_ch...) [ 28%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-str2-7050qx-32s-acs-02-ipv4-dst] SKIPPED (No port_ch...) [ 29%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[port_channel_members-str2-7050qx-32s-acs-02-ipv6-dst] SKIPPED (No port_ch...) [ 30%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-str2-7050qx-32s-acs-02-ipv4-src] PASSED                          [ 31%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-str2-7050qx-32s-acs-02-ipv6-src] PASSED                          [ 32%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-str2-7050qx-32s-acs-02-ipv4-dst] PASSED                          [ 33%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-str2-7050qx-32s-acs-02-ipv6-dst] PASSED                          [ 34%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-str2-7050qx-32s-acs-02-ipv4-src] SKIPPED (No rif_members avai...) [ 35%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-str2-7050qx-32s-acs-02-ipv6-src] SKIPPED (No rif_members avai...) [ 36%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-str2-7050qx-32s-acs-02-ipv4-dst] SKIPPED (No rif_members avai...) [ 37%]
drop_packets/test_drop_counters.py::test_ip_is_zero_addr[rif_members-str2-7050qx-32s-acs-02-ipv6-dst] SKIPPED (No rif_members avai...) [ 38%]
drop_packets/test_drop_counters.py::test_dst_ip_link_local[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port_channel_m...) [ 39%]
drop_packets/test_drop_counters.py::test_dst_ip_link_local[vlan_members-str2-7050qx-32s-acs-02] SKIPPED (BRCM does not drop DIP li...) [ 40%]
drop_packets/test_drop_counters.py::test_dst_ip_link_local[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members available)      [ 41%]
drop_packets/test_drop_counters.py::test_loopback_filter[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (SONiC can't enable ...) [ 42%]
drop_packets/test_drop_counters.py::test_loopback_filter[vlan_members-str2-7050qx-32s-acs-02] SKIPPED (SONiC can't enable loop-bac...) [ 43%]
drop_packets/test_drop_counters.py::test_loopback_filter[rif_members-str2-7050qx-32s-acs-02] SKIPPED (SONiC can't enable loop-back...) [ 44%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port_cha...) [ 45%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[vlan_members-str2-7050qx-32s-acs-02] PASSED                           [ 46%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members avail...) [ 47%]
drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-str2-7050qx-32s-acs-02-version-1] SKIPPED (No port_...) [ 48%]
drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-str2-7050qx-32s-acs-02-chksum-10] SKIPPED (No port_...) [ 49%]
drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-str2-7050qx-32s-acs-02-ihl-1] SKIPPED (No port_chan...) [ 50%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-str2-7050qx-32s-acs-02-version-1] PASSED                        [ 50%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-str2-7050qx-32s-acs-02-chksum-10] PASSED                        [ 51%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-str2-7050qx-32s-acs-02-ihl-1] PASSED                            [ 52%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-str2-7050qx-32s-acs-02-version-1] SKIPPED (No rif_members av...) [ 53%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-str2-7050qx-32s-acs-02-chksum-10] SKIPPED (No rif_members av...) [ 54%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-str2-7050qx-32s-acs-02-ihl-1] SKIPPED (No rif_members available) [ 55%]
drop_packets/test_drop_counters.py::test_absent_ip_header[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port_channel_me...) [ 56%]
drop_packets/test_drop_counters.py::test_absent_ip_header[vlan_members-str2-7050qx-32s-acs-02] PASSED                                  [ 57%]
drop_packets/test_drop_counters.py::test_absent_ip_header[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members available)       [ 58%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[port_channel_members-str2-7050qx-32s-acs-02-01:00:5e:00:01:02] SKIPPED [ 59%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[port_channel_members-str2-7050qx-32s-acs-02-ff:ff:ff:ff:ff:ff] SKIPPED [ 60%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[vlan_members-str2-7050qx-32s-acs-02-01:00:5e:00:01:02] SKIPPED   [ 61%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[vlan_members-str2-7050qx-32s-acs-02-ff:ff:ff:ff:ff:ff] SKIPPED   [ 62%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[rif_members-str2-7050qx-32s-acs-02-01:00:5e:00:01:02] SKIPPED    [ 63%]
drop_packets/test_drop_counters.py::test_unicast_ip_incorrect_eth_dst[rif_members-str2-7050qx-32s-acs-02-ff:ff:ff:ff:ff:ff] SKIPPED    [ 64%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-str2-7050qx-32s-acs-02-v1-general_query] SKIPPED  [ 65%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-str2-7050qx-32s-acs-02-v3-general_query] SKIPPED  [ 66%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-str2-7050qx-32s-acs-02-v1-membership_report] SKIPPED [ 67%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-str2-7050qx-32s-acs-02-v2-membership_report] SKIPPED [ 68%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-str2-7050qx-32s-acs-02-v3-membership_report] SKIPPED [ 69%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[port_channel_members-str2-7050qx-32s-acs-02-v2-leave_group] SKIPPED    [ 70%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-str2-7050qx-32s-acs-02-v1-general_query] SKIPPED (Tes...) [ 71%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-str2-7050qx-32s-acs-02-v3-general_query] SKIPPED (Tes...) [ 72%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-str2-7050qx-32s-acs-02-v1-membership_report] SKIPPED      [ 73%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-str2-7050qx-32s-acs-02-v2-membership_report] SKIPPED      [ 74%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-str2-7050qx-32s-acs-02-v3-membership_report] SKIPPED      [ 75%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[vlan_members-str2-7050qx-32s-acs-02-v2-leave_group] SKIPPED (Test ...) [ 76%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-str2-7050qx-32s-acs-02-v1-general_query] SKIPPED (No r...) [ 77%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-str2-7050qx-32s-acs-02-v3-general_query] SKIPPED (No r...) [ 78%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-str2-7050qx-32s-acs-02-v1-membership_report] SKIPPED (...) [ 79%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-str2-7050qx-32s-acs-02-v2-membership_report] SKIPPED (...) [ 80%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-str2-7050qx-32s-acs-02-v3-membership_report] SKIPPED (...) [ 81%]
drop_packets/test_drop_counters.py::test_non_routable_igmp_pkts[rif_members-str2-7050qx-32s-acs-02-v2-leave_group] SKIPPED (No rif...) [ 82%]
drop_packets/test_drop_counters.py::test_acl_drop[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port_channel_members av...) [ 83%]
drop_packets/test_drop_counters.py::test_acl_drop[vlan_members-str2-7050qx-32s-acs-02] SKIPPED (RX DUT port absent in 'DATAACL' table) [ 84%]
drop_packets/test_drop_counters.py::test_acl_drop[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members available)               [ 85%]
drop_packets/test_drop_counters.py::test_acl_egress_drop[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (Not supported on Br...) [ 86%]
drop_packets/test_drop_counters.py::test_acl_egress_drop[vlan_members-str2-7050qx-32s-acs-02] SKIPPED (Not supported on Broadcom p...) [ 87%]
drop_packets/test_drop_counters.py::test_acl_egress_drop[rif_members-str2-7050qx-32s-acs-02] SKIPPED (Not supported on Broadcom pl...) [ 88%]
drop_packets/test_drop_counters.py::test_reserved_dmac_drop[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port_channel_...) [ 89%]
drop_packets/test_drop_counters.py::test_reserved_dmac_drop[vlan_members-str2-7050qx-32s-acs-02] SKIPPED (Test case requires expli...) [ 90%]
drop_packets/test_drop_counters.py::test_reserved_dmac_drop[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members available)     [ 91%]
drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port...) [ 92%]
drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link[vlan_members-str2-7050qx-32s-acs-02] SKIPPED (RIF interface i...) [ 93%]
drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members a...) [ 94%]
drop_packets/test_drop_counters.py::test_src_ip_link_local[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port_channel_m...) [ 95%]
drop_packets/test_drop_counters.py::test_src_ip_link_local[vlan_members-str2-7050qx-32s-acs-02] SKIPPED (BRCM does not drop SIP li...) [ 96%]
drop_packets/test_drop_counters.py::test_src_ip_link_local[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members available)      [ 97%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_exceeded_mtu[port_channel_members-str2-7050qx-32s-acs-02] SKIPPED (No port_ch...) [ 98%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_exceeded_mtu[vlan_members-str2-7050qx-32s-acs-02] SKIPPED (Test case is not s...) [ 99%]
drop_packets/test_drop_counters.py::test_ip_pkt_with_exceeded_mtu[rif_members-str2-7050qx-32s-acs-02] SKIPPED (No rif_members avai...) [100%]
```
