### PR TITLE
[Mellanox] Split test_device_checker into to two cases

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -166,8 +166,6 @@ def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname,
     wait_system_health_boot_up(duthost)
     with ConfigFileContext(duthost, os.path.join(FILES_DIR, DEVICE_CHECK_CONFIG_FILE)):
         time.sleep(DEFAULT_INTERVAL)
-        fan_mock_result, fan_name = device_mocker.mock_fan_speed(False)
-        fan_expect_value = EXPECT_FAN_INVALID_SPEED.format(fan_name)
 
         asic_mock_result = 'not support asic mock'
         if is_support_mock_asic:
@@ -177,17 +175,12 @@ def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname,
         psu_mock_result, psu_name = device_mocker.mock_psu_presence(False)
         psu_expect_value = EXPECT_PSU_MISSING.format(psu_name)
 
-        if fan_mock_result and asic_mock_result and psu_mock_result:
-            logger.info('Mocked invalid fan speed for {}'.format(fan_name))
+        if asic_mock_result and psu_mock_result:
             logger.info('Mocked ASIC overheated')
             logger.info('Mocked PSU absence for {}'.format(psu_name))
             logger.info('Waiting {} seconds for it to take effect'.format(
                 THERMAL_CHECK_INTERVAL))
             time.sleep(THERMAL_CHECK_INTERVAL)
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
-            assert value and fan_expect_value in value,\
-                'Mock fan invalid speed, expect {}, but got {}'.format(fan_expect_value, value)
             if is_support_mock_asic:
                 value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, 'ASIC')
                 assert value and asic_expect_value in value,\
@@ -197,21 +190,16 @@ def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname,
                 duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name)
             assert value and psu_expect_value == value,\
                 'Mock PSU absence, expect {}, but got {}'.format(psu_expect_value, value)
-        fan_mock_result, fan_name = device_mocker.mock_fan_speed(True)
+
         if is_support_mock_asic:
             asic_mock_result = device_mocker.mock_asic_temperature(True)
         psu_mock_result, psu_name = device_mocker.mock_psu_presence(True)
-        if fan_mock_result and asic_mock_result and psu_mock_result:
-            logger.info('Mocked valid fan speed for {}'.format(fan_name))
+        if asic_mock_result and psu_mock_result:
             logger.info('Mocked ASIC normal temperatue')
             logger.info('Mocked PSU presence for {}'.format(psu_name))
             logger.info('Waiting {} seconds for it to take effect'.format(
                 THERMAL_CHECK_INTERVAL))
             time.sleep(THERMAL_CHECK_INTERVAL)
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
-            assert not value or fan_expect_value not in value,\
-                'Mock fan valid speed, expect {}, but it still report invalid speed'.format(fan_expect_value)
 
             if is_support_mock_asic:
                 value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, 'ASIC')
@@ -403,6 +391,40 @@ def test_system_health_config(duthosts, enum_rand_one_per_hwsku_hostname,
                 duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name)
             assert not value or expect_value != value, 'PSU check is still performed after it ' \
                                                        'is configured to be ignored'
+
+
+@pytest.mark.disable_loganalyzer
+def test_device_fan_speed_checker(duthosts, enum_rand_one_per_hwsku_hostname,
+                                  device_mocker_factory, disable_thermal_policy, is_support_mock_asic):  # noqa F811
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    device_mocker = device_mocker_factory(duthost)
+    wait_system_health_boot_up(duthost)
+    with ConfigFileContext(duthost, os.path.join(FILES_DIR, DEVICE_CHECK_CONFIG_FILE)):
+        time.sleep(DEFAULT_INTERVAL)
+
+        fan_mock_result, fan_name = device_mocker.mock_fan_speed(False)
+        fan_expect_value = EXPECT_FAN_INVALID_SPEED.format(fan_name)
+
+        if fan_mock_result:
+            logger.info('Mocked invalid fan speed for {}'.format(fan_name))
+            logger.info('Waiting {} seconds for it to take effect'.format(
+                THERMAL_CHECK_INTERVAL))
+            time.sleep(THERMAL_CHECK_INTERVAL)
+            value = redis_get_field_value(
+                duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
+            assert value and fan_expect_value in value, \
+                'Mock fan invalid speed, expect {}, but got {}'.format(fan_expect_value, value)
+
+        fan_mock_result, fan_name = device_mocker.mock_fan_speed(True)
+        if fan_mock_result:
+            logger.info('Mocked valid fan speed for {}'.format(fan_name))
+            logger.info('Waiting {} seconds for it to take effect'.format(
+                THERMAL_CHECK_INTERVAL))
+            time.sleep(THERMAL_CHECK_INTERVAL)
+            value = redis_get_field_value(
+                duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
+            assert not value or fan_expect_value not in value, \
+                'Mock fan valid speed, expect {}, but it still report invalid speed'.format(fan_expect_value)
 
 
 def wait_system_health_boot_up(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When test mocks fan target speed and actual speed, it will cause fan tacho err, because the actual speed is not equal to target speed. This tacho err will exists until the whole test is finished, because we don't recover the mocked fan soft links until the test is finished. Therefore, when mocking the fan dir err, there will be two tc errors, so the  the pwm will be adjusted to 100, and the speed of fan also should be adjusted to full speed accordingly. But usually the fan speed cannot be adjusted to 100 in a short time, before it is adjusted to the full speed, there will be some waring msg such as "WARNING pmon#thermalctld: Fan low speed warning: fan*".

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Stablize the test_device_checker

#### How did you do it?
Split test_device_checker into two

#### How did you verify/test it?
run the two tests on Mellanox device

#### Any platform specific information?
Mellanox

#### Supported testbed topology if it's a new test case?


### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
