### PR TITLE
Skip soft-reboot on all platforms except Dell s6100 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -863,6 +863,10 @@ platform_tests/test_reboot.py::test_soft_reboot:
     reason: "Skip test_soft_reboot for m0/mx"
     conditions:
       - "topo_type in ['m0', 'mx']"
+  skip:
+    reason: "test_soft_reboot is only supported on S6100 platform"
+    conditions:
+      - "hwsku not in ['Force10-S6100']"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -860,13 +860,9 @@ platform_tests/test_reboot.py::test_fast_reboot:
 
 platform_tests/test_reboot.py::test_soft_reboot:
   skip:
-    reason: "Skip test_soft_reboot for m0/mx"
+    reason: "Skip test_soft_reboot for m0/mx and test is supported only on S6100 hwsku"
     conditions:
-      - "topo_type in ['m0', 'mx']"
-  skip:
-    reason: "test_soft_reboot is only supported on S6100 platform"
-    conditions:
-      - "hwsku not in ['Force10-S6100']"
+      - "topo_type in ['m0', 'mx'] or hwsku not in ['Force10-S6100']"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -192,10 +192,6 @@ def test_soft_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
     if duthost.is_multi_asic:
         pytest.skip("Multi-ASIC devices not supporting soft reboot")
 
-    if "s6100" not in duthost.facts['platform']:
-        pytest.skip("Soft-reboot is not supported on this {} platform, skip this test case"
-                    .format(duthost.facts['platform']))
-
     reboot_and_check(localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
                      xcvr_skip_list, reboot_type=REBOOT_TYPE_SOFT, duthosts=duthosts)
 

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -192,6 +192,10 @@ def test_soft_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
     if duthost.is_multi_asic:
         pytest.skip("Multi-ASIC devices not supporting soft reboot")
 
+    if "s6100" not in duthost.facts['platform']:
+        pytest.skip("Soft-reboot is not supported on this {} platform, skip this test case"
+                    .format(duthost.facts['platform']))
+
     reboot_and_check(localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
                      xcvr_skip_list, reboot_type=REBOOT_TYPE_SOFT, duthosts=duthosts)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip soft-reboot test on all the platforms except Dell s6100 platform.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Soft-reboot is only supported on Dell s6100 platform

#### How did you do it?
Skip the soft-reboot test if platform is not s6100

#### How did you verify/test it?
==================================================================== short test summary info =====================================================================
SKIPPED [1] platform_tests/test_reboot.py: Skip test_soft_reboot for m0/mx and test is supported only on S6100 hwsku
================================================================= 1 skipped, 1 warning in 40.04s =================================================================

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
