### PR TITLE
[pc]: Skip if there's not enough members in the VLAN

### DIFF
--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -241,9 +241,6 @@ def generate_port_config(duthost, tbinfo, most_common_port_speed):
     dut_hwsku = duthost.facts["hwsku"]
     number_of_lag_member = HWSKU_INTF_NUMBERS_DICT.get(dut_hwsku, DEAFULT_NUMBER_OF_MEMBER_IN_LAG)
 
-    if src_vlan_id == -1:
-        pytest.skip("No VLAN found with {} members up".format(number_of_lag_member))
-
     # Get id of vlan that concludes enough up ports as src_vlan_id, port in this vlan is used for testing
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
     port_status = cfg_facts["PORT"]
@@ -402,10 +399,7 @@ def most_common_port_speed(duthost):
     port_status = cfg_facts["PORT"]
     number_of_lag_member = HWSKU_INTF_NUMBERS_DICT.get(duthost.facts["hwsku"], DEAFULT_NUMBER_OF_MEMBER_IN_LAG)
     src_vlan_id = get_vlan_id(cfg_facts, number_of_lag_member)
-
-    if src_vlan_id == -1:
-        pytest.skip("No VLAN found with {} members up".format(number_of_lag_member))
-
+    pytest_require(src_vlan_id != -1, "Can't get usable vlan concluding enough member")
     src_vlan_members = cfg_facts["VLAN_MEMBER"]["Vlan{}".format(src_vlan_id)]
     # specific LAG interface from t0-56-po2vlan topo, which can't be tested
     src_vlan_members.pop('PortChannel201', None)

--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -241,6 +241,10 @@ def generate_port_config(duthost, tbinfo, most_common_port_speed):
     dut_hwsku = duthost.facts["hwsku"]
     number_of_lag_member = HWSKU_INTF_NUMBERS_DICT.get(dut_hwsku, DEAFULT_NUMBER_OF_MEMBER_IN_LAG)
 
+    if tbinfo["topo"] == "t0-8-lag" and number_of_lag_member > 15:
+        logger.info("Limiting to only 12 LAG members on t0-8-lag topo, since there are only 15 ports in the VLAN")
+        number_of_lag_member = 12
+
     # Get id of vlan that concludes enough up ports as src_vlan_id, port in this vlan is used for testing
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
     port_status = cfg_facts["PORT"]

--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -241,9 +241,8 @@ def generate_port_config(duthost, tbinfo, most_common_port_speed):
     dut_hwsku = duthost.facts["hwsku"]
     number_of_lag_member = HWSKU_INTF_NUMBERS_DICT.get(dut_hwsku, DEAFULT_NUMBER_OF_MEMBER_IN_LAG)
 
-    if tbinfo["topo"] == "t0-8-lag" and number_of_lag_member > 15:
-        logger.info("Limiting to only 12 LAG members on t0-8-lag topo, since there are only 15 ports in the VLAN")
-        number_of_lag_member = 12
+    if src_vlan_id == -1:
+        pytest.skip("No VLAN found with {} members up".format(number_of_lag_member))
 
     # Get id of vlan that concludes enough up ports as src_vlan_id, port in this vlan is used for testing
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
@@ -403,6 +402,10 @@ def most_common_port_speed(duthost):
     port_status = cfg_facts["PORT"]
     number_of_lag_member = HWSKU_INTF_NUMBERS_DICT.get(duthost.facts["hwsku"], DEAFULT_NUMBER_OF_MEMBER_IN_LAG)
     src_vlan_id = get_vlan_id(cfg_facts, number_of_lag_member)
+
+    if src_vlan_id == -1:
+        pytest.skip("No VLAN found with {} members up".format(number_of_lag_member))
+
     src_vlan_members = cfg_facts["VLAN_MEMBER"]["Vlan{}".format(src_vlan_id)]
     # specific LAG interface from t0-56-po2vlan topo, which can't be tested
     src_vlan_members.pop('PortChannel201', None)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

For the t0-8-lag topology, there are only 15 interfaces in the VLAN that will be up. This means that for topos where we want to test 16-member LAGs, this will be impossible.

#### How did you do it?

As a general fix, if there's not enough members in the VLAN, skip the test case. This was already being done in one place, but that line of code just needed to be copied to another fixture.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
