### PR TITLE
Enable feature autorestart before test_encap_with_mirror_session

### DIFF
--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -184,7 +184,24 @@ def _wait_portchannel_up(duthost, portchannel):
 
 
 @pytest.fixture
-def setup_uplink(rand_selected_dut, tbinfo):
+def enable_feature_autorestart(rand_selected_dut):
+    # Enable autorestart for all features before the test begins
+    duthost = rand_selected_dut
+    feature_list, _ = duthost.get_feature_status()
+    autorestart_states = duthost.get_container_autorestart_states()
+    changed_features = []
+    for feature, status in list(feature_list.items()):
+        if status == 'enabled' and autorestart_states.get(feature) == 'disabled':
+            duthost.shell("sudo config feature autorestart {} enabled".format(feature))
+            changed_features.append(feature)
+    yield
+    # Restore the autorestart status after the test ends
+    for feature in changed_features:
+        duthost.shell("sudo config feature autorestart {} disabled".format(feature))
+
+
+@pytest.fixture
+def setup_uplink(rand_selected_dut, tbinfo, enable_feature_autorestart):
     """
     Function level fixture.
     1. Only keep 1 uplink up. Shutdown others to force the bounced back traffic is egressed


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #11744 
`test_encap_with_mirror_session` would invoke fixture `setup_mirror_session`, and it would invoke fixture `setup_uplink`. There are steps in fixture `setup_uplink`, which could restart teamd docker, it would lead `swss` and `syncd` docker exits.
If the autorestart is disabled in `test_pretest.py`, then `swss` and `syncd` will fail to restart, and then leads to test failure.

This PR fixed the issue by adding a fixture to enable container autorestart before the test running.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR is to enable feature autorestart before `test_encap_with_mirror_session`.

#### How did you do it?
This PR fixed the issue by adding a fixture to enable container autorestart before the test running.

#### How did you verify/test it?
The change is verified by running `test_encap_with_mirror_session` after `test_disable_container_autorestart`.
```
collected 2 items                                                                                                                                                                                     

test_pretest.py::test_disable_container_autorestart[str2-7050cx3-acs-10] PASSED                                                                                                                 [ 50%]
test_pretest.py::test_disable_container_autorestart[str2-7050cx3-acs-11] PASSED                                                                                                                 [100%]
collected 1 item                                                                                                                                                                                      

dualtor/test_ipinip.py::test_encap_with_mirror_session  ^HPASSED                                                                                                                                   [100%] ^H
```

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
