### PR TITLE
Use lldp0/lldp1 instead of lldp, since container lldp was removed from the host

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -64,17 +64,18 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost,
 
 
 def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_duts,
-                        enum_frontend_asic_index, tbinfo, request):
+                        enum_rand_one_frontend_asic_index, tbinfo, request):
     """ verify LLDP information on neighbors """
+    asic = enum_rand_one_frontend_asic_index
 
     res = duthost.shell(
-        "docker exec -i lldp lldpcli show chassis | grep \"SysDescr:\" | sed -e 's/^\\s*SysDescr:\\s*//g'")
+        "docker exec -i lldp{} lldpcli show chassis | grep \"SysDescr:\" | sed -e 's/^\\s*SysDescr:\\s*//g'".format(asic))
     dut_system_description = res['stdout']
     internal_port_list = get_dpu_npu_ports_from_hwsku(duthost)
     lldpctl_facts = duthost.lldpctl_facts(
-        asic_instance_id=enum_frontend_asic_index,
-        skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list)['ansible_facts']
-    config_facts = duthost.asic_instance(enum_frontend_asic_index).config_facts(host=duthost.hostname,
+        asic_instance_id=asic,
+        skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"])['ansible_facts']
+    config_facts = duthost.asic_instance(asic).config_facts(host=duthost.hostname,
                                                                                 source="running")['ansible_facts']
     if not list(lldpctl_facts['lldpctl'].items()):
         pytest.fail("No LLDP neighbors received (lldpctl_facts are empty)")

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -76,8 +76,7 @@ def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_
     lldpctl_facts = duthost.lldpctl_facts(
         asic_instance_id=asic,
         skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"])['ansible_facts']
-    config_facts = duthost.asic_instance(asic).config_facts(host=duthost.hostname,
-                                                                                source="running")['ansible_facts']
+    config_facts = duthost.asic_instance(asic).config_facts(host=duthost.hostname, source="running")['ansible_facts']
     if not list(lldpctl_facts['lldpctl'].items()):
         pytest.fail("No LLDP neighbors received (lldpctl_facts are empty)")
     # We use the MAC of mgmt port to generate chassis ID as LLDPD dose.

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -70,7 +70,7 @@ def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_
 
     res = duthost.shell(
         "docker exec -i lldp{} lldpcli show chassis | grep \"SysDescr:\" | sed -e 's/^\\s*SysDescr:\\s*//g'".format(
-            asic))
+            '' if asic is None else asic))
     dut_system_description = res['stdout']
     internal_port_list = get_dpu_npu_ports_from_hwsku(duthost)
     lldpctl_facts = duthost.lldpctl_facts(

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -69,7 +69,8 @@ def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_
     asic = enum_rand_one_frontend_asic_index
 
     res = duthost.shell(
-        "docker exec -i lldp{} lldpcli show chassis | grep \"SysDescr:\" | sed -e 's/^\\s*SysDescr:\\s*//g'".format(asic))
+        "docker exec -i lldp{} lldpcli show chassis | grep \"SysDescr:\" | sed -e 's/^\\s*SysDescr:\\s*//g'".format(
+            asic))
     dut_system_description = res['stdout']
     internal_port_list = get_dpu_npu_ports_from_hwsku(duthost)
     lldpctl_facts = duthost.lldpctl_facts(

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -75,7 +75,7 @@ def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_
     internal_port_list = get_dpu_npu_ports_from_hwsku(duthost)
     lldpctl_facts = duthost.lldpctl_facts(
         asic_instance_id=asic,
-        skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"])['ansible_facts']
+        skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list)['ansible_facts']
     config_facts = duthost.asic_instance(asic).config_facts(host=duthost.hostname, source="running")['ansible_facts']
     if not list(lldpctl_facts['lldpctl'].items()):
         pytest.fail("No LLDP neighbors received (lldpctl_facts are empty)")


### PR DESCRIPTION

### Description of PR
test_lldp_neighbor testcase fails since container lldp was removed form the host

admin@ixre-board7:~$ docker exec -i lldp lldpcli show chassis
Error response from daemon: No such container: lldp

for this reason, we will test either lldp0 or lldp1 based on randomly selected Asic.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
since container lldp was removed from the host, we will test on lldp0 or lldp1 to test the test_lldp_neighbor testcase.

#### How did you do it?
Use enum_rand_one_frontend_asic_index to randomly select an Asic index
Use the Asic index to select either lldp0 or lldp1

#### How did you verify/test it?
Tested on a multi cards multi Asics chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
