### PR TITLE
[sdn_tests]:Adding single switch Ethernet Counter test to pins_ondatra.

### DIFF
--- a/sdn_tests/pins_ondatra/tests/ethcounter_sw_single_switch_test.go
+++ b/sdn_tests/pins_ondatra/tests/ethcounter_sw_single_switch_test.go
@@ -1,0 +1,369 @@
+// This file contains all the front panel port counter tests that can be
+// done with a single switch, both egress (out) and ingress (in) if they
+// can be done in loopback mode.  Tests requiring two switches or Ixia
+// to accomplish are elsewhere.
+
+package ethernet_counter_test
+
+import (
+        "net"
+        "testing"
+        "time"
+
+        "github.com/google/gopacket"
+        "github.com/google/gopacket/layers"
+        "github.com/openconfig/ondatra"
+        "github.com/openconfig/ondatra/gnmi"
+        "github.com/openconfig/ondatra/gnmi/oc"
+        "github.com/sonic-net/sonic-mgmt/sdn_tests/pins_ondatra/infrastructure/binding/pinsbind"
+        "github.com/sonic-net/sonic-mgmt/sdn_tests/pins_ondatra/infrastructure/testhelper/testhelper"
+)
+// These are the counters we track in these tests.
+type Counters struct {
+        inPkts           uint64
+        outPkts          uint64
+        inOctets         uint64
+        outOctets        uint64
+        inUnicastPkts    uint64
+        outUnicastPkts   uint64
+        inMulticastPkts  uint64
+        outMulticastPkts uint64
+        inBroadcastPkts  uint64
+        outBroadcastPkts uint64
+        inErrors         uint64
+        outErrors        uint64
+        inDiscards       uint64
+        outDiscards      uint64
+        inMTUExceeded    uint64
+        inIPv6Discards   uint64
+        outIPv6Discards  uint64
+}
+
+var (
+        initialMTU uint16 = 9100
+        pktsPer uint64 = 7
+        dmiWriteDelay time.Duration = 250 * time.Millisecond
+        counterUpdateDelay time.Duration = 5000 * time.Millisecond
+)
+
+const (
+        loopbackStateTimeout = 15 * time.Second
+)
+
+// Helper functions are here.
+// CheckInitial validates preconditions before test starts.
+func CheckInitial(t *testing.T, dut *ondatra.DUTDevice, intf string) {
+        t.Helper()
+
+        intfPath := gnmi.OC().Interface(intf)
+        operStatus := gnmi.Get(t, dut, intfPath.OperStatus().State())
+
+        if operStatus != oc.Interface_OperStatus_UP {
+                t.Fatalf("%v OperStatus is unexpected: %v", intf, operStatus)
+        }
+
+        loopbackMode := gnmi.Get(t, dut, intfPath.LoopbackMode().State())
+        if loopbackMode != oc.Interfaces_LoopbackModeType_NONE {
+                gnmi.Replace(t, dut, gnmi.OC().Interface(intf).LoopbackMode().Config(), oc.Interfaces_LoopbackModeType_NONE)
+                gnmi.Await(t, dut, intfPath.LoopbackMode().State(), loopbackStateTimeout, oc.Interfaces_LoopbackModeType_NONE)
+        }
+
+        // Read the initial MTU to restore at test end.
+        initialMTU = gnmi.Get(t, dut, intfPath.Mtu().State())
+}
+
+// RestoreInitial restores the initial conditions at the end of the test.
+//
+// This routine is called, deferred, at the start of the test to restore
+// any conditions tests in this file might modify.
+func RestoreInitial(t *testing.T, dut *ondatra.DUTDevice, intf string) {
+        t.Helper()
+        intfPath := gnmi.OC().Interface(intf)
+
+        // Set loopback mode to false in case we changed it.
+        loopbackMode := gnmi.Get(t, dut, intfPath.LoopbackMode().State())
+        if loopbackMode != oc.Interfaces_LoopbackModeType_NONE {
+                gnmi.Replace(t, dut, gnmi.OC().Interface(intf).LoopbackMode().Config(), oc.Interfaces_LoopbackModeType_NONE)
+                gnmi.Await(t, dut, intfPath.LoopbackMode().State(), loopbackStateTimeout, oc.Interfaces_LoopbackModeType_NONE)
+        }
+
+        // Restore the initial value of the MTU on the port.
+        gnmi.Replace(t, dut, gnmi.OC().Interface(intf).Mtu().Config(), initialMTU)
+        got := gnmi.Get(t, dut, intfPath.Mtu().State())
+        if got != initialMTU {
+                t.Fatalf("MTU restore failed! got:%v, want:%v", got, initialMTU)
+        }
+}
+
+// ReadCounters reads all the counters via GNMI and returns a Counters struct.
+func ReadCounters(t *testing.T, dut *ondatra.DUTDevice, intf string) Counters {
+        t.Helper()
+
+        c := Counters{}
+        cntStruct := gnmi.Get(t, dut, gnmi.OC().Interface(intf).Counters().State())
+        subPath := gnmi.OC().Interface(intf).Subinterface(0)
+        ip6Struct := gnmi.Get(t, dut, subPath.Ipv6().Counters().State())
+        c.inPkts = cntStruct.GetInPkts()
+        c.outPkts = cntStruct.GetOutPkts()
+        c.inOctets = cntStruct.GetInOctets()
+        c.outOctets = cntStruct.GetOutOctets()
+        c.inUnicastPkts = cntStruct.GetInUnicastPkts()
+        c.outUnicastPkts = cntStruct.GetOutUnicastPkts()
+        c.inMulticastPkts = cntStruct.GetInMulticastPkts()
+        c.outMulticastPkts = cntStruct.GetOutMulticastPkts()
+        c.inBroadcastPkts = cntStruct.GetInBroadcastPkts()
+        c.outBroadcastPkts = cntStruct.GetOutBroadcastPkts()
+        c.inErrors = cntStruct.GetInErrors()
+        c.outErrors = cntStruct.GetOutErrors()
+        c.inDiscards = cntStruct.GetInDiscards()
+        c.outDiscards = cntStruct.GetOutDiscards()
+        c.inIPv6Discards = ip6Struct.GetInDiscardedPkts()
+        c.outIPv6Discards = ip6Struct.GetOutDiscardedPkts()
+        c.inMTUExceeded = gnmi.Get(t, dut, gnmi.OC().Interface(intf).Ethernet().Counters().InMaxsizeExceeded().State())
+
+        return c
+}
+
+// ShowCountersDelta shows debug info after an unexpected change in counters.
+func ShowCountersDelta(t *testing.T, before Counters, after Counters, expect Counters) {
+        t.Helper()
+
+        for _, s := range []struct {
+                desc                  string
+                before, after, expect uint64
+        }{
+                {"in-pkts", before.inPkts, after.inPkts, expect.inPkts},
+                {"out-pkts", before.outPkts, after.outPkts, expect.outPkts},
+                {"in-octets", before.inOctets, after.inOctets, expect.inOctets},
+                {"out-octets", before.outOctets, after.outOctets, expect.outOctets},
+                {"in-unicast-pkts", before.inUnicastPkts, after.inUnicastPkts, expect.inUnicastPkts},
+                {"out-unicast-pkts", before.outUnicastPkts, after.outUnicastPkts, expect.outUnicastPkts},
+                {"in-multicast-pkts", before.inMulticastPkts, after.inMulticastPkts, expect.inMulticastPkts},
+                {"out-multicast-pkts", before.outMulticastPkts, after.outMulticastPkts, expect.outMulticastPkts},
+                {"in-broadcast-pkts", before.inBroadcastPkts, after.inBroadcastPkts, expect.inBroadcastPkts},
+                {"out-broadcast-pkts", before.outBroadcastPkts, after.outBroadcastPkts, expect.outBroadcastPkts},
+                {"in-errors", before.inErrors, after.inErrors, expect.inErrors},
+                {"out-errors", before.outErrors, after.outErrors, expect.outErrors},
+                {"in-discards", before.inDiscards, after.inDiscards, expect.inDiscards},
+                {"out-discards", before.outDiscards, after.outDiscards, expect.outDiscards},
+                {"in-mtu-exceeded", before.inMTUExceeded, after.inMTUExceeded, expect.inMTUExceeded},
+                {"in-ipv6-discards", before.inIPv6Discards, after.inIPv6Discards, expect.inIPv6Discards},
+                {"out-ipv6-discards", before.outIPv6Discards, after.outIPv6Discards, expect.outIPv6Discards},
+        } {
+                if s.before != s.after || s.expect != s.before {
+                        t.Logf("%v %d -> %d expected %d (%+d)", s.desc, s.before, s.after, s.expect, s.after-s.before)
+                }
+        }
+}
+
+// ----------------------------------------------------------------------------
+// Tests start here.
+func TestMain(m *testing.M) {
+        ondatra.RunTests(m, pinsbind.New)
+}
+
+// ----------------------------------------------------------------------------
+// TestGNMIEthernetInterfaceRole - Check EthernetX interface role.
+// - management should be false
+// - CPU should be false
+func TestGNMIEthernetInterfaceRole(t *testing.T) {
+        // Report results to TestTracker at the end.
+        defer testhelper.NewTearDownOptions(t).WithID("e0619932-46c8-4e49-9e2b-d79a67d03dea").Teardown(t)
+
+        // Select the dut, or device under test.
+        dut := ondatra.DUT(t, "DUT")
+
+        // Select a random front panel interface EthernetX.
+        intf, err := testhelper.RandomInterface(t, dut, nil)
+        if err != nil {
+                t.Fatalf("Failed to fetch random interface: %v", err)
+        }
+        intfPath := gnmi.OC().Interface(intf)
+
+        // Read management via /state.  Note that the config path for
+        // this doesn't exist since it's read-only.
+        if stateMgmt := gnmi.Get(t, dut, intfPath.Management().State()); stateMgmt {
+                t.Errorf("%v state Management is %v, wanted false", intf, stateMgmt)
+        }
+
+        // Read cpu via /state.
+        if stateCPU := gnmi.Get(t, dut, intfPath.Cpu().State()); stateCPU {
+                t.Errorf("%v state CPU is %v, wanted false", intf, stateCPU)
+        }
+}
+
+// ----------------------------------------------------------------------------
+// TestGNMIEthParentPaths - Check EthernetX counters and interface paths.
+func TestGNMIEthParentPaths(t *testing.T) {
+        // Reports results to TestTracker at the end.
+        defer testhelper.NewTearDownOptions(t).WithID("1aaa6fc9-da57-4751-89b1-56751ac209c6").Teardown(t)
+
+        // Select the dut, or device under test.
+        dut := ondatra.DUT(t, "DUT")
+
+        // Pick a random interface, EthernetX
+        intf, err := testhelper.RandomInterface(t, dut, nil)
+        if err != nil {
+                t.Fatalf("Failed to fetch random interface: %v", err)
+        }
+        intfPath := gnmi.OC().Interface(intf)
+
+        // Read all counters via /state.  The config path for
+        // this doesn't exist since it's read-only.  The type
+        // for the return value is "type Interface_Counters struct"
+        stateCounters := gnmi.Get(t, dut, intfPath.Counters().State())
+
+        // For most counters, simply require them not to be nil.
+        if stateCounters.CarrierTransitions == nil {
+                t.Errorf("%v CarrierTransitions wasn't nil", intf)
+        }
+
+        if stateCounters.InBroadcastPkts == nil {
+                t.Errorf("%v BroadcastPkts is nil", intf)
+        }
+
+        if stateCounters.InDiscards == nil {
+                t.Errorf("%v InDicards is nil", intf)
+        }
+
+        if stateCounters.InErrors == nil {
+                t.Errorf("%v InErrors is nil", intf)
+        }
+
+        if stateCounters.InFcsErrors == nil {
+                t.Errorf("%v InFcsErrors is nil", intf)
+        }
+
+        if stateCounters.InMulticastPkts == nil {
+                t.Errorf("%v InMulticastPkts is nil", intf)
+        }
+
+        if stateCounters.InOctets == nil {
+                t.Errorf("%v InOctets is nil", intf)
+        }
+
+        if stateCounters.InPkts == nil {
+                t.Errorf("%v InPkts is nil", intf)
+        }
+
+        if stateCounters.InUnicastPkts == nil {
+                t.Errorf("%v InUnicastPkts is nil", intf)
+        }
+
+        if stateCounters.InUnknownProtos == nil {
+                t.Errorf("%v InUnknownProtos is nil", intf)
+        }
+
+        if stateCounters.LastClear == nil {
+                t.Errorf("%v LastClear is nil", intf)
+        }
+
+        if stateCounters.OutBroadcastPkts == nil {
+                t.Errorf("%v OutBroadcastPkts is nil", intf)
+        }
+
+        if stateCounters.OutDiscards == nil {
+                t.Errorf("%v OutDiscards is nil", intf)
+        }
+
+        if stateCounters.OutErrors == nil {
+                t.Errorf("%v OutErrors is nil", intf)
+        }
+
+        if stateCounters.OutMulticastPkts == nil {
+                t.Errorf("%v OutMulticastPkts is nil", intf)
+        }
+
+        if stateCounters.OutOctets == nil {
+                t.Errorf("%v OutOctets is nil", intf)
+        }
+
+        if stateCounters.OutPkts == nil {
+                t.Errorf("%v OutPkts is nil", intf)
+        }
+
+        if stateCounters.OutUnicastPkts == nil {
+                t.Errorf("%v OutUnicastPkts is nil", intf)
+        }
+
+        // Read parent via /state.  Note that the config path for
+        // this doesn't exist since it is read-only.  The type
+        // for the return value is
+        // "type OpenconfigInterfaces_Interfaces_Interface_State struct"
+        stateIntf := gnmi.Get(t, dut, intfPath.State())
+
+        // Verify the information received.
+        t.Logf("%v AdminStatus is %v", intf, stateIntf.AdminStatus)
+
+        // Validate AdminStatus is UP.
+        if stateIntf.AdminStatus != oc.Interface_AdminStatus_UP {
+                t.Errorf("%v AdminStatus is unexpected: %v", intf, stateIntf.AdminStatus)
+        }
+
+        // Validate Counters is not nil.
+        if stateIntf.Counters == nil {
+                t.Errorf("%v Counters is nil", intf)
+        }
+
+        // Description may not be valid, allow. Typically ''.
+        if stateIntf.Description != nil {
+                t.Logf("%v Description is '%v'", intf, stateIntf.GetDescription())
+        }
+
+        // Validate Enabled.
+        if stateIntf.Enabled == nil {
+                t.Error("Ethernet0 Enabled is nil")
+        } else {
+                if !stateIntf.GetEnabled() {
+                        t.Errorf("%v is not enabled", intf)
+                }
+        }
+
+        // Ifindex may not be valid, allow.
+        if stateIntf.Ifindex != nil {
+                t.Logf("%v Ifindex is %v", intf, stateIntf.GetIfindex())
+        }
+
+        // LastChange may not be valid, allow.
+        if stateIntf.LastChange != nil {
+                t.Logf("%v LastChange is %v", intf, stateIntf.GetLastChange())
+        }
+
+        // Validate the LoopbackMode.
+        if stateIntf.LoopbackMode == oc.Interfaces_LoopbackModeType_UNSET {
+                t.Errorf("%v LoopbackMode is unset", intf)
+        } else {
+                if stateIntf.GetLoopbackMode() != oc.Interfaces_LoopbackModeType_NONE {
+                        t.Errorf("LoopbackMode is not valid: got: %v, want: %v", stateIntf.GetLoopbackMode(), oc.Interfaces_LoopbackModeType_NONE)
+                }
+        }
+
+        // Validate the MTU.
+        if stateIntf.Mtu == nil {
+                t.Errorf("%v Mtu is nil", intf)
+        } else {
+                if stateIntf.GetMtu() < 1500 || stateIntf.GetMtu() > 9216 {
+                        t.Errorf("%v Mtu is unexpected: %v (expected [1514-9216]", intf, stateIntf.GetMtu())
+                }
+        }
+
+        // Validate the Name.
+        if stateIntf.Name == nil {
+                t.Errorf("%v Name is nil", intf)
+        } else {
+                if stateIntf.GetName() != intf {
+                        t.Errorf("%v Name is %v", intf, stateIntf.GetName())
+                }
+        }
+
+        // Validate OperStatus.  Looks like links are often down in
+        // current testbed so allow, at least for this test.
+        if stateIntf.OperStatus != oc.Interface_OperStatus_UP {
+                t.Logf("%v OperStatus is %v", intf, stateIntf.OperStatus)
+        }
+
+        // Validate the Type.
+        if stateIntf.Type != oc.IETFInterfaces_InterfaceType_ethernetCsmacd {
+                t.Errorf("%v Type is unexpected: %v", intf, stateIntf.Type)
+        }
+}

--- a/sdn_tests/pins_ondatra/tests/gnmi_subscribe_modes_test.go
+++ b/sdn_tests/pins_ondatra/tests/gnmi_subscribe_modes_test.go
@@ -1,0 +1,182 @@
+package gnmi_subscribe_modes_test
+
+import (
+        "context"
+        "errors"
+        "fmt"
+        "strings"
+        "testing"
+        "time"
+
+        "github.com/google/go-cmp/cmp"
+        "github.com/google/go-cmp/cmp/cmpopts"
+        gpb "github.com/openconfig/gnmi/proto/gnmi"
+        "github.com/openconfig/ondatra"
+        "github.com/openconfig/ondatra/gnmi"
+        "github.com/openconfig/ygot/ygot"
+        "github.com/sonic-net/sonic-mgmt/sdn_tests/pins_ondatra/infrastructure/binding/pinsbind"
+        "github.com/sonic-net/sonic-mgmt/sdn_tests/pins_ondatra/infrastructure/testhelper/testhelper"
+        "google.golang.org/grpc"
+        "google.golang.org/protobuf/encoding/prototext"
+)
+
+const (
+        deleteTreePath = "/system/config/"
+        deletePath     = "/system/config/hostname"
+        timePath       = "/system/state/current-datetime"
+        nodePath       = "/system/state/hostname"
+        subTreePath    = "/system/state"
+        containerPath  = "/components"
+        rootPath       = "/"
+        onChangePath   = "/interfaces/interface[name=%s]/state/mtu"
+        errorResponse  = "expectedError"
+        syncResponse   = "expectedSync"
+
+        shortTime  = 5 * time.Second
+        mediumTime = 10 * time.Second
+        longTime   = 30 * time.Second
+)
+
+func TestMain(m *testing.M) {
+        ondatra.RunTests(m, pinsbind.New)
+}
+
+type subscribeTest struct {
+        uuid              string
+        reqPath           string
+        mode              gpb.SubscriptionList_Mode
+        updatesOnly       bool
+        subMode           gpb.SubscriptionMode
+        sampleInterval    uint64 // nanoseconds
+        suppressRedundant bool
+        heartbeatInterval uint64 // nanoseconds
+        expectError       bool
+        timeout           time.Duration
+}
+
+type operStatus struct {
+        match  bool
+        delete bool
+        value  string
+}
+
+func ignorePaths(path string) bool {
+        // Paths that change during root and container level tests
+        subPaths := []string{
+                // TODO Check back if lb/bond are needed after this bug is corrected.
+                "/ethernet/state/counters/",
+                "//interfaces/interface[name=Loopback0]",
+                "//interfaces/interface[name=bond0]",
+                "//qos/interfaces/interface",
+                "//snmp/engine/version/",
+                "//system/mount-points/mount-point",
+                "//system/processes/process",
+                "//system/cpus/cpu",
+                "//system/crm/threshold",
+                "//system/ntp/",
+                "//system/memory/",
+                "//system/ssh-server/ssh-server-vrfs",
+                "/subinterface[index=0]/ipv4/unnumbered/",
+                "/subinterface[index=0]/ipv4/sag-ipv4/",
+                "/subinterface[index=0]/ipv6/sag-ipv6/",
+                "/gnmi-pathz-policy-counters/paths/path",
+                "/system/state/boot-time",
+                "/system/state/uptime",
+        }
+
+        for _, sub := range subPaths {
+                if strings.Contains(path, sub) {
+                        return true
+                }
+        }
+        return false
+}
+
+var skipTest = map[string]bool{
+        // TODO Ondatra fails to delete subtree
+        "TestGNMISubscribeModes/subscribeDeleteNodeLevel":    true,
+        "TestGNMISubscribeModes/subscribeDeleteSubtreeLevel": true,
+}
+
+// Test for gNMI Subscribe Stream mode for OnChange subscriptions.
+func (c subscribeTest) subModeOnChangeTest(t *testing.T) {
+        defer testhelper.NewTearDownOptions(t).WithID(c.uuid).Teardown(t)
+        if skipTest[t.Name()] {
+                t.Skip()
+        }
+        dut := ondatra.DUT(t, "DUT")
+
+        var intf string
+        if c.expectError == false {
+                var err error
+                intf, err = testhelper.RandomInterface(t, dut, nil)
+                if err != nil {
+                        t.Fatalf("Failed to fetch random interface: %v", err)
+                }
+                c.reqPath = fmt.Sprintf(c.reqPath, intf)
+        }
+        subscribeRequest := buildRequest(t, c, dut.Name())
+        t.Logf("SubscribeRequest:\n%v", prototext.Format(subscribeRequest))
+
+        ctx, cancel := context.WithCancel(context.Background())
+        defer cancel()
+        gnmiClient, err := dut.RawAPIs().BindingDUT().DialGNMI(ctx, grpc.WithBlock())
+        if err != nil {
+                t.Fatalf("Unable to get gNMI client (%v)", err)
+        }
+        subscribeClient, err := gnmiClient.Subscribe(ctx)
+        if err != nil {
+                t.Fatalf("Unable to get subscribe client (%v)", err)
+        }
+
+        if err := subscribeClient.Send(subscribeRequest); err != nil {
+                t.Fatalf("Failed to send gNMI subscribe request (%v)", err)
+        }
+
+        expectedPaths := make(map[string]operStatus)
+        if !c.updatesOnly {
+                expectedPaths = c.buildExpectedPaths(t, dut)
+        }
+        expectedPaths[syncResponse] = operStatus{}
+
+        foundPaths, _ := collectResponse(t, subscribeClient, expectedPaths)
+        if c.expectError {
+                foundErr, ok := foundPaths[errorResponse]
+                if !ok {
+                        t.Fatal("Expected error but got none")
+                }
+                if !strings.Contains(foundErr.value, "InvalidArgument") {
+                        t.Errorf("Error is not an InvalidArgument: %s", foundErr.value)
+                }
+                return
+        }
+        if diff := cmp.Diff(expectedPaths, foundPaths, cmpopts.IgnoreUnexported(operStatus{})); diff != "" {
+                t.Errorf("collectResponse(expectedPaths):\n%v \nResponse mismatch (-missing +extra):\n%s", expectedPaths, diff)
+        }
+        delete(expectedPaths, syncResponse)
+
+        got := gnmi.Get(t, dut, gnmi.OC().Interface(intf).Mtu().State())
+        defer gnmi.Update(t, dut, gnmi.OC().Interface(intf).Mtu().Config(), got)
+        mtu := uint16(1500)
+        if got == 1500 {
+                mtu = 9000
+        }
+        if c.heartbeatInterval == 0 {
+                gnmi.Update(t, dut, gnmi.OC().Interface(intf).Mtu().Config(), mtu)
+        }
+
+        foundPaths, delay := collectResponse(t, subscribeClient, expectedPaths)
+        if diff := cmp.Diff(expectedPaths, foundPaths, cmpopts.IgnoreUnexported(operStatus{})); diff != "" {
+                t.Errorf("collectResponse(expectedPaths):\n%v \nResponse mismatch (-missing +extra):\n%s", expectedPaths, diff)
+        }
+        if c.heartbeatInterval != 0 {
+                if delay > time.Duration(c.heartbeatInterval+(c.heartbeatInterval/2)) {
+                        t.Errorf("Failed sampleInterval with time of %v", delay)
+                }
+                gnmi.Update(t, dut, gnmi.OC().Interface(intf).Mtu().Config(), mtu)
+                foundPaths, _ := collectResponse(t, subscribeClient, expectedPaths)
+                if diff := cmp.Diff(expectedPaths, foundPaths, cmpopts.IgnoreUnexported(operStatus{})); diff != "" {
+                        t.Errorf("collectResponse(expectedPaths):\n%v \nResponse mismatch (-missing +extra):\n%s", expectedPaths, diff)
+                }
+        }
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

- [sdn_tests]:Adding single switch Ethernet Counter test to pins_ondatra.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

- Adding single switch Ethernet Counter test to pins_ondatra.

### Build Results:
INFO: From Generating Descriptor Set proto_library @com_github_openconfig_gnsi//credentialz:credentialz_proto:
github.com/openconfig/gnsi/credentialz/credentialz.proto:21:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
INFO: From Generating Descriptor Set proto_library @com_github_openconfig_gnsi//pathz:pathz_proto:
github.com/openconfig/gnsi/pathz/authorization.proto:43:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
github.com/openconfig/gnsi/pathz/pathz.proto:25:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
INFO: Elapsed time: 317.554s, Critical Path: 122.82s
INFO: 975 processes: 251 internal, 724 linux-sandbox.
INFO: Build completed successfully, 975 total actions

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [-] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
