### PR TITLE
Include advanced-reboot ptf exception in pytest assertion

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -579,8 +579,9 @@ class AdvancedReboot:
                     self.postboot_setup()
             except Exception:
                 traceback_msg = traceback.format_exc()
-                logger.error("Exception caught while running advanced-reboot test on ptf: \n{}".format(traceback_msg))
-                test_results[test_case_name].append("Exception caught while running advanced-reboot test on ptf")
+                err_msg = "Exception caught while running advanced-reboot test on ptf: \n{}".format(traceback_msg)
+                logger.error(err_msg)
+                test_results[test_case_name].append(err_msg)
             finally:
                 # capture the test logs, and print all of them in case of failure, or a summary in case of success
                 log_dir = self.__fetchTestLogs(rebootOper)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This allows the ptf exception to be reported in the Summary field of the V2TestCases table in Kusto.

ADO: 28078972

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Surface more information in our test reporting infrastructure to aid in debugging
#### How did you do it?
Added more information to a pytest assertion.
#### How did you verify/test it?
Artificially added an exception to the try-except block and saw that it was printed out in the pytest assertions.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
