### PR TITLE
[dualtor][active-standby] disable timed oscillation 

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1861,3 +1861,15 @@ def setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditi
         standby_tor = upper_tor_host if active_tor == lower_tor_host else lower_tor_host
         config_active_active_dualtor_active_standby(active_tor, standby_tor, active_active_ports, True)
     return
+
+
+@pytest.fixture(scope='session', autouse=True)
+def disable_timed_oscillation_active_standby(duthosts, tbinfo):
+    """
+    Disable timed oscillation for active-standby mux ports
+    """
+    if 'dualtor' not in tbinfo['topo']['name']:
+        return
+
+    for duthost in duthosts:
+        duthost.shell('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|TIMED_OSCILLATION" "oscillation_enabled" "false"')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_ses
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file                        # noqa F401
 from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active         # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder_session              # noqa F401
+from tests.common.dualtor.dual_tor_utils import disable_timed_oscillation_active_standby# noqa F401
 
 from tests.common.helpers.constants import (
     ASIC_PARAM_TYPE_ALL, ASIC_PARAM_TYPE_FRONTEND, DEFAULT_ASIC_ID, ASICS_PRESENT
@@ -2175,6 +2176,7 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
             # The keys that we don't care
             # Current skipped keys:
             # 1. "MUX_LINKMGR|LINK_PROBER"
+            # 2. "MUX_LINKMGR|TIMED_OSCILLATION"
             # NOTE: this key is edited by the `run_icmp_responder_session` or `run_icmp_responder`
             # to account for the lower performance of the ICMP responder/mux simulator compared to
             # real servers and mux cables.
@@ -2183,7 +2185,8 @@ def core_dump_and_config_check(duthosts, tbinfo, request):
             # let's skip checking it.
             if "dualtor" in tbinfo["topo"]["name"]:
                 EXCLUDE_CONFIG_KEY_NAMES = [
-                    'MUX_LINKMGR|LINK_PROBER'
+                    'MUX_LINKMGR|LINK_PROBER',
+                    'MUX_LINKMGR|TIMED_OSCILLATION'
                 ]
             else:
                 EXCLUDE_CONFIG_KEY_NAMES = []


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

We need to disable `icmp_responder` for qos tests.
-> Hence dualtor testbed will always be unhealthy. 
-> Per design timed oscillation is triggered.
-> It causes some tests to be flaky. 

Adding a fixture to disable the oscillation knob as a workaround. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Ran a random test case again the testbed, no more toggle after the fixture is called. 
```
May 29 17:00:57.019500 NOTICE mux#linkmgrd: DbInterface.cpp:238 handlePostSwitchCause: Ethernet68: post last switch cause Timed_Oscillation
May 29 17:11:04.324339 NOTICE mux#linkmgrd: DbInterface.cpp:238 handlePostSwitchCause: Ethernet68: post last switch cause Timed_Oscillation
May 29 17:21:11.458202 NOTICE mux#linkmgrd: DbInterface.cpp:238 handlePostSwitchCause: Ethernet68: post last switch cause Timed_Oscillation
May 29 17:31:18.579574 NOTICE mux#linkmgrd: DbInterface.cpp:238 handlePostSwitchCause: Ethernet68: post last switch cause Timed_Oscillation
May 29 17:41:25.715478 NOTICE mux#linkmgrd: DbInterface.cpp:238 handlePostSwitchCause: Ethernet68: post last switch cause Timed_Oscillation
May 29 17:48:31.169833 INFO python[1117713]: ansible-ansible.legacy.command Invoked with _raw_params=sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|TIMED_OSCILLATION" "oscillation_enabled" "false" _uses_shell=True warn=False stdin_add_newline=True strip_empty_ends=True argv=None chdir=None executable=None creates=None removes=None stdin=None
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
