### PR TITLE
Improve test_bgpmon - use `ip route replace` instead of `ip route add`

### DIFF
--- a/tests/bgp/test_bgpmon.py
+++ b/tests/bgp/test_bgpmon.py
@@ -152,7 +152,7 @@ def test_bgpmon(dut_with_default_route, localhost, enum_rand_one_frontend_asic_i
                    peer_asn=asn,
                    port=BGP_MONITOR_PORT, passive=True)
     ptfhost.shell("ip neigh add %s lladdr %s dev %s" % (local_addr, duthost.facts["router_mac"], ptf_interface))
-    ptfhost.shell("ip route add %s dev %s" % (local_addr + "/32", ptf_interface))
+    ptfhost.shell("ip route replace %s dev %s" % (local_addr + "/32", ptf_interface))
     try:
         pytest_assert(wait_tcp_connection(localhost, ptfhost.mgmt_ip, BGP_MONITOR_PORT, timeout_s=60),
                       "Failed to start bgp monitor session on PTF")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
This PR is to improve `test_bgpmon.py`.
The test was failing occasionally with below error.
```
tests.common.errors.RunAnsibleModuleFail: run module shell failed, Ansible Results =>
{"changed": true, "cmd": "ip route add 10.1.0.32/32 dev eth13", "delta": "0:00:00.262854", "end": "2024-05-30 23:14:57.051726", "failed": true, "msg": "non-zero return code", "rc": 2, "start": "2024-05-30 23:14:56.788872", "stderr": "RTNETLINK answers: File exists", "stderr_lines": ["RTNETLINK answers: File exists"], "stdout": "", "stdout_lines": []}
```
We believe it's because some test cases running before `test_bgpmon` also configured route on the same port, but didn't cleanup.
This PR addressed the issue by using `ip route replace` instead of `ip route add`.

#### How did you do it?
This PR addressed the issue by using `ip route replace` instead of `ip route add`.

#### How did you verify/test it?
The PR is verified on a physical testbed.
```
collected 2 items                                                                                                                                                                                                                  

bgp/test_bgpmon.py::test_bgpmon[str-msn2700a1-03-None] PASSED                                                                                                                                                                [ 50%]
bgp/test_bgpmon.py::test_bgpmon_no_resolve_via_default[str-msn2700a1-03-None] PASSED                                                                                                                                         [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
