### PR TITLE
Add asic sensors info to minigraph_device.j2 to support ASIC thermal …

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -287,6 +287,16 @@
 
     when: switch_type is defined and switch_type == 'voq' and slot_num is defined and asic_topo_config|length > 0
 
+  - name: Gather hwsku for duts that support asic sensor polling
+    set_fact:
+      hwsku_asic_sensors_list: "['Nokia-7215-A1', 'Nokia-IXR7250E-36x400G', 'Nokia-IXR7250E-36x100G']"
+
+  - name: Set asic sensors poller
+    set_fact:
+      asic_sensors_poller_status: "enable"
+      asic_sensors_poller_interval: "10"
+    when: "(hwsku in hwsku_asic_sensors_list)"
+
   - name: create minigraph file in ansible minigraph folder
     template: src=templates/minigraph_template.j2
               dest=minigraph/{{ inventory_hostname}}.{{ topo }}.xml

--- a/ansible/templates/minigraph_device.j2
+++ b/ansible/templates/minigraph_device.j2
@@ -51,5 +51,11 @@
       <Height>0</Height>
       <HwSku>{{ hwsku }}</HwSku>
       <ManagementInterfaces/>
+{% if asic_sensors_poller_status is defined %}
+      <AsicSensors>
+      <AsicSensorsPollerStatus>{{asic_sensors_poller_status}}</AsicSensorsPollerStatus>
+      <AsicSensorsPollerInterval>{{asic_sensors_poller_interval}}</AsicSensorsPollerInterval>
+      </AsicSensors>
+{% endif %}
     </DeviceInfo>
   </DeviceInfos>


### PR DESCRIPTION
…monitoring

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR helps enable asic sensors thermal monitoring for Nokia Platforms. 
Fixed issue : https://github.com/sonic-net/sonic-mgmt/issues/13091
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Currently Nokia platforms with hwsku 'Nokia-7215-A1', 'Nokia-IXR7250E-36x400G' 'Nokia-IXR7250E-36x100G' support asic sensors thermal monitoring. To enable this, we need to add AsicSensors entry in the minigraph.xml file so that sonic-cfggen can parse it and enable these sensors in config_db. 
#### How did you do it?
Added AsicSensors in the minigraph_device.j2 template. When gen-mg runs, config_sonic_basedon_testbed.yaml runs a set of tasks which include generating the minigraph based on these templates. I have added a task in this file to set the asic sensors poller status and poller interval values. When the minigraph.xml is generated, it is generated with the set values. 
#### How did you verify/test it?
1.Ran gen-mg to see if all the tasks are successfully completed. 
2.Checked the minigraph.xml generated to see if the values for AsicSensors are set appropriately.
```
cat /etc/sonic/minigraph.xml | grep AsicSensors -A 10
      <AsicSensors>
      <AsicSensorsPollerStatus>enable</AsicSensorsPollerStatus>
      <AsicSensorsPollerInterval>10</AsicSensorsPollerInterval>
      </AsicSensors>
    </DeviceInfo>
```
3. Checked if the the asic sensors entry is present in the config_db.json
```
cat /etc/sonic/config_db.json | grep ASIC_SENSORS -A 10
    "ASIC_SENSORS": {
        "ASIC_SENSORS_POLLER_INTERVAL": {
            "interval": "10"
        },
        "ASIC_SENSORS_POLLER_STATUS": {
            "admin_status": "enable"
        }
    },
```

5. Checked the output of show platform temperature.
```
 show platform temperature 
   Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
---------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
     ASIC         54            100       N/A           110.0            N/A      False  20240524 16:33:07
 CPU CORE         59.055        100       N/A           106.0            N/A      False  20240524 16:33:07
 PCB BACK         37.187         80       N/A             N/A            N/A      False  20240524 16:33:07
PCB FRONT         38.062         80       N/A             N/A            N/A      False  20240524 16:33:07
  PCB MID         42.812         80       N/A             N/A            N/A      False  20240524 16:33:07
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
