### PR TITLE
Pin requests to version 2.31.0

### DIFF
--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -94,4 +94,15 @@
     pip: name=docker version=6.1.0 state=forcereinstall executable={{ pip_executable }}
     become: yes
     environment: "{{ proxy_env | default({}) }}"
+    # Workaround for '"Error connecting: Error while fetching server API version: Not supported URL scheme http+docker'
+    # See https://github.com/docker/docker-py/issues/3256
+  - name: Remove old requests package >=2.32.0
+    pip: name=requests state=absent executable={{ pip_executable }}
+    become: yes
+    environment: "{{ proxy_env | default({}) }}"
+    ignore_errors: yes
+  - name: Install requests package <2.32.0
+    pip: name=requests version=2.31.0 state=present executable={{ pip_executable }}
+    become: yes
+    environment: "{{ proxy_env | default({}) }}"
   when: pip_executable=="pip3"


### PR DESCRIPTION
Short-term workaround to avoid issue where testbed-cli.sh ... add-topo errored out with 'Not supported URL scheme http+docker' due to the update of the transitive dependency python requests through docker-py.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
