### PR TITLE
Enable fdb and qos tests for t0-standalone-* topology

### DIFF
--- a/tests/common/helpers/portchannel_to_vlan.py
+++ b/tests/common/helpers/portchannel_to_vlan.py
@@ -383,7 +383,7 @@ def setup_acl_table(duthost, tbinfo, acl_rule_cleanup):
 def setup_po2vlan(duthosts, ptfhost, rand_one_dut_hostname, rand_selected_dut, ptfadapter,
                ports_list, tbinfo, vlan_intfs_dict, setup_acl_table, fanouthosts):  # noqa F811
 
-    if any(topo in tbinfo["topo"]["name"] for topo in ["dualtor", "t0-backend"]):
+    if any(topo in tbinfo["topo"]["name"] for topo in ["dualtor", "t0-backend", "t0-standalone"]):
         yield
         return
 

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -36,7 +36,8 @@ class QosBase:
     Common APIs
     """
     SUPPORTED_T0_TOPOS = ["t0", "t0-56-po2vlan", "t0-64", "t0-116", "t0-35", "dualtor-56", "dualtor-64", "dualtor-120",
-                          "dualtor", "t0-120", "t0-80", "t0-backend", "t0-56-o8v48", "t0-8-lag"]
+                          "dualtor", "t0-120", "t0-80", "t0-backend", "t0-56-o8v48", "t0-8-lag", "t0-standalone-32",
+                          "t0-standalone-64", "t0-standalone-128", "t0-standalone-256"]
     SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-56-lag", "t1-backend", "t1-28-lag"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
     SUPPORTED_ASIC_LIST = ["pac", "gr", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "td3", "th3",


### PR DESCRIPTION
### Description of PR

Summary:

This commit is to enable the fdb tests and qos tests for the t0-standalone topologies.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

The t0-standalone topologies should support the FDB and QoS test cases, however we have per topology filters on these tests, so these tests will be skipped or failed.

#### How did you do it?

This change updates the whitelists that we have to allow the tests to be run.

#### How did you verify/test it?

Run locally with the new settings, both fdb and qos tests are not filtered out anymore.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
