### PR TITLE
Add acl test to pr test and skip traffic test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -270,6 +270,11 @@ dpu:
   - dash/test_dash_vnet.py
 
 onboarding_t0:
+  - acl/custom_acl_table/test_custom_acl_table.py
+  - acl/null_route/test_null_route_helper.py
+  - acl/test_acl.py
+  - acl/test_acl_outer_vlan.py
+  - acl/test_stress_acl.py
   - console/test_console_availability.py
   - everflow/test_everflow_ipv6.py
   - platform_tests/test_power_off_reboot.py

--- a/tests/acl/custom_acl_table/test_custom_acl_table.py
+++ b/tests/acl/custom_acl_table/test_custom_acl_table.py
@@ -11,6 +11,7 @@ import ptf.testutils as testutils
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa F401
+from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -250,7 +251,7 @@ def build_exp_pkt(input_pkt):
 
 def test_custom_acl(rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter,
                     setup_acl_rules, toggle_all_simulator_ports_to_rand_selected_tor,  # noqa F811
-                    setup_counterpoll_interval, remove_dataacl_table):
+                    setup_counterpoll_interval, remove_dataacl_table, skip_traffic_test):   # noqa F811
     """
     The test case is to verify the functionality of custom ACL table
     Test steps
@@ -287,14 +288,15 @@ def test_custom_acl(rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter,
         exp_pkt = build_exp_pkt(pkt)
         # Send and verify packet
         clear_acl_counter(rand_selected_dut)
-        if "dualtor-aa" in tbinfo["topo"]["name"]:
-            clear_acl_counter(rand_unselected_dut)
-        ptfadapter.dataplane.flush()
-        testutils.send(ptfadapter, pkt=pkt, port_id=src_port_indice)
-        testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=dst_port_indices, timeout=5)
-        acl_counter = read_acl_counter(rand_selected_dut, rule)
-        if "dualtor-aa" in tbinfo["topo"]["name"]:
-            acl_counter_unselected_dut = read_acl_counter(rand_unselected_dut, rule)
-            acl_counter += acl_counter_unselected_dut
-        # Verify acl counter
-        pytest_assert(acl_counter == 1, "ACL counter for {} didn't increase as expected".format(rule))
+        if not skip_traffic_test:
+            if "dualtor-aa" in tbinfo["topo"]["name"]:
+                clear_acl_counter(rand_unselected_dut)
+            ptfadapter.dataplane.flush()
+            testutils.send(ptfadapter, pkt=pkt, port_id=src_port_indice)
+            testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=dst_port_indices, timeout=5)
+            acl_counter = read_acl_counter(rand_selected_dut, rule)
+            if "dualtor-aa" in tbinfo["topo"]["name"]:
+                acl_counter_unselected_dut = read_acl_counter(rand_unselected_dut, rule)
+                acl_counter += acl_counter_unselected_dut
+            # Verify acl counter
+            pytest_assert(acl_counter == 1, "ACL counter for {} didn't increase as expected".format(rule))

--- a/tests/acl/null_route/test_null_route_helper.py
+++ b/tests/acl/null_route/test_null_route_helper.py
@@ -9,7 +9,7 @@ import json
 from ptf.mask import Mask
 import ptf.packet as scapy
 
-from tests.common.fixtures.ptfhost_utils import remove_ip_addresses  # noqa F401
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses, skip_traffic_test  # noqa F401
 import ptf.testutils as testutils
 from tests.common.helpers.assertions import pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
@@ -229,10 +229,12 @@ def generate_packet(src_ip, dst_ip, dst_mac):
     return pkt, exp_pkt
 
 
-def send_and_verify_packet(ptfadapter, pkt, exp_pkt, tx_port, rx_port, expected_action):
+def send_and_verify_packet(ptfadapter, pkt, exp_pkt, tx_port, rx_port, expected_action, skip_traffic_test):     # noqa F811
     """
     Send packet with ptfadapter and verify if packet is forwarded or dropped as expected.
     """
+    if skip_traffic_test:
+        return
     ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, pkt=pkt, port_id=tx_port)
     if expected_action == FORWARD:
@@ -241,7 +243,8 @@ def send_and_verify_packet(ptfadapter, pkt, exp_pkt, tx_port, rx_port, expected_
         testutils.verify_no_packet(ptfadapter, pkt=exp_pkt, port_id=rx_port, timeout=5)
 
 
-def test_null_route_helper(rand_selected_dut, tbinfo, ptfadapter, apply_pre_defined_rules, setup_ptf):
+def test_null_route_helper(rand_selected_dut, tbinfo, ptfadapter,
+                           apply_pre_defined_rules, setup_ptf, skip_traffic_test):  # noqa F811
     """
     Test case to verify script null_route_helper.
     Some packets are generated as defined in TEST_DATA and sent to DUT,
@@ -276,4 +279,5 @@ def test_null_route_helper(rand_selected_dut, tbinfo, ptfadapter, apply_pre_defi
             rand_selected_dut.shell(NULL_ROUTE_HELPER + " " + action)
             time.sleep(1)
 
-        send_and_verify_packet(ptfadapter, pkt, exp_pkt, random.choice(ptf_interfaces), rx_port, expected_result)
+        send_and_verify_packet(ptfadapter, pkt, exp_pkt, random.choice(ptf_interfaces),
+                               rx_port, expected_result, skip_traffic_test)

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -731,6 +731,9 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         time.sleep(self.ACL_COUNTERS_UPDATE_INTERVAL_SECS)
 
         for duthost in duthosts:
+            if duthost.facts["asic_type"] == 'vs':
+                logger.info('Skip checking rule counters for vs platform')
+                return
             if duthost.is_supervisor_node():
                 continue
             acl_facts[duthost]['after'] = \

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -17,7 +17,8 @@ from tests.common import reboot, port_toggle
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.config_reload import config_reload
-from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py, run_garp_service, change_mac_addresses   # noqa F401
+from tests.common.fixtures.ptfhost_utils import \
+    copy_arp_responder_py, run_garp_service, change_mac_addresses, skip_traffic_test   # noqa F401
 from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr # noqa F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
@@ -785,8 +786,11 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         return request.param
 
     def check_rule_counters(self, duthost):
-        logger.info('Wait all rule counters are ready')
+        if duthost.facts['asic_type'] == 'vs':
+            logger.info('Skip checking rule counters for vs platform')
+            return True
 
+        logger.info('Wait all rule counters are ready')
         return wait_until(60, 2, 0, self.check_rule_counters_internal, duthost)
 
     def check_rule_counters_internal(self, duthost):
@@ -921,53 +925,57 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
 
         return exp_pkt
 
-    def test_ingress_unmatched_blocked(self, setup, direction, ptfadapter, ip_version, stage):
+    def test_ingress_unmatched_blocked(self, setup, direction, ptfadapter, ip_version, stage, skip_traffic_test):   # noqa F811
         """Verify that unmatched packets are dropped for ingress."""
         if stage == "egress":
             pytest.skip("Only run for ingress")
 
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version)
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
 
-    def test_egress_unmatched_forwarded(self, setup, direction, ptfadapter, ip_version, stage):
+    def test_egress_unmatched_forwarded(self, setup, direction, ptfadapter, ip_version, stage, skip_traffic_test):  # noqa F811
         """Verify that default egress rule allow all traffics"""
         if stage == "ingress":
             pytest.skip("Only run for egress")
 
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version)
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
 
-    def test_source_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_source_ip_match_forwarded(self, setup, direction, ptfadapter,
+                                       counters_sanity_check, ip_version, skip_traffic_test):   # noqa F811
         """Verify that we can match and forward a packet on source IP."""
         src_ip = "20.0.0.2" if ip_version == "ipv4" else "60c0:a800::6"
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
         counters_sanity_check.append(1)
 
-    def test_rules_priority_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_rules_priority_forwarded(self, setup, direction, ptfadapter,
+                                      counters_sanity_check, ip_version, skip_traffic_test):    # noqa F811
         """Verify that we respect rule priorites in the forwarding case."""
         src_ip = "20.0.0.7" if ip_version == "ipv4" else "60c0:a800::7"
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
         counters_sanity_check.append(20)
 
-    def test_rules_priority_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_rules_priority_dropped(self, setup, direction, ptfadapter,
+                                    counters_sanity_check, ip_version, skip_traffic_test):      # noqa F811
         """Verify that we respect rule priorites in the drop case."""
         src_ip = "20.0.0.3" if ip_version == "ipv4" else "60c0:a800::4"
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
         counters_sanity_check.append(7)
 
-    def test_dest_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version, vlan_name):
+    def test_dest_ip_match_forwarded(self, setup, direction, ptfadapter,
+                                     counters_sanity_check, ip_version, vlan_name, skip_traffic_test):  # noqa F811
         """Verify that we can match and forward a packet on destination IP."""
         dst_ip = DOWNSTREAM_IP_TO_ALLOW[ip_version] \
             if direction == "uplink->downlink" else UPSTREAM_IP_TO_ALLOW[ip_version]
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dst_ip=dst_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
         # Because m0_l3_scenario use differnet IPs, so need to verify different acl rules.
         if direction == "uplink->downlink":
             if setup["topo"] == "m0_l3":
@@ -986,13 +994,14 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
             rule_id = 3
         counters_sanity_check.append(rule_id)
 
-    def test_dest_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version, vlan_name):
+    def test_dest_ip_match_dropped(self, setup, direction, ptfadapter,
+                                   counters_sanity_check, ip_version, vlan_name, skip_traffic_test):    # noqa F811
         """Verify that we can match and drop a packet on destination IP."""
         dst_ip = DOWNSTREAM_IP_TO_BLOCK[ip_version] \
             if direction == "uplink->downlink" else UPSTREAM_IP_TO_BLOCK[ip_version]
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dst_ip=dst_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
         # Because m0_l3_scenario use differnet IPs, so need to verify different acl rules.
         if direction == "uplink->downlink":
             if setup["topo"] == "m0_l3":
@@ -1011,145 +1020,167 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
             rule_id = 16
         counters_sanity_check.append(rule_id)
 
-    def test_source_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_source_ip_match_dropped(self, setup, direction, ptfadapter,
+                                     counters_sanity_check, ip_version, skip_traffic_test):     # noqa F811
         """Verify that we can match and drop a packet on source IP."""
         src_ip = "20.0.0.6" if ip_version == "ipv4" else "60c0:a800::3"
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
         counters_sanity_check.append(14)
 
-    def test_udp_source_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_udp_source_ip_match_forwarded(self, setup, direction, ptfadapter,
+                                           counters_sanity_check, ip_version, skip_traffic_test):       # noqa F811
         """Verify that we can match and forward a UDP packet on source IP."""
         src_ip = "20.0.0.4" if ip_version == "ipv4" else "60c0:a800::8"
         pkt = self.udp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
         counters_sanity_check.append(13)
 
-    def test_udp_source_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_udp_source_ip_match_dropped(self, setup, direction, ptfadapter,
+                                         counters_sanity_check, ip_version, skip_traffic_test):     # noqa F811
         """Verify that we can match and drop a UDP packet on source IP."""
         src_ip = "20.0.0.8" if ip_version == "ipv4" else "60c0:a800::2"
         pkt = self.udp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
         counters_sanity_check.append(26)
 
-    def test_icmp_source_ip_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_icmp_source_ip_match_dropped(self, setup, direction, ptfadapter,
+                                          counters_sanity_check, ip_version, skip_traffic_test):    # noqa F811
         """Verify that we can match and drop an ICMP packet on source IP."""
         src_ip = "20.0.0.8" if ip_version == "ipv4" else "60c0:a800::2"
         pkt = self.icmp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
         counters_sanity_check.append(25)
 
-    def test_icmp_source_ip_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_icmp_source_ip_match_forwarded(self, setup, direction, ptfadapter,
+                                            counters_sanity_check, ip_version, skip_traffic_test):  # noqa F811
         """Verify that we can match and forward an ICMP packet on source IP."""
         src_ip = "20.0.0.4" if ip_version == "ipv4" else "60c0:a800::8"
         pkt = self.icmp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
         counters_sanity_check.append(12)
 
-    def test_l4_dport_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_l4_dport_match_forwarded(self, setup, direction, ptfadapter,
+                                      counters_sanity_check, ip_version, skip_traffic_test):        # noqa F811
         """Verify that we can match and forward on L4 destination port."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dport=0x1217)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
         counters_sanity_check.append(9)
 
-    def test_l4_sport_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_l4_sport_match_forwarded(self, setup, direction, ptfadapter,
+                                      counters_sanity_check, ip_version, skip_traffic_test):        # noqa F811
         """Verify that we can match and forward on L4 source port."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, sport=0x120D)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
         counters_sanity_check.append(4)
 
-    def test_l4_dport_range_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_l4_dport_range_match_forwarded(self, setup, direction, ptfadapter,
+                                            counters_sanity_check, ip_version, skip_traffic_test):  # noqa F811
         """Verify that we can match and forward on a range of L4 destination ports."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dport=0x123B)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
         counters_sanity_check.append(11)
 
-    def test_l4_sport_range_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_l4_sport_range_match_forwarded(self, setup, direction, ptfadapter,
+                                            counters_sanity_check, ip_version, skip_traffic_test):  # noqa F811
         """Verify that we can match and forward on a range of L4 source ports."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, sport=0x123A)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
         counters_sanity_check.append(10)
 
-    def test_l4_dport_range_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_l4_dport_range_match_dropped(self, setup, direction, ptfadapter,
+                                          counters_sanity_check, ip_version, skip_traffic_test):    # noqa F811
         """Verify that we can match and drop on a range of L4 destination ports."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dport=0x127B)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
         counters_sanity_check.append(22)
 
-    def test_l4_sport_range_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_l4_sport_range_match_dropped(self, setup, direction, ptfadapter,
+                                          counters_sanity_check, ip_version, skip_traffic_test):    # noqa F811
         """Verify that we can match and drop on a range of L4 source ports."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, sport=0x1271)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
         counters_sanity_check.append(17)
 
-    def test_ip_proto_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_ip_proto_match_forwarded(self, setup, direction, ptfadapter,
+                                      counters_sanity_check, ip_version, skip_traffic_test):        # noqa F811
         """Verify that we can match and forward on the IP protocol."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, proto=0x7E)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
         counters_sanity_check.append(5)
 
-    def test_tcp_flags_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_tcp_flags_match_forwarded(self, setup, direction, ptfadapter,
+                                       counters_sanity_check, ip_version, skip_traffic_test):       # noqa F811
         """Verify that we can match and forward on the TCP flags."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, flags=0x1B)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
         counters_sanity_check.append(6)
 
-    def test_l4_dport_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_l4_dport_match_dropped(self, setup, direction, ptfadapter,
+                                    counters_sanity_check, ip_version, skip_traffic_test):          # noqa F811
         """Verify that we can match and drop on L4 destination port."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dport=0x127B)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
         counters_sanity_check.append(22)
 
-    def test_l4_sport_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_l4_sport_match_dropped(self, setup, direction, ptfadapter,
+                                    counters_sanity_check, ip_version, skip_traffic_test):          # noqa F811
         """Verify that we can match and drop on L4 source port."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, sport=0x1271)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
         counters_sanity_check.append(17)
 
-    def test_ip_proto_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_ip_proto_match_dropped(self, setup, direction, ptfadapter,
+                                    counters_sanity_check, ip_version, skip_traffic_test):          # noqa F811
         """Verify that we can match and drop on the IP protocol."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, proto=0x7F)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
         counters_sanity_check.append(18)
 
-    def test_tcp_flags_match_dropped(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_tcp_flags_match_dropped(self, setup, direction, ptfadapter,
+                                     counters_sanity_check, ip_version, skip_traffic_test):         # noqa F811
         """Verify that we can match and drop on the TCP flags."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, flags=0x24)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
         counters_sanity_check.append(19)
 
-    def test_icmp_match_forwarded(self, setup, direction, ptfadapter, counters_sanity_check, ip_version):
+    def test_icmp_match_forwarded(self, setup, direction, ptfadapter,
+                                  counters_sanity_check, ip_version, skip_traffic_test):            # noqa F811
         """Verify that we can match and drop on the TCP flags."""
         src_ip = "20.0.0.10" if ip_version == "ipv4" else "60c0:a800::10"
         pkt = self.icmp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip, icmp_type=3, icmp_code=1)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
         counters_sanity_check.append(29)
 
-    def _verify_acl_traffic(self, setup, direction, ptfadapter, pkt, dropped, ip_version):
+    def _verify_acl_traffic(self, setup, direction, ptfadapter, pkt, dropped, ip_version, skip_traffic_test):   # noqa F811
         exp_pkt = self.expected_mask_routed_packet(pkt, ip_version)
 
         if ip_version == "ipv4":
             downstream_dst_port = DOWNSTREAM_IP_PORT_MAP.get(pkt[packet.IP].dst)
         else:
             downstream_dst_port = DOWNSTREAM_IP_PORT_MAP.get(pkt[packet.IPv6].dst)
+
+        if skip_traffic_test:
+            return
+
         ptfadapter.dataplane.flush()
         testutils.send(ptfadapter, self.src_port, pkt)
         if direction == "uplink->downlink" and downstream_dst_port:

--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -14,7 +14,7 @@ from scapy.all import Ether, IP
 from tests.common.utilities import wait_until
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert, pytest_require
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses    # noqa F401
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses, skip_traffic_test    # noqa F401
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from abc import abstractmethod
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
@@ -476,7 +476,8 @@ class AclVlanOuterTest_Base(object):
         logger.info("Creating ACL rule matching vlan {} action {}".format(vlan_id, action))
         duthost.shell("config load -y {}".format(dest_path))
 
-        pytest_assert(wait_until(60, 2, 0, check_rule_counters, duthost), "Acl rule counters are not ready")
+        if duthost.facts['asic_type'] != 'vs':
+            pytest_assert(wait_until(60, 2, 0, check_rule_counters, duthost), "Acl rule counters are not ready")
 
     def _remove_acl_rules(self, duthost, stage, ip_ver):
         table_name = ACL_TABLE_NAME_TEMPLATE.format(stage, ip_ver)
@@ -514,7 +515,8 @@ class AclVlanOuterTest_Base(object):
         finally:
             self.post_running_hook(rand_selected_dut, ptfhost, ip_version)
 
-    def _do_verification(self, ptfadapter, duthost, tbinfo, vlan_setup_info, ip_version, tagged_mode, action):
+    def _do_verification(self, ptfadapter, duthost, tbinfo, vlan_setup_info,
+                         ip_version, tagged_mode, action, skip_traffic_test):   # noqa F811
         vlan_setup, _, _, _ = vlan_setup_info
         test_setup_config = self.setup_cfg(duthost, tbinfo, vlan_setup, tagged_mode, ip_version)
 
@@ -557,14 +559,15 @@ class AclVlanOuterTest_Base(object):
         table_name = ACL_TABLE_NAME_TEMPLATE.format(stage, ip_version)
         try:
             self._setup_acl_rules(duthost, stage, ip_version, outer_vlan_id, action)
-            count_before = get_acl_counter(duthost, table_name, RULE_1, timeout=0)
+            if not skip_traffic_test:
+                count_before = get_acl_counter(duthost, table_name, RULE_1, timeout=0)
+                send_and_verify_traffic(ptfadapter, pkt, exp_pkt, src_port, dst_port, pkt_action=action)
+                count_after = get_acl_counter(duthost, table_name, RULE_1)
 
-            send_and_verify_traffic(ptfadapter, pkt, exp_pkt, src_port, dst_port, pkt_action=action)
-            count_after = get_acl_counter(duthost, table_name, RULE_1)
-
-            logger.info("Verify Acl counter incremented {} > {}".format(count_after, count_before))
-            pytest_assert(count_after >= count_before + 1,
-                          "Unexpected results, counter_after {} > counter_before {}".format(count_after, count_before))
+                logger.info("Verify Acl counter incremented {} > {}".format(count_after, count_before))
+                pytest_assert(count_after >= count_before + 1,
+                              "Unexpected results, counter_after {} > counter_before {}"
+                              .format(count_after, count_before))
         except Exception as e:
             raise (e)
         finally:
@@ -572,83 +575,83 @@ class AclVlanOuterTest_Base(object):
 
     @pytest.mark.po2vlan
     def test_tagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m  # noqa F811
-                              ):
+                              ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
+                              skip_traffic_test):   # noqa F811
         """
         Verify packet is forwarded by ACL rule on tagged interface
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_TAGGED, ACTION_FORWARD)
+                              ip_version, TYPE_TAGGED, ACTION_FORWARD, skip_traffic_test)
 
     @pytest.mark.po2vlan
     def test_tagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                            ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m  # noqa F811
-                            ):
+                            ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
+                            skip_traffic_test):   # noqa F811
         """
         Verify packet is dropped by ACL rule on tagged interface
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_TAGGED, ACTION_DROP)
+                              ip_version, TYPE_TAGGED, ACTION_DROP, skip_traffic_test)
 
     @pytest.mark.po2vlan
     def test_untagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                                ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m  # noqa F811
-                                ):
+                                ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
+                                skip_traffic_test):   # noqa F811
         """
         Verify packet is forwarded by ACL rule on untagged interface
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_UNTAGGED, ACTION_FORWARD)
+                              ip_version, TYPE_UNTAGGED, ACTION_FORWARD, skip_traffic_test)
 
     @pytest.mark.po2vlan
     def test_untagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m  # noqa F811
-                              ):
+                              ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
+                              skip_traffic_test):   # noqa F811
         """
         Verify packet is dropped by ACL rule on untagged interface
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_UNTAGGED, ACTION_DROP)
+                              ip_version, TYPE_UNTAGGED, ACTION_DROP, skip_traffic_test)
 
     @pytest.mark.po2vlan
     def test_combined_tagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                                       ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m  # noqa F811
-                                       ):
+                                       ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
+                                       skip_traffic_test):   # noqa F811
         """
         Verify packet is forwarded by ACL rule on tagged interface, and the interface belongs to two vlans
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_COMBINE_TAGGED, ACTION_FORWARD)
+                              ip_version, TYPE_COMBINE_TAGGED, ACTION_FORWARD, skip_traffic_test)
 
     @pytest.mark.po2vlan
     def test_combined_tagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                                     ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m  # noqa F811
-                                     ):
+                                     ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
+                                     skip_traffic_test):   # noqa F811
         """
         Verify packet is dropped by ACL rule on tagged interface, and the interface belongs to two vlans
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_COMBINE_TAGGED, ACTION_DROP)
+                              ip_version, TYPE_COMBINE_TAGGED, ACTION_DROP, skip_traffic_test)
 
     @pytest.mark.po2vlan
     def test_combined_untagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                                         ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m  # noqa F811
-                                         ):
+                                         ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
+                                         skip_traffic_test):   # noqa F811
         """
         Verify packet is forwarded by ACL rule on untagged interface, and the interface belongs to two vlans
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_COMBINE_UNTAGGED, ACTION_FORWARD)
+                              ip_version, TYPE_COMBINE_UNTAGGED, ACTION_FORWARD, skip_traffic_test)
 
     @pytest.mark.po2vlan
     def test_combined_untagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                                       ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m  # noqa F811
-                                       ):
+                                       ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
+                                       skip_traffic_test):   # noqa F811
         """
         Verify packet is dropped by ACL rule on untagged interface, and the interface belongs to two vlans
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_COMBINE_UNTAGGED, ACTION_DROP)
+                              ip_version, TYPE_COMBINE_UNTAGGED, ACTION_DROP, skip_traffic_test)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa F401
 from tests.common.utilities import wait_until
 from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
+from tests.common.fixtures.ptfhost_utils import skip_traffic_test   # noqa F401
 
 pytestmark = [
     pytest.mark.topology("t0", "t1", "m0", "mx"),
@@ -118,8 +119,8 @@ def prepare_test_port(rand_selected_dut, tbinfo):
     return ptf_src_port, upstream_port_ids, dut_port
 
 
-def verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port,
-                     ptf_dst_ports, acl_rule_list, del_rule_id, verity_status):
+def verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
+                     acl_rule_list, del_rule_id, verity_status, skip_traffic_test):     # noqa F811
 
     for acl_id in acl_rule_list:
         ip_addr1 = acl_id % 256
@@ -146,12 +147,13 @@ def verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port,
         exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
         exp_pkt.set_do_not_care_scapy(packet.IP, "chksum")
 
-        ptfadapter.dataplane.flush()
-        testutils.send(test=ptfadapter, port_id=ptf_src_port, pkt=pkt)
-        if verity_status == "forward" or acl_id == del_rule_id:
-            testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt, ports=ptf_dst_ports)
-        elif verity_status == "drop" and acl_id != del_rule_id:
-            testutils.verify_no_packet_any(test=ptfadapter, pkt=exp_pkt, ports=ptf_dst_ports)
+        if not skip_traffic_test:
+            ptfadapter.dataplane.flush()
+            testutils.send(test=ptfadapter, port_id=ptf_src_port, pkt=pkt)
+            if verity_status == "forward" or acl_id == del_rule_id:
+                testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt, ports=ptf_dst_ports)
+            elif verity_status == "drop" and acl_id != del_rule_id:
+                testutils.verify_no_packet_any(test=ptfadapter, pkt=exp_pkt, ports=ptf_dst_ports)
 
 
 def acl_rule_loaded(rand_selected_dut, acl_rule_list):
@@ -167,7 +169,7 @@ def acl_rule_loaded(rand_selected_dut, acl_rule_list):
 
 def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_file,
                             prepare_test_port, get_function_conpleteness_level,
-                            toggle_all_simulator_ports_to_rand_selected_tor):   # noqa F811
+                            toggle_all_simulator_ports_to_rand_selected_tor, skip_traffic_test):   # noqa F811
 
     ptf_src_port, ptf_dst_ports, dut_port = prepare_test_port
 
@@ -184,7 +186,8 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
 
     rand_selected_dut.shell(cmd_create_table)
     acl_rule_list = list(range(1, ACL_RULE_NUMS + 1))
-    verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports, acl_rule_list, 0, "forward")
+    verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
+                     acl_rule_list, 0, "forward", skip_traffic_test)
     try:
         loops = 0
         while loops <= loop_times:
@@ -201,7 +204,8 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
                 acl_rule_list.append(readd_id)
 
             wait_until(wait_timeout, 2, 0, acl_rule_loaded, rand_selected_dut, acl_rule_list)
-            verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports, acl_rule_list, 0, "drop")
+            verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
+                             acl_rule_list, 0, "drop", skip_traffic_test)
 
             del_rule_id = random.choice(acl_rule_list)
             rand_selected_dut.shell('sonic-db-cli CONFIG_DB del "ACL_RULE|STRESS_ACL| RULE_{}"'.format(del_rule_id))
@@ -209,7 +213,7 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
 
             wait_until(wait_timeout, 2, 0, acl_rule_loaded, rand_selected_dut, acl_rule_list)
             verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
-                             acl_rule_list, del_rule_id, "drop")
+                             acl_rule_list, del_rule_id, "drop", skip_traffic_test)
 
             loops += 1
     finally:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -1,4 +1,37 @@
 #######################################
+#####            acl              #####
+#######################################
+acl/custom_acl_table/test_custom_acl_table.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+acl/null_route/test_null_route_helper.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+acl/test_acl.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+acl/test_acl_outer_vlan.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+acl/test_stress_acl.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
 #####         everflow            #####
 #######################################
 everflow/test_everflow_ipv6.py:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed
#### How did you do it?
Add acl test to optional test job and skip traffic test
#### How did you verify/test it?
run test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
