### PR TITLE
Added temporary skip to system health TC for MLX platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1508,6 +1508,12 @@ syslog/test_syslog_source_ip.py:
 #######################################
 #####         system_health       #####
 #######################################
+system_health/test_system_health.py::test_device_checker:
+  skip:
+    reason: "Temporary skip for Mellanox platforms"
+    conditions:
+      - "asic_type in ['mellanox']"
+
 system_health/test_system_health.py::test_service_checker_with_process_exit:
   xfail:
     strict: True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Test is no longer supported on mellanox asic because asic temperature is read from sdk sysfs rather than /run/hw-management/thermal/asic. TC will be updated and skip removed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
TC has to be temporary skipped until TC will be updated
#### How did you do it?
Add skip 
#### How did you verify/test it?
Run TC, TC skipped
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
