### PR TITLE
Fix dualtor_mgmt/test_toggle_mux.py

### DIFF
--- a/tests/dualtor_mgmt/test_toggle_mux.py
+++ b/tests/dualtor_mgmt/test_toggle_mux.py
@@ -36,8 +36,9 @@ def restore_mux_auto_mode(duthosts):
 def get_interval_v4(duthosts):
     mux_linkmgr_output = duthosts.shell('sonic-cfggen -d --var-json MUX_LINKMGR')
     mux_linkmgr = list(mux_linkmgr_output.values())[0]['stdout']
-    if len(mux_linkmgr) != 0:
-        cur_interval_v4 = json.loads(mux_linkmgr)['LINK_PROBER']['interval_v4']
+    mux_linkmgr_json = json.loads(mux_linkmgr)
+    if len(mux_linkmgr) != 0 and 'LINK_PROBER' in mux_linkmgr_json:
+        cur_interval_v4 = mux_linkmgr_json['LINK_PROBER']['interval_v4']
         return cur_interval_v4
     else:
         return None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix `dualtor_mgmt/test_toggle_mux.py`
Fixes [#161](https://github.com/aristanetworks/sonic-qual.msft/issues/161)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Regression due to: https://github.com/sonic-net/sonic-mgmt/pull/13004

The test fails with key error.

After the mentioned change https://github.com/sonic-net/sonic-mgmt/pull/13004 the mux_linkmgr can never be empty as it will always contain the key `TIMED_OSCILLATION`.

#### How did you do it?
The proposed fix is to make the check more specific for the key `LINK_PROBER.`

Check PR comment for debugging info.

#### How did you verify/test it?
Verified on Arista-7050 platform using dualtor topology.

```
dualtor_mgmt/test_toggle_mux.py::test_toggle_mux_from_simulator[upper_tor] PASSED                                                                                     
                                                                                                              [ 25%]                                                  
dualtor_mgmt/test_toggle_mux.py::test_toggle_mux_from_simulator[lower_tor] PASSED                                                                                     
                                                                                                              [ 50%]                                                  
dualtor_mgmt/test_toggle_mux.py::test_toggle_mux_from_cli[upper_tor] PASSED                                                                                           
                                                                                                              [ 75%]                                                  
dualtor_mgmt/test_toggle_mux.py::test_toggle_mux_from_cli[lower_tor] PASSED                                                                                           
                                                                                                              [100%]                              
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
