### PR TITLE
Add error tolerance for drop counter test

### DIFF
--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -103,7 +103,11 @@ def verify_drop_counters(duthosts, asic_index, dut_iface, get_cnt_cli_cmd, colum
             # if the dut_iface is not found ignore this device
             if dut_iface not in pkt_drops:
                 continue
-            drop_list.append(int(pkt_drops[dut_iface][column_key].replace(",", "")))
+            try:
+                drop_list.append(int(pkt_drops[dut_iface][column_key].replace(",", "")))
+            except ValueError:
+                # Catch error invalid literal for int() with base 10: 'N/A'
+                drop_list.append(0)
         return drop_list
 
     def _check_drops_on_dut():

--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -110,14 +110,14 @@ def verify_drop_counters(duthosts, asic_index, dut_iface, get_cnt_cli_cmd, colum
         return packets_count in _get_drops_across_all_duthosts()
 
     if not wait_until(25, 1, 0, _check_drops_on_dut):
-        # The actual Drop count should always be equal or 1 or 2 packets more than what is expected
-        # due to some other drop may occur over the interface being examined.
-        # When that happens if looking onlyu for exact count it will be a false positive failure.
-        # So do one more check to allow up to 2 packets more dropped than what was expected as an allowed case.
+        # We were seeing a few more drop counters than expected, so we are allowing a small margin of error
+        DEOP_MARGIN = 10
         actual_drop = _get_drops_across_all_duthosts()
-        if ((packets_count+2) in actual_drop) or ((packets_count+1) in actual_drop):
-            logger.warning("Actual drops {} exceeded expected drops {} on iface {}\n"
-                           .format(actual_drop, packets_count, dut_iface))
+        for drop in actual_drop:
+            if drop >= packets_count and drop <= packets_count + DEOP_MARGIN:
+                logger.warning("Actual drops {} exceeded expected drops {} on iface {}\n".format(
+                    actual_drop, packets_count, dut_iface))
+                break
         else:
             fail_msg = "'{}' drop counter was not incremented on iface {}. DUT {} == {}; Sent == {}".format(
                 column_key, dut_iface, column_key, actual_drop, packets_count)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to stabilize drop counter test.
The test is flaky because there are unexpected RX_ERR in addition to the testing packet, which leads to increament of drop counter is larger than expected. The error message is 
```
Failed: 'RX_ERR' drop counter was not incremented on iface PortChannel1020. DUT RX_ERR == [1003]; Sent == 1000
```
This PR fixed the issue by adding tolerance to the drop counter check. The default tolerance is `10`.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to stabilize drop counter test.

#### How did you do it?
This PR fixed the issue by adding tolerance to the drop counter check. 

#### How did you verify/test it?
The change is verified on a physical testbed. Test can pass if additional RX_ERR is seen.
```
collected 9 items                                                                                                                                                                                 

drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-str3-msn4700-01-version-1] <- drop_packets/drop_packets.py PASSED                                            [ 11%]
drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-str3-msn4700-01-chksum-10] <- drop_packets/drop_packets.py 
------------------------------------------------------------------------------------------ live log call ------------------------------------------------------------------------------------------
00:56:17 drop_counters.verify_drop_counters       L0118 WARNING| Actual drops [1006] exceeded expected drops 1000 on iface PortChannel103

PASSED                                                                                                                                                                                      [ 22%]
drop_packets/test_drop_counters.py::test_broken_ip_header[port_channel_members-str3-msn4700-01-ihl-1] <- drop_packets/drop_packets.py PASSED                                                [ 33%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-str3-msn4700-01-version-1] <- drop_packets/drop_packets.py SKIPPED (No vlan_members available)                       [ 44%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-str3-msn4700-01-chksum-10] <- drop_packets/drop_packets.py SKIPPED (No vlan_members available)                       [ 55%]
drop_packets/test_drop_counters.py::test_broken_ip_header[vlan_members-str3-msn4700-01-ihl-1] <- drop_packets/drop_packets.py SKIPPED (No vlan_members available)                           [ 66%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-str3-msn4700-01-version-1] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                         [ 77%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-str3-msn4700-01-chksum-10] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                         [ 88%]
drop_packets/test_drop_counters.py::test_broken_ip_header[rif_members-str3-msn4700-01-ihl-1] <- drop_packets/drop_packets.py SKIPPED (No rif_members available)                             [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
