### PR TITLE
Fixing Oversubscription verification and removing config_reload from ecn

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -763,23 +763,17 @@ def verify_egress_queue_frame_count(duthost,
                               "Queue counters should increment for invalid PFC pause frames")
 
 
-def verify_m2o_oversubscribtion_results(duthost,
-                                        rows,
+def verify_m2o_oversubscribtion_results(rows,
                                         test_flow_name,
                                         bg_flow_name,
-                                        rx_port,
-                                        rx_frame_count_deviation,
                                         flag):
     """
     Verify if we get expected experiment results
 
     Args:
-        duthost (obj): DUT host object
         rows (list): per-flow statistics
         test_flow_name (str): name of test flows
         bg_flow_name (str): name of background flows
-        rx_port: Rx port of the dut
-        rx_frame_count_deviation (float): deviation for rx frame count (default to 1%)
         flag (dict): Comprises of flow name and its loss criteria ,loss criteria value can be integer values
                      of string type for definite results or 'continuing' for non definite loss value results
                      example:{
@@ -801,7 +795,6 @@ def verify_m2o_oversubscribtion_results(duthost,
         N/A
     """
 
-    sum_rx = 0
     for flow_type, criteria in flag.items():
         for row in rows:
             tx_frames = row.frames_tx
@@ -831,10 +824,3 @@ def verify_m2o_oversubscribtion_results(duthost,
                     else:
                         pytest_assert(False, 'Wrong criteria given in flag, accepted values are of type \
                                       string for loss criteria')
-            sum_rx += int(row.frames_rx)
-
-    tx_frames = get_tx_frame_count(duthost, rx_port['peer_port'])[0]
-    pytest_assert(abs(sum_rx - tx_frames)/sum_rx <= rx_frame_count_deviation,
-                  "FAIL: DUT counters doesn't match with the total frames received on Rx port, \
-                  Deviation of more than {} observed".format(rx_frame_count_deviation))
-    logger.info("PASS: DUT counters match with the total frames received on Rx port")

--- a/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
@@ -15,7 +15,6 @@ from tests.snappi_tests.multidut.ecn.files.multidut_helper import run_ecn_test
 from tests.common.snappi_tests.read_pcap import is_ecn_marked
 from tests.snappi_tests.files.helper import skip_ecn_tests
 from tests.common.snappi_tests.common_helpers import packet_capture
-from tests.common.config_reload import config_reload
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen')]
@@ -117,8 +116,3 @@ def test_dequeue_ecn(request,
     # Check if the last packet is not ECN marked
     pytest_assert(not is_ecn_marked(ip_pkts[-1]),
                   "The last packet should not be marked")
-
-    # Teardown ECN config through a reload
-    logger.info("Reloading config to teardown ECN config")
-    config_reload(sonic_host=duthost1, config_source='config_db', safe_reload=True)
-    config_reload(sonic_host=duthost2, config_source='config_db', safe_reload=True)

--- a/tests/snappi_tests/multidut/ecn/test_multidut_red_accuracy_with_snappi.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_red_accuracy_with_snappi.py
@@ -16,7 +16,6 @@ from tests.common.snappi_tests.read_pcap import is_ecn_marked
 from tests.snappi_tests.multidut.ecn.files.multidut_helper import run_ecn_test
 from tests.common.snappi_tests.common_helpers import packet_capture # noqa F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.common.config_reload import config_reload
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen')]
 
@@ -145,8 +144,3 @@ def test_red_accuracy(request,
     for queue, mark_cnt in list(queue_mark_cnt.items()):
         output_table.append([queue, float(mark_cnt)/num_iterations])
     logger.info(tabulate(output_table, headers=['Queue Length', 'ECN Marking Probability']))
-
-    # Teardown ECN config through a reload
-    logger.info("Reloading config to teardown ECN config")
-    config_reload(sonic_host=duthost1, config_source='config_db', safe_reload=True)
-    config_reload(sonic_host=duthost2, config_source='config_db', safe_reload=True)

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
@@ -27,7 +27,6 @@ PAUSE_FLOW_DURATION_SEC = 10
 PAUSE_FLOW_DELAY_SEC = 5
 DATA_FLOW_DELAY_SEC = 0
 SNAPPI_POLL_DELAY_SEC = 2
-TOLERANCE_THRESHOLD = 0.05
 PAUSE_FLOW_RATE = 15
 PAUSE_FLOW_NAME = 'PFC Traffic'
 
@@ -110,13 +109,13 @@ def run_lossless_response_to_external_pause_storms_test(api,
     data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
 
     """ Run traffic """
-    flow_stats, switch_flow_stats = run_traffic(duthost=duthost1,
-                                                api=api,
-                                                config=testbed_config,
-                                                data_flow_names=data_flow_names,
-                                                all_flow_names=all_flow_names,
-                                                exp_dur_sec=DATA_FLOW_DURATION_SEC + DATA_FLOW_DELAY_SEC,
-                                                snappi_extra_params=snappi_extra_params)
+    flow_stats, switch_flow_stats, _ = run_traffic(duthost=duthost1,
+                                                   api=api,
+                                                   config=testbed_config,
+                                                   data_flow_names=data_flow_names,
+                                                   all_flow_names=all_flow_names,
+                                                   exp_dur_sec=DATA_FLOW_DURATION_SEC + DATA_FLOW_DELAY_SEC,
+                                                   snappi_extra_params=snappi_extra_params)
     flag = {
         'Test Flow': {
             'loss': '0'
@@ -126,12 +125,9 @@ def run_lossless_response_to_external_pause_storms_test(api,
         }
     }
 
-    verify_m2o_oversubscribtion_results(duthost=duthost2,
-                                        rows=flow_stats,
+    verify_m2o_oversubscribtion_results(rows=flow_stats,
                                         test_flow_name=TEST_FLOW_NAME,
                                         bg_flow_name=BG_FLOW_NAME,
-                                        rx_port=rx_port,
-                                        rx_frame_count_deviation=TOLERANCE_THRESHOLD,
                                         flag=flag)
 
     # Verify pause flows

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
@@ -114,13 +114,13 @@ def run_lossless_response_to_throttling_pause_storms_test(api,
     data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
 
     """ Run traffic """
-    flow_stats, switch_flow_stats = run_traffic(duthost=duthost1,
-                                                api=api,
-                                                config=testbed_config,
-                                                data_flow_names=data_flow_names,
-                                                all_flow_names=all_flow_names,
-                                                exp_dur_sec=DATA_FLOW_DURATION_SEC + DATA_FLOW_DELAY_SEC,
-                                                snappi_extra_params=snappi_extra_params)
+    flow_stats, switch_flow_stats, _ = run_traffic(duthost=duthost1,
+                                                   api=api,
+                                                   config=testbed_config,
+                                                   data_flow_names=data_flow_names,
+                                                   all_flow_names=all_flow_names,
+                                                   exp_dur_sec=DATA_FLOW_DURATION_SEC + DATA_FLOW_DELAY_SEC,
+                                                   snappi_extra_params=snappi_extra_params)
     flag = {
         'Test Flow': {
             'loss': '0'
@@ -130,12 +130,9 @@ def run_lossless_response_to_throttling_pause_storms_test(api,
             },
         }
 
-    verify_m2o_oversubscribtion_results(duthost=duthost2,
-                                        rows=flow_stats,
+    verify_m2o_oversubscribtion_results(rows=flow_stats,
                                         test_flow_name=TEST_FLOW_NAME,
                                         bg_flow_name=BG_FLOW_NAME,
-                                        rx_port=rx_port,
-                                        rx_frame_count_deviation=TOLERANCE_THRESHOLD,
                                         flag=flag)
 
     # Verify pause flows

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_helper.py
@@ -103,13 +103,13 @@ def run_m2o_oversubscribe_lossless_test(api,
     data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
 
     """ Run traffic """
-    flow_stats, switch_flow_stats = run_traffic(duthost=duthost1,
-                                                api=api,
-                                                config=testbed_config,
-                                                data_flow_names=data_flow_names,
-                                                all_flow_names=all_flow_names,
-                                                exp_dur_sec=DATA_FLOW_DURATION_SEC + DATA_FLOW_DELAY_SEC,
-                                                snappi_extra_params=snappi_extra_params)
+    flow_stats, switch_flow_stats, _ = run_traffic(duthost=duthost1,
+                                                   api=api,
+                                                   config=testbed_config,
+                                                   data_flow_names=data_flow_names,
+                                                   all_flow_names=all_flow_names,
+                                                   exp_dur_sec=DATA_FLOW_DURATION_SEC + DATA_FLOW_DELAY_SEC,
+                                                   snappi_extra_params=snappi_extra_params)
 
     flag = {
         'Test Flow': {
@@ -120,12 +120,9 @@ def run_m2o_oversubscribe_lossless_test(api,
         }
     }
 
-    verify_m2o_oversubscribtion_results(duthost=duthost2,
-                                        rows=flow_stats,
+    verify_m2o_oversubscribtion_results(rows=flow_stats,
                                         test_flow_name=TEST_FLOW_NAME,
                                         bg_flow_name=BG_FLOW_NAME,
-                                        rx_port=rx_port,
-                                        rx_frame_count_deviation=TOLERANCE_THRESHOLD,
                                         flag=flag)
 
 

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -103,13 +103,13 @@ def run_pfc_m2o_oversubscribe_lossless_lossy_test(api,
     data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
 
     """ Run traffic """
-    flow_stats, switch_flow_stats = run_traffic(duthost=duthost1,
-                                                api=api,
-                                                config=testbed_config,
-                                                data_flow_names=data_flow_names,
-                                                all_flow_names=all_flow_names,
-                                                exp_dur_sec=DATA_FLOW_DURATION_SEC + DATA_FLOW_DELAY_SEC,
-                                                snappi_extra_params=snappi_extra_params)
+    flow_stats, switch_flow_stats, _ = run_traffic(duthost=duthost1,
+                                                   api=api,
+                                                   config=testbed_config,
+                                                   data_flow_names=data_flow_names,
+                                                   all_flow_names=all_flow_names,
+                                                   exp_dur_sec=DATA_FLOW_DURATION_SEC + DATA_FLOW_DELAY_SEC,
+                                                   snappi_extra_params=snappi_extra_params)
 
     flag = {
         'Test Flow 1 -> 0 Rate:40': {
@@ -126,12 +126,9 @@ def run_pfc_m2o_oversubscribe_lossless_lossy_test(api,
         },
     }
     # Background Flow 2 -> 0 Rate:40
-    verify_m2o_oversubscribtion_results(duthost=duthost2,
-                                        rows=flow_stats,
+    verify_m2o_oversubscribtion_results(rows=flow_stats,
                                         test_flow_name=TEST_FLOW_NAME,
                                         bg_flow_name=BG_FLOW_NAME,
-                                        rx_port=rx_port,
-                                        rx_frame_count_deviation=TOLERANCE_THRESHOLD,
                                         flag=flag)
 
 

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossy_helper.py
@@ -112,21 +112,18 @@ def run_pfc_m2o_oversubscribe_lossy_test(api,
                 },
            }
     """ Run traffic """
-    flow_stats, switch_flow_stats = run_traffic(duthost=duthost1,
-                                                api=api,
-                                                config=testbed_config,
-                                                data_flow_names=data_flow_names,
-                                                all_flow_names=all_flow_names,
-                                                exp_dur_sec=DATA_FLOW_DURATION_SEC + DATA_FLOW_DELAY_SEC,
-                                                snappi_extra_params=snappi_extra_params)
+    flow_stats, switch_flow_stats, _ = run_traffic(duthost=duthost1,
+                                                   api=api,
+                                                   config=testbed_config,
+                                                   data_flow_names=data_flow_names,
+                                                   all_flow_names=all_flow_names,
+                                                   exp_dur_sec=DATA_FLOW_DURATION_SEC + DATA_FLOW_DELAY_SEC,
+                                                   snappi_extra_params=snappi_extra_params)
 
     """ Verify Results """
-    verify_m2o_oversubscribtion_results(duthost=duthost2,
-                                        rows=flow_stats,
+    verify_m2o_oversubscribtion_results(rows=flow_stats,
                                         test_flow_name=TEST_FLOW_NAME,
                                         bg_flow_name=BG_FLOW_NAME,
-                                        rx_port=rx_port,
-                                        rx_frame_count_deviation=TOLERANCE_THRESHOLD,
                                         flag=flag)
 
 

--- a/tests/snappi_tests/multidut/pfc/test_lossless_response_to_external_pause_storms.py
+++ b/tests/snappi_tests/multidut/pfc/test_lossless_response_to_external_pause_storms.py
@@ -5,11 +5,10 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
     fanout_graph_facts                                                                      # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_dut_base_config, get_tgen_peer_ports, get_multidut_snappi_ports, \
-    get_multidut_tgen_peer_port_set, cleanup_config                                         # noqa: F401
+    get_multidut_tgen_peer_port_set                                         # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
     lossless_prio_list                                                                      # noqa: F401
 from tests.snappi_tests.variables import config_set, line_card_choice
-from tests.common.config_reload import config_reload
 from tests.snappi_tests.multidut.pfc.files.lossless_response_to_external_pause_storms_helper import (
      run_lossless_response_to_external_pause_storms_test,
     )
@@ -100,8 +99,3 @@ def test_lossless_response_to_external_pause_storms_test(snappi_api,            
                                                         bg_prio_list=bg_prio_list,
                                                         prio_dscp_map=prio_dscp_map,
                                                         snappi_extra_params=snappi_extra_params)
-
-    # Teardown config through a reload
-    logger.info("Reloading config to teardown")
-    config_reload(sonic_host=duthost1, config_source='config_db', safe_reload=True)
-    config_reload(sonic_host=duthost2, config_source='config_db', safe_reload=True)

--- a/tests/snappi_tests/multidut/pfc/test_lossless_response_to_throttling_pause_storms.py
+++ b/tests/snappi_tests/multidut/pfc/test_lossless_response_to_throttling_pause_storms.py
@@ -6,11 +6,10 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
     fanout_graph_facts                                                                          # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_dut_base_config, get_tgen_peer_ports, get_multidut_snappi_ports, \
-    get_multidut_tgen_peer_port_set, cleanup_config                                             # noqa: F401
+    get_multidut_tgen_peer_port_set                                             # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
     lossless_prio_list                                                                          # noqa: F401
 from tests.snappi_tests.variables import config_set, line_card_choice
-from tests.common.config_reload import config_reload
 from tests.snappi_tests.multidut.pfc.files.lossless_response_to_throttling_pause_storms_helper import (
     run_lossless_response_to_throttling_pause_storms_test)
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
@@ -102,8 +101,3 @@ def test_lossless_response_to_throttling_pause_storms(snappi_api,               
                                                           bg_prio_list=bg_prio_list,
                                                           prio_dscp_map=prio_dscp_map,
                                                           snappi_extra_params=snappi_extra_params)
-
-    # Teardown config through a reload
-    logger.info("Reloading config to teardown")
-    config_reload(sonic_host=duthost1, config_source='config_db', safe_reload=True)
-    config_reload(sonic_host=duthost2, config_source='config_db', safe_reload=True)

--- a/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless.py
@@ -6,11 +6,10 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
     fanout_graph_facts                                                                          # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_dut_base_config, get_tgen_peer_ports, get_multidut_snappi_ports, \
-    get_multidut_tgen_peer_port_set, cleanup_config                                             # noqa: F401
+    get_multidut_tgen_peer_port_set                                             # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
     lossless_prio_list                                                                          # noqa: F401
 from tests.snappi_tests.variables import config_set, line_card_choice
-from tests.common.config_reload import config_reload
 from tests.snappi_tests.multidut.pfc.files.m2o_oversubscribe_lossless_helper import (
      run_m2o_oversubscribe_lossless_test
     )
@@ -100,8 +99,3 @@ def test_m2o_oversubscribe_lossless(snappi_api,                              # n
                                         bg_prio_list=bg_prio_list,
                                         prio_dscp_map=prio_dscp_map,
                                         snappi_extra_params=snappi_extra_params)
-
-    # Teardown config through a reload
-    logger.info("Reloading config to teardown")
-    config_reload(sonic_host=duthost1, config_source='config_db', safe_reload=True)
-    config_reload(sonic_host=duthost2, config_source='config_db', safe_reload=True)

--- a/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless_lossy.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless_lossy.py
@@ -4,7 +4,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
     fanout_graph_facts                                                                          # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_dut_base_config, get_tgen_peer_ports, get_multidut_snappi_ports, \
-    get_multidut_tgen_peer_port_set, cleanup_config                                             # noqa: F401
+    get_multidut_tgen_peer_port_set                                             # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
     lossless_prio_list                                                                          # noqa: F401
 from tests.snappi_tests.variables import config_set, line_card_choice
@@ -98,5 +98,3 @@ def test_m2o_oversubscribe_lossless_lossy(snappi_api,                   # noqa: 
                                                   bg_prio_list=bg_prio_list,
                                                   prio_dscp_map=prio_dscp_map,
                                                   snappi_extra_params=snappi_extra_params)
-
-    cleanup_config(dut_list, snappi_ports)

--- a/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossy.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossy.py
@@ -6,11 +6,10 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
     fanout_graph_facts                                                                          # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_dut_base_config, get_tgen_peer_ports, get_multidut_snappi_ports, \
-    get_multidut_tgen_peer_port_set, cleanup_config                                             # noqa: F401
+    get_multidut_tgen_peer_port_set                                             # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
     lossless_prio_list                                                                          # noqa: F401
 from tests.snappi_tests.variables import config_set, line_card_choice
-from tests.common.config_reload import config_reload
 from tests.snappi_tests.multidut.pfc.files.m2o_oversubscribe_lossy_helper import run_pfc_m2o_oversubscribe_lossy_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
@@ -96,8 +95,3 @@ def test_m2o_oversubscribe_lossy(snappi_api,                                  # 
                                          bg_prio_list=bg_prio_list,
                                          prio_dscp_map=prio_dscp_map,
                                          snappi_extra_params=snappi_extra_params)
-
-    # Teardown config through a reload
-    logger.info("Reloading config to teardown")
-    config_reload(sonic_host=duthost1, config_source='config_db', safe_reload=True)
-    config_reload(sonic_host=duthost2, config_source='config_db', safe_reload=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Removing flawed config_reload and fixing the verify_m2o_oversubscribtion_results fixture from the traffic_generator.py
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
1.Removing flawed config_reload from ecn and pfc cases as handle by `conftest.py`
2. Modifying oversubscription verification from the multidut rdma cases inorder to incorporate the latest change
3. Fixed the handling of API `run_traffic`
#### How did you do it?

#### How did you verify/test it?
Removed the config reload fixture and added extra value to unpack from run_traffic() fixture from traffic_generator.py
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
