### PR TITLE
[Mellanox]Revert "Skip available route check for mellanox platforms (#12787)"

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -511,7 +511,7 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
         duthost.command(route_add)
 
     check_available_counters = True
-    if duthost.facts['asic_type'] in ['broadcom', 'mellanox']:
+    if duthost.facts['asic_type'] == 'broadcom':
         check_available_counters = False
 
     # Make sure CRM counters updated


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Revert https://github.com/sonic-net/sonic-mgmt/pull/12787, because there is another fix: https://github.com/sonic-net/sonic-mgmt/pull/12882#

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Revert the PR, so the  crm test can run on mellanox device

#### How did you do it?
Revert the PR

#### How did you verify/test it?
run the test_crm_route on mellanox device 

#### Any platform specific information?
any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
