### PR TITLE
Skip 'route/test_forced_mgmt_route.py' on 'Arista-7050CX3' platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1339,6 +1339,12 @@ restapi/test_restapi_vxlan_ecmp.py:
 #######################################
 #####           route             #####
 #######################################
+route/test_forced_mgmt_route.py::test_forced_mgmt_route_add_and_remove_by_mgmt_port_status:
+  skip:
+    reason: "Platform does not support two management interfaces"
+    conditions:
+      - "platform in ['x86_64-arista_7050cx3_32s']"
+
 route/test_route_flap.py:
   skip:
     reason: "Test case has issue on the t0-56-povlan and dualtor-64 topo."
@@ -1359,12 +1365,6 @@ route/test_static_route.py::test_static_route_ecmp_ipv6:
   skip:
     reason: "Test case may fail due to a known issue"
     conditions: https://github.com/sonic-net/sonic-buildimage/issues/4930
-
-route/test_forced_mgmt_route.py::test_forced_mgmt_route_add_and_remove_by_mgmt_port_status:
-  skip:
-    reason: "Platform does not support two management interfaces"
-    conditions:
-      - "platform in ['x86_64-arista_7050cx3_32s']"
 
 #######################################
 #####      show_techsupport       #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1360,6 +1360,12 @@ route/test_static_route.py::test_static_route_ecmp_ipv6:
     reason: "Test case may fail due to a known issue"
     conditions: https://github.com/sonic-net/sonic-buildimage/issues/4930
 
+route/test_forced_mgmt_route.py::test_forced_mgmt_route_add_and_remove_by_mgmt_port_status:
+  skip:
+    reason: "Platform does not support two management interfaces"
+    conditions:
+      - "platform in ['x86_64-arista_7050cx3_32s']"
+
 #######################################
 #####      show_techsupport       #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes [#120](https://github.com/aristanetworks/sonic-qual.msft/issues/120)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
The test `route/test_forced_mgmt_route.py` needs to be skipped on the platform `Arista-7050` as the platform supports only one management interface

#### How did you do it?
Skipping the test on the platform `Arista-7050` by updating the file `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`

#### How did you verify/test it?
Tested on Arista-7050 platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
