### PR TITLE
Add ipv6 address check for ntp case

### DIFF
--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -47,6 +47,8 @@ def config_long_jump(duthost, enable=False):
 
 @pytest.fixture(scope="module")
 def setup_ntp(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6):
+    if ptf_use_ipv6 and not ptfhost.mgmt_ipv6:
+        pytest.skip("No IPv6 address on PTF host")
     with _context_for_setup_ntp(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6) as result:
         yield result
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
When `ptf_use_ipv6=True` and ptf does not config IPv6 mgmt address, the `ptfhost.mgmt_ipv6` value is `None`. The test command will be `config ntp add none`. This is an invalid command and case will fail.

Fixes # (issue)
Add a check, if `ptf_use_ipv6=True` and `ptfhost.mgmt_ipv6` is `None`, skip this case.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run test case tests/ntp/test_ntp.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
