### PR TITLE
Optimize loganalyzer regex matching by using match() instead of findall()

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -404,8 +404,15 @@ class AnsibleLogAnalyzer:
         '''
 
         ret_code = False
-        if (expect_messages_regex is not None) and (expect_messages_regex.match(str)):
-            ret_code = True
+        if self.run_id.startswith("test_advanced_reboot_test_"):
+            # Use the stricter (and better-performing) match instead of findall, but only when analyzing
+            # logs for advanced reboot test cases. This is so that other test cases are not affected in
+            # case their regexes don't start with .*
+            if (expect_messages_regex is not None) and (expect_messages_regex.match(str)):
+                ret_code = True
+        else:
+            if (expect_messages_regex is not None) and (expect_messages_regex.findall(str)):
+                ret_code = True
 
         return ret_code
 

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -404,7 +404,7 @@ class AnsibleLogAnalyzer:
         '''
 
         ret_code = False
-        if (expect_messages_regex is not None) and (expect_messages_regex.findall(str)):
+        if (expect_messages_regex is not None) and (expect_messages_regex.match(str)):
             ret_code = True
 
         return ret_code


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

Loganalyzer takes an unusally long time to test syslog messages to see if they match some expected regex. This is because of using `findall` (search anywhere in the string for all instances) instead of `match` (search from the starting of the string). The time it takes to search for different starting positions of a match appears to be expensive.

#### How did you do it?

Most of our match strings have a `.*` at the beginning anyways, and we're not returning the exact matching substrings (only whether or not the regex matches), so change to using `match`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
