### PR TITLE
Ignore error log from ctrmgrd in test_k8s_config_patch_apply

### DIFF
--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -154,5 +154,9 @@ def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loga
             # sonic-sairedis/vslib/HostInterfaceInfo.cpp: Need investigation
             ".*ERR syncd[0-9]*#syncd.*tap2veth_fun: failed to write to socket.*",   # test_portchannel_interface tc2
             ".*ERR.*'apply-patch' executed failed.*",  # negative cases that are expected to fail
+
+            # Ignore errors from k8s config test
+            ".*ERR ctrmgrd.py: Refer file.*",
+            ".*ERR ctrmgrd.py: Join failed.*"
         ]
         loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Test case `test_k8s_config_patch_apply` is error out because error logs in syslog. The error message is expected as DUT doesn't have public DNS access.
```
E               May 11 13:35:04.494371 sonic ERR ctrmgrd.py: Refer file /tmp/tmp8apufdr7kube_hints_ for troubleshooting tips
E               
E               May 11 13:35:04.495918 sonic ctrmgrd.py: Join failed: HTTPSConnectionPool(host='k8svip.ap.gbl', port=6443): Max retries exceeded with url: /api/v1/namespaces/default/configmaps/kube-root-ca.crt (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7fdd64a9a250>: Failed to resolve 'k8svip.ap.gbl' ([Errno -2] Name or service not known)"))
```
This PR addressed the issue by ignoring the error log.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR is to ignore error log from ctrmgrd in `test_k8s_config_patch_apply`.

#### How did you do it?
Add the expected log pattern into ignore list of LogAnalyzer.

#### How did you verify/test it?
Verified by running the test in a physical testbed. The test can pass now.
```
collected 1 item                                                                                                                                                                                      

generic_config_updater/test_kubernetes_config.py::test_k8s_config_patch_apply PASSED                                                                                                            [100%]

```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
