### PR TITLE
Fix BGP status sanity check failure when topology doesn't have any VMs.

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -229,6 +229,13 @@ def check_bgp(duthosts, tbinfo):
         logger.info("Checking bgp status on host %s ..." % dut.hostname)
         check_result = {"failed": False, "check_item": "bgp", "host": dut.hostname}
 
+        # If the topology doesn't have any VMs, it is not using BGP feature at all, hence skip checking
+        # the BGP status here.
+        if len(tbinfo['topo']['properties']['topology']['VMs']) == 0:
+            logger.info("No VMs in topology, skip checking bgp status on host %s ..." % dut.hostname)
+            results[dut.hostname] = check_result
+            return
+
         networking_uptime = dut.get_networking_uptime().seconds
         if SYSTEM_STABILIZE_MAX_TIME - networking_uptime + 480 > 500:
             # If max_timeout is higher than 600, it will exceed parallel_run's timeout


### PR DESCRIPTION
### Description of PR

Summary:
If a topology doesn't have any VMs, e.g. T0 without any uplinks, it is not using BGP sessions in the setup. However, the current pytests will always think the BGP is used, hence checking the BGP status.

This PR is trying to address this issue, by checking the topology setup before running the BGP status sanity checks.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

If a topology doesn't have any VMs, e.g. T0 without any uplinks, it is not using BGP sessions in the setup. However, the current pytests will always think the BGP is used, hence checking the BGP status.

This will cause all tests failing for this type of topologies, because of sanity check is failing.

#### How did you do it?

This PR adds a topology check before the BGP sanity checks. If this type of topology is detected, we skip the BGP status checks.

#### How did you verify/test it?

Have run tests with existing non-BGP test, such as link flap. And the test passed with the new topology.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A