### PR TITLE
Update skip conditions for drop packets DIP/SIP link local IP

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -3,11 +3,20 @@
 ####################################################
 #Link local address(169.254.xxx.xxx) as a source address as IPv4 header is not invalid in all the cases
 #Hence, it is not dropped by default in Cisco-8000. For dropping link local address, it should be done through security/DATA ACL
+drop_packets/test_configurable_drop_counters.py::test_dip_link_local:
+  skip:
+    reason: "Some mlx platforms does not drop DIP link local packets"
+    conditions:
+      - "'Mellanox' in hwsku"
+
 drop_packets/test_configurable_drop_counters.py::test_sip_link_local:
   skip:
-    reason: "Cisco 8000 platform does not drop SIP link local packets"
+    reason: "Cisco 8000 platform and some MLX platforms does not drop SIP link local packets"
+    conditions_logical_operator: or
     conditions:
-       - asic_type=="cisco-8000"
+      - asic_type=="cisco-8000"
+      - "'Mellanox' in hwsku"
+
 
 #######################################
 #####     test_drop_counters.py   #####
@@ -54,9 +63,11 @@ drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[vlan_members]:
 
 drop_packets/test_drop_counters.py::test_dst_ip_link_local:
   skip:
-    reason: "Cisco 8000 and broadcom DNX platforms do not drop DIP linklocal packets"
+    reason: "Cisco 8000 broadcom DNX platforms and some MLX platforms do not drop DIP linklocal packets"
+    conditions_logical_operator: or
     conditions:
       - "(asic_type=='cisco-8000') or (asic_subtype in ['broadcom-dnx'])"
+      - "'Mellanox' in hwsku"
 
 drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop:
   skip:
@@ -163,6 +174,8 @@ drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[vlan_members-i
 
 drop_packets/test_drop_counters.py::test_src_ip_link_local:
   skip:
-    reason: "Cisco 8000 platform does not drop SIP link local packets"
+    reason: "Cisco 8000 broadcom DNX platforms and some MLX platforms do not drop SIP linklocal packets"
+    conditions_logical_operator: or
     conditions:
-      - "asic_type=='cisco-8000'"
+      - "(asic_type=='cisco-8000') or (asic_subtype in ['broadcom-dnx'])"
+      - "'Mellanox' in hwsku"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
After  # (https://github.com/sonic-net/sonic-buildimage/pull/18487) Mellanox platforms mentioned in PR won't be drop DIP/SIP IP link local address.

Note!!! Backport to 202311 has to be after https://github.com/sonic-net/sonic-buildimage/pull/18692 merged

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Skip drop TC related to IP link local address
#### How did you do it?
Add skip into appropriate yaml 
#### How did you verify/test it?
Run TC, TC has been skipped
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
