### PR TITLE
Handle failure during dualtor setup deployment

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -426,6 +426,20 @@ class VMTopology(object):
             self.destroy_ovs_bridge(VS_CHASSIS_INBAND_BRIDGE_NAME)
             self.destroy_ovs_bridge(VS_CHASSIS_MIDPLANE_BRIDGE_NAME)
 
+    def reinsert_8021q(self):
+        """
+        Reinsert module 8021q in case of vconfig add command failed to work
+        Would not do reinsert in a shared test server, in case of affect traffic
+        """
+        ngts_docker_count = 0
+        out = VMTopology.cmd('docker ps')
+        for line in out.split('\n'):
+            if 'docker-ngts' in line:
+                ngts_docker_count += 1
+        if ngts_docker_count < 2:
+            VMTopology.cmd('rmmod 8021q')
+            VMTopology.cmd('modprobe 8021q')
+
     def destroy_ovs_bridge(self, bridge_name):
         logging.info('=== Destroy bridge %s ===' % bridge_name)
         VMTopology.cmd('ovs-vsctl --if-exists del-br %s' % bridge_name)
@@ -1268,6 +1282,13 @@ class VMTopology(object):
                 if isinstance(intf, list):
                     host_ifindex = intf[0][2] if len(intf[0]) == 3 else i
                     is_active_active = intf in self.host_interfaces_active_active
+                    dual_if_template = ACTIVE_ACTIVE_INTERFACES_TEMPLATE \
+                        if is_active_active else MUXY_INTERFACES_TEMPLATE
+                    dual_if = adaptive_name(
+                        dual_if_template, self.vm_set_name, host_ifindex)
+                    ptf_if = PTF_FP_IFACE_TEMPLATE % host_ifindex
+                    tmp_name = ptf_if + VMTopology._generate_fingerprint(dual_if, MAX_INTF_LEN-len(ptf_if))
+                    self.remove_veth_if_from_docker(dual_if, ptf_if, tmp_name)
                     self.remove_dualtor_cable(
                         host_ifindex, is_active_active=is_active_active)
                 else:
@@ -1726,7 +1747,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             cmd=dict(required=True, choices=['create', 'bind', 'bind_keysight_api_server_ip',
-                     'renumber', 'unbind', 'destroy', "connect-vms", "disconnect-vms"]),
+                     'renumber', 'unbind', 'destroy', "connect-vms", "disconnect-vms", "reinsert-8021q"]),
             vm_set_name=dict(required=False, type='str'),
             topo=dict(required=False, type='dict'),
             vm_names=dict(required=True, type='list'),
@@ -1772,6 +1793,8 @@ def main():
             net.create_bridges()
         elif cmd == 'destroy':
             net.destroy_bridges()
+        elif cmd == 'reinsert-8021q':
+            net.reinsert_8021q()
         elif cmd == 'bind':
             check_params(module, ['vm_set_name',
                                   'topo',

--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -147,3 +147,10 @@
     vm_names: "{{ VM_targets }}"
   become: yes
   when: vm_type is defined and vm_type=="ceos"
+
+- name: Reinsert 8021q module
+  vm_topology:
+    cmd: 'reinsert-8021q'
+    vm_names: "{{ VM_targets }}"
+  become: yes
+  when: vm_type is defined and vm_type=="ceos"


### PR DESCRIPTION
1. Remove muxy-vm related interfaces directly to handle nsenter failure
2. Do 8021q module reinstall to handle vconfig add failure

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR is used to handle 2 issues during dual-tor setup deployment.
In a t0/t1 and dualtor shared setup, sometimes, cross deployment action would happened. Someone is deploying t0/t1 setup while other one is deploying dualtor setup. As a result, 2 issues would exist after deployment.

Summary:
Fixes # (issue)
1. Some muxy-vm related interfaces would be left, and it would leads to next round of dualtor deployment failure. The failure reason would be nsenter command failure in ansible playbook.
2. Vlan module stuck in abnormal state, vconfig add and even vconfig remove command could not be executed for a specific vlan. And it could not be recovered automatically.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fix dualtor setup deployment issue in a shared setup.
#### How did you do it?
1. Remove muxy-vm related interfaces during removing topology.
2. Do 8021q module reinstall during removing topology.
#### How did you verify/test it?
Validate it in internal regression.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
