### PR TITLE
[TACACS] Fix error in accounting test case

### DIFF
--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -118,7 +118,7 @@ def check_local_log_exist(duthost, tacacs_creds, command):
 
     if len(logs) == 0:
         # print recent logs for debug
-        recent_logs = duthost.command("cat /var/log/syslog | tail -n 500")
+        recent_logs = duthost.command("tail /var/log/syslog -n 1000")
         logger.debug("Found logs: %s", recent_logs)
 
     pytest_assert(len(logs) > 0)


### PR DESCRIPTION
Fix error in accounting test case.

#### Why I did it
Accounting test case failed with RunAnsibleModuleFail error

##### Work item tracking
- Microsoft ADO: 28343053

#### How I did it
Fix command, use tail command show recent log

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
[TACACS] Fix error in accounting test case.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

