### PR TITLE
[Feat] Enhance upgrade image script to support chassis devices

### DIFF
--- a/ansible/devutil/devices/ansible_hosts.py
+++ b/ansible/devutil/devices/ansible_hosts.py
@@ -741,6 +741,7 @@ class AnsibleHostsBase(object):
                 }
         """
         caller_info = kwargs.pop("caller_info", None)
+        target_hosts = kwargs.pop("target_hosts", None)
         if not caller_info:
             previous_frame = inspect.currentframe().f_back
             caller_info = inspect.getframeinfo(previous_frame)
@@ -763,7 +764,10 @@ class AnsibleHostsBase(object):
         self._log_modules(caller_info, module_info, verbosity)
 
         task = self.build_task(**module_info)
-        results = self.run_tasks(self.host_pattern, self.loader, self.im, self.vm, self.options, tasks=[task])
+        host_pattern = self.host_pattern
+        if target_hosts:
+            host_pattern = target_hosts
+        results = self.run_tasks(host_pattern, self.loader, self.im, self.vm, self.options, tasks=[task])
 
         self._log_results(caller_info, module_info, results, verbosity)
         self._check_results(caller_info, module_info, results, module_ignore_errors, verbosity)

--- a/ansible/devutil/devices/chassis_utils.py
+++ b/ansible/devutil/devices/chassis_utils.py
@@ -1,0 +1,26 @@
+import enum
+
+
+class ChassisCardType(str, enum.Enum):
+    # Sample: lab-1111-sup-1
+    SUPERVISOR_CARD = "-sup-"
+    # Sample: lab-1111-lc1-1
+    LINE_CARD = "-lc"
+
+
+def is_chassis(sonichosts):
+    supervisor_card_exists, line_card_exists = False, False
+    for hostname in sonichosts.hostnames:
+        if ChassisCardType.SUPERVISOR_CARD.value in hostname:
+            supervisor_card_exists = True
+        if ChassisCardType.LINE_CARD.value in hostname:
+            line_card_exists = True
+    return supervisor_card_exists and line_card_exists
+
+
+def get_chassis_hostnames(sonichosts, chassis_card_type: ChassisCardType):
+    res = []
+    for hostname in sonichosts.hostnames:
+        if chassis_card_type.value in hostname:
+            res.append(hostname)
+    return res


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->


Summary:
Enhance upgrade image script to support chassis device.
For chassis device, we need to firstly upgrade the image for supervisor cards, then upgrade the image for line cards.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Enhance the upgrade_image script to support chassis devices.
#### How did you do it?
1. Upgrade image on the supervisor cards, then wait 900s for the supervisor card to be ready.
2. Upgrade image on the line cards, then wait 300s for the line cards to be ready.
3. The sonichosts defautly run commands on all supervisor cards and line cards at the same time, enhance the framework to be able to upgrade specific hosts.
#### How did you verify/test it?
Run upgrade image script on the chassis device and pizzbox device, both of them works well

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
