### PR TITLE
[TACACS] Handle log rotate failed issue

### DIFF
--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -184,7 +184,7 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
             duthost.shell("logrotate --force /etc/logrotate.d/rsyslog")
         except RunAnsibleModuleFail as e:
             # command will failed when log already in rotating
-            logger.warning("logrotate command failed".format(e))
+            logger.warning("logrotate command failed: {}".format(e))
 
         res = duthost.shell("systemctl restart rsyslog")
         assert res["rc"] == 0, "failed to restart rsyslog"

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -180,7 +180,11 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
         duthost.copy(src=conf_path, dest="/etc/rsyslog.d/000-ro_disk.conf")
 
         # To get file in decent size. Force a rotate
-        duthost.shell("logrotate --force /etc/logrotate.d/rsyslog")
+        try:
+            duthost.shell("logrotate --force /etc/logrotate.d/rsyslog")
+        except RunAnsibleModuleFail as e:
+            # command will failed when log already in rotating
+            logger.warning("logrotate command failed".format(e))
 
         res = duthost.shell("systemctl restart rsyslog")
         assert res["rc"] == 0, "failed to restart rsyslog"

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -183,8 +183,11 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
         try:
             duthost.shell("logrotate --force /etc/logrotate.d/rsyslog")
         except RunAnsibleModuleFail as e:
-            # command will failed when log already in rotating
-            logger.warning("logrotate command failed: {}".format(e))
+            if "logrotate does not support parallel execution on the same set of logfiles" in e.message:
+                # command will failed when log already in rotating
+                logger.warning("logrotate command failed: {}".format(e))
+            else:
+                raise e
 
         res = duthost.shell("systemctl restart rsyslog")
         assert res["rc"] == 0, "failed to restart rsyslog"


### PR DESCRIPTION
Handle log rotate failed issue

#### Why I did it
sonic test_ro_disk test case failed because log rotate command failed.

##### Work item tracking
- Microsoft ADO: 27929530

#### How I did it
Ignore log rotate failed because log already rotating

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Handle log rotate failed issue

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

