### PR TITLE
fix: update syslog timestamp parsing logic

### DIFF
--- a/ansible/roles/test/tasks/pfc_wd/functional_test/timer_test.yml
+++ b/ansible/roles/test/tasks/pfc_wd/functional_test/timer_test.yml
@@ -23,8 +23,14 @@
   become: true
 
 - name: Convert start marker time to milliseconds
-  shell: "date -d {{storm_start.stdout.replace('  ',' ').split(' ')[2]}} +'%s%3N'"
-  register: storm_start_millis
+  block:
+    - name: Parse syslog msg timestamp
+      shell: "date -d {{storm_start.stdout.replace('  ',' ').split(' ')[3]}} +'%s%3N'"
+      register: storm_start_millis
+  rescue:
+    - name: Parse different field when error
+      shell: "date -d {{storm_start.stdout.replace('  ',' ').split(' ')[2]}} +'%s%3N'"
+      register: storm_start_millis
 
 - name: Find PFC storm detect message
   shell: grep "[d]etected PFC storm" /var/log/syslog
@@ -32,8 +38,14 @@
   become: true
 
 - name: Convert detect message time to milliseconds
-  shell: "date -d {{storm_detect.stdout.replace('  ',' ').split(' ')[2]}} +'%s%3N'"
-  register: storm_detect_millis
+  block:
+    - name: Parse syslog msg timestamp
+      shell: "date -d {{storm_detect.stdout.replace('  ',' ').split(' ')[3]}} +'%s%3N'"
+      register: storm_detect_millis
+  rescue:
+    - name: Parse different field when error
+      shell: "date -d {{storm_detect.stdout.replace('  ',' ').split(' ')[2]}} +'%s%3N'"
+      register: storm_detect_millis
 
 - name: Wait for PFC storm end marker to appear in logs
   pause:
@@ -45,8 +57,14 @@
   become: true
 
 - name: Convert end marker time to milliseconds
-  shell: "date -d {{storm_end.stdout.replace('  ',' ').split(' ')[2]}} +'%s%3N'"
-  register: storm_end_millis
+  block:
+    - name: Parse syslog msg timestamp
+      shell: "date -d {{storm_end.stdout.replace('  ',' ').split(' ')[3]}} +'%s%3N'"
+      register: storm_end_millis
+  rescue:
+    - name: Parse different field when error
+      shell: "date -d {{storm_end.stdout.replace('  ',' ').split(' ')[2]}} +'%s%3N'"
+      register: storm_end_millis
 
 - name: Find PFC storm restore message
   shell: grep "[s]torm restored" /var/log/syslog
@@ -54,8 +72,14 @@
   become: true
 
 - name: Convert restore message time to milliseconds
-  shell: "date -d {{storm_restore.stdout.replace('  ',' ').split(' ')[2]}} +'%s%3N'"
-  register: storm_restore_millis
+  block:
+    - name: Parse syslog msg timestamp
+      shell: "date -d {{storm_restore.stdout.replace('  ',' ').split(' ')[3]}} +'%s%3N'"
+      register: storm_restore_millis
+  rescue:
+    - name: Parse different field when error
+      shell: "date -d {{storm_restore.stdout.replace('  ',' ').split(' ')[2]}} +'%s%3N'"
+      register: storm_restore_millis
 
 - set_fact:
     real_detect_time: "{{(storm_detect_millis.stdout | int) - (storm_start_millis.stdout | int)}}"

--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -9,6 +9,7 @@ from scapy.all import sniff, IP
 from scapy.contrib import bgp
 
 from tests.bgp.bgp_helpers import capture_bgp_packages_to_file, fetch_and_delete_pcap_file
+from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.bgp import BGPNeighbor
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.utilities import wait_until, delete_running_config
@@ -160,9 +161,18 @@ def get_bgp_down_timestamp(duthost, peer_ip, timestamp_before_teardown):
     cmd = (
         "grep \"[b]gp#bgpcfgd: Peer 'default|{}' admin state is set to 'down'\" /var/log/syslog | tail -1"
     ).format(peer_ip)
+
     bgp_down_msg_list = duthost.shell(cmd)['stdout'].split()
-    timestamp = " ".join(bgp_down_msg_list[0:3])
-    timestamp_in_sec = float(duthost.shell("date -d \"{}\" +%s.%6N".format(timestamp))['stdout'])
+    try:
+        timestamp = " ".join(bgp_down_msg_list[1:4])
+        timestamp_in_sec = float(duthost.shell("date -d \"{}\" +%s.%6N".format(timestamp))['stdout'])
+    except RunAnsibleModuleFail:
+        timestamp = " ".join(bgp_down_msg_list[0:3])
+        timestamp_in_sec = float(duthost.shell("date -d \"{}\" +%s.%6N".format(timestamp))['stdout'])
+    except Exception as e:
+        logging.error("Error when parsing syslog message timestamp: {}".format(repr(e)))
+        pytest.fail("Failed to parse syslog message timestamp")
+
     if timestamp_in_sec < timestamp_before_teardown:
         pytest.fail("Could not find the BGP session down time")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In the recent PR https://github.com/sonic-net/sonic-buildimage/pull/18099 in `sonic-buildimage`, we changed the timestamp format of the syslog message (`ActionFileDefaultTemplate`) for latest and some previous SONiC image versions. More specifically, we added the "year" field at the front of each syslog message:

**Before**
```bash
admin@str3-dut:~$ sudo tail -f /var/log/syslog
May 29 02:47:40.345257 str3-dut INFO acms#start.py: start: check_bootstrap_status: Checking bootstrap status
May 29 02:47:40.345257 str3-dut INFO acms#start.py: start: check_bootstrap_status: /var/opt/msft/client/dsms.conf file not found!
May 29 02:47:40.346080 str3-dut INFO acms#start.py: start: main: acms_secrets.ini copied to /var/opt/msft/client
May 29 02:47:40.346236 str3-dut INFO acms#start.py: start: main: Waiting for bootstrap cert
```

**After**
```bash
admin@str3-dut:~$ sudo tail -f /var/log/syslog
2024 May 29 02:47:40.345257 str3-dut INFO acms#start.py: start: check_bootstrap_status: Checking bootstrap status
2024 May 29 02:47:40.345257 str3-dut INFO acms#start.py: start: check_bootstrap_status: /var/opt/msft/client/dsms.conf file not found!
2024 May 29 02:47:40.346080 str3-dut INFO acms#start.py: start: main: acms_secrets.ini copied to /var/opt/msft/client
2024 May 29 02:47:40.346236 str3-dut INFO acms#start.py: start: main: Waiting for bootstrap cert
```

There are several places in `sonic-mgmt` which are expecting the previous syslog timestamp format, so we need this PR to fix them.

Summary:
Fixes # (issue) Microsoft ADO 26399333

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [x] 202012
- [x] 202205
- [x] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
To fix the error raised by the new syslog timestamp format

#### How did you do it?
Try to parse the syslog timestamp based on the new timestamp format first. Fall back to old parsing logic if having `RunAnsibleModuleFail` exception, because not all testbeds are having the latest image version/syslog timestamp format at the moment.

#### How did you verify/test it?
I verified the PR on testbeds with both old and new syslog timestamp format, and they all passed. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

