### PR TITLE
Add arp test to pr test and skip traffic test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -343,6 +343,9 @@ onboarding_t0:
   - acl/test_acl.py
   - acl/test_acl_outer_vlan.py
   - acl/test_stress_acl.py
+  - arp/test_stress_arp.py
+  - arp/test_unknown_mac.py
+  - arp/test_wr_arp.py
 
 specific_param:
   t0-sonic:

--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -10,6 +10,7 @@ from scapy.all import Ether, IPv6, ICMPv6ND_NS, ICMPv6NDOptSrcLLAddr, in6_getnsm
 from ipaddress import ip_address, ip_network
 from tests.common.utilities import wait_until
 from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
+from tests.common.fixtures.ptfhost_utils import skip_traffic_test   # noqa F401
 
 ARP_BASE_IP = "172.16.0.1/16"
 ARP_SRC_MAC = "00:00:01:02:03:04"
@@ -57,7 +58,7 @@ def genrate_ipv4_ip():
 
 
 def test_ipv4_arp(duthost, garp_enabled, ip_and_intf_info, intfs_for_test,
-                  ptfadapter, get_function_conpleteness_level):
+                  ptfadapter, get_function_conpleteness_level, skip_traffic_test):  # noqa F811
     """
     Send gratuitous ARP (GARP) packet sfrom the PTF to the DUT
 
@@ -86,9 +87,9 @@ def test_ipv4_arp(duthost, garp_enabled, ip_and_intf_info, intfs_for_test,
         loop_times -= 1
         try:
             add_arp(ptf_intf_ipv4_hosts, intf1_index, ptfadapter)
-
-            pytest_assert(wait_until(20, 1, 0, lambda: get_fdb_dynamic_mac_count(duthost) >= arp_avaliable),
-                          "ARP Table Add failed")
+            if not skip_traffic_test:
+                pytest_assert(wait_until(20, 1, 0, lambda: get_fdb_dynamic_mac_count(duthost) >= arp_avaliable),
+                              "ARP Table Add failed")
         finally:
             clear_dut_arp_cache(duthost)
             fdb_cleanup(duthost)
@@ -137,7 +138,7 @@ def add_nd(ptfadapter, ip_and_intf_info, ptf_intf_index, nd_avaliable):
 
 
 def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
-                 ptfadapter, get_function_conpleteness_level, proxy_arp_enabled):
+                 ptfadapter, get_function_conpleteness_level, proxy_arp_enabled, skip_traffic_test):    # noqa F811
     _, _, ptf_intf_ipv6_addr, _, ptf_intf_index = ip_and_intf_info
     ptf_intf_ipv6_addr = increment_ipv6_addr(ptf_intf_ipv6_addr)
     pytest_require(proxy_arp_enabled, 'Proxy ARP not enabled for all VLANs')
@@ -160,9 +161,9 @@ def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
         loop_times -= 1
         try:
             add_nd(ptfadapter, ip_and_intf_info, ptf_intf_index, nd_avaliable)
-
-            pytest_assert(wait_until(20, 1, 0, lambda: get_fdb_dynamic_mac_count(duthost) >= nd_avaliable),
-                          "Neighbor Table Add failed")
+            if not skip_traffic_test:
+                pytest_assert(wait_until(20, 1, 0, lambda: get_fdb_dynamic_mac_count(duthost) >= nd_avaliable),
+                              "Neighbor Table Add failed")
         finally:
             clear_dut_arp_cache(duthost)
             fdb_cleanup(duthost)

--- a/tests/arp/test_unknown_mac.py
+++ b/tests/arp/test_unknown_mac.py
@@ -14,6 +14,7 @@ import ptf.packet as packet
 from tests.common import constants
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses    # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py   # noqa F401
+from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
@@ -237,7 +238,7 @@ class TrafficSendVerify(object):
     """ Send traffic and check interface counters and ptf ports """
     @initClassVars
     def __init__(self, duthost, ptfadapter, dst_ip, ptf_dst_port, ptf_vlan_ports,
-                 intfs, ptf_ports, arp_entry, dscp):
+                 intfs, ptf_ports, arp_entry, dscp, skip_traffic_test):     # noqa F811
         """
         Args:
             duthost(AnsibleHost) : dut instance
@@ -255,6 +256,7 @@ class TrafficSendVerify(object):
         self.pkt_map = dict()
         self.pre_rx_drops = dict()
         self.dut_mac = duthost.facts['router_mac']
+        self.skip_traffic_test = skip_traffic_test
 
     def _constructPacket(self):
         """
@@ -337,23 +339,24 @@ class TrafficSendVerify(object):
         self._constructPacket()
         logger.info("Clear all counters before test run")
         self.duthost.command("sonic-clear counters")
-        time.sleep(1)
-        logger.info("Collect drop counters before test run")
-        self._verifyIntfCounters(pretest=True)
-        for pkt, exp_pkt in zip(self.pkts, self.exp_pkts):
-            self.ptfadapter.dataplane.flush()
-            out_intf = self.pkt_map[str(pkt)][0]
-            src_port = self.ptf_ports[out_intf][0]
-            logger.info("Sending traffic on intf {}".format(out_intf))
-            testutils.send(self.ptfadapter, src_port, pkt, count=TEST_PKT_CNT)
-            testutils.verify_no_packet_any(self.ptfadapter, exp_pkt, ports=self.ptf_vlan_ports)
-        logger.info("Collect and verify drop counters after test run")
-        self.verifyIntfCounters()
+        if not self.skip_traffic_test:
+            time.sleep(1)
+            logger.info("Collect drop counters before test run")
+            self._verifyIntfCounters(pretest=True)
+            for pkt, exp_pkt in zip(self.pkts, self.exp_pkts):
+                self.ptfadapter.dataplane.flush()
+                out_intf = self.pkt_map[str(pkt)][0]
+                src_port = self.ptf_ports[out_intf][0]
+                logger.info("Sending traffic on intf {}".format(out_intf))
+                testutils.send(self.ptfadapter, src_port, pkt, count=TEST_PKT_CNT)
+                testutils.verify_no_packet_any(self.ptfadapter, exp_pkt, ports=self.ptf_vlan_ports)
+            logger.info("Collect and verify drop counters after test run")
+            self.verifyIntfCounters()
 
 
 class TestUnknownMac(object):
     @pytest.mark.parametrize("dscp", ["dscp-3", "dscp-4", "dscp-8"])
-    def test_unknown_mac(self, unknownMacSetup, dscp, duthosts, rand_one_dut_hostname, ptfadapter):
+    def test_unknown_mac(self, unknownMacSetup, dscp, duthosts, rand_one_dut_hostname, ptfadapter, skip_traffic_test):  # noqa F811
         """
         Verify unknown mac behavior for lossless and lossy priority
 
@@ -379,6 +382,7 @@ class TestUnknownMac(object):
         self.ptf_vlan_ports = setup['ptf_vlan_ports']
         self.intfs = setup['intfs']
         self.ptf_ports = setup['ptf_ports']
+        self.skip_traffic_test = skip_traffic_test
         self.validateEntries()
         self.run()
 
@@ -396,5 +400,5 @@ class TestUnknownMac(object):
         thandle = TrafficSendVerify(self.duthost, self.ptfadapter, self.dst_ip, self.ptf_dst_port,
                                     self.ptf_vlan_ports,
                                     self.intfs, self.ptf_ports,
-                                    self.arp_entry, self.dscp)
+                                    self.arp_entry, self.dscp, self.skip_traffic_test)
         thandle.runTest()

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -6,6 +6,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                             # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                                # noqa F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses                                 # noqa F401
+from tests.common.fixtures.ptfhost_utils import skip_traffic_test                                   # noqa F401
 from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies     # noqa F401
 from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_until
@@ -234,7 +235,7 @@ class TestWrArp:
         duthost.command('sonic-clear arp')
         self.teardownRouteToPtfhost(duthost, self.route, self.ptfIp, self.gwIp)
 
-    def testWrArp(self, request, duthost, ptfhost, creds):
+    def testWrArp(self, request, duthost, ptfhost, creds, skip_traffic_test):   # noqa F811
         '''
             Control Plane Assistant test for Warm-Reboot.
 
@@ -258,28 +259,29 @@ class TestWrArp:
         logger.info('Warm-Reboot Control-Plane assist feature')
         sonicadmin_alt_password = duthost.host.options['variable_manager'].\
             _hostvars[duthost.hostname]['sonic_default_passwords']
-        ptf_runner(
-            ptfhost,
-            'ptftests',
-            'wr_arp.ArpTest',
-            qlen=PTFRUNNER_QLEN,
-            platform_dir='ptftests',
-            platform='remote',
-            params={
-                'ferret_ip': ptfIp,
-                'dut_ssh': dutIp,
-                'dut_username': creds['sonicadmin_user'],
-                'dut_password': creds['sonicadmin_password'],
-                "alt_password": sonicadmin_alt_password,
-                'config_file': VXLAN_CONFIG_FILE,
-                'how_long': testDuration,
-                'advance': False,
-            },
-            log_file='/tmp/wr_arp.ArpTest.log',
-            is_python3=True
-        )
+        if not skip_traffic_test:
+            ptf_runner(
+                ptfhost,
+                'ptftests',
+                'wr_arp.ArpTest',
+                qlen=PTFRUNNER_QLEN,
+                platform_dir='ptftests',
+                platform='remote',
+                params={
+                    'ferret_ip': ptfIp,
+                    'dut_ssh': dutIp,
+                    'dut_username': creds['sonicadmin_user'],
+                    'dut_password': creds['sonicadmin_password'],
+                    "alt_password": sonicadmin_alt_password,
+                    'config_file': VXLAN_CONFIG_FILE,
+                    'how_long': testDuration,
+                    'advance': False,
+                },
+                log_file='/tmp/wr_arp.ArpTest.log',
+                is_python3=True
+            )
 
-    def testWrArpAdvance(self, request, duthost, ptfhost, creds):
+    def testWrArpAdvance(self, request, duthost, ptfhost, creds, skip_traffic_test):    # noqa F811
         testDuration = request.config.getoption('--test_duration', default=DEFAULT_TEST_DURATION)
         ptfIp = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
         dutIp = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
@@ -287,23 +289,24 @@ class TestWrArp:
         logger.info('Warm-Reboot Control-Plane assist feature')
         sonicadmin_alt_password = duthost.host.options['variable_manager'].\
             _hostvars[duthost.hostname]['sonic_default_passwords']
-        ptf_runner(
-            ptfhost,
-            'ptftests',
-            'wr_arp.ArpTest',
-            qlen=PTFRUNNER_QLEN,
-            platform_dir='ptftests',
-            platform='remote',
-            params={
-                'ferret_ip': ptfIp,
-                'dut_ssh': dutIp,
-                'dut_username': creds['sonicadmin_user'],
-                'dut_password': creds['sonicadmin_password'],
-                "alt_password": sonicadmin_alt_password,
-                'config_file': VXLAN_CONFIG_FILE,
-                'how_long': testDuration,
-                'advance': True,
-            },
-            log_file='/tmp/wr_arp.ArpTest.Advance.log',
-            is_python3=True
-        )
+        if not skip_traffic_test:
+            ptf_runner(
+                ptfhost,
+                'ptftests',
+                'wr_arp.ArpTest',
+                qlen=PTFRUNNER_QLEN,
+                platform_dir='ptftests',
+                platform='remote',
+                params={
+                    'ferret_ip': ptfIp,
+                    'dut_ssh': dutIp,
+                    'dut_username': creds['sonicadmin_user'],
+                    'dut_password': creds['sonicadmin_password'],
+                    "alt_password": sonicadmin_alt_password,
+                    'config_file': VXLAN_CONFIG_FILE,
+                    'how_long': testDuration,
+                    'advance': True,
+                },
+                log_file='/tmp/wr_arp.ArpTest.Advance.log',
+                is_python3=True
+            )

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -259,27 +259,28 @@ class TestWrArp:
         logger.info('Warm-Reboot Control-Plane assist feature')
         sonicadmin_alt_password = duthost.host.options['variable_manager'].\
             _hostvars[duthost.hostname]['sonic_default_passwords']
-        if not skip_traffic_test:
-            ptf_runner(
-                ptfhost,
-                'ptftests',
-                'wr_arp.ArpTest',
-                qlen=PTFRUNNER_QLEN,
-                platform_dir='ptftests',
-                platform='remote',
-                params={
-                    'ferret_ip': ptfIp,
-                    'dut_ssh': dutIp,
-                    'dut_username': creds['sonicadmin_user'],
-                    'dut_password': creds['sonicadmin_password'],
-                    "alt_password": sonicadmin_alt_password,
-                    'config_file': VXLAN_CONFIG_FILE,
-                    'how_long': testDuration,
-                    'advance': False,
-                },
-                log_file='/tmp/wr_arp.ArpTest.log',
-                is_python3=True
-            )
+        if skip_traffic_test is True:
+            return
+        ptf_runner(
+            ptfhost,
+            'ptftests',
+            'wr_arp.ArpTest',
+            qlen=PTFRUNNER_QLEN,
+            platform_dir='ptftests',
+            platform='remote',
+            params={
+                'ferret_ip': ptfIp,
+                'dut_ssh': dutIp,
+                'dut_username': creds['sonicadmin_user'],
+                'dut_password': creds['sonicadmin_password'],
+                "alt_password": sonicadmin_alt_password,
+                'config_file': VXLAN_CONFIG_FILE,
+                'how_long': testDuration,
+                'advance': False,
+            },
+            log_file='/tmp/wr_arp.ArpTest.log',
+            is_python3=True
+        )
 
     def testWrArpAdvance(self, request, duthost, ptfhost, creds, skip_traffic_test):    # noqa F811
         testDuration = request.config.getoption('--test_duration', default=DEFAULT_TEST_DURATION)
@@ -289,24 +290,25 @@ class TestWrArp:
         logger.info('Warm-Reboot Control-Plane assist feature')
         sonicadmin_alt_password = duthost.host.options['variable_manager'].\
             _hostvars[duthost.hostname]['sonic_default_passwords']
-        if not skip_traffic_test:
-            ptf_runner(
-                ptfhost,
-                'ptftests',
-                'wr_arp.ArpTest',
-                qlen=PTFRUNNER_QLEN,
-                platform_dir='ptftests',
-                platform='remote',
-                params={
-                    'ferret_ip': ptfIp,
-                    'dut_ssh': dutIp,
-                    'dut_username': creds['sonicadmin_user'],
-                    'dut_password': creds['sonicadmin_password'],
-                    "alt_password": sonicadmin_alt_password,
-                    'config_file': VXLAN_CONFIG_FILE,
-                    'how_long': testDuration,
-                    'advance': True,
-                },
-                log_file='/tmp/wr_arp.ArpTest.Advance.log',
-                is_python3=True
-            )
+        if skip_traffic_test is True:
+            return
+        ptf_runner(
+            ptfhost,
+            'ptftests',
+            'wr_arp.ArpTest',
+            qlen=PTFRUNNER_QLEN,
+            platform_dir='ptftests',
+            platform='remote',
+            params={
+                'ferret_ip': ptfIp,
+                'dut_ssh': dutIp,
+                'dut_username': creds['sonicadmin_user'],
+                'dut_password': creds['sonicadmin_password'],
+                "alt_password": sonicadmin_alt_password,
+                'config_file': VXLAN_CONFIG_FILE,
+                'how_long': testDuration,
+                'advance': True,
+            },
+            log_file='/tmp/wr_arp.ArpTest.Advance.log',
+            is_python3=True
+        )

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -32,6 +32,27 @@ acl/test_stress_acl.py:
       - "asic_type in ['vs']"
 
 #######################################
+#####            arp              #####
+#######################################
+arp/test_stress_arp.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+arp/test_unknown_mac.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+arp/test_wr_arp.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
 #####         everflow            #####
 #######################################
 everflow/test_everflow_ipv6.py:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed
#### How did you do it?
Add some arp test to pr test and skip traffic test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
