### PR TITLE
[TACACS] Add debug info for check nss config missing issue.

### DIFF
--- a/tests/tacacs/conftest.py
+++ b/tests/tacacs/conftest.py
@@ -9,11 +9,11 @@ logger = logging.getLogger(__name__)
 
 
 def check_nss_config(duthost):
-    nss_config_attribute = duthost.command("ls -la /etc/nsswitch.conf", module_ignore_errors=True)['stdout']
-    if "No such file or directory" in nss_config_attribute:
-        logger.error("NSS config file missing.")
+    nss_config_attribute = duthost.command("ls -la /etc/nsswitch.conf", module_ignore_errors=True)
+    if nss_config_attribute['failed']:
+        logger.error("NSS config file missing: %s", nss_config_attribute['stderr'])
     else:
-        logger.debug("NSS config file attribute: %s", nss_config_attribute)
+        logger.debug("NSS config file attribute: %s", nss_config_attribute['stdout'])
 
 
 @pytest.fixture(scope="module")

--- a/tests/tacacs/conftest.py
+++ b/tests/tacacs/conftest.py
@@ -8,18 +8,36 @@ from .utils import setup_tacacs_client, setup_tacacs_server,\
 logger = logging.getLogger(__name__)
 
 
+def check_nss_config(duthost):
+    nss_config_attribute = duthost.command("ls -la /etc/nsswitch.conf", module_ignore_errors=True)
+    if "No such file or directory" in nss_config_attribute:
+        logger.error("NSS config file missing.")
+    else:
+        logger.debug("NSS config file attribute: %s", nss_config_attribute)
+
+
 @pytest.fixture(scope="module")
 def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds): # noqa F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     tacacs_server_ip = ptfhost.mgmt_ip
     tacacs_server_passkey = tacacs_creds[duthost.hostname]['tacacs_passkey']
+
+    # Accounting test case randomly failed, need debug info to confirm NSS config file missing issue.
+    check_nss_config(duthost)
+
     setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip, tacacs_server_passkey, ptfhost)
     setup_tacacs_server(ptfhost, tacacs_creds, duthost)
 
+    check_nss_config(duthost)
+
     yield
+
+    check_nss_config(duthost)
 
     cleanup_tacacs(ptfhost, tacacs_creds, duthost)
     restore_tacacs_servers(duthost)
+
+    check_nss_config(duthost)
 
 
 @pytest.fixture(scope="module")

--- a/tests/tacacs/conftest.py
+++ b/tests/tacacs/conftest.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def check_nss_config(duthost):
-    nss_config_attribute = duthost.command("ls -la /etc/nsswitch.conf", module_ignore_errors=True)
+    nss_config_attribute = duthost.command("ls -la /etc/nsswitch.conf", module_ignore_errors=True)['stdout']
     if "No such file or directory" in nss_config_attribute:
         logger.error("NSS config file missing.")
     else:


### PR DESCRIPTION
Add debug info for check nss config missing issue.

#### Why I did it
TACACS accounting test case randomly failed because can't login device with remote account.
According syslog, seems nss config file been deleted on device.
Add debug log to check and confirm the root cause.

#### How I did it
Add debug info for check nss config missing issue.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Add debug info for check nss config missing issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

