### PR TITLE
[tests/wr_arp] Migrate warm reboot management plane script ferret to py3

### DIFF
--- a/tests/arp/files/ferret.conf.j2
+++ b/tests/arp/files/ferret.conf.j2
@@ -1,5 +1,5 @@
 [program:ferret]
-command=/usr/bin/python /opt/ferret.py {{ ferret_args }}
+command=/root/env-python3/bin/python3 /opt/ferret.py {{ ferret_args }}
 process_name=ferret
 stdout_logfile=/tmp/ferret.out.log
 stderr_logfile=/tmp/ferret.err.log


### PR DESCRIPTION
### Description of PR

In an effort to move/migrate test scripts from Python 2 to 3 this PR migrates the warm reboot management plane script `ferret.py` and `ferret.conf.j2` to Python 3. The configuration refers to the `python3` in the virtual environment.

Summary:
Fixes N/A

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

The warm reboot test scripts have been migrated to Python 3. The ferret script still runs in Python 2 environment. This PR migrates that to Py3.

#### How did you do it?

- Run 2to3
- Modified script as struct packing handles bytes instead of str.
- Modified other affected parts to handle bytes directly

#### How did you verify/test it?

Ran warm reboot and warm reboot advanced tests on Dell S6100. Tests have passed successfully.

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

Existing test case.

### Documentation

Not applicable.