### PR TITLE
Ignore received packets that weren't sent during examine_flow

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -2005,10 +2005,10 @@ class ReloadTest(BaseTest):
                     prev_pkt_pt = prev_payload + 1
                     prev_sent_packet_time = None
                     while prev_pkt_pt < received_payload:
-                        try:
+                        if prev_pkt_pt in sent_packets:
                             prev_sent_packet_time = sent_packets[prev_pkt_pt]
                             break  # Found it
-                        except KeyError:
+                        else:
                             if prev_pkt_pt not in received_but_not_sent_packets:
                                 missing_sent_and_received_pkt_count += 1
                             prev_pkt_pt += 1

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1951,6 +1951,7 @@ class ReloadTest(BaseTest):
             prev_payload, prev_time = 0, 0
             sent_payload = 0
             received_counter = 0    # Counts packets from dut.
+            received_but_not_sent_packets = set()
             sent_counter = 0
             received_t1_to_vlan = 0
             received_vlan_to_t1 = 0
@@ -1985,31 +1986,56 @@ class ReloadTest(BaseTest):
                     prev_time = received_time
                     continue
                 if received_payload - prev_payload > 1:
-                    # Packets in a row are missing, a disruption.
+                    if received_payload not in sent_packets:
+                        self.log("Ignoring received packet with payload {}, as it was not sent".format(
+                            received_payload))
+                        received_but_not_sent_packets.add(received_payload)
+                        continue
+                    # Packets in a row are missing, a potential disruption.
                     self.log("received_payload: {}, prev_payload: {}, sent_counter: {}, received_counter: {}".format(
                         received_payload, prev_payload, sent_counter, received_counter))
                     # How many packets lost in a row.
                     lost_id = (received_payload - 1) - prev_payload
-                    # How long disrupt lasted.
-                    disrupt = (
-                        sent_packets[received_payload] - sent_packets[prev_payload + 1])
-                    # Add disrupt to the dict:
-                    self.lost_packets[prev_payload] = (
-                        lost_id, disrupt, received_time - disrupt, received_time)
-                    self.log("Disruption between packet ID %d and %d. For %.4f " % (
-                        prev_payload, received_payload, disrupt))
-                    for lost_index in range(prev_payload + 1, received_payload):
-                        # lost received for packet sent from vlan to T1.
-                        if (lost_index % 5) == 0:
-                            missed_vlan_to_t1 += 1
-                        else:
-                            missed_t1_to_vlan += 1
-                    self.log("")
-                    if not self.disruption_start:
-                        self.disruption_start = datetime.datetime.fromtimestamp(
-                            prev_time)
-                    self.disruption_stop = datetime.datetime.fromtimestamp(
-                        received_time)
+
+                    # Find previous sequential sent packet that was captured
+                    missing_sent_and_received_packet_ids = []
+                    prev_pkt_pt = prev_payload + 1
+                    prev_sent_packet_time = None
+                    while prev_pkt_pt < received_payload:
+                        try:
+                            prev_sent_packet_time = sent_packets[prev_pkt_pt]
+                            break  # Found it
+                        except KeyError:
+                            if prev_pkt_pt not in received_but_not_sent_packets:
+                                missing_sent_and_received_packet_ids.append(prev_pkt_pt)
+                            prev_pkt_pt += 1
+                    if missing_sent_and_received_packet_ids:
+                        self.log("Missing sent and received packets: {}".format(missing_sent_and_received_packet_ids))
+                    if prev_sent_packet_time is not None:
+                        # Disruption occurred - some sent packets were not received
+
+                        # How long disrupt lasted.
+                        this_sent_packet_time = sent_packets[received_payload]
+                        disrupt = this_sent_packet_time - prev_sent_packet_time
+
+                        # Add disrupt to the dict:
+                        self.lost_packets[prev_payload] = (
+                            lost_id, disrupt, received_time - disrupt, received_time)
+                        self.log("Disruption between packet ID %d and %d. For %.4f " % (
+                            prev_payload, received_payload, disrupt))
+                        for lost_index in range(prev_payload + 1, received_payload):
+                            # lost received for packet sent from vlan to T1.
+                            if lost_index in sent_packets:
+                                if (lost_index % 5) == 0:
+                                    missed_vlan_to_t1 += 1
+                                else:
+                                    missed_t1_to_vlan += 1
+                        self.log("")
+                        if not self.disruption_start:
+                            self.disruption_start = datetime.datetime.fromtimestamp(
+                                prev_time)
+                        self.disruption_stop = datetime.datetime.fromtimestamp(
+                            received_time)
                 prev_payload = received_payload
                 prev_time = received_time
             self.log(

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1951,7 +1951,7 @@ class ReloadTest(BaseTest):
         self.fails['dut'].clear()
         prev_payload = None
         if packets:
-            prev_payload, prev_time = 0, 0
+            prev_payload, prev_time = -1, 0
             sent_payload = 0
             received_counter = 0    # Counts packets from dut.
             received_but_not_sent_packets = set()


### PR DESCRIPTION
Attempts to process received packets that weren't sent resulted in a KeyError exception in the examine_flow disruption calculation. This commit ignores them.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Microsoft ADO: 27806353

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
The platform_tests.test_advanced_reboot.test_fast_reboot test was failing due to received packets that weren't sent.

#### How did you do it?

#### How did you verify/test it?
Modified the `examine_flow` function to run independently then tested the logic with a series of pcap files with various missing packets in the sequence. The cases included:

- 100 packets, happy path
- 100 packets, 0th packet receive missing
- 100 packets, 0th packet send missing
- 100 packets, 10th packet both missing, 11th packet both missing
- 100 packets, 10th packet both missing, 11th packet receive missing
- 100 packets, 10th packet both missing, 11th packet send missing
- 100 packets, 10th packet both missing
- 100 packets, 10th packet receive missing, 11th packet receive missing
- 100 packets, 10th packet receive missing, 11th packet send missing
- 100 packets, 10th packet receive missing
- 100 packets, 10th packet send missing, 11th packet receive missing
- 100 packets, 10th packet send missing, 11th packet send missing
- 100 packets, 10th packet send missing
- 100 packets, bunch of sad cases all in one:
    - pkt-10 both missing
    - pkt-15 send missing
    - pkt-20 receive missing
    - pkt-25 both missing, pkt-26 both missing
    - pkt-30 both missing, pkt-31 send missing
    - pkt-35 both missing, pkt-36 receive missing
    - pkt-45 receive missing, pkt-46 receive missing
    - pkt-55 receive missing, pkt-56 send missing
    - pkt-65 send missing, pkt-66 send missing
    - pkt-75 send missing, pkt-76 receive missing
- 100 packets, first 10 packets missing


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
