### PR TITLE
Fix test_update_forced_mgmt failed because check interfaces-config status with systemctl take 45 seconds.

### DIFF
--- a/tests/route/test_forced_mgmt_route.py
+++ b/tests/route/test_forced_mgmt_route.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # https://github.com/sonic-net/sonic-buildimage/blob/master/files/image_config/interfaces/interfaces.j2#L82
 FORCED_MGMT_ROUTE_PRIORITY = 32764
 
+FILE_CHANGE_TIMEOUT = 60
 
 @pytest.fixture
 def backup_restore_config(duthosts, enum_rand_one_per_hwsku_hostname):
@@ -64,8 +65,8 @@ def wait_for_file_changed(duthost, file, action, *args, **kwargs):
         latest_timestamp = get_interface_reload_timestamp(duthost)
         return latest_hash != original_hash and latest_timestamp != last_timestamp
 
-    exist = wait_until(60, 1, 0, hash_and_timestamp_changed, duthost, file)
-    pytest_assert(exist, "File {} does not change after 10 seconds.".format(file))
+    exist = wait_until(FILE_CHANGE_TIMEOUT, 1, 0, hash_and_timestamp_changed, duthost, file)
+    pytest_assert(exist, "File {} does not change after {} seconds.".format(file, FILE_CHANGE_TIMEOUT))
 
 
 def address_type(address):

--- a/tests/route/test_forced_mgmt_route.py
+++ b/tests/route/test_forced_mgmt_route.py
@@ -64,7 +64,7 @@ def wait_for_file_changed(duthost, file, action, *args, **kwargs):
         latest_timestamp = get_interface_reload_timestamp(duthost)
         return latest_hash != original_hash and latest_timestamp != last_timestamp
 
-    exist = wait_until(10, 1, 0, hash_and_timestamp_changed, duthost, file)
+    exist = wait_until(60, 1, 0, hash_and_timestamp_changed, duthost, file)
     pytest_assert(exist, "File {} does not change after 10 seconds.".format(file))
 
 

--- a/tests/route/test_forced_mgmt_route.py
+++ b/tests/route/test_forced_mgmt_route.py
@@ -22,7 +22,9 @@ logger = logging.getLogger(__name__)
 FORCED_MGMT_ROUTE_PRIORITY = 32764
 
 
-FILE_CHANGE_TIMEOUT = 60
+# Wait 300 seconds because sometime 'interfaces-config' service take 45 seconds to response
+# interfaces-config service issue track by: https://github.com/sonic-net/sonic-buildimage/issues/19045
+FILE_CHANGE_TIMEOUT = 300
 
 
 @pytest.fixture

--- a/tests/route/test_forced_mgmt_route.py
+++ b/tests/route/test_forced_mgmt_route.py
@@ -21,7 +21,9 @@ logger = logging.getLogger(__name__)
 # https://github.com/sonic-net/sonic-buildimage/blob/master/files/image_config/interfaces/interfaces.j2#L82
 FORCED_MGMT_ROUTE_PRIORITY = 32764
 
+
 FILE_CHANGE_TIMEOUT = 60
+
 
 @pytest.fixture
 def backup_restore_config(duthosts, enum_rand_one_per_hwsku_hostname):


### PR DESCRIPTION
Fix test_update_forced_mgmt failed because check interfaces-config status with systemctl take too much time.

#### Why I did it
Check interfaces-config status with systemctl some times take 45 seconds, however the wait timeout is 10 seconds, which cause test case break:

13/05/2024 23:01:03 base._run                                L0071 DEBUG  | /var/src/sonic-mgmt_vms21-t0-2700_646f1402735219c3e5444094/tests/common/devices/multi_asic.py::_run_on_asics#128: [] AnsibleModule::command, args=["sudo systemctl show --no-pager interfaces-config -p ExecMainExitTimestamp --value"], kwargs={}

13/05/2024 23:01:45 base._run                                L0108 DEBUG  | /var/src/sonic-mgmt_vms21-t0-2700_646f1402735219c3e5444094/tests/common/devices/multi_asic.py::_run_on_asics#128: [] AnsibleModule::command Result => {"changed": true, "stdout": "", "stderr": "", "rc": 0, "cmd": ["sudo", "systemctl", "show", "--no-pager", "interfaces-config", "-p", "ExecMainExitTimestamp", "--value"], "start": "2024-05-13 23:01:00.605392", "end": "2024-05-13 23:01:00.682419", "delta": "0:00:00.077027", "msg": "", "invocation": {"module_args": {"_raw_params": "sudo systemctl show --no-pager interfaces-config -p ExecMainExitTimestamp --value", "_uses_shell": false, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": [], "stderr_lines": [], "_ansible_no_log": null, "failed": false}

##### Work item tracking
- Microsoft ADO: 27683903

#### How I did it
Increase wait timeout to 60 seconds, because the some time the check status command take 45 seconds.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Fix test_update_forced_mgmt failed because check interfaces-config status with systemctl take too much time.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

