### PR TITLE
feat: add completeness level to BFD static route tests

### DIFF
--- a/tests/bfd/conftest.py
+++ b/tests/bfd/conftest.py
@@ -15,6 +15,11 @@ def pytest_addoption(parser):
     parser.addoption("--num_sessions_scale", action="store", default=128)
 
 
+@pytest.fixture(scope='module')
+def get_function_completeness_level(pytestconfig):
+    return pytestconfig.getoption("--completeness_level")
+
+
 @pytest.fixture(scope="function")
 def bfd_cleanup_db(request, duthosts, enum_supervisor_dut_hostname):
     orch_cpu_threshold = 10

--- a/tests/bfd/test_bfd_static_route.py
+++ b/tests/bfd/test_bfd_static_route.py
@@ -19,7 +19,13 @@ logger = logging.getLogger(__name__)
 
 
 class TestBfdStaticRoute(BfdBase):
-    TOTAL_ITERATIONS = 100
+    COMPLETENESS_TO_ITERATIONS = {
+        'debug': 1,
+        'basic': 10,
+        'confident': 50,
+        'thorough': 100,
+        'diagnose': 200,
+    }
 
     @pytest.fixture(autouse=True, scope="class")
     def modify_bfd_sessions(self, duthosts):
@@ -347,6 +353,7 @@ class TestBfdStaticRoute(BfdBase):
         tbinfo,
         get_src_dst_asic_and_duts,
         bfd_cleanup_db,
+        get_function_completeness_level,
         version,
     ):
         """
@@ -403,8 +410,13 @@ class TestBfdStaticRoute(BfdBase):
             ),
         )
 
+        completeness_level = get_function_completeness_level
+        if completeness_level is None:
+            completeness_level = "basic"
+
+        total_iterations = self.COMPLETENESS_TO_ITERATIONS[completeness_level]
         successful_iterations = 0  # Counter for successful iterations
-        for i in range(self.TOTAL_ITERATIONS):
+        for i in range(total_iterations):
             logger.info("Iteration {}".format(i))
 
             logger.info("BFD deletion on source dut")
@@ -492,7 +504,7 @@ class TestBfdStaticRoute(BfdBase):
 
         # Determine the success rate
         logger.info("successful_iterations: %d", successful_iterations)
-        success_rate = (successful_iterations / self.TOTAL_ITERATIONS) * 100
+        success_rate = (successful_iterations / total_iterations) * 100
 
         logger.info("Current success rate: %.2f%%", success_rate)
         # Check if the success rate is above the threshold (e.g., 98%)

--- a/tests/bfd/test_bfd_static_route.py
+++ b/tests/bfd/test_bfd_static_route.py
@@ -412,7 +412,7 @@ class TestBfdStaticRoute(BfdBase):
 
         completeness_level = get_function_completeness_level
         if completeness_level is None:
-            completeness_level = "basic"
+            completeness_level = "thorough"
 
         total_iterations = self.COMPLETENESS_TO_ITERATIONS[completeness_level]
         successful_iterations = 0  # Counter for successful iterations


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add completeness level config option to `test_bfd_static_route.py`, so we can dynamically adjust the iterations for `test_bfd_flap`

Summary:
Fixes # (issue) Microsoft ADO 28210614

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
I ran the `test_bfd_flap()` test case on a T2 chassis with a `--completeness_level` config option and can confirm it's working as expected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
