### PR TITLE
Modified the checking of line[0] of the output of show int transceiver lpmode

### DIFF
--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -76,7 +76,7 @@ def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     portmap, dev_conn = get_dev_conn(
         duthost, conn_graph_facts, enum_frontend_asic_index)
-    sfp_lpmode = duthost.command(cmd_sfp_lpmode)
+    sfp_lpmode = duthost.command(cmd_sfp_lpmode)['stdout']
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
             assert validate_transceiver_lpmode(

--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -76,7 +76,7 @@ def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     portmap, dev_conn = get_dev_conn(
         duthost, conn_graph_facts, enum_frontend_asic_index)
-    sfp_lpmode = duthost.command(cmd_sfp_lpmode)['stdout']
+    sfp_lpmode = duthost.command(cmd_sfp_lpmode)
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
             assert validate_transceiver_lpmode(

--- a/tests/platform_tests/sfp/util.py
+++ b/tests/platform_tests/sfp/util.py
@@ -50,9 +50,8 @@ def get_dev_conn(duthost, conn_graph_facts, asic_index):
 def validate_transceiver_lpmode(output):
     lines = output.strip().split('\n')
     # Check if the header is present
-    if lines[0].strip() != "Port         Low-power Mode":
-        logging.error("Invalid output format: Header missing. "
-                      "Current header is {}".format(lines[0].strip()))
+    if lines[0].replace(" ", "") != "Port        Low-power Mode".replace(" ", ""):
+        logging.error("Invalid output format: Header missing")
         return False
     for line in lines[2:]:
         port, lpmode = line.strip().split()


### PR DESCRIPTION
### Description of PR
Modified the checking of line[0] of the output of show int transceiver lpmode

```
show int transceiver lpmode
Port         Low-power Mode
```
The number of spaces between "Port" and "Low" are not constant.
It will change depending on how many letters and numbers are in the interfaces name. 
such as Ethernet2, Ethernet20, Ethernet200 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To remove all spaces on the first line (Port         Low-power Mode) of output of "show int transceiver lpmode". These spaces could change.

#### How did you do it?
 Modified the checking of line[0] since the number of spaces could change

#### How did you verify/test it?
Tested the testcase on a multi cards multi Asics chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
