### PR TITLE
Fix sonic-mgmt testbed-cli interface_to_vms undefined failure.

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -262,7 +262,7 @@
     set_fact:
       intf_names: "{{ intf_names | default({}) | combine({item.0.name:  intf_names[item.0.name]|default([]) + [ port_alias[item.1]] }) }}"
     with_subelements:
-      - "{{ interface_to_vms }}"
+      - "{{ interface_to_vms | default([]) }}"
       - "ports"
     when: "'cable' not in topo"
 
@@ -272,7 +272,7 @@
       vm_asic_ifnames: "{{ vm_asic_ifnames | default({}) | combine({item.0.name: vm_asic_ifnames[item.0.name]|default([]) + [ front_panel_asic_ifnames[item.1]] }) }}"
       vm_asic_ids: "{{ vm_asic_ids | default({}) | combine({item.0.name: vm_asic_ids[item.0.name]|default([]) + [ front_panel_asic_ifs_asic_id[item.1]] }) }}"
     with_subelements:
-      - "{{ interface_to_vms }}"
+      - "{{ interface_to_vms | default([]) }}"
       - "ports"
     when: front_panel_asic_ifnames != []
 


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
If any topology without any VMs, e.g. no T1s for T0 topology, the testbed-cli deploy-mg will fail, due to error below:

```text
TASK [find all interface names] *****************************************************************************************************************************************************************************
task path: /var/src/mgmt-int/ansible/config_sonic_basedon_testbed.yml:273
Sunday 19 May 2024  18:06:26 +0000 (0:00:00.021)       0:00:16.756 ************
fatal: [str3-7060x6-64pe-1]: FAILED! => {
    "msg": "'interface_to_vms' is undefined"
}
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

This change is to fix the error above, when VM list is empty.

#### How did you do it?

The fix is straightforward - to give it a default value that is an empty list when enumerating.

#### How did you verify/test it?

The change is run locally with topology with empty VMs, and it works.

![image](https://github.com/sonic-net/sonic-mgmt/assets/1533278/6518d7d0-0602-4a1e-80f9-ca5d86877b0a)


#### Any platform specific information?

No.

#### Supported testbed topology if it's a new test case?

### Documentation

No doc needs to be updated for this change.