### PR TITLE
Modify snmp link local test to use config cli

### DIFF
--- a/tests/snmp/test_snmp_link_local.py
+++ b/tests/snmp/test_snmp_link_local.py
@@ -22,7 +22,8 @@ def test_snmp_link_local_ip(duthosts,
                             nbrhosts, tbinfo, localhost, creds_all_duts):
     """
     Test SNMP query to DUT over link local IP
-      - Send SNMP query over link local IP from one of the BGP Neighbors
+      - configure eth0's link local IP as snmpagentaddress
+      - Query over linklocal IP from within snmp docker
       - Get SysDescr from snmpfacts
       - compare result from snmp query over link local IP and snmpfacts
     """
@@ -44,13 +45,9 @@ def test_snmp_link_local_ip(duthosts,
             link_local_ip = ip.split()[1]
             break
     # configure link local IP in config_db
-    duthost.shell(
-            'sonic-db-cli CONFIG_DB hset "MGMT_INTERFACE|eth0|{}" \
-            "gwaddr" "fe80::1"'
-            .format(link_local_ip))
     # Restart snmp service to regenerate snmpd.conf with
     # link local IP configured in MGMT_INTERFACE
-    duthost.shell("systemctl restart snmp")
+    duthost.shell("config snmpagentaddress add {}%eth0".format(link_local_ip))
     stdout_lines = duthost.shell("docker exec snmp snmpget \
                                  -v2c -c {} {}%eth0 {}"
                                  .format(creds_all_duts[duthost.hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Modify snmp_link_local_test to test after configuring link local snmp agent address using config snmpagentaddress cli.
Pre requisite: https://github.com/sonic-net/sonic-utilities/pull/3215
#### How did you verify/test it?
```
Manual test:
admin@host:~$ sonic-db-cli CONFIG_DB keys "*SNMP*"
ACL_TABLE|SNMP_ACL
SNMP_AGENT_ADDRESS_CONFIG|10.1.1.1|161|
SNMP_AGENT_ADDRESS_CONFIG|fc00:2::32|161|
SNMP|LOCATION
SNMP_AGENT_ADDRESS_CONFIG|10.1.0.32|161|
SNMP_AGENT_ADDRESS_CONFIG|FC00:1::32|161|
SNMP_COMMUNITY|public

sudo config snmpagentaddress add fe80:1::32%eth0

admin@host:~$ sonic-db-cli CONFIG_DB keys "*SNMP*"
ACL_TABLE|SNMP_ACL
SNMP_AGENT_ADDRESS_CONFIG|10.1.1.1|161|
SNMP_AGENT_ADDRESS_CONFIG|fc00:2::32|161|
SNMP|LOCATION
SNMP_AGENT_ADDRESS_CONFIG|10.1.0.32|161|
SNMP_AGENT_ADDRESS_CONFIG|fe80:1::32%eth0||
SNMP_AGENT_ADDRESS_CONFIG|FC00:1::32|161|
SNMP_COMMUNITY|foo


admin@host:~$ docker exec -it snmp cat /etc/snmp/snmpd.conf | grep agentAddress
agentAddress udp:[10.1.0.32]:161
agentAddress udp:[10.1.1.1]:161
agentAddress udp6:[fc00:2::32]:161
agentAddress udp6:[FC00:1::32]:161
agentAddress udp:[fe80:1::32%eth0]

admin@host:~$ sudo netstat -tulnp | grep 161
udp        0      0 10.1.1.1:161         0.0.0.0:*                           432467/snmpd        
udp        0      0 10.1.0.32:161           0.0.0.0:*                           432467/snmpd        
udp6       0      0 fe80:1::32:161 :::*                                432467/snmpd        
udp6       0      0 fc00:1::32:161          :::*                                432467/snmpd        
udp6       0      0 fc00:2::32:161 :::*                                432467/snmpd    

root@host:/# snmpget -v2c -c public fe80:1::32%eth0 1.3.6.1.2.1.1.1.0
iso.3.6.1.2.1.1.1.0 = STRING: "SONiC Software Version: SONiC.20231110.10 - HwSku: Arista-7260CX3-C64 - Distribution: Debian 11.9 - Kernel: 5.10.0-23-2-amd64"

admin@host:~$ sudo config snmpagentaddress del fe80:1::32%eth0

root@host:/# snmpget -v2c -c public fe80:1::32%eth0 1.3.6.1.2.1.1.1.0
Timeout: No Response from fe80:1::32%eth0.

Run sonic-mgmt test:
snmp/test_snmp_link_local.py::test_snmp_link_local_ip[host] PASSED                                                                                                                                                      [100%]

```



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
