### PR TITLE
Add vlan test to t0-2vlans test job

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -165,6 +165,8 @@ t0:
 t0-2vlans:
   - dhcp_relay/test_dhcp_relay.py
   - dhcp_relay/test_dhcpv6_relay.py
+  - vlan/test_host_vlan.py
+  - vlan/test_vlan_ping.py
 
 t0-sonic:
   - bgp/test_bgp_fact.py
@@ -273,10 +275,6 @@ onboarding_t0:
   - platform_tests/test_power_off_reboot.py
   - platform_tests/test_sequential_restart.py
   - platform_tests/test_xcvr_info_in_db.py
-
-onboarding_t0-2vlans:
-  - vlan/test_host_vlan.py
-  - vlan/test_vlan_ping.py
 
 specific_param:
   t0-sonic:

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -274,6 +274,9 @@ onboarding_t0:
   - platform_tests/test_sequential_restart.py
   - platform_tests/test_xcvr_info_in_db.py
 
+onboarding_t0-2vlans:
+  - vlan/test_host_vlan.py
+  - vlan/test_vlan_ping.py
 
 specific_param:
   t0-sonic:

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -276,6 +276,7 @@ onboarding_t0:
   - platform_tests/test_sequential_restart.py
   - platform_tests/test_xcvr_info_in_db.py
 
+
 specific_param:
   t0-sonic:
   - name: bgp/test_bgp_fact.py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -181,6 +181,21 @@ stages:
           MGMT_BRANCH: $(BUILD_BRANCH)
           TEST_SET: onboarding_t0
 
+  - job: onboarding_t0_2vlans_elastictest
+    displayName: "kvmtest-t0-2vlans by Elastictest"
+    timeoutInMinutes: 240
+    continueOnError: true
+    pool: sonic-ubuntu-1c
+    steps:
+    - template: .azure-pipelines/run-test-elastictest-template.yml
+      parameters:
+        TOPOLOGY: t0
+        TEST_SET: onboarding_t0-2vlans
+        MIN_WORKER: $(T0_2VLANS_INSTANCE_NUM)
+        MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
+        DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
+        KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+        MGMT_BRANCH: $(BUILD_BRANCH)
 
 #  - job: wan_elastictest
 #    displayName: "kvmtest-wan by Elastictest"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,7 +182,7 @@ stages:
           TEST_SET: onboarding_t0
 
   - job: onboarding_t0_2vlans_elastictest
-    displayName: "kvmtest-t0-2vlans by Elastictest"
+    displayName: "onboarding kvmtest-t0-2vlans by Elastictest"
     timeoutInMinutes: 240
     continueOnError: true
     pool: sonic-ubuntu-1c

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -181,6 +181,7 @@ stages:
           MGMT_BRANCH: $(BUILD_BRANCH)
           TEST_SET: onboarding_t0
 
+
 #  - job: wan_elastictest
 #    displayName: "kvmtest-wan by Elastictest"
 #    timeoutInMinutes: 240

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -181,22 +181,6 @@ stages:
           MGMT_BRANCH: $(BUILD_BRANCH)
           TEST_SET: onboarding_t0
 
-  - job: onboarding_t0_2vlans_elastictest
-    displayName: "onboarding kvmtest-t0-2vlans by Elastictest"
-    timeoutInMinutes: 240
-    continueOnError: true
-    pool: sonic-ubuntu-1c
-    steps:
-    - template: .azure-pipelines/run-test-elastictest-template.yml
-      parameters:
-        TOPOLOGY: t0
-        TEST_SET: onboarding_t0-2vlans
-        MIN_WORKER: $(T0_2VLANS_INSTANCE_NUM)
-        MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
-        DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
-        KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-        MGMT_BRANCH: $(BUILD_BRANCH)
-
 #  - job: wan_elastictest
 #    displayName: "kvmtest-wan by Elastictest"
 #    timeoutInMinutes: 240


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker
#### How did you do it?
Add vlan test to t0-2vlans test job
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
