### PR TITLE
Fix ASIC check on Non-SONiC leaf fanout

### DIFF
--- a/tests/iface_loopback_action/conftest.py
+++ b/tests/iface_loopback_action/conftest.py
@@ -234,8 +234,6 @@ def is_sonic_mlnx_leaf_fanout(fanouthosts):
     More info https://github.com/sonic-net/SONiC/blob/master/doc/tpid/SonicTPIDSettingHLD1.md
     """
     for fanouthost in list(fanouthosts.values()):
-        os = fanouthost.get_fanout_os()
-        asic_type = fanouthost.facts['asic_type']
-        if os == 'sonic' and asic_type in ["mellanox"]:
+        if fanouthost.get_fanout_os() == 'sonic' and fanouthost.facts['asic_type'] == "mellanox":
             return True
     return False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix an issue brought by PR https://github.com/sonic-net/sonic-mgmt/pull/12931.
```
>       raise AttributeError(
            "'%s' object has no attribute '%s'" % (self.__class__, module_name)
            )
E       AttributeError: '<class 'tests.common.devices.eos.EosHost'>' object has no attribute 'facts'
```
The issue is because if the leaf fanout is not running SONiC, then the host has no attribute `facts`.
This PR addressed the issue by checking OS first and the ASIC check is bypassed if OS is not SONiC.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
This PR is to fix an issue caused by PR https://github.com/sonic-net/sonic-mgmt/pull/12931.

#### How did you do it?
This PR addressed the issue by checking OS first and the ASIC check is bypassed if OS is not SONiC.

#### How did you verify/test it?
The change is verified on a physical testbed **without** leaf fanout running SONiC.
```
collected 1 item                                                                                                                                                                                      

iface_loopback_action/test_iface_loopback_action.py::test_loopback_action_basic  ^HPASSED                                                                                                          [100%]
```
#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
