### PR TITLE
use python3 ptf cmd for case test_no_pfc

### DIFF
--- a/tests/qos/test_pfc_pause.py
+++ b/tests/qos/test_pfc_pause.py
@@ -188,9 +188,17 @@ def run_test(pfc_test_setup, fanouthosts, duthost, ptfhost, conn_graph_facts,   
                        + "vlan_id=%s;" % vlan_id
                        + "testbed_type=\'%s\'" % testbed_type)
 
-        cmd = 'ptf --test-dir %s pfc_pause_test %s --test-params="%s"' % (
-            os.path.dirname(PTF_FILE_REMOTE_PATH), intf_info, test_params)
+        # ptf_runner; from tests.ptf_runner import ptf_runner
+        # need to check the output of ptf cmd, could not use the ptf_runner directly
+        path_exists = ptfhost.stat(path="/root/env-python3/bin/ptf")
+        if path_exists["stat"]["exists"]:
+            cmd = '/root/env-python3/bin/ptf --test-dir %s pfc_pause_test %s --test-params="%s"' % (
+                os.path.dirname(PTF_FILE_REMOTE_PATH), intf_info, test_params)
+        else:
+            cmd = 'ptf --test-dir %s pfc_pause_test %s --test-params="%s"' % (
+                os.path.dirname(PTF_FILE_REMOTE_PATH), intf_info, test_params)
         print(cmd)
+
         stdout = ansible_stdout_to_str(ptfhost.shell(cmd)['stdout'])
         words = stdout.split()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
28179409

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
case failure due to below error message.
    "  File \"/root/ptftests/py3/pfc_wd_background_traffic.py\", line 40",
    "    print(f\"traffic from {src_port} to {dst_port}: {queue} \")",

The case use CMD ptf to run the script. The default python version in ptf is python2, which is not support f string.
then cause the issue.

#### How did you do it?
Better to call "ptf_runner" function and use the input parameter is_python3=True.
But in this case, it needs to check the output of the cmd ptf, could not call the "ptf_runner" function directly.
add a workaround to check the ptf in python3 first, if exist, call ptf in python3.

#### How did you verify/test it?
Run the original case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
