### PR TITLE
Add some tests to verify Redis DB configuration

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -21,6 +21,7 @@ t0:
   - console/test_console_udevrule.py
   - container_checker/test_container_checker.py
   - container_hardening/test_container_hardening.py
+  - database/test_db_config.py
   - database/test_db_scripts.py
   - dhcp_relay/test_dhcp_pkt_recv.py
   - dhcp_relay/test_dhcp_relay.py

--- a/tests/database/test_db_config.py
+++ b/tests/database/test_db_config.py
@@ -24,3 +24,27 @@ def test_redis_save_disabled(duthosts, rand_one_dut_hostname):
     save_config = json.loads(save_config_json)
     pytest_assert(save_config["save"] == "", "Redis should not be persisting contents to disk, save config is {}"
                   .format(save_config["save"]))
+
+
+def test_redis_database_count(duthosts, rand_one_dut_hostname):
+    """
+    @summary: Test that redis is configured to support 100 databases
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    database_config_json = duthost.command(argv=["redis-cli", "--json", "CONFIG", "GET", "databases"])["stdout"]
+    database_config = json.loads(database_config_json)
+    pytest_assert(database_config["databases"] == "100", "Redis is configured to support {} instead of 100 databases"
+                  .format(database_config["databases"]))
+
+
+def test_redis_unix_socket(duthosts, rand_one_dut_hostname):
+    """
+    @summary: Test that redis has the unix socket option enabled
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    unixsocket_config_json = duthost.command(argv=["redis-cli", "--json", "CONFIG", "GET", "unixsocket"])["stdout"]
+    unixsocket_config = json.loads(unixsocket_config_json)
+    pytest_assert(unixsocket_config["unixsocket"] == "/var/run/redis/redis.sock",
+                  "Redis unixsocket is not configured correctly")

--- a/tests/database/test_db_config.py
+++ b/tests/database/test_db_config.py
@@ -13,6 +13,7 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
+
 def test_redis_save_disabled(duthosts, rand_one_dut_hostname):
     """
     @summary: Test that the database isn't being saved to disk
@@ -21,4 +22,5 @@ def test_redis_save_disabled(duthosts, rand_one_dut_hostname):
 
     save_config_json = duthost.command(argv=["redis-cli", "--json", "CONFIG", "GET", "save"])["stdout"]
     save_config = json.loads(save_config_json)
-    pytest_assert(save_config["save"] == "", "Redis should not be persisting contents to disk, save config is {}".format(save_config["save"]))
+    pytest_assert(save_config["save"] == "", "Redis should not be persisting contents to disk, save config is {}"
+                  .format(save_config["save"]))

--- a/tests/database/test_db_config.py
+++ b/tests/database/test_db_config.py
@@ -1,0 +1,24 @@
+"""
+Test the database config
+"""
+import logging
+import pytest
+import json
+
+from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+def test_redis_save_disabled(duthosts, rand_one_dut_hostname):
+    """
+    @summary: Test that the database isn't being saved to disk
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    save_config_json = duthost.command(argv=["redis-cli", "--json", "CONFIG", "GET", "save"])["stdout"]
+    save_config = json.loads(save_config_json)
+    pytest_assert(save_config["save"] == "", "Redis should not be persisting contents to disk, save config is {}".format(save_config["save"]))

--- a/tests/kvmtest.sh
+++ b/tests/kvmtest.sh
@@ -174,6 +174,7 @@ test_t0() {
       show_techsupport/test_techsupport_no_secret.py \
       system_health/test_system_status.py \
       radv/test_radv_ipv6_ra.py \
+      database/test_db_config.py \
       database/test_db_scripts.py"
 
       pushd $SONIC_MGMT_DIR/tests


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Add a test script to check that the redis config for the save setting, database count, and unix socket are correct. This can be extended to check for other config options.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

This is in response to sonic-net/sonic-buildimage#18979 and sonic-net/sonic-buildimage#18108, where with the database container upgrade to Bookworm, redis DB was configured to save to disk by default. This then caused issues in multi-ASIC setups.

#### How did you do it?

#### How did you verify/test it?

Tested on T0 KVM with sonic-net/sonic-buildimage#18979 applied.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
