### PR TITLE
Set mux mode to manual to disable port toggle in cacl scripts on dualtor testbed

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -17,6 +17,18 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(scope="module", autouse=True)
+def disable_port_toggle(duthosts, tbinfo):
+    # set mux mode to manual on both TORs to avoid port state change during test
+    if "dualtor" in tbinfo['topo']['name']:
+        for dut in duthosts:
+            dut.shell("sudo config mux mode manual all")
+    yield
+    if "dualtor" in tbinfo['topo']['name']:
+        for dut in duthosts:
+            dut.shell("sudo config mux mode auto all")
+
+
 @pytest.fixture(scope="function", params=["active_tor", "standby_tor"])
 def duthost_dualtor(request, upper_tor_host, lower_tor_host):       # noqa F811
     which_tor = request.param
@@ -28,12 +40,7 @@ def duthost_dualtor(request, upper_tor_host, lower_tor_host):       # noqa F811
     else:
         logger.info("Select upper tor...")
         dut = upper_tor_host
-    # set mux mode to manual on both TORs to avoid port state change during test
-    upper_tor_host.shell("sudo config mux mode manual all")
-    lower_tor_host.shell("sudo config mux mode manual all")
-    yield dut
-    upper_tor_host.shell("sudo config mux mode auto all")
-    lower_tor_host.shell("sudo config mux mode auto all")
+    return dut
 
 
 @pytest.fixture

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -28,9 +28,12 @@ def duthost_dualtor(request, upper_tor_host, lower_tor_host):       # noqa F811
     else:
         logger.info("Select upper tor...")
         dut = upper_tor_host
-    dut.shell("sudo config mux mode manual all")
+    # set mux mode to manual on both TORs to avoid port state change during test
+    upper_tor_host.shell("sudo config mux mode manual all")
+    lower_tor_host.shell("sudo config mux mode manual all")
     yield dut
-    dut.shell("sudo config mux mode auto all")
+    upper_tor_host.shell("sudo config mux mode auto all")
+    lower_tor_host.shell("sudo config mux mode auto all")
 
 
 @pytest.fixture

--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -55,7 +55,7 @@ def disable_port_toggle(duthosts, tbinfo):
 
 
 @pytest.fixture(autouse=True)
-def setup_env(duthosts, rand_one_dut_hostname, tbinfo):
+def setup_env(duthosts, rand_one_dut_hostname):
     """
     Setup/teardown fixture for acl config
     Args:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
GCU test_cacl case failed on dualtor testbed randomly.
The failed message:
`failed on teardown with "Failed: iptable rules are not suppose to change after test. diff: ['+ -A DHCP -m mark --mark 0x67008 -j DROP', '+ -A DHCP -m mark --mark 0x67024 -j DROP', '+ -A DHCP -m mark --mark 0x67022 -j DROP', '+ -A DHCP -m mark --mark 0x67018 -j DROP', '+ -A DHCP -m mark --mark 0x67014 -j DROP', '+ -A DHCP -m mark --mark 0x67013 -j DROP', '+ -A DHCP -m mark --mark 0x67010 -j DROP', '+ -A DHCP -m mark --mark 0x67009 -j DROP', '+ -A DHCP -m mark --mark 0x67004 -j DROP', '+ -A DHCP -m mark --mark 0x67007 -j DROP', '+ -A DHCP -m mark --mark 0x67006 -j DROP', '+ -A DHCP -m mark --mark 0x67002 -j DROP', '+ -A DHCP -m mark --mark 0x67001 -j DROP', '+ -A DHCP -m mark --mark 0x67005 -j DROP']"`

Summary:
Fixes # (issue)
The failed reason is dualtor oscillation feature is enabled by default in 202311/mater/internal branch.
In nightly test environment, it's easy to trigger oscillation between standby and active ports. 
In this case, before running test case, some ports are active on DUT, but after test case, when do iptables verification, some ports turn to be standby, that causes iptables DHCP rules to change. The consequence is there is diff between original and latest iptables, which will fail the test case in teardown phase.
We have to disable oscillation by set mux to manual mode on both TORs.

Enhance the change in https://github.com/sonic-net/sonic-mgmt/pull/11878,
set mux mode to manual on both TORs to avoid port state change during test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fix random failure of GCU test_cacl.py on dualtor testbed

#### How did you do it?
Change mux mode to manual before test case and set it back to auto after test case.

#### How did you verify/test it?
run generic_config_updater.test_cacl on dualtor testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
