### PR TITLE
clean up and adjust fanout deploy file

### DIFF
--- a/ansible/roles/fanout/templates/sonic_deploy_202305.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202305.j2
@@ -166,15 +166,15 @@
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
     {% for port_name in fanout_port_config %}
-         "{{ port_name }}|": {
-            "profile_list": "egress_lossless_profile,egress_lossy_profile"
+         "{{ port_name }}": {
+            "profile_list": "egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
     {% endfor %}
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
     {% for port_name in fanout_port_config %}
-         "{{ port_name }}|": {
-            "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+         "{{ port_name }}": {
+            "profile_list": "ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
     {% endfor %}
     },

--- a/ansible/roles/fanout/templates/sonic_deploy_202311.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202311.j2
@@ -166,15 +166,15 @@
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
     {% for port_name in fanout_port_config %}
-         "{{ port_name }}|": {
-            "profile_list": "egress_lossless_profile,egress_lossy_profile"
+         "{{ port_name }}": {
+            "profile_list": "egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
     {% endfor %}
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
     {% for port_name in fanout_port_config %}
-         "{{ port_name }}|": {
-            "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+         "{{ port_name }}": {
+            "profile_list": "ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
     {% endfor %}
     },


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Remove unnecessary char after names in the config db for BUFFER_PORT_EGRESS_PROFILE_LIST

#### How did you do it?
Adjust the ansible\roles\fanout\templates\sonic_deploy_202305.j2 and 202311.j2 file

#### How did you verify/test it?
`cat config_db.json | grep -A 5 BUFFER_PORT_EGRESS_PROFILE_LIST`
Before
```
    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
        "Ethernet8|": {
            "profile_list": "egress_lossless_profile,egress_lossy_profile"
        },
        "Ethernet184|": {
            "profile_list": "egress_lossless_profile,egress_lossy_profile"
```
After
```
    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
        "Ethernet0": {
            "profile_list": "egress_lossy_profile"
        },
        "Ethernet8": {
            "profile_list": "egress_lossy_profile"
```
#### Any platform specific information?
Is for 202305 and 202311
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
