### PR TITLE
[202305]Skip voq test cases on Cisco 8800 (#13197)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1341,6 +1341,12 @@ vlan/test_vlan_ping.py:
 #######################################
 #####             voq             #####
 #######################################
+voq:
+  skip:
+    reason: "Cisco 8800 doesn't support voq tests"
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
 voq/test_fabric_reach.py:
   skip:
     reason: "Skip test_fabric_reach on unsupported testbed."


### PR DESCRIPTION
Skipped the VoQ test modules on Cisco8800 platform

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Skipped the VoQ test modules on Cisco8800 platform
#### How did you do it?

#### How did you verify/test it?
=============================================================================== short test summary info ================================================================================
SKIPPED [17] voq/test_voq_ipfwd.py: Cisco 8800 doesn't support voq tests
SKIPPED [16] voq/test_voq_ipfwd.py:614: Cisco 8800 doesn't support voq tests
SKIPPED [16] voq/test_voq_ipfwd.py:645: Cisco 8800 doesn't support voq tests
SKIPPED [16] voq/test_voq_ipfwd.py:682: Cisco 8800 doesn't support voq tests
SKIPPED [16] voq/test_voq_ipfwd.py:720: Cisco 8800 doesn't support voq tests
SKIPPED [16] voq/test_voq_ipfwd.py:764: Cisco 8800 doesn't support voq tests
SKIPPED [12] voq/test_voq_ipfwd.py:881: Cisco 8800 doesn't support voq tests
SKIPPED [4] voq/test_voq_ipfwd.py:923: Cisco 8800 doesn't support voq tests
SKIPPED [4] voq/test_voq_ipfwd.py:1013: Cisco 8800 doesn't support voq tests
SKIPPED [20] voq/test_voq_ipfwd.py:1155: Cisco 8800 doesn't support voq tests
========================================================================== 137 skipped, 4 warnings in 47.96s ===========================================================================
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
