### PR TITLE
[platform_tests.broadcom.test_ser] add failure info in assert log if script return failure

### DIFF
--- a/tests/platform_tests/broadcom/test_ser.py
+++ b/tests/platform_tests/broadcom/test_ser.py
@@ -147,7 +147,31 @@ def test_ser(duthosts, rand_one_dut_hostname, enum_asic_index):
     else:
         logger.info('Test complete failed with timeout')
 
+    pattern_asic = re.compile(r'SER test on ASIC :(.*)')
+    match_asic = pattern_asic.search(get_log_cmd_stdout)
+    result_asic = match_asic.group(0) if match_asic else None
+
+    pattern_failed = re.compile(r'SER Test failed for memories (.*)')
+    match_failed_memories = pattern_failed.search(get_log_cmd_stdout)
+    result_failed_memories = match_failed_memories.group(0) if match_failed_memories else None
+
+    pattern_timeout = re.compile(r'SER Test timed out for memories (.*)')
+    match_timed_out_memories = pattern_timeout.search(get_log_cmd_stdout)
+    result_timed_out_memories = match_timed_out_memories.group(0) if match_timed_out_memories else None
+    logger.info('result_asic {}; \n'
+                'result_failed_memories {}; \n'
+                'result_timed_out_memories {}'.format(
+                    result_asic, result_failed_memories, result_timed_out_memories)
+                )
+
     logger.debug("test ser script output: \n {}".format(get_log_cmd_response['stdout_lines']))
     time.sleep(5)
     assert not_timeout, 'ser_injector scirpt timeout'
-    assert False, 'ser_injector scirpt failed '
+    assert False, (
+        'ser_injector script failed; \n'
+        'result_asic {}; \n'
+        'result_failed_memories {}; \n'
+        'result_timed_out_memories {}'.format(
+            result_asic, result_failed_memories, result_timed_out_memories
+        )
+    )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
28179454

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
The test_ser case failure on 202311 image.
Error log like: SER Test timed out for memories (1): ['MMU_MTRO_CONFIG_L1_MEM_PIPE1.mmu_sed0']"
Seems caused by the address from "bcmcmd 'list MMU_MTRO_CONFIG_L1_MEM_PIPE1.mmu_sed0'" is not same with the address in the log of "SER_CORRECTION"

#### How did you do it?
For memory address, need sync with Arista and Broadcom teamfirst.
Meanwhile, add these results information into assert log by this PR to track the failure more easily.

#### How did you verify/test it?
Run the case locally.
```
>       assert False, (                                                                                                                                                                                                                               
            'ser_injector script failed; \n'                                                                                                                                                                                                          
            'result_asic {}; \n'                                                                                                                                                                                                                      
            'result_failed_memories {}; \n'                                                                                                                                                                                                           
            'result_timed_out_memories {}'.format(                                                                                                                                                                                                    
                result_asic, result_failed_memories, result_timed_out_memories                                                                                                                                                                        
            )                                                                                                                                                                                                                                         
        )                                                                                                                                                                                                                                             
E       AssertionError: ser_injector script failed;                                                                                                                                                                                                   
E       result_asic SER test on ASIC : th2;                                                                                                                                                                                                           
E       result_failed_memories SER Test failed for memories (0): {} [];                                                                                                                                                                               
E       result_timed_out_memories SER Test timed out for memories (4): ['MMU_MTRO_CONFIG_L1_MEM_PIPE1.mmu_sed0', 'MMU_MTRO_CONFIG_L1_MEM_PIPE0.mmu_sed0', 'MMU_MTRO_CONFIG_L1_MEM_PIPE2.mmu_sed0', 'MMU_MTRO_CONFIG_L1_MEM_PIPE3.mmu_sed0']           
  ```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
