### PR TITLE
Fix multi-asic lldp fix (#13190)

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -65,7 +65,7 @@ class MultiAsicSonicHost(object):
         service_list = []
         active_asics = self.asics
         if self.sonichost.is_supervisor_node():
-            self._DEFAULT_SERVICES.append("lldp")
+            service_list.append("lldp")
             if self.get_facts()['asic_type'] != 'vs':
                 active_asics = []
                 sonic_db_cli_out = \
@@ -98,7 +98,7 @@ class MultiAsicSonicHost(object):
                 if config_facts['FEATURE'][service]['state'] == "disabled":
                     self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
         else:
-            self._DEFAULT_SERVICES.append("lldp")
+            service_list.append("lldp")
 
         for asic in active_asics:
             service_list += asic.get_critical_services()


### PR DESCRIPTION
The global variable _DEFAULT_SERVICES will affect any future MultiAsicSonicHost instances for the test; this means that if this runs for the supervisor instance first then lldp gets incorrectly added for the linecard instances.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Cherry-pick #13190 to 202405 since it's reported conflict

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

The global variable _DEFAULT_SERVICES will affect any future MultiAsicSonicHost instances for the test; this means that if this runs for the supervisor instance first then lldp gets incorrectly added for the linecard instances.

#### How did you do it?
Fix this by just modifying the local service_list that we're making anyways.

#### How did you verify/test it?
Tested manually on 202405 on Arista hardware and verified that the pre-sanity check does not fail because the lldp service is not running.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
