### PR TITLE
Pin requests to version 2.31.0 in main.yml

### DIFF
--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -94,15 +94,4 @@
     pip: name=docker version=6.1.0 state=forcereinstall executable={{ pip_executable }}
     become: yes
     environment: "{{ proxy_env | default({}) }}"
-    # Workaround for '"Error connecting: Error while fetching server API version: Not supported URL scheme http+docker'
-    # See https://github.com/docker/docker-py/issues/3256
-  - name: Remove old requests package >=2.32.0
-    pip: name=requests state=absent executable={{ pip_executable }}
-    become: yes
-    environment: "{{ proxy_env | default({}) }}"
-    ignore_errors: yes
-  - name: Install requests package <2.32.0
-    pip: name=requests version=2.31.0 state=present executable={{ pip_executable }}
-    become: yes
-    environment: "{{ proxy_env | default({}) }}"
   when: pip_executable=="pip3"

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -124,6 +124,21 @@
 - include_tasks: docker.yml
   when: package_installation|bool
 
+- name: Update python3 packages
+  block:
+    # Workaround for '"Error connecting: Error while fetching server API version: Not supported URL scheme http+docker'
+    # See https://github.com/docker/docker-py/issues/3256
+  - name: Remove old requests package >=2.32.0
+    pip: name=requests state=absent executable={{ pip_executable }}
+    become: yes
+    environment: "{{ proxy_env | default({}) }}"
+    ignore_errors: yes
+  - name: Install requests package <2.32.0
+    pip: name=requests version=2.31.0 state=present executable={{ pip_executable }}
+    become: yes
+    environment: "{{ proxy_env | default({}) }}"
+  when: pip_executable=="pip3"
+
 - name: Ensure {{ ansible_user }} in docker,sudo group
   user:
     name: "{{ ansible_user }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
In latest requests python package, would got error in some steps like add-topo and restart-ptf with message 'Not supported URL scheme http+docker'
We already have fix PR https://github.com/sonic-net/sonic-mgmt/pull/12910  in master branch to install stable requests version in docker.yml, but  once package_installation was set to false like restart-ptf, docker.yml would skip and report error again
#### How did you do it?
Install stable requests version in main.yml after executing docker.yml to cover all scenario
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
