### PR TITLE
Fix test_neighbor_mac on t1-lag and t1-64-lag

### DIFF
--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -53,8 +53,12 @@ class TestNeighborMac:
             try:
                 if portchannel:
                     duthost.command("sudo config portchannel member del {} {}".format(portchannel, intf))
-                    pytest_assert(wait_until(10, 1, 0, lambda: 'routed' in duthost.show_interface(command="status")["ansible_facts"]["int_status"][intf]["vlan"]),
-                                  '{} is not in routed status'.format(intf))
+                    pytest_assert(wait_until(
+                        10, 1, 0,
+                        lambda: 'routed' in duthost.show_interface(command="status")
+                        ["ansible_facts"]["int_status"][intf]["vlan"]),
+                        '{} is not in routed status'.format(intf)
+                    )
                 yield
             finally:
                 if portchannel:

--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -4,6 +4,7 @@ import pytest
 import time
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -52,9 +53,8 @@ class TestNeighborMac:
             try:
                 if portchannel:
                     duthost.command("sudo config portchannel member del {} {}".format(portchannel, intf))
-                    time.sleep(2)
-                    intfStatus = duthost.show_interface(command="status")["ansible_facts"]["int_status"]
-                    pytest_assert('routed' in intfStatus[intf]["vlan"], '{} not in routed status'.format(intf))
+                    pytest_assert(wait_until(10, 1, 0, lambda: 'routed' in duthost.show_interface(command="status")["ansible_facts"]["int_status"][intf]["vlan"]),
+                                  '{} is not in routed status'.format(intf))
                 yield
             finally:
                 if portchannel:

--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import pytest
 import time
@@ -35,15 +36,41 @@ class TestNeighborMac:
                 None
         """
         duthost = duthosts[rand_one_dut_hostname]
-        logger.info("Configure the DUT interface, start interface, add IP address")
-        self.__startInterface(duthost)
-        self.__configureInterfaceIp(duthost, action="add")
 
-        yield
+        intfStatus = duthost.show_interface(command="status")["ansible_facts"]["int_status"]
+        if self.DUT_ETH_IF not in intfStatus:
+            pytest.skip('{} not found'.format(self.DUT_ETH_IF))
 
-        logger.info("Restore the DUT interface config, remove IP address")
-        self.__configureInterfaceIp(duthost, action="remove")
-        self.__shutdownInterface(duthost)
+        status = intfStatus[self.DUT_ETH_IF]
+        if "up" not in status["oper_state"]:
+            pytest.skip('{} is down'.format(self.DUT_ETH_IF))
+
+        portchannel = status["vlan"] if "PortChannel" in status["vlan"] else None
+
+        @contextlib.contextmanager
+        def removeFromPortChannel(duthost, portchannel, intf):
+            try:
+                if portchannel:
+                    duthost.command("sudo config portchannel member del {} {}".format(portchannel, intf))
+                    time.sleep(2)
+                    intfStatus = duthost.show_interface(command="status")["ansible_facts"]["int_status"]
+                    if 'routed' not in intfStatus[intf]["vlan"]:
+                        pytest.skip('{} is not in routed status'.format(self.DUT_ETH_IF))
+                yield
+            finally:
+                if portchannel:
+                    duthost.command("sudo config portchannel member add {} {}".format(portchannel, intf))
+
+        with removeFromPortChannel(duthost, portchannel, self.DUT_ETH_IF):
+            logger.info("Configure the DUT interface, start interface, add IP address")
+            self.__startInterface(duthost)
+            self.__configureInterfaceIp(duthost, action="add")
+
+            yield
+
+            logger.info("Restore the DUT interface config, remove IP address")
+            self.__configureInterfaceIp(duthost, action="remove")
+            self.__shutdownInterface(duthost)
 
     @pytest.fixture(params=[0, 1])
     def macIndex(self, request):

--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -54,8 +54,7 @@ class TestNeighborMac:
                     duthost.command("sudo config portchannel member del {} {}".format(portchannel, intf))
                     time.sleep(2)
                     intfStatus = duthost.show_interface(command="status")["ansible_facts"]["int_status"]
-                    if 'routed' not in intfStatus[intf]["vlan"]:
-                        pytest.skip('{} is not in routed status'.format(self.DUT_ETH_IF))
+                    pytest_assert('routed' in intfStatus[intf]["vlan"], '{} not in routed status'.format(intf))
                 yield
             finally:
                 if portchannel:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
A recent change applies this test to the topo of t1 and t1-variants:
https://github.com/sonic-net/sonic-mgmt/pull/12952

The test can pass on topo t1 without any change.

For t1-lag or t1-64-lag, the Ethernet0 to test is in portchannel, so IP address cannot be set to it. 

#### How did you do it?
The fix here is to remove the intf from the portchanenl before testing it.
Skip the test if Ethernet0 is not available or down at the beginning of test
Assert Ethernet0 is in routed state after removing it from portchannel 

#### How did you verify/test it?
Run the test on t1-lag and t1-64-lag topo.
 - The test can pass
 - Verified in the log that removing and adding the member to PortChannel succeeded
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
