### PR TITLE
Skip test_clock if ntp_server is not provided

### DIFF
--- a/tests/clock/conftest.py
+++ b/tests/clock/conftest.py
@@ -7,7 +7,7 @@ from tests.clock.test_clock import ClockConsts, ClockUtils
 
 
 def pytest_addoption(parser):
-    parser.addoption("--ntp_server", action="store", default=None, required=True, help="IP of NTP server to use")
+    parser.addoption("--ntp_server", action="store", default=None, required=False, help="IP of NTP server to use")
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -18,7 +18,7 @@ def ntp_server(request):
     ntp_server_ip = request.config.getoption("ntp_server")
     logging.info(f'NTP server ip from execution parameter: {ntp_server_ip}')
     if ntp_server_ip is None:
-        pytest.fail("IP of NTP server was not given")
+        pytest.skip("IP of NTP server was not given")
     return ntp_server_ip
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip test modules in `tests/clock` if `ntp_server` is not provided.
The test is consistently failing in nightly test because `ntp_server` is not specified for this particular test case.
```
UsageError: usage: __main__.py [options] [file_or_dir] [file_or_dir] [...]
__main__.py: error: the following arguments are required: --ntp_serve
``` 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR is to skip test modules in `tests/clock` if `ntp_server` is not provided.

#### How did you do it?
1. Change `ntp_server` to optional argument
2. Skip the test if `net_server` is not provided. This is aligned with the comment.

#### How did you verify/test it?
The change is verified on a physical testbed. The test cases are skipped.
```
collected 3 items                                                                                                                                                                                     

clock/test_clock.py::test_show_clock SKIPPED (IP of NTP server was not given)                                                                                                                   [ 33%]
clock/test_clock.py::test_config_clock_timezone SKIPPED (IP of NTP server was not given)                                                                                                        [ 66%]
clock/test_clock.py::test_config_clock_date SKIPPED (IP of NTP server was not given)                                                                                                            [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
