### PR TITLE
[Manually cherry-pick #13362] Remove skip conditional - test_decap on 8111 T0 and 8111 T1 topo

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -254,9 +254,9 @@ decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=set_unset]:
 
 decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=disable]:
   skip:
-    reason: "Not supported on backend , broadcom before 202012 release and innovium, x86_64-8111_32eh_o-r0 platform"
+    reason: "Not supported on backend , broadcom before 202012 release and innovium platform"
     conditions:
-      - "(topo_name in ['t1-backend', 't0-backend']) or (asic_type in ['broadcom'] and release in ['201811', '201911']) or asic_type in ['innovium'] or platform in ['x86_64-8111_32eh_o-r0']"
+      - "(topo_name in ['t1-backend', 't0-backend']) or (asic_type in ['broadcom'] and release in ['201811', '201911']) or asic_type in ['innovium']"
 
 decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset]:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
[Manually cherry-pick #13362] Remove skip conditional - test_decap on 8111 T0 and 8111 T1 topo

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Now the testcase can pass so remove skip conditional - test_decap on 8111 T0 and 8111 T1 topo

#### How did you do it?
Remove skip conditional

#### How did you verify/test it?
Test on 8111 T0 and 8111 T1 physical topo
decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=disable]
--------------------------------------------------------------------- live log setup ----------------------------------------------------------------------
06:40:46 init.set_default L0053 INFO | Completeness level not set during test execution. Setting to default level: CompletenessLe
vel.basic
06:40:46 init.check_test_completeness L0151 INFO | Test has no defined levels. Continue without test completeness checks
06:40:48 facts_cache.read L0092 INFO | Load cache file "/var/src/sonic-mgmt-int/tests/_cache/str3-8111-02/basic_facts.pickle" fai
led with exception: FileNotFoundError(2, 'No such file or directory')
......
---------------------------------------------------------------------- live log call ----------------------------------------------------------------------
06:43:28 ptfhost_utils.ptf_test_port_map_active_a L0534 INFO | active_dut_map={}
06:43:28 ptfhost_utils.ptf_test_port_map_active_a L0535 INFO | disabled_ptf_ports=set()
06:43:28 ptfhost_utils.ptf_test_port_map_active_a L0536 INFO | router_macs=['24:2a:04:fa:42:00']
PASSED

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
