### PR TITLE
[TACACS] Improve TACACS run command on IPV6 failed issue.

### DIFF
--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -82,7 +82,7 @@ def ssh_remote_run_with_ipv6(localhost, dutip, ptfhost, user, password, command)
     retry_count = RETRY_COUNT
     while retry_count > 0:
         res = ssh_remote_run(localhost, dutip, user,
-                            password, command)
+                             password, command)
 
         # TACACS server randomly crash after receive authorization request from IPV6
         if not tacacs_running(ptfhost):
@@ -193,7 +193,8 @@ def test_ro_user_allowed_command(localhost, duthosts, enum_rand_one_per_hwsku_ho
                                           " 'sudo sonic-installer list' is banned")
 
 
-def test_ro_user_banned_by_sudoers_command(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
+def test_ro_user_banned_by_sudoers_command(localhost, duthosts, enum_rand_one_per_hwsku_hostname,
+                                           tacacs_creds, check_tacacs):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutip = duthost.mgmt_ip
 

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 SLEEP_TIME = 10
 TIMEOUT_LIMIT = 120
-RETRY_COUNT = 3
 
 
 def ssh_remote_run(localhost, remote_ip, username, password, cmd):
@@ -78,8 +77,7 @@ def wait_for_tacacs(localhost, remote_ip, username, password):
                 current_attempt += 1
 
 
-def ssh_remote_run_with_ipv6(localhost, dutip, ptfhost, user, password, command):
-    retry_count = RETRY_COUNT
+def ssh_remote_run_retry(localhost, dutip, ptfhost, user, password, command, retry_count = 3):
     while retry_count > 0:
         res = ssh_remote_run(localhost, dutip, user,
                              password, command)
@@ -107,9 +105,9 @@ def test_ro_user_ipv6(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_host
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutip = duthost.mgmt_ip
 
-    res = ssh_remote_run_with_ipv6(localhost, dutip, ptfhost,
-                                   tacacs_creds['tacacs_rw_user'],
-                                   tacacs_creds['tacacs_rw_user_passwd'],
+    res = ssh_remote_run_retry(localhost, dutip, ptfhost,
+                                   tacacs_creds['tacacs_ro_user'],
+                                   tacacs_creds['tacacs_ro_user_passwd'],
                                    "cat /etc/passwd")
 
     check_output(res, 'testadmin', 'remote_user_su')

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -77,7 +77,7 @@ def wait_for_tacacs(localhost, remote_ip, username, password):
                 current_attempt += 1
 
 
-def ssh_remote_run_retry(localhost, dutip, ptfhost, user, password, command, retry_count = 3):
+def ssh_remote_run_retry(localhost, dutip, ptfhost, user, password, command, retry_count=3):
     while retry_count > 0:
         res = ssh_remote_run(localhost, dutip, user,
                              password, command)
@@ -106,9 +106,9 @@ def test_ro_user_ipv6(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_host
     dutip = duthost.mgmt_ip
 
     res = ssh_remote_run_retry(localhost, dutip, ptfhost,
-                                   tacacs_creds['tacacs_ro_user'],
-                                   tacacs_creds['tacacs_ro_user_passwd'],
-                                   "cat /etc/passwd")
+                               tacacs_creds['tacacs_ro_user'],
+                               tacacs_creds['tacacs_ro_user_passwd'],
+                               "cat /etc/passwd")
 
     check_output(res, 'testadmin', 'remote_user_su')
 

--- a/tests/tacacs/test_rw_user.py
+++ b/tests/tacacs/test_rw_user.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .test_ro_user import ssh_remote_run
+from .test_ro_user import ssh_remote_run, ssh_remote_run_with_ipv6
 from .utils import check_output
 
 pytestmark = [
@@ -21,12 +21,14 @@ def test_rw_user(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_c
     check_output(res, 'testadmin', 'remote_user_su')
 
 
-def test_rw_user_ipv6(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs_v6):
+def test_rw_user_ipv6(localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs_v6):
     """test tacacs rw user
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutip = duthost.mgmt_ip
-    res = ssh_remote_run(localhost, dutip, tacacs_creds['tacacs_rw_user'],
-                         tacacs_creds['tacacs_rw_user_passwd'], "cat /etc/passwd")
+    res = ssh_remote_run_with_ipv6(localhost, dutip, ptfhost,
+                                   tacacs_creds['tacacs_rw_user'],
+                                   tacacs_creds['tacacs_rw_user_passwd'],
+                                   "cat /etc/passwd")
 
     check_output(res, 'testadmin', 'remote_user_su')

--- a/tests/tacacs/test_rw_user.py
+++ b/tests/tacacs/test_rw_user.py
@@ -28,8 +28,8 @@ def test_rw_user_ipv6(localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_host
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutip = duthost.mgmt_ip
     res = ssh_remote_run_retry(localhost, dutip, ptfhost,
-                                   tacacs_creds['tacacs_rw_user'],
-                                   tacacs_creds['tacacs_rw_user_passwd'],
-                                   "cat /etc/passwd")
+                               tacacs_creds['tacacs_rw_user'],
+                               tacacs_creds['tacacs_rw_user_passwd'],
+                               "cat /etc/passwd")
 
     check_output(res, 'testadmin', 'remote_user_su')

--- a/tests/tacacs/test_rw_user.py
+++ b/tests/tacacs/test_rw_user.py
@@ -21,7 +21,8 @@ def test_rw_user(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_c
     check_output(res, 'testadmin', 'remote_user_su')
 
 
-def test_rw_user_ipv6(localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs_v6):
+def test_rw_user_ipv6(localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_hostname,
+                      tacacs_creds, check_tacacs_v6):
     """test tacacs rw user
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]

--- a/tests/tacacs/test_rw_user.py
+++ b/tests/tacacs/test_rw_user.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .test_ro_user import ssh_remote_run, ssh_remote_run_with_ipv6
+from .test_ro_user import ssh_remote_run, ssh_remote_run_retry
 from .utils import check_output
 
 pytestmark = [
@@ -27,7 +27,7 @@ def test_rw_user_ipv6(localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_host
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutip = duthost.mgmt_ip
-    res = ssh_remote_run_with_ipv6(localhost, dutip, ptfhost,
+    res = ssh_remote_run_retry(localhost, dutip, ptfhost,
                                    tacacs_creds['tacacs_rw_user'],
                                    tacacs_creds['tacacs_rw_user_passwd'],
                                    "cat /etc/passwd")

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -33,9 +33,11 @@ def check_all_services_status(ptfhost):
     res = ptfhost.command("service --status-all")
     logger.info(res["stdout_lines"])
 
+
 def tacacs_running(ptfhost):
     out = ptfhost.command("service tacacs_plus status", module_ignore_errors=True)["stdout"]
     return "tacacs+ running" in out
+
 
 def start_tacacs_server(ptfhost):
     ptfhost.command("service tacacs_plus restart", module_ignore_errors=True)

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -33,12 +33,11 @@ def check_all_services_status(ptfhost):
     res = ptfhost.command("service --status-all")
     logger.info(res["stdout_lines"])
 
+def tacacs_running(ptfhost):
+    out = ptfhost.command("service tacacs_plus status", module_ignore_errors=True)["stdout"]
+    return "tacacs+ running" in out
 
 def start_tacacs_server(ptfhost):
-    def tacacs_running(ptfhost):
-        out = ptfhost.command("service tacacs_plus status", module_ignore_errors=True)["stdout"]
-        return "tacacs+ running" in out
-
     ptfhost.command("service tacacs_plus restart", module_ignore_errors=True)
     return wait_until(5, 1, 0, tacacs_running, ptfhost)
 


### PR DESCRIPTION
Improve TACACS run command on IPV6 failed issue.

#### Why I did it
Tacplus server crash when receive authorization request from IPV6 address.

##### Work item tracking
- Microsoft ADO: 27895362

#### How I did it
Check TACACS server status after run command with IPV6 address.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Improve TACACS run command on IPV6 failed issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

