### PR TITLE
Enable TACACS on test cases

### DIFF
--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -7,6 +7,7 @@ from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import get_host_visible_vars
 from tests.common.reboot import reboot, REBOOT_TYPE_COLD, REBOOT_TYPE_WARM
 from tests.common.utilities import wait_until
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 logger = logging.getLogger(__name__)

--- a/tests/ecmp/test_fgnhg.py
+++ b/tests/ecmp/test_fgnhg.py
@@ -15,6 +15,7 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs       # noqa F401
 
 # Constants
 NUM_NHs = 8

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -15,6 +15,7 @@ import ptf.packet as packet
 
 from abc import abstractmethod
 from ptf.mask import Mask
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import find_duthost_on_role
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -4,6 +4,7 @@ import pytest
 import ptf.testutils as testutils
 from . import everflow_test_utilities as everflow_utils
 from .everflow_test_utilities import BaseEverflowTest, DOWN_STREAM, UP_STREAM
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 # Module-level fixtures
 from .everflow_test_utilities import setup_info      # noqa: F401

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -9,6 +9,7 @@ from . import everflow_test_utilities as everflow_utils
 from .everflow_test_utilities import BaseEverflowTest
 from .everflow_test_utilities import TEMPLATE_DIR, EVERFLOW_RULE_CREATE_TEMPLATE, \
                                     DUT_RUN_DIR, EVERFLOW_RULE_CREATE_FILE, UP_STREAM
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_require
 
 from .everflow_test_utilities import setup_info, EVERFLOW_DSCP_RULES       # noqa: F401

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -13,6 +13,7 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory         
 from tests.common.fixtures.ptfhost_utils import copy_acstests_directory                                 # noqa: F401
 from .everflow_test_utilities import setup_info, setup_arp_responder, EVERFLOW_DSCP_RULES                # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py                                   # noqa: F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs                                     # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
 
 pytestmark = [

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -12,6 +12,7 @@ import re
 import random
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs         # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # noqa F401
 from tests.common.fixtures.duthost_utils import disable_fdb_aging           # noqa F401

--- a/tests/fdb/test_fdb_flush.py
+++ b/tests/fdb/test_fdb_flush.py
@@ -6,6 +6,7 @@ import os
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs       # noqa F401
 from tests.ptf_runner import ptf_runner
 from .utils import fdb_cleanup
 

--- a/tests/fdb/test_fdb_mac_expire.py
+++ b/tests/fdb/test_fdb_mac_expire.py
@@ -4,6 +4,7 @@ import time
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401  # lgtm [py/unused-import]
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs       # noqa F401
 from tests.ptf_runner import ptf_runner
 
 pytestmark = [

--- a/tests/fdb/test_fdb_mac_move.py
+++ b/tests/fdb/test_fdb_mac_move.py
@@ -4,6 +4,7 @@ import math
 import pytest
 
 from collections import defaultdict
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from .utils import MacToInt, IntToMac, fdb_cleanup, get_crm_resources, send_arp_request, get_fdb_dynamic_mac_count

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 import pytest
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs         # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401

--- a/tests/flow_counter/flow_counter_utils.py
+++ b/tests/flow_counter/flow_counter_utils.py
@@ -2,6 +2,7 @@ import allure
 import logging
 import pytest
 import random
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until, check_skip_release
 

--- a/tests/generic_config_updater/test_bgp_prefix.py
+++ b/tests/generic_config_updater/test_bgp_prefix.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import re
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_failure, expect_op_success
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile

--- a/tests/generic_config_updater/test_bgp_sentinel.py
+++ b/tests/generic_config_updater/test_bgp_sentinel.py
@@ -3,6 +3,7 @@ import pytest
 import re
 import ipaddress
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile

--- a/tests/generic_config_updater/test_bgp_speaker.py
+++ b/tests/generic_config_updater/test_bgp_speaker.py
@@ -3,6 +3,7 @@ import pytest
 import re
 import ipaddress
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile

--- a/tests/generic_config_updater/test_bgpl.py
+++ b/tests/generic_config_updater/test_bgpl.py
@@ -3,6 +3,7 @@ import pytest
 import re
 
 from netaddr import IPNetwork
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.generators import generate_ip_through_default_route
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success

--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -3,6 +3,7 @@ import pytest
 import time
 import difflib
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_res_success, expect_op_failure
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile

--- a/tests/generic_config_updater/test_dhcp_relay.py
+++ b/tests/generic_config_updater/test_dhcp_relay.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.fixtures.duthost_utils import utils_vlan_intfs_dict_orig, \

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -5,6 +5,7 @@ import binascii
 import netaddr
 import struct
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 
 import scapy

--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -57,10 +57,10 @@ def ensure_application_of_updated_config(duthost, configdb_field, values):
     def _confirm_value_in_asic_db():
         wred_objects = duthost.shell('sonic-db-cli ASIC_DB keys *WRED*')["stdout"]
         wred_objects = wred_objects.split("\n")
-        if(len(wred_objects) > 1):
+        if (len(wred_objects) > 1):
             for wred_object in wred_objects:
                 wred_data = duthost.shell('sonic-db-cli ASIC_DB hgetall {}'.format(wred_object))["stdout"]
-                if('NULL' in wred_data):
+                if ('NULL' in wred_data):
                     continue
                 wred_data = ast.literal_eval(wred_data)
                 for field, value in zip(configdb_field.split(','), values.split(',')):

--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -2,6 +2,7 @@ import ast
 import logging
 import pytest
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import verify_orchagent_running_or_assert

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -3,6 +3,7 @@ import pytest
 import re
 import random
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_op_failure

--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -3,6 +3,7 @@ import logging
 import json
 import pytest
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import verify_orchagent_running_or_assert

--- a/tests/generic_config_updater/test_ipv6.py
+++ b/tests/generic_config_updater/test_ipv6.py
@@ -3,6 +3,7 @@ import pytest
 import ipaddress
 import re
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_op_failure
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile

--- a/tests/generic_config_updater/test_kubernetes_config.py
+++ b/tests/generic_config_updater/test_kubernetes_config.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import re
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_op_failure
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile

--- a/tests/generic_config_updater/test_lo_interface.py
+++ b/tests/generic_config_updater/test_lo_interface.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import ipaddress
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_op_failure
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile

--- a/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
+++ b/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import re
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import verify_orchagent_running_or_assert

--- a/tests/generic_config_updater/test_monitor_config.py
+++ b/tests/generic_config_updater/test_monitor_config.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_res_success
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile

--- a/tests/generic_config_updater/test_ntp.py
+++ b/tests/generic_config_updater/test_ntp.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 import re
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_failure, expect_op_success
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile

--- a/tests/generic_config_updater/test_pfcwd_interval.py
+++ b/tests/generic_config_updater/test_pfcwd_interval.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import json
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_op_failure

--- a/tests/generic_config_updater/test_pfcwd_status.py
+++ b/tests/generic_config_updater/test_pfcwd_status.py
@@ -4,6 +4,7 @@ import pytest
 
 from collections import defaultdict
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import verify_orchagent_running_or_assert

--- a/tests/generic_config_updater/test_pg_headroom_update.py
+++ b/tests/generic_config_updater/test_pg_headroom_update.py
@@ -2,6 +2,7 @@ import ast
 import logging
 import pytest
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import verify_orchagent_running_or_assert

--- a/tests/generic_config_updater/test_portchannel_interface.py
+++ b/tests/generic_config_updater/test_portchannel_interface.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import ipaddress
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_op_failure

--- a/tests/generic_config_updater/test_syslog.py
+++ b/tests/generic_config_updater/test_syslog.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_res_success, expect_op_failure, expect_op_success
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile

--- a/tests/generic_config_updater/test_vlan_interface.py
+++ b/tests/generic_config_updater/test_vlan_interface.py
@@ -4,6 +4,7 @@ import sys
 import re
 import pytest
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success, expect_op_failure
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile

--- a/tests/gnmi/test_gnmi.py
+++ b/tests/gnmi/test_gnmi.py
@@ -2,6 +2,7 @@ import pytest
 import logging
 
 from .helper import gnmi_capabilities
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/gnmi/test_gnmi_appldb.py
+++ b/tests/gnmi/test_gnmi_appldb.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from .helper import gnmi_set, gnmi_get
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/gnmi/test_gnmi_configdb.py
+++ b/tests/gnmi/test_gnmi_configdb.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 
 from .helper import gnmi_set, gnmi_get, gnoi_reboot
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.platform.processes_utils import wait_critical_processes

--- a/tests/http/test_http_copy.py
+++ b/tests/http/test_http_copy.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import time
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [

--- a/tests/iface_loopback_action/test_iface_loopback_action.py
+++ b/tests/iface_loopback_action/test_iface_loopback_action.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 import random
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.reboot import reboot
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -318,7 +318,7 @@ class TestShowInterfaces():
             if regex_int.match(line):
                 interfaces.append(regex_int.match(line).group(0))
 
-        assert(len(interfaces) > 0)
+        assert (len(interfaces) > 0)
 
         for item in interfaces:
             if mode == 'alias':
@@ -552,7 +552,7 @@ class TestShowQueue():
                 intfsChecked += 1
 
         # At least one interface should have been checked to have a valid result
-        assert(intfsChecked > 0)
+        assert (intfsChecked > 0)
 
     def test_show_queue_counters_interface(self, setup_config_mode, sample_intf):
         """

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -4,6 +4,7 @@ import re
 import ipaddress
 
 from tests.common.devices.base import AnsibleHostBase
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.utilities import wait, wait_until
 from netaddr import IPAddress
 from tests.common.helpers.assertions import pytest_assert

--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -8,6 +8,7 @@ import pytest
 from ptf import mask, packet
 
 from collections import defaultdict
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.portstat_utilities import parse_column_positions
 from tests.common.portstat_utilities import parse_portstat

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -3,7 +3,6 @@ import logging
 import pytest
 import re
 
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.utilities import get_mgmt_ipv6
 from tests.common.helpers.assertions import pytest_assert
 from tests.tacacs.utils import check_output

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 import re
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.utilities import get_mgmt_ipv6
 from tests.common.helpers.assertions import pytest_assert
 from tests.tacacs.utils import check_output

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -4,6 +4,7 @@ import logging
 
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs       # noqa F401
 
 DEFAULT_HLIM_TTL = 64
 WAIT_EXPECTED_PACKET_TIMEOUT = 5

--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -3,6 +3,7 @@ import json
 import logging
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs       # noqa F401
 from tests.ptf_runner import ptf_runner
 from datetime import datetime
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401

--- a/tests/ipfwd/test_mtu.py
+++ b/tests/ipfwd/test_mtu.py
@@ -3,6 +3,7 @@ import logging
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs         # noqa F401
 from tests.ptf_runner import ptf_runner
 from datetime import datetime
 

--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from ptf.mask import Mask
 import ptf.packet as scapy
 import ptf.testutils as testutils
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 from tests.common.cisco_data import is_cisco_device
 from tests.common.mellanox_data import is_mellanox_device, get_chip_type

--- a/tests/ixia/ecn/test_dequeue_ecn.py
+++ b/tests/ixia/ecn/test_dequeue_ecn.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts         # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs                             # noqa F401
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config                     # noqa F401
 from tests.common.ixia.qos_fixtures import prio_dscp_map, lossless_prio_list                    # noqa F401

--- a/tests/ixia/ecn/test_red_accuracy.py
+++ b/tests/ixia/ecn/test_red_accuracy.py
@@ -3,6 +3,7 @@ import collections
 
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs                         # noqa F401
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config                 # noqa F401
 from tests.common.ixia.qos_fixtures import prio_dscp_map, lossless_prio_list                # noqa F401

--- a/tests/ixia/ixanvl/test_bgp_conformance.py
+++ b/tests/ixia/ixanvl/test_bgp_conformance.py
@@ -3,6 +3,7 @@ import paramiko
 import pytest
 
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from scp import SCPClient
 
 pytestmark = [pytest.mark.disable_loganalyzer]

--- a/tests/ixia/pfc/test_global_pause.py
+++ b/tests/ixia/pfc/test_global_pause.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts         # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs                             # noqa F401
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config                     # noqa F401
 from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\

--- a/tests/ixia/pfc/test_pfc_congestion.py
+++ b/tests/ixia/pfc/test_pfc_congestion.py
@@ -6,6 +6,7 @@ from tests.common.helpers.assertions import pytest_require    # noqa: F401
 from tests.common.fixtures.conn_graph_facts import (      # noqa: F401
     conn_graph_facts,
     fanout_graph_facts)
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs  # noqa F401
 from tests.common.ixia.ixia_fixtures import (    # noqa: F401
     ixia_api_serv_ip,
     ixia_api_serv_port,

--- a/tests/ixia/pfc/test_pfc_pause_lossless.py
+++ b/tests/ixia/pfc/test_pfc_pause_lossless.py
@@ -3,6 +3,7 @@ import pytest
 
 from .files.helper import run_pfc_test
 from tests.common.cisco_data import is_cisco_device
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs        # noqa F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.reboot import reboot
 from tests.common.utilities import wait_until

--- a/tests/ixia/pfc/test_pfc_pause_lossy.py
+++ b/tests/ixia/pfc/test_pfc_pause_lossy.py
@@ -4,6 +4,7 @@ import pytest
 from .files.helper import run_pfc_test
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts         # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs                             # noqa F401
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config                     # noqa F401
 from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\

--- a/tests/ixia/pfcwd/test_pfcwd_a2a.py
+++ b/tests/ixia/pfcwd/test_pfcwd_a2a.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs                         # noqa F401
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config                 # noqa F401
 from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list,\

--- a/tests/ixia/pfcwd/test_pfcwd_basic.py
+++ b/tests/ixia/pfcwd/test_pfcwd_basic.py
@@ -3,6 +3,7 @@ import logging
 
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs                         # noqa F401
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config                 # noqa F401
 from tests.common.ixia.qos_fixtures import prio_dscp_map, lossless_prio_list                # noqa F401

--- a/tests/ixia/pfcwd/test_pfcwd_burst_storm.py
+++ b/tests/ixia/pfcwd/test_pfcwd_burst_storm.py
@@ -3,6 +3,7 @@ import logging
 
 from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs                         # noqa F401
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config                 # noqa F401
 from tests.common.ixia.qos_fixtures import prio_dscp_map                                    # noqa F401

--- a/tests/ixia/pfcwd/test_pfcwd_m2o.py
+++ b/tests/ixia/pfcwd/test_pfcwd_m2o.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs                         # noqa F401
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config                 # noqa F401
 from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list,\

--- a/tests/ixia/pfcwd/test_pfcwd_runtime_traffic.py
+++ b/tests/ixia/pfcwd/test_pfcwd_runtime_traffic.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs                         # noqa F401
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config                 # noqa F401
 from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list                     # noqa F401

--- a/tests/ixia/test_ixia_traffic.py
+++ b/tests/ixia/test_ixia_traffic.py
@@ -13,6 +13,7 @@ import time
 import pytest
 
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs                         # noqa F401
 from tests.common.helpers.assertions import pytest_require
 from tests.common.reboot import logger
 

--- a/tests/ixia/test_tgen.py
+++ b/tests/ixia/test_tgen.py
@@ -4,6 +4,7 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts                                                                      # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs                         # noqa F401
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config                 # noqa F401
 from tests.common.ixia.port import select_ports

--- a/tests/k8s/test_config_reload.py
+++ b/tests/k8s/test_config_reload.py
@@ -1,6 +1,7 @@
 import pytest
 import k8s_test_utilities as ku
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.config_reload import config_reload

--- a/tests/k8s/test_disable_flag.py
+++ b/tests/k8s/test_disable_flag.py
@@ -1,6 +1,7 @@
 import pytest
 import k8s_test_utilities as ku
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [

--- a/tests/k8s/test_join_available_master.py
+++ b/tests/k8s/test_join_available_master.py
@@ -2,6 +2,7 @@ import pytest
 import time
 import k8s_test_utilities as ku
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 
 WAIT_FOR_SYNC = 60

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -1,7 +1,10 @@
 import logging
 import pytest
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
+
 logger = logging.getLogger(__name__)
+
 
 pytestmark = [
     pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx'),

--- a/tests/log_fidelity/test_bgp_shutdown.py
+++ b/tests/log_fidelity/test_bgp_shutdown.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 
 logger = logging.getLogger(__name__)

--- a/tests/macsec/test_controlplane.py
+++ b/tests/macsec/test_controlplane.py
@@ -5,6 +5,7 @@ import re
 
 from tests.common.utilities import wait_until
 from tests.common.devices.eos import EosHost
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from .macsec_helper import check_wpa_supplicant_process, check_appl_db, check_mka_session,\
                            get_mka_session, get_sci, get_appl_db, get_ipnetns_prefix
 from .macsec_platform_helper import get_platform, get_macsec_ifname

--- a/tests/macsec/test_dataplane.py
+++ b/tests/macsec/test_dataplane.py
@@ -7,6 +7,7 @@ import ptf.testutils as testutils
 from collections import Counter
 
 from tests.common.devices.eos import EosHost
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from .macsec_helper import create_pkt, create_exp_pkt, check_macsec_pkt,\
                            get_ipnetns_prefix, get_macsec_sa_name, get_macsec_counters
 from .macsec_platform_helper import get_portchannel, find_portchannel_from_member

--- a/tests/macsec/test_deployment.py
+++ b/tests/macsec/test_deployment.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.utilities import wait_until
 from tests.common import config_reload
 from .macsec_helper import check_appl_db

--- a/tests/macsec/test_fault_handling.py
+++ b/tests/macsec/test_fault_handling.py
@@ -2,6 +2,7 @@ from time import sleep
 import pytest
 import logging
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.utilities import wait_until
 from tests.common.devices.eos import EosHost
 from .macsec_helper import get_appl_db

--- a/tests/macsec/test_interop_protocol.py
+++ b/tests/macsec/test_interop_protocol.py
@@ -2,6 +2,7 @@ import pytest
 import logging
 import ipaddress
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.utilities import wait_until
 from .macsec_helper import getns_prefix
 from .macsec_config_helper import disable_macsec_port, enable_macsec_port

--- a/tests/macsec/test_interop_wan_isis.py
+++ b/tests/macsec/test_interop_wan_isis.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from .macsec_platform_helper import get_portchannel

--- a/tests/mclag/test_mclag_l3.py
+++ b/tests/mclag/test_mclag_l3.py
@@ -3,6 +3,7 @@ import ipaddress
 import pytest
 import time
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from mclag_helpers import check_partner_lag_member

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -10,6 +10,7 @@ import time
 import pytest
 
 from pkg_resources import parse_version
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require

--- a/tests/minigraph/test_masked_services.py
+++ b/tests/minigraph/test_masked_services.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common import config_reload

--- a/tests/monit/test_monit_status.py
+++ b/tests/monit/test_monit_status.py
@@ -5,6 +5,7 @@ import logging
 
 import pytest
 
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require

--- a/tests/mpls/test_mpls.py
+++ b/tests/mpls/test_mpls.py
@@ -6,6 +6,7 @@ import ptf.packet as packet
 import ptf.testutils as testutils
 import pytest
 import time
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -4,6 +4,7 @@ import re
 import logging
 
 from tests.common import reboot
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.utilities import wait_until
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert

--- a/tests/nat/test_dynamic_nat.py
+++ b/tests/nat/test_dynamic_nat.py
@@ -38,6 +38,7 @@ from .nat_helpers import get_cli_show_nat_config_output
 from .nat_helpers import write_json
 from .nat_helpers import check_peers_by_ping
 import ptf.testutils as testutils
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [

--- a/tests/nat/test_static_nat.py
+++ b/tests/nat/test_static_nat.py
@@ -39,6 +39,7 @@ from .nat_helpers import dut_nat_iptables_status
 from .nat_helpers import dut_interface_control
 from .nat_helpers import get_public_ip
 import tests.common.reboot as common_reboot
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.nat.conftest import nat_global_config
 

--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -4,6 +4,7 @@ import logging
 import time
 import pytest
 from contextlib import contextmanager
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs     # noqa F401
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Enable TACACS on test cases.

#### Why I did it
Enable TACACS on test cases to improve TACACS feature coverage.

##### Work item tracking
- Microsoft ADO: 26156377

#### How I did it
Add TACACS module level fixture to test case file.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Enable TACACS on test cases.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

