### PR TITLE
[Nokia-7215] Skip test_dynamic_acl on Nokia-7215 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -639,6 +639,12 @@ generic_config_updater/test_dhcp_relay.py:
       - "platform in ['x86_64-8111_32eh_o-r0']"
       - "'backend' in topo_name"
 
+generic_config_updater/test_dynamic_acl.py:
+  skip:
+    reason: "Skip on unsupported platforms"
+    conditions:
+      - "release in ['202311', '202405'] and platform in ['armhf-nokia_ixs7215_52x-r0']"
+
 generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
   skip:
     reason: "This test is not run on this asic type, topology, or version currently"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip `test_dynamic_acl` on Nokia-7215 platform. This feature cannot be supported on Nokia-7215 before 202411 branch cut-over.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Skip `test_dynamic_acl` on Nokia-7215 platform. This feature cannot be supported on Nokia-7215 before 202411 branch cut-over.

#### How did you do it?
Use conditional mark.

#### How did you verify/test it?
Verified on Nokia-7215 M0 testbed.

```
=============================================== short test summary info ================================================
SKIPPED [18] generic_config_updater/test_dynamic_acl.py: Skip on unsupported platforms
SKIPPED [4] generic_config_updater/test_dynamic_acl.py:1166: Skip on unsupported platforms
=========================================== 22 skipped, 3 warnings in 45.82s ===========================================
```

#### Any platform specific information?
Nokia-7215 platform specific.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
