### PR TITLE
Update the correct loganalyzer_exceptions with routeCheck fail message

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -385,6 +385,7 @@ def ignore_expected_loganalyzer_exceptions_lag2(duthosts, rand_one_dut_hostname,
         ignoreRegex = [
             # Valid test_lag_db_status and test_lag_db_status_with_po_update
             ".*ERR swss[0-9]*#orchagent: :- getPortOperSpeed.*",
+            r".* ERR monit\[\d+\]: 'routeCheck' status failed \(255\) -- Failure results:.*",
         ]
         loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
 


### PR DESCRIPTION

Summary:
Add the routeCheck fail message to the right log analyzer exception handler

Fixes # [(issue)](https://github.com/sonic-net/sonic-mgmt/issues/10147)


#### What is the motivation for this PR?

#### How did you do it?
Add the routeCheck fail message to the right log analyzer exception handler

#### How did you verify/test it?
Verified that the testcases pass even when syslog is present.
<TO add test pass logs here >

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
