### PR TITLE
Fix qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit. 

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2158,6 +2158,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         # TODO: pass in dst_port_id and _ip as a list
         dst_port_2_id = int(self.test_params['dst_port_2_id'])
         dst_port_2_ip = self.test_params['dst_port_2_ip']
+        dst_port_2_mac = self.dataplane.get_mac(0, dst_port_2_id)
         dst_port_3_id = int(self.test_params['dst_port_3_id'])
         dst_port_3_ip = self.test_params['dst_port_3_ip']
         dst_port_3_mac = self.dataplane.get_mac(0, dst_port_3_id)
@@ -2207,6 +2208,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         else:
             cell_occupancy = 1
 
+        pkt_dst_mac2 = router_mac if router_mac != '' else dst_port_2_mac
         pkt_dst_mac3 = router_mac if router_mac != '' else dst_port_3_mac
 
         is_dualtor = self.test_params.get('is_dualtor', False)
@@ -2280,7 +2282,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                 src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, dst_port_id, src_port_vlan
             )
             pkt2 = construct_ip_pkt(packet_length,
-                                    pkt_dst_mac,
+                                    pkt_dst_mac2,
                                     src_port_mac,
                                     src_port_ip,
                                     dst_port_2_ip,
@@ -2289,7 +2291,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                                     ecn=ecn,
                                     ttl=ttl)
             dst_port_2_id = self.get_rx_port(
-                src_port_id, pkt_dst_mac, dst_port_2_ip, src_port_ip, dst_port_2_id, src_port_vlan
+                src_port_id, pkt_dst_mac2, dst_port_2_ip, src_port_ip, dst_port_2_id, src_port_vlan
             )
             pkt3 = construct_ip_pkt(packet_length,
                                     pkt_dst_mac3,
@@ -2301,7 +2303,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                                     ecn=ecn,
                                     ttl=ttl)
             dst_port_3_id = self.get_rx_port(
-                src_port_id, pkt_dst_mac, dst_port_3_ip, src_port_ip, dst_port_3_id, src_port_vlan
+                src_port_id, pkt_dst_mac3, dst_port_3_ip, src_port_ip, dst_port_3_id, src_port_vlan
             )
 
         # For TH3/Cisco-8000, some packets stay in egress memory and doesn't show up in shared buffer or leakout


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit.
Fixes [#111](https://github.com/aristanetworks/sonic-qual.msft/issues/111)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Regression introduced by [#9780](https://github.com/sonic-net/sonic-mgmt/pull/9780)

qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit fails with 

```qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit.```

Qos tests would fail on testQosSaiPfcXonLimit, because step 1 of the tests, which disable TX for dst_port_id, dst_port_2_id, dst_port_3_id is getting incorrect DST ports.

Due to this the tx is disabled on a port but never enabled and switch keeps on sending PFC packets and all the subsequent testcases in the module fail.



#### How did you do it?
Cherry picked [#12151](https://github.com/sonic-net/sonic-mgmt/pull/12151) to 202311 with additional fix mentioned in https://github.com/sonic-net/sonic-mgmt/pull/12151#pullrequestreview-2027789431 as correct dst mac should be passed.

#### How did you verify/test it?
Verified on Arista-7050 platform with 202311 image.

```
qos/test_qos_sai.py::TestQosSai::testParameter[single_asic] PASSED                                [  0%]                                                                                                            
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_1] PASSED                [  1%]                                                                                                            
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_2] PASSED                [  2%]                                                                                                            
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_3] SKIPPED (Addition...) [  2%]                                                                                                            
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_4] SKIPPED (Addition...) [  3%]                                                                                                            
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_asic-xon_1] SKIPPED [  4%]                                                                                                          
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_asic-xon_2] SKIPPED [  5%]                                                                                                          
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_asic-xon_3] SKIPPED [  5%]                                                                                                          
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_asic-xon_4] SKIPPED [  6%]                                                                                                          
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1] PASSED                  [  7%]                                                                                                            
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2] PASSED                  [  8%]                                                                                                            
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_3] SKIPPED (Additional...) [  8%]                                                                                                            
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_4] SKIPPED (Additional...) [  9%]                                                                                                            
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_1] SKIPPED (L...) [ 10%]                                                                                                            
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_2] SKIPPED (L...) [ 11%]                                                                                                            
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_3] SKIPPED (L...) [ 11%]                                                                                                            
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_4] SKIPPED (L...) [ 12%]                                                                                                            
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[single_asic] PASSED                                                                                                                              [ 13%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize[single_asic-shared_res_size_1] SKIPPED                                                                                                      [ 14%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize[single_asic-shared_res_size_2] SKIPPED                                                                                                      [ 14%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark[single_asic] PASSED                                                                                                                         [ 15%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[single_asic-wm_buf_pool_lossless] SKIPPED                                                                                                     [ 16%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[single_asic-wm_buf_pool_lossy] SKIPPED                                                                                                        [ 17%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_asic] PASSED                                                                                                                                    [ 17%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq[single_asic-lossy_queue_voq_1] SKIPPED                                                                                                              [ 18%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_asic-ipv4] SKIPPED (Skip this                                                                                                                    
test since separated DSCP_TO_TC_MAP is applied)                                                                                                                                                              [ 19%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_asic-ipv6] SKIPPED (Skip this                                                                                                                    
test since separated DSCP_TO_TC_MAP is applied)                                                                                                                                                              [ 20%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpQueueMapping[single_asic-downstream] SKIPPED                                                                                                         [ 20%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpQueueMapping[single_asic-upstream] SKIPPED                                                                                                           [ 21%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping[single_asic] SKIPPED (Dot1p-queue                                                                                                                      
mapping is only supported on backend.)                                                                                                                                                                       [ 22%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping[single_asic] SKIPPED (Dot1p-PG mapping                                                                                                                    
is only supported on backend.)                                                                                                                                                                               [ 22%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[single_asic] PASSED                                                                                                                                          [ 23%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossless] PASSED                                                                                                       [ 24%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossy] PASSED                                                                                                          [ 25%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark[single_asic] PASSED                                                                                                                           [ 25%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop[single_asic] SKIPPED (PG drop size test is not                                                                                                                    
supported.)                                                                                                                                                                                                  [ 26%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_asic-wm_q_shared_lossless] PASSED                                                                                                         [ 27%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_asic-wm_q_shared_lossy] PASSED                                                                                                            [ 28%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping[single_asic] SKIPPED (DSCP to PG                                                                                                                         
mapping test disabled)                                                                                                                                                                                       [ 28%] 
qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping[single_asic-uniform] SKIPPED (Skip                                                                                                                   
this test since separated DSCP_TO_TC_MAP is applied)                                                                                                                                                         [ 29%] 
qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping[single_asic-pipe] SKIPPED (Skip                                                                                                                      
this test since separated DSCP_TO_TC_MAP is applied)                                                                                                                                                         [ 30%] 
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpToPgMapping[single_asic-upstream] SKIPPED                                                                                                            [ 31%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange[single_asic] PASSED                                                                                                                              [ 32%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts[single_asic-wm_q_wm_all_ports] SKIPPED                                                                                                         [ 33%]
qos/test_qos_sai.py::TestQosSai::testParameter[single_dut_multi_asic] SKIPPED                                                                                                                  [ 34%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_dut_multi_asic-xoff_1] SKIPPED                                                                                                  [ 34%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_dut_multi_asic-xoff_2] SKIPPED                                                                                                  [ 35%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_dut_multi_asic-xoff_3] SKIPPED                                                                                                  [ 36%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_dut_multi_asic-xoff_4] SKIPPED                                                                                                  [ 37%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_dut_multi_asic-xon_1] SKIPPED                                                                                  [ 37%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_dut_multi_asic-xon_2] SKIPPED                                                                                  [ 38%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_dut_multi_asic-xon_3] SKIPPED                                                                                  [ 39%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[single_dut_multi_asic-xon_4] SKIPPED                                                                                  [ 40%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_dut_multi_asic-xon_1] SKIPPED                                                                                                    [ 40%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_dut_multi_asic-xon_2] SKIPPED                                                                                                    [ 41%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_dut_multi_asic-xon_3] SKIPPED                                                                                                    [ 42%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_dut_multi_asic-xon_4] SKIPPED                                                                                                    [ 42%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_dut_multi_asic-lossless_voq_1] SKIPPED                                                                                           [ 43%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_dut_multi_asic-lossless_voq_2] SKIPPED                                                                                           [ 44%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_dut_multi_asic-lossless_voq_3] SKIPPED                                                                                           [ 45%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_dut_multi_asic-lossless_voq_4] SKIPPED                                                                                           [ 45%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[single_dut_multi_asic] SKIPPED                                                                                                     [ 46%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize[single_dut_multi_asic-shared_res_size_1] SKIPPED                                                                              [ 47%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize[single_dut_multi_asic-shared_res_size_2] SKIPPED                                                                              [ 48%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark[single_dut_multi_asic] SKIPPED                                                                                                [ 48%]
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[single_dut_multi_asic-wm_buf_pool_lossless] SKIPPED                                                                             [ 49%]
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[single_dut_multi_asic-wm_buf_pool_lossy] SKIPPED                                                                                [ 50%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_dut_multi_asic] SKIPPED                                                                                                           [ 51%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq[single_dut_multi_asic-lossy_queue_voq_1] SKIPPED                                                                                      [ 51%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_dut_multi_asic-ipv4] SKIPPED                                                                                                [ 52%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_dut_multi_asic-ipv6] SKIPPED                                                                                                [ 53%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpQueueMapping[single_dut_multi_asic-downstream] SKIPPED                                                                                 [ 54%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpQueueMapping[single_dut_multi_asic-upstream] SKIPPED                                                                                   [ 54%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping[single_dut_multi_asic] SKIPPED                                                                                                    [ 55%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping[single_dut_multi_asic] SKIPPED                                                                                                       [ 56%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[single_dut_multi_asic] SKIPPED                                                                                                                 [ 57%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_dut_multi_asic-wm_pg_shared_lossless] SKIPPED                                                                              [ 57%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_dut_multi_asic-wm_pg_shared_lossy] SKIPPED                                                                                 [ 58%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark[single_dut_multi_asic] SKIPPED                                                                                                  [ 59%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop[single_dut_multi_asic] SKIPPED (PG drop size            
test is not supported.)                                                                                                                                                                        [ 60%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_dut_multi_asic-wm_q_shared_lossless] SKIPPED                                                                                [ 60%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_dut_multi_asic-wm_q_shared_lossy] SKIPPED                                                                                   [ 61%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping[single_dut_multi_asic] SKIPPED                                                                                                      [ 62%]
qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping[single_dut_multi_asic-uniform] SKIPPED                                                                                          [ 62%]
qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping[single_dut_multi_asic-pipe] SKIPPED                                                                                             [ 63%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpToPgMapping[single_dut_multi_asic-downstream] SKIPPED                                                                                  [ 64%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpToPgMapping[single_dut_multi_asic-upstream] SKIPPED                                                                                    [ 65%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange[single_dut_multi_asic] SKIPPED                                                                                                     [ 65%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts[single_dut_multi_asic-wm_q_wm_all_ports] SKIPPED                                                                                 [ 66%]
qos/test_qos_sai.py::TestQosSai::testParameter[multi_dut] SKIPPED (multi-dut is not supported on          
T0 topologies)                                                                                                                                                                                 [ 67%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[multi_dut-xoff_1] SKIPPED (multi-dut is           
not supported on T0 topologies)                                                                                                                                                                [ 68%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[multi_dut-xoff_2] SKIPPED (multi-dut is           
not supported on T0 topologies)                                                                                                                                                                [ 68%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[multi_dut-xoff_3] SKIPPED (multi-dut is           
not supported on T0 topologies)                                                                                                                                                                [ 69%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[multi_dut-xoff_4] SKIPPED (multi-dut is           
not supported on T0 topologies)                                                                                                                                                                [ 70%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[multi_dut-xon_1] SKIPPED                                                                                              [ 71%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[multi_dut-xon_2] SKIPPED                                                                                              [ 71%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[multi_dut-xon_3] SKIPPED                                                                                              [ 72%]
qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy[multi_dut-xon_4] SKIPPED                                                                                              [ 73%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut-xon_1] SKIPPED (multi-dut is not         
supported on T0 topologies)                                                                                                                                                                    [ 74%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut-xon_2] SKIPPED (multi-dut is not         
supported on T0 topologies)                                                                                                                                                                    [ 74%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut-xon_3] SKIPPED (multi-dut is not         
supported on T0 topologies)                                                                                                                                                                    [ 75%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut-xon_4] SKIPPED (multi-dut is not         
supported on T0 topologies)                                                                                                                                                                    [ 76%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[multi_dut-lossless_voq_1] SKIPPED                                                                                                       [ 77%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[multi_dut-lossless_voq_2] SKIPPED                                                                                                       [ 77%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[multi_dut-lossless_voq_3] SKIPPED                                                                                                       [ 78%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[multi_dut-lossless_voq_4] SKIPPED                                                                                                       [ 79%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[multi_dut] SKIPPED (multi-dut is not          
supported on T0 topologies)                                                                                                                                                                    [ 80%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize[multi_dut-shared_res_size_1] SKIPPED                                                                                          [ 80%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize[multi_dut-shared_res_size_2] SKIPPED                                                                                          [ 81%]
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark[multi_dut] SKIPPED (multi-dut is         
not supported on T0 topologies)                                                                                                                                                                [ 82%]
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[multi_dut-wm_buf_pool_lossless] SKIPPED                                                                                         [ 82%]
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[multi_dut-wm_buf_pool_lossy] SKIPPED                                                                                            [ 83%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[multi_dut] SKIPPED (multi-dut is not                
supported on T0 topologies)                                                                                                                                                                    [ 84%]
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq[multi_dut-lossy_queue_voq_1] SKIPPED                                                                                                  [ 85%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[multi_dut-ipv4] SKIPPED (multi-dut is         
not supported on T0 topologies)                                                                                                                                                                [ 85%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[multi_dut-ipv6] SKIPPED (multi-dut is         
not supported on T0 topologies)                                                                                                                                                                [ 86%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpQueueMapping[multi_dut-downstream] SKIPPED                                                                                             [ 87%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpQueueMapping[multi_dut-upstream] SKIPPED                                                                                               [ 88%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping[multi_dut] SKIPPED (Dot1p-queue              
mapping is only supported on backend.)                                                                                                                                                         [ 88%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping[multi_dut] SKIPPED (Dot1p-PG mapping is         
only supported on backend.)                                                                                                                                                                    [ 89%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[multi_dut] SKIPPED (multi-dut is not supported on         
T0 topologies)                                                                                                                                                                                 [ 90%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[multi_dut-wm_pg_shared_lossless] SKIPPED                                                                                          [ 91%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[multi_dut-wm_pg_shared_lossy] SKIPPED                                                                                             [ 91%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark[multi_dut] SKIPPED (multi-dut is           
not supported on T0 topologies)                                                                                                                                                                [ 92%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop[multi_dut] SKIPPED (PG drop size test is not            
supported.)                                                                                                                                                                                    [ 93%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[multi_dut-wm_q_shared_lossless] SKIPPED                                                                                            [ 94%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[multi_dut-wm_q_shared_lossy] SKIPPED                                                                                               [ 94%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping[multi_dut] SKIPPED (multi-dut is not           
supported on T0 topologies)                                                                                                                                                                    [ 95%]
qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping[multi_dut-uniform] SKIPPED (multi-         
dut is not supported on T0 topologies)                                                                                                                                                         [ 96%]
qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping[multi_dut-pipe] SKIPPED (multi-dut         
is not supported on T0 topologies)                                                                                                                                                             [ 97%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpToPgMapping[multi_dut-downstream] SKIPPED                                                                                              [ 97%]
qos/test_qos_sai.py::TestQosSai::testQosSaiSeparatedDscpToPgMapping[multi_dut-upstream] SKIPPED                                                                                                [ 98%]
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange[multi_dut] SKIPPED (multi-dut is not          
supported on T0 topologies)                                                                                                                                                                    [ 99%]
qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts[multi_dut-wm_q_wm_all_ports] SKIPPED                                                                                             [100%]

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
