### PR TITLE
Fix mux simulator post

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -176,7 +176,7 @@ def _post(server_url, data):
     """
     try:
         session = Session()
-        if "allowed_methods" in inspect.getargspec(Retry).args:
+        if "allowed_methods" in inspect.signature(Retry).parameters:
             retry = Retry(total=3, connect=3, backoff_factor=1,
                           allowed_methods=frozenset(['GET', 'POST']),
                           status_forcelist=[x for x in requests.status_codes._codes if x != 200])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix the `ValueError` for mux simulator utilities:
```
08:21:52 mux_simulator_control._post              L0196 WARNING| POST http://10.64.*.*:8082/mux/vms21-6 with data {'active_side': 'lower_tor'} failed, err: ValueError('Function has keyword-only parameters or annotations, use inspect.signature() API which can support them')
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
Use `inspect.signature` instead.

#### How did you verify/test it?
Run over dualtor testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
