### PR TITLE
add support of IPv6 tc field in bfd responder

### DIFF
--- a/ansible/roles/test/files/helpers/bfd_responder.py
+++ b/ansible/roles/test/files/helpers/bfd_responder.py
@@ -12,6 +12,9 @@ from scapy.contrib.bfd import BFD
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 scapy2.conf.use_pcap = True
 
+IPv4 = '4'
+IPv6 = '6'
+
 
 def get_if(iff, cmd):
     s = socket.socket()
@@ -78,7 +81,7 @@ class Poller(object):
 class BFDResponder(object):
     def __init__(self, sessions):
         self.sessions = sessions
-        self.bfd_default_ip_tos = 192
+        self.bfd_default_ip_priority = 192
         return
 
     def action(self, interface):
@@ -111,13 +114,15 @@ class BFDResponder(object):
         mac_dst = ether.dst
         ip_src = ether.payload.src
         ip_dst = ether.payload.dst
-        ip_tos = ether.payload.tos
+        ip_version = str(ether.payload.version)
+        ip_priority_field = 'tos' if ip_version == IPv4 else 'tc'
+        ip_priority = getattr(ether.payload, ip_priority_field)
         bfdpkt = BFD(ether.payload.payload.payload.load)
         bfd_remote_disc = bfdpkt.my_discriminator
         bfd_state = bfdpkt.sta
-        if ip_tos != self.bfd_default_ip_tos:
-            raise RuntimeError("Received BFD packet with incorrect tos: {}".format(ip_tos))
-        logging.debug('BFD packet info: sip {}, dip {}, tos {}'.format(ip_src, ip_dst, ip_tos))
+        if ip_priority != self.bfd_default_ip_priority:
+            raise RuntimeError("Received BFD packet with incorrect priority value: {}".format(ip_priority))
+        logging.debug('BFD packet info: sip {}, dip {}, priority {}'.format(ip_src, ip_dst, ip_priority))
         return mac_src, mac_dst, ip_src, ip_dst, bfd_remote_disc, bfd_state
 
     def craft_bfd_packet(self, session, data, mac_src, mac_dst, ip_src, ip_dst, bfd_remote_disc, bfd_state):


### PR DESCRIPTION
Change-Id: Ia75304532a975289ba1f61feef44374b769d1484

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Adding support of IPv6 priority field named "tc" in bfd_responder.py

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix bfd tests that are running with both IPv4 and IPv6

#### How did you do it?
Defined dynamical ip_priority variable equal to "tos" for IPv4 and equal to "tc" for IPv6

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
