### PR TITLE
Skip keys in table TUNNEL_DECAP_TERM_TABLE for db_cmp 

### DIFF
--- a/tests/configlet/util/common.py
+++ b/tests/configlet/util/common.py
@@ -103,7 +103,12 @@ scan_dbs = {
                 "TUNNEL_DECAP_TABLE",
                 # BUFFER_PG.*3-4 is an auto created entry by buffermgr
                 # configlet skips it. So skip verification too.
-                "BUFFER_PG_TABLE:Ethernet[0-9][0-9]*:3-4"},
+                "BUFFER_PG_TABLE:Ethernet[0-9][0-9]*:3-4",
+                # Diff in TUNNEL_DECAP_TERM_TABLE is expected because router port
+                # is set admin down in the test, which leads to tunnel term change
+                "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL",
+                "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL"
+                },
             "keys_skip_val_comp": {
                 "last_up_time",
                 "flap_count"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip comparing keys in table `TUNNEL_DECAP_TERM_TABLE` in `test_add_rack`.
The keys need to be skipped because the test shutdown a port on the device, and then reload it. Then the entry in table ``TUNNEL_DECAP_TERM_TABLE` for this particular admin down port is lost. 
The error message is 
```
11:18:00 helpers.log_msg                          L0060 ERROR  | /var/src/sonic-mgmt/tests/configlet/util/common.py:318:11:18:00 patch_add: app-db.json: Missing key: TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL:fc00::41
11:18:00 helpers.log_msg                          L0060 ERROR  | /var/src/sonic-mgmt/tests/configlet/util/common.py:318:11:18:00 patch_add: app-db.json: Missing key: TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.0.0.32
``` 

Related PR https://github.com/sonic-net/sonic-buildimage/pull/18752 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
This PR is to skip comparing keys in table `TUNNEL_DECAP_TERM_TABLE` in `test_add_rack`.

#### How did you do it?
Add `TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL` and `TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL` into the skip list.

#### How did you verify/test it?
The change is verified on a physical DUT with change in PR https://github.com/sonic-net/sonic-buildimage/pull/18752 
```
collected 1 item                                                                                                                                                                                      

configlet/test_add_rack.py::test_add_rack 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
 ^H ^H ^H ^HPASSED                                                                                                                                                                                          [100%] ^H
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
