### PR TITLE
Add test coverage for sfp eeprom dump

### DIFF
--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -10,7 +10,7 @@ import copy
 from natsort import natsorted
 import pytest
 
-from .util import parse_eeprom
+from .util import parse_eeprom, parse_eeprom_hexdump
 from .util import parse_output
 from .util import get_dev_conn
 from tests.common.utilities import skip_release, wait_until
@@ -21,6 +21,7 @@ from tests.common.platform.interface_utils import get_physical_port_indices
 
 cmd_sfp_presence = "sudo sfputil show presence"
 cmd_sfp_eeprom = "sudo sfputil show eeprom"
+cmd_sfp_eeprom_hexdump = "sudo sfputil show eeprom-hexdump"
 cmd_sfp_reset = "sudo sfputil reset"
 cmd_sfp_show_lpmode = "sudo sfputil show lpmode"
 cmd_sfp_set_lpmode = "sudo sfputil lpmode"
@@ -388,6 +389,24 @@ def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
         if intf not in xcvr_skip_list[duthost.hostname]:
             assert intf in parsed_eeprom, "Interface is not in output of 'sfputil show eeprom'"
             assert parsed_eeprom[intf] == "SFP EEPROM detected"
+
+
+@pytest.mark.device_type('physical')
+def test_check_sfputil_eeprom_hexdump(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                      enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):
+    """
+    @summary: Check eeprom hexdump using 'sfputil show eeprom-hexdump'
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    portmap, dev_conn = get_dev_conn(duthost, conn_graph_facts, enum_frontend_asic_index)
+
+    logging.info("Check output of '{}'".format(cmd_sfp_eeprom_hexdump))
+    sfp_eeprom_hexdump = duthost.command(cmd_sfp_eeprom_hexdump)
+    parsed_eeprom_hexdump = parse_eeprom_hexdump(sfp_eeprom_hexdump["stdout"])
+    for intf in dev_conn:
+        if intf not in xcvr_skip_list[duthost.hostname]:
+            assert intf in parsed_eeprom_hexdump, f"Interface{intf} is not in output of 'sfputil show eeprom-hexdump'"
+            assert len(parsed_eeprom_hexdump[intf]) > 0, f"EEPROM hexdump not detected for {intf}"
 
 
 def test_check_sfputil_reset(duthosts, enum_rand_one_per_hwsku_frontend_hostname,

--- a/tests/platform_tests/sfp/util.py
+++ b/tests/platform_tests/sfp/util.py
@@ -32,6 +32,36 @@ def parse_eeprom(output_lines):
     return res
 
 
+def parse_eeprom_hexdump(data):
+    # Define a regular expression to capture all required data
+    regex = re.compile(
+        r"EEPROM hexdump for port (\S+)\n"  # Capture port name
+        r"(?:\s+)?"  # Match and skip intermediate lines
+        r"((?:Lower|Upper) page \S+|\S+ dump)\n"  # Capture full page type string
+        r"((?:\s+[0-9a-fA-F]{8}(?: [0-9a-fA-F]{2}){8} (?: [0-9a-fA-F]{2}){8} .*\n)+)"  # Capture hex data block
+    )
+    # Dictionary to store parsed results
+    parsed_data = {}
+
+    # Find all matches in the data
+    matches = regex.findall(data)
+    for port, page_type, hex_data in matches:
+        if port not in parsed_data:
+            parsed_data[port] = {}
+
+        # Parse hex data block into individual hex values
+        hex_lines = hex_data.splitlines()
+        hex_values = [
+            value
+            for line in hex_lines
+            for value in line[9:56].split()  # Extract hex bytes from columns 9-56
+        ]
+
+        parsed_data[port][page_type] = hex_values
+
+    return parsed_data
+
+
 def get_dev_conn(duthost, conn_graph_facts, asic_index):
     dev_conn = conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {})
 

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -410,6 +410,7 @@ def validate_dump_file_content(duthost, dump_folder_path):
     assert len(etc) > MIN_FILES_NUM, "Seems like not all expected files available in 'etc' folder in dump archive. " \
                                      "Test expects not less than 50 files. Available files: {}".format(etc)
     assert len(log), "Folder 'log' in dump archive is empty. Expected not empty folder"
+    assert "interface.xcvrs.eeprom.raw" in dump, "EEPROM hexdump no exist in the dump"
 
 
 def add_asic_arg(format_str, cmds_list, asic_num):


### PR DESCRIPTION
Add test coverage for "Dump SFP EEPROM page data in show techsupport command", here is the HLD: https://github.com/sonic-net/SONiC/blob/master/doc/sfputil/dump_sfp_eeprom.md

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run the relavent test case, and it pass.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
