### PR TITLE
Skip bfd/test_bfd_static_route.py for single_asic systems and non cisco platforms - Fix for Issue #12948

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -82,10 +82,9 @@ bfd/test_bfd.py::test_bfd_scale:
 
 bfd/test_bfd_static_route.py:
   skip:
-    reason: "Only supported on chassis system & cisco platform."
+    reason: "Only supported on multi-asic system & Cisco LCs."
     conditions:
-      - "is_multi_asic is False"
-      - "asic_type in ['cisco-8000']"
+      - "(is_multi_asic is False) or (hwsku not in ['Cisco-88-LC0-36FH-M-O36', 'Cisco-8800-LC-48H-C48', 'Cisco-88-LC0-36FH-O36'])"
 
 #######################################
 #####            bgp              #####


### PR DESCRIPTION
### Description of PR

Issue:
bfd/test_bfd_static_route.py assumes that config_db.json is a mulit-asic system.
If it's a single asic it will use the wrong file name.

Resolution
The test is supposed to run only on a multi-asic system and on specific cisco LC, Modified the conditional mark to skip accordingly.  This PR is a fix for Jira #12948

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
PR is a fix for Jira https://github.com/sonic-net/sonic-mgmt/issues/12948

#### How did you do it?

#### How did you verify/test it?
Verified that the testcase skips on single_asic system. Would request @arista-nwolfe  to confirm that it skips for them too.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
