### PR TITLE
Fix test_copp stuck due to ptf issue

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -146,6 +146,7 @@ class TestCOPP(object):
         2. Remove trap according to remove trap type
         4. Verify the trap status is uninstalled by sending traffic
         """
+        time.sleep(120)
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
         if self.trap_id == "bgp":
@@ -303,6 +304,7 @@ def _copp_runner(dut, ptf, protocol, test_params, dut_type, has_trap=True):
                relax=None,
                debug_level=None,
                device_sockets=device_sockets,
+               timeout = 1800,
                is_python3=True)
     return True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In Cisco platform, the copp/test_copp.py::TestCOPP::test_remove_trap may stuck. The pipeline may stall.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
In Cisco 8102 T1 and 8111 T1 testbed, the copp/test_copp.py::TestCOPP::test_remove_trap may stick. So the pipeline may stall.
We can see PTF docker sent packet and stuck there.

#### How did you do it?
Add a sleep at the beginning of the test_remove_trap test case.

#### How did you verify/test it?
Manually run the testcase for 10 times.
Run entire nightly test for 2 times.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
