### PR TITLE
Increase warmboot_finalizer_timeout from 180s to 300s.

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -82,7 +82,7 @@ reboot_ctrl_dict = {
         "command": "warm-reboot",
         "timeout": 300,
         "wait": 90,
-        "warmboot_finalizer_timeout": 180,
+        "warmboot_finalizer_timeout": 300,
         "cause": "warm-reboot",
         "test_reboot_cause_only": False
     },


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Increase warmboot_finalizer_timeout from 180s to 300s.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Test cases failed on platform Force10-S6100 t0, ran into issues: `Exception: warmboot-finalizer service timeout on DUT strtk5-s6100-acs-2`.
#### How did you do it?
Increased warmboot_finalzier_timeout from 180s to 300s.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
