### PR TITLE
Skip IPV6 variant of testQosSaiDscpQueueMapping if IPV6 is not config…

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1335,6 +1335,9 @@ class TestQosSai(QosSaiBase):
         testParams.update(dutTestParams["basicParams"])
 
         if ip_version == "ipv6":
+            if "src_port_ipv6" not in dutConfig["testPorts"] or "dst_port_ipv6" not in dutConfig["testPorts"]:
+                pytest.skip("Skip IPV6 variant as IPV6 not configured")
+
             testParams.update({
                 "src_port_ip": dutConfig["testPorts"]["src_port_ipv6"],
                 "dst_port_ip": dutConfig["testPorts"]["dst_port_ipv6"],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip 
Fixes [#118](https://github.com/aristanetworks/sonic-qual.msft/issues/118)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
IPV6 variant of the test fails 
```
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_asic-ipv6]
---------------------------------------------------------------------------------------- live log call ----------------------------------------------------------------------------------------
06:25:52 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 1788, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 493, in __call__
    return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 115, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 113, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 77, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/data/tests/qos/test_qos_sai.py", line 1337, in testQosSaiDscpQueueMapping
    "src_port_ip": dutConfig["testPorts"]["src_port_ipv6"],
KeyError: 'src_port_ipv6'

FAILED
```

This is because IPV6 is disabled on the DUT for the entire `qos/test_qos_sai.py`: https://github.com/sonic-net/sonic-mgmt/blob/master/tests/qos/qos_sai_base.py#L1818

#### How did you do it?
The IPV6 variant of this test needs more work or probably should be a new test module altogether therefore skipping the test for now if IPV6 is not found for the interfaces.

#### How did you verify/test it?
Ran the test with with 202311 image

```
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_asic-ipv6] SKIPPED (Skip IPV6 variant as IPV6 not configured)                                                        [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
