### PR TITLE
Fix gnmi client compatible issue

### DIFF
--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -35,7 +35,7 @@ def download_gnmi_client(duthosts, rand_one_dut_hostname, localhost):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost):
+def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost, ptfhost):
     '''
     Create GNMI client certificates
     '''
@@ -112,10 +112,16 @@ def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost):
                         -sha256"
     localhost.shell(local_command)
 
-    # Copy CA certificate and server certificate over to the DUT
+    # Copy CA certificate, server certificate and client certificate over to the DUT
     duthost.copy(src='gnmiCA.pem', dest='/etc/sonic/telemetry/')
     duthost.copy(src='gnmiserver.crt', dest='/etc/sonic/telemetry/')
     duthost.copy(src='gnmiserver.key', dest='/etc/sonic/telemetry/')
+    duthost.copy(src='gnmiclient.crt', dest='/etc/sonic/telemetry/')
+    duthost.copy(src='gnmiclient.key', dest='/etc/sonic/telemetry/')
+    # Copy CA certificate and client certificate over to the PTF
+    ptfhost.copy(src='gnmiCA.pem', dest='/root/')
+    ptfhost.copy(src='gnmiclient.crt', dest='/root/')
+    ptfhost.copy(src='gnmiclient.key', dest='/root/')
 
     create_checkpoint(duthost, SETUP_ENV_CP)
     apply_cert_config(duthost)

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -1,5 +1,4 @@
 import time
-import re
 import logging
 import pytest
 from tests.common.utilities import wait_until

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -107,6 +107,7 @@ def gnmi_capabilities(duthost, localhost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     ip = duthost.mgmt_ip
     port = env.gnmi_port
+    # Run gnmi_cli in gnmi container as workaround
     cmd = "docker exec %s gnmi_cli -client_types=gnmi -a %s:%s " % (env.gnmi_container, ip, port)
     cmd += "-client_crt /etc/sonic/telemetry/gnmiclient.crt "
     cmd += "-client_key /etc/sonic/telemetry/gnmiclient.key "
@@ -237,6 +238,7 @@ def gnoi_reboot(duthost, method, delay, message):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     ip = duthost.mgmt_ip
     port = env.gnmi_port
+    # Run gnoi_client in gnmi container as workaround
     cmd = "docker exec %s gnoi_client -target %s:%s " % (env.gnmi_container, ip, port)
     cmd += "-cert /etc/sonic/telemetry/gnmiclient.crt "
     cmd += "-key /etc/sonic/telemetry/gnmiclient.key "

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -108,9 +108,12 @@ def gnmi_capabilities(duthost, localhost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     ip = duthost.mgmt_ip
     port = env.gnmi_port
-    cmd = "gnmi/gnmi_cli -client_types=gnmi -a %s:%s " % (ip, port)
-    cmd += "-logtostderr -client_crt ./gnmiclient.crt -client_key ./gnmiclient.key -ca_crt ./gnmiCA.pem -capabilities"
-    output = localhost.shell(cmd, module_ignore_errors=True)
+    cmd = "docker exec %s gnmi_cli -client_types=gnmi -a %s:%s " % (env.gnmi_container, ip, port)
+    cmd += "-client_crt /etc/sonic/telemetry/gnmiclient.crt "
+    cmd += "-client_key /etc/sonic/telemetry/gnmiclient.key "
+    cmd += "-ca_crt /etc/sonic/telemetry/gnmiCA.pem "
+    cmd += "-logtostderr -capabilities"
+    output = duthost.shell(cmd, module_ignore_errors=True)
     if output['stderr']:
         dump_gnmi_log(duthost)
         dump_system_status(duthost)
@@ -120,60 +123,130 @@ def gnmi_capabilities(duthost, localhost):
         return 0, output['stdout']
 
 
-def gnmi_set(duthost, localhost, delete_list, update_list, replace_list):
+def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list):
+    """
+    Send GNMI set request with GNMI client
+
+    Args:
+        duthost: fixture for duthost
+        ptfhost: fixture for ptfhost
+        delete_list: list for delete operations
+        update_list: list for update operations
+        replace_list: list for replace operations
+
+    Returns:
+    """
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     ip = duthost.mgmt_ip
     port = env.gnmi_port
-    cmd = "gnmi/gnmi_set -target_addr %s:%s " % (ip, port)
-    cmd += "-alsologtostderr -cert ./gnmiclient.crt -key ./gnmiclient.key -ca ./gnmiCA.pem -time_out 60s"
-    for delete in delete_list:
-        cmd += " -delete " + delete
+    cmd = 'python2 /root/gnxi/gnmi_cli_py/py_gnmicli.py '
+    cmd += '--timeout 30 '
+    cmd += '-t %s -p %u ' % (ip, port)
+    cmd += '-xo sonic-db '
+    cmd += '-rcert /root/gnmiCA.pem '
+    cmd += '-pkey /root/gnmiclient.key '
+    cmd += '-cchain /root/gnmiclient.crt '
+    cmd += '-m set-update '
+    xpath = ''
+    xvalue = ''
+    for path in delete_list:
+        path = path.replace('sonic-db:', '')
+        xpath += ' ' + path
+        xvalue += ' ""'
     for update in update_list:
-        cmd += " -update " + update
+        update = update.replace('sonic-db:', '')
+        result = update.rsplit(':', 1)
+        xpath += ' ' + result[0]
+        xvalue += ' ' + result[1]
     for replace in replace_list:
-        cmd += " -replace " + replace
-    output = localhost.shell(cmd, module_ignore_errors=True)
+        replace = replace.replace('sonic-db:', '')
+        result = replace.rsplit(':', 1)
+        xpath += ' ' + result[0]
+        if '#' in result[1]:
+            xvalue += ' ""'
+        else:
+            xvalue += ' ' + result[1]
+    cmd += '--xpath ' + xpath
+    cmd += ' '
+    cmd += '--value ' + xvalue
+    output = ptfhost.shell(cmd, module_ignore_errors=True)
+    error = "GRPC error\n"
+    if error in output['stdout']:
+        dump_gnmi_log(duthost)
+        dump_system_status(duthost)
+        result = output['stdout'].split(error, 1)
+        raise Exception("GRPC error:" + result[1])
     if output['stderr']:
         dump_gnmi_log(duthost)
         dump_system_status(duthost)
-        verify_tcp_port(localhost, ip, port)
-        return -1, output['stderr']
+        raise Exception("error:" + output['stderr'])
     else:
-        return 0, output['stdout']
+        return
 
 
-def gnmi_get(duthost, localhost, path_list):
+def gnmi_get(duthost, ptfhost, path_list):
+    """
+    Send GNMI get request with GNMI client
+
+    Args:
+        duthost: fixture for duthost
+        ptfhost: fixture for ptfhost
+        path_list: list for get path
+
+    Returns:
+        msg_list: list for get result
+    """
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     ip = duthost.mgmt_ip
     port = env.gnmi_port
-    cmd = "gnmi/gnmi_get -target_addr %s:%s " % (ip, port)
-    cmd += "-alsologtostderr -cert ./gnmiclient.crt -key ./gnmiclient.key -ca ./gnmiCA.pem"
+    cmd = 'python2 /root/gnxi/gnmi_cli_py/py_gnmicli.py '
+    cmd += '--timeout 30 '
+    cmd += '-t %s -p %u ' % (ip, port)
+    cmd += '-xo sonic-db '
+    cmd += '-rcert /root/gnmiCA.pem '
+    cmd += '-pkey /root/gnmiclient.key '
+    cmd += '-cchain /root/gnmiclient.crt '
+    cmd += '--encoding 4 '
+    cmd += '-m get '
+    cmd += '--xpath '
     for path in path_list:
-        cmd += " -xpath " + path
-    output = localhost.shell(cmd, module_ignore_errors=True)
+        path = path.replace('sonic-db:', '')
+        cmd += " " + path
+    output = ptfhost.shell(cmd, module_ignore_errors=True)
     if output['stderr']:
-        dump_gnmi_log(duthost)
-        dump_system_status(duthost)
-        verify_tcp_port(localhost, ip, port)
-        return -1, [output['stderr']]
+        raise Exception("error:" + output['stderr'])
     else:
         msg = output['stdout'].replace('\\', '')
-        find_list = re.findall(r'json_ietf_val:\s*"(.*?)"\s*>', msg)
-        if find_list:
-            return 0, find_list
+        error = "GRPC error\n"
+        if error in msg:
+            dump_gnmi_log(duthost)
+            dump_system_status(duthost)
+            result = msg.split(error, 1)
+            raise Exception("GRPC error:" + result[1])
+        mark = 'The GetResponse is below\n' + '-'*25 + '\n'
+        if mark in msg:
+            result = msg.split(mark, 1)
+            msg_list = result[1].split('-'*25)[0:-1]
+            return [msg.strip("\n") for msg in msg_list]
         else:
-            return -1, [msg]
+            dump_gnmi_log(duthost)
+            dump_system_status(duthost)
+            raise Exception("error:" + msg)
 
 
-def gnoi_reboot(duthost, localhost, method, delay, message):
+def gnoi_reboot(duthost, method, delay, message):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     ip = duthost.mgmt_ip
     port = env.gnmi_port
-    cmd = "gnmi/gnoi_client -target %s:%s " % (ip, port)
-    cmd += "-logtostderr -cert ./gnmiclient.crt -key ./gnmiclient.key -ca ./gnmiCA.pem -rpc Reboot "
+    cmd = "docker exec %s gnoi_client -target %s:%s " % (env.gnmi_container, ip, port)
+    cmd += "-cert /etc/sonic/telemetry/gnmiclient.crt "
+    cmd += "-key /etc/sonic/telemetry/gnmiclient.key "
+    cmd += "-ca /etc/sonic/telemetry/gnmiCA.pem "
+    cmd += "-logtostderr -rpc Reboot "
     cmd += '-jsonin "{\\\"method\\\":%d, \\\"delay\\\":%d, \\\"message\\\":\\\"%s\\\"}"' % (method, delay, message)
-    output = localhost.shell(cmd, module_ignore_errors=True)
+    output = duthost.shell(cmd, module_ignore_errors=True)
     if output['stderr']:
+        logger.error(output['stderr'])
         return -1, output['stderr']
     else:
         return 0, output['stdout']

--- a/tests/gnmi/test_gnmi_appldb.py
+++ b/tests/gnmi/test_gnmi_appldb.py
@@ -24,7 +24,7 @@ def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
     ptfhost.copy(src=file_name, dest='/root')
     # Add DASH_VNET_TABLE
     update_list = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE:@/root/%s" % (file_name)]
-    msg = gnmi_set(duthost, ptfhost, [], update_list, [])
+    gnmi_set(duthost, ptfhost, [], update_list, [])
     # Check gnmi_get result
     path_list1 = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE/Vnet1/vni"]
     path_list2 = ["/sonic-db:APPL_DB/localhost/_DASH_VNET_TABLE/Vnet1/vni"]
@@ -44,7 +44,7 @@ def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
 
     # Remove DASH_VNET_TABLE
     delete_list = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE/Vnet1"]
-    msg = gnmi_set(duthost, ptfhost, delete_list, [], [])
+    gnmi_set(duthost, ptfhost, delete_list, [], [])
     # Check gnmi_get result
     path_list1 = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE/Vnet1/vni"]
     path_list2 = ["/sonic-db:APPL_DB/localhost/_DASH_VNET_TABLE/Vnet1/vni"]

--- a/tests/gnmi/test_gnmi_appldb.py
+++ b/tests/gnmi/test_gnmi_appldb.py
@@ -11,7 +11,7 @@ pytestmark = [
 ]
 
 
-def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, localhost):
+def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
     '''
     Verify GNMI native write with ApplDB
     Update DASH_VNET_TABLE
@@ -21,29 +21,42 @@ def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, localhost):
     text = "{\"Vnet1\": {\"vni\": \"1000\", \"guid\": \"559c6ce8-26ab-4193-b946-ccc6e8f930b2\"}}"
     with open(file_name, 'w') as file:
         file.write(text)
+    ptfhost.copy(src=file_name, dest='/root')
     # Add DASH_VNET_TABLE
-    update_list = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE:@./%s" % (file_name)]
-    ret, msg = gnmi_set(duthost, localhost, [], update_list, [])
-    assert ret == 0, msg
+    update_list = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE:@/root/%s" % (file_name)]
+    msg = gnmi_set(duthost, ptfhost, [], update_list, [])
     # Check gnmi_get result
     path_list1 = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE/Vnet1/vni"]
     path_list2 = ["/sonic-db:APPL_DB/localhost/_DASH_VNET_TABLE/Vnet1/vni"]
-    ret1, msg_list1 = gnmi_get(duthost, localhost, path_list1)
-    ret2, msg_list2 = gnmi_get(duthost, localhost, path_list2)
-    output = ""
-    if ret1 == 0:
+    try:
+        msg_list1 = gnmi_get(duthost, ptfhost, path_list1)
+    except Exception as e:
+        logger.info("Failed to read path1: " + str(e))
+    else:
         output = msg_list1[0]
-    if ret2 == 0:
+    try:
+        msg_list2 = gnmi_get(duthost, ptfhost, path_list2)
+    except Exception as e:
+        logger.info("Failed to read path2: " + str(e))
+    else:
         output = msg_list2[0]
     assert output == "\"1000\"", output
 
     # Remove DASH_VNET_TABLE
     delete_list = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE/Vnet1"]
-    ret, msg = gnmi_set(duthost, localhost, delete_list, [], [])
-    assert ret == 0, msg
+    msg = gnmi_set(duthost, ptfhost, delete_list, [], [])
     # Check gnmi_get result
     path_list1 = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE/Vnet1/vni"]
     path_list2 = ["/sonic-db:APPL_DB/localhost/_DASH_VNET_TABLE/Vnet1/vni"]
-    ret1, msg_list1 = gnmi_get(duthost, localhost, path_list1)
-    ret2, msg_list2 = gnmi_get(duthost, localhost, path_list2)
-    assert ret1 != 0 and ret2 != 0, msg_list1[0] + msg_list2[0]
+    try:
+        msg_list1 = gnmi_get(duthost, ptfhost, path_list1)
+    except Exception as e:
+        logger.info("Failed to read path1: " + str(e))
+    else:
+        pytest.fail("Remove DASH_VNET_TABLE failed: " + msg_list1[0])
+    try:
+        msg_list2 = gnmi_get(duthost, ptfhost, path_list2)
+    except Exception as e:
+        logger.info("Failed to read path2: " + str(e))
+    else:
+        pytest.fail("Remove DASH_VNET_TABLE failed: " + msg_list2[0])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Microsoft ADO: 28273229

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
GNMI end to end test is broken.
The root cause is:
GNMI end to end test copies gnmi client from gnmi container to sonic-mgmt container. We have upgraded gnmi container to bookworm, and then gnmi client is not compatible with sonic-mgmt container.

#### How did you do it?
Run gnmi_cli_py in ptf container to support GNMI set request and get request.
Run gnmi_cli in gnmi container to support GNMI capability request.
Run gnoi_client in gnmi container to support GNOI request. 

#### How did you verify/test it?
Run gnmi end to end test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
