### PR TITLE
Add Nokia-7215-A1 platform support for watchdog api testcases

### DIFF
--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -46,7 +46,8 @@ class TestWatchdogApi(PlatformApiTestBase):
         and disables it after the test ends'''
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0':
+        if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0' or \
+                duthost.facts['platform'] == 'arm64-nokia_ixs7215_52xb-r0':
             duthost.shell("watchdogutil disarm")
 
         assert not watchdog.is_armed(platform_api_conn)
@@ -55,7 +56,8 @@ class TestWatchdogApi(PlatformApiTestBase):
             yield
         finally:
             watchdog.disarm(platform_api_conn)
-            if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0':
+            if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0' or \
+                    duthost.facts['platform'] == 'arm64-nokia_ixs7215_52xb-r0':
                 duthost.shell("systemctl start cpu_wdt.service")
 
     @pytest.fixture(scope='module')

--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -94,6 +94,13 @@ armhf-nokia_ixs7215_52x-r0:
     greater_timeout: 170
     too_big_timeout: 200
 
+# Nokia IXS-7215-A1 watchdog
+arm64-nokia_ixs7215_52xb-r0:
+  default:
+    valid_timeout: 30
+    greater_timeout: 170
+    too_big_timeout: 400
+
 # Cisco-8000 watchdog
 x86_64-8102_64h_o-r0:
   default:


### PR DESCRIPTION

### Description of PR
This PR is for adding Nokia-7215-A1 platform support for test_watchdog.py testcases.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Currently, there is no support for platform_tests/api/test_watchdog.py testcases for Nokia-7215-A1 platform. This PR helps add support for these testcases.
#### How did you do it?
Added platform specific condition for arm64-nokia_ixs7215_52xb-r0 in test_watchdog.py to arm/disarm watchdog.
#### How did you verify/test it?
Ran test_watchdog.py testcases and verified that all the testcases pass
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA

