### PR TITLE
Re-enable ICMP responder and gratuitous ARP service for active-standby dualtor topologies.

### DIFF
--- a/tests/arp/test_unknown_mac.py
+++ b/tests/arp/test_unknown_mac.py
@@ -14,9 +14,11 @@ import ptf.packet as packet
 from tests.common import constants
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses    # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py   # noqa F401
+from tests.common.fixtures.ptfhost_utils import pause_garp_service_dualtor_m      # noqa F401
+from tests.common.fixtures.ptfhost_utils import pause_icmp_responder_dualtor_m    # noqa F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_unconditionally    # noqa F401
 from tests.common.utilities import get_intf_by_sub_intf, wait_until
 
 logger = logging.getLogger(__name__)
@@ -42,7 +44,7 @@ def initClassVars(func):
 
 
 @pytest.fixture(autouse=True, scope="module")
-def unknownMacSetup(duthosts, rand_one_dut_hostname, tbinfo):
+def unknownMacSetup(duthosts, rand_one_dut_hostname, tbinfo, pause_icmp_responder_dualtor_m, pause_garp_service_dualtor_m):   # noqa F811
     """
     Fixture to populate all the parameters needed for the test
 
@@ -152,7 +154,7 @@ def flushArpFdb(duthosts, rand_one_dut_hostname):
 
 @pytest.fixture(autouse=True)
 def populateArp(unknownMacSetup, flushArpFdb, ptfhost, duthosts, rand_one_dut_hostname,
-                toggle_all_simulator_ports_to_rand_selected_tor_m):     # noqa F811
+                toggle_all_simulator_ports_to_rand_selected_tor_unconditionally):     # noqa F811
     """
     Fixture to populate ARP entry on the DUT for the traffic destination
 

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -45,6 +45,7 @@ __all__ = [
     'simulator_flap_counter',
     'config_active_standby_ports',
     'toggle_all_simulator_ports_to_rand_selected_tor_unconditionally',
+    'toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_unconditionally',
     ]
 
 logger = logging.getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,9 @@ from tests.platform_tests.args.cont_warm_reboot_args import add_cont_warm_reboot
 from tests.platform_tests.args.normal_reboot_args import add_normal_reboot_args
 from ptf import testutils
 from ptf.mask import Mask
+from tests.common.fixtures.ptfhost_utils import run_garp_service_dualtor_session                        # noqa F401
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses                    # noqa F401
+
 
 logger = logging.getLogger(__name__)
 cache = FactsCache()

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -13,7 +13,8 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory         
 from tests.common.fixtures.ptfhost_utils import copy_acstests_directory                                 # noqa: F401
 from .everflow_test_utilities import setup_info, setup_arp_responder, EVERFLOW_DSCP_RULES                # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py                                   # noqa: F401
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
+from tests.common.dualtor.mux_simulator_control \
+      import toggle_all_simulator_ports_to_rand_selected_tor_unconditionally  # noqa: F401
 
 pytestmark = [
     pytest.mark.topology("t0", "t1", "t2", "m0")
@@ -129,7 +130,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     def test_everflow_basic_forwarding(self, setup_info, setup_mirror_session,              # noqa F811
                                        dest_port_type, ptfadapter, tbinfo,
-                                       toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
+                                       toggle_all_simulator_ports_to_rand_selected_tor_unconditionally,     # noqa F811
                                        setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa F811
         """
         Verify basic forwarding scenarios for the Everflow feature.
@@ -230,7 +231,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     def test_everflow_neighbor_mac_change(self, setup_info, setup_mirror_session,               # noqa F811
                                           dest_port_type, ptfadapter, tbinfo,
-                                          toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
+                                          toggle_all_simulator_ports_to_rand_selected_tor_unconditionally,      # noqa F811
                                           setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa F811
         """Verify that session destination MAC address is changed after neighbor MAC address update."""
 
@@ -300,7 +301,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     def test_everflow_remove_unused_ecmp_next_hop(self, setup_info, setup_mirror_session,               # noqa F811
                                                   dest_port_type, ptfadapter, tbinfo,
-                                                  toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
+                                                  toggle_all_simulator_ports_to_rand_selected_tor_unconditionally,      # noqa F811
                                                   setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa F811
         """Verify that session is still active after removal of next hop from ECMP route that was not in use."""
 
@@ -392,7 +393,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     def test_everflow_remove_used_ecmp_next_hop(self, setup_info, setup_mirror_session,                 # noqa F811
                                                 dest_port_type, ptfadapter, tbinfo,
-                                                toggle_all_simulator_ports_to_rand_selected_tor,        # noqa F811
+                                                toggle_all_simulator_ports_to_rand_selected_tor_unconditionally,        # noqa F811
                                                 setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa F811
         """Verify that session is still active after removal of next hop from ECMP route that was in use."""
 
@@ -504,7 +505,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             partial_ptf_runner,
             config_method,
             tbinfo,
-            toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
+            toggle_all_simulator_ports_to_rand_selected_tor_unconditionally,    # noqa F811
             setup_standby_ports_on_rand_unselected_tor_unconditionally,    # noqa F811
     ):
         """Verify that we can rate-limit mirrored traffic from the MIRROR_DSCP table.

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -5,6 +5,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts         # no
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
+from tests.common.fixtures.ptfhost_utils import pause_garp_service_dualtor_m # noqa F401
 from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
 from .files.pfcwd_helper import TrafficPorts, set_pfc_timers, select_test_ports
 from tests.common.utilities import str2bool
@@ -210,7 +211,7 @@ def setup_dut_test_params(
 # icmp_responder need to be paused during the test because the test case
 # configures static IP address on ptf host and sends ICMP reply to DUT.
 @pytest.fixture(scope="module")
-def pause_icmp_responder(ptfhost):
+def pause_icmp_responder(ptfhost, pause_garp_service_dualtor_m):  # noqa F811
     icmp_responder_status = ptfhost.shell("supervisorctl status icmp_responder", module_ignore_errors=True)["stdout"]
     if "RUNNING" not in icmp_responder_status:
         yield

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -16,8 +16,8 @@ from tests.ptf_runner import ptf_runner
 from tests.common import port_toggle
 from tests.common import constants
 from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled, dualtor_ports # noqa F401
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m_unconditionally # noqa F401, E501
 from .files.pfcwd_helper import send_background_traffic
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_unconditionally # noqa F401, E501
 
 
 PTF_PORT_MAPPING_MODE = 'use_orig_interface'
@@ -838,7 +838,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_actions(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
                            ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
                            setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,         # noqa F811
-                           pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m_unconditionally): # noqa F811
+                           pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_unconditionally): # noqa F811
         """
         PFCwd functional test
 
@@ -912,7 +912,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_multi_port(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
                               ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
                               setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,         # noqa F811
-                              pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m_unconditionally): # noqa F811
+                              pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_unconditionally): # noqa F811
         """
         Tests pfcwd behavior when 2 ports are under pfc storm one after the other
 
@@ -990,7 +990,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_mmu_change(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,   # noqa F811
                               ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, dualtor_ports, # noqa F811
                               setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,       # noqa F811
-                              pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m_unconditionally): # noqa F811
+                              pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_unconditionally): # noqa F811
         """
         Tests if mmu changes impact Pfcwd functionality
 
@@ -1081,7 +1081,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_port_toggle(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
                                tbinfo, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
                                setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,         # noqa F811
-                               pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m_unconditionally): # noqa F811
+                               pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_unconditionally): # noqa F811
         """
         Test PfCWD functionality after toggling port
 

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -16,7 +16,7 @@ from tests.ptf_runner import ptf_runner
 from tests.common import port_toggle
 from tests.common import constants
 from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled, dualtor_ports # noqa F401
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m # noqa F401, E501
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m_unconditionally # noqa F401, E501
 
 
 PTF_PORT_MAPPING_MODE = 'use_orig_interface'
@@ -832,7 +832,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_actions(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
                            ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
                            setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,         # noqa F811
-                           pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m): # noqa F811
+                           pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m_unconditionally): # noqa F811
         """
         PFCwd functional test
 
@@ -906,7 +906,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_multi_port(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
                               ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
                               setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,         # noqa F811
-                              pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m): # noqa F811
+                              pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m_unconditionally): # noqa F811
         """
         Tests pfcwd behavior when 2 ports are under pfc storm one after the other
 
@@ -984,7 +984,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_mmu_change(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,   # noqa F811
                               ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, dualtor_ports, # noqa F811
                               setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,       # noqa F811
-                              pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m): # noqa F811
+                              pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m_unconditionally): # noqa F811
         """
         Tests if mmu changes impact Pfcwd functionality
 
@@ -1075,7 +1075,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_port_toggle(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
                                tbinfo, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
                                setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,         # noqa F811
-                               pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m): # noqa F811
+                               pause_icmp_responder, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m_unconditionally): # noqa F811
         """
         Test PfCWD functionality after toggling port
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes [#119](https://github.com/aristanetworks/sonic-qual.msft/issues/119)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

[#221](https://github.com/sonic-net/sonic-linkmgrd/pull/221) introduced oscillation logic in active-standby dualtor. These oscillations happen continuously in the testing environment as well because we don't run ICMP responder as it was disabled some time back in [#9117](https://github.com/sonic-net/sonic-mgmt/pull/9117).

These continuous oscillations interfere with the testing and has made a lot of traffic tests flaky in active-standby dualtor.

Details can be found in [#119](https://github.com/aristanetworks/sonic-qual.msft/issues/119)

#### How did you do it?
Re-enabled ICMP responder and gratuitous ARP service in active-standby dualtor topologies. 

We have introduced new fixtures `toggle_all_simulator_ports_to_rand_selected_tor_unconditionally` and `toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_unconditionally` similar to `active-active` dualtor to run few tests in active-standby mode where ICMP responder interferes with the testing and we need to pause it.

This also affects then following tests which have been fixed
1. everflow tests: These tests shutdown BGP on the randomly selected ToR and if ICMP responder is running `toggle_all_simulator_ports_to_rand_selected_tor` fails to toggle the MUX direction towards this ToR because it is now technically unhealthy as it lost routes ( which should be the expected behaviour in the production environment as well ). The fix for this test is very similar to active-active dualtor by using the fixture  `toggle_all_simulator_ports_to_rand_selected_tor_unconditionally`. If ICMP responder is not running then `toggle_all_simulator_ports_to_rand_selected_tor` successfully toggles the MUX direction towards the unhealthy ToR which is a testing gap that got introduced due to disabling of ICMP responder.

2. In case of  `pfcwd/test_pfcwd_function.py` and `arp/test_unknown_mac.py`. ICMP responder and GARP interferes with the testing therefore the fix is to selectively pause them for these tests and run them in active-standby mode by using the new fixtures.

#### How did you verify/test it?
Tested on Arista-7260 and Arista-7050 platforms with dualtor and dualtor-120. 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
