### PR TITLE
[sdn_tests]: Adding Ethernet Counter In-Discards Check test to pins_ondatra.

### DIFF
--- a/sdn_tests/pins_ondatra/tests/ethcounter_sw_single_switch_test.go
+++ b/sdn_tests/pins_ondatra/tests/ethcounter_sw_single_switch_test.go
@@ -1217,3 +1217,118 @@ func TestGNMIEthernetInIPv6(t *testing.T) {
 
 	t.Logf("\n\n----- TestGNMIEthernetInIPv6: SUCCESS after %v Iteration(s) -----\n\n", i)
 }
+
+// ----------------------------------------------------------------------------
+// TestGNMIEthernetInDiscards - Check EthernetX in-discards
+func TestGNMIEthernetInDiscards(t *testing.T) {
+        // Report results to TestTracker at the end.
+        defer testhelper.NewTearDownOptions(t).WithID("dde5578a-33f2-40b2-a7fa-a978b9ee0a51").Teardown(t)
+
+        // Select the dut, or device under test.
+        dut := ondatra.DUT(t, "DUT")
+
+        // Select a random front panel interface EthernetX.
+        intf, err := testhelper.RandomInterface(t, dut, nil)
+        if err != nil {
+                t.Fatalf("Failed to fetch random interface: %v", err)
+        }
+        CheckInitial(t, dut, intf)
+        defer RestoreInitial(t, dut, intf)
+
+        // To get ingress traffic in Ondatra, turn on loopback mode on
+        // the selected port just for this test.
+        gnmi.Replace(t, dut, gnmi.OC().Interface(intf).LoopbackMode().Config(), oc.Interfaces_LoopbackModeType_FACILITY)
+        gnmi.Await(t, dut, gnmi.OC().Interface(intf).LoopbackMode().State(), loopbackStateTimeout, oc.Interfaces_LoopbackModeType_FACILITY)
+
+        var bad bool
+        var i int
+
+        // Iterate up to 10 times to get a successful test.
+        for i = 1; i <= 10; i++ {
+                t.Logf("\n----- TestGNMIEthernetInDiscards: Iteration %v -----\n", i)
+                bad = false
+
+                // Read all the relevant counters initial values.
+                before := ReadCounters(t, dut, intf)
+
+                // Compute the expected counters after the test. Since
+                // we're seeing some discard traffic (1 or 2 per second) during
+                // normal operation on the Ondatra testbeds with loopback
+                // turned on, setting the number of packets to be sent larger
+                // so we can actually verify its those packets that we got.
+                expect := before
+                expect.outPkts += pktsPer
+                expect.outOctets += pktsPer * 64
+                expect.outUnicastPkts += pktsPer
+                expect.inPkts += pktsPer
+                expect.inOctets += pktsPer * 64
+                expect.inUnicastPkts += pktsPer
+                expect.inDiscards += pktsPer
+
+                // Construct a simple IPv4 packet that will get discarded.  In
+                // offline testing, setting the IP protocol field to zero
+                // worked to cause a discard on ingest.
+                eth := &layers.Ethernet{
+                        SrcMAC:       net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+                        DstMAC:       net.HardwareAddr{0x00, 0x1A, 0x11, 0x17, 0x5F, 0x80},
+                        EthernetType: layers.EthernetTypeIPv4,
+                }
+
+                ip := &layers.IPv4{
+                        Version:  4,
+                        TTL:      0,
+                        Protocol: layers.IPProtocol(0),
+                        SrcIP:    net.ParseIP("100.0.0.1").To4(),
+                        DstIP:    net.ParseIP("200.0.0.1").To4(),
+                }
+
+                buf := gopacket.NewSerializeBuffer()
+
+                // Enable reconstruction of length and checksum fields based on packet headers.
+                opts := gopacket.SerializeOptions{
+                        FixLengths:       true,
+                        ComputeChecksums: true,
+                }
+
+                if err := gopacket.SerializeLayers(buf, opts, eth, ip); err != nil {
+                        t.Fatalf("Failed to serialize packet (%v)", err)
+                }
+
+                packetOut := &testhelper.PacketOut{
+                        EgressPort: intf,
+                        Count:      uint(pktsPer),
+                        Interval:   1 * time.Millisecond,
+                        Packet:     buf.Bytes(),
+                }
+
+                p4rtClient, err := testhelper.FetchP4RTClient(t, dut, dut.RawAPIs().P4RT(t), nil)
+                if err != nil {
+                        t.Fatalf("Failed to create P4RT client: %v", err)
+                }
+                if err := p4rtClient.SendPacketOut(t, packetOut); err != nil {
+                        t.Fatalf("SendPacketOut operation failed for %+v (%v)", packetOut, err)
+                }
+
+                // Sleep for enough time that the counters are polled after the
+                // transmit completes sending bytes.
+                time.Sleep(counterUpdateDelay)
+
+                // Read all the relevant counters again.
+                after := ReadCounters(t, dut, intf)
+
+                if after != expect {
+                        ShowCountersDelta(t, before, after, expect)
+                        bad = true
+                }
+
+                if !bad {
+                        break
+                }
+        }
+
+        if bad {
+                t.Fatalf("\n\n----- TestGNMIEthernetInDiscards: FAILED after %v Iterations -----\n\n", i-1)
+        }
+
+        t.Logf("\n\n----- TestGNMIEthernetInDiscards: SUCCESS after %v Iteration(s) -----\n\n", i)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

- [sdn_tests]: Adding Ethernet Counter In-Discards Check test to pins_ondatra.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

- Added Ethernet Counter In-Discards Check test to pins_ondatra.

### Build Results:

> INFO: From Generating Descriptor Set proto_library @com_github_openconfig_gnsi//credentialz:credentialz_proto:
> github.com/openconfig/gnsi/credentialz/credentialz.proto:21:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
> INFO: From Generating Descriptor Set proto_library @com_github_openconfig_gnsi//pathz:pathz_proto:
> github.com/openconfig/gnsi/pathz/authorization.proto:43:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
> github.com/openconfig/gnsi/pathz/pathz.proto:25:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
> INFO: Elapsed time: 319.016s, Critical Path: 124.45s
> INFO: 975 processes: 251 internal, 724 linux-sandbox.
> INFO: Build completed successfully, 975 total actions

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [-] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

- HLD - SDN Test framework for SONiC - https://github.com/sonic-net/sonic-mgmt/pull/11771

<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
