### PR TITLE
[QoS] J2C+ _qos_yaml  for 400 and 100G 

### DIFF
--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -264,7 +264,7 @@ qos_params:
                     pkts_num_dismiss_pfc: 3243
                     pkts_num_margin: 150
                 lossy_queue_1:
-                    dscp: 7
+                    dscp: 8
                     ecn: 1
                     pg: 0
                     pkts_num_trig_egr_drp: 2396745
@@ -371,7 +371,7 @@ qos_params:
                     pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 lossy_queue_1:
-                    dscp: 7
+                    dscp: 8
                     ecn: 1
                     pg: 0
                     pkts_num_trig_egr_drp: 2396745
@@ -478,7 +478,7 @@ qos_params:
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 lossy_queue_1:
-                    dscp: 7
+                    dscp: 8
                     ecn: 1
                     pg: 0
                     pkts_num_trig_egr_drp: 2396745

--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -220,15 +220,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 97133
+                    pkts_num_trig_pfc: 415213
+                    pkts_num_trig_ingr_drp: 418723
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 97133
+                    pkts_num_trig_pfc: 415213
+                    pkts_num_trig_ingr_drp: 418723
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -237,7 +237,7 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 93635
+                    pkts_num_trig_pfc: 415213
                     pkts_num_hdrm_full: 3510
                     pkts_num_hdrm_partial: 3500
                     margin: 5
@@ -245,36 +245,36 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 97133
+                    pkts_num_trig_pfc: 415213
+                    pkts_num_trig_ingr_drp: 418723
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 415213
+                    pkts_num_dismiss_pfc: 3243
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 415213
+                    pkts_num_dismiss_pfc: 3243
                     pkts_num_margin: 150
                 lossy_queue_1:
                     dscp: 7
                     ecn: 1
-                    pg: 1
-                    pkts_num_trig_egr_drp: 2396745
+                    pg: 0
+                    pkts_num_trig_egr_drp: 1198372
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 51
-                    pkts_num_trig_pfc: 93622
+                    pkts_num_trig_pfc: 415213
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -283,7 +283,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_fill_min: 51
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 1198372
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -292,7 +292,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 97133
+                    pkts_num_trig_ingr_drp: 418723
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -309,7 +309,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 1198372
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8
@@ -327,15 +327,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 272237
+                    pkts_num_trig_pfc: 415213
+                    pkts_num_trig_ingr_drp: 593827
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 272237
+                    pkts_num_trig_pfc: 415213
+                    pkts_num_trig_ingr_drp: 593827
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -344,7 +344,7 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 93635
+                    pkts_num_trig_pfc: 415213
                     pkts_num_hdrm_full: 176849
                     pkts_num_hdrm_partial: 176749
                     margin: 100
@@ -352,36 +352,36 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 272237
+                    pkts_num_trig_pfc: 415213
+                    pkts_num_trig_ingr_drp: 593827
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 415213
+                    pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 415213
+                    pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 lossy_queue_1:
                     dscp: 7
                     ecn: 1
-                    pg: 1
-                    pkts_num_trig_egr_drp: 2396745
+                    pg: 0
+                    pkts_num_trig_egr_drp: 1198372
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_fill_min: 51
-                    pkts_num_trig_pfc: 93622
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 415213
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -389,8 +389,8 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_fill_min: 51
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 1198372
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -399,7 +399,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 272237
+                    pkts_num_trig_ingr_drp: 593827
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -416,7 +416,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 1198372
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8
@@ -434,15 +434,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 807021
+                    pkts_num_trig_pfc: 657410
+                    pkts_num_trig_ingr_drp: 1370800
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 807021
+                    pkts_num_trig_pfc: 657410
+                    pkts_num_trig_ingr_drp: 1370800
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -451,44 +451,44 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 93635
-                    pkts_num_hdrm_full: 713000
-                    pkts_num_hdrm_partial: 712950
+                    pkts_num_trig_pfc: 657540
+                    pkts_num_hdrm_full: 622850
+                    pkts_num_hdrm_partial: 622750
                     margin: 300
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_trig_ingr_drp: 807021
+                    pkts_num_trig_pfc: 657410
+                    pkts_num_trig_ingr_drp: 1370800
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 657410
+                    pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 93622
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 657410
+                    pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 lossy_queue_1:
                     dscp: 7
                     ecn: 1
-                    pg: 1
-                    pkts_num_trig_egr_drp: 2396745
-                    pkts_num_margin: 3500
+                    pg: 0
+                    pkts_num_trig_egr_drp: 1198372
+                    pkts_num_margin: 100
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_fill_min: 71
-                    pkts_num_trig_pfc: 37449
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 657410
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -496,8 +496,8 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_fill_min: 71
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 1198372
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -506,7 +506,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 807021
+                    pkts_num_trig_ingr_drp: 1370800
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -523,7 +523,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 1198372
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8

--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -220,15 +220,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 415213
-                    pkts_num_trig_ingr_drp: 418723
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 418781
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 415213
-                    pkts_num_trig_ingr_drp: 418723
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 418781
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -237,7 +237,7 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 415213
+                    pkts_num_trig_pfc: 415271
                     pkts_num_hdrm_full: 3510
                     pkts_num_hdrm_partial: 3500
                     margin: 5
@@ -245,36 +245,36 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 415213
-                    pkts_num_trig_ingr_drp: 418723
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 418781
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 415213
+                    pkts_num_trig_pfc: 415271
                     pkts_num_dismiss_pfc: 3243
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 415213
+                    pkts_num_trig_pfc: 415271
                     pkts_num_dismiss_pfc: 3243
                     pkts_num_margin: 150
                 lossy_queue_1:
                     dscp: 7
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 1198372
+                    pkts_num_trig_egr_drp: 2396745
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_fill_min: 51
-                    pkts_num_trig_pfc: 415213
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 415271
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -282,8 +282,8 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_fill_min: 51
-                    pkts_num_trig_egr_drp: 1198372
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 2396745
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -292,7 +292,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 418723
+                    pkts_num_trig_ingr_drp: 418781
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -309,7 +309,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 1198372
+                    pkts_num_trig_egr_drp: 2396745
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8
@@ -327,15 +327,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 415213
-                    pkts_num_trig_ingr_drp: 593827
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 593885
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 415213
-                    pkts_num_trig_ingr_drp: 593827
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 593885
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -344,7 +344,7 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 415213
+                    pkts_num_trig_pfc: 415271
                     pkts_num_hdrm_full: 176849
                     pkts_num_hdrm_partial: 176749
                     margin: 100
@@ -352,36 +352,36 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 415213
-                    pkts_num_trig_ingr_drp: 593827
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 593885
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 415213
+                    pkts_num_trig_pfc: 415271
                     pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 415213
+                    pkts_num_trig_pfc: 415271
                     pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 lossy_queue_1:
                     dscp: 7
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 1198372
+                    pkts_num_trig_egr_drp: 2396745
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 415213
+                    pkts_num_trig_pfc: 415271
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -390,7 +390,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 1198372
+                    pkts_num_trig_egr_drp: 2396745
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -399,7 +399,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 593827
+                    pkts_num_trig_ingr_drp: 593885
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -416,7 +416,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 1198372
+                    pkts_num_trig_egr_drp: 2396745
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8
@@ -434,15 +434,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 657410
-                    pkts_num_trig_ingr_drp: 1370800
+                    pkts_num_trig_pfc: 657523
+                    pkts_num_trig_ingr_drp: 1370921
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 657410
-                    pkts_num_trig_ingr_drp: 1370800
+                    pkts_num_trig_pfc: 657523
+                    pkts_num_trig_ingr_drp: 1370921
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -451,7 +451,7 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 657540
+                    pkts_num_trig_pfc: 657523
                     pkts_num_hdrm_full: 622850
                     pkts_num_hdrm_partial: 622750
                     margin: 300
@@ -459,36 +459,36 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 657410
-                    pkts_num_trig_ingr_drp: 1370800
+                    pkts_num_trig_pfc: 657523
+                    pkts_num_trig_ingr_drp: 1370921
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 657410
+                    pkts_num_trig_pfc: 657523
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 657410
+                    pkts_num_trig_pfc: 657523
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 lossy_queue_1:
                     dscp: 7
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 1198372
+                    pkts_num_trig_egr_drp: 2396745
                     pkts_num_margin: 100
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 657410
+                    pkts_num_trig_pfc: 657523
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -497,7 +497,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 1198372
+                    pkts_num_trig_egr_drp: 2396745
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -506,7 +506,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 1370800
+                    pkts_num_trig_ingr_drp: 1370921
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -523,7 +523,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 1198372
+                    pkts_num_trig_egr_drp: 2396745
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Updated qos test params for 400g and 100g port speeds for the new vsq threshold introduced in PR#https://github.com/sonic-net/sonic-buildimage/pull/18239

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Executed  Qos test for  j2C+  t2 topology 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
