### PR TITLE
Fix 104 connection issue in testcase `test_stress_routes.py`. 

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -150,9 +150,21 @@ def change_routes(action, ptf_ip, port, routes):
     wait_for_http(ptf_ip, port, timeout=60)
     url = "http://%s:%d" % (ptf_ip, port)
     data = {"commands": ";".join(messages)}
+
     # nosemgrep-next-line
-    time.sleep(0.01)
-    r = requests.post(url, data=data, timeout=360, proxies={"http": None, "https": None})
+    # Flaky error `ConnectionResetError(104, 'Connection reset by peer')` may happen while using `requests.post`
+    # To avoid this error, we add sleep time before sending request.
+    # We use a "backoff" algorithm here, the maximum retry times is five.
+    # If one retry fails, we increase the waiting time.
+    for i in range(0, 5):
+        try:
+            r = requests.post(url, data=data, timeout=360, proxies={"http": None, "https": None})
+            break
+        except ConnectionError as e:
+            time.sleep(0.01 * (i+1))
+            if i == 4:
+                raise e
+
     if r.status_code != 200:
         raise Exception(
             "Change routes failed: url={}, data={}, r.status_code={}, r.reason={}, r.headers={}, r.text={}".format(

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -10,6 +10,7 @@ import json
 import sys
 import socket
 import random
+import time
 from multiprocessing.pool import ThreadPool
 from ansible.module_utils.basic import AnsibleModule
 
@@ -150,6 +151,7 @@ def change_routes(action, ptf_ip, port, routes):
     url = "http://%s:%d" % (ptf_ip, port)
     data = {"commands": ";".join(messages)}
     # nosemgrep-next-line
+    time.sleep(0.1)
     r = requests.post(url, data=data, timeout=360, proxies={"http": None, "https": None})
     if r.status_code != 200:
         raise Exception(

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -151,7 +151,7 @@ def change_routes(action, ptf_ip, port, routes):
     url = "http://%s:%d" % (ptf_ip, port)
     data = {"commands": ";".join(messages)}
     # nosemgrep-next-line
-    time.sleep(0.1)
+    time.sleep(0.01)
     r = requests.post(url, data=data, timeout=360, proxies={"http": None, "https": None})
     if r.status_code != 200:
         raise Exception(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
There is a flaky issue in testcase `test_stress_routes.py` `ConnectionError(ProtocolError('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer')))` in baseline test. 

Regarding to some articles
[https://stackoverflow.com/questions/383738/104-connection-reset-by-peer-socket-error-or-when-does-closing-a-socket-resu](https://stackoverflow.com/questions/383738/104-connection-reset-by-peer-socket-error-or-when-does-closing-a-socket-resu)
[https://stackoverflow.com/questions/52051989/requests-exceptions-connectionerror-connection-aborted-connectionreseterro](https://stackoverflow.com/questions/52051989/requests-exceptions-connectionerror-connection-aborted-connectionreseterro)

Adding sleep time may fix this issue. This PR is just to have a try. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
There is a flaky issue in testcase `test_stress_routes.py` `ConnectionError(ProtocolError('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer')))` in baseline test. 

Regarding to some articles
[https://stackoverflow.com/questions/383738/104-connection-reset-by-peer-socket-error-or-when-does-closing-a-socket-resu](https://stackoverflow.com/questions/383738/104-connection-reset-by-peer-socket-error-or-when-does-closing-a-socket-resu)
[https://stackoverflow.com/questions/52051989/requests-exceptions-connectionerror-connection-aborted-connectionreseterro](https://stackoverflow.com/questions/52051989/requests-exceptions-connectionerror-connection-aborted-connectionreseterro)

Adding sleep time may fix this issue. This PR is just to have a try. 

#### How did you do it?

#### How did you verify/test it?
I tested such as add topo, deploy minigraph, where announce route is used. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
