### PR TITLE
Fix voq fabric tests to use yaml.safe_load instead of yaml.load

### DIFF
--- a/tests/voq/test_fabric_reach.py
+++ b/tests/voq/test_fabric_reach.py
@@ -37,7 +37,7 @@ def refData(duthosts):
         fileName = lc_sku + "_" + fabric_sku + "_" + "LC" + str(slot) + ".yaml"
         f = open("voq/fabric_data/{}".format(fileName))
         pytest_assert(f, "Need to update expected data for {}".format(fileName))
-        referenceData[slot] = yaml.load(f)
+        referenceData[slot] = yaml.safe_load(f)
     return referenceData
 
 
@@ -54,7 +54,7 @@ def supData(duthosts):
     fileName = fabric_sku + ".yaml"
     f = open("voq/fabric_data/{}".format(fileName))
     pytest_assert(f, "Need to update expected data for {}".format(fileName))
-    supData = yaml.load(f)
+    supData = yaml.safe_load(f)
     f.close()
     return supData
 

--- a/tests/voq/test_voq_fabric_status_all.py
+++ b/tests/voq/test_voq_fabric_status_all.py
@@ -38,7 +38,7 @@ def refData(duthosts):
         fileName = lc_sku + "_" + fabric_sku + "_" + "LC" + str(slot) + ".yaml"
         f = open("voq/fabric_data/{}".format(fileName))
         pytest_assert(f, "Need to update expected data for {}".format(fileName))
-        referenceData[slot] = yaml.load(f)
+        referenceData[slot] = yaml.safe_load(f)
     return referenceData
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This fixes a bug where VOQ fabric tests would raise an exception due to a missing Loader argument to yaml.load (due to new pyyaml version since the tests were written).

#### How did you do it?
I switched from `yaml.load()` to `yaml.safe_load()`.

#### How did you verify/test it?
I ran the tests against a local testbed and verified that the test passed and did not raise any exception.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
