### PR TITLE
[TACACS] Improve IPv6 TACACS cases to workaround tacacs_plus server crash issue

### DIFF
--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -8,7 +8,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.tacacs.utils import check_output
 from tests.bgp.test_bgp_fact import run_bgp_facts
 from tests.test_features import run_show_features
-from tests.tacacs.test_ro_user import ssh_remote_run
+from tests.tacacs.test_ro_user import ssh_remote_run_retry
 from tests.ntp.test_ntp import run_ntp, setup_ntp_func # noqa F401
 from tests.common.helpers.assertions import pytest_require
 from tests.tacacs.conftest import tacacs_creds, check_tacacs_v6_func # noqa F401
@@ -128,29 +128,29 @@ def test_snmp_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname, localhost, c
 
 # use function scope fixture so that convert_and_restore_config_db_to_ipv6_only will setup before check_tacacs_v6_func.
 # Otherwise, tacacs_v6 config may be lost after config reload in ipv6_only fixture.
-def test_ro_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname,
+def test_ro_user_ipv6_only(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
                            tacacs_creds, convert_and_restore_config_db_to_ipv6_only, check_tacacs_v6_func): # noqa F811
     # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
     log_eth0_interface_info(duthosts)
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutipv6 = get_mgmt_ipv6(duthost)
 
-    res = ssh_remote_run(localhost, dutipv6, tacacs_creds['tacacs_ro_user'],
-                         tacacs_creds['tacacs_ro_user_passwd'], 'cat /etc/passwd')
+    res = ssh_remote_run_retry(localhost, dutipv6, ptfhost, tacacs_creds['tacacs_ro_user'],
+                               tacacs_creds['tacacs_ro_user_passwd'], 'cat /etc/passwd')
     check_output(res, 'test', 'remote_user')
 
 
 # use function scope fixture so that convert_and_restore_config_db_to_ipv6_only will setup before check_tacacs_v6_func.
 # Otherwise, tacacs_v6 config may be lost after config reload in ipv6_only fixture.
-def test_rw_user_ipv6_only(localhost, duthosts, enum_rand_one_per_hwsku_hostname,
+def test_rw_user_ipv6_only(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
                            tacacs_creds, convert_and_restore_config_db_to_ipv6_only, check_tacacs_v6_func): # noqa F811
     # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
     log_eth0_interface_info(duthosts)
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutipv6 = get_mgmt_ipv6(duthost)
 
-    res = ssh_remote_run(localhost, dutipv6, tacacs_creds['tacacs_rw_user'],
-                         tacacs_creds['tacacs_rw_user_passwd'], "cat /etc/passwd")
+    res = ssh_remote_run_retry(localhost, dutipv6, ptfhost, tacacs_creds['tacacs_rw_user'],
+                               tacacs_creds['tacacs_rw_user_passwd'], "cat /etc/passwd")
     check_output(res, 'testadmin', 'remote_user_su')
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes TACACS failures in test_mgmt_ipv6_only module.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
It's observed that tacacs_plus process may crash when receiving ipv6 tacacs requests. Need a way to workaround it.

#### How did you do it?
Similar issue in tacacs/test_ro_user has been fixed in https://github.com/sonic-net/sonic-mgmt/pull/12819
Using the similar method to restart tacacs_plus process if it fails.

#### How did you verify/test it?
Verified in both virtual testbed and physical testbed. Not seeing tacacs failures anymore.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
