### PR TITLE
Skip iface loopback test if Leaf-fanout switch is running SONiC and Mellanox ASIC 

### DIFF
--- a/tests/iface_loopback_action/conftest.py
+++ b/tests/iface_loopback_action/conftest.py
@@ -218,3 +218,17 @@ def recover(duthost, ptfhost, ports_configuration):
     """
     yield
     recover_config(duthost, ptfhost, ports_configuration)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def skip_sonic_mlnx_leaf_fanout(fanouthosts):
+    """
+    The test sends QinQ packet for testing purpose. However, the QinQ packet will be dropped on leaf fanout
+    if it's running SONiC and Mellanox ASIC.
+    More info https://github.com/sonic-net/SONiC/blob/master/doc/tpid/SonicTPIDSettingHLD1.md
+    """
+    for fanouthost in list(fanouthosts.values()):
+        os = fanouthost.get_fanout_os()
+        asic_type = fanouthost.facts['asic_type']
+        if os == 'sonic' and asic_type in ["mellanox"]:
+            pytest.skip("Not supporteds on SONiC leaf-fanout platform")

--- a/tests/iface_loopback_action/conftest.py
+++ b/tests/iface_loopback_action/conftest.py
@@ -183,7 +183,7 @@ def generate_ip_list():
 
 @pytest.fixture(scope="module", autouse=True)
 def setup(duthost, ptfhost, orig_ports_configuration, ports_configuration,
-          backup_and_restore_config_db_package, nbrhosts, tbinfo):                # noqa: F811
+          backup_and_restore_config_db_package, nbrhosts, tbinfo, is_sonic_mlnx_leaf_fanout):                # noqa: F811
     """
     Config: Cleanup the original port configuration and add new configurations before test
     Cleanup: restore the config on the VMs
@@ -195,6 +195,9 @@ def setup(duthost, ptfhost, orig_ports_configuration, ports_configuration,
     :param nbrhosts: nbrhosts fixture.
     :param tbinfo: Testbed object
     """
+    if is_sonic_mlnx_leaf_fanout:
+        pytest.skip("Not supporteds on Mellanox leaf-fanout running SONiC")
+        return
     peer_shutdown_ports = get_portchannel_peer_port_map(duthost, orig_ports_configuration, tbinfo, nbrhosts)
     remove_orig_dut_port_config(duthost, orig_ports_configuration)
     for vm_host, peer_ports in list(peer_shutdown_ports.items()):
@@ -209,19 +212,22 @@ def setup(duthost, ptfhost, orig_ports_configuration, ports_configuration,
 
 
 @pytest.fixture(scope="module", autouse=True)
-def recover(duthost, ptfhost, ports_configuration):
+def recover(duthost, ptfhost, ports_configuration, is_sonic_mlnx_leaf_fanout):
     """
     restore the original configurations
     :param duthost: DUT host object
     :param ptfhost: PTF host object
     :param ports_configuration: ports configuration parameters
     """
+    if is_sonic_mlnx_leaf_fanout:
+        yield
+        return
     yield
     recover_config(duthost, ptfhost, ports_configuration)
 
 
-@pytest.fixture(scope='module', autouse=True)
-def skip_sonic_mlnx_leaf_fanout(fanouthosts):
+@pytest.fixture(scope='module')
+def is_sonic_mlnx_leaf_fanout(fanouthosts):
     """
     The test sends QinQ packet for testing purpose. However, the QinQ packet will be dropped on leaf fanout
     if it's running SONiC and Mellanox ASIC.
@@ -231,4 +237,6 @@ def skip_sonic_mlnx_leaf_fanout(fanouthosts):
         os = fanouthost.get_fanout_os()
         asic_type = fanouthost.facts['asic_type']
         if os == 'sonic' and asic_type in ["mellanox"]:
-            pytest.skip("Not supporteds on SONiC leaf-fanout platform")
+            return True
+    return False
+

--- a/tests/iface_loopback_action/conftest.py
+++ b/tests/iface_loopback_action/conftest.py
@@ -183,7 +183,7 @@ def generate_ip_list():
 
 @pytest.fixture(scope="module", autouse=True)
 def setup(duthost, ptfhost, orig_ports_configuration, ports_configuration,
-          backup_and_restore_config_db_package, nbrhosts, tbinfo, is_sonic_mlnx_leaf_fanout):                # noqa: F811
+          backup_and_restore_config_db_package, nbrhosts, tbinfo, is_sonic_mlnx_leaf_fanout):  # noqa: F811
     """
     Config: Cleanup the original port configuration and add new configurations before test
     Cleanup: restore the config on the VMs
@@ -239,4 +239,3 @@ def is_sonic_mlnx_leaf_fanout(fanouthosts):
         if os == 'sonic' and asic_type in ["mellanox"]:
             return True
     return False
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test cases in `test_iface_loopback_action.py` is failing consistently on some testbed when the leaf-fanout is Mellanox and running SONiC. This is because the test sends packets with Vlan tag for testing, while TPID is not supported on Mellanox if running SONiC OS.
So the test needs to be skipped in the above setup.
   
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR is to skip  `test_iface_loopback_action.py` if the leaf-fanout is Mellanox and running SONiC. 

#### How did you do it?
Add a fixture to check OS and ASIC of leaf-fanout switch.

#### How did you verify/test it?
The change is verified on a physical testbed.
```
collected 3 items                                                                                                                                                                                     

iface_loopback_action/test_iface_loopback_action.py::test_loopback_action_basic SKIPPED (Not supporteds on Mellanox leaf-fanout running SONiC)                                                  [ 33%]
iface_loopback_action/test_iface_loopback_action.py::test_loopback_action_port_flap SKIPPED (Not supporteds on Mellanox leaf-fanout running SONiC)                                              [ 66%]
iface_loopback_action/test_iface_loopback_action.py::test_loopback_action_reload SKIPPED (Not supporteds on Mellanox leaf-fanout running SONiC)                                                 [100%]
```
#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
