### PR TITLE
Added a retry mechanism on hash test

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -295,29 +295,46 @@ class HashTest(BaseTest):
             masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
 
-        send_packet(self, src_port, pkt)
-        logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={}, proto={})/TCP(sport={}, dport={} on port {})'
-                     .format(pkt.src,
-                             pkt.dst,
-                             pkt['IP'].src,
-                             pkt['IP'].dst,
-                             pkt['IP'].proto,
-                             sport,
-                             dport,
-                             src_port))
-        logging.info('Expect Ether(src={}, dst={})/IP(src={}, dst={}, proto={})/TCP(sport={}, dport={})'
-                     .format('any',
-                             'any',
-                             ip_src,
-                             ip_dst,
-                             ip_proto,
-                             sport,
-                             dport))
+        try:
+            send_packet(self, src_port, pkt)
+            logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={}, proto={})/TCP(sport={}, dport={} on port {})'
+                         .format(pkt.src,
+                                 pkt.dst,
+                                 pkt['IP'].src,
+                                 pkt['IP'].dst,
+                                 pkt['IP'].proto,
+                                 sport,
+                                 dport,
+                                 src_port))
+            logging.info('Expect Ether(src={}, dst={})/IP(src={}, dst={}, proto={})/TCP(sport={}, dport={})'
+                         .format('any',
+                                 'any',
+                                 ip_src,
+                                 ip_dst,
+                                 ip_proto,
+                                 sport,
+                                 dport))
 
-        dst_ports = list(itertools.chain(*dst_port_lists))
-        rcvd_port_index, rcvd_pkt = verify_packet_any_port(
-            self, masked_exp_pkt, dst_ports, timeout=1)
-        rcvd_port = dst_ports[rcvd_port_index]
+            dst_ports = list(itertools.chain(*dst_port_lists))
+            rcvd_port_index, rcvd_pkt = verify_packet_any_port(
+                self, masked_exp_pkt, dst_ports, timeout=1)
+            rcvd_port = dst_ports[rcvd_port_index]
+
+        except AssertionError:
+            logging.error("Traffic wasn't sent successfully, trying again")
+            send_packet(self, src_port, pkt, count=5)
+            logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={}, proto={})/TCP(sport={}, dport={} on port {})'
+                         .format(pkt.src,
+                                 pkt.dst,
+                                 pkt['IP'].src,
+                                 pkt['IP'].dst,
+                                 pkt['IP'].proto,
+                                 sport,
+                                 dport,
+                                 src_port))
+            rcvd_port_index, rcvd_pkt = verify_packet_any_port(
+                self, masked_exp_pkt, dst_ports, timeout=1)
+            rcvd_port = dst_ports[rcvd_port_index]
 
         exp_src_mac = None
         if len(self.ptf_test_port_map[str(rcvd_port)]["target_src_mac"]) > 1:
@@ -392,29 +409,56 @@ class HashTest(BaseTest):
             masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
 
-        send_packet(self, src_port, pkt)
-        logging.info('Sent Ether(src={}, dst={})/IPv6(src={}, dst={}, proto={})/TCP(sport={}, dport={} on port {})'
-                     .format(pkt.src,
-                             pkt.dst,
-                             pkt['IPv6'].src,
-                             pkt['IPv6'].dst,
-                             pkt['IPv6'].nh,
-                             sport,
-                             dport,
-                             src_port))
-        logging.info('Expect Ether(src={}, dst={})/IPv6(src={}, dst={}, proto={})/TCP(sport={}, dport={})'
-                     .format('any',
-                             'any',
-                             ip_src,
-                             ip_dst,
-                             ip_proto,
-                             sport,
-                             dport))
+        try:
+            send_packet(self, src_port, pkt)
+            logging.info('Sent Ether(src={}, dst={})/IPv6(src={}, dst={}, proto={})/TCP(sport={}, dport={} on port {})'
+                         .format(pkt.src,
+                                 pkt.dst,
+                                 pkt['IPv6'].src,
+                                 pkt['IPv6'].dst,
+                                 pkt['IPv6'].nh,
+                                 sport,
+                                 dport,
+                                 src_port))
+            logging.info('Expect Ether(src={}, dst={})/IPv6(src={}, dst={}, proto={})/TCP(sport={}, dport={})'
+                         .format('any',
+                                 'any',
+                                 ip_src,
+                                 ip_dst,
+                                 ip_proto,
+                                 sport,
+                                 dport))
 
-        dst_ports = list(itertools.chain(*dst_port_lists))
-        rcvd_port_index, rcvd_pkt = verify_packet_any_port(
-            self, masked_exp_pkt, dst_ports, timeout=1)
-        rcvd_port = dst_ports[rcvd_port_index]
+            dst_ports = list(itertools.chain(*dst_port_lists))
+            rcvd_port_index, rcvd_pkt = verify_packet_any_port(
+                self, masked_exp_pkt, dst_ports, timeout=1)
+            rcvd_port = dst_ports[rcvd_port_index]
+
+        except AssertionError:
+            logging.error("Traffic wasn't sent successfully, trying again")
+            send_packet(self, src_port, pkt, count=5)
+            logging.info('Sent Ether(src={}, dst={})/IPv6(src={}, dst={}, proto={})/TCP(sport={}, dport={} on port {})'
+                         .format(pkt.src,
+                                 pkt.dst,
+                                 pkt['IPv6'].src,
+                                 pkt['IPv6'].dst,
+                                 pkt['IPv6'].nh,
+                                 sport,
+                                 dport,
+                                 src_port))
+            logging.info('Expect Ether(src={}, dst={})/IPv6(src={}, dst={}, proto={})/TCP(sport={}, dport={})'
+                         .format('any',
+                                 'any',
+                                 ip_src,
+                                 ip_dst,
+                                 ip_proto,
+                                 sport,
+                                 dport))
+
+            dst_ports = list(itertools.chain(*dst_port_lists))
+            rcvd_port_index, rcvd_pkt = verify_packet_any_port(
+                self, masked_exp_pkt, dst_ports, timeout=1)
+            rcvd_port = dst_ports[rcvd_port_index]
 
         exp_src_mac = None
         if len(self.ptf_test_port_map[str(rcvd_port)]["target_src_mac"]) > 1:
@@ -634,6 +678,7 @@ class IPinIPHashTest(HashTest):
             self, masked_exp_pkt, dst_ports)
         rcvd_port = dst_ports[rcvd_port_index]
         exp_src_mac = None
+
         if len(self.ptf_test_port_map[str(rcvd_port)]["target_src_mac"]) > 1:
             # active-active dualtor, the packet could be received from either ToR, so use the received
             # port to find the corresponding ToR


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [X] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Preventing the hash test to fail in case of congestion on PTF.

#### How did you do it?
Added a retry mechanism on hash test in case a packet wasn't sent correctly to the DUT, the retry will be applied on the same hash ket and same IPs

#### How did you verify/test it?
Ran the hash test on ipv4/6 mode multiple times and ensured it was passing.


