### PR TITLE
[sdn_tests]: Adding Installation test to pins_ondatra.

### DIFF
--- a/sdn_tests/pins_ondatra/tests/installation_test.go
+++ b/sdn_tests/pins_ondatra/tests/installation_test.go
@@ -1,0 +1,33 @@
+package installation_test
+
+import (
+	"testing"
+	"time"
+
+	syspb "github.com/openconfig/gnoi/system"
+	"github.com/openconfig/ondatra"
+	"github.com/sonic-net/sonic-mgmt/sdn_tests/pins_ondatra/infrastructure/binding/pinsbind"
+	"github.com/sonic-net/sonic-mgmt/sdn_tests/pins_ondatra/infrastructure/testhelper/testhelper"
+)
+
+func TestMain(m *testing.M) {
+	ondatra.RunTests(m, pinsbind.New)
+}
+
+func TestConfigInstallationSuccess(t *testing.T) {
+	ttID := "0dedda87-1b76-40a2-8712-24c1572587ee"
+	defer testhelper.NewTearDownOptions(t).WithID(ttID).Teardown(t)
+	dut := ondatra.DUT(t, "DUT")
+	err :=testhelper.ConfigPush(t, dut, nil)
+	if err != nil {
+		t.Fatalf("switch config push failed due to err : %v", err)
+	}
+	waitTime, err := testhelper.RebootTimeForDevice(t, dut)
+	if err != nil {
+		t.Fatalf("Unable to get reboot wait time: %v", err)
+	}
+	params := testhelper.NewRebootParams().WithWaitTime(waitTime).WithCheckInterval(30*time.Second).WithRequest(syspb.RebootMethod_COLD).WithLatencyMeasurement(ttID, "gNOI Reboot With Type: "+syspb.RebootMethod_COLD.String())
+	if err := testhelper.Reboot(t, dut, params); err != nil {
+		t.Fatalf("Failed to reboot DUT: %v", err)
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
- [sdn_tests]: Adding Installation test to pins_ondatra.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
- Added Installation test to pins_ondatra.

Build results:

         INFO: From Generating Descriptor Set proto_library @com_github_openconfig_gnsi//acctz:acctz_proto:
         github.com/openconfig/gnsi/acctz/acctz.proto:36:1: 
         warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
         INFO: Elapsed time: 848.985s, Critical Path: 191.63s
         INFO: 975 processes: 251 internal, 724 linux-sandbox.
         INFO: Build completed successfully, 975 total actions

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [-] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
