### PR TITLE
[sonic-mgmt] Increase link-up timeout for test_lag_2 test_lag_db_status()

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -524,7 +524,7 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level,
                 # Retrieve lag_facts after no shutdown interface
                 asichost.startup_interface(po_intf)
                 # Sometimes, it has to wait seconds for booting up interface
-                pytest_assert(wait_until(60, 1, 0, check_link_is_up, duthost, asichost, po_intf, port_info, lag_name),
+                pytest_assert(wait_until(180, 1, 0, check_link_is_up, duthost, asichost, po_intf, port_info, lag_name),
                               "{} member {}'s status or netdev_oper_status in state_db is not up."
                               .format(lag_name, po_intf))
     finally:


### PR DESCRIPTION
### Description of PR
For chassis, link-up after after shutdown/no shutdown on lag member often takes longer than the test timeout resulting in failure.  Fix by increasing the link-up timeout to 3x original value.

Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run test in our internal environment and confirm increased timeout is required.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
