### PR TITLE
[TACACS] Increase check local log wait time and print debug info.

### DIFF
--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -39,17 +39,33 @@ def cleanup_tacacs_log(ptfhost, rw_user_client):
     ssh_run_command(rw_user_client, 'sudo truncate -s 0 /var/log/syslog')
 
 
-def wait_for_log(host, log_file, pattern, timeout=30, check_interval=1):
+def host_run_command(host, command):
+    if isinstance(host, PTFHost):
+        return host.command(command)
+    else:
+        return host.shell("sudo {0}".format(command))
+
+
+def flush_log(host, log_file):
+    if "syslog" in log_file:
+        # force flush syslog by reopen log file and write cached data to disk:
+        #   https://man7.org/linux/man-pages/man8/rsyslogd.8.html
+        #   https://man7.org/linux/man-pages/man1/sync.1.html
+        host_run_command(host, "kill -HUP $(cat /var/run/rsyslogd.pid)")
+        host_run_command(host, "sync {0}".format(log_file))
+    else:
+        host_run_command(host, "sync {0}".format(log_file))
+
+
+def wait_for_log(host, log_file, pattern, timeout=20, check_interval=1):
     wait_time = 0
     while wait_time <= timeout:
-        sed_command = "sed -nE '{0}' {1}".format(pattern, log_file)
-        logger.info(sed_command)  # lgtm [py/clear-text-logging-sensitive-data]
-        if isinstance(host, PTFHost):
-            res = host.command(sed_command)
-        else:
-            res = host.shell(sed_command)
+        flush_log(host, log_file)
+        sed_command = "sed -nE '{1}' {2}".format(log_file, pattern, log_file)
+        logger.debug(sed_command)  # lgtm [py/clear-text-logging-sensitive-data]
+        res = host_run_command(host, sed_command)
 
-        logger.info(res["stdout_lines"])
+        logger.debug(res["stdout_lines"])
         if len(res["stdout_lines"]) > 0:
             return res["stdout_lines"]
 

--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -39,7 +39,7 @@ def cleanup_tacacs_log(ptfhost, rw_user_client):
     ssh_run_command(rw_user_client, 'sudo truncate -s 0 /var/log/syslog')
 
 
-def wait_for_log(host, log_file, pattern, timeout=20, check_interval=1):
+def wait_for_log(host, log_file, pattern, timeout=30, check_interval=1):
     wait_time = 0
     while wait_time <= timeout:
         sed_command = "sed -nE '{0}' {1}".format(pattern, log_file)
@@ -99,6 +99,12 @@ def check_local_log_exist(duthost, tacacs_creds, command):
                   /INFO audisp-tacplus.+Accounting: user: {0},.*, command: .*{1},/P" \
                   .format(username, command)
     logs = wait_for_log(duthost, "/var/log/syslog", log_pattern)
+
+    if len(logs) == 0:
+        # print recent logs for debug
+        recent_logs = duthost.command(("cat /var/log/syslog | tail -n 500")
+        logger.debug("Found logs: %s", recent_logs)
+
     pytest_assert(len(logs) > 0)
 
     # exclude logs of the sed command produced by Ansible

--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -102,7 +102,7 @@ def check_local_log_exist(duthost, tacacs_creds, command):
 
     if len(logs) == 0:
         # print recent logs for debug
-        recent_logs = duthost.command(("cat /var/log/syslog | tail -n 500")
+        recent_logs = duthost.command("cat /var/log/syslog | tail -n 500")
         logger.debug("Found logs: %s", recent_logs)
 
     pytest_assert(len(logs) > 0)

--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -61,7 +61,7 @@ def wait_for_log(host, log_file, pattern, timeout=20, check_interval=1):
     wait_time = 0
     while wait_time <= timeout:
         flush_log(host, log_file)
-        sed_command = "sed -nE '{1}' {2}".format(log_file, pattern, log_file)
+        sed_command = "sed -nE '{0}' {1}".format(pattern, log_file)
         logger.debug(sed_command)  # lgtm [py/clear-text-logging-sensitive-data]
         res = host_run_command(host, sed_command)
 


### PR DESCRIPTION
Increase check local log wait time and print debug info.

#### Why I did it
test_accounting failed because local log does not exist.

##### Work item tracking
- Microsoft ADO: 27895350

#### How I did it
Increase check local log wait time and print debug info.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Increase check local log wait time and print debug info.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

