### PR TITLE
[Nvidia] Skip the mellanox reboot cause test on Nvidia 4280 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1026,6 +1026,12 @@ platform_tests/mellanox/test_check_sfp_using_ethtool.py:
     conditions:
       - "asic_type in ['mellanox']"
 
+platform_tests/mellanox/test_reboot_cause.py:
+  skip:
+    reason: "sn4280 driver doesn't support reset_from_asic and reset_reload_bios"
+    conditions:
+      - "'sn4280' in platform"
+
 platform_tests/sfp/test_sfputil.py::test_check_sfputil_low_power_mode:
   skip:
     reason: "Get/Set low power mode is not supported in Cisco 8000 platform or in bluefield platform"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The asic and bios reboot causes are not supported by Nvidia 4280 platform.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Skip the mellanox reboot cause test on Nvidia 4280 platform. 
#### How did you do it?
Skip the test on sn4280 plarform.
#### How did you verify/test it?
Run the test, check it is skipped.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
