### PR TITLE
Skip the temperature checks for empty SFP ports

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -163,6 +163,10 @@ def check_sysfs(dut):
 
     logging.info("Check SFP related sysfs")
     for sfp_id, sfp_info in list(sysfs_facts['sfp_info'].items()):
+        # Skip the check for empty values
+        if not sfp_info["temp_fault"]:
+            continue
+
         assert sfp_info["temp_fault"] == '0', "SFP%d temp fault" % int(sfp_id)
         sfp_temp = float(sfp_info['temp']) if sfp_info['temp'] != '0' else 0
         sfp_temp_crit = float(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # This fix will skip the assert condition for the ports that does not have transceiver plugged in.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
If a transceiver is not plugged in, the `"check_sysfs"` function throws an assertion error as below, causing the reboot test cases to fail.

<mark>`AssertionError: SFP32 temp fault`</mark>

#### How did you do it?
Updated the `"check_sysfs"` function to skip the temperature fault checks for `"sfp_info[temp_fault]"` if it is empty.

#### How did you verify/test it?
Test proceeds successfully after adding this fix:

21:30:23 check_sysfs.check_sysfs                  L0164 INFO   | Check SFP related sysfs
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 1
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 2
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 3
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 4
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 5
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 6
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 7
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 8
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 9
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 10
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 11
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 12
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 13
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 14
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 15
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 16
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 17
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 18
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 19
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 20
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 21
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 22
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 23
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 24
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 25
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 26
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 27
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 28
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 29
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 30
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault] 0 for sfp id 31
21:30:23 check_sysfs.check_sysfs                  L0166 INFO   | sfp_info[temp_fault]  for sfp id 32
21:30:23 check_sysfs.check_sysfs                  L0182 INFO   | Finish checking sysfs
.
.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
