### PR TITLE
Fix module level fixture rand_one_dut_hostname run multiple times in same test module issue.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -407,7 +407,6 @@ def rand_one_dut_hostname(request):
     """
     """
     global rand_one_dut_hostname_var
-    set_rand_one_dut_hostname(request)
     return rand_one_dut_hostname_var
 
 
@@ -1484,6 +1483,12 @@ def pytest_generate_tests(metafunc):        # noqa E302
     # When selected_dut used and select a dut for test, parameterize dut for enable TACACS on all UT
     if dut_fixture_name and "selected_dut" in metafunc.fixturenames:
         metafunc.parametrize("selected_dut", duts_selected, scope="module", indirect=True)
+
+    # When rand_one_dut_hostname used and select a dut for test, initialize rand_one_dut_hostname_var
+    # rand_one_dut_hostname and rand_selected_dut will use this variable for setup test case
+    # selected_rand_dut will use this variable for setup TACACS
+    if "rand_one_dut_hostname" in metafunc.fixturenames:
+        set_rand_one_dut_hostname(metafunc)
 
     if "enum_dut_portname" in metafunc.fixturenames:
         metafunc.parametrize("enum_dut_portname", generate_port_lists(metafunc, "all_ports"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -397,7 +397,7 @@ def rand_one_dut_hostname(request):
     """
     """
     global rand_one_dut_hostname_var
-    if rand_one_dut_hostname_var == None:
+    if rand_one_dut_hostname_var is None:
         dut_hostnames = generate_params_dut_hostname(request)
         if len(dut_hostnames) > 1:
             dut_hostnames = random.sample(dut_hostnames, 1)
@@ -413,6 +413,11 @@ def rand_selected_dut(duthosts, rand_one_dut_hostname):
     Return the randomly selected duthost
     """
     return duthosts[rand_one_dut_hostname]
+
+
+@pytest.fixture(scope="module")
+def selected_rand_dut(request):
+    return rand_one_dut_hostname(request)
 
 
 @pytest.fixture(scope="module")
@@ -1594,15 +1599,6 @@ def enum_frontend_dut_hostname(request):
 def selected_dut(request):
     try:
         logger.debug("selected_dut host: {}".format(request.param))
-        return request.param
-    except AttributeError:
-        return None
-
-
-@pytest.fixture(scope="module")
-def selected_rand_dut(request):
-    try:
-        logger.debug("selected_rand_dut host: {}".format(request.param))
         return request.param
     except AttributeError:
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -392,10 +392,7 @@ def macsec_duthost(duthosts, tbinfo):
 rand_one_dut_hostname_var = None
 
 
-@pytest.fixture(scope="module")
-def rand_one_dut_hostname(request):
-    """
-    """
+def set_rand_one_dut_hostname(request):
     global rand_one_dut_hostname_var
     if rand_one_dut_hostname_var is None:
         dut_hostnames = generate_params_dut_hostname(request)
@@ -404,6 +401,13 @@ def rand_one_dut_hostname(request):
         rand_one_dut_hostname_var = dut_hostnames[0]
         logger.info("Randomly select dut {} for testing".format(rand_one_dut_hostname_var))
 
+
+@pytest.fixture(scope="module")
+def rand_one_dut_hostname(request):
+    """
+    """
+    global rand_one_dut_hostname_var
+    set_rand_one_dut_hostname(request)
     return rand_one_dut_hostname_var
 
 
@@ -417,7 +421,8 @@ def rand_selected_dut(duthosts, rand_one_dut_hostname):
 
 @pytest.fixture(scope="module")
 def selected_rand_dut(request):
-    return rand_one_dut_hostname(request)
+    global rand_one_dut_hostname_var
+    return rand_one_dut_hostname_var
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -388,10 +388,23 @@ def macsec_duthost(duthosts, tbinfo):
     return macsec_dut
 
 
+# Make sure in same test module, always use same random DUT
+rand_one_dut_hostname_var = None
+
+
 @pytest.fixture(scope="module")
 def rand_one_dut_hostname(request):
-    logger.info("Randomly select dut {} for testing".format(request.param))
-    return request.param
+    """
+    """
+    global rand_one_dut_hostname_var
+    if rand_one_dut_hostname_var == None:
+        dut_hostnames = generate_params_dut_hostname(request)
+        if len(dut_hostnames) > 1:
+            dut_hostnames = random.sample(dut_hostnames, 1)
+        rand_one_dut_hostname_var = dut_hostnames[0]
+        logger.info("Randomly select dut {} for testing".format(rand_one_dut_hostname_var))
+
+    return rand_one_dut_hostname_var
 
 
 @pytest.fixture(scope="module")
@@ -1461,17 +1474,6 @@ def pytest_generate_tests(metafunc):        # noqa E302
     # When selected_dut used and select a dut for test, parameterize dut for enable TACACS on all UT
     if dut_fixture_name and "selected_dut" in metafunc.fixturenames:
         metafunc.parametrize("selected_dut", duts_selected, scope="module", indirect=True)
-
-    # When rand_one_dut_hostname used and select a dut for test, parameterize dut for enable TACACS on all UT
-    if "rand_one_dut_hostname" in metafunc.fixturenames:
-        rand_one_dut = generate_params_dut_hostname(metafunc)
-        if len(rand_one_dut) > 1:
-            rand_one_dut = random.sample(rand_one_dut, 1)
-        # parameterize only on DUT
-        metafunc.parametrize("rand_one_dut_hostname", rand_one_dut, scope="module", indirect=True)
-
-        if "selected_rand_dut" in metafunc.fixturenames:
-            metafunc.parametrize("selected_rand_dut", rand_one_dut, scope="module", indirect=True)
 
     if "enum_dut_portname" in metafunc.fixturenames:
         metafunc.parametrize("enum_dut_portname", generate_port_lists(metafunc, "all_ports"))


### PR DESCRIPTION
Fix module level fixture rand_one_dut_hostname run multiple times in same test module issue.

#### Why I did it
rand_one_dut_hostname run multiple times in same module cause acl/test_acl.py run long time

##### Work item tracking
- Microsoft ADO: 27997617

#### How I did it
Store random DUT name in global variable, remove parameterization code.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Fix module level fixture rand_one_dut_hostname run multiple times in same test module issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

