### PR TITLE
[Baseline] Fix 1 test plan fail may cancel others issue

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -231,11 +231,12 @@ steps:
     displayName: "Trigger test"
 
   - script: |
-      set -e
+      set -o
       echo "Lock testbed"
 
       echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
       IFS=',' read -ra TEST_PLAN_ID_LIST <<< "$TEST_PLAN_ID_LIST_STRING"
+      failure_count=0
       for TEST_PLAN_ID in "${TEST_PLAN_ID_LIST[@]}"
       do
           echo -e -n "\033[33mPlease visit Elastictest page \033[0m"
@@ -244,17 +245,27 @@ steps:
           # When "LOCK_TESTBED" finish, it changes into "PREPARE_TESTBED"
           echo "[test_plan.py] poll LOCK_TESTBED status"
           python ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state LOCK_TESTBED
+          RET=$?
+          if [ $RET -ne 0 ]; then
+              ((failure_count++))
+          fi
       done
+
+      if [ $failure_count -eq ${#TEST_PLAN_ID_LIST[@]} ]; then
+          echo "All testplan failed, cancel following steps"
+          exit 3
+      fi
 
     displayName: "Lock testbed"
 
   - script: |
-      set -e
+      set -o
       echo "Prepare testbed"
       echo "Preparing the testbed(add-topo, deploy-mg) may take 15-30 minutes. Before the testbed is ready, the progress of the test plan keeps displayed as 0, please be patient"
 
       echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
       IFS=',' read -ra TEST_PLAN_ID_LIST <<< "$TEST_PLAN_ID_LIST_STRING"
+      failure_count=0
       for TEST_PLAN_ID in "${TEST_PLAN_ID_LIST[@]}"
       do
           echo -e -n "\033[33mPlease visit Elastictest page \033[0m"
@@ -263,16 +274,26 @@ steps:
           # When "PREPARE_TESTBED" finish, it changes into "EXECUTING"
           echo "[test_plan.py] poll PREPARE_TESTBED status"
           python ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state PREPARE_TESTBED
+          RET=$?
+          if [ $RET -ne 0 ]; then
+              ((failure_count++))
+          fi
       done
+
+      if [ "$failure_count" -eq ${#TEST_PLAN_ID_LIST[@]} ]; then
+          echo "All testplan failed, cancel following steps"
+          exit 3
+      fi
 
     displayName: "Prepare testbed"
 
   - script: |
-      set -e
+      set -o
       echo "Run test"
 
       echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
       IFS=',' read -ra TEST_PLAN_ID_LIST <<< "$TEST_PLAN_ID_LIST_STRING"
+      failure_count=0
       for TEST_PLAN_ID in "${TEST_PLAN_ID_LIST[@]}"
       do
           echo -e -n "\033[33mPlease visit Elastictest page \033[0m"
@@ -281,7 +302,16 @@ steps:
           # When "EXECUTING" finish, it changes into "KVMDUMP", "FAILED", "CANCELLED" or "FINISHED"
           echo "[test_plan.py] poll EXECUTING status"
           python ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state EXECUTING --expected-result ${{ parameters.EXPECTED_RESULT }}
+          RET=$?
+          if [ $RET -ne 0 ]; then
+              ((failure_count++))
+          fi
       done
+
+      if [ $failure_count -eq ${#TEST_PLAN_ID_LIST[@]} ]; then
+          echo "All testplan failed, cancel following steps"
+          exit 3
+      fi
 
     displayName: "Run test"
     timeoutInMinutes: ${{ parameters.MAX_RUN_TEST_MINUTES }}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Baseline test will run a batch of PR tests, and in baseline test, test plan in same platform will run in 1 test job in azure devops.
In current logic, once a test plan fails, the test job would catch the sys.exit code and cancel following steps, but we want it only cancel following steps when all test plans fail in the test job
#### How did you do it?
Use set -o to continue bash command when fails, get the return code of polling test plan status, if all polling results fail, raise exit code to cancel following steps
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
