### PR TITLE
Added flow rules for OSPF and BFD

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -1025,14 +1025,14 @@ class VMTopology(object):
                            (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
 
         # Add flow for BFD Control packets (UDP port 3784)
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,udp,in_port=%s,\
-                           udp_dst=3784,action=output:%s,%s" %
+            VMTopology.cmd("ovs-ofctl add-flow %s 'table=0,priority=10,udp,in_port=%s,\
+                           udp_dst=3784,action=output:%s,%s'" %
                            (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,udp6,in_port=%s,\
-                           udp_dst=3784,action=output:%s,%s" %
+            VMTopology.cmd("ovs-ofctl add-flow %s 'table=0,priority=10,udp6,in_port=%s,\
+                           udp_dst=3784,action=output:%s,%s'" %
                            (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
         # Add flow from a ptf container to an external iface
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" %
+            VMTopology.cmd("ovs-ofctl add-flow %s 'table=0,in_port=%s,action=output:%s'" %
                            (br_name, injected_iface_id, dut_iface_id))
 
     def unbind_ovs_ports(self, br_name, vm_port):

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -1031,6 +1031,14 @@ class VMTopology(object):
             VMTopology.cmd("ovs-ofctl add-flow %s 'table=0,priority=10,udp6,in_port=%s,\
                            udp_dst=3784,action=output:%s,%s'" %
                            (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            # Add flow for BFD Control packets (UDP port 3784)
+            VMTopology.cmd("ovs-ofctl add-flow %s 'table=0,priority=10,udp,in_port=%s,\
+                           udp_src=49152,udp_dst=3784,action=output:%s,%s'" %
+                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            VMTopology.cmd("ovs-ofctl add-flow %s 'table=0,priority=10,udp6,in_port=%s,\
+                           udp_src=49152,udp_dst=3784,action=output:%s,%s'" %
+                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+
         # Add flow from a ptf container to an external iface
             VMTopology.cmd("ovs-ofctl add-flow %s 'table=0,in_port=%s,action=output:%s'" %
                            (br_name, injected_iface_id, dut_iface_id))

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -1019,10 +1019,21 @@ class VMTopology(object):
                            (br_name, dut_iface_id, injected_iface_id))
             VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=3,in_port=%s,action=output:%s,%s" %
                            (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,ip,in_port=%s,nw_proto=89,action=output:%s,%s" %
+                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,ipv6,in_port=%s,nw_proto=89,action=output:%s,%s" %
+                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
 
+        # Add flow for BFD Control packets (UDP port 3784)
+            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,udp,in_port=%s,\
+                           udp_dst=3784,action=output:%s,%s" %
+                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,udp6,in_port=%s,\
+                           udp_dst=3784,action=output:%s,%s" %
+                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
         # Add flow from a ptf container to an external iface
-        VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" %
-                       (br_name, injected_iface_id, dut_iface_id))
+            VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" %
+                           (br_name, injected_iface_id, dut_iface_id))
 
     def unbind_ovs_ports(self, br_name, vm_port):
         """unbind all ports except the vm port from an ovs bridge"""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is intended to add flow rules for OSPF and BFD traffic from an external interface to a VM and a PTF container

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
To allow OSPF and BFD traffic between DUT and the neighboring devices in t0 or t1 topology by adding flow rules.
#### How did you do it?
By adding flow rules to sonic-mgmt/ansible/roles/vm_set/library/vm_topology.py file.
