### PR TITLE
Verify the PCIe daemon status before retrieving the PCIE_DEVICES table from the database

### DIFF
--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -53,6 +53,18 @@ def setup(duthosts, rand_one_dut_hostname):
 
 
 @pytest.fixture(scope="module", autouse=True)
+def get_pcie_devices_tbl_key(duthosts, rand_one_dut_hostname, setup):
+    duthost = duthosts[rand_one_dut_hostname]
+    skip_release(duthost, ["201811", "201911"])
+    pytest_assert(wait_until(30, 10, 0, check_pcie_devices_table_ready, duthost),
+                  "PCIE_DEVICES table is empty")
+    command_output = duthost.shell("sonic-db-cli STATE_DB KEYS '*' | grep PCIE_DEVICES")
+
+    global pcie_devices_status_tbl_key
+    pcie_devices_status_tbl_key = command_output["stdout"]
+
+
+@pytest.fixture(scope="module", autouse=True)
 def teardown_module(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     yield
@@ -79,18 +91,6 @@ def check_pcie_devices_table_ready(duthost):
     if duthost.shell("sonic-db-cli STATE_DB KEYS '*' | grep PCIE_DEVICES"):
         return True
     return False
-
-
-@pytest.fixture(scope="module", autouse=True)
-def get_pcie_devices_tbl_key(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    skip_release(duthost, ["201811", "201911"])
-    pytest_assert(wait_until(60, 10, 0, check_pcie_devices_table_ready, duthost),
-                  "PCIE_DEVICES table is empty")
-    command_output = duthost.shell("sonic-db-cli STATE_DB KEYS '*' | grep PCIE_DEVICES")
-
-    global pcie_devices_status_tbl_key
-    pcie_devices_status_tbl_key = command_output["stdout"]
 
 
 def collect_data(duthost):

--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -85,7 +85,7 @@ def check_pcie_devices_table_ready(duthost):
 def get_pcie_devices_tbl_key(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     skip_release(duthost, ["201811", "201911"])
-    pytest_assert(wait_until(30, 10, 0, check_pcie_devices_table_ready, duthost),
+    pytest_assert(wait_until(60, 10, 0, check_pcie_devices_table_ready, duthost),
                   "PCIE_DEVICES table is empty")
     command_output = duthost.shell("sonic-db-cli STATE_DB KEYS '*' | grep PCIE_DEVICES")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The "get_pcie_devices_tbl_key" fixture is currently invoked before the "setup" fixture. When the PCIe daemon is not running, the "get_pcie_devices_tbl_key" fixture asserts that the PCIE_DEVICES table is empty in the database and causes the test to fail. Instead, make the "get_pcie_devices_tbl_key" fixture dependent on the "setup" fixture to verify the daemon status before retrieving the PCIE_DEVICES table from the database, which skips the test if daemon is not running.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

There are occasional failures with the "PCIE_DEVICES table is empty" message when running PCIe tests. This fix ensures the PCIe daemon is running before retrieving the PCIE_DEVICES table, thereby increasing test reliability.

#### How did you do it?

Make the "get_pcie_devices_tbl_key" fixture dependent on the "setup" fixture to verify the daemon status before retrieving the PCIE_DEVICES table from the database.

#### How did you verify/test it?
- Ran test_pcied.py tests on lab testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
