### PR TITLE
[Mellanox] Stabilize test_crm_route 

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -333,5 +333,5 @@ def get_sai_sdk_dump_file(duthost, dump_file_name):
     compressed_dump_file = f"/tmp/{dump_file_name}.tar.gz"
     duthost.archive(path=full_path_dump_file, dest=compressed_dump_file, format='gz')
 
-    duthost.fetch(src=compressed_dump_file, dest=f"/tmp/", flat=True)
+    duthost.fetch(src=compressed_dump_file, dest="/tmp/", flat=True)
     allure.attach.file(compressed_dump_file, dump_file_name, extension=".tar.gz")

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -1,4 +1,5 @@
 import logging
+import allure
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import get_host_visible_vars
 from tests.common.utilities import wait_until
@@ -319,3 +320,18 @@ def ignore_t2_syslog_msgs(duthost):
             # DUT's loganalyzer would be null if we have disable_loganalyzer specified
             if a_dut.loganalyzer:
                 a_dut.loganalyzer.ignore_regex.extend(ignoreRegex)
+
+
+def get_sai_sdk_dump_file(duthost, dump_file_name):
+    full_path_dump_file = f"/tmp/{dump_file_name}"
+    cmd_gen_sdk_dump = f"docker exec syncd bash -c 'saisdkdump -f {full_path_dump_file}' "
+    duthost.shell(cmd_gen_sdk_dump)
+
+    cmd_copy_dmp_from_syncd_to_host = f"docker cp syncd:{full_path_dump_file}  {full_path_dump_file}"
+    duthost.shell(cmd_copy_dmp_from_syncd_to_host)
+
+    compressed_dump_file = f"/tmp/{dump_file_name}.tar.gz"
+    duthost.archive(path=full_path_dump_file, dest=compressed_dump_file, format='gz')
+
+    duthost.fetch(src=compressed_dump_file, dest=f"/tmp/", flat=True)
+    allure.attach.file(compressed_dump_file, dump_file_name, extension=".tar.gz")

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -3,12 +3,15 @@ import time
 import json
 import logging
 import re
+import ipaddress
 
-from test_crm import RESTORE_CMDS
+from test_crm import RESTORE_CMDS, get_nh_ip
 from tests.common.helpers.crm import CRM_POLLING_INTERVAL
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.utilities import wait_until, recover_acl_rule
 from tests.common.platform.interface_utils import parse_intf_status
+from tests.common.mellanox_data import is_mellanox_device
+from tests.common.helpers.dut_utils import get_sai_sdk_dump_file
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +94,7 @@ def crm_thresholds(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     return res
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def crm_interface(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, enum_frontend_asic_index):
     """ Return tuple of two DUT interfaces """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
@@ -188,16 +191,73 @@ def check_interface_status(duthost, intf_list, expected_oper='up'):
     return True
 
 
+def configure_a_route_with_same_prefix_as_vlan_for_mlnx(duthost, asichost, tbinfo, crm_interface):
+    """
+    For mellanox device, the crm available counter is related to LPM tree.
+    When shutdown all interfaces in vlan (e.g. vlan 1000),
+    it will cause the route (e.g. 192.168.0.1/21 )for vlan to be removed, we have only one route for the prefix (21),
+    so after it is removed, the corresponding prefix in LPM tree will be removed too,
+    which will lead to the LPM tree structure is changed.
+    LPM tree change might cause available counter change dramatically,
+    but we cannot estimate how long the change is ready.
+    Therefore, it will lead the first case of test_crm_route fail occasionally
+    because the expected available counter is not decreased.
+    So, we add another route with the same prefix(21) as the vlan's so that the LPM tree is not changed.
+    """
+    # Get NH IP
+    nh_ip = get_nh_ip(duthost, asichost, crm_interface, '4')
+
+    dump_ip_for_construct_test_route_with_same_prefix_as_vlan_interface = '21.21.21.21'
+    network_with_same_prefix_as_vlan_interface = str(
+        ipaddress.IPv4Interface(
+            f"{dump_ip_for_construct_test_route_with_same_prefix_as_vlan_interface}/"
+            f"{get_vlan_ipv4_prefix_len(asichost, tbinfo)}").network)
+    add_route_command = f"sudo ip route add {network_with_same_prefix_as_vlan_interface} via {nh_ip}"
+    duthost.shell(add_route_command)
+    assert wait_until(30, 5, 0, check_route_exist, duthost, network_with_same_prefix_as_vlan_interface, nh_ip), \
+        f"Failed to add route {network_with_same_prefix_as_vlan_interface} via {nh_ip} "
+
+    # Get sai sdk dump file in case test fail, we can get the LPM tree information
+    get_sai_sdk_dump_file(duthost, "sai_sdk_dump_before_shutdown_vlan_ports")
+
+    del_dump_route_with_same_prefix_as_vlan_interface_cmd = f" sudo ip route del {network_with_same_prefix_as_vlan_interface} via {nh_ip}"
+
+    return del_dump_route_with_same_prefix_as_vlan_interface_cmd
+
+
+def check_route_exist(duthost, network_with_same_prefix_as_vlan_interface, nh_ip):
+    route_output = duthost.shell(f"show ip route {network_with_same_prefix_as_vlan_interface}")["stdout"]
+    return f"Routing entry for {network_with_same_prefix_as_vlan_interface}" in route_output and nh_ip in route_output
+
+
+def get_vlan_ipv4_prefix_len(asichost, tbinfo):
+    mg_facts = asichost.get_extended_minigraph_facts(tbinfo)
+    for vlan_port_data in mg_facts["minigraph_vlan_interfaces"]:
+        if ipaddress.ip_interface(vlan_port_data['addr']).version == 4:
+            logger.info(f"vlan interface v4 prefix is :{vlan_port_data['prefixlen']}")
+            return vlan_port_data['prefixlen']
+    assert False, "Not find v4 prefix for vlan interface config"
+
+
 @pytest.fixture(scope="module", autouse=True)
-def shutdown_unnecessary_intf(duthosts, tbinfo, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname):
+def shutdown_unnecessary_intf(
+        duthosts, tbinfo, enum_frontend_asic_index, enum_rand_one_per_hwsku_frontend_hostname, crm_interface):
     """ Shutdown unused interfaces to avoid fdb entry influenced by mac learning """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    asichost = duthost.asic_instance(enum_frontend_asic_index)
     intfs_connect_with_ptf = get_intf_list(duthost, tbinfo, enum_frontend_asic_index)
     if intfs_connect_with_ptf:
+        if is_mellanox_device(duthost):
+            del_dump_route_with_same_prefix_as_vlan_interface_cmd = configure_a_route_with_same_prefix_as_vlan_for_mlnx(
+                duthost, asichost, tbinfo, crm_interface)
         logger.info("Shutdown interfaces: {}".format(intfs_connect_with_ptf))
         duthost.shutdown_multiple(intfs_connect_with_ptf)
         assert wait_until(300, 20, 0, check_interface_status, duthost, intfs_connect_with_ptf, 'down'), \
             "All interfaces should be down!"
+
+        if is_mellanox_device(duthost):
+            # Get sai sdk dump file in case test fail, we can get the LPM tree information
+            get_sai_sdk_dump_file(duthost, "sai_sdk_dump_after_shutdown_vlan_ports")
 
     yield
 
@@ -206,6 +266,8 @@ def shutdown_unnecessary_intf(duthosts, tbinfo, enum_frontend_asic_index, enum_r
         duthost.no_shutdown_multiple(intfs_connect_with_ptf)
         assert wait_until(300, 20, 0, check_interface_status, duthost, intfs_connect_with_ptf), \
             "All interfaces should be up!"
+        if is_mellanox_device(duthost):
+            duthost.shell(del_dump_route_with_same_prefix_as_vlan_interface_cmd)
 
 
 @pytest.fixture(scope="module")

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -220,7 +220,8 @@ def configure_a_route_with_same_prefix_as_vlan_for_mlnx(duthost, asichost, tbinf
     # Get sai sdk dump file in case test fail, we can get the LPM tree information
     get_sai_sdk_dump_file(duthost, "sai_sdk_dump_before_shutdown_vlan_ports")
 
-    del_dump_route_with_same_prefix_as_vlan_interface_cmd = f" sudo ip route del {network_with_same_prefix_as_vlan_interface} via {nh_ip}"
+    del_dump_route_with_same_prefix_as_vlan_interface_cmd = \
+        f" sudo ip route del {network_with_same_prefix_as_vlan_interface} via {nh_ip}"
 
     return del_dump_route_with_same_prefix_as_vlan_interface_cmd
 

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -18,6 +18,8 @@ from tests.common.fixtures.duthost_utils import disable_route_checker   # noqa F
 from tests.common.fixtures.duthost_utils import disable_fdb_aging       # noqa F401
 from tests.common.utilities import wait_until, get_data_acl
 from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
+from tests.common.mellanox_data import is_mellanox_device
+from tests.common.helpers.dut_utils import get_sai_sdk_dump_file
 
 
 pytestmark = [
@@ -450,6 +452,16 @@ def get_crm_resources_fdb_and_ip_route(duthost, asic_ix):
     return result
 
 
+def get_nh_ip(duthost, asichost, crm_interface, ip_ver):
+    # Get NH IP
+    cmd = "{ip_cmd} -{ip_ver} neigh show dev {crm_intf} nud reachable nud stale \
+                        | grep -v fe80".format(ip_cmd=asichost.ip_cmd, ip_ver=ip_ver, crm_intf=crm_interface[0])
+    out = duthost.shell(cmd)
+    assert (out["stdout"] != "", "Get Next Hop IP failed. Neighbor not found")
+    nh_ip = [item.split()[0] for item in out["stdout"].split("\n") if "REACHABLE" in item][0]
+    return nh_ip
+
+
 @pytest.mark.usefixtures('disable_route_checker')
 @pytest.mark.parametrize("ip_ver,route_add_cmd,route_del_cmd", [("4", "{} route add 2.{}.2.0/24 via {}",
                                                                 "{} route del 2.{}.2.0/24 via {}"),
@@ -490,11 +502,7 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     logging.info("crm_stats_route_used {}, crm_stats_route_available {}, crm_stats_fdb_used {}".format(
         crm_stats_route_used, crm_stats_route_available, crm_stats_fdb_used))
     # Get NH IP
-    cmd = "{ip_cmd} -{ip_ver} neigh show dev {crm_intf} nud reachable nud stale \
-            | grep -v fe80".format(ip_cmd=asichost.ip_cmd, ip_ver=ip_ver, crm_intf=crm_interface[0])
-    out = duthost.shell(cmd)
-    pytest_assert(out["stdout"] != "", "Get Next Hop IP failed. Neighbor not found")
-    nh_ip = [item.split()[0] for item in out["stdout"].split("\n") if "REACHABLE" in item][0]
+    nh_ip = get_nh_ip(duthost, asichost, crm_interface, ip_ver)
 
     # Add IPv[4/6] routes
     # Cisco platforms need an upward of 64 routes for crm_stats_ipv4_route_available to decrement
@@ -536,6 +544,9 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
         pytest.fail("\"crm_stats_ipv{}_route_used\" counter was not incremented".format(ip_ver))
     # Verify "crm_stats_ipv[4/6]_route_available" counter was decremented
     if check_available_counters and not (crm_stats_route_available - new_crm_stats_route_available >= 1):
+        if is_mellanox_device(duthost):
+            # Get sai sdk dump file in case test fail, we can get the LPM tree information
+            get_sai_sdk_dump_file(duthost, f"sai_sdk_dump_after_add_v{ip_ver}_router")
         for i in range(total_routes):
             RESTORE_CMDS["test_crm_route"].append(route_del_cmd.format(asichost.ip_cmd, i, nh_ip))
         pytest.fail("\"crm_stats_ipv{}_route_available\" counter was not decremented".format(ip_ver))

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -457,7 +457,7 @@ def get_nh_ip(duthost, asichost, crm_interface, ip_ver):
     cmd = "{ip_cmd} -{ip_ver} neigh show dev {crm_intf} nud reachable nud stale \
                         | grep -v fe80".format(ip_cmd=asichost.ip_cmd, ip_ver=ip_ver, crm_intf=crm_interface[0])
     out = duthost.shell(cmd)
-    assert (out["stdout"] != "", "Get Next Hop IP failed. Neighbor not found")
+    assert out["stdout"] != "", "Get Next Hop IP failed. Neighbor not found"
     nh_ip = [item.split()[0] for item in out["stdout"].split("\n") if "REACHABLE" in item][0]
     return nh_ip
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix test issue:https://github.com/sonic-net/sonic-mgmt/issues/12725
For mellanox device, the crm available counter is related to LPM tree. When shutdown all interfaces in vlan (e.g. vlan 1000), it will cause the route (e.g. 192.168.0.1/21 )for vlan to be removed, we have only one route for the prefix (21), after it is removed, the corresponding prefix in LPM tree will be removed too, which will lead to the LPM tree structure is changed. LPM tree change might cause available counter change dramatically, and we cannot estimate how long the change is ready. Therefore, it will lead the first case of test_crm_route fail occasionally because the expected available counter is not decreased. So, we add another route with the same prefix(21) as the vlan's so that the LPM tree is not changed.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Stabilize test_crm_route

#### How did you do it?
Add another route with the same prefix(21) as the vlan's so that the LPM tree is not changed.

#### How did you verify/test it?
run test_crm_route tests

#### Any platform specific information?
Mellanox

#### Supported testbed topology if it's a new test case?
T0

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
