### PR TITLE
Fix the definition of fixture toggle_all_simulator_ports_to_rand_unse…

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -609,7 +609,8 @@ def toggle_all_simulator_ports_to_rand_selected_tor(duthosts, mux_server_url,
 
 
 @pytest.fixture
-def toggle_all_simulator_ports_to_rand_unselected_tor(duthosts, rand_unselected_dut, mux_server_url, tbinfo):
+def toggle_all_simulator_ports_to_rand_unselected_tor(duthosts, rand_unselected_dut, mux_server_url, tbinfo,
+                                                      active_standby_ports):
     """
     A function level fixture to toggle all ports to randomly unselected tor
 
@@ -617,7 +618,7 @@ def toggle_all_simulator_ports_to_rand_unselected_tor(duthosts, rand_unselected_
     is imported in test script. The run_icmp_responder fixture is defined in tests.common.fixtures.ptfhost_utils
     """
     # Skip on non dualtor testbed
-    if 'dualtor' not in tbinfo['topo']['name']:
+    if 'dualtor' not in tbinfo['topo']['name'] or not active_standby_ports:
         return
 
     _toggle_all_simulator_ports_to_target_dut(rand_unselected_dut.hostname, duthosts, mux_server_url, tbinfo)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix the definition of fixture `toggle_all_simulator_ports_to_rand_unselected_tor`
Fixes [#110](https://github.com/aristanetworks/sonic-qual.msft/issues/110)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The tests using this fixture fail in active-active dualtor as 

```
    def _toggle_all_simulator_ports_to_target_dut(target_dut_hostname, duthosts, mux_server_url, tbinfo):                                                                                                           
        """Helper function to toggle all ports to active on the target DUT."""                                                                                                                                      
                                                                                                                                                                                                                    
        def _check_toggle_done(duthosts, target_dut_hostname, probe=False):                                                                                                                                         
            active_duthost = duthosts[target_dut_hostname]                                                                                                                                                          
            standby_duthost = [_ for _ in duthosts if _.hostname != target_dut_hostname][0]                                                                                                                         
            inactive_ports = _get_mux_ports(active_duthost, exclude_status="active")                                                                                                                                
            not_standby_ports = _get_mux_ports(standby_duthost, exclude_status="standby")                                                                                                                           
                                                                                                                                                                                                                    
            if not inactive_ports and not not_standby_ports:                                                                                                                                                        
                return True                                                                                                                                                                                         
                                                                                                                                                                                                                    
            # NOTE: if ICMP responder is not running, linkmgrd is stuck in waiting for heartbeats and                                                                                                               
            # the mux probe interval is backed off. Adding a probe here to notify linkmgrd to shorten                                                                                                               
            # the wait for linkmgrd's sync with the mux.                                                                                                                                                            
            if probe:                                                                                                                                                                                               
                probe_ports = set(inactive_ports.keys()) | set(not_standby_ports.keys())                                                                                                                            
                _probe_mux_ports(duthosts, probe_ports)                                                                                                                                                             
                                                                                                                                                                                                                    
            logger.info('Found muxcables not active on {}: {}'.format(                                                                                                                                              
                active_duthost.hostname, json.dumps(list(inactive_ports.keys()))))                                                                                                                                  
            logger.info('Found muxcables not standby on {}: {}'.format(                                                                                                                                             
                standby_duthost.hostname, json.dumps(list(not_standby_ports.keys()))))                                                                                                                              
            return False                                                                                                                                                                                            
                                                                                                                                                                                                                    
        logging.info("Toggling mux cable to {}".format(target_dut_hostname))                                                                                                                                        
        dut_index = tbinfo['duts'].index(target_dut_hostname)                                                                                                                                                       
        if dut_index == 0:                                                                                                                                                                                          
            data = {"active_side": UPPER_TOR}                                                                                                                                                                       
        else:                                                                                                                                                                                                       
            data = {"active_side": LOWER_TOR}                                                                                                                                                                       
                                                                                                                                                                                                                    
        # Allow retry for mux cable toggling                                                                                                                                                                        
        is_toggle_done = False                                                                                                                                                                                      
        for attempt in range(1, 6):                                                                                                                                                                                 
            logger.info('attempt={}, toggle active side of all muxcables to {} from mux simulator'.format(                                                                                                          
            _post(mux_server_url, data)                                                                                                                                                                             
            if utilities.wait_until(60, 10, 0, _check_toggle_done, duthosts, target_dut_hostname):                                                                                                                  
                is_toggle_done = True                                                                                                                                                                               
                break                                                                                                                                                                                               
                                                                                                                                                                                                                    
        if not is_toggle_done and \                                                                                                                                                                                 
                not utilities.wait_until(120, 10, 0, _check_toggle_done, duthosts, target_dut_hostname, probe=True):                                                                                                
>           pytest_assert(False, "Failed to toggle all ports to {} from mux simulator".format(target_dut_hostname))                                                                                                 
E           Failed: Failed to toggle all ports to gd377 from mux simulator 
```

This happening because the check for the existence of active-standby ports is missing here: https://github.com/sonic-net/sonic-mgmt/blob/202305/tests/common/dualtor/mux_simulator_control.py#L620


#### How did you do it?
Restricted the fixture to run only when active-standby ports are present.

#### How did you verify/test it?
Ran the tests in dualtor topologies on Arista-7050CX3 platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
