### PR TITLE
Fix qos/test_qos_dscp_mapping.py

### DIFF
--- a/tests/common/helpers/ptf_tests_helper.py
+++ b/tests/common/helpers/ptf_tests_helper.py
@@ -14,17 +14,18 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def downstream_links(duthost, tbinfo):
+def downstream_links(rand_selected_dut, tbinfo):
     """
     Returns a dictionary of all the links that are downstream from the DUT.
 
     Args:
-        duthost: DUT fixture
+        rand_selected_dut: DUT fixture
         tbinfo: testbed information fixture
     Returns:
         links: Dictionary of links downstream from the DUT
     """
     links = dict()
+    duthost = rand_selected_dut
 
     def filter(interface, neighbor, mg_facts, tbinfo):
         if ((tbinfo["topo"]["type"] == "t0" and "Server" in neighbor["name"])
@@ -41,18 +42,19 @@ def downstream_links(duthost, tbinfo):
 
 
 @pytest.fixture(scope="module")
-def upstream_links(duthost, tbinfo, nbrhosts):
+def upstream_links(rand_selected_dut, tbinfo, nbrhosts):
     """
     Returns a dictionary of all the links that are upstream from the DUT.
 
     Args:
-        duthost: DUT fixture
+        rand_selected_dut: DUT fixture
         tbinfo: testbed information fixture
         nbrhosts: neighbor host fixture
     Returns:
         links: Dictionary of links upstream from the DUT
     """
     links = dict()
+    duthost = rand_selected_dut
 
     def filter(interface, neighbor, mg_facts, tbinfo):
         if ((tbinfo["topo"]["type"] == "t0" and "T1" in neighbor["name"])

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -11,7 +11,7 @@ from ptf import mask
 from scapy.all import Ether, IP
 from tabulate import tabulate
 
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor # noqa F401
 from tests.common.helpers.ptf_tests_helper import downstream_links, upstream_links, select_random_link,\
     get_stream_ptf_ports, get_dut_pair_port_from_ptf_port, apply_dscp_cfg_setup, apply_dscp_cfg_teardown # noqa F401
 from tests.common.utilities import get_ipv4_loopback_ip, get_dscp_to_queue_value, find_egress_queue,\
@@ -337,7 +337,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         apply_dscp_cfg_teardown(duthost)
 
     def test_dscp_to_queue_mapping_pipe_mode(self, ptfadapter, rand_selected_dut,
-                                             toggle_all_simulator_ports_to_rand_selected_tor,
+                                             toggle_all_simulator_ports_to_rand_selected_tor, # noqa F811
                                              setup_standby_ports_on_rand_unselected_tor,
                                              tbinfo, downstream_links, upstream_links, dut_qos_maps_module): # noqa F811
         """
@@ -349,7 +349,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         self._teardown_test(duthost)
 
     def test_dscp_to_queue_mapping_uniform_mode(self, ptfadapter, rand_selected_dut,
-                                                toggle_all_simulator_ports_to_rand_selected_tor,
+                                                toggle_all_simulator_ports_to_rand_selected_tor, # noqa F811
                                                 setup_standby_ports_on_rand_unselected_tor,
                                                 tbinfo, downstream_links, upstream_links, dut_qos_maps_module): # noqa F811
         """

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -11,6 +11,7 @@ from ptf import mask
 from scapy.all import Ether, IP
 from tabulate import tabulate
 
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor
 from tests.common.helpers.ptf_tests_helper import downstream_links, upstream_links, select_random_link,\
     get_stream_ptf_ports, get_dut_pair_port_from_ptf_port, apply_dscp_cfg_setup, apply_dscp_cfg_teardown # noqa F401
 from tests.common.utilities import get_ipv4_loopback_ip, get_dscp_to_queue_value, find_egress_queue,\
@@ -27,8 +28,7 @@ pytestmark = [
 DEFAULT_DSCP = 4
 DEFAULT_TTL = 64
 DEFAULT_ECN = 1
-DEFAULT_PKT_COUNT = 10000
-TOLERANCE = 0.05 * DEFAULT_PKT_COUNT  # Account for noise and polling delays
+DEFAULT_PKT_COUNT = 2000
 DUMMY_OUTER_SRC_IP = '8.8.8.8'
 DUMMY_INNER_SRC_IP = '9.9.9.9'
 DUMMY_INNER_DST_IP = '10.10.10.10'
@@ -271,8 +271,9 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
                                                           ptf_src_port_id=ptf_src_port_id,
                                                           ptf_dst_port_ids=ptf_dst_port_ids)
 
-            except Exception as e:
-                logger.error(str(e))
+            except ConnectionError as e:
+                # Sending large number of packets can cause socket buffer to be full and leads connection timeout.
+                logger.error("{}: Try reducing DEFAULT_PKT_COUNT value".format(str(e)))
                 failed_once = True
 
             global packet_egressed_success
@@ -285,7 +286,8 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
                     time.sleep(2)
                     egress_queue_count, egress_queue_val = find_queue_count_and_value(duthost, queue_val,
                                                                                       dut_egress_port)
-                verification_success = abs(egress_queue_count - DEFAULT_PKT_COUNT) < TOLERANCE
+                # Due to protocol packets, egress_queue_count can be greater than expected count.
+                verification_success = egress_queue_count >= DEFAULT_PKT_COUNT
 
                 if verification_success:
                     logger.info("SUCCESS: Received expected number of packets on queue {}".format(queue_val))
@@ -311,6 +313,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
                     failed_once = True
             else:
                 output_table.append([rotating_dscp, queue_val, 0, "FAILURE - NO PACKETS EGRESSED", "N/A"])
+                failed_once = True
 
             # Reset packet egress status
             packet_egressed_success = False
@@ -319,6 +322,8 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
                     .format(tabulate(output_table,
                                      headers=["Inner Packet DSCP Value", "Expected Egress Queue",
                                               "Egress Queue Count", "Result", "Actual Egress Queue"])))
+        # Clear the output_table (for next test functions).
+        output_table = []
 
         pytest_assert(not failed_once, "FAIL: Test failed. Please check table for details.")
 
@@ -331,18 +336,26 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         """
         apply_dscp_cfg_teardown(duthost)
 
-    def test_dscp_to_queue_mapping_pipe_mode(self, ptfadapter, duthost, tbinfo, downstream_links, upstream_links, dut_qos_maps_module): # noqa F811
+    def test_dscp_to_queue_mapping_pipe_mode(self, ptfadapter, rand_selected_dut,
+                                             toggle_all_simulator_ports_to_rand_selected_tor,
+                                             setup_standby_ports_on_rand_unselected_tor,
+                                             tbinfo, downstream_links, upstream_links, dut_qos_maps_module): # noqa F811
         """
             Test QoS SAI DSCP to queue mapping for IP-IP packets in DSCP "pipe" mode
         """
+        duthost = rand_selected_dut
         test_params = self._setup_test_params(duthost, downstream_links, upstream_links, "pipe")
         self._run_test(ptfadapter, duthost, tbinfo, test_params, dut_qos_maps_module, "pipe")
         self._teardown_test(duthost)
 
-    def test_dscp_to_queue_mapping_uniform_mode(self, ptfadapter, duthost, tbinfo, downstream_links, upstream_links, dut_qos_maps_module): # noqa F811
+    def test_dscp_to_queue_mapping_uniform_mode(self, ptfadapter, rand_selected_dut,
+                                                toggle_all_simulator_ports_to_rand_selected_tor,
+                                                setup_standby_ports_on_rand_unselected_tor,
+                                                tbinfo, downstream_links, upstream_links, dut_qos_maps_module): # noqa F811
         """
             Test QoS SAI DSCP to queue mapping for IP-IP packets in DSCP "uniform" mode
         """
+        duthost = rand_selected_dut
         test_params = self._setup_test_params(duthost, downstream_links, upstream_links, "uniform")
         self._run_test(ptfadapter, duthost, tbinfo, test_params, dut_qos_maps_module, "uniform")
         self._teardown_test(duthost)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix qos/test_qos_dscp_mapping.py failures
Fixes # [aristanetworks/sonic-qual.msft#132](https://github.com/aristanetworks/sonic-qual.msft/issues/132)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?

This test is mainly failing due to:
   - Sending 10K packets at once on a ptf interface is sometimes causing nnpy socket to be non-functional for a moment and connection is getting timedout (logic to timeout is introduced by https://github.com/p4lang/ptf/pull/183).
   - Sometimes egress_queue_count on queue 7 is way greater than no of packets being sent and the queue_count is not within the TOLERANCE, this could be due to protocol packets.
   - Test is not enhanced to be run on dualtor topologies (packets are going to unexpected ToR).
   - Fixtures "upstream_links" and "downstream_links" are always referring to upper ToR, thus return values of these fixtures is not really considering the ToR type and causing failures.
   
#### How did you do it?
Fixes involve adding right fixtures to the test methods (to consider dualtor topologies) and minor changes to address above issues.

#### How did you verify/test it?
With the fix test is passing well (earlier it was failing most of the times with one or other reason). Verified the fix on Arista-7260CX3-C64 202311 branch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
