### PR TITLE
[platform_tests.broadcom.test_ser] update timeout items for test ser case

### DIFF
--- a/tests/platform_tests/broadcom/files/ser_injector.py
+++ b/tests/platform_tests/broadcom/files/ser_injector.py
@@ -123,6 +123,11 @@ SKIP_MEMORY_PER_ASIC = {
             'EGR_ZONE_1_DOT1P_MAPPING_TABLE_4.eABLE_4.epipe0', 'EGR_ZONE_3_DOT1P_MAPPING_TABLE_1.epipe0',
             'EGR_FLEX_CONTAINER_UPDATE_PROFILE_1.epipe0', 'EGR_ZONE_3_DOT1P_MAPPING_TABLE_3.epipe0',
             'EGR_VLAN_CONTROL_2.epipe0', 'EGR_ZONE_1_DOT1P_MAPPING_TABLE_4.epipe0',
+            'MMU_MTRO_CONFIG_L1_MEM.mmu_sed0',
+            'MMU_MTRO_CONFIG_L1_MEM_A.mmu_sed0', 'MMU_MTRO_CONFIG_L1_MEM_B.mmu_sed0',
+            'MMU_MTRO_CONFIG_L1_MEM_A_PIPE0.mmu_sed0', 'MMU_MTRO_CONFIG_L1_MEM_B_PIPE0.mmu_sed0',
+            'MMU_MTRO_CONFIG_L1_MEM_PIPE0.mmu_sed0', 'MMU_MTRO_CONFIG_L1_MEM_PIPE1.mmu_sed0',
+            'MMU_MTRO_CONFIG_L1_MEM_PIPE2.mmu_sed0', 'MMU_MTRO_CONFIG_L1_MEM_PIPE3.mmu_sed0',
         ],
         'timeout_basic': [
             'EGR_ZONE_0_EDITOR_CONTROL_TCAM.epipe0', 'DLB_ECMP_FLOWSET_MEMBER.ipipe0',
@@ -269,7 +274,11 @@ SKIP_MEMORY_PER_ASIC = {
             'IS_TDM_CALENDAR0.ipipe0', 'IS_TDM_CALENDAR1.ipipe0', 'IS_TDM_CALENDAR0_PIPE0.ipipe0',
             'IS_TDM_CALENDAR0_PIPE1.ipipe0', 'IS_TDM_CALENDAR0_PIPE2.ipipe0', 'IS_TDM_CALENDAR0_PIPE3.ipipe0',
             'IS_TDM_CALENDAR1_PIPE0.ipipe0', 'IS_TDM_CALENDAR1_PIPE1.ipipe0', 'IS_TDM_CALENDAR1_PIPE2.ipipe0',
-            'IS_TDM_CALENDAR1_PIPE3.ipipe0',
+            'IS_TDM_CALENDAR1_PIPE3.ipipe0', 'MMU_MTRO_CONFIG_L1_MEM.mmu_sed0',
+            'MMU_MTRO_CONFIG_L1_MEM_A.mmu_sed0', 'MMU_MTRO_CONFIG_L1_MEM_B.mmu_sed0',
+            'MMU_MTRO_CONFIG_L1_MEM_A_PIPE0.mmu_sed0', 'MMU_MTRO_CONFIG_L1_MEM_B_PIPE0.mmu_sed0',
+            'MMU_MTRO_CONFIG_L1_MEM_PIPE0.mmu_sed0', 'MMU_MTRO_CONFIG_L1_MEM_PIPE1.mmu_sed0',
+            'MMU_MTRO_CONFIG_L1_MEM_PIPE2.mmu_sed0', 'MMU_MTRO_CONFIG_L1_MEM_PIPE3.mmu_sed0',
         ],
         'timeout_basic': [
         ],
@@ -380,7 +389,8 @@ def get_asic_name():
     if ("Broadcom Limited Device b960" in output or
         "Broadcom Limited Broadcom BCM56960" in output or
         "Broadcom Inc. and subsidiaries Device b960" in output or
-            "Broadcom Inc. and subsidiaries Broadcom BCM56960" in output):
+        "Broadcom Inc. and subsidiaries Broadcom BCM56960" in output or
+            "Broadcom Inc. and subsidiaries BCM56960" in output):
         asic = "th"
     elif ("Broadcom Limited Device b971" in output or
           "Broadcom Inc. and subsidiaries Device b971" in output):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
28290229

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

1. Case platform_tests.broadcom.test_ser failed sometimes due to timeout in TD3 and TH2.
2. Get asic type failed for th

#### How did you do it?
Ignore these memory items for basic test
update the output string for latest version

#### How did you verify/test it?
Run the case locally

#### Any platform specific information?
broadcom asic td3, th2, th

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
