### PR TITLE
Fix force_mgmt_route failed on some hardware because snmp agent can't bind to eth1 address issue.

### DIFF
--- a/tests/override_config_table/utilities.py
+++ b/tests/override_config_table/utilities.py
@@ -23,13 +23,13 @@ def get_running_config(duthost, asic=None):
     return json.loads(duthost.shell("sonic-cfggen {} -d --print-data".format(ns))['stdout'])
 
 
-def reload_minigraph_with_golden_config(duthost, json_data):
+def reload_minigraph_with_golden_config(duthost, json_data, safe_reload=True):
     """
     for multi-asic/single-asic devices, we only have 1 golden_config_db.json
     """
     golden_config = "/etc/sonic/golden_config_db.json"
     duthost.copy(content=json.dumps(json_data, indent=4), dest=golden_config)
-    config_reload(duthost, config_source="minigraph", safe_reload=True, override_config=True)
+    config_reload(duthost, config_source="minigraph", safe_reload=safe_reload, override_config=True)
 
 
 def file_exists_on_dut(duthost, filename):

--- a/tests/route/test_forced_mgmt_route.py
+++ b/tests/route/test_forced_mgmt_route.py
@@ -164,6 +164,11 @@ def test_forced_mgmt_route_add_and_remove_by_mgmt_port_status(
                         override_config,
                         False)
 
+    # for device can't config eth1, ignore this test case
+    eth1_status = duthost.command("sudo ifconfig eth1")['stdout']
+    if "Device not found" in eth1_status:
+        pytest.skip("Skip test_forced_mgmt_route_add_and_remove_by_mgmt_port_status because hardware can't config eth1")
+
     # Get interface and check config generate correct
     interfaces = duthost.command("cat /etc/network/interfaces")['stdout']
     logging.debug("interfaces: {}".format(interfaces))

--- a/tests/route/test_forced_mgmt_route.py
+++ b/tests/route/test_forced_mgmt_route.py
@@ -11,6 +11,7 @@ from tests.override_config_table.utilities import backup_config, restore_config,
 from tests.syslog.syslog_utils import is_mgmt_vrf_enabled
 
 pytestmark = [
+    pytest.mark.disable_loganalyzer,
     pytest.mark.topology('t0'),
     pytest.mark.device_type('vs')
 ]

--- a/tests/route/test_forced_mgmt_route.py
+++ b/tests/route/test_forced_mgmt_route.py
@@ -160,7 +160,8 @@ def test_forced_mgmt_route_add_and_remove_by_mgmt_port_status(
                         "/etc/network/interfaces",
                         reload_minigraph_with_golden_config,
                         duthost,
-                        override_config)
+                        override_config,
+                        False)
 
     # Get interface and check config generate correct
     interfaces = duthost.command("cat /etc/network/interfaces")['stdout']


### PR DESCRIPTION
Fix force_mgmt_route failed on some hardware because snmp agent can't bind to eth1 address issue.

#### Why I did it
force_mgmt_route test case failed on some hardware because snmp agent can't bind to eth1 address.

##### Work item tracking
- Microsoft ADO: 28434014

#### How I did it
Ignore check SNMP agent process status by use unsafe config reload.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Fix force_mgmt_route failed on some hardware because snmp agent can't bind to eth1 address issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

