### PR TITLE
Add TH5 ASIC type for QoS Tests

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -41,7 +41,7 @@ class QosBase:
     SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-56-lag", "t1-backend", "t1-28-lag", "t1-32-lag"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
     SUPPORTED_ASIC_LIST = ["pac", "gr", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "td3", "th3",
-                           "j2c+", "jr2"]
+                           "j2c+", "jr2", "th5"]
 
     BREAKOUT_SKUS = ['Arista-7050-QX-32S']
 


### PR DESCRIPTION
The TH5 ASIC type is being added to the qos base test file here so it can be properly identified during testing,
such as in the case of test_qos_sai.py.

Summary:
Fixes https://github.com/aristanetworks/sonic-qual.msft/issues/137

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Proper identification of the TH5 ASIC for qos tests.

#### How did you verify/test it?
Verified that the error "Cannot identify DUT ASIC type" no longer occurs when running test_qos_sai.py (the test advances beyond this point of failure now).