### PR TITLE
[Mellanox] Select 4 lanes port on Spectrum-1 platform in QOS buffer test

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -933,10 +933,17 @@ def port_to_test(request, duthost):
             "LAG member port {} can not be used for dynamic buffer test".format(PORT_TO_TEST))
         PORT_TO_TEST = None
     if not PORT_TO_TEST:
-        PORT_TO_TEST = list(testPort)[0]
-    lanes = duthost.shell(
-        'redis-cli -n 4 hget "PORT|{}" lanes'.format(PORT_TO_TEST))['stdout']
-    NUMBER_OF_LANES = len(lanes.split(','))
+        # The NVIDIA SPC1 platform requires a 4 lanes port for testing to avoid exceeding the maximum available headroom
+        if duthost.facts['asic_type'].lower() == 'mellanox' and 'sn2' in duthost.facts['hwsku'].lower():
+            for port in list(testPort):
+                if duthost.count_portlanes(port) >= 4:
+                    PORT_TO_TEST = port
+                    break
+            pytest_require(PORT_TO_TEST is not None, "No 4 lanes port in DUT for Mellanox SPC1 platform")
+        else:
+            PORT_TO_TEST = list(testPort)[0]
+
+    NUMBER_OF_LANES = duthost.count_portlanes(PORT_TO_TEST)
 
     logging.info("Port to test {}, number of lanes {}".format(
         PORT_TO_TEST, NUMBER_OF_LANES))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The maximum available headroom is different for 2-lane ports and 4-lane ports. In Melanox Spectrum-1 platform, if 2 Lanes port is selected, the Headroom value on the port will exceed the maximum available Headroom, so this test case requires selecting 4 Lanes port.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
