### PR TITLE
[QoS]qos_yaml j2C+ changes for new _vsq thresholds

### DIFF
--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -267,7 +267,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2396560
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
@@ -374,7 +374,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2396560
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
@@ -481,7 +481,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2396560
                     pkts_num_margin: 100
                 wm_pg_shared_lossless:
                     dscp: 3

--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -220,15 +220,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 105029
+                    pkts_num_trig_ingr_drp: 108620
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 105029
+                    pkts_num_trig_ingr_drp: 108620
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -237,43 +237,44 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 35208
-                    pkts_num_hdrm_full: 362
-                    pkts_num_hdrm_partial: 182
+                    pkts_num_trig_pfc: 105029
+                    pkts_num_hdrm_full: 3510
+                    pkts_num_hdrm_partial: 3500
+                    margin: 5
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 105029
+                    pkts_num_trig_ingr_drp: 108620
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 105029
+                    pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 105029
+                    pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 lossy_queue_1:
-                    dscp: 7
+                    dscp: 8
                     ecn: 1
-                    pg: 1
-                    pkts_num_trig_egr_drp: 2396745
+                    pg: 0
+                    pkts_num_trig_egr_drp: 333550
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_fill_min: 51
-                    pkts_num_trig_pfc: 9874
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 105029
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -281,8 +282,8 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_fill_min: 51
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 333550
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -291,7 +292,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_ingr_drp: 108620
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -308,7 +309,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 333550
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8
@@ -326,15 +327,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 216064
+                    pkts_num_trig_pfc: 105029
+                    pkts_num_trig_ingr_drp: 283550
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 216064
+                    pkts_num_trig_pfc: 105029
+                    pkts_num_trig_ingr_drp: 283550
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -343,43 +344,44 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 37549
-                    pkts_num_hdrm_full: 362
-                    pkts_num_hdrm_partial: 182
+                    pkts_num_trig_pfc: 105029
+                    pkts_num_hdrm_full: 176849
+                    pkts_num_hdrm_partial: 176749
+                    margin: 100
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 216064
+                    pkts_num_trig_pfc: 105029
+                    pkts_num_trig_ingr_drp: 283550
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 105029
+                    pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 105029
+                    pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 lossy_queue_1:
-                    dscp: 7
+                    dscp: 8
                     ecn: 1
-                    pg: 1
+                    pg: 0
                     pkts_num_trig_egr_drp: 2396745
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_fill_min: 51
-                    pkts_num_trig_pfc: 37449
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 105029
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -387,7 +389,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_fill_min: 51
+                    pkts_num_fill_min: 0
                     pkts_num_trig_egr_drp: 2396745
                     packet_size: 64
                     cell_size: 4096
@@ -397,7 +399,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 216064
+                    pkts_num_trig_ingr_drp: 283550
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -432,15 +434,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 750848
+                    pkts_num_trig_pfc: 84429
+                    pkts_num_trig_ingr_drp: 797780
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 750848
+                    pkts_num_trig_pfc: 84429
+                    pkts_num_trig_ingr_drp: 797780
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -449,44 +451,44 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 37549
-                    pkts_num_hdrm_full: 362
-                    pkts_num_hdrm_partial: 182
-                    margin: 1
+                    pkts_num_trig_pfc: 84429
+                    pkts_num_hdrm_full: 712000
+                    pkts_num_hdrm_partial: 711800
+                    margin: 300
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 750848
+                    pkts_num_trig_pfc: 84429
+                    pkts_num_trig_ingr_drp: 797780
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_dismiss_pfc: 200
-                    pkts_num_margin: 150
+                    pkts_num_trig_pfc: 84429
+                    pkts_num_dismiss_pfc: 12985
+                    pkts_num_margin: 1
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_dismiss_pfc: 200
-                    pkts_num_margin: 150
+                    pkts_num_trig_pfc: 84429
+                    pkts_num_dismiss_pfc: 12985
+                    pkts_num_margin: 1
                 lossy_queue_1:
-                    dscp: 7
+                    dscp: 8
                     ecn: 1
-                    pg: 1
-                    pkts_num_trig_egr_drp: 2396745
-                    pkts_num_margin: 3500
+                    pg: 0
+                    pkts_num_trig_egr_drp: 333550
+                    pkts_num_margin: 100
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_fill_min: 71
-                    pkts_num_trig_pfc: 37449
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 84429
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -494,8 +496,8 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_fill_min: 71
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 333550
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -504,7 +506,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 750848
+                    pkts_num_trig_ingr_drp: 797780
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -521,7 +523,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 333550
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8

--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -220,15 +220,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 105029
-                    pkts_num_trig_ingr_drp: 108620
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 418781
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 105029
-                    pkts_num_trig_ingr_drp: 108620
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 418781
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -237,7 +237,7 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 105029
+                    pkts_num_trig_pfc: 415271
                     pkts_num_hdrm_full: 3510
                     pkts_num_hdrm_partial: 3500
                     margin: 5
@@ -245,36 +245,36 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 105029
-                    pkts_num_trig_ingr_drp: 108620
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 418781
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 105029
-                    pkts_num_dismiss_pfc: 3245
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_dismiss_pfc: 3243
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 105029
-                    pkts_num_dismiss_pfc: 3245
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_dismiss_pfc: 3243
                     pkts_num_margin: 150
                 lossy_queue_1:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 333550
+                    pkts_num_trig_egr_drp: 2396745
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 105029
+                    pkts_num_trig_pfc: 415271
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -283,7 +283,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 333550
+                    pkts_num_trig_egr_drp: 2396745
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -292,7 +292,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 108620
+                    pkts_num_trig_ingr_drp: 418781
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -309,7 +309,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 333550
+                    pkts_num_trig_egr_drp: 2396745
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8
@@ -327,15 +327,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 105029
-                    pkts_num_trig_ingr_drp: 283550
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 593885
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 105029
-                    pkts_num_trig_ingr_drp: 283550
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 593885
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -344,7 +344,7 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 105029
+                    pkts_num_trig_pfc: 415271
                     pkts_num_hdrm_full: 176849
                     pkts_num_hdrm_partial: 176749
                     margin: 100
@@ -352,22 +352,22 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 105029
-                    pkts_num_trig_ingr_drp: 283550
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 593885
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 105029
+                    pkts_num_trig_pfc: 415271
                     pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 105029
+                    pkts_num_trig_pfc: 415271
                     pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 lossy_queue_1:
@@ -381,7 +381,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 105029
+                    pkts_num_trig_pfc: 415271
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -399,7 +399,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 283550
+                    pkts_num_trig_ingr_drp: 593885
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -434,15 +434,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 84429
-                    pkts_num_trig_ingr_drp: 797780
+                    pkts_num_trig_pfc: 657523
+                    pkts_num_trig_ingr_drp: 1370921
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 84429
-                    pkts_num_trig_ingr_drp: 797780
+                    pkts_num_trig_pfc: 657523
+                    pkts_num_trig_ingr_drp: 1370921
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -451,44 +451,44 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 84429
-                    pkts_num_hdrm_full: 712000
-                    pkts_num_hdrm_partial: 711800
+                    pkts_num_trig_pfc: 657523
+                    pkts_num_hdrm_full: 622850
+                    pkts_num_hdrm_partial: 622750
                     margin: 300
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 84429
-                    pkts_num_trig_ingr_drp: 797780
+                    pkts_num_trig_pfc: 657523
+                    pkts_num_trig_ingr_drp: 1370921
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 84429
+                    pkts_num_trig_pfc: 657523
                     pkts_num_dismiss_pfc: 12985
-                    pkts_num_margin: 1
+                    pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 84429
+                    pkts_num_trig_pfc: 657523
                     pkts_num_dismiss_pfc: 12985
-                    pkts_num_margin: 1
+                    pkts_num_margin: 150
                 lossy_queue_1:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 333550
+                    pkts_num_trig_egr_drp: 2396745
                     pkts_num_margin: 100
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 84429
+                    pkts_num_trig_pfc: 657523
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -497,7 +497,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 333550
+                    pkts_num_trig_egr_drp: 2396745
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -506,7 +506,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 797780
+                    pkts_num_trig_ingr_drp: 1370921
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -523,7 +523,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 333550
+                    pkts_num_trig_egr_drp: 2396745
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Updated qos test params for 400g and 100g port speeds for the new vsq threshold introduced in   PR #https://github.com/sonic-net/sonic-buildimage/pull/18239
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
The new   MMU settings to enhance performance for RDMA traffic in production.
Hence the qos_params needs to be tweaked according to the set buffer profiles.

However, the existing sonic-mgmt LossyQueueTest  doesn't fairly verify the buffer threshold for headroom for Lossy traffic. As per the new vsq profile setting the XOFF FADT threshold/PG is way lesser than the Nominal headroom, which limits it to not utilize the headroom buffer completely and send pause frames before reaching the MAX headroom limit.
Either the test case needs to be improvised by adding more source ports or a new test case should be added to verify the Lossy queue traffic at PG level 
#### How did you do it?

#### How did you verify/test it?
Executed the qos test cases   and verify the results
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
