### PR TITLE
Add script `platform_tests/test_platform_info.py` into T0 PR checker.

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -174,7 +174,7 @@ def get_healthy_psu_num(duthost):
     PSUUTIL_CMD = "sudo psuutil status"
     healthy_psus = 0
     psuutil_status_output = duthost.command(PSUUTIL_CMD, module_ignore_errors=True)
-    # For vs testbed, we will get expected Error code `ERROR_CHASSIS_LOAD = 2` here.
+    # For kvm testbed, we will get expected Error code `ERROR_CHASSIS_LOAD = 2` here.
     if duthost.facts["asic_type"] == "vs" and psuutil_status_output['rc'] == 2:
         return
     assert psuutil_status_output["rc"] == 0, "Run command '{}' failed".format(PSUUTIL_CMD)
@@ -257,6 +257,8 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
     psu_line_pattern = get_dut_psu_line_pattern(duthost)
 
     psu_num = get_healthy_psu_num(duthost)
+    # For kvm testbed, psu_num will return None
+    # Only physical testbeds need to check the psu number
     if psu_num:
         pytest_require(
             psu_num >= 2, "At least 2 PSUs required for rest of the testing in this case")
@@ -403,6 +405,8 @@ def check_thermal_control_load_invalid_file(duthost, file_name):
     loganalyzer = LogAnalyzer(ansible_host=duthost,
                               marker_prefix='thermal_control')
     loganalyzer.expect_regex = [LOG_EXPECT_POLICY_FILE_INVALID]
+    # For kvm testbed, we will not restart the deamon `thermal`
+    # So we will not get the syslog as expected.
     if duthost.facts["asic_type"] == "vs":
         return
     with loganalyzer:

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -174,7 +174,7 @@ def get_healthy_psu_num(duthost):
     PSUUTIL_CMD = "sudo psuutil status"
     healthy_psus = 0
     psuutil_status_output = duthost.command(PSUUTIL_CMD, module_ignore_errors=True)
-    if psuutil_status_output['rc'] != 0:
+    if psuutil_status_output['rc'] != 0 and duthost.facts["asic_type"] == "vs":
         pytest.skip("No PSU for {}, skip rest of the testing in this case".format(duthost.hostname))
 
     psus_status = psuutil_status_output["stdout_lines"][2:]

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -177,6 +177,7 @@ def get_healthy_psu_num(duthost):
     # For vs testbed, we will get expected Error code `ERROR_CHASSIS_LOAD = 2` here.
     if duthost.facts["asic_type"] == "vs" and psuutil_status_output['rc'] == 2:
         return
+    assert psuutil_status_output["rc"] == 0, "Run command '{}' failed".format(PSUUTIL_CMD)
 
     psus_status = psuutil_status_output["stdout_lines"][2:]
     for iter in psus_status:

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -284,10 +284,7 @@ def restart_thermal_control_daemon(dut):
     find_thermalctld_pid_cmd = 'docker exec -i pmon bash -c \'pgrep -f thermalctld\' | sort'
     output = dut.shell(find_thermalctld_pid_cmd)
 
-    if dut.facts["asic_type"] == "vs" and output["rc"] == 0:
-        return
-    else:
-        assert output["rc"] == 0, "Run command '{}' failed".format(find_thermalctld_pid_cmd)
+    assert output["rc"] == 0, "Run command '{}' failed".format(find_thermalctld_pid_cmd)
     # Usually there should be 2 thermalctld processes, but there is chance that
     # sonic platform API might use subprocess which creates extra thermalctld process.
     # For example, chassis.get_all_sfps will call sfp constructor, and sfp constructor may
@@ -295,9 +292,12 @@ def restart_thermal_control_daemon(dut):
     # So we check here thermalcltd must have at least 2 processes.
     # For mellanox, it has at least two processes, but for celestica(broadcom),
     # it only has one thermalctld process
+    # For kvm, there is no thermalctld process
     if dut.facts["asic_type"] == "mellanox":
         assert len(output["stdout_lines"]
                    ) >= 2, "There should be at least 2 thermalctld process"
+    elif dut.facts["asic_type"] == "vs":
+        assert len(output["stdout_lines"]) == 0, "There should be 0 thermalctld process"
     else:
         assert len(output["stdout_lines"]
                    ) >= 1, "There should be at least 1 thermalctld process"

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -285,7 +285,7 @@ def restart_thermal_control_daemon(dut):
     output = dut.shell(find_thermalctld_pid_cmd)
 
     if dut.facts["asic_type"] == "vs" and output["rc"] == 0:
-        pytest.skip("Thermalctld doesn't support on vs testbed")
+        return
     else:
         assert output["rc"] == 0, "Run command '{}' failed".format(find_thermalctld_pid_cmd)
     # Usually there should be 2 thermalctld processes, but there is chance that

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -303,7 +303,7 @@ def restart_thermal_control_daemon(dut):
                    ) >= 1, "There should be at least 1 thermalctld process"
 
     restart_thermalctl_cmd = "docker exec -i pmon bash -c 'supervisorctl restart thermalctld'"
-    output = dut.shell(restart_thermalctl_cmd)
+    output = dut.shell(restart_thermalctl_cmd, module_ignore_errors=True)
     if output["rc"] == 0:
         output = dut.shell(find_thermalctld_pid_cmd)
         assert output["rc"] == 0, "Run command '{}' failed after restart of thermalctld on {}".format(
@@ -316,6 +316,8 @@ def restart_thermal_control_daemon(dut):
                 output["stdout_lines"]) >= 1, "There should be at least 1 thermalctld process"
         logging.info(
             "thermalctld processes restarted successfully on {}".format(dut.hostname))
+        return
+    if output["rc"] == 1 and dut.facts["asic_type"] == "vs":
         return
     # try restore by config reload...
     config_reload(dut)

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -120,7 +120,7 @@ def mocker_factory(localhost, duthosts, enum_rand_one_per_hwsku_hostname):
                 mocker_object = mocker_type(dut)
                 mockers.append(mocker_object)
         else:
-            pytest.skip("No mocker defined for this platform %s")
+            pytest.skip("No mocker defined for this platform {}".format(platform))
         return mocker_object
 
     yield _create_mocker
@@ -283,7 +283,11 @@ def restart_thermal_control_daemon(dut):
         'Restarting thermal control daemon on {}...'.format(dut.hostname))
     find_thermalctld_pid_cmd = 'docker exec -i pmon bash -c \'pgrep -f thermalctld\' | sort'
     output = dut.shell(find_thermalctld_pid_cmd)
-    assert output["rc"] == 0, "Run command '%s' failed" % find_thermalctld_pid_cmd
+
+    if dut.facts["asic_type"] == "vs" and output["rc"] == 0:
+        pytest.skip("Thermalctld doesn't support on vs testbed")
+    else:
+        assert output["rc"] == 0, "Run command '%s' failed" % find_thermalctld_pid_cmd
     # Usually there should be 2 thermalctld processes, but there is chance that
     # sonic platform API might use subprocess which creates extra thermalctld process.
     # For example, chassis.get_all_sfps will call sfp constructor, and sfp constructor may

--- a/tests/platform_tests/thermal_control_test_helper.py
+++ b/tests/platform_tests/thermal_control_test_helper.py
@@ -287,7 +287,7 @@ def restart_thermal_control_daemon(dut):
     if dut.facts["asic_type"] == "vs" and output["rc"] == 0:
         pytest.skip("Thermalctld doesn't support on vs testbed")
     else:
-        assert output["rc"] == 0, "Run command '%s' failed" % find_thermalctld_pid_cmd
+        assert output["rc"] == 0, "Run command '{}' failed".format(find_thermalctld_pid_cmd)
     # Usually there should be 2 thermalctld processes, but there is chance that
     # sonic platform API might use subprocess which creates extra thermalctld process.
     # For example, chassis.get_all_sfps will call sfp constructor, and sfp constructor may


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR [#13220](https://github.com/sonic-net/sonic-mgmt/pull/13220), we add a batch of control plane test scripts into onboarding T0 PR checker, but some of them failed. In this PR, we fix the failed test script `platform_tests/test_platform_info.py` and let it run successfully in T0 PR checker. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In PR [#13220](https://github.com/sonic-net/sonic-mgmt/pull/13220), we add a batch of control plane test scripts into onboarding T0 PR checker, but some of them failed. In this PR, we fix the failed test script `platform_tests/test_platform_info.py` and let it run successfully in T0 PR checker. 

#### How did you do it?

#### How did you verify/test it?
```
=========================== short test summary info ============================
SKIPPED [1] common/helpers/assertions.py:16: No PSU controller for vlab-01, skip rest of the testing in this case
SKIPPED [3] platform_tests/thermal_control_test_helper.py:123: No mocker defined for this platform x86_64-kvm_x86_64-r0
============== 2 passed, 4 skipped, 1 warning in 64.33s (0:01:04) ==============
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
