### PR TITLE
Use new agent-pool "sonic-ubuntu-1c" for PR checkers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ stages:
     displayName: "Static Analysis"
     timeoutInMinutes: 10
     continueOnError: false
-    pool: ubuntu-20.04
+    pool: sonic-ubuntu-1c
     steps:
     - template: .azure-pipelines/pre-commit-check.yml
 
@@ -39,7 +39,7 @@ stages:
     displayName: "Validate Test Cases"
     timeoutInMinutes: 20
     continueOnError: false
-    pool: ubuntu-20.04
+    pool: sonic-ubuntu-1c
     steps:
     - template: .azure-pipelines/pytest-collect-only.yml
 
@@ -64,7 +64,7 @@ stages:
     displayName: "kvmtest-t0 by Elastictest"
     timeoutInMinutes: 240
     continueOnError: false
-    pool: ubuntu-20.04
+    pool: sonic-ubuntu-1c
     steps:
     - template: .azure-pipelines/run-test-elastictest-template.yml
       parameters:
@@ -78,7 +78,7 @@ stages:
     displayName: "kvmtest-t0-2vlans by Elastictest"
     timeoutInMinutes: 240
     continueOnError: false
-    pool: ubuntu-20.04
+    pool: sonic-ubuntu-1c
     steps:
     - template: .azure-pipelines/run-test-elastictest-template.yml
       parameters:
@@ -94,7 +94,7 @@ stages:
     displayName: "kvmtest-t1-lag by Elastictest"
     timeoutInMinutes: 240
     continueOnError: false
-    pool: ubuntu-20.04
+    pool: sonic-ubuntu-1c
     steps:
     - template: .azure-pipelines/run-test-elastictest-template.yml
       parameters:
@@ -108,7 +108,7 @@ stages:
     displayName: "kvmtest-dualtor-t0 by Elastictest"
     timeoutInMinutes: 240
     continueOnError: false
-    pool: ubuntu-20.04
+    pool: sonic-ubuntu-1c
     steps:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
@@ -123,7 +123,7 @@ stages:
     displayName: "kvmtest-multi-asic-t1-lag by Elastictest"
     timeoutInMinutes: 240
     continueOnError: false
-    pool: ubuntu-20.04
+    pool: sonic-ubuntu-1c
     steps:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
@@ -139,7 +139,7 @@ stages:
     displayName: "kvmtest-t0-sonic by Elastictest"
     timeoutInMinutes: 240
     continueOnError: false
-    pool: ubuntu-20.04
+    pool: sonic-ubuntu-1c
     steps:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
@@ -156,7 +156,7 @@ stages:
     displayName: "kvmtest-dpu by Elastictest"
     timeoutInMinutes: 240
     continueOnError: false
-    pool: ubuntu-20.04
+    pool: sonic-ubuntu-1c
     steps:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
@@ -170,7 +170,7 @@ stages:
     displayName: "onboarding testcases by Elastictest"
     timeoutInMinutes: 240
     continueOnError: true
-    pool: ubuntu-20.04
+    pool: sonic-ubuntu-1c
     steps:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
@@ -186,7 +186,7 @@ stages:
 #    displayName: "kvmtest-wan by Elastictest"
 #    timeoutInMinutes: 240
 #    continueOnError: false
-#    pool: ubuntu-20.04
+#    pool: sonic-ubuntu-1c
 #    steps:
 #      - template: .azure-pipelines/run-test-elastictest-template.yml
 #        parameters:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Use new agent-pool "sonic-ubuntu-1c" to avoid quota limitation/security risks.

#### How did you do it?
Update the PR checkers pipeline yaml to use new agent pool `sonic-ubuntu-1c`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
