### PR TITLE
Use is_python3=True in test_ipinip_hash_negative ptf_runner

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -436,4 +436,5 @@ def test_ipinip_hash_negative(add_default_route_to_dut, duthosts, fib_info_files
                },
                log_file=log_file,
                qlen=PTF_QLEN,
-               socket_recv_size=16384)
+               socket_recv_size=16384,
+               is_python3=True)


### PR DESCRIPTION
### Description of PR
`test_ipinip_hash_negative` was using `ptf_runner` without passing `is_python3=True`.
This resulted in some code which did string formatting unique to Python3 to assert:
```
"Traceback (most recent call last):"
"  File \"/usr/bin/ptf\", line 522, in <module>"
"    test_modules = load_test_modules(config)"
"  File \"/usr/bin/ptf\", line 413, in load_test_modules"
"    mod = imp.load_module(modname, *imp.find_module(modname, [root]))"
"  File \"ptftests/py3/pfc_wd_background_traffic.py\", line 40"
"    print(f\"traffic from {src_port} to {dst_port}: {queue} \")"
"                                                           ^"
"SyntaxError: invalid syntax"]
```

Summary:
Fixes #13313 

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
