### PR TITLE
Skip test_bfd_static_route.py on all single-asic systems

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -82,10 +82,10 @@ bfd/test_bfd.py::test_bfd_scale:
 
 bfd/test_bfd_static_route.py:
   skip:
-    reason: "Only supported on chassis system & cisco platform."
+    reason: "Test not supported on single-asic systems"
     conditions:
       - "is_multi_asic is False"
-      - "asic_type in ['cisco-8000']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/12948
 
 #######################################
 #####            bgp              #####


### PR DESCRIPTION
I opened https://github.com/sonic-net/sonic-mgmt/issues/12948 to track the fact that test_bfd_static_route.py doesn't support single-asic systems.

This PR updates the skip conditional for this test to be `any single asic system` rather than `single-asic system && cisco sku`

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)
