### PR TITLE
Don't call expensive fixtures if skipping sanity

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -305,6 +305,5 @@ def sanity_check(request):
     if request.config.option.skip_sanity:
         logger.info("Skip sanity check according to command line argument")
         yield
-        return
     else:
-        return request.getfixturevalue('sanity_check_full')
+        yield request.getfixturevalue('sanity_check_full')

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -119,13 +119,8 @@ def do_checks(request, check_items, *args, **kwargs):
     return check_results
 
 
-@pytest.fixture(scope="module", autouse=True)
-def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
-    if request.config.option.skip_sanity:
-        logger.info("Skip sanity check according to command line argument")
-        yield
-        return
-
+@pytest.fixture(scope="module")
+def sanity_check_full(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
     logger.info("Prepare sanity check")
 
     skip_sanity = False
@@ -303,3 +298,13 @@ def sanity_check(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
         logger.info("Done post-test sanity check")
     else:
         logger.info('No post-test sanity check item, skip post-test sanity check.')
+
+
+@pytest.fixture(scope="module", autouse=True)
+def sanity_check(request):
+    if request.config.option.skip_sanity:
+        logger.info("Skip sanity check according to command line argument")
+        yield
+        return
+    else:
+        return request.getfixturevalue('sanity_check_full')


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

If the `--skip_sanity` option has been given, then don't call expensive fixtures and get the values of those fixtures just to end up not using them. Instead, have a small function that only gets the request fixture, and if sanity checks are not skipped, then call the full function that gets all fixtures.

This saves about 20-30 seconds of time.

#### How did you do it?

#### How did you verify/test it?

Verified with repeated runs of advanced reboot test case, to see that it actually does save time.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
