### PR TITLE
added Nokia-7215-A1 support for fdb testcases

### DIFF
--- a/tests/common/helpers/portchannel_to_vlan.py
+++ b/tests/common/helpers/portchannel_to_vlan.py
@@ -400,7 +400,8 @@ def setup_po2vlan(duthosts, ptfhost, rand_one_dut_hostname, rand_selected_dut, p
                 pytest.skip("OS Version of fanout is older than 202205, unsupported")
             asic_type = fanouthost.facts['asic_type']
             platform = fanouthost.facts["platform"]
-            if not (asic_type in ["broadcom"] or platform in ["armhf-nokia_ixs7215_52x-r0"]):
+            if not (asic_type in ["broadcom"] or platform in
+                    ["armhf-nokia_ixs7215_52x-r0", "arm64-nokia_ixs7215_52xb-r0"]):
                 pytest.skip("Not supporteds on SONiC leaf-fanout platform")
 
     duthost = duthosts[rand_one_dut_hostname]


### PR DESCRIPTION
### Description of PR
This PR helps add Nokia-7215-A1 support for test_fdb.py testcases 

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR helps add support for Nokia-7215-A1 in test_fdb.py testcases. Currently it is skipped as there is no support.
#### How did you do it?
Added arm64-nokia_ixs7215_52xb-r0 in setup_po2vlan in portchannel_to_vlan.py.
#### How did you verify/test it?
Ran the entire fdb suite to see it is not skipped.
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA