### PR TITLE
Support new topology t1-32-lag in acl test

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -315,7 +315,6 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
     # For M0_VLAN/MX/T0/dual ToR scenario, we need to use the VLAN MAC to interact with downstream ports
     # For T1/M0_L3 scenario, no VLANs are present so using the router MAC is acceptable
     downlink_dst_mac = vlan_mac if vlan_mac is not None else rand_selected_dut.facts["router_mac"]
-
     if topo == "t2":
         t2_info = get_t2_info(duthosts, tbinfo)
         downstream_port_ids = t2_info['downstream_port_ids']
@@ -372,7 +371,7 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
                 acl_table_ports[''] += port
 
     if topo in ["t0", "m0_vlan", "m0_l3"] or tbinfo["topo"]["name"] in ("t1-lag", "t1-64-lag", "t1-64-lag-clet",
-                                                                        "t1-56-lag", "t1-28-lag"):
+                                                                        "t1-56-lag", "t1-28-lag", "t1-32-lag"):
         for k, v in list(port_channels.items()):
             acl_table_ports[v['namespace']].append(k)
             # In multi-asic we need config both in host and namespace.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
`test_acl.py` is failing on `t1-32-lag` because the port selection mechanism is not correct. All portchannels should be selected as testing port as all ports are in LAG in this topology.
```
{"changed": true, "cmd": ["config", "acl", "add", "table", "DATA_INGRESS_IPV4_TEST", "L3", "-s", "ingress", "-p", "Ethernet104,Ethernet112,Ethernet120,Ethernet128,Ethernet136,Ethernet144,Ethernet152,Ethernet160"], "delta": "0:00:00.492203", "end": "2024-05-13 20:35:37.842050", "failed": true, "msg": "non-zero return code", "rc": 2, "start": "2024-05-13 20:35:37.349847", "stderr": "Usage: config acl add table [OPTIONS] <table_name> <table_type>\nTry \"config acl add table -h\" for help.\n\nError: Failed to parse ACL table config: exception=Cannot bind ACL to specified port Ethernet160", "stderr_lines": ["Usage: config acl add table [OPTIONS] <table_name> <table_type>", "Try \"config acl add table -h\" for help.", "", "Error: Failed to parse ACL table config: exception=Cannot bind ACL to specified port Ethernet160"], "stdout": "", "stdout_lines": []}
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR is to improve `test_acl` to support a new topology `t1-32-lag`.

#### How did you do it?
Select only portchannels if the topology is `t1-32-lag`.
```
collected 200 items                                                                                                                                                                                   

acl/test_acl.py::TestBasicAcl::test_ingress_unmatched_blocked[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                                                                             [  0%]
acl/test_acl.py::TestBasicAcl::test_egress_unmatched_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] SKIPPED (Only run for egress)                                                     [  1%]
acl/test_acl.py::TestBasicAcl::test_source_ip_match_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                                                                             [  1%]
acl/test_acl.py::TestBasicAcl::test_rules_priority_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                                                                              [  2%]
acl/test_acl.py::TestBasicAcl::test_rules_priority_dropped[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                                                                                [  2%]
acl/test_acl.py::TestBasicAcl::test_dest_ip_match_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                                                                               [  3%]
acl/test_acl.py::TestBasicAcl::test_dest_ip_match_dropped[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                                                                                 [  3%]
acl/test_acl.py::TestBasicAcl::test_source_ip_match_dropped[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                                                                               [  4%]
acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                                                                         [  4%]
acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_dropped[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                                                                           [  5%]
acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_dropped[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                                                                          [  5%]
acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                                                                        [  6%]
acl/test_acl.py::TestBasicAcl::test_l4_dport_match_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                                                                              [  6%]
acl/test_acl.py::TestBasicAcl::test_l4_sport_match_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                                                                              [  7%]
acl/test_acl.py::TestBasicAcl::test_l4_dport_range_match_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                                                                        [  7%]
acl/test_acl.py::TestBasicAcl::test_l4_sport_range_match_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED                               
```

#### How did you verify/test it?
The change is verified on a `t1-32-lag` testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
