### PR TITLE
Remove comma from counter string before type casting to integer

### DIFF
--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -116,7 +116,7 @@ def check_queue_counter(duthost, intfs, queue, counter):
     for line in output:
         fields = line.split()
         if len(fields) == 6 and fields[0] in intfs and fields[1] == 'UC{}'.format(queue):
-            if int(fields[2]) >= counter:
+            if int(fields[2].replace(',', '')) >= counter:
                 return True
 
     return False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Summary: Fix string to integer type casting issue in qos/tunnel_qos_remap_base.py::check_queue_counter
Fixes # [aristanetworks/sonic-qual.msft#131](https://github.com/aristanetworks/sonic-qual.msft/issues/131)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
In `qos/tunnel_qos_remap_base.py::check_queue_counter` method, we are trying to convert string counter value to an integer, but the string can contain a comma (for numbers > 999, Ex: "1,000"), which will lead to error `invalid literal for int() with base 10`.

#### How did you do it?
Remove commas (if any) in the counter (string) before trying to convert it to integer.

#### How did you verify/test it?
Ran the test `qos/test_tunnel_qos_remap.py` and verified there is no breakage with the fix.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
