### PR TITLE
Fix 'drop_packets/test_configurable_drop_counters.py' on dualtor

### DIFF
--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -199,7 +199,7 @@ def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_d
 
 @pytest.mark.parametrize("drop_reason", ["DIP_LINK_LOCAL"])
 def test_dip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_hostname,
-                        toggle_all_simulator_ports_to_rand_selected_tor_m,
+                        toggle_all_simulator_ports_to_rand_selected_tor_m,                      # noqa F811
                         setup_standby_ports_on_rand_unselected_tor,                             # noqa F811
                         send_dropped_traffic, drop_reason, add_default_route_to_dut, generate_dropped_packet):
     """
@@ -226,7 +226,7 @@ def test_dip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_h
 
 @pytest.mark.parametrize("drop_reason", ["SIP_LINK_LOCAL"])
 def test_sip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_hostname,
-                        toggle_all_simulator_ports_to_rand_selected_tor_m,
+                        toggle_all_simulator_ports_to_rand_selected_tor_m,                      # noqa F811
                         setup_standby_ports_on_rand_unselected_tor,                             # noqa F811
                         send_dropped_traffic, drop_reason, add_default_route_to_dut, generate_dropped_packet):
     """

--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -199,6 +199,7 @@ def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_d
 
 @pytest.mark.parametrize("drop_reason", ["DIP_LINK_LOCAL"])
 def test_dip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_hostname,
+                        toggle_all_simulator_ports_to_rand_selected_tor_m,
                         setup_standby_ports_on_rand_unselected_tor,                             # noqa F811
                         send_dropped_traffic, drop_reason, add_default_route_to_dut, generate_dropped_packet):
     """
@@ -225,6 +226,7 @@ def test_dip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_h
 
 @pytest.mark.parametrize("drop_reason", ["SIP_LINK_LOCAL"])
 def test_sip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_hostname,
+                        toggle_all_simulator_ports_to_rand_selected_tor_m,
                         setup_standby_ports_on_rand_unselected_tor,                             # noqa F811
                         send_dropped_traffic, drop_reason, add_default_route_to_dut, generate_dropped_packet):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes [#133](https://github.com/aristanetworks/sonic-qual.msft/issues/133)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fix the failure of the test 'drop_packets/test_configurable_drop_counters.py' on dualtor testbeds

#### How did you do it?
Toggled all mux simulator ports to the selected tor before sending traffic

#### How did you verify/test it?
Tested on Arista-7050 and Arista-7260 platforms

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
