### PR TITLE
Stabilize setup_tacacs_client

### DIFF
--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -5,6 +5,7 @@ import os
 import pytest
 import re
 import yaml
+import time
 
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.utilities import wait_until, check_skip_release, delete_running_config
@@ -77,14 +78,21 @@ def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip,
     """setup tacacs client"""
 
     # UT should failed when set reachable TACACS server with this setup_tacacs_client
-    ping_result = duthost.shell("ping {} -c 1 -W 3".format(tacacs_server_ip))['stdout']
-    logger.info("TACACS server ping result: {}".format(ping_result))
-    if "100% packet loss" in ping_result:
-        # collect more information for debug testbed network issue
-        duthost_interface = duthost.shell("sudo ifconfig eth0")['stdout']
-        ptfhost_interface = ptfhost.shell("ifconfig mgmt")['stdout']
-        logger.debug("PTF IPV6 address not reachable, dut interfaces: {}, ptfhost interfaces:{}"
-                     .format(duthost_interface, ptfhost_interface))
+    retry = 5
+    while retry > 0:
+        ping_result = duthost.shell("ping {} -c 1 -W 3".format(tacacs_server_ip), module_ignore_errors=True)['stdout']
+        logger.info("TACACS server ping result: {}".format(ping_result))
+        if "100% packet loss" in ping_result:
+            # collect more information for debug testbed network issue
+            duthost_interface = duthost.shell("sudo ifconfig eth0")['stdout']
+            ptfhost_interface = ptfhost.shell("ifconfig mgmt")['stdout']
+            logger.debug("PTF IPV6 address not reachable, dut interfaces: {}, ptfhost interfaces:{}"
+                         .format(duthost_interface, ptfhost_interface))
+            time.sleep(5)
+            retry -= 1
+        else:
+            break
+    if retry == 0:
         pytest_assert(False, "TACACS server not reachable: {}".format(ping_result))
 
     # configure tacacs client


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
We are seeing unstable test result in `test_ro_user_ipv6_only` with below error.
```
failed on setup with "tests.common.errors.RunAnsibleModuleFail: run module shell failed, Ansible Results =>
{"changed": true, "cmd": "ping 2603:x -c 1 -W 3", "delta": "0:00:03.016826", "end": "2024-06-05 21:51:23.791447", "failed": true, "msg": "non-zero return code", "rc": 1, "start": "2024-06-05 21:51:20.774621", "stderr": "", "stderr_lines": [], "stdout": "PING 2603:x(2603:x) 56 data bytes\n\n--- 2603:x ping statistics ---\n1 packets transmitted, 0 received, 100% packet loss, time 0ms", "stdout_lines": ["PING 2603:x(2603:x) 56 data bytes", "", "--- 2603:x ping statistics ---", "1 packets transmitted, 0 received, 100% packet loss, time 0ms"]}"
```
It's because the random packet drop between DUT and ptf container on some testbed.
```
--- 2603:x ping statistics ---
1000 packets transmitted, 909 received, +8 errors, 9.1% packet loss, time 205159ms
rtt min/avg/max/mdev = 0.260/0.429/4.158/0.182 ms
```
This PR improve the function by adding some retry (5 times).
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This test is to stabilize `setup_tacacs_client`.

#### How did you do it?
Add 5 retries in the ping test.

#### How did you verify/test it?
The change is verified on a physical testbed.
```
collected 1 item                                                                                                                                                                                      

ip/test_mgmt_ipv6_only.py::test_ro_user_ipv6_only[str-msn2700-02]  ^HPASSED                                                                                                                        [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
