### PR TITLE
feat: cherry-pick bfd static route test to 202305

### DIFF
--- a/tests/bfd/bfd_base.py
+++ b/tests/bfd/bfd_base.py
@@ -1,0 +1,67 @@
+import logging
+import random
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+class BfdBase:
+    @pytest.fixture(scope="class", name="select_src_dst_dut_and_asic", params=(["multi_dut"]))
+    def select_src_dst_dut_and_asic(self, duthosts, request, tbinfo):
+        if (len(duthosts.frontend_nodes)) < 2:
+            pytest.skip("Don't have 2 frontend nodes - so can't run multi_dut tests")
+        # Random selection of dut indices based on number of front end nodes
+        dut_indices = random.sample(list(range(len(duthosts.frontend_nodes))), 2)
+        src_dut_index = dut_indices[0]
+        dst_dut_index = dut_indices[1]
+
+        # Random selection of source asic based on number of asics available on source dut
+        src_asic_index_selection = random.choice(
+            duthosts[src_dut_index].get_asic_namespace_list()
+        )
+        src_asic_index = src_asic_index_selection.split("asic")[1]
+
+        # Random selection of destination asic based on number of asics available on destination dut
+        dst_asic_index_selection = random.choice(
+            duthosts[dst_dut_index].get_asic_namespace_list()
+        )
+        dst_asic_index = dst_asic_index_selection.split("asic")[1]
+
+        yield {
+            "src_dut_index": src_dut_index,
+            "dst_dut_index": dst_dut_index,
+            "src_asic_index": int(src_asic_index),
+            "dst_asic_index": int(dst_asic_index),
+        }
+
+    @pytest.fixture(scope="class")
+    def get_src_dst_asic_and_duts(self, duthosts, select_src_dst_dut_and_asic):
+        logger.info("Printing select_src_dst_dut_and_asic")
+        logger.info(select_src_dst_dut_and_asic)
+
+        logger.info("Printing duthosts.frontend_nodes")
+        logger.info(duthosts.frontend_nodes)
+        src_dut = duthosts.frontend_nodes[select_src_dst_dut_and_asic["src_dut_index"]]
+        dst_dut = duthosts.frontend_nodes[select_src_dst_dut_and_asic["dst_dut_index"]]
+
+        logger.info("Printing source dut asics")
+        logger.info(src_dut.asics)
+        logger.info("Printing destination dut asics")
+        logger.info(dst_dut.asics)
+        src_asic = src_dut.asics[select_src_dst_dut_and_asic["src_asic_index"]]
+        dst_asic = dst_dut.asics[select_src_dst_dut_and_asic["dst_asic_index"]]
+
+        all_asics = [src_asic, dst_asic]
+        all_duts = [src_dut, dst_dut]
+
+        rtn_dict = {
+            "src_asic": src_asic,
+            "dst_asic": dst_asic,
+            "src_dut": src_dut,
+            "dst_dut": dst_dut,
+            "all_asics": all_asics,
+            "all_duts": all_duts,
+        }
+        rtn_dict.update(select_src_dst_dut_and_asic)
+        yield rtn_dict

--- a/tests/bfd/bfd_helpers.py
+++ b/tests/bfd/bfd_helpers.py
@@ -1,0 +1,477 @@
+import logging
+import re
+import sys
+import time
+
+import pytest
+
+from tests.common.utilities import wait_until
+from tests.platform_tests.cli import util
+
+logger = logging.getLogger(__name__)
+
+
+def select_src_dst_dut_with_asic(
+    request, get_src_dst_asic_and_duts, version
+):
+    logger.debug("Selecting source and destination DUTs with ASICs...")
+    # Random selection of dut & asic.
+    src_asic = get_src_dst_asic_and_duts["src_asic"]
+    dst_asic = get_src_dst_asic_and_duts["dst_asic"]
+    src_dut = get_src_dst_asic_and_duts["src_dut"]
+    dst_dut = get_src_dst_asic_and_duts["dst_dut"]
+
+    logger.info("Source Asic: %s", src_asic)
+    logger.info("Destination Asic: %s", dst_asic)
+    logger.info("Source dut: %s", src_dut)
+    logger.info("Destination dut: %s", dst_dut)
+
+    request.config.src_asic = src_asic
+    request.config.dst_asic = dst_asic
+    request.config.src_dut = src_dut
+    request.config.dst_dut = dst_dut
+
+    # Extracting static routes
+    if version == "ipv4":
+        static_route_command = "show ip route static"
+    elif version == "ipv6":
+        static_route_command = "show ipv6 route static"
+    else:
+        assert False, "Invalid version"
+
+    src_dut_static_route = src_dut.shell(static_route_command, module_ignore_errors=True)["stdout"]
+    if sys.version_info.major < 3:
+        src_dut_static_route_output = src_dut_static_route.encode("utf-8").strip().split("\n")
+    else:
+        src_dut_static_route_output = src_dut_static_route.strip().split("\n")
+
+    src_asic_routes = extract_routes(
+        src_dut_static_route_output, version
+    )
+    logger.info("Source asic routes, {}".format(src_asic_routes))
+    assert len(src_asic_routes) > 0, "static routes on source dut are empty"
+
+    dst_dut_static_route = dst_dut.shell(static_route_command, module_ignore_errors=True)["stdout"]
+    if sys.version_info.major < 3:
+        dst_dut_static_route_output = dst_dut_static_route.encode("utf-8").strip().split("\n")
+    else:
+        dst_dut_static_route_output = dst_dut_static_route.strip().split("\n")
+
+    dst_asic_routes = extract_routes(
+        dst_dut_static_route_output, version
+    )
+    logger.info("Destination asic routes, {}".format(dst_asic_routes))
+    assert len(dst_asic_routes) > 0, "static routes on destination dut are empty"
+
+    # Extracting nexthops
+    dst_dut_nexthops = (
+        extract_ip_addresses_for_backend_portchannels(
+            src_dut, src_asic, version
+        )
+    )
+    logger.info("Destination nexthops, {}".format(dst_dut_nexthops))
+    assert len(dst_dut_nexthops) != 0, "Destination Nexthops are empty"
+
+    src_dut_nexthops = (
+        extract_ip_addresses_for_backend_portchannels(
+            dst_dut, dst_asic, version
+        )
+    )
+    logger.info("Source nexthops, {}".format(src_dut_nexthops))
+    assert len(src_dut_nexthops) != 0, "Source Nexthops are empty"
+
+    # Picking a static route to delete correspinding BFD session
+    src_prefix = selecting_route_to_delete(
+        src_asic_routes, src_dut_nexthops.values()
+    )
+    logger.info("Source prefix: %s", src_prefix)
+    request.config.src_prefix = src_prefix
+    assert src_prefix is not None and src_prefix != "", "Source prefix not found"
+
+    dst_prefix = selecting_route_to_delete(
+        dst_asic_routes, dst_dut_nexthops.values()
+    )
+    logger.info("Destination prefix: %s", dst_prefix)
+    request.config.dst_prefix = dst_prefix
+    assert (
+        dst_prefix is not None and dst_prefix != ""
+    ), "Destination prefix not found"
+
+    return (
+        src_asic,
+        dst_asic,
+        src_dut,
+        dst_dut,
+        src_dut_nexthops,
+        dst_dut_nexthops,
+        src_prefix,
+        dst_prefix,
+    )
+
+
+def verify_bfd_state(dut, dut_nexthops, dut_asic, expected_bfd_state):
+    logger.info("Verifying BFD state on {} ".format(dut))
+    for nexthop in dut_nexthops:
+        current_bfd_state = extract_current_bfd_state(
+            nexthop, dut_asic.asic_index, dut
+        )
+        logger.info("current_bfd_state: {}".format(current_bfd_state))
+        logger.info("expected_bfd_state: {}".format(expected_bfd_state))
+        if current_bfd_state != expected_bfd_state:
+            return False
+    return True
+
+
+def verify_static_route(
+    request,
+    asic,
+    prefix,
+    dut,
+    expected_prefix_state,
+    version,
+):
+    # Verification of static route
+    if version == "ipv4":
+        command = "show ip route static"
+    elif version == "ipv6":
+        command = "show ipv6 route static"
+    else:
+        assert False, "Invalid version"
+
+    static_route = dut.shell(command, module_ignore_errors=True)["stdout"]
+    if sys.version_info.major < 3:
+        static_route_output = static_route.encode("utf-8").strip().split("\n")
+    else:
+        static_route_output = static_route.strip().split("\n")
+
+    asic_routes = extract_routes(static_route_output, version)
+    logger.info("Here are asic routes, {}".format(asic_routes))
+
+    if expected_prefix_state == "Route Removal":
+        if len(asic_routes) == 0 and request.config.interface_shutdown:
+            logger.info("asic routes are empty post interface shutdown")
+        else:
+            assert len(asic_routes) > 0, "static routes on source dut are empty"
+            assert (
+                prefix
+                not in asic_routes.get("asic{}".format(asic.asic_index), {}).keys()
+            ), "Prefix removal is not successful. Prefix being validated: {}.".format(
+                prefix
+            )
+    elif expected_prefix_state == "Route Addition":
+        assert (
+            prefix in asic_routes.get("asic{}".format(asic.asic_index), {}).keys()
+        ), "Prefix has not been added even though BFD is expected. Prefix: {}".format(
+            prefix
+        )
+
+
+def control_interface_state(dut, asic, interface, action):
+    int_status = dut.show_interface(
+        command="status", include_internal_intfs=True, asic_index=asic.asic_index
+    )["ansible_facts"]["int_status"][interface]
+    oper_state = int_status["oper_state"]
+    if action == "shutdown":
+        target_state = "down"
+    elif action == "startup":
+        target_state = "up"
+    else:
+        raise ValueError("Invalid action specified")
+
+    if oper_state != target_state:
+        command = "shutdown" if action == "shutdown" else "startup"
+        exec_cmd = (
+            "sudo ip netns exec asic{} config interface -n asic{} {} {}".format(
+                asic.asic_index, asic.asic_index, command, interface
+            )
+        )
+        logger.info("Command: {}".format(exec_cmd))
+        logger.info("Target state: {}".format(target_state))
+        dut.shell(exec_cmd)
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: dut.show_interface(
+                command="status",
+                include_internal_intfs=True,
+                asic_index=asic.asic_index,
+            )["ansible_facts"]["int_status"][interface]["oper_state"]
+            == target_state,
+        )
+    else:
+        raise ValueError("Invalid action specified")
+
+
+def check_bgp_status(request):
+    check_bgp = request.getfixturevalue("check_bgp")
+    results = check_bgp()
+    failed = [
+        result for result in results if "failed" in result and result["failed"]
+    ]
+    if failed:
+        pytest.fail(
+            "BGP check failed, not all BGP sessions are up. Failed: {}".format(failed)
+        )
+
+
+def selecting_route_to_delete(asic_routes, nexthops):
+    for asic in asic_routes:
+        for prefix in asic_routes[asic]:
+            nexthops_in_static_route_output = asic_routes[asic][prefix]
+            # If nexthops on source dut are same destination dut's interfaces, we are picking that static route
+            if sorted(nexthops_in_static_route_output) == sorted(nexthops):
+                time.sleep(2)
+                logger.info("Nexthops from static route output")
+                logger.info(sorted(nexthops_in_static_route_output))
+                logger.info("Given Nexthops")
+                logger.info(sorted(nexthops))
+                logger.info("Prefix")
+                logger.info(prefix)
+                return prefix
+
+
+def modify_all_bfd_sessions(dut, flag):
+    # Extracting asic count
+    cmd = "show platform summary"
+    logging.info("Verifying output of '{}' on '{}'...".format(cmd, dut.hostname))
+    summary_output_lines = dut.command(cmd)["stdout_lines"]
+    summary_dict = util.parse_colon_speparated_lines(summary_output_lines)
+    asic_count = int(summary_dict["ASIC Count"])
+
+    # Creating bfd.json, bfd0.json, bfd1.json, bfd2.json ...
+    for i in range(asic_count):
+        file_name = "config_db{}.json".format(i)
+        dut.shell("cp /etc/sonic/{} /etc/sonic/{}.bak".format(file_name, file_name))
+        if flag == "false":
+            command = """sed -i 's/"bfd": "true"/"bfd": "false"/' {}""".format(
+                "/etc/sonic/" + file_name
+            )
+        elif flag == "true":
+            command = """sed -i 's/"bfd": "false"/"bfd": "true"/' {}""".format(
+                "/etc/sonic/" + file_name
+            )
+        dut.shell(command)
+
+
+def extract_backend_portchannels(dut):
+    output = dut.show_and_parse("show int port -d all")
+    port_channel_dict = {}
+
+    for item in output:
+        if "BP" in item.get("ports", ""):
+            port_channel = item.get("team dev", "")
+            ports_with_status = [
+                port.strip()
+                for port in item.get("ports", "").split()
+                if "BP" in port
+            ]
+            ports = [
+                (
+                    re.match(r"^([\w-]+)\([A-Za-z]\)", port).group(1)
+                    if re.match(r"^([\w-]+)\([A-Za-z]\)", port)
+                    else None
+                )
+                for port in ports_with_status
+            ]
+            status_match = re.search(
+                r"LACP\(A\)\((\w+)\)", item.get("protocol", "")
+            )
+            status = status_match.group(1) if status_match else ""
+            if ports:
+                port_channel_dict[port_channel] = {
+                    "members": ports,
+                    "status": status,
+                }
+
+    return port_channel_dict
+
+
+def extract_ip_addresses_for_backend_portchannels(dut, dut_asic, version):
+    backend_port_channels = extract_backend_portchannels(dut)
+    if version == "ipv4":
+        command = "show ip int -d all"
+    elif version == "ipv6":
+        command = "show ipv6 int -d all"
+    data = dut.show_and_parse("{} -n asic{}".format(command, dut_asic.asic_index))
+    result_dict = {}
+    for item in data:
+        if version == "ipv4":
+            ip_address = item.get("ipv4 address/mask", "").split("/")[0]
+        elif version == "ipv6":
+            ip_address = item.get("ipv6 address/mask", "").split("/")[0]
+        interface = item.get("interface", "")
+
+        if interface in backend_port_channels:
+            result_dict[interface] = ip_address
+    return result_dict
+
+
+def delete_bfd(asic_number, prefix, dut):
+    command = "sonic-db-cli -n asic{} CONFIG_DB HSET \"STATIC_ROUTE|{}\" bfd 'false'".format(
+        asic_number, prefix
+    ).replace(
+        "\\", ""
+    )
+    logger.info(command)
+    dut.shell(command)
+    time.sleep(15)
+
+
+def add_bfd(asic_number, prefix, dut):
+    command = "sonic-db-cli -n asic{} CONFIG_DB HSET \"STATIC_ROUTE|{}\" bfd 'true'".format(
+        asic_number, prefix
+    ).replace(
+        "\\", ""
+    )
+    logger.info(command)
+    dut.shell(command)
+    time.sleep(15)
+
+
+def list_to_dict(sample_list):
+    data_rows = sample_list[3:]
+    for data in data_rows:
+        data_dict = {}
+        if sys.version_info.major < 3:
+            data = data.encode("utf-8").split()
+        else:
+            data = data.split()
+
+        data_dict["Peer Addr"] = data[0]
+        data_dict["Interface"] = data[1]
+        data_dict["Vrf"] = data[2]
+        data_dict["State"] = data[3]
+        data_dict["Type"] = data[4]
+        data_dict["Local Addr"] = data[5]
+        data_dict["TX Interval"] = data[6]
+        data_dict["RX Interval"] = data[7]
+        data_dict["Multiplier"] = data[8]
+        data_dict["Multihop"] = data[9]
+        data_dict["Local Discriminator"] = data[10]
+    return data_dict
+
+
+def extract_current_bfd_state(nexthop, asic_number, dut):
+    bfd_peer_command = "ip netns exec asic{} show bfd peer {}".format(
+        asic_number, nexthop
+    )
+    logger.info("Verifying BFD status on {}".format(dut))
+    logger.info(bfd_peer_command)
+    bfd_peer_status = dut.shell(bfd_peer_command, module_ignore_errors=True)["stdout"]
+    if sys.version_info.major < 3:
+        bfd_peer_output = bfd_peer_status.encode("utf-8").strip().split("\n")
+    else:
+        bfd_peer_output = bfd_peer_status.strip().split("\n")
+
+    if "No BFD sessions found" in bfd_peer_output[0]:
+        return "No BFD sessions found"
+    else:
+        entry = list_to_dict(bfd_peer_output)
+        return entry["State"]
+
+
+def parse_bfd_output(output):
+    data_rows = output[3:]
+    data_dict = {}
+    for data in data_rows:
+        data = data.split()
+        data_dict[data[0]] = {}
+        data_dict[data[0]]['Interface'] = data[1]
+        data_dict[data[0]]['Vrf'] = data[2]
+        data_dict[data[0]]['State'] = data[3]
+        data_dict[data[0]]['Type'] = data[4]
+        data_dict[data[0]]['Local Addr'] = data[5]
+        data_dict[data[0]]['TX Interval'] = data[6]
+        data_dict[data[0]]['RX Interval'] = data[7]
+        data_dict[data[0]]['Multiplier'] = data[8]
+        data_dict[data[0]]['Multihop'] = data[9]
+        data_dict[data[0]]['Local Discriminator'] = data[10]
+    return data_dict
+
+
+def find_bfd_peers_with_given_state(dut, dut_asic, expected_bfd_state):
+    # Expected BFD states: Up, Down, No BFD sessions found
+    bfd_cmd = "ip netns exec asic{} show bfd sum"
+    result = True
+    asic_bfd_sum = dut.shell(bfd_cmd.format(dut_asic))["stdout"]
+    if sys.version_info.major < 3:
+        bfd_peer_output = asic_bfd_sum.encode("utf-8").strip().split("\n")
+    else:
+        bfd_peer_output = asic_bfd_sum.strip().split("\n")
+
+    invalid_peers = []
+    if any(
+        keyword in bfd_peer_output[0]
+        for keyword in ("Total number of BFD sessions: 0", "No BFD sessions found")
+    ):
+        return result
+    else:
+        bfd_output = parse_bfd_output(bfd_peer_output)
+        for peer in bfd_output:
+            if bfd_output[peer]["State"] != expected_bfd_state:
+                invalid_peers.append(peer)
+
+    if len(invalid_peers) > 0:
+        result = False
+    return result
+
+
+def extract_routes(static_route_output, version):
+    asic_routes = {}
+    asic = None
+
+    for line in static_route_output:
+        if line.startswith("asic"):
+            asic = line.split(":")[0]
+            asic_routes[asic] = {}
+        elif line.startswith("S>*") or line.startswith("  *"):
+            parts = line.split(",")
+            if line.startswith("S>*"):
+                if version == "ipv4":
+                    prefix_match = re.search(r"(\d+\.\d+\.\d+\.\d+/\d+)", parts[0])
+                elif version == "ipv6":
+                    prefix_match = re.search(r"([0-9a-fA-F:.\/]+)", parts[0])
+                if prefix_match:
+                    prefix = prefix_match.group(1)
+                else:
+                    continue
+            if version == "ipv4":
+                next_hop_match = re.search(r"via\s+(\d+\.\d+\.\d+\.\d+)", parts[0])
+            elif version == "ipv6":
+                next_hop_match = re.search(r"via\s+([0-9a-fA-F:.\/]+)", parts[0])
+            if next_hop_match:
+                next_hop = next_hop_match.group(1)
+            else:
+                continue
+
+            asic_routes[asic].setdefault(prefix, []).append(next_hop)
+    return asic_routes
+
+
+def ensure_interface_is_up(dut, asic, interface):
+    int_oper_status = dut.show_interface(
+        command="status", include_internal_intfs=True, asic_index=asic.asic_index
+    )["ansible_facts"]["int_status"][interface]["oper_state"]
+    if int_oper_status == "down":
+        logger.info(
+            "Starting downed interface {} on {} asic{}".format(interface, dut, asic.asic_index)
+        )
+        exec_cmd = (
+            "sudo ip netns exec asic{} config interface -n asic{} startup {}".format(
+                asic.asic_index, asic.asic_index, interface
+            )
+        )
+
+        logger.info("Command: {}".format(exec_cmd))
+        dut.shell(exec_cmd)
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: dut.show_interface(
+                command="status",
+                include_internal_intfs=True,
+                asic_index=asic.asic_index,
+            )["ansible_facts"]["int_status"][interface]["oper_state"] == "up",
+        )

--- a/tests/bfd/conftest.py
+++ b/tests/bfd/conftest.py
@@ -1,3 +1,115 @@
+import logging
+
+import pytest
+
+from tests.bfd.bfd_helpers import ensure_interface_is_up
+from tests.common.config_reload import config_reload
+from tests.common.utilities import wait_until
+from tests.platform_tests.link_flap.link_flap_utils import check_orch_cpu_utilization
+
+logger = logging.getLogger(__name__)
+
+
 def pytest_addoption(parser):
     parser.addoption("--num_sessions", action="store", default=5)
     parser.addoption("--num_sessions_scale", action="store", default=128)
+
+
+@pytest.fixture(scope='module')
+def get_function_completeness_level(pytestconfig):
+    return pytestconfig.getoption("--completeness_level")
+
+
+@pytest.fixture(scope="function")
+def bfd_cleanup_db(request, duthosts, enum_supervisor_dut_hostname):
+    orch_cpu_threshold = 10
+    # Make Sure Orch CPU < orch_cpu_threshold before starting test.
+    logger.info(
+        "Make Sure orchagent CPU utilization is less that %d before starting the test",
+        orch_cpu_threshold,
+    )
+    duts = duthosts.frontend_nodes
+    for dut in duts:
+        assert wait_until(
+            100, 2, 0, check_orch_cpu_utilization, dut, orch_cpu_threshold
+        ), "Orch CPU utilization {} > orch cpu threshold {} before starting the test".format(
+            dut.shell("show processes cpu | grep orchagent | awk '{print $9}'")[
+                "stdout"
+            ],
+            orch_cpu_threshold,
+        )
+
+    yield
+    orch_cpu_threshold = 10
+    # Orchagent CPU should consume < orch_cpu_threshold at last.
+    logger.info(
+        "watch orchagent CPU utilization when it goes below %d", orch_cpu_threshold
+    )
+    for dut in duts:
+        assert wait_until(
+            120, 4, 0, check_orch_cpu_utilization, dut, orch_cpu_threshold
+        ), "Orch CPU utilization {} > orch cpu threshold {} after the test".format(
+            dut.shell("show processes cpu | grep orchagent | awk '{print $9}'")[
+                "stdout"
+            ],
+            orch_cpu_threshold,
+        )
+
+    logger.info("Verifying swss container status on RP")
+    rp = duthosts[enum_supervisor_dut_hostname]
+    container_status = True
+    if hasattr(request.config, "rp_asic_ids"):
+        for id in request.config.rp_asic_ids:
+            docker_output = rp.shell(
+                "docker ps | grep swss{} | awk '{{print $NF}}'".format(id)
+            )["stdout"]
+            if len(docker_output) == 0:
+                container_status = False
+    if not container_status:
+        config_reload(rp)
+
+    logger.info(
+        "Clearing BFD configs on {}, {}".format(
+            request.config.src_dut, request.config.dst_dut
+        )
+    )
+    command = (
+        "sonic-db-cli -n asic{} CONFIG_DB HSET \"STATIC_ROUTE|{}\" bfd 'false'".format(
+            request.config.src_asic.asic_index, request.config.src_prefix
+        ).replace("\\", "")
+    )
+    request.config.src_dut.shell(command)
+    command = (
+        "sonic-db-cli -n asic{} CONFIG_DB HSET \"STATIC_ROUTE|{}\" bfd 'false'".format(
+            request.config.dst_asic.asic_index, request.config.dst_prefix
+        ).replace("\\", "")
+    )
+    request.config.dst_dut.shell(command)
+
+    logger.info("Bringing up portchannels or respective members")
+    portchannels_on_dut = None
+    if hasattr(request.config, "portchannels_on_dut"):
+        portchannels_on_dut = request.config.portchannels_on_dut
+        selected_interfaces = request.config.selected_portchannels
+    elif hasattr(request.config, "selected_portchannel_members"):
+        portchannels_on_dut = request.config.portchannels_on_dut
+        selected_interfaces = request.config.selected_portchannel_members
+    else:
+        logger.info(
+            "None of the portchannels are selected to flap. So skipping portchannel interface check"
+        )
+        selected_interfaces = []
+
+    if selected_interfaces:
+        dut = (
+            request.config.src_dut
+            if portchannels_on_dut == "src"
+            else request.config.dst_dut
+        )
+        asic = (
+            request.config.src_asic
+            if portchannels_on_dut == "src"
+            else request.config.dst_asic
+        )
+        for interface in selected_interfaces:
+            ensure_interface_is_up(dut, asic, interface)

--- a/tests/bfd/test_bfd_static_route.py
+++ b/tests/bfd/test_bfd_static_route.py
@@ -1,0 +1,1488 @@
+import logging
+import time
+
+import pytest
+
+from tests.bfd.bfd_base import BfdBase
+from tests.bfd.bfd_helpers import verify_static_route, select_src_dst_dut_with_asic, control_interface_state, \
+    check_bgp_status, modify_all_bfd_sessions, find_bfd_peers_with_given_state, add_bfd, verify_bfd_state, delete_bfd, \
+    extract_backend_portchannels
+from tests.common.config_reload import config_reload
+from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.reboot import reboot
+from tests.common.utilities import wait_until
+
+pytestmark = [pytest.mark.topology("t2")]
+
+logger = logging.getLogger(__name__)
+
+
+class TestBfdStaticRoute(BfdBase):
+    COMPLETENESS_TO_ITERATIONS = {
+        'debug': 1,
+        'basic': 10,
+        'confident': 50,
+        'thorough': 100,
+        'diagnose': 200,
+    }
+
+    @pytest.fixture(autouse=True, scope="class")
+    def modify_bfd_sessions(self, duthosts):
+        """
+        1. Gather all front end nodes
+        2. Modify BFD state to required state & issue config reload.
+        3. Wait for Critical processes
+        4. Gather all ASICs for each dut
+        5. Calls find_bfd_peers_with_given_state using wait_until
+            a. Runs ip netns exec asic{} show bfd sum
+            b. If expected state is "Total number of BFD sessions: 0" and it is in result, output is True
+            c. If expected state is "Up" and no. of down peers is 0, output is True
+            d. If expected state is "Down" and no. of up peers is 0, output is True
+        """
+        try:
+            duts = duthosts.frontend_nodes
+            for dut in duts:
+                modify_all_bfd_sessions(dut, "false")
+            for dut in duts:
+                # config reload
+                config_reload(dut)
+                wait_critical_processes(dut)
+            # Verification that all BFD sessions are deleted
+            for dut in duts:
+                asics = [
+                    asic.split("asic")[1] for asic in dut.get_asic_namespace_list()
+                ]
+                for asic in asics:
+                    assert wait_until(
+                        600,
+                        10,
+                        0,
+                        lambda: find_bfd_peers_with_given_state(
+                            dut, asic, "No BFD sessions found"
+                        ),
+                    )
+
+            yield
+
+        finally:
+            duts = duthosts.frontend_nodes
+            for dut in duts:
+                modify_all_bfd_sessions(dut, "true")
+            for dut in duts:
+                config_reload(dut)
+                wait_critical_processes(dut)
+            # Verification that all BFD sessions are added
+            for dut in duts:
+                asics = [
+                    asic.split("asic")[1] for asic in dut.get_asic_namespace_list()
+                ]
+                for asic in asics:
+                    assert wait_until(
+                        600,
+                        10,
+                        0,
+                        lambda: find_bfd_peers_with_given_state(
+                            dut, asic, "Up"
+                        ),
+                    )
+
+    @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
+    def test_bfd_with_lc_reboot(
+        self,
+        localhost,
+        duthost,
+        request,
+        tbinfo,
+        get_src_dst_asic_and_duts,
+        bfd_cleanup_db,
+        version,
+    ):
+        """
+        Author:  Harsha Golla
+        Email : harsgoll@cisco.com
+        """
+        # Selecting source, destination dut & prefix & BFD status verification for all nexthops
+        logger.info(
+            "Selecting Source dut, destination dut, source asic, destination asic, source prefix, destination prefix"
+        )
+        (
+            src_asic,
+            dst_asic,
+            src_dut,
+            dst_dut,
+            src_dut_nexthops,
+            dst_dut_nexthops,
+            src_prefix,
+            dst_prefix,
+        ) = select_src_dst_dut_with_asic(
+            request, get_src_dst_asic_and_duts, version
+        )
+
+        # Creation of BFD
+        logger.info("BFD addition on source dut")
+        add_bfd(src_asic.asic_index, src_prefix, src_dut)
+
+        logger.info("BFD addition on destination dut")
+        add_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            300,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            300,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        # Savings the configs
+        src_dut.shell("sudo config save -y")
+
+        # Perform a cold reboot on source dut
+        reboot(src_dut, localhost)
+
+        # Waiting for all processes on Source dut
+        wait_critical_processes(src_dut)
+
+        check_bgp_status(request)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        logger.info("BFD deletion on source & destination dut")
+        delete_bfd(src_asic.asic_index, src_prefix, src_dut)
+        delete_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Save the configs
+        src_dut.shell("sudo config save -y")
+
+        # Config reload of Source dut
+        reboot(src_dut, localhost)
+
+        # Waiting for all processes on Source dut
+        wait_critical_processes(src_dut)
+
+        check_bgp_status(request)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "No BFD sessions found"
+            ),
+        )
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "No BFD sessions found"
+            ),
+        )
+
+    @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
+    def test_bfd_static_route_deletion(
+        self,
+        duthost,
+        request,
+        tbinfo,
+        get_src_dst_asic_and_duts,
+        bfd_cleanup_db,
+        version,
+    ):
+        """
+        Author:  Harsha Golla
+        Email : harsgoll@cisco.com
+
+        To verify deletion of BFD session between two line cards.
+        Test Steps:
+            1. Delete BFD on Source dut
+            2. Verify that on Source dut BFD gets cleaned up and static route exists.
+            3. Verify that on Destination dut BFD goes down and static route will be removed.
+            4. Delete BFD on Destination dut.
+            5. Verify that on Destination dut BFD gets cleaned up and static route will be added back.
+        """
+        logger.info(
+            "Selecting Source dut, destination dut, source asic, destination asic, source prefix, destination prefix"
+        )
+        (
+            src_asic,
+            dst_asic,
+            src_dut,
+            dst_dut,
+            src_dut_nexthops,
+            dst_dut_nexthops,
+            src_prefix,
+            dst_prefix,
+        ) = select_src_dst_dut_with_asic(
+            request, get_src_dst_asic_and_duts, version
+        )
+
+        # Creation of BFD
+        logger.info("BFD addition on source dut")
+        add_bfd(src_asic.asic_index, src_prefix, src_dut)
+        logger.info("BFD addition on destination dut")
+        add_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        logger.info("BFD deletion on source dut")
+        delete_bfd(src_asic.asic_index, src_prefix, src_dut)
+
+        logger.info("BFD & Static route verifications")
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Down"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "No BFD sessions found"
+            ),
+        )
+        verify_static_route(
+            request,
+            dst_asic,
+            dst_prefix,
+            dst_dut,
+            "Route Removal",
+            version,
+        )
+        verify_static_route(
+            request,
+            src_asic,
+            src_prefix,
+            src_dut,
+            "Route Addition",
+            version,
+        )
+
+        logger.info("BFD deletion on destination dut")
+        delete_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        logger.info("BFD & Static route verifications")
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "No BFD sessions found"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "No BFD sessions found"
+            ),
+        )
+        verify_static_route(
+            request,
+            dst_asic,
+            dst_prefix,
+            dst_dut,
+            "Route Addition",
+            version,
+        )
+        verify_static_route(
+            request,
+            src_asic,
+            src_prefix,
+            src_dut,
+            "Route Addition",
+            version,
+        )
+
+        logger.info("BFD deletion did not influence static routes and test completed successfully")
+
+    @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
+    def test_bfd_flap(
+        self,
+        duthost,
+        request,
+        duthosts,
+        tbinfo,
+        get_src_dst_asic_and_duts,
+        bfd_cleanup_db,
+        get_function_completeness_level,
+        version,
+    ):
+        """
+        Author:  Harsha Golla
+        Email : harsgoll@cisco.com
+
+        To flap the BFD session ( Up <--> Down <---> Up) between linecards for 100 times.
+            Test Steps:
+            1. Delete BFD on Source dut
+            2. Verify that on Source dut BFD gets cleaned up and static route exists.
+            3. Verify that on Destination dut BFD goes down and static route will be removed.
+            4. Add BFD on Source dut.
+            5. Verify that on Source dut BFD is up
+            6. Verify that on destination dut BFD is up and static route is added back.
+            7. Repeat above steps 100 times.
+        """
+        logger.info(
+            "Selecting Source dut, destination dut, source asic, destination asic, source prefix, destination prefix"
+        )
+        (
+            src_asic,
+            dst_asic,
+            src_dut,
+            dst_dut,
+            src_dut_nexthops,
+            dst_dut_nexthops,
+            src_prefix,
+            dst_prefix,
+        ) = select_src_dst_dut_with_asic(
+            request, get_src_dst_asic_and_duts, version
+        )
+
+        # Creation of BFD
+        logger.info("BFD addition on source dut")
+        add_bfd(src_asic.asic_index, src_prefix, src_dut)
+        logger.info("BFD addition on destination dut")
+        add_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        completeness_level = get_function_completeness_level
+        if completeness_level is None:
+            completeness_level = "thorough"
+
+        total_iterations = self.COMPLETENESS_TO_ITERATIONS[completeness_level]
+        successful_iterations = 0  # Counter for successful iterations
+        for i in range(total_iterations):
+            logger.info("Iteration {}".format(i))
+
+            logger.info("BFD deletion on source dut")
+            delete_bfd(src_asic.asic_index, src_prefix, src_dut)
+
+            logger.info("Waiting for 5s post BFD shutdown")
+            time.sleep(5)
+
+            logger.info("BFD & Static route verifications")
+            assert wait_until(
+                180,
+                10,
+                0,
+                lambda: verify_bfd_state(
+                    dst_dut, dst_dut_nexthops.values(), dst_asic, "Down"
+                ),
+            )
+            assert wait_until(
+                180,
+                10,
+                0,
+                lambda: verify_bfd_state(
+                    src_dut,
+                    src_dut_nexthops.values(),
+                    src_asic,
+                    "No BFD sessions found",
+                ),
+            )
+            verify_static_route(
+                request,
+                dst_asic,
+                dst_prefix,
+                dst_dut,
+                "Route Removal",
+                version,
+            )
+            verify_static_route(
+                request,
+                src_asic,
+                src_prefix,
+                src_dut,
+                "Route Addition",
+                version,
+            )
+
+            logger.info("BFD addition on source dut")
+            add_bfd(src_asic.asic_index, src_prefix, src_dut)
+
+            logger.info("BFD & Static route verifications")
+            assert wait_until(
+                180,
+                10,
+                0,
+                lambda: verify_bfd_state(
+                    dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+                ),
+            )
+            assert wait_until(
+                180,
+                10,
+                0,
+                lambda: verify_bfd_state(
+                    src_dut, src_dut_nexthops.values(), src_asic, "Up"
+                ),
+            )
+            verify_static_route(
+                request,
+                dst_asic,
+                dst_prefix,
+                dst_dut,
+                "Route Addition",
+                version,
+            )
+            verify_static_route(
+                request,
+                src_asic,
+                src_prefix,
+                src_dut,
+                "Route Addition",
+                version,
+            )
+
+            # Check if both iterations were successful and increment the counter
+            successful_iterations += 1
+
+        # Determine the success rate
+        logger.info("successful_iterations: %d", successful_iterations)
+        success_rate = (successful_iterations / total_iterations) * 100
+
+        logger.info("Current success rate: %.2f%%", success_rate)
+        # Check if the success rate is above the threshold (e.g., 98%)
+        assert (
+            success_rate >= 98
+        ), "BFD flap verification success rate is below 98% ({}%)".format(success_rate)
+
+        logger.info("test_bfd_flap completed")
+
+    @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
+    def test_bfd_with_rp_reboot(
+        self,
+        localhost,
+        duthost,
+        request,
+        duthosts,
+        tbinfo,
+        get_src_dst_asic_and_duts,
+        enum_supervisor_dut_hostname,
+        bfd_cleanup_db,
+        version,
+    ):
+        """
+        Author:  Harsha Golla
+        Email : harsgoll@cisco.com
+        """
+        rp = duthosts[enum_supervisor_dut_hostname]
+
+        # Selecting source, destination dut & prefix & BFD status verification for all nexthops
+        logger.info(
+            "Selecting Source dut, destination dut, source asic, destination asic, source prefix, destination prefix"
+        )
+        (
+            src_asic,
+            dst_asic,
+            src_dut,
+            dst_dut,
+            src_dut_nexthops,
+            dst_dut_nexthops,
+            src_prefix,
+            dst_prefix,
+        ) = select_src_dst_dut_with_asic(
+            request, get_src_dst_asic_and_duts, version
+        )
+
+        # Creation of BFD
+        logger.info("BFD addition on source dut")
+        add_bfd(src_asic.asic_index, src_prefix, src_dut)
+
+        logger.info("BFD addition on destination dut")
+        add_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        # Savings the configs
+        src_dut.shell("sudo config save -y")
+        dst_dut.shell("sudo config save -y")
+
+        # Perform a cold reboot on source dut
+        reboot(rp, localhost)
+
+        # Waiting for all processes on Source & destination dut
+        wait_critical_processes(src_dut)
+        wait_critical_processes(dst_dut)
+
+        check_bgp_status(request)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        logger.info("BFD deletion on source & destination dut")
+        delete_bfd(src_asic.asic_index, src_prefix, src_dut)
+        delete_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Savings the configs
+        src_dut.shell("sudo config save -y")
+        dst_dut.shell("sudo config save -y")
+
+        # Config reload of Source dut
+        reboot(rp, localhost)
+
+        # Waiting for all processes on Source & destination dut
+        wait_critical_processes(src_dut)
+        wait_critical_processes(dst_dut)
+
+        check_bgp_status(request)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "No BFD sessions found"
+            ),
+        )
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "No BFD sessions found"
+            ),
+        )
+
+    @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
+    def test_bfd_remote_link_flap(
+        self,
+        duthost,
+        request,
+        tbinfo,
+        get_src_dst_asic_and_duts,
+        bfd_cleanup_db,
+        version,
+    ):
+        """
+        Author:  Harsha Golla
+        Email : harsgoll@cisco.com
+        """
+        request.config.interface_shutdown = True
+
+        # Selecting source, destination dut & prefix & BFD status verification for all nexthops
+        logger.info(
+            "Selecting Source dut, destination dut, source asic, destination asic, source prefix, destination prefix"
+        )
+        (
+            src_asic,
+            dst_asic,
+            src_dut,
+            dst_dut,
+            src_dut_nexthops,
+            dst_dut_nexthops,
+            src_prefix,
+            dst_prefix,
+        ) = select_src_dst_dut_with_asic(
+            request, get_src_dst_asic_and_duts, version
+        )
+
+        # Creation of BFD
+        logger.info("BFD addition on source dut")
+        add_bfd(src_asic.asic_index, src_prefix, src_dut)
+        logger.info("BFD addition on destination dut")
+        add_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        # Extract portchannel interfaces on dst
+        list_of_portchannels_on_dst = src_dut_nexthops.keys()
+        request.config.portchannels_on_dut = "dst"
+        request.config.selected_portchannels = list_of_portchannels_on_dst
+
+        # Shutdown PortChannels on destination dut
+        for interface in list_of_portchannels_on_dst:
+            action = "shutdown"
+            control_interface_state(
+                dst_dut, dst_asic, interface, action
+            )
+
+        # Verification of BFD session state on src dut
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Down"
+            ),
+        )
+
+        # Verify that corresponding static route has been removed on both duts
+        logger.info("BFD & Static route verifications")
+        verify_static_route(
+            request,
+            src_asic,
+            src_prefix,
+            src_dut,
+            "Route Removal",
+            version,
+        )
+
+        for interface in list_of_portchannels_on_dst:
+            action = "startup"
+            control_interface_state(
+                dst_dut, dst_asic, interface, action
+            )
+
+        # Verification of BFD session state.
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        # Verify that corresponding static route has been added on both duts
+        logger.info("BFD & Static route verifications")
+        verify_static_route(
+            request,
+            dst_asic,
+            dst_prefix,
+            dst_dut,
+            "Route Addition",
+            version,
+        )
+        verify_static_route(
+            request,
+            src_asic,
+            src_prefix,
+            src_dut,
+            "Route Addition",
+            version,
+        )
+
+    @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
+    def test_bfd_lc_asic_shutdown(
+        self,
+        duthost,
+        request,
+        tbinfo,
+        get_src_dst_asic_and_duts,
+        bfd_cleanup_db,
+        version,
+    ):
+        """
+        Author:  Harsha Golla
+        Email : harsgoll@cisco.com
+        """
+        request.config.interface_shutdown = True
+
+        # Selecting source, destination dut & prefix & BFD status verification for all nexthops
+        logger.info(
+            "Selecting Source dut, destination dut, source asic, destination asic, source prefix, destination prefix"
+        )
+        (
+            src_asic,
+            dst_asic,
+            src_dut,
+            dst_dut,
+            src_dut_nexthops,
+            dst_dut_nexthops,
+            src_prefix,
+            dst_prefix,
+        ) = select_src_dst_dut_with_asic(
+            request, get_src_dst_asic_and_duts, version
+        )
+
+        # Creation of BFD
+        logger.info("BFD addition on source dut")
+        add_bfd(src_asic.asic_index, src_prefix, src_dut)
+        logger.info("BFD addition on destination dut")
+        add_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        # Extract portchannel interfaces on src
+        list_of_portchannels_on_src = dst_dut_nexthops.keys()
+        request.config.portchannels_on_dut = "src"
+        request.config.selected_portchannels = list_of_portchannels_on_src
+
+        # Shutdown PortChannels
+        for interface in list_of_portchannels_on_src:
+            action = "shutdown"
+            control_interface_state(
+                src_dut, src_asic, interface, action
+            )
+
+        # Verification of BFD session state.
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Down"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Down"
+            ),
+        )
+
+        # Verify that corresponding static route has been removed on both duts
+        logger.info("BFD & Static route verifications")
+        verify_static_route(
+            request,
+            dst_asic,
+            dst_prefix,
+            dst_dut,
+            "Route Removal",
+            version,
+        )
+        verify_static_route(
+            request,
+            src_asic,
+            src_prefix,
+            src_dut,
+            "Route Removal",
+            version,
+        )
+
+        for interface in list_of_portchannels_on_src:
+            action = "startup"
+            control_interface_state(
+                src_dut, src_asic, interface, action
+            )
+
+        # Verification of BFD session state.
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        # Verify that corresponding static route has been added on both duts
+        logger.info("BFD & Static route verifications")
+        verify_static_route(
+            request,
+            dst_asic,
+            dst_prefix,
+            dst_dut,
+            "Route Addition",
+            version,
+        )
+        verify_static_route(
+            request,
+            src_asic,
+            src_prefix,
+            src_dut,
+            "Route Addition",
+            version,
+        )
+
+    @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
+    def test_bfd_portchannel_member_flap(
+        self,
+        duthost,
+        request,
+        tbinfo,
+        get_src_dst_asic_and_duts,
+        bfd_cleanup_db,
+        version,
+    ):
+        """
+        Author:  Harsha Golla
+        Email : harsgoll@cisco.com
+        """
+        request.config.interface_shutdown = True
+
+        # Selecting source, destination dut & prefix & BFD status verification for all nexthops
+        logger.info(
+            "Selecting Source dut, destination dut, source asic, destination asic, source prefix, destination prefix"
+        )
+        (
+            src_asic,
+            dst_asic,
+            src_dut,
+            dst_dut,
+            src_dut_nexthops,
+            dst_dut_nexthops,
+            src_prefix,
+            dst_prefix,
+        ) = select_src_dst_dut_with_asic(
+            request, get_src_dst_asic_and_duts, version
+        )
+
+        # Creation of BFD
+        logger.info("BFD addition on source dut")
+        add_bfd(src_asic.asic_index, src_prefix, src_dut)
+        logger.info("BFD addition on destination dut")
+        add_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        # Extract portchannel interfaces on src
+        list_of_portchannels_on_src = dst_dut_nexthops.keys()
+        request.config.portchannels_on_dut = "src"
+        request.config.selected_portchannels = list_of_portchannels_on_src
+
+        # Shutdown PortChannel members
+        for portchannel_interface in list_of_portchannels_on_src:
+            action = "shutdown"
+            list_of_portchannel_members_on_src = (
+                extract_backend_portchannels(src_dut)[
+                    portchannel_interface
+                ]["members"]
+            )
+            request.config.selected_portchannel_members = (
+                list_of_portchannel_members_on_src
+            )
+            for each_member in list_of_portchannel_members_on_src:
+                control_interface_state(
+                    src_dut, src_asic, each_member, action
+                )
+
+        # Verification of BFD session state.
+        assert wait_until(
+            300,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Down"
+            ),
+        )
+        assert wait_until(
+            300,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Down"
+            ),
+        )
+
+        # Verify that corresponding static route has been removed on both duts
+        logger.info("BFD & Static route verifications")
+        verify_static_route(
+            request,
+            dst_asic,
+            dst_prefix,
+            dst_dut,
+            "Route Removal",
+            version,
+        )
+        verify_static_route(
+            request,
+            src_asic,
+            src_prefix,
+            src_dut,
+            "Route Removal",
+            version,
+        )
+
+        # Bring up of PortChannel members
+        for portchannel_interface in list_of_portchannels_on_src:
+            action = "startup"
+            list_of_portchannel_members_on_src = (
+                extract_backend_portchannels(src_dut)[
+                    portchannel_interface
+                ]["members"]
+            )
+            for each_member in list_of_portchannel_members_on_src:
+                control_interface_state(
+                    src_dut, src_asic, each_member, action
+                )
+
+        # Verification of BFD session state.
+        assert wait_until(
+            300,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            300,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        # Verify that corresponding static route has been added on both duts
+        logger.info("Static route verifications")
+        verify_static_route(
+            request,
+            dst_asic,
+            dst_prefix,
+            dst_dut,
+            "Route Addition",
+            version,
+        )
+        verify_static_route(
+            request,
+            src_asic,
+            src_prefix,
+            src_dut,
+            "Route Addition",
+            version,
+        )
+
+    @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
+    def test_bfd_config_reload(
+        self,
+        duthost,
+        request,
+        tbinfo,
+        get_src_dst_asic_and_duts,
+        bfd_cleanup_db,
+        version,
+    ):
+        """
+        Author:  Harsha Golla
+        Email : harsgoll@cisco.com
+        """
+        # Selecting source, destination dut & prefix & BFD status verification for all nexthops
+        logger.info(
+            "Selecting Source dut, destination dut, source asic, destination asic, source prefix, destination prefix"
+        )
+        (
+            src_asic,
+            dst_asic,
+            src_dut,
+            dst_dut,
+            src_dut_nexthops,
+            dst_dut_nexthops,
+            src_prefix,
+            dst_prefix,
+        ) = select_src_dst_dut_with_asic(
+            request, get_src_dst_asic_and_duts, version
+        )
+
+        # Creation of BFD
+        logger.info("BFD addition on source dut")
+        add_bfd(src_asic.asic_index, src_prefix, src_dut)
+
+        logger.info("BFD addition on destination dut")
+        add_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        # Savings the configs
+        src_dut.shell("sudo config save -y")
+
+        # Config reload of Source dut
+        config_reload(src_dut)
+
+        # Waiting for all processes on Source dut
+        wait_critical_processes(src_dut)
+
+        check_bgp_status(request)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        logger.info("BFD deletion on source & destination dut")
+        delete_bfd(src_asic.asic_index, src_prefix, src_dut)
+        delete_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Savings the configs
+        src_dut.shell("sudo config save -y")
+
+        # Config reload of Source dut
+        config_reload(src_dut)
+
+        # Waiting for all processes on Source dut
+        wait_critical_processes(src_dut)
+
+        check_bgp_status(request)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "No BFD sessions found"
+            ),
+        )
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "No BFD sessions found"
+            ),
+        )
+
+    @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
+    def test_bfd_with_rp_config_reload(
+        self,
+        localhost,
+        duthost,
+        request,
+        duthosts,
+        tbinfo,
+        get_src_dst_asic_and_duts,
+        enum_supervisor_dut_hostname,
+        bfd_cleanup_db,
+        version,
+    ):
+        """
+        Author:  Harsha Golla
+        Email : harsgoll@cisco.com
+        """
+        rp = duthosts[enum_supervisor_dut_hostname]
+
+        # Selecting source, destination dut & prefix & BFD status verification for all nexthops
+        logger.info(
+            "Selecting Source dut, destination dut, source asic, destination asic, source prefix, destination prefix"
+        )
+        (
+            src_asic,
+            dst_asic,
+            src_dut,
+            dst_dut,
+            src_dut_nexthops,
+            dst_dut_nexthops,
+            src_prefix,
+            dst_prefix,
+        ) = select_src_dst_dut_with_asic(
+            request, get_src_dst_asic_and_duts, version
+        )
+
+        # Creation of BFD
+        logger.info("BFD addition on source dut")
+        add_bfd(src_asic.asic_index, src_prefix, src_dut)
+
+        logger.info("BFD addition on destination dut")
+        add_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        # Savings the configs
+        src_dut.shell("sudo config save -y")
+        dst_dut.shell("sudo config save -y")
+
+        # Perform a cold reboot on source dut
+        config_reload(rp)
+
+        # Waiting for all processes on Source & destination dut
+        wait_critical_processes(src_dut)
+        wait_critical_processes(dst_dut)
+
+        check_bgp_status(request)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        logger.info("BFD deletion on source & destination dut")
+        delete_bfd(src_asic.asic_index, src_prefix, src_dut)
+        delete_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Savings the configs
+        src_dut.shell("sudo config save -y")
+        dst_dut.shell("sudo config save -y")
+
+        # Config reload of Source dut
+        config_reload(rp)
+
+        # Waiting for all processes on Source & destination dut
+        wait_critical_processes(src_dut)
+        wait_critical_processes(dst_dut)
+
+        check_bgp_status(request)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "No BFD sessions found"
+            ),
+        )
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "No BFD sessions found"
+            ),
+        )
+
+    @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
+    def test_bfd_with_bad_fc_asic(
+        self,
+        localhost,
+        duthost,
+        request,
+        duthosts,
+        tbinfo,
+        get_src_dst_asic_and_duts,
+        enum_supervisor_dut_hostname,
+        bfd_cleanup_db,
+        version,
+    ):
+        """
+        Author:  Harsha Golla
+        Email : harsgoll@cisco.com
+        """
+        rp = duthosts[enum_supervisor_dut_hostname]
+
+        # Selecting source, destination dut & prefix & BFD status verification for all nexthops
+        logger.info(
+            "Selecting Source dut, destination dut, source asic, destination asic, source prefix, destination prefix"
+        )
+        (
+            src_asic,
+            dst_asic,
+            src_dut,
+            dst_dut,
+            src_dut_nexthops,
+            dst_dut_nexthops,
+            src_prefix,
+            dst_prefix,
+        ) = select_src_dst_dut_with_asic(
+            request, get_src_dst_asic_and_duts, version
+        )
+
+        # Creation of BFD
+        logger.info("BFD addition on source dut")
+        add_bfd(src_asic.asic_index, src_prefix, src_dut)
+
+        logger.info("BFD addition on destination dut")
+        add_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        # Savings the configs
+        src_dut.shell("sudo config save -y")
+        dst_dut.shell("sudo config save -y")
+
+        # Extract asic ids
+        docker_output = rp.shell("docker ps | grep swss | awk '{print $NF}'")[
+            "stdout"
+        ].split("\n")
+        asic_ids = [int(element.split("swss")[1]) for element in docker_output]
+
+        # Shut down corresponding asic on supervisor to simulate bad asic
+        for asic_id in asic_ids:
+            rp.shell("systemctl stop swss@{}".format(asic_id))
+
+        # Verify that BFD sessions are down
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Down"
+            ),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Down"
+            ),
+        )
+
+        # Config reload RP to bring up the swss containers
+        config_reload(rp)
+
+        # Waiting for all processes on Source & destination dut
+        wait_critical_processes(src_dut)
+        wait_critical_processes(dst_dut)
+
+        check_bgp_status(request)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "Up"
+            ),
+        )
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "Up"
+            ),
+        )
+
+        logger.info("BFD deletion on source dut")
+        delete_bfd(src_asic.asic_index, src_prefix, src_dut)
+        delete_bfd(dst_asic.asic_index, dst_prefix, dst_dut)
+
+        # Savings the configs
+        src_dut.shell("sudo config save -y")
+        dst_dut.shell("sudo config save -y")
+
+        # Config reload RP
+        config_reload(rp)
+
+        # Waiting for all processes on Source & destination dut
+        wait_critical_processes(src_dut)
+        wait_critical_processes(dst_dut)
+
+        check_bgp_status(request)
+
+        # Verification of BFD session state.
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                dst_dut, dst_dut_nexthops.values(), dst_asic, "No BFD sessions found"
+            ),
+        )
+        assert wait_until(
+            300,
+            20,
+            0,
+            lambda: verify_bfd_state(
+                src_dut, src_dut_nexthops.values(), src_asic, "No BFD sessions found"
+            ),
+        )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Cherry-pick the latest `bfd/test_bfd_static_route.py` into 202305 branch.

Summary:
Fixes # (issue) Microsoft ADO 28210614

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
We need this change in 202305 to run nightly

#### How did you do it?

#### How did you verify/test it?
I ran `test_bfd_static_route.py` with the cherry branch in a T2 chassis and can confirm it's working

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
