### PR TITLE
feat: add BFD traffic test

### DIFF
--- a/tests/bfd/bfd_base.py
+++ b/tests/bfd/bfd_base.py
@@ -3,10 +3,75 @@ import random
 
 import pytest
 
+from tests.bfd.bfd_helpers import modify_all_bfd_sessions, find_bfd_peers_with_given_state
+from tests.common import config_reload
+from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.utilities import wait_until
+
 logger = logging.getLogger(__name__)
 
 
 class BfdBase:
+    @pytest.fixture(autouse=True, scope="class")
+    def modify_bfd_sessions(self, duthosts):
+        """
+        1. Gather all front end nodes
+        2. Modify BFD state to required state & issue config reload.
+        3. Wait for Critical processes
+        4. Gather all ASICs for each dut
+        5. Calls find_bfd_peers_with_given_state using wait_until
+            a. Runs ip netns exec asic{} show bfd sum
+            b. If expected state is "Total number of BFD sessions: 0" and it is in result, output is True
+            c. If expected state is "Up" and no. of down peers is 0, output is True
+            d. If expected state is "Down" and no. of up peers is 0, output is True
+        """
+        try:
+            duts = duthosts.frontend_nodes
+            for dut in duts:
+                modify_all_bfd_sessions(dut, "false")
+            for dut in duts:
+                # config reload
+                config_reload(dut)
+                wait_critical_processes(dut)
+            # Verification that all BFD sessions are deleted
+            for dut in duts:
+                asics = [
+                    asic.split("asic")[1] for asic in dut.get_asic_namespace_list()
+                ]
+                for asic in asics:
+                    assert wait_until(
+                        600,
+                        10,
+                        0,
+                        lambda: find_bfd_peers_with_given_state(
+                            dut, asic, "No BFD sessions found"
+                        ),
+                    )
+
+            yield
+
+        finally:
+            duts = duthosts.frontend_nodes
+            for dut in duts:
+                modify_all_bfd_sessions(dut, "true")
+            for dut in duts:
+                config_reload(dut)
+                wait_critical_processes(dut)
+            # Verification that all BFD sessions are added
+            for dut in duts:
+                asics = [
+                    asic.split("asic")[1] for asic in dut.get_asic_namespace_list()
+                ]
+                for asic in asics:
+                    assert wait_until(
+                        600,
+                        10,
+                        0,
+                        lambda: find_bfd_peers_with_given_state(
+                            dut, asic, "Up"
+                        ),
+                    )
+
     @pytest.fixture(scope="class", name="select_src_dst_dut_and_asic", params=(["multi_dut"]))
     def select_src_dst_dut_and_asic(self, duthosts, request, tbinfo):
         if (len(duthosts.frontend_nodes)) < 2:
@@ -18,13 +83,13 @@ class BfdBase:
 
         # Random selection of source asic based on number of asics available on source dut
         src_asic_index_selection = random.choice(
-            duthosts[src_dut_index].get_asic_namespace_list()
+            duthosts.frontend_nodes[src_dut_index].get_asic_namespace_list()
         )
         src_asic_index = src_asic_index_selection.split("asic")[1]
 
         # Random selection of destination asic based on number of asics available on destination dut
         dst_asic_index_selection = random.choice(
-            duthosts[dst_dut_index].get_asic_namespace_list()
+            duthosts.frontend_nodes[dst_dut_index].get_asic_namespace_list()
         )
         dst_asic_index = dst_asic_index_selection.split("asic")[1]
 
@@ -64,4 +129,53 @@ class BfdBase:
             "all_duts": all_duts,
         }
         rtn_dict.update(select_src_dst_dut_and_asic)
+        yield rtn_dict
+
+    @pytest.fixture(scope="class")
+    def select_dut_and_src_dst_asic_index(self, duthosts):
+        if not duthosts.frontend_nodes:
+            pytest.skip("DUT does not have any frontend nodes")
+
+        dut_index = random.choice(list(range(len(duthosts.frontend_nodes))))
+        asic_namespace_list = duthosts.frontend_nodes[dut_index].get_asic_namespace_list()
+        if len(asic_namespace_list) < 2:
+            pytest.skip("DUT does not have more than one ASICs")
+
+        # Random selection of src asic & dst asic on DUT
+        src_asic_namespace, dst_asic_namespace = random.sample(asic_namespace_list, 2)
+        src_asic_index = src_asic_namespace.split("asic")[1]
+        dst_asic_index = dst_asic_namespace.split("asic")[1]
+
+        yield {
+            "dut_index": dut_index,
+            "src_asic_index": int(src_asic_index),
+            "dst_asic_index": int(dst_asic_index),
+        }
+
+    @pytest.fixture(scope="class")
+    def get_src_dst_asic(self, request, duthosts, select_dut_and_src_dst_asic_index):
+        logger.info("Printing select_dut_and_src_dst_asic_index")
+        logger.info(select_dut_and_src_dst_asic_index)
+
+        logger.info("Printing duthosts.frontend_nodes")
+        logger.info(duthosts.frontend_nodes)
+        dut = duthosts.frontend_nodes[select_dut_and_src_dst_asic_index["dut_index"]]
+
+        logger.info("Printing dut asics")
+        logger.info(dut.asics)
+
+        src_asic = dut.asics[select_dut_and_src_dst_asic_index["src_asic_index"]]
+        dst_asic = dut.asics[select_dut_and_src_dst_asic_index["dst_asic_index"]]
+
+        request.config.src_asic = src_asic
+        request.config.dst_asic = dst_asic
+        request.config.dut = dut
+
+        rtn_dict = {
+            "src_asic": src_asic,
+            "dst_asic": dst_asic,
+            "dut": dut,
+        }
+
+        rtn_dict.update(select_dut_and_src_dst_asic_index)
         yield rtn_dict

--- a/tests/bfd/bfd_helpers.py
+++ b/tests/bfd/bfd_helpers.py
@@ -599,7 +599,11 @@ def get_asic_frontend_port_channels(dut, dst_asic_index):
 
 def get_ptf_src_port(src_asic, tbinfo):
     src_asic_mg_facts = src_asic.get_extended_minigraph_facts(tbinfo)
-    return random.choice(list(src_asic_mg_facts["minigraph_ptf_indices"].values()))
+    ptf_src_ports = list(src_asic_mg_facts["minigraph_ptf_indices"].values())
+    if not ptf_src_ports:
+        pytest.skip("No PTF ports found for asic{}".format(src_asic.asic_index))
+
+    return random.choice(ptf_src_ports)
 
 
 def clear_interface_counters(dut):
@@ -647,17 +651,27 @@ def get_backend_interface_in_use_by_counter(
     ptfadapter,
     ptf_src_port,
     dst_neighbor_ip,
-    asic_index,
-    counter_key,
+    src_asic_index,
+    dst_asic_index,
 ):
     clear_interface_counters(dut)
     send_packets_batch_from_ptf(packet_count, version, src_asic_router_mac, ptfadapter, ptf_src_port, dst_neighbor_ip)
-    output = dut.show_and_parse("show int counters -n asic{} -d all".format(asic_index))
-    for item in output:
-        if "BP" in item.get("iface", "") and int(item.get(counter_key, "0").replace(',', '')) >= packet_count:
-            return item.get("iface", "")
+    src_output = dut.show_and_parse("show int counters -n asic{} -d all".format(src_asic_index))
+    dst_output = dut.show_and_parse("show int counters -n asic{} -d all".format(dst_asic_index))
+    src_bp_iface = None
+    for item in src_output:
+        if "BP" in item.get("iface", "") and int(item.get("tx_ok", "0").replace(',', '')) >= packet_count:
+            src_bp_iface = item.get("iface", "")
 
-    return None
+    dst_bp_iface = None
+    for item in dst_output:
+        if "BP" in item.get("iface", "") and int(item.get("rx_ok", "0").replace(',', '')) >= packet_count:
+            dst_bp_iface = item.get("iface", "")
+
+    if not src_bp_iface or not dst_bp_iface:
+        pytest.fail("Backend interface in use not found")
+
+    return src_bp_iface, dst_bp_iface
 
 
 def get_src_dst_asic_next_hops(version, dut, src_asic, dst_asic, request, backend_port_channels):
@@ -680,65 +694,165 @@ def get_src_dst_asic_next_hops(version, dut, src_asic, dst_asic, request, backen
     return src_asic_next_hops, dst_asic_next_hops, src_prefix, dst_prefix
 
 
-# def get_bfd_count_of_state(dut, asic_index, expected_bfd_state):
-#     bfd_cmd = "ip netns exec asic{} show bfd sum | grep -c {}"
-#     bfd_count = dut.shell(bfd_cmd.format(asic_index, expected_bfd_state))["stdout"]
-#     return int(bfd_count)
-#
-#
-# def verify_bfd_count_of_state(dut, asic_index, expected_bfd_state, expected_bfd_count):
-#     bfd_count = get_bfd_count_of_state(dut, asic_index, expected_bfd_state)
-#     return bfd_count == expected_bfd_count
-
-
-def toggle_port_channel(dut, asic, backend_port_channels, bp_iface_in_use_before_shutdown, request, action):
-    port_channel_to_toggle = None
+def get_port_channel_by_member(backend_port_channels, member):
     for port_channel in backend_port_channels:
-        if bp_iface_in_use_before_shutdown in backend_port_channels[port_channel]["members"]:
-            port_channel_to_toggle = port_channel
-            break
+        if member in backend_port_channels[port_channel]["members"]:
+            return port_channel
 
-    if not port_channel_to_toggle:
-        pytest.fail("No port channel found with interface in use")
+    return None
 
+
+def toggle_port_channel_or_member(
+    target_to_toggle,
+    dut,
+    asic,
+    request,
+    action,
+):
     request.config.portchannels_on_dut = "dut"
-    request.config.selected_portchannels = [port_channel_to_toggle]
+    request.config.selected_portchannels = [target_to_toggle]
     request.config.asic = asic
 
-    control_interface_state(dut, asic, port_channel_to_toggle, action)
-    if action == "shutdown":
-        # wait until the corresponding BFD sessions are down
-        time.sleep(120)
-
-
-def toggle_port_channel_member(dut, asic, bp_iface_in_use_before_shutdown, request, action):
-    request.config.portchannels_on_dut = "dut"
-    request.config.selected_portchannels = [bp_iface_in_use_before_shutdown]
-    request.config.asic = asic
-
-    control_interface_state(dut, asic, bp_iface_in_use_before_shutdown, action)
+    control_interface_state(dut, asic, target_to_toggle, action)
     if action == "shutdown":
         time.sleep(120)
 
 
 def assert_bp_iface_after_shutdown(
-    bp_iface_in_use_after_shutdown,
-    asic_index,
+    src_bp_iface_before_shutdown,
+    dst_bp_iface_before_shutdown,
+    src_bp_iface_after_shutdown,
+    dst_bp_iface_after_shutdown,
+    src_asic_index,
+    dst_asic_index,
     dut_hostname,
-    bp_iface_in_use_before_shutdown,
 ):
-    if not bp_iface_in_use_after_shutdown:
+    if src_bp_iface_before_shutdown == src_bp_iface_after_shutdown:
         pytest.fail(
-            "Backend interface in use on asic{} of dut {} is None after shutdown".format(
-                asic_index,
+            "Source backend interface in use on asic{} of dut {} does not change after shutdown".format(
+                src_asic_index,
                 dut_hostname,
             )
         )
 
-    if bp_iface_in_use_before_shutdown == bp_iface_in_use_after_shutdown:
+    if dst_bp_iface_before_shutdown == dst_bp_iface_after_shutdown:
         pytest.fail(
-            "Backend interface in use on asic{} of dut {} does not change after shutdown".format(
-                asic_index,
+            "Destination backend interface in use on asic{} of dut {} does not change after shutdown".format(
+                dst_asic_index,
                 dut_hostname,
             )
         )
+
+
+def assert_port_channel_after_shutdown(
+    src_port_channel_before_shutdown,
+    dst_port_channel_before_shutdown,
+    src_port_channel_after_shutdown,
+    dst_port_channel_after_shutdown,
+    src_asic_index,
+    dst_asic_index,
+    dut_hostname,
+):
+    if src_port_channel_before_shutdown == src_port_channel_after_shutdown:
+        pytest.fail(
+            "Source port channel in use on asic{} of dut {} does not change after shutdown".format(
+                src_asic_index,
+                dut_hostname,
+            )
+        )
+
+    if dst_port_channel_before_shutdown == dst_port_channel_after_shutdown:
+        pytest.fail(
+            "Destination port channel in use on asic{} of dut {} does not change after shutdown".format(
+                dst_asic_index,
+                dut_hostname,
+            )
+        )
+
+
+def verify_given_bfd_state(asic_next_hops, port_channel, asic_index, dut, expected_state):
+    current_state = extract_current_bfd_state(asic_next_hops[port_channel], asic_index, dut)
+    return current_state == expected_state
+
+
+def wait_until_given_bfd_down(
+    src_asic_next_hops,
+    src_port_channel,
+    src_asic_index,
+    dst_asic_next_hops,
+    dst_port_channel,
+    dst_asic_index,
+    dut,
+):
+    assert wait_until(
+        180,
+        10,
+        0,
+        lambda: verify_given_bfd_state(src_asic_next_hops, dst_port_channel, src_asic_index, dut, "Down"),
+    )
+
+    assert wait_until(
+        180,
+        10,
+        0,
+        lambda: verify_given_bfd_state(dst_asic_next_hops, src_port_channel, dst_asic_index, dut, "Down"),
+    )
+
+
+def assert_traffic_switching(
+    dut,
+    backend_port_channels,
+    src_asic_index,
+    src_bp_iface_before_shutdown,
+    src_bp_iface_after_shutdown,
+    src_port_channel_before_shutdown,
+    dst_asic_index,
+    dst_bp_iface_after_shutdown,
+    dst_bp_iface_before_shutdown,
+    dst_port_channel_before_shutdown,
+):
+    assert_bp_iface_after_shutdown(
+        src_bp_iface_before_shutdown,
+        dst_bp_iface_before_shutdown,
+        src_bp_iface_after_shutdown,
+        dst_bp_iface_after_shutdown,
+        src_asic_index,
+        dst_asic_index,
+        dut.hostname,
+    )
+
+    src_port_channel_after_shutdown = get_port_channel_by_member(
+        backend_port_channels,
+        src_bp_iface_after_shutdown,
+    )
+
+    dst_port_channel_after_shutdown = get_port_channel_by_member(
+        backend_port_channels,
+        dst_bp_iface_after_shutdown,
+    )
+
+    assert_port_channel_after_shutdown(
+        src_port_channel_before_shutdown,
+        dst_port_channel_before_shutdown,
+        src_port_channel_after_shutdown,
+        dst_port_channel_after_shutdown,
+        src_asic_index,
+        dst_asic_index,
+        dut.hostname,
+    )
+
+
+def wait_until_bfd_up(dut, src_asic_next_hops, src_asic, dst_asic_next_hops, dst_asic):
+    assert wait_until(
+        180,
+        10,
+        0,
+        lambda: verify_bfd_state(dut, src_asic_next_hops.values(), src_asic, "Up"),
+    )
+
+    assert wait_until(
+        180,
+        10,
+        0,
+        lambda: verify_bfd_state(dut, dst_asic_next_hops.values(), dst_asic, "Up"),
+    )

--- a/tests/bfd/bfd_helpers.py
+++ b/tests/bfd/bfd_helpers.py
@@ -703,3 +703,36 @@ def toggle_port_channel(dut, asic, backend_port_channels, bp_iface_in_use_before
     if action == "shutdown":
         # wait until the corresponding BFD sessions are down
         time.sleep(120)
+
+
+def toggle_port_channel_member(dut, asic, bp_iface_in_use_before_shutdown, request, action):
+    request.config.portchannels_on_dut = "dut"
+    request.config.selected_portchannels = [bp_iface_in_use_before_shutdown]
+    request.config.asic = asic
+
+    control_interface_state(dut, asic, bp_iface_in_use_before_shutdown, action)
+    if action == "shutdown":
+        time.sleep(120)
+
+
+def assert_bp_iface_after_shutdown(
+    bp_iface_in_use_after_shutdown,
+    asic_index,
+    dut_hostname,
+    bp_iface_in_use_before_shutdown,
+):
+    if not bp_iface_in_use_after_shutdown:
+        pytest.fail(
+            "Backend interface in use on asic{} of dut {} is None after shutdown".format(
+                asic_index,
+                dut_hostname,
+            )
+        )
+
+    if bp_iface_in_use_before_shutdown == bp_iface_in_use_after_shutdown:
+        pytest.fail(
+            "Backend interface in use on asic{} of dut {} does not change after shutdown".format(
+                asic_index,
+                dut_hostname,
+            )
+        )

--- a/tests/bfd/bfd_helpers.py
+++ b/tests/bfd/bfd_helpers.py
@@ -545,7 +545,13 @@ def get_random_bgp_neighbor_ip_of_asic(dut, asic_index, version):
     if not output:
         return None
 
-    return random.choice(output).get("neighbhor", "")
+    random_neighbor_bgp_info = random.choice(output)
+    if "neighbhor" in random_neighbor_bgp_info:
+        return random_neighbor_bgp_info["neighbhor"]
+    elif "neighbor" in random_neighbor_bgp_info:
+        return random_neighbor_bgp_info["neighbor"]
+    else:
+        return None
 
 
 def get_bgp_neighbor_ip_of_port_channel(dut, asic_index, port_channel, version):

--- a/tests/bfd/bfd_helpers.py
+++ b/tests/bfd/bfd_helpers.py
@@ -1,14 +1,36 @@
 import logging
+import random
 import re
 import sys
 import time
 
 import pytest
+from ptf import testutils
 
 from tests.common.utilities import wait_until
 from tests.platform_tests.cli import util
 
 logger = logging.getLogger(__name__)
+
+
+def get_dut_asic_static_routes(version, dut):
+    if version == "ipv4":
+        static_route_command = "show ip route static"
+    elif version == "ipv6":
+        static_route_command = "show ipv6 route static"
+    else:
+        assert False, "Invalid version"
+
+    stdout = dut.shell(static_route_command, module_ignore_errors=True)["stdout"]
+    if sys.version_info.major < 3:
+        static_routes_output = stdout.encode("utf-8").strip().split("\n")
+    else:
+        static_routes_output = stdout.strip().split("\n")
+
+    asic_static_routes = extract_routes(static_routes_output, version)
+    logger.info("asic routes, {}".format(asic_static_routes))
+    assert len(asic_static_routes) > 0, "static routes on dut are empty"
+    return asic_static_routes
 
 
 def select_src_dst_dut_with_asic(
@@ -31,37 +53,8 @@ def select_src_dst_dut_with_asic(
     request.config.src_dut = src_dut
     request.config.dst_dut = dst_dut
 
-    # Extracting static routes
-    if version == "ipv4":
-        static_route_command = "show ip route static"
-    elif version == "ipv6":
-        static_route_command = "show ipv6 route static"
-    else:
-        assert False, "Invalid version"
-
-    src_dut_static_route = src_dut.shell(static_route_command, module_ignore_errors=True)["stdout"]
-    if sys.version_info.major < 3:
-        src_dut_static_route_output = src_dut_static_route.encode("utf-8").strip().split("\n")
-    else:
-        src_dut_static_route_output = src_dut_static_route.strip().split("\n")
-
-    src_asic_routes = extract_routes(
-        src_dut_static_route_output, version
-    )
-    logger.info("Source asic routes, {}".format(src_asic_routes))
-    assert len(src_asic_routes) > 0, "static routes on source dut are empty"
-
-    dst_dut_static_route = dst_dut.shell(static_route_command, module_ignore_errors=True)["stdout"]
-    if sys.version_info.major < 3:
-        dst_dut_static_route_output = dst_dut_static_route.encode("utf-8").strip().split("\n")
-    else:
-        dst_dut_static_route_output = dst_dut_static_route.strip().split("\n")
-
-    dst_asic_routes = extract_routes(
-        dst_dut_static_route_output, version
-    )
-    logger.info("Destination asic routes, {}".format(dst_asic_routes))
-    assert len(dst_asic_routes) > 0, "static routes on destination dut are empty"
+    src_asic_routes = get_dut_asic_static_routes(version, src_dut)
+    dst_asic_routes = get_dut_asic_static_routes(version, dst_dut)
 
     # Extracting nexthops
     dst_dut_nexthops = (
@@ -287,15 +280,17 @@ def extract_backend_portchannels(dut):
     return port_channel_dict
 
 
-def extract_ip_addresses_for_backend_portchannels(dut, dut_asic, version):
-    backend_port_channels = extract_backend_portchannels(dut)
+def extract_ip_addresses_for_backend_portchannels(dut, dut_asic, version, backend_port_channels=None):
+    if not backend_port_channels:
+        backend_port_channels = extract_backend_portchannels(dut)
+
     if version == "ipv4":
         command = "show ip int -d all"
     elif version == "ipv6":
         command = "show ipv6 int -d all"
-    data = dut.show_and_parse("{} -n asic{}".format(command, dut_asic.asic_index))
+    output = dut.show_and_parse("{} -n asic{}".format(command, dut_asic.asic_index))
     result_dict = {}
-    for item in data:
+    for item in output:
         if version == "ipv4":
             ip_address = item.get("ipv4 address/mask", "").split("/")[0]
         elif version == "ipv6":
@@ -475,3 +470,236 @@ def ensure_interface_is_up(dut, asic, interface):
                 asic_index=asic.asic_index,
             )["ansible_facts"]["int_status"][interface]["oper_state"] == "up",
         )
+
+
+def prepare_traffic_test_variables(get_src_dst_asic, request, version):
+    dut = get_src_dst_asic["dut"]
+    src_asic = get_src_dst_asic["src_asic"]
+    src_asic_index = get_src_dst_asic["src_asic_index"]
+    dst_asic = get_src_dst_asic["dst_asic"]
+    dst_asic_index = get_src_dst_asic["dst_asic_index"]
+    logger.info(
+        "DUT: {}, src_asic_index: {}, dst_asic_index: {}".format(dut.hostname, src_asic_index, dst_asic_index)
+    )
+
+    backend_port_channels = extract_backend_portchannels(dut)
+    src_asic_next_hops, dst_asic_next_hops, src_prefix, dst_prefix = get_src_dst_asic_next_hops(
+        version,
+        dut,
+        src_asic,
+        dst_asic,
+        request,
+        backend_port_channels,
+    )
+
+    add_bfd(src_asic_index, src_prefix, dut)
+    add_bfd(dst_asic_index, dst_prefix, dut)
+    assert wait_until(
+        180,
+        10,
+        0,
+        lambda: verify_bfd_state(dut, src_asic_next_hops.values(), src_asic, "Up"),
+    )
+    assert wait_until(
+        180,
+        10,
+        0,
+        lambda: verify_bfd_state(dut, dst_asic_next_hops.values(), dst_asic, "Up"),
+    )
+
+    src_asic_router_mac = src_asic.get_router_mac()
+
+    return (
+        dut,
+        src_asic,
+        src_asic_index,
+        dst_asic,
+        dst_asic_index,
+        src_asic_next_hops,
+        dst_asic_next_hops,
+        src_asic_router_mac,
+        backend_port_channels,
+    )
+
+
+def clear_bfd_configs(dut, asic_index, prefix):
+    logger.info("Clearing BFD configs on {}".format(dut))
+    command = (
+        "sonic-db-cli -n asic{} CONFIG_DB HSET \"STATIC_ROUTE|{}\" bfd 'false'".format(
+            asic_index,
+            prefix,
+        ).replace("\\", "")
+    )
+
+    dut.shell(command)
+
+
+def get_random_bgp_neighbor_ip_of_asic(dut, asic_index, version):
+    command = "show ip bgp sum"
+    if version == "ipv4":
+        command = "show ip bgp sum"
+    elif version == "ipv6":
+        command = "show ipv6 bgp sum"
+
+    output = dut.show_and_parse("{} -n asic{}".format(command, asic_index))
+    if not output:
+        return None
+
+    return random.choice(output).get("neighbhor", "")
+
+
+def get_bgp_neighbor_ip_of_port_channel(dut, asic_index, port_channel, version):
+    command = None
+    if version == "ipv4":
+        command = "show ip int"
+    elif version == "ipv6":
+        command = "show ipv6 int"
+
+    output = dut.show_and_parse("{} -n asic{}".format(command, asic_index))
+    for item in output:
+        if item.get("interface", "") == port_channel:
+            return item.get("neighbor ip", "")
+
+    return None
+
+
+def get_asic_frontend_port_channels(dut, dst_asic_index):
+    output = dut.show_and_parse("show int port -n asic{}".format(dst_asic_index))
+    asic_port_channel_info = {}
+
+    for item in output:
+        port_channel = item.get("team dev", "")
+        ports_with_status = [port.strip() for port in item.get("ports", "").split()]
+        ports = [
+            (
+                re.match(r"^([\w-]+)\([A-Za-z]\)", port).group(1)
+                if re.match(r"^([\w-]+)\([A-Za-z]\)", port)
+                else None
+            )
+            for port in ports_with_status
+        ]
+        status_match = re.search(
+            r"LACP\(A\)\((\w+)\)", item.get("protocol", "")
+        )
+        status = status_match.group(1) if status_match else ""
+        if ports:
+            asic_port_channel_info[port_channel] = {
+                "members": ports,
+                "status": status,
+            }
+
+    return asic_port_channel_info
+
+
+def get_ptf_src_port(src_asic, tbinfo):
+    src_asic_mg_facts = src_asic.get_extended_minigraph_facts(tbinfo)
+    return random.choice(list(src_asic_mg_facts["minigraph_ptf_indices"].values()))
+
+
+def clear_interface_counters(dut):
+    dut.shell("sonic-clear counters")
+
+
+def send_packets_batch_from_ptf(
+    packet_count,
+    version,
+    src_asic_router_mac,
+    ptfadapter,
+    ptf_src_port,
+    dst_neighbor_ip,
+):
+    for _ in range(packet_count):
+        if version == "ipv4":
+            pkt = testutils.simple_ip_packet(
+                eth_dst=src_asic_router_mac,
+                eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port),
+                # ip_src=src_ip_addr,
+                ip_dst=dst_neighbor_ip,
+                ip_proto=47,
+                ip_tos=0x84,
+                ip_id=0,
+                ip_ihl=5,
+                ip_ttl=121
+            )
+        else:
+            pkt = testutils.simple_ipv6ip_packet(
+                eth_dst=src_asic_router_mac,
+                eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port),
+                # ip_src=src_ip_addr,
+                ipv6_dst=dst_neighbor_ip,
+            )
+
+        ptfadapter.dataplane.flush()
+        testutils.send(test=ptfadapter, port_id=ptf_src_port, pkt=pkt)
+
+
+def get_backend_interface_in_use_by_counter(
+    dut,
+    packet_count,
+    version,
+    src_asic_router_mac,
+    ptfadapter,
+    ptf_src_port,
+    dst_neighbor_ip,
+    asic_index,
+    counter_key,
+):
+    clear_interface_counters(dut)
+    send_packets_batch_from_ptf(packet_count, version, src_asic_router_mac, ptfadapter, ptf_src_port, dst_neighbor_ip)
+    output = dut.show_and_parse("show int counters -n asic{} -d all".format(asic_index))
+    for item in output:
+        if "BP" in item.get("iface", "") and int(item.get(counter_key, "0").replace(',', '')) >= packet_count:
+            return item.get("iface", "")
+
+    return None
+
+
+def get_src_dst_asic_next_hops(version, dut, src_asic, dst_asic, request, backend_port_channels):
+    src_asic_next_hops = extract_ip_addresses_for_backend_portchannels(dut, dst_asic, version, backend_port_channels)
+    assert len(src_asic_next_hops) != 0, "Source next hops are empty"
+    dst_asic_next_hops = extract_ip_addresses_for_backend_portchannels(dut, src_asic, version, backend_port_channels)
+    assert len(dst_asic_next_hops) != 0, "Destination next hops are empty"
+
+    dut_asic_static_routes = get_dut_asic_static_routes(version, dut)
+
+    # Picking a static route to delete its BFD session
+    src_prefix = selecting_route_to_delete(dut_asic_static_routes, src_asic_next_hops.values())
+    request.config.src_prefix = src_prefix
+    assert src_prefix is not None and src_prefix != "", "Source prefix not found"
+
+    dst_prefix = selecting_route_to_delete(dut_asic_static_routes, dst_asic_next_hops.values())
+    request.config.dst_prefix = dst_prefix
+    assert dst_prefix is not None and dst_prefix != "", "Destination prefix not found"
+
+    return src_asic_next_hops, dst_asic_next_hops, src_prefix, dst_prefix
+
+
+# def get_bfd_count_of_state(dut, asic_index, expected_bfd_state):
+#     bfd_cmd = "ip netns exec asic{} show bfd sum | grep -c {}"
+#     bfd_count = dut.shell(bfd_cmd.format(asic_index, expected_bfd_state))["stdout"]
+#     return int(bfd_count)
+#
+#
+# def verify_bfd_count_of_state(dut, asic_index, expected_bfd_state, expected_bfd_count):
+#     bfd_count = get_bfd_count_of_state(dut, asic_index, expected_bfd_state)
+#     return bfd_count == expected_bfd_count
+
+
+def toggle_port_channel(dut, asic, backend_port_channels, bp_iface_in_use_before_shutdown, request, action):
+    port_channel_to_toggle = None
+    for port_channel in backend_port_channels:
+        if bp_iface_in_use_before_shutdown in backend_port_channels[port_channel]["members"]:
+            port_channel_to_toggle = port_channel
+            break
+
+    if not port_channel_to_toggle:
+        pytest.fail("No port channel found with interface in use")
+
+    request.config.portchannels_on_dut = "dut"
+    request.config.selected_portchannels = [port_channel_to_toggle]
+    request.config.asic = asic
+
+    control_interface_state(dut, asic, port_channel_to_toggle, action)
+    if action == "shutdown":
+        # wait until the corresponding BFD sessions are down
+        time.sleep(120)

--- a/tests/bfd/conftest.py
+++ b/tests/bfd/conftest.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from tests.bfd.bfd_helpers import ensure_interface_is_up
+from tests.bfd.bfd_helpers import ensure_interface_is_up, clear_bfd_configs
 from tests.common.config_reload import config_reload
 from tests.common.utilities import wait_until
 from tests.platform_tests.link_flap.link_flap_utils import check_orch_cpu_utilization
@@ -32,14 +32,10 @@ def bfd_cleanup_db(request, duthosts, enum_supervisor_dut_hostname):
     for dut in duts:
         assert wait_until(
             100, 2, 0, check_orch_cpu_utilization, dut, orch_cpu_threshold
-        ), "Orch CPU utilization {} > orch cpu threshold {} before starting the test".format(
-            dut.shell("show processes cpu | grep orchagent | awk '{print $9}'")[
-                "stdout"
-            ],
-            orch_cpu_threshold,
-        )
+        ), "Orch CPU utilization exceeds orch cpu threshold {} before starting the test".format(orch_cpu_threshold)
 
     yield
+
     orch_cpu_threshold = 10
     # Orchagent CPU should consume < orch_cpu_threshold at last.
     logger.info(
@@ -48,12 +44,7 @@ def bfd_cleanup_db(request, duthosts, enum_supervisor_dut_hostname):
     for dut in duts:
         assert wait_until(
             120, 4, 0, check_orch_cpu_utilization, dut, orch_cpu_threshold
-        ), "Orch CPU utilization {} > orch cpu threshold {} after the test".format(
-            dut.shell("show processes cpu | grep orchagent | awk '{print $9}'")[
-                "stdout"
-            ],
-            orch_cpu_threshold,
-        )
+        ), "Orch CPU utilization exceeds orch cpu threshold {} after finishing the test".format(orch_cpu_threshold)
 
     logger.info("Verifying swss container status on RP")
     rp = duthosts[enum_supervisor_dut_hostname]
@@ -68,23 +59,13 @@ def bfd_cleanup_db(request, duthosts, enum_supervisor_dut_hostname):
     if not container_status:
         config_reload(rp)
 
-    logger.info(
-        "Clearing BFD configs on {}, {}".format(
-            request.config.src_dut, request.config.dst_dut
-        )
-    )
-    command = (
-        "sonic-db-cli -n asic{} CONFIG_DB HSET \"STATIC_ROUTE|{}\" bfd 'false'".format(
-            request.config.src_asic.asic_index, request.config.src_prefix
-        ).replace("\\", "")
-    )
-    request.config.src_dut.shell(command)
-    command = (
-        "sonic-db-cli -n asic{} CONFIG_DB HSET \"STATIC_ROUTE|{}\" bfd 'false'".format(
-            request.config.dst_asic.asic_index, request.config.dst_prefix
-        ).replace("\\", "")
-    )
-    request.config.dst_dut.shell(command)
+    if hasattr(request.config, "dut"):
+        clear_bfd_configs(request.config.dut, request.config.src_asic.asic_index, request.config.src_prefix)
+        clear_bfd_configs(request.config.dut, request.config.dst_asic.asic_index, request.config.dst_prefix)
+
+    if hasattr(request.config, "src_dut") and hasattr(request.config, "dst_dut"):
+        clear_bfd_configs(request.config.src_dut, request.config.src_asic.asic_index, request.config.src_prefix)
+        clear_bfd_configs(request.config.dst_dut, request.config.dst_asic.asic_index, request.config.dst_prefix)
 
     logger.info("Bringing up portchannels or respective members")
     portchannels_on_dut = None
@@ -101,15 +82,19 @@ def bfd_cleanup_db(request, duthosts, enum_supervisor_dut_hostname):
         selected_interfaces = []
 
     if selected_interfaces:
-        dut = (
-            request.config.src_dut
-            if portchannels_on_dut == "src"
-            else request.config.dst_dut
-        )
-        asic = (
-            request.config.src_asic
-            if portchannels_on_dut == "src"
-            else request.config.dst_asic
-        )
+        if portchannels_on_dut == "src":
+            dut = request.config.src_dut
+        elif portchannels_on_dut == "dst":
+            dut = request.config.dst_dut
+        else:
+            dut = request.config.dut
+
+        if portchannels_on_dut == "src":
+            asic = request.config.src_asic
+        elif portchannels_on_dut == "dst":
+            asic = request.config.dst_asic
+        else:
+            asic = request.config.asic
+
         for interface in selected_interfaces:
             ensure_interface_is_up(dut, asic, interface)

--- a/tests/bfd/conftest.py
+++ b/tests/bfd/conftest.py
@@ -59,13 +59,12 @@ def bfd_cleanup_db(request, duthosts, enum_supervisor_dut_hostname):
     if not container_status:
         config_reload(rp)
 
-    if hasattr(request.config, "dut"):
-        clear_bfd_configs(request.config.dut, request.config.src_asic.asic_index, request.config.src_prefix)
-        clear_bfd_configs(request.config.dut, request.config.dst_asic.asic_index, request.config.dst_prefix)
-
     if hasattr(request.config, "src_dut") and hasattr(request.config, "dst_dut"):
         clear_bfd_configs(request.config.src_dut, request.config.src_asic.asic_index, request.config.src_prefix)
         clear_bfd_configs(request.config.dst_dut, request.config.dst_asic.asic_index, request.config.dst_prefix)
+    elif hasattr(request.config, "dut"):
+        clear_bfd_configs(request.config.dut, request.config.src_asic.asic_index, request.config.src_prefix)
+        clear_bfd_configs(request.config.dut, request.config.dst_asic.asic_index, request.config.dst_prefix)
 
     logger.info("Bringing up portchannels or respective members")
     portchannels_on_dut = None

--- a/tests/bfd/test_bfd_static_route.py
+++ b/tests/bfd/test_bfd_static_route.py
@@ -5,8 +5,7 @@ import pytest
 
 from tests.bfd.bfd_base import BfdBase
 from tests.bfd.bfd_helpers import verify_static_route, select_src_dst_dut_with_asic, control_interface_state, \
-    check_bgp_status, modify_all_bfd_sessions, find_bfd_peers_with_given_state, add_bfd, verify_bfd_state, delete_bfd, \
-    extract_backend_portchannels
+    check_bgp_status, add_bfd, verify_bfd_state, delete_bfd, extract_backend_portchannels
 from tests.common.config_reload import config_reload
 from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs  # noqa F401
 from tests.common.platform.processes_utils import wait_critical_processes
@@ -29,66 +28,6 @@ class TestBfdStaticRoute(BfdBase):
         'thorough': 100,
         'diagnose': 200,
     }
-
-    @pytest.fixture(autouse=True, scope="class")
-    def modify_bfd_sessions(self, duthosts):
-        """
-        1. Gather all front end nodes
-        2. Modify BFD state to required state & issue config reload.
-        3. Wait for Critical processes
-        4. Gather all ASICs for each dut
-        5. Calls find_bfd_peers_with_given_state using wait_until
-            a. Runs ip netns exec asic{} show bfd sum
-            b. If expected state is "Total number of BFD sessions: 0" and it is in result, output is True
-            c. If expected state is "Up" and no. of down peers is 0, output is True
-            d. If expected state is "Down" and no. of up peers is 0, output is True
-        """
-        try:
-            duts = duthosts.frontend_nodes
-            for dut in duts:
-                modify_all_bfd_sessions(dut, "false")
-            for dut in duts:
-                # config reload
-                config_reload(dut)
-                wait_critical_processes(dut)
-            # Verification that all BFD sessions are deleted
-            for dut in duts:
-                asics = [
-                    asic.split("asic")[1] for asic in dut.get_asic_namespace_list()
-                ]
-                for asic in asics:
-                    assert wait_until(
-                        600,
-                        10,
-                        0,
-                        lambda: find_bfd_peers_with_given_state(
-                            dut, asic, "No BFD sessions found"
-                        ),
-                    )
-
-            yield
-
-        finally:
-            duts = duthosts.frontend_nodes
-            for dut in duts:
-                modify_all_bfd_sessions(dut, "true")
-            for dut in duts:
-                config_reload(dut)
-                wait_critical_processes(dut)
-            # Verification that all BFD sessions are added
-            for dut in duts:
-                asics = [
-                    asic.split("asic")[1] for asic in dut.get_asic_namespace_list()
-                ]
-                for asic in asics:
-                    assert wait_until(
-                        600,
-                        10,
-                        0,
-                        lambda: find_bfd_peers_with_given_state(
-                            dut, asic, "Up"
-                        ),
-                    )
 
     @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
     def test_bfd_with_lc_reboot(

--- a/tests/bfd/test_bfd_traffic.py
+++ b/tests/bfd/test_bfd_traffic.py
@@ -4,7 +4,8 @@ import pytest
 
 from tests.bfd.bfd_base import BfdBase
 from tests.bfd.bfd_helpers import get_ptf_src_port, get_backend_interface_in_use_by_counter, verify_bfd_state, \
-    prepare_traffic_test_variables, toggle_port_channel, get_random_bgp_neighbor_ip_of_asic
+    prepare_traffic_test_variables, toggle_port_channel, get_random_bgp_neighbor_ip_of_asic, \
+    toggle_port_channel_member, assert_bp_iface_after_shutdown
 from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs  # noqa F401
 from tests.common.utilities import wait_until
 
@@ -79,21 +80,12 @@ class TestBfdTraffic(BfdBase):
             "rx_ok",
         )
 
-        if not bp_iface_in_use_after_shutdown:
-            pytest.fail(
-                "Backend interface in use on asic{} of dut {} is None after shutdown".format(
-                    dst_asic_index,
-                    dut.hostname,
-                )
-            )
-
-        if bp_iface_in_use_before_shutdown == bp_iface_in_use_after_shutdown:
-            pytest.fail(
-                "Backend interface in use on asic{} of dut {} does not change after shutdown".format(
-                    dst_asic_index,
-                    dut.hostname,
-                )
-            )
+        assert_bp_iface_after_shutdown(
+            bp_iface_in_use_after_shutdown,
+            dst_asic_index,
+            dut.hostname,
+            bp_iface_in_use_before_shutdown,
+        )
 
         toggle_port_channel(
             dut,
@@ -180,26 +172,197 @@ class TestBfdTraffic(BfdBase):
             "tx_ok",
         )
 
-        if not bp_iface_in_use_after_shutdown:
-            pytest.fail(
-                "Backend interface in use on asic{} of dut {} is None after shutdown".format(
-                    src_asic_index,
-                    dut.hostname,
-                )
-            )
-
-        if bp_iface_in_use_before_shutdown == bp_iface_in_use_after_shutdown:
-            pytest.fail(
-                "Backend interface in use on asic{} of dut {} does not change after shutdown".format(
-                    src_asic_index,
-                    dut.hostname,
-                )
-            )
+        assert_bp_iface_after_shutdown(
+            bp_iface_in_use_after_shutdown,
+            src_asic_index,
+            dut.hostname,
+            bp_iface_in_use_before_shutdown,
+        )
 
         toggle_port_channel(
             dut,
             src_asic,
             backend_port_channels,
+            bp_iface_in_use_before_shutdown,
+            request,
+            "startup",
+        )
+
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(dut, src_asic_next_hops.values(), src_asic, "Up"),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(dut, dst_asic_next_hops.values(), dst_asic, "Up"),
+        )
+
+    @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
+    def test_bfd_traffic_remote_port_channel_member_shutdown(
+        self,
+        request,
+        tbinfo,
+        ptfadapter,
+        get_src_dst_asic,
+        bfd_cleanup_db,
+        version,
+    ):
+        (
+            dut,
+            src_asic,
+            src_asic_index,
+            dst_asic,
+            dst_asic_index,
+            src_asic_next_hops,
+            dst_asic_next_hops,
+            src_asic_router_mac,
+            backend_port_channels,
+        ) = prepare_traffic_test_variables(get_src_dst_asic, request, version)
+
+        dst_neighbor_ip = get_random_bgp_neighbor_ip_of_asic(dut, dst_asic_index, version)
+        if not dst_neighbor_ip:
+            pytest.skip("No BGP neighbor found on asic{} of dut {}".format(dst_asic_index, dut.hostname))
+
+        ptf_src_port = get_ptf_src_port(src_asic, tbinfo)
+        bp_iface_in_use_before_shutdown = get_backend_interface_in_use_by_counter(
+            dut,
+            self.PACKET_COUNT,
+            version,
+            src_asic_router_mac,
+            ptfadapter,
+            ptf_src_port,
+            dst_neighbor_ip,
+            dst_asic_index,
+            "rx_ok",
+        )
+
+        if not bp_iface_in_use_before_shutdown:
+            pytest.fail("No backend interface in use on asic{} of dut {}".format(dst_asic_index, dut.hostname))
+
+        toggle_port_channel_member(
+            dut,
+            dst_asic,
+            bp_iface_in_use_before_shutdown,
+            request,
+            "shutdown",
+        )
+
+        bp_iface_in_use_after_shutdown = get_backend_interface_in_use_by_counter(
+            dut,
+            self.PACKET_COUNT,
+            version,
+            src_asic_router_mac,
+            ptfadapter,
+            ptf_src_port,
+            dst_neighbor_ip,
+            dst_asic_index,
+            "rx_ok",
+        )
+
+        assert_bp_iface_after_shutdown(
+            bp_iface_in_use_after_shutdown,
+            dst_asic_index,
+            dut.hostname,
+            bp_iface_in_use_before_shutdown,
+        )
+
+        toggle_port_channel_member(
+            dut,
+            dst_asic,
+            bp_iface_in_use_before_shutdown,
+            request,
+            "startup",
+        )
+
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(dut, src_asic_next_hops.values(), src_asic, "Up"),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(dut, dst_asic_next_hops.values(), dst_asic, "Up"),
+        )
+
+    @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
+    def test_bfd_traffic_local_port_channel_member_shutdown(
+        self,
+        request,
+        tbinfo,
+        ptfadapter,
+        get_src_dst_asic,
+        bfd_cleanup_db,
+        version,
+    ):
+        (
+            dut,
+            src_asic,
+            src_asic_index,
+            dst_asic,
+            dst_asic_index,
+            src_asic_next_hops,
+            dst_asic_next_hops,
+            src_asic_router_mac,
+            backend_port_channels,
+        ) = prepare_traffic_test_variables(get_src_dst_asic, request, version)
+
+        dst_neighbor_ip = get_random_bgp_neighbor_ip_of_asic(dut, dst_asic_index, version)
+        if not dst_neighbor_ip:
+            pytest.skip("No BGP neighbor found on asic{} of dut {}".format(dst_asic_index, dut.hostname))
+
+        ptf_src_port = get_ptf_src_port(src_asic, tbinfo)
+        bp_iface_in_use_before_shutdown = get_backend_interface_in_use_by_counter(
+            dut,
+            self.PACKET_COUNT,
+            version,
+            src_asic_router_mac,
+            ptfadapter,
+            ptf_src_port,
+            dst_neighbor_ip,
+            src_asic_index,
+            "tx_ok",
+        )
+
+        if not bp_iface_in_use_before_shutdown:
+            pytest.fail("No backend interface in use on asic{} of dut {}".format(src_asic_index, dut.hostname))
+
+        toggle_port_channel_member(
+            dut,
+            src_asic,
+            bp_iface_in_use_before_shutdown,
+            request,
+            "shutdown",
+        )
+
+        bp_iface_in_use_after_shutdown = get_backend_interface_in_use_by_counter(
+            dut,
+            self.PACKET_COUNT,
+            version,
+            src_asic_router_mac,
+            ptfadapter,
+            ptf_src_port,
+            dst_neighbor_ip,
+            src_asic_index,
+            "tx_ok",
+        )
+
+        assert_bp_iface_after_shutdown(
+            bp_iface_in_use_after_shutdown,
+            src_asic_index,
+            dut.hostname,
+            bp_iface_in_use_before_shutdown,
+        )
+
+        toggle_port_channel_member(
+            dut,
+            src_asic,
             bp_iface_in_use_before_shutdown,
             request,
             "startup",

--- a/tests/bfd/test_bfd_traffic.py
+++ b/tests/bfd/test_bfd_traffic.py
@@ -6,7 +6,6 @@ from tests.bfd.bfd_base import BfdBase
 from tests.bfd.bfd_helpers import get_ptf_src_port, get_backend_interface_in_use_by_counter, verify_bfd_state, \
     prepare_traffic_test_variables, toggle_port_channel, get_random_bgp_neighbor_ip_of_asic, \
     toggle_port_channel_member, assert_bp_iface_after_shutdown
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs  # noqa F401
 from tests.common.utilities import wait_until
 
 pytestmark = [pytest.mark.topology("t2")]

--- a/tests/bfd/test_bfd_traffic.py
+++ b/tests/bfd/test_bfd_traffic.py
@@ -5,8 +5,7 @@ import pytest
 from tests.bfd.bfd_base import BfdBase
 from tests.bfd.bfd_helpers import get_ptf_src_port, get_backend_interface_in_use_by_counter, \
     prepare_traffic_test_variables, get_random_bgp_neighbor_ip_of_asic, toggle_port_channel_or_member, \
-    assert_bp_iface_after_shutdown, get_port_channel_by_member, wait_until_bfd_up, wait_until_given_bfd_down, \
-    assert_port_channel_after_shutdown, assert_traffic_switching
+    get_port_channel_by_member, wait_until_bfd_up, wait_until_given_bfd_down, assert_traffic_switching
 
 pytestmark = [pytest.mark.topology("t2")]
 

--- a/tests/bfd/test_bfd_traffic.py
+++ b/tests/bfd/test_bfd_traffic.py
@@ -1,0 +1,219 @@
+import logging
+
+import pytest
+
+from tests.bfd.bfd_base import BfdBase
+from tests.bfd.bfd_helpers import get_ptf_src_port, get_backend_interface_in_use_by_counter, verify_bfd_state, \
+    prepare_traffic_test_variables, toggle_port_channel, get_random_bgp_neighbor_ip_of_asic
+from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs  # noqa F401
+from tests.common.utilities import wait_until
+
+pytestmark = [pytest.mark.topology("t2")]
+
+logger = logging.getLogger(__name__)
+
+
+class TestBfdTraffic(BfdBase):
+    PACKET_COUNT = 10000
+
+    @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
+    def test_bfd_traffic_remote_port_channel_shutdown(
+        self,
+        request,
+        tbinfo,
+        ptfadapter,
+        get_src_dst_asic,
+        bfd_cleanup_db,
+        version,
+    ):
+        (
+            dut,
+            src_asic,
+            src_asic_index,
+            dst_asic,
+            dst_asic_index,
+            src_asic_next_hops,
+            dst_asic_next_hops,
+            src_asic_router_mac,
+            backend_port_channels,
+        ) = prepare_traffic_test_variables(get_src_dst_asic, request, version)
+
+        dst_neighbor_ip = get_random_bgp_neighbor_ip_of_asic(dut, dst_asic_index, version)
+        if not dst_neighbor_ip:
+            pytest.skip("No BGP neighbor found on asic{} of dut {}".format(dst_asic_index, dut.hostname))
+
+        ptf_src_port = get_ptf_src_port(src_asic, tbinfo)
+        bp_iface_in_use_before_shutdown = get_backend_interface_in_use_by_counter(
+            dut,
+            self.PACKET_COUNT,
+            version,
+            src_asic_router_mac,
+            ptfadapter,
+            ptf_src_port,
+            dst_neighbor_ip,
+            dst_asic_index,
+            "rx_ok",
+        )
+
+        if not bp_iface_in_use_before_shutdown:
+            pytest.fail("No backend interface in use on asic{} of dut {}".format(dst_asic_index, dut.hostname))
+
+        toggle_port_channel(
+            dut,
+            dst_asic,
+            backend_port_channels,
+            bp_iface_in_use_before_shutdown,
+            request,
+            "shutdown",
+        )
+
+        bp_iface_in_use_after_shutdown = get_backend_interface_in_use_by_counter(
+            dut,
+            self.PACKET_COUNT,
+            version,
+            src_asic_router_mac,
+            ptfadapter,
+            ptf_src_port,
+            dst_neighbor_ip,
+            dst_asic_index,
+            "rx_ok",
+        )
+
+        if not bp_iface_in_use_after_shutdown:
+            pytest.fail(
+                "Backend interface in use on asic{} of dut {} is None after shutdown".format(
+                    dst_asic_index,
+                    dut.hostname,
+                )
+            )
+
+        if bp_iface_in_use_before_shutdown == bp_iface_in_use_after_shutdown:
+            pytest.fail(
+                "Backend interface in use on asic{} of dut {} does not change after shutdown".format(
+                    dst_asic_index,
+                    dut.hostname,
+                )
+            )
+
+        toggle_port_channel(
+            dut,
+            dst_asic,
+            backend_port_channels,
+            bp_iface_in_use_before_shutdown,
+            request,
+            "startup",
+        )
+
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(dut, src_asic_next_hops.values(), src_asic, "Up"),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(dut, dst_asic_next_hops.values(), dst_asic, "Up"),
+        )
+
+    @pytest.mark.parametrize("version", ["ipv4", "ipv6"])
+    def test_bfd_traffic_local_port_channel_shutdown(
+        self,
+        request,
+        tbinfo,
+        ptfadapter,
+        get_src_dst_asic,
+        bfd_cleanup_db,
+        version,
+    ):
+        (
+            dut,
+            src_asic,
+            src_asic_index,
+            dst_asic,
+            dst_asic_index,
+            src_asic_next_hops,
+            dst_asic_next_hops,
+            src_asic_router_mac,
+            backend_port_channels,
+        ) = prepare_traffic_test_variables(get_src_dst_asic, request, version)
+
+        dst_neighbor_ip = get_random_bgp_neighbor_ip_of_asic(dut, dst_asic_index, version)
+        if not dst_neighbor_ip:
+            pytest.skip("No BGP neighbor found on asic{} of dut {}".format(dst_asic_index, dut.hostname))
+
+        ptf_src_port = get_ptf_src_port(src_asic, tbinfo)
+        bp_iface_in_use_before_shutdown = get_backend_interface_in_use_by_counter(
+            dut,
+            self.PACKET_COUNT,
+            version,
+            src_asic_router_mac,
+            ptfadapter,
+            ptf_src_port,
+            dst_neighbor_ip,
+            src_asic_index,
+            "tx_ok",
+        )
+
+        if not bp_iface_in_use_before_shutdown:
+            pytest.fail("No backend interface in use on asic{} of dut {}".format(src_asic_index, dut.hostname))
+
+        toggle_port_channel(
+            dut,
+            src_asic,
+            backend_port_channels,
+            bp_iface_in_use_before_shutdown,
+            request,
+            "shutdown",
+        )
+
+        bp_iface_in_use_after_shutdown = get_backend_interface_in_use_by_counter(
+            dut,
+            self.PACKET_COUNT,
+            version,
+            src_asic_router_mac,
+            ptfadapter,
+            ptf_src_port,
+            dst_neighbor_ip,
+            src_asic_index,
+            "tx_ok",
+        )
+
+        if not bp_iface_in_use_after_shutdown:
+            pytest.fail(
+                "Backend interface in use on asic{} of dut {} is None after shutdown".format(
+                    src_asic_index,
+                    dut.hostname,
+                )
+            )
+
+        if bp_iface_in_use_before_shutdown == bp_iface_in_use_after_shutdown:
+            pytest.fail(
+                "Backend interface in use on asic{} of dut {} does not change after shutdown".format(
+                    src_asic_index,
+                    dut.hostname,
+                )
+            )
+
+        toggle_port_channel(
+            dut,
+            src_asic,
+            backend_port_channels,
+            bp_iface_in_use_before_shutdown,
+            request,
+            "startup",
+        )
+
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(dut, src_asic_next_hops.values(), src_asic, "Up"),
+        )
+        assert wait_until(
+            180,
+            10,
+            0,
+            lambda: verify_bfd_state(dut, dst_asic_next_hops.values(), dst_asic, "Up"),
+        )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Implement BFD PTF-based traffic test.

Summary:
Fixes # (issue) Microsoft ADO 28382949

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
We need to confirm the patch switching behavior when one of the backend port channels is down in a T2 chassis.

#### How did you do it?
Test case 1: remote port channel shutdown
1. send 10k pkt from src PTF to dst's BGP neighbor to find the remote (dst) backend portchannel in use
2. shut down the remote backend portchannel found in step 1
3. traffic now should shift to an alternative backend portchannel
4. send 10k pkt again to verify the new traffic path is in use now

Test case 2: local port channel shutdown
1. send 10k pkt from src PTF to dst's BGP neighbor to find the local (src) backend portchannel in use
2. shut down the local backend portchannel found in step 1
3. traffic now should shift to an alternative backend portchannel
4. send 10k pkt again to verify the new traffic path is in use now

Test case 3: remote port channel member shutdown
1. send 10k pkt from src PTF to dst's BGP neighbor to find the remote (dst) backend portchannel member in use
2. shut down the remote backend portchannel member found in step 1
3. traffic now should shift to an alternative backend portchannel member
4. send 10k pkt again to verify the new traffic path is in use now

Test case 2: local port channel member shutdown
1. send 10k pkt from src PTF to dst's BGP neighbor to find the local (src) backend portchannel member in use
2. shut down the local backend portchannel member found in step 1
3. traffic now should shift to an alternative backend portchannel member
4. send 10k pkt again to verify the new traffic path is in use now

#### How did you verify/test it?
I ran the traffic test cases I added in a T2 testbed and I can see they passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
This test only supports T2 topology

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
