### PR TITLE
Fix GCU Dynamic ACL ARP bug caused by stale ip config in PTFhost

### DIFF
--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -1087,8 +1087,6 @@ def test_gcu_acl_arp_rule_creation(rand_selected_dut,
         output = rand_selected_dut.show_and_parse("nbrshow -6")
         logger.info("Result of nbrshow -6 is: " + str(output))
 
-
-
     dynamic_acl_create_secondary_drop_rule(rand_selected_dut, setup, port_name)
 
     rand_selected_dut.shell("ping -c 3 {} {}".format(ipv6_ping_option, ip_address_for_test), module_ignore_errors=True)

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -1078,14 +1078,16 @@ def test_gcu_acl_arp_rule_creation(rand_selected_dut,
         show_cmd = "show arp"
         ipv6_ping_option = ""
         dynamic_acl_create_arp_forward_rule(rand_selected_dut, setup)
+        output = rand_selected_dut.show_and_parse("show arp")
+        logger.info("Result of show arp is: " + str(output))
     else:
         show_cmd = "nbrshow -6 -ip"
         ipv6_ping_option = "-6"
         dynamic_acl_create_ndp_forward_rule(rand_selected_dut, setup)
+        output = rand_selected_dut.show_and_parse("nbrshow -6")
+        logger.info("Result of nbrshow -6 is: " + str(output))
 
-    output = rand_selected_dut.show_and_parse(show_cmd)
 
-    logger.info("Result of " + show_cmd + " is: " + str(output))
 
     dynamic_acl_create_secondary_drop_rule(rand_selected_dut, setup, port_name)
 

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -1083,9 +1083,9 @@ def test_gcu_acl_arp_rule_creation(rand_selected_dut,
         ipv6_ping_option = "-6"
         dynamic_acl_create_ndp_forward_rule(rand_selected_dut, setup)
 
-    output = rand_selected_dut.shell(show_cmd)
+    output = rand_selected_dut.show_and_parse(show_cmd)
 
-    logger.info("Result of " + show_cmd + " is: " + output)
+    logger.info("Result of " + show_cmd + " is: " + str(output))
 
     dynamic_acl_create_secondary_drop_rule(rand_selected_dut, setup, port_name)
 

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -25,6 +25,7 @@ import ptf.testutils as testutils
 from ipaddress import ip_network, IPv6Network, IPv4Network
 from tests.arp.arp_utils import increment_ipv6_addr, increment_ipv4_addr
 
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses  # noqa F401
 from tests.generic_config_updater.gu_utils import expect_op_success, expect_op_failure
 from tests.generic_config_updater.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
 from tests.generic_config_updater.gu_utils import format_and_apply_template, load_and_apply_json_patch
@@ -1081,6 +1082,10 @@ def test_gcu_acl_arp_rule_creation(rand_selected_dut,
         show_cmd = "nbrshow -6 -ip"
         ipv6_ping_option = "-6"
         dynamic_acl_create_ndp_forward_rule(rand_selected_dut, setup)
+
+    output = rand_selected_dut.shell(show_cmd)
+
+    logger.info("Result of " + show_cmd + " is: " + output)
 
     dynamic_acl_create_secondary_drop_rule(rand_selected_dut, setup, port_name)
 


### PR DESCRIPTION
Summary:

Clear PTFhost before running GCU Dynamic ACL tests

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
Fixing an error that seems to only appear when tested as a part of nightly testing suite due to stale ptfconfig
#### How did you do it?
Added fixture to remove ip addresses from ptfhost at start of test
#### How did you verify/test it?
Manually ran on testbed and observed test pass

<img width="604" alt="image" src="https://github.com/sonic-net/sonic-mgmt/assets/156464693/f689d95b-bb14-4592-bc22-346d89334b73">
