### PR TITLE
Fix add-topo failure when deploying topology with empty VM list.

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -234,7 +234,7 @@ class VMTopology(object):
             self.pid = None
 
         self.VMs = {}
-        if 'VMs' in self.topo:
+        if 'VMs' in self.topo and len(self.topo['VMs']) > 0:
             self.vm_base = vm_base
             if vm_base in self.vm_names:
                 self.vm_base_index = self.vm_names.index(vm_base)

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -280,8 +280,6 @@
           <Type>EverflowV6</Type>
         </AclInterface>
 {% if enable_data_plane_acl|default('true')|bool and vm_topo_config['topo_type'] != 'wan' %}
-        <AclInterface>
-          <AttachTo>
 {%- set acl_intfs = [] -%}
 {%- for index in range(vms_number) %}
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
@@ -297,11 +295,15 @@
 {% endif %}
 {% endif %}
 {% endfor -%}
+{%- if acl_intfs | length > 0 -%}
+        <AclInterface>
+          <AttachTo>
 {{- acl_intfs|join(';') -}}
           </AttachTo>
           <InAcl>DataAcl</InAcl>
           <Type>DataPlane</Type>
         </AclInterface>
+{% endif %}
 {% endif %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
### Description of PR

Summary:
When deploying any topology without the VM list as below, we will running into a few errors. And this PR is to fix these issues:

![image](https://github.com/sonic-net/sonic-mgmt/assets/1533278/74edbe46-a45e-45f2-bcea-de6c59d84b03)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

There are 2 issues are hitting, when deploying any topology without the VM list:

- Ansible Bind topology to VMs task task will fail, because the vm list is empty, but it is checking the VM base in the VM list.
- The generated minigraph will fail to load, because minigraph.py is not expecting any ACL interface with empty attached to list.

#### How did you do it?

This change fixes both issue with adding the empty list checks in these 2 places.

#### How did you verify/test it?

Run the add-topo and deploy-mg locally, both works.

#### Any platform specific information?

No.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
