### PR TITLE
Fix test_check_show_lpmode testcase failure

### DIFF
--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -80,4 +80,4 @@ def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
             assert validate_transceiver_lpmode(
-                sfp_lpmode), "Interface mode incorrect in 'show interface transceiver lpmode'"
+                sfp_lpmode['stdout']), "Interface mode incorrect in 'show interface transceiver lpmode'"

--- a/tests/platform_tests/sfp/util.py
+++ b/tests/platform_tests/sfp/util.py
@@ -50,12 +50,13 @@ def get_dev_conn(duthost, conn_graph_facts, asic_index):
 def validate_transceiver_lpmode(output):
     lines = output.strip().split('\n')
     # Check if the header is present
-    if lines[0].strip() != "Port        Low-power Mode":
-        print("Invalid output format: Header missing")
+    if lines[0].strip() != "Port         Low-power Mode":
+        logging.error("Invalid output format: Header missing. "
+                      "Current header is {}".format(lines[0].strip()))
         return False
     for line in lines[2:]:
         port, lpmode = line.strip().split()
         if lpmode not in ["Off", "On"]:
-            print(f"Invalid low-power mode '{lpmode}' for port '{port}'")
+            logging.error("Invalid low-power mode {} for port {}".format(lpmode, port))
             return False
     return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The test_check_show_lpmode testcase is failing for all platforms and needs to be fixed.

MSFT ADO - 27894685

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The test_check_show_lpmode testcase is failing for all platforms and needs to be fixed.
The failure is due to a day-1 issue in the testcase definition. Following are the details

1. The function validate_transceiver_lpmode is called by passing a dict (sfp_lpmode) instead of passing a string.
2. Also, the expected header string has 1 less empty space than the actual command output
3. print is being used to log errors instead of using logging.error.

#### How did you do it?
1. Passing a string to validate_transceiver_lpmode function
2. Corrected the expected header
3. Modified print to logging.error

#### How did you verify/test it?
Ran the test_check_show_lpmode testcase manually and ensured it passes.
```
platform_tests/sfp/test_show_intf_xcvr.py::test_check_show_lpmode[device-None] PASSED  [100%]

============================================ warnings summary =============================================
../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------- generated xml file: /var/src/mgmt_int/tests/logs/tr.xml -------------------------
================================ 1 passed, 1 warning in 172.17s (0:02:52) =================================
INFO:root:Can not get Allure report URL. Please check logs
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
