### PR TITLE
Add pkts_num_hysteresis for new rx cgm profile

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -65,12 +65,19 @@ class QosParamCisco(object):
             # Tune thresholds with padding for precise testing
             self.pause_thr = pre_pad_pause + (8 * self.buffer_size)
             self.drop_thr = pre_pad_drop + (12 * self.buffer_size)
+            if self.is_deep_buffer:
+                self.reduced_pause_thr = 10 * (1024 ** 2) * (2 ** dynamic_th)
+            elif self.is_large_sms:
+                self.reduced_pause_thr = 3 * (1024 ** 2)
+            else:
+                self.reduced_pause_thr = 2.25 * (1024 ** 2)
             self.log("Max pause thr bytes:       {}".format(max_pause))
             self.log("Attempted pause thr bytes: {}".format(attempted_pause))
             self.log("Pre-pad pause thr bytes:   {}".format(pre_pad_pause))
             self.log("Pause thr bytes:           {}".format(self.pause_thr))
             self.log("Pre-pad drop thr bytes:    {}".format(pre_pad_drop))
             self.log("Drop thr bytes:            {}".format(self.drop_thr))
+            self.log("Reduced pause thr bytes:   {}".format(self.reduced_pause_thr))
 
     def run(self):
         '''
@@ -246,6 +253,7 @@ class QosParamCisco(object):
                       "ecn": 1,
                       "pg": dscp_pg,
                       "pkts_num_trig_pfc": (self.pause_thr // self.buffer_size // packet_buffs) - 1,
+                      "pkts_num_hysteresis": int(((self.pause_thr - self.reduced_pause_thr) // self.buffer_size // packet_buffs) - 2),
                       "pkts_num_dismiss_pfc": 2,
                       "packet_size": packet_size}
             self.write_params("xon_{}".format(param_i), params)

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -253,7 +253,8 @@ class QosParamCisco(object):
                       "ecn": 1,
                       "pg": dscp_pg,
                       "pkts_num_trig_pfc": (self.pause_thr // self.buffer_size // packet_buffs) - 1,
-                      "pkts_num_hysteresis": int(((self.pause_thr - self.reduced_pause_thr) // self.buffer_size // packet_buffs) - 2),
+                      "pkts_num_hysteresis": int(((self.pause_thr - self.reduced_pause_thr)
+                                                  // self.buffer_size // packet_buffs) - 2),
                       "pkts_num_dismiss_pfc": 2,
                       "packet_size": packet_size}
             self.write_params("xon_{}".format(param_i), params)

--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -421,6 +421,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 3415
+                    pkts_num_hysteresis: 1365
                     pkts_num_dismiss_pfc: 23
                     packet_size: 1350
                 xon_2:
@@ -428,6 +429,7 @@ qos_params:
                     ecn: 1
                     pg: 4
                     pkts_num_trig_pfc: 3415
+                    pkts_num_hysteresis: 1365
                     pkts_num_dismiss_pfc: 23
                     packet_size: 1350
                 lossy_queue_1:
@@ -544,6 +546,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 3038
+                    pkts_num_hysteresis: 1140
                     pkts_num_dismiss_pfc: 23
                     packet_size: 1350
                 xon_2:
@@ -551,6 +554,7 @@ qos_params:
                     ecn: 1
                     pg: 4
                     pkts_num_trig_pfc: 3038
+                    pkts_num_hysteresis: 1140
                     pkts_num_dismiss_pfc: 23
                     packet_size: 1350
                 lossless_voq_1:

--- a/tests/qos/files/qos_params.pac.yaml
+++ b/tests/qos/files/qos_params.pac.yaml
@@ -93,6 +93,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 2561
+                    pkts_num_hysteresis: 1024
                     pkts_num_dismiss_pfc: 2
                     packet_size: 1350
                 xon_2:
@@ -100,6 +101,7 @@ qos_params:
                     ecn: 1
                     pg: 4
                     pkts_num_trig_pfc: 2561
+                    pkts_num_hysteresis: 1024
                     pkts_num_dismiss_pfc: 2
                     packet_size: 1350
                 lossless_voq_1:
@@ -226,6 +228,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_trig_pfc: 2562
+                    pkts_num_hysteresis: 1024
                     pkts_num_dismiss_pfc: 21
                     packet_size: 1350
                 xon_2:
@@ -233,6 +236,7 @@ qos_params:
                     ecn: 1
                     pg: 4
                     pkts_num_trig_pfc: 2562
+                    pkts_num_hysteresis: 1024
                     pkts_num_dismiss_pfc: 21
                     packet_size: 1350
                 lossless_voq_1:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The fix of https://migsonic.atlassian.net/browse/MIGSMSFT-388 introduces xon hysteresis, qos params in xon testcases need to be updated.

Summary:
Fixes # (issue)
Add pkts_num_hysteresis for new rx cgm profile.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Update qos params used in xon testcases.

#### How did you do it?
Add pkts_num_hysteresis in file qos_param_generator.py, qos_params.gb.yaml and qos_params.pac.yaml.

#### How did you verify/test it?
Run it on testbed.

T1-100G
```
============================================================================ PASSES =============================================================================
______________________________________________________ TestQosSai.testQosSaiPfcXonLimit[single_asic-xon_1] ______________________________________________________
______________________________________________________ TestQosSai.testQosSaiPfcXonLimit[single_asic-xon_2] ______________________________________________________
---------------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit_2024-05-10-00-06-29.xml ----------------------------
INFO:root:Can not get Allure report URL. Please check logs
-------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------
00:23:30 init.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
==================================================================== short test summary info ====================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2]
SKIPPED [2] qos/test_qos_sai.py:600: Additional DSCPs are not supported on non-dual ToR ports
SKIPPED [4] qos/qos_sai_base.py:613: Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests
SKIPPED [4] qos/qos_sai_base.py:620: multi-dut is not supported on T1 topologies
===================================================== 2 passed, 10 skipped, 1 warning in 1019.97s (0:16:59) =====================================================
```
T2 Vanguard:
```
===================================================================== PASSES ======================================================================
_______________________________________________ TestQosSai.testQosSaiPfcXonLimit[single_asic-xon_1] _______________________________________________
_______________________________________________ TestQosSai.testQosSaiPfcXonLimit[single_asic-xon_2] _______________________________________________
--------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit_2024-05-14-05-30-43.xml ---------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------
05:44:19 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
============================================================= short test summary info =============================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2]
SKIPPED [2] qos/test_qos_sai.py:599: Additional DSCPs are not supported on non-dual ToR ports
=============================================== 2 passed, 2 skipped, 1 warning in 815.24s (0:13:35) ===============================================
```

T2 pacific:
```
===================================================================== PASSES ======================================================================
_______________________________________________ TestQosSai.testQosSaiPfcXonLimit[single_asic-xon_1] _______________________________________________
_______________________________________________ TestQosSai.testQosSaiPfcXonLimit[single_asic-xon_2] _______________________________________________
--------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit_2024-05-14-06-12-17.xml ---------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------
06:28:47 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
============================================================= short test summary info =============================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2]
SKIPPED [2] qos/test_qos_sai.py:599: Additional DSCPs are not supported on non-dual ToR ports
=============================================== 2 passed, 2 skipped, 1 warning in 988.42s (0:16:28) ===============================================
```
T2 lancer:
```
===================================================================== PASSES ======================================================================
_______________________________________________ TestQosSai.testQosSaiPfcXonLimit[single_asic-xon_1] _______________________________________________
_______________________________________________ TestQosSai.testQosSaiPfcXonLimit[single_asic-xon_2] _______________________________________________
--------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit_2024-05-14-17-57-03.xml ---------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------
18:10:46 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
============================================================= short test summary info =============================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2]
SKIPPED [2] qos/test_qos_sai.py:599: Additional DSCPs are not supported on non-dual ToR ports
=============================================== 2 passed, 2 skipped, 1 warning in 821.44s (0:13:41) ===============================================
sonic@sonic-ucs-m5-1:/data/tests$ 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
