### PR TITLE
Add test filter in run_tests.sh.

### DIFF
--- a/docs/tests/pytest.run.md
+++ b/docs/tests/pytest.run.md
@@ -16,10 +16,14 @@
     * executed t1 test cases.
 
 
-### Run a single test case ###
+### Run a single test file ###
 * ./run_tests.sh -d <dut_name> -n <testbed_name> [-s <list of test cases or files to skip>] -u -c platform_tests/test_link_flap.py
     * execute link flap test case.
     * when specifying test cast list, no need to specify topology with -t.
+
+### Run a single test case ###
+* ./run_tests.sh -d <dut_name> -n <testbed_name> [-s <list of test cases or files to skip>] -u -c qos/test_qos_sai.py -C "testParameter[single_asic]"
+    * execute testParameter[single_asic] in qos/test_qos_sai.py.
 
 ### Run scripts under a folder ###
 * ./run_tests.sh -d <dut_name> -n <testbed_name> -u -c "snmp/test_*.py" -s "snmp/test_snmp_cpu.py"

--- a/docs/tests/pytest.run.md
+++ b/docs/tests/pytest.run.md
@@ -16,14 +16,17 @@
     * executed t1 test cases.
 
 
-### Run a single test file ###
+### Run all tests in a single test file ###
 * ./run_tests.sh -d <dut_name> -n <testbed_name> [-s <list of test cases or files to skip>] -u -c platform_tests/test_link_flap.py
     * execute link flap test case.
     * when specifying test cast list, no need to specify topology with -t.
 
-### Run a single test case ###
-* ./run_tests.sh -d <dut_name> -n <testbed_name> [-s <list of test cases or files to skip>] -u -c qos/test_qos_sai.py -C "testParameter[single_asic]"
-    * execute testParameter[single_asic] in qos/test_qos_sai.py.
+### Run test cases in a single test file with filter ###
+* ./run_tests.sh -d <dut_name> -n <testbed_name> [-s <list of test cases or files to skip>] -u -c arp/test_arpall.py -C garp
+    * execute all tests that has garp in the name in arp/test_arpall.py
+* ./run_tests.sh -d <dut_name> -n <testbed_name> [-s <list of test cases or files to skip>] -u -c arp/test_arpall.py -C "garp or unicast"
+    * execute all tests that has garp or unicast in the name in arp/test_arpall.py
+* For more information on the filter, please refer to the [pytest documentation](https://docs.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name)
 
 ### Run scripts under a folder ###
 * ./run_tests.sh -d <dut_name> -n <testbed_name> -u -c "snmp/test_*.py" -s "snmp/test_snmp_cpu.py"

--- a/docs/tests/pytest.run.md
+++ b/docs/tests/pytest.run.md
@@ -26,6 +26,8 @@
     * execute all tests that has garp in the name in arp/test_arpall.py
 * ./run_tests.sh -d <dut_name> -n <testbed_name> [-s <list of test cases or files to skip>] -u -c arp/test_arpall.py -C "garp or unicast"
     * execute all tests that has garp or unicast in the name in arp/test_arpall.py
+* ./run_tests.sh -d <dut_name> -n <testbed_name> [-s <list of test cases or files to skip>] -u -c arp/test_arpall.py -C "not garp"
+    * execute all tests that don't have garp in the name in arp/test_arpall.py
 * For more information on the filter, please refer to the [pytest documentation](https://docs.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name)
 
 ### Run scripts under a folder ###

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -103,6 +103,7 @@ function setup_environment()
     SKIP_FOLDERS="ptftests acstests saitests scripts k8s sai_qualify"
     TESTBED_FILE="${BASE_PATH}/ansible/testbed.yaml"
     TEST_CASES=""
+    TEST_FILTER=""
     TEST_INPUT_ORDER="False"
     TEST_METHOD='group'
     TEST_MAX_FAIL=0
@@ -193,6 +194,10 @@ function setup_test_options()
         fi
     done
 
+    if [[ ! -z $TEST_FILTER ]]; then
+        PYTEST_COMMON_OPTS="${PYTEST_COMMON_OPTS} -k ${TEST_FILTER}"
+    fi
+
     if [[ -d ${LOG_PATH} ]]; then
         rm -rf ${LOG_PATH}
     fi
@@ -245,6 +250,7 @@ function run_debug_tests()
     echo "SKIP_SCRIPTS:          ${SKIP_SCRIPTS}"
     echo "SKIP_FOLDERS:          ${SKIP_FOLDERS}"
     echo "TEST_CASES:            ${TEST_CASES}"
+    echo "TEST_FILTER:           ${TEST_FILTER}"
     echo "TEST_INPUT_ORDER:      ${TEST_INPUT_ORDER}"
     echo "TEST_MAX_FAIL:         ${TEST_MAX_FAIL}"
     echo "TEST_METHOD:           ${TEST_METHOD}"
@@ -348,7 +354,7 @@ function run_individual_tests()
 setup_environment
 
 
-while getopts "h?a:b:c:d:e:Ef:i:I:k:l:m:n:oOp:q:rs:S:t:ux" opt; do
+while getopts "h?a:b:c:C:d:e:Ef:i:I:k:l:m:n:oOp:q:rs:S:t:ux" opt; do
     case ${opt} in
         h|\? )
             show_help_and_exit 0
@@ -362,6 +368,9 @@ while getopts "h?a:b:c:d:e:Ef:i:I:k:l:m:n:oOp:q:rs:S:t:ux" opt; do
             ;;
         c )
             TEST_CASES="${TEST_CASES} ${OPTARG}"
+            ;;
+        C )
+            TEST_FILTER="${TEST_FILTER} ${OPTARG}"
             ;;
         d )
             DUT_NAME=${OPTARG}


### PR DESCRIPTION
### Description of PR

Summary:

This change added a "-C" command option to support filtering the test cases by test case name.


### Type of change

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

When test failed, it is fairly frequently to only rerun one of the failed test cases for deep analysis. However, our current run_tests.sh only support filtering tests cases on file level, not test case level.

#### How did you do it?

This change adds a "-C" command operation to filter the test cases by name. It leverages the "-k" option in pytest to achieve the filtering.

To add the filter, here is an example:

```bash
./run_tests.sh -i ../ansible/<inv>,../ansible/veos -n <testbed> -u -m individual -a False -l debug -c qos/test_qos_sai.py -C "testParameter[single_asic]"
```

#### How did you verify/test it?

Have run the test locally, and correctly filtered out the test cases.

![image](https://github.com/sonic-net/sonic-mgmt/assets/1533278/99d5cb5b-1972-400a-8817-431c76d67b3a)

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

both run_tests.sh help and doc are updated.