### PR TITLE
[sdn_tests]:Adding GNMI stress test to pins_ondatra.

### DIFF
--- a/sdn_tests/pins_ondatra/tests/gnmi_stress_test.go
+++ b/sdn_tests/pins_ondatra/tests/gnmi_stress_test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"sync"
 	"testing"
 	"time"
 
-        "github.com/sonic-net/sonic-mgmt/sdn_tests/pins_ondatra/infrastructure/binding/pinsbind"
-        "github.com/sonic-net/sonic-mgmt/sdn_tests/pins_ondatra/infrastructure/testhelper/testhelper"
-	gst "github.com/sonic-net/sonic-mgmt/sdn_tests/pins_ondatra/tests/ondatra/gnmi_stress_helper"
+	"github.com/sonic-net/sonic-mgmt/sdn_tests/pins_ondatra/infrastructure/binding/pinsbind"
+	"github.com/sonic-net/sonic-mgmt/sdn_tests/pins_ondatra/infrastructure/testhelper/testhelper"
+	gst "github.com/sonic-net/sonic-mgmt/sdn_tests/pins_ondatra/tests/gnmi_stress_helper"
 
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/ondatra"
@@ -23,11 +22,177 @@ func TestMain(m *testing.M) {
 	ondatra.RunTests(m, pinsbind.New)
 }
 
+// gNMI load test - Replacing a single leaf 100 times.
+func TestGNMILoadTest(t *testing.T) {
+	defer testhelper.NewTearDownOptions(t).WithID("f5e40be6-9913-4926-8d69-505e51f566f1").Teardown(t)
+	dut := ondatra.DUT(t, "DUT")
+	port, err := testhelper.RandomInterface(t, dut, nil)
+	if err != nil {
+		t.Fatalf("Failed to fetch random interface: %v", err)
+	}
+	oldMtu := gnmi.Get(t, dut, gnmi.OC().Interface(port).Mtu().Config())
+	gst.SanityCheck(t, dut, port)
+
+	for i := gst.MinMtuStepInc; i < gst.MaxMtuStepInc; i++ {
+		// Configure port MTU and verify that state path reflects configured MTU.
+		mtu := uint16(1500 + i)
+		gnmi.Replace(t, dut, gnmi.OC().Interface(port).Mtu().Config(), mtu)
+		gst.CollectPerformanceMetrics(t, dut)
+		got := gnmi.Get(t, dut, gnmi.OC().Interface(port).Mtu().Config())
+		if got != mtu {
+			t.Errorf("MTU matched failed! got:%v, want:%v", got, mtu)
+		}
+	}
+	t.Logf("After 10 seconds of idle time, the performance metrics are:")
+	time.Sleep(gst.IdleTime * time.Second)
+	gst.CollectPerformanceMetrics(t, dut)
+	// Replace the old MTU value as a test cleanup.
+	gnmi.Replace(t, dut, gnmi.OC().Interface(port).Mtu().Config(), oldMtu)
+	gst.SanityCheck(t, dut, port)
+
+}
+
 // gNMI load test short interval(30 minutes).
 func TestGNMIShortStressTest(t *testing.T) {
 	defer testhelper.NewTearDownOptions(t).WithID("44fa854f-5d85-42aa-9ad0-4ee8dbce7f10").Teardown(t)
 	dut := ondatra.DUT(t, "DUT")
 	gst.StressTestHelper(t, dut, gst.ShortStressTestInterval)
+	gst.SanityCheck(t, dut)
+}
+
+// gNMI broken client test
+func TestGNMIBrokenClientTest(t *testing.T) {
+	defer testhelper.NewTearDownOptions(t).WithID("cd36ba68-a2c1-485a-bc1a-c79463ed80d9").Teardown(t)
+	dut := ondatra.DUT(t, "DUT")
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	gst.SanityCheck(t, dut)
+	for i := 0; i < gst.MinIteration; i++ {
+		// Create getRequest message with ASCII encoding.
+		getRequest := &gpb.GetRequest{
+			Prefix: &gpb.Path{Origin: "openconfig", Target: dut.Name()},
+			Path: []*gpb.Path{{
+				Elem: []*gpb.PathElem{{
+					Name: "interfaces",
+				}},
+			}},
+			Type:     gpb.GetRequest_ALL,
+			Encoding: gpb.Encoding_PROTO,
+		}
+		t.Logf("GetRequest:\n%v", getRequest)
+
+		// Fetch get client using the raw gNMI client.
+		gnmiClient, err := dut.RawAPIs().BindingDUT().DialGNMI(context.Background(), grpc.WithBlock())
+		if err != nil {
+			t.Fatalf("Unable to get gNMI client (%v)", err)
+		}
+		getResp, err := gnmiClient.Get(ctx, getRequest)
+		if err == nil {
+			t.Logf("GetResponse:\n%v", getResp)
+			t.Fatalf("The getRequest is successfully received on broken client")
+		}
+		if getResp != nil {
+			t.Fatalf("getResponse is received successfully")
+		}
+	}
+	gst.SanityCheck(t, dut)
+}
+
+// gNMI different leaf get test
+func TestGNMIGetDifferentLeafTest(t *testing.T) {
+	defer testhelper.NewTearDownOptions(t).WithID("08f9ffba-54a9-4d47-a3dc-0e4420fe296b").Teardown(t)
+	dut := ondatra.DUT(t, "DUT")
+	gst.SanityCheck(t, dut)
+	rand.Seed(time.Now().Unix())
+	gst.CollectPerformanceMetrics(t, dut)
+	for i := 0; i < gst.AvgIteration; i++ {
+		port, err := testhelper.RandomInterface(t, dut, nil)
+		if err != nil {
+			t.Fatalf("Failed to fetch random interface: %v", err)
+		}
+		reqPath := fmt.Sprintf(gst.Path[rand.Intn(len(gst.Path))], port)
+		// Create Get Request.
+		sPath, err := ygot.StringToStructuredPath(reqPath)
+		if err != nil {
+			t.Fatalf("Unable to convert string to path (%v)", err)
+		}
+		paths := []*gpb.Path{sPath}
+
+		// Create getRequest message with data type.
+		getRequest := &gpb.GetRequest{
+			Prefix:   &gpb.Path{Origin: "openconfig", Target: dut.Name()},
+			Path:     paths,
+			Type:     gpb.GetRequest_ALL,
+			Encoding: gpb.Encoding_PROTO,
+		}
+		t.Logf("GetRequest:\n%v", getRequest)
+
+		// Fetch get client using the raw gNMI client.
+		ctx := context.Background()
+		gnmiClient, err := dut.RawAPIs().BindingDUT().DialGNMI(ctx, grpc.WithBlock())
+		if err != nil {
+			t.Fatalf("Unable to get gNMI client (%v)", err)
+		}
+		getResp, err := gnmiClient.Get(ctx, getRequest)
+		if err != nil {
+			t.Fatalf("Error while calling Get Raw API: (%v)", err)
+		}
+
+		if getResp == nil {
+			t.Fatalf("Get response is nil")
+		}
+		t.Logf("GetResponse:\n%v", getResp)
+		gst.CollectPerformanceMetrics(t, dut)
+	}
+	t.Logf("After 10 seconds of idle time, the performance metrics are:")
+	time.Sleep(gst.IdleTime * time.Second)
+	gst.CollectPerformanceMetrics(t, dut)
+	gst.SanityCheck(t, dut)
+}
+
+// gNMI different subtrees get test
+func TestGNMIGetDifferentSubtreeTest(t *testing.T) {
+	defer testhelper.NewTearDownOptions(t).WithID("357762b4-4d34-467e-b321-90a2d271d50d").Teardown(t)
+	dut := ondatra.DUT(t, "DUT")
+	gst.SanityCheck(t, dut)
+	rand.Seed(time.Now().Unix())
+	gst.CollectPerformanceMetrics(t, dut)
+	for i := 0; i < gst.MinIteration; i++ {
+		reqPath := gst.Subtree[rand.Intn(len(gst.Subtree))]
+		// Create Get Request.
+		sPath, err := ygot.StringToStructuredPath(reqPath)
+		if err != nil {
+			t.Fatalf("Unable to convert string to path (%v)", err)
+		}
+		// Create getRequest message with data type.
+		getRequest := &gpb.GetRequest{
+			Prefix:   &gpb.Path{Origin: "openconfig", Target: dut.Name()},
+			Path:     []*gpb.Path{sPath},
+			Type:     gpb.GetRequest_ALL,
+			Encoding: gpb.Encoding_PROTO,
+		}
+		t.Logf("GetRequest:\n%v", getRequest)
+
+		// Fetch get client using the raw gNMI client.
+		ctx := context.Background()
+		gnmiClient, err := dut.RawAPIs().BindingDUT().DialGNMI(ctx, grpc.WithBlock())
+		if err != nil {
+			t.Fatalf("Unable to get gNMI client (%v)", err)
+		}
+		getResp, err := gnmiClient.Get(ctx, getRequest)
+		if err != nil {
+			t.Fatalf("Error while calling Get Raw API: (%v)", err)
+		}
+
+		if getResp == nil {
+			t.Fatalf("Get response is nil")
+		}
+		t.Logf("GetResponse:\n%v", getResp)
+		gst.CollectPerformanceMetrics(t, dut)
+	}
+	t.Logf("After 10 seconds of idle time, the performance metrics are:")
+	time.Sleep(gst.IdleTime * time.Second)
+	gst.CollectPerformanceMetrics(t, dut)
 	gst.SanityCheck(t, dut)
 }
 

--- a/sdn_tests/pins_ondatra/tests/platforms_hardware_component_test.go
+++ b/sdn_tests/pins_ondatra/tests/platforms_hardware_component_test.go
@@ -2,6 +2,7 @@ package platforms_hardware_component_test
 
 import (
         "regexp"
+	"reflect"
         "testing"
         "time"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
- [sdn_tests]:Adding GNMI stress test to pins_ondatra.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
- Added GNMI stress test to pins_ondatra.

Build Result:
```
INFO: From Generating Descriptor Set proto_library @com_github_openconfig_gnsi//acctz:acctz_proto:
github.com/openconfig/gnsi/acctz/acctz.proto:36:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
INFO: From Generating Descriptor Set proto_library @com_github_openconfig_gnsi//certz:certz_proto:
github.com/openconfig/gnsi/certz/certz.proto:22:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
INFO: From Generating Descriptor Set proto_library @com_github_openconfig_gnsi//pathz:pathz_proto:
github.com/openconfig/gnsi/pathz/authorization.proto:43:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
github.com/openconfig/gnsi/pathz/pathz.proto:25:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
INFO: Elapsed time: 547.302s, Critical Path: 158.38s
INFO: 976 processes: 251 internal, 725 linux-sandbox.
INFO: Build completed successfully, 976 total actions

~/JUNE-10-2/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build tests:z_gnmi_stress_test 
INFO: Analyzed target //tests:z_gnmi_stress_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:z_gnmi_stress_test up-to-date:
  bazel-bin/tests/z_gnmi_stress_test_/z_gnmi_stress_test
INFO: Elapsed time: 29.864s, Critical Path: 29.50s
INFO: 9 processes: 1 internal, 8 linux-sandbox.
INFO: Build completed successfully, 9 total actions
~/JUNE-10-2/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build tests:platforms_hardware_component_test 
INFO: Analyzed target //tests:platforms_hardware_component_test (1 packages loaded, 4 targets configured).
INFO: Found 1 target...
Target //tests:platforms_hardware_component_test up-to-date:
  bazel-bin/tests/platforms_hardware_component_test_/platforms_hardware_component_test
INFO: Elapsed time: 12.169s, Critical Path: 11.48s
INFO: 9 processes: 3 internal, 6 linux-sandbox.
INFO: Build completed successfully, 9 total actions
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [-] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
- HLD - SDN Test framework for SONiC - https://github.com/sonic-net/sonic-mgmt/pull/11771