### PR TITLE
[dhcp_server_test] support dhcp server container auto restarted test on mx topo

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -561,7 +561,7 @@ def dhcp_server_enabled(duthost):
     duthost.shell("sudo systemctl restart dhcp_relay.service")
 
     yield
-    
+
     duthost.shell("config feature state dhcp_server disabled")
     duthost.shell("sudo systemctl restart dhcp_relay.service")
 

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -33,22 +33,18 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname, tb
     # Enable autorestart for all features before the test begins
     for hostname in selected_rand_one_per_hwsku_hostname:
         duthost = duthosts[hostname]
-        # Enable dhcp_server feature for mx topo
-        if tbinfo["topo"]["type"] == "mx":
-            duthost.shell("config feature state dhcp_server enabled")
-            duthost.shell("sudo systemctl restart dhcp_relay.service")
         feature_list, _ = duthost.get_feature_status()
         for feature, status in list(feature_list.items()):
             if status == 'enabled':
                 duthost.shell("sudo config feature autorestart {} enabled".format(feature))
+        # Enable dhcp_server feature for mx topo
+        if tbinfo["topo"]["type"] == "mx" and "enabled" not in feature_list.get("dhcp_server", ""):
+            duthost.shell("config feature state dhcp_server enabled")
+            duthost.shell("sudo systemctl restart dhcp_relay.service")
     yield
     # Config reload should set the auto restart back to state before test started
     for hostname in selected_rand_one_per_hwsku_hostname:
         duthost = duthosts[hostname]
-        # Disable dhcp_server feature for mx topo
-        if tbinfo["topo"]["type"] == "mx":
-            duthost.shell("config feature state dhcp_server disabled")
-            duthost.shell("sudo systemctl restart dhcp_relay.service")
         config_reload(duthost, config_source='config_db', safe_reload=True)
 
 

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -573,5 +573,3 @@ def test_containers_autorestart(duthosts, enum_rand_one_per_hwsku_hostname, enum
     service_name = asic.get_service_name(enum_dut_feature)
     container_name = asic.get_docker_name(enum_dut_feature)
     run_test_on_single_container(duthost, container_name, service_name, tbinfo)
-
-

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -23,6 +23,7 @@ CONTAINER_CHECK_INTERVAL_SECS = 1
 CONTAINER_STOP_THRESHOLD_SECS = 60
 CONTAINER_RESTART_THRESHOLD_SECS = 300
 CONTAINER_NAME_REGEX = r"([a-zA-Z_-]+)(\d*)([a-zA-Z_-]+)(\d*)$"
+DHCP_RELAY = "dhcp_relay"
 DHCP_SERVER = "dhcp_server"
 POST_CHECK_INTERVAL_SECS = 1
 POST_CHECK_THRESHOLD_SECS = 360
@@ -40,10 +41,20 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname, tb
             if status == 'enabled':
                 duthost.shell("sudo config feature autorestart {} enabled".format(feature))
         # Enable dhcp_server feature for mx topo
-        remove_dhcp_server = False
-        if tbinfo["topo"]["type"] == "mx" and DHCP_SERVER in feature_list and "enabled" not in feature_list.get(DHCP_SERVER, ""):
+        if tbinfo["topo"]["type"] == "mx" \
+            and DHCP_SERVER in feature_list \
+                and "enabled" not in feature_list.get(DHCP_SERVER, ""):
             dhcp_server_hosts.append(hostname)
             duthost.shell("config feature state %s enabled" % DHCP_SERVER)
+            duthost.shell("sudo systemctl restart %s.service" % DHCP_RELAY)
+            pytest_require(
+                wait_until(120, 1, 1,
+                           is_supervisor_program_running,
+                           duthost,
+                           DHCP_RELAY,
+                           "dhcp-relay:dhcprelayd"),
+                "dhcp-relay:dhcprelayd is not running"
+            )
     yield
     # Config reload should set the auto restart back to state before test started
     for hostname in selected_rand_one_per_hwsku_hostname:
@@ -51,6 +62,10 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname, tb
         config_reload(duthost, config_source='config_db', safe_reload=True)
         if hostname in dhcp_server_hosts:
             duthost.shell("docker rm %s" % DHCP_SERVER, module_ignore_errors=True)
+
+
+def is_supervisor_program_running(duthost, container_name, program_name):
+    return "RUNNING" in duthost.shell(f"docker exec {container_name} supervisorctl status {program_name}")["stdout"]
 
 
 def enable_autorestart(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
We need to test if dhcp_server container auto restart will work, however the dhcp_server feature is disabled by default, we need to enable it before the test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
We need to test if dhcp_server container auto restart will work.
#### How did you do it?
Enable dhcp_server feature before the test.
#### How did you verify/test it?
Run test on mx topo
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
