### PR TITLE
[fwutil] Copy next image for fpd upgrade to a generic path

### DIFF
--- a/tests/platform_tests/fwutil/conftest.py
+++ b/tests/platform_tests/fwutil/conftest.py
@@ -8,7 +8,6 @@ from fwutil_common import show_firmware
 
 logger = logging.getLogger(__name__)
 
-DUT_HOME = "/home/admin"
 DEVICES_PATH = "/usr/share/sonic/device"
 FS_PATH_TEMPLATE = "/host/image-{}/fs.squashfs"
 FS_RW_TEMPLATE = "/host/image-{}/rw"
@@ -121,11 +120,11 @@ def next_image(duthost, fw_pkg):
     logger.info("Installing new image {}".format(target))
 
     if fw_pkg["images"][target].startswith("http"):
-        duthost.get_url(url=fw_pkg["images"][target], dest=DUT_HOME)
+        duthost.get_url(url=fw_pkg["images"][target], dest='/var/tmp/')
     else:
-        duthost.copy(src=os.path.join("firmware", fw_pkg["images"][target]), dest=DUT_HOME)
+        duthost.copy(src=os.path.join("firmware", fw_pkg["images"][target]), dest='/var/tmp/')
 
-    remote_path = os.path.join(DUT_HOME, os.path.basename(fw_pkg["images"][target]))
+    remote_path = os.path.join('/var/tmp/', os.path.basename(fw_pkg["images"][target]))
     duthost.command("sonic-installer install -y {}".format(remote_path), module_ignore_errors=True)
 
     # Mount newly installed image


### PR DESCRIPTION
### Description of PR

For fpd upgrade on next image using fwutil, test case is written to copy the next image to '/home/admin'. On cisco routers and/or for non admin users in general, this path does not exist and causes a failure in accessing the next image during install process. Make changes to copy the image to a generic path (/var/tmp/) instead of '/home/admin'.
Alternatively as a suggestion, if we do want to maintain /home/admin for any specific reason, we can also instead add a line to create the admin directory before copying the next image. Although it makes sense to copy the image to a generic path as it does not have a dependency to be on the home directory.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Change the destination path for the next image to be copied

#### How did you verify/test it?
```
        if (res.is_failed or 'exception' in res) and not module_ignore_errors:                                                                                        
>           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)                                                                          
E           RunAnsibleModuleFail: run module command failed, Ansible Results =>                                                                                       
E           {"changed": true, "cmd": ["sonic-installer", "install", "-y", "/home/admin/sonic-cisco-8000.bin"], "delta": "0:00:00.313280", "end": "2023-08-05 05:55:07.
815213", "failed": true, "msg": "non-zero return code", "rc": 1, "start": "2023-08-05 05:55:07.501933", "stderr": "cat: /home/admin/sonic-cisco-8000.bin: Not a direct
ory\nImage file does not exist or is not a valid SONiC image file\nAborted!", "stderr_lines": ["cat: /home/admin/sonic-cisco-8000.bin: Not a directory", "Image file d
oes not exist or is not a valid SONiC image file", "Aborted!"], "stdout": "", "stdout_lines": []} 
```
```
root@yy39-lc1:/home/cisco# ls -ltr /home/admin/
ls: cannot access '/home/admin/': Not a directory
root@yy39-lc1:/home/cisco#
root@yy39-lc1:/home/cisco# ls -ltr /var/tmp/sonic-cisco-8000.bin 
-rw-r--r-- 1 root root 1784547330 Aug  5 06:00 /var/tmp/sonic-cisco-8000.bin
root@yy39-lc1:/home/cisco# 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
