### PR TITLE
Update getbuild.py to support both PAT and access_token

### DIFF
--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -62,16 +62,24 @@ def validate_url_or_abort(url):
             sys.exit(1)
 
 
-def get_download_url(buildid, artifact_name, url_prefix, access_token):
+def get_download_url(buildid, artifact_name, url_prefix, access_token, token):
     """get download url"""
 
     artifact_req = Request("https://dev.azure.com/{}/_apis/build/builds/{}/artifacts?artifactName={}&api-version=5.0"
                            .format(url_prefix, buildid, artifact_name))
 
-    # If access token is not empty, set headers
-    if access_token:
-        artifact_req.add_header('Authorization',
-                                'Basic {}'.format(base64.b64encode(access_token.encode('utf-8')).decode('utf-8')))
+    # Here "access_token" indeed is Azure DevOps PAT token.
+    # "token" should be the actual bearer token for Azure DevOps.
+    # PAT should be deprecated. below logic is to handle both cases for smooth transition from PAT to bearer token.
+    if token:
+        artifact_req.add_header(
+            'Authorization', 'Bearer {}'.format(token)
+        )
+    elif access_token:
+        artifact_req.add_header(
+            'Authorization',
+            'Basic {}'.format(base64.b64encode(access_token.encode('utf-8')).decode('utf-8'))
+        )
 
     resp = urlopen(artifact_req)
 
@@ -83,7 +91,7 @@ def get_download_url(buildid, artifact_name, url_prefix, access_token):
     return (download_url, artifact_size)
 
 
-def download_artifacts(url, content_type, platform, buildid, num_asic, access_token):
+def download_artifacts(url, content_type, platform, buildid, num_asic, access_token, token):
     """find latest successful build id for a branch"""
 
     if content_type == 'image':
@@ -109,13 +117,27 @@ def download_artifacts(url, content_type, platform, buildid, num_asic, access_to
             try:
                 print(('Downloading {} from build {}...'.format(filename, buildid)))
                 download_times += 1
-                # If access token is not empty, set headers
-                if access_token:
+                opener = build_opener()
+                # Here "access_token" indeed is Azure DevOps PAT token.
+                # "token" should be the actual bearer token for Azure DevOps.
+                # PAT should be deprecated.
+                # Below logic is to handle both cases for smooth transition from PAT to bearer token.
+                if token:
+                    opener.addheaders = [
+                        (
+                            "Authorization",
+                            "Bearer {}".format(token)
+                         )
+                    ]
+                elif access_token:
                     opener = build_opener()
                     opener.addheaders = [
-                        ('Authorization',
-                         'Basic {}'.format(base64.b64encode(access_token.encode('utf-8')).decode('utf-8')))]
-                    install_opener(opener)
+                        (
+                            'Authorization',
+                            'Basic {}'.format(base64.b64encode(access_token.encode('utf-8')).decode('utf-8'))
+                        )
+                    ]
+                install_opener(opener)
                 urlretrieve(url, filename, reporthook)
                 print('\nDownload finished!')
                 break
@@ -172,7 +194,9 @@ def main():
     parser.add_argument('--url_prefix', metavar='url_prefix',
                         type=str, default='mssonic/build', help='url prefix')
     parser.add_argument('--access_token', metavar='access_token', type=str,
-                        default='', nargs='?', const='', required=False, help='access token')
+                        default='', nargs='?', const='', required=False, help='access token (PAT)')
+    parser.add_argument('--token', metavar='token', type=str,
+                        default='', nargs='?', const='', required=False, help='bearer token')
 
     args = parser.parse_args()
 
@@ -193,10 +217,11 @@ def main():
 
     (dl_url, artifact_size) = get_download_url(buildid, artifact_name,
                                                url_prefix=args.url_prefix,
-                                               access_token=args.access_token)
+                                               access_token=args.access_token,
+                                               token=args.token)
 
     download_artifacts(dl_url, args.content, args.platform,
-                       buildid, args.num_asic, access_token=args.access_token)
+                       buildid, args.num_asic, access_token=args.access_token, token=args.token)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
The getbuild.py tool was indeed using Azure DevOps PAT for downloading artifacts. We need to deprecate using PAT. 

#### How did you do it?
This change updated the getbuild.py to support using bearer access_token. With this change, both PAT and bearer access_token are supported. However, bearer access_token has higher priority.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
