### PR TITLE
Fix the issue where test_copp.py::TestCOPP::test_remove_trap is stuck on Cisco platform

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -148,6 +148,7 @@ class TestCOPP(object):
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         if (duthost.facts["hwsku"] == "Cisco-8111-O64" or
+                duthost.facts["hwsku"] == "Cisco-8101-O8C48" or
                 duthost.facts["hwsku"] == "Cisco-8102-C64"):
             logger.info("Sleep 120 seconds for Cisco platform")
             time.sleep(120)

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -147,6 +147,10 @@ class TestCOPP(object):
         4. Verify the trap status is uninstalled by sending traffic
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        if (duthost.facts["hwsku"] == "Cisco-8111-O64" or
+            duthost.facts["hwsku"] == "Cisco-8102-C64"):
+            logger.info("Sleep 120 seconds for Cisco platform")
+            time.sleep(120)
 
         if self.trap_id == "bgp":
             logger.info("Uninstall trap ip2me")

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -148,7 +148,7 @@ class TestCOPP(object):
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         if (duthost.facts["hwsku"] == "Cisco-8111-O64" or
-            duthost.facts["hwsku"] == "Cisco-8102-C64"):
+                duthost.facts["hwsku"] == "Cisco-8102-C64"):
             logger.info("Sleep 120 seconds for Cisco platform")
             time.sleep(120)
 

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -147,9 +147,7 @@ class TestCOPP(object):
         4. Verify the trap status is uninstalled by sending traffic
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        if (duthost.facts["hwsku"] == "Cisco-8111-O64" or
-                duthost.facts["hwsku"] == "Cisco-8101-O8C48" or
-                duthost.facts["hwsku"] == "Cisco-8102-C64"):
+        if (duthost.facts["asic_type"] == "cisco-8000"):
             logger.info("Sleep 120 seconds for Cisco platform")
             time.sleep(120)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test_copp.py::TestCOPP::test_remove_trap stuck in Cisco platform

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
test_copp.py::TestCOPP::test_remove_trap stuck in Cisco platform. It will make whole pipeline stall.

#### How did you do it?
Add sleep 120 seconds at the beginning of the test case.

#### How did you verify/test it?
Manually run the testcase for 10 times. All pass.
Run the entire pipeline for 3 times. All pass.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
