### PR TITLE
Fix bug on Dualtor testbeds caused by muxcable switching from standby to active

### DIFF
--- a/tests/generic_config_updater/gu_utils.py
+++ b/tests/generic_config_updater/gu_utils.py
@@ -379,7 +379,7 @@ def format_and_apply_template(duthost, template_name, extra_vars, setup):
 
     duts_to_apply = [duthost]
     outputs = []
-    if setup["is_dualtor_aa"]:
+    if setup["is_dualtor"]:
         duts_to_apply.append(setup["rand_unselected_dut"])
 
     for dut in duts_to_apply:
@@ -404,7 +404,7 @@ def load_and_apply_json_patch(duthost, file_name, setup):
 
     duts_to_apply = [duthost]
     outputs = []
-    if setup["is_dualtor_aa"]:
+    if setup["is_dualtor"]:
         duts_to_apply.append(setup["rand_unselected_dut"])
 
     for dut in duts_to_apply:
@@ -425,7 +425,7 @@ def apply_formed_json_patch(duthost, json_patch, setup):
 
     duts_to_apply = [duthost]
     outputs = []
-    if setup["is_dualtor_aa"]:
+    if setup["is_dualtor"]:
         duts_to_apply.append(setup["rand_unselected_dut"])
 
     for dut in duts_to_apply:
@@ -460,7 +460,7 @@ def expect_acl_table_match_multiple_bindings(duthost,
     cmds = "show acl table {}".format(table_name)
 
     duts_to_check = [duthost]
-    if setup["is_dualtor_aa"]:
+    if setup["is_dualtor"]:
         duts_to_check.append(setup["rand_unselected_dut"])
 
     for dut in duts_to_check:
@@ -482,7 +482,7 @@ def expect_acl_rule_match(duthost, rulename, expected_content_list, setup):
     cmds = "show acl rule DYNAMIC_ACL_TABLE {}".format(rulename)
 
     duts_to_check = [duthost]
-    if setup["is_dualtor_aa"]:
+    if setup["is_dualtor"]:
         duts_to_check.append(setup["rand_unselected_dut"])
 
     for dut in duts_to_check:
@@ -509,7 +509,7 @@ def expect_acl_rule_removed(duthost, rulename, setup):
     cmds = "show acl rule DYNAMIC_ACL_TABLE {}".format(rulename)
 
     duts_to_check = [duthost]
-    if setup["is_dualtor_aa"]:
+    if setup["is_dualtor"]:
         duts_to_check.append(setup["rand_unselected_dut"])
 
     for dut in duts_to_check:

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -130,14 +130,11 @@ def setup(rand_selected_dut, rand_unselected_dut, tbinfo, vlan_name, topo_scenar
 
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     is_dualtor = False
-    is_dualtor_aa = False
     if "dualtor" in tbinfo["topo"]["name"]:
         vlan_name = list(mg_facts['minigraph_vlans'].keys())[0]
         # Use VLAN MAC as router MAC on dual-tor testbed
         router_mac = rand_selected_dut.get_dut_iface_mac(vlan_name)
         is_dualtor = True
-        if "aa" in tbinfo["topo"]["name"]:
-            is_dualtor_aa = True
     else:
         router_mac = rand_selected_dut.facts['router_mac']
 
@@ -264,7 +261,6 @@ def setup(rand_selected_dut, rand_unselected_dut, tbinfo, vlan_name, topo_scenar
         "dut_mac": dut_mac,
         "vlan_ips": vlan_ips,
         "is_dualtor": is_dualtor,
-        "is_dualtor_aa": is_dualtor_aa,
         "rand_unselected_dut": rand_unselected_dut,
         "switch_loopback_ip": switch_loopback_ip,
         "ipv4_vlan_mac": v4_vlan_mac,
@@ -285,7 +281,7 @@ def setup_env(rand_selected_dut, rand_unselected_dut, setup):
     """
 
     create_checkpoint(rand_selected_dut)
-    if setup["is_dualtor_aa"]:
+    if setup["is_dualtor"]:
         create_checkpoint(rand_unselected_dut)
 
     yield
@@ -293,11 +289,11 @@ def setup_env(rand_selected_dut, rand_unselected_dut, setup):
     try:
         logger.info("Rolled back to original checkpoint")
         rollback_or_reload(rand_selected_dut)
-        if setup["is_dualtor_aa"]:
+        if setup["is_dualtor"]:
             rollback_or_reload(rand_unselected_dut)
     finally:
         delete_checkpoint(rand_selected_dut)
-        if setup["is_dualtor_aa"]:
+        if setup["is_dualtor"]:
             delete_checkpoint(rand_unselected_dut)
 
 


### PR DESCRIPTION

### Description of PR

Fixes a bug in GCU Dynamic ACL test where dualtor tests would periodically fail if the active DUT swapped to standby in the middle of test.  Applies ACL Rules on both TORs regardless of whether it is active-standby or active-active, causing packets to not get dropped.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach

#### How did you verify/test it?
Tested on a dualtor testbed that it was previously failed on, observed success.

