### PR TITLE
 ipv6_fixture needs to wait for all services to be up

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -17,6 +17,7 @@ from tests.common.utilities import wait_until
 from jinja2 import Template
 from netaddr import valid_ipv4, valid_ipv6
 from tests.common.mellanox_data import is_mellanox_device
+from tests.common.platform.processes_utils import wait_critical_processes
 
 
 logger = logging.getLogger(__name__)
@@ -753,6 +754,12 @@ def convert_and_restore_config_db_to_ipv6_only(duthosts):
             logger.info(f"config changed. Doing config reload for {duthost.hostname}")
             config_reload(duthost, wait=120)
     duthosts.reset()
+
+    for duthost in duthosts.nodes:
+        if config_db_modified[duthost.hostname]:
+            # Wait until all critical processes are up,
+            # especially snmpd as it needs to be up for SNMP status verification
+            wait_critical_processes(duthost)
 
     # Verify mgmt-interface status
     mgmt_intf_name = "eth0"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes MSFT ADO 28332318

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fix case error with the following error message:
` failed on setup with "Failed: <ipv6 address> not appeared in xxx netstat"`

On some physical testbed, the snmpd process took around 3 minutes to come up.
Current convert_and_restore_config_db_to_ipv6_only needs to check all process to be up before proceeding with SNMP checking.

#### How did you do it?

wait_critical_processes() checks for the critical process which includes snmpd.

#### How did you verify/test it?
Tested it locally.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
