### PR TITLE
Increase debug info in wait_until utility

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -167,7 +167,7 @@ def wait_until(timeout, interval, delay, condition, *args, **kwargs):
             elapsed_time = time.time() - start_time
 
     if elapsed_time >= timeout:
-        logger.debug("%s is still False after %d seconds, exit with False" % (condition.__name__, timeout))
+        logger.debug("%s is still False after %d seconds, exit with False" % (condition.__name__, elapsed_time))
         return False
 
 


### PR DESCRIPTION
### Description of PR
1. increased the timeout for /etc/network/interfaces file update
2. changed the debug log in wait_until to print the actual time elapsed instead of timeout passed

Summary:
Increase the timeout in Fix route/test_forced_mgmt_route.py::test_update_forced_mgmt for /etc/network/interfaces file to get updated.

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
route/test_forced_mgmt_route.py::test_update_forced_mgmt failure on dualtor topo.

#### How did you do it?
increased the timeout

#### How did you verify/test it?
Verified that the tests are passing  on dualtor-aa

NOK log excerpts:
```
15/05/2024 08:47:53 utilities.wait_until                     L0118 DEBUG  | Wait until hash_and_timestamp_changed is True, timeout is 10 seconds, checking interval is 1, delay is 0 seconds
…
15/05/2024 08:48:28 utilities.wait_until                     L0151 DEBUG  | hash_and_timestamp_changed is still False after 34 seconds, exit with False
15/05/2024 08:48:28 utilities.wait_until                     L0151 DEBUG  | hash_and_timestamp_changed is still False after 10 seconds, exit with False
```

UT:
```
-------------------------- generated xml file: /run_logs/ananshr/tr_2024-05-15-08-54-01.xml ---------------------------
----------------------------------------------- live log sessionfinish ------------------------------------------------
08:57:24 __init__.pytest_terminal_summary         L0064 INFO   | Can not get Allure report URL. Please check logs
====================================== 1 passed, 1 warning in 202.02s (0:03:22) =======================================
```

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
NA
