### PR TITLE
Fix test_qos_sai teardown for dualtor

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1275,7 +1275,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class')
     def stopServices(
-        self, duthosts, get_src_dst_asic_and_duts,
+        self, duthosts, get_src_dst_asic_and_duts, dut_disable_ipv6,
         swapSyncd_on_selected_duts, enable_container_autorestart, disable_container_autorestart, get_mux_status, # noqa F811
         tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports):  # noqa F811
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix qos/tes_qos_sai.py teardown failure for dualtor.
Fixes [#130](https://github.com/aristanetworks/sonic-qual.msft/issues/130)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
qos/test_qos_sai.py fails at teardown 

```
failed on setup with "Failed: All critical services should be fully started!
```

Regression introduced by https://github.com/sonic-net/sonic-mgmt/pull/10651 for dualtor.

#### How did you do it?
The config_reload in the fixture `dut_disable_ipv6` waits until all critical processes are up after issuing config reload command and it timeouts in case of dualtor because mux container doesn't come up. Mux container is disabled by another fixture `stopServices` in the same file. These two fixtures have no dependency on each other hence the execution can happen in any order, so if the teardown of `dut_disable_ipv6` happens before `stopServices` then this issue is seen.

This change ensures that the teardown of `stopServices` happens before `dut_disable_ipv6` so that mux is no longer disabled at the time of config_reload.


#### How did you verify/test it?
Ran qos/test_qos_sai.py on Arista-7260CX3 platform with dualtor topology with 202305 and 202311 images.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
