### PR TITLE
[PR:12393]  Adding ipv6_mgmt_only test case into PR testing and fix ntp fixture errors

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -70,6 +70,7 @@ t0:
   - test_procdockerstatsd.py
   - database/test_db_scripts.py
   - system_health/test_watchdog.py
+  - ip/test_mgmt_ipv6_only.py
 
 t0-2vlans:
   - dhcp_relay/test_dhcp_relay.py

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -9,7 +9,7 @@ from tests.tacacs.utils import check_output
 from tests.bgp.test_bgp_fact import run_bgp_facts
 from tests.test_features import run_show_features
 from tests.tacacs.test_ro_user import ssh_remote_run
-from tests.ntp.test_ntp import run_ntp, setup_ntp  # noqa F401
+from tests.ntp.test_ntp import run_ntp, setup_ntp_func # noqa F401
 from tests.common.helpers.assertions import pytest_require
 from tests.tacacs.conftest import tacacs_creds, check_tacacs_v6_func # noqa F401
 from tests.syslog.test_syslog import run_syslog, check_default_route # noqa F401
@@ -179,5 +179,5 @@ def test_telemetry_output_ipv6_only(convert_and_restore_config_db_to_ipv6_only, 
 
 # use function scope fixture so that convert_and_restore_config_db_to_ipv6_only will run before setup_ntp_func
 def test_ntp_ipv6_only(duthosts, rand_one_dut_hostname,
-                                  convert_and_restore_config_db_to_ipv6_only, setup_ntp): # noqa F811
-    run_ntp(duthosts, rand_one_dut_hostname, setup_ntp)
+                                  convert_and_restore_config_db_to_ipv6_only, setup_ntp_func): # noqa F811
+    run_ntp(duthosts, rand_one_dut_hostname, setup_ntp_func)

--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -3,6 +3,7 @@ from tests.common.helpers.assertions import pytest_assert
 import logging
 import time
 import pytest
+from contextlib import contextmanager
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,18 @@ def config_long_jump(duthost, enable=False):
 
 @pytest.fixture(scope="module")
 def setup_ntp(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6):
+    with _context_for_setup_ntp(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6) as result:
+        yield result
+
+
+@pytest.fixture(scope="function")
+def setup_ntp_func(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6):
+    with _context_for_setup_ntp(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6) as result:
+        yield result
+
+
+@contextmanager
+def _context_for_setup_ntp(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6):
     """setup ntp client and server"""
     duthost = duthosts[rand_one_dut_hostname]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Original PR: https://github.com/sonic-net/sonic-mgmt/pull/12393

Summary:
1. Add `ip/test_mgmt_ipv6_only.py` into PR pipeline testing.
2. Rearrange fixture order for two test cases: `ip/test_mgmt_ipv6_only.py::test_rw_user_ipv6_only` and `ip/test_mgmt_ipv6_only.py::test_ro_user_ipv6_only`.
3. Workaround pytest fixture teardown bug affecting `setup_ntp` when run the `ip/test_mgmt_ipv6_only.py` tests.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
