### PR TITLE
Ignore message SDK_LOG|-E-HLD-0

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -262,6 +262,7 @@ r, ".* ERR syncd\d*#syncd:.*SAI_API_BUFFER: get_buffer_pool_stats unknown counte
 r, ".* ERR syncd\d*#syncd:.*SAI_API_BUFFER: get_ingress_priority_group_stats unknown counter 5.*"
 r, ".* ERR syncd\d*#syncd:.*SAI_API_BUFFER: get_ingress_priority_group_stats unknown counter 7.*"
 r, ".* ERR syncd.*#syncd:.*SAI_API_HOSTIF: src/sai_trap.cpp:.*: Invalid trap event code .*"
+r, ".* ERR syncd.*#syncd:.*SDK_LOG|-E-HLD-0.*"
 r, ".* ERR syncd\d*#syncd:.*SAI_API_LAG: resolve_feat_over_member_ports: found port index .*"
 r, ".* ERR syncd\d*#syncd:.*SAI_API_LAG: resolve_feat_over_member_ports: port index .* now selected.*"
 r, ".* ERR syncd\d*#syncd:.*SAI_API_PORT: Invalid port counter .*index.*"


### PR DESCRIPTION
**What is the motivation for this PR?**
In recent sonic-mgmt runs, some testcases are failing with loganalyzer error message like 'Mar  6 19:52:31.977493 str3-8111-05 ERR syncd#syncd#syncd: SDK_LOG|-E-HLD-0- would fail config'

Cisco team confirmed that these error messages can be ignored and do not cause any functionality impact.
Adding this message to loganalyzer Ignore list so that Testcases will not fail


**How did you do it?**
Modified the file ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt to add this Ignore message

**How did you verify/test it?**
Made sure that the testcases did not fail after these errors messages are ignored.

**Back port request**
202305
202311