### PR TITLE
feat: support stress routes test on T2 topo

### DIFF
--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -1,9 +1,9 @@
 import logging
+
 import pytest
-import time
+
 from tests.common.utilities import wait_until
 from utils import get_crm_resource_status, check_queue_status, sleep_to_wait
-from tests.common import config_reload
 
 CRM_POLLING_INTERVAL = 1
 CRM_DEFAULT_POLL_INTERVAL = 300

--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import time
 from tests.common.utilities import wait_until
-from utils import get_crm_resources, check_queue_status, sleep_to_wait
+from utils import get_crm_resource_status, check_queue_status, sleep_to_wait
 from tests.common import config_reload
 
 CRM_POLLING_INTERVAL = 1
@@ -17,22 +17,27 @@ def get_function_conpleteness_level(pytestconfig):
     return pytestconfig.getoption("--completeness_level")
 
 
-@pytest.fixture(scope="module", autouse=True)
-def set_polling_interval(duthost):
-    wait_time = 2
-    duthost.command("crm config polling interval {}".format(CRM_POLLING_INTERVAL))
-    logger.info("Waiting {} sec for CRM counters to become updated".format(wait_time))
-    time.sleep(wait_time)
-
-    yield
-
-    duthost.command("crm config polling interval {}".format(CRM_DEFAULT_POLL_INTERVAL))
-    logger.info("Waiting {} sec for CRM counters to become updated".format(wait_time))
-    time.sleep(wait_time)
+# @pytest.fixture(scope="module", autouse=True)
+# def set_polling_interval(duthost):
+#     wait_time = 2
+#     duthost.command("crm config polling interval {}".format(CRM_POLLING_INTERVAL))
+#     logger.info("Waiting {} sec for CRM counters to become updated".format(wait_time))
+#     time.sleep(wait_time)
+#
+#     yield
+#
+#     duthost.command("crm config polling interval {}".format(CRM_DEFAULT_POLL_INTERVAL))
+#     logger.info("Waiting {} sec for CRM counters to become updated".format(wait_time))
+#     time.sleep(wait_time)
 
 
 @pytest.fixture(scope='module')
-def withdraw_and_announce_existing_routes(duthost, localhost, tbinfo):
+def withdraw_and_announce_existing_routes(duthosts, localhost, tbinfo, enum_rand_one_per_hwsku_frontend_hostname,
+                                          enum_rand_one_frontend_asic_index):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
+    namespace = asichost.namespace
+
     ptf_ip = tbinfo["ptf_ip"]
     topo_name = tbinfo["topo"]["name"]
 
@@ -41,8 +46,8 @@ def withdraw_and_announce_existing_routes(duthost, localhost, tbinfo):
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") is True)
     sleep_to_wait(CRM_POLLING_INTERVAL * 100)
-    ipv4_route_used_before = get_crm_resources(duthost, "ipv4_route", "used")
-    ipv6_route_used_before = get_crm_resources(duthost, "ipv6_route", "used")
+    ipv4_route_used_before = get_crm_resource_status(duthost, "ipv4_route", "used", namespace)
+    ipv6_route_used_before = get_crm_resource_status(duthost, "ipv6_route", "used", namespace)
     logger.info("ipv4 route used {}".format(ipv4_route_used_before))
     logger.info("ipv6 route used {}".format(ipv6_route_used_before))
 
@@ -53,23 +58,23 @@ def withdraw_and_announce_existing_routes(duthost, localhost, tbinfo):
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") is True)
     sleep_to_wait(CRM_POLLING_INTERVAL * 5)
-    logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
-    logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
+    logger.info("ipv4 route used {}".format(get_crm_resource_status(duthost, "ipv4_route", "used", namespace)))
+    logger.info("ipv6 route used {}".format(get_crm_resource_status(duthost, "ipv6_route", "used", namespace)))
 
 
-@pytest.fixture(scope="module", autouse=True)
-def check_system_memmory(duthost):
-    for index in range(1, 4):
-        cmd = 'echo {} >  /proc/sys/vm/drop_caches'.format(index)
-        duthost.shell(cmd, module_ignore_errors=True)
-
-    cmd = "show system-memory"
-    cmd_response = duthost.shell(cmd, module_ignore_errors=True)
-    logger.debug("CMD {}: before test {}".format(cmd, cmd_response.get('stdout', None)))
-
-    yield
-    cmd = "show system-memory"
-    cmd_response = duthost.shell(cmd, module_ignore_errors=True)
-    logger.debug("CMD {}: after test {}".format(cmd, cmd_response.get('stdout', None)))
-
-    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+# @pytest.fixture(scope="module", autouse=True)
+# def check_system_memmory(duthost):
+#     for index in range(1, 4):
+#         cmd = 'echo {} >  /proc/sys/vm/drop_caches'.format(index)
+#         duthost.shell(cmd, module_ignore_errors=True)
+#
+#     cmd = "show system-memory"
+#     cmd_response = duthost.shell(cmd, module_ignore_errors=True)
+#     logger.debug("CMD {}: before test {}".format(cmd, cmd_response.get('stdout', None)))
+#
+#     yield
+#     cmd = "show system-memory"
+#     cmd_response = duthost.shell(cmd, module_ignore_errors=True)
+#     logger.debug("CMD {}: after test {}".format(cmd, cmd_response.get('stdout', None)))
+#
+#     config_reload(duthost, safe_reload=True, check_intf_up_ports=True)

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -5,7 +5,7 @@ import pytest
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from utils import get_crm_resources, check_queue_status, sleep_to_wait, LOOP_TIMES_LEVEL_MAP
+from utils import get_crm_resource_status, check_queue_status, sleep_to_wait, LOOP_TIMES_LEVEL_MAP
 
 ALLOW_ROUTES_CHANGE_NUMS = 5
 CRM_POLLING_INTERVAL = 1
@@ -14,18 +14,18 @@ MAX_WAIT_TIME = 120
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 'm0', 'mx')
+    pytest.mark.topology('t0', 't1', 'm0', 'mx', 't2')
 ]
 
 
-def announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name):
+def announce_withdraw_routes(duthost, namespace, localhost, ptf_ip, topo_name):
     logger.info("announce ipv4 and ipv6 routes")
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") is True)
 
-    logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
-    logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
+    logger.info("ipv4 route used {}".format(get_crm_resource_status(duthost, "ipv4_route", "used", namespace)))
+    logger.info("ipv6 route used {}".format(get_crm_resource_status(duthost, "ipv6_route", "used", namespace)))
     sleep_to_wait(CRM_POLLING_INTERVAL * 5)
 
     logger.info("withdraw ipv4 and ipv6 routes")
@@ -33,16 +33,18 @@ def announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name):
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") is True)
     sleep_to_wait(CRM_POLLING_INTERVAL * 5)
-    logger.info("ipv4 route used {}".format(get_crm_resources(duthost, "ipv4_route", "used")))
-    logger.info("ipv6 route used {}".format(get_crm_resources(duthost, "ipv6_route", "used")))
+    logger.info("ipv4 route used {}".format(get_crm_resource_status(duthost, "ipv4_route", "used", namespace)))
+    logger.info("ipv6 route used {}".format(get_crm_resource_status(duthost, "ipv6_route", "used", namespace)))
 
 
 def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_conpleteness_level,
                                  withdraw_and_announce_existing_routes, loganalyzer,
-                                 enum_rand_one_per_hwsku_frontend_hostname):
+                                 enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index):
     ptf_ip = tbinfo["ptf_ip"]
     topo_name = tbinfo["topo"]["name"]
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
+    namespace = asichost.namespace
 
     if loganalyzer:
         ignoreRegex = [
@@ -71,13 +73,13 @@ def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_conpl
     loop_times = LOOP_TIMES_LEVEL_MAP[normalized_level]
 
     while loop_times > 0:
-        announce_withdraw_routes(duthost, localhost, ptf_ip, topo_name)
+        announce_withdraw_routes(duthost, namespace, localhost, ptf_ip, topo_name)
         loop_times -= 1
 
     sleep_to_wait(CRM_POLLING_INTERVAL * 120)
 
-    ipv4_route_used_after = get_crm_resources(duthost, "ipv4_route", "used")
-    ipv6_route_used_after = get_crm_resources(duthost, "ipv6_route", "used")
+    ipv4_route_used_after = get_crm_resource_status(duthost, "ipv4_route", "used", namespace)
+    ipv6_route_used_after = get_crm_resource_status(duthost, "ipv6_route", "used", namespace)
 
     pytest_assert(abs(ipv4_route_used_after - ipv4_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
                   "ipv4 route used after is not equal to it used before")

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import logging
+
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert

--- a/tests/stress/utils.py
+++ b/tests/stress/utils.py
@@ -1,6 +1,8 @@
 import re
 import time
 
+from tests.common.helpers.constants import DEFAULT_NAMESPACE
+
 TOPO_FILENAME_TEMPLATE = 'topo_{}.yml'
 SHOW_BGP_SUMMARY_CMD = "show ip bgp summary"
 LOOP_TIMES_LEVEL_MAP = {
@@ -12,8 +14,8 @@ LOOP_TIMES_LEVEL_MAP = {
 }
 
 
-def get_crm_resources(duthost, resource, status):
-    return duthost.get_crm_resources().get("main_resources").get(resource).get(status)
+def get_crm_resource_status(duthost, resource, status, namespace=DEFAULT_NAMESPACE):
+    return duthost.get_crm_resources(namespace).get("main_resources").get(resource).get(status)
 
 
 def check_queue_status(duthost, queue):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Support `test_stress_routes.py` on T2 topology.

Summary:
Fixes # (issue) Microsoft ADO 28357470

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [x] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Currently, the `test_stress_routes.py` only runs on the following topologies: T0, T1, M0, MX. We wanted to support this test on T2 topology as well. 

#### How did you do it?
Add T2 topology marker and make necessary changes to make the test pass on a T2 testbed.

#### How did you verify/test it?
I run the updated test on a T2 testbed and confirm it passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
