### PR TITLE
[Fanout] Fix fanout config template for Arista-7260 and Arista-720DT

### DIFF
--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -54,14 +54,14 @@ vrf definition management
 {%          for sub in range (1,5) %}
 {%             set subintf = 'Ethernet' + i|string + '/' + sub|string %}
    interface {{ subintf }}
-   description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-   switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
+   description {{ device_conn[inventory_hostname][subintf]['peerdevice'] }}-{{ device_conn[inventory_hostname][subintf]['peerport'] }}
+   switchport access vlan {{ device_port_vlans[inventory_hostname][subintf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 10gfull
    no shutdown
 !
-{% endfor %}
+{%          endfor %}
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "50000" %}
 interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}

--- a/ansible/roles/fanout/templates/sonic_deploy_202311.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202311.j2
@@ -16,6 +16,9 @@
             "lanes": "{{ fanout_port_config[port_name]['lanes'] }}",
             "pfc_asym": "off",
             "mtu": "9100",
+    {% if fanout_hwsku == "Arista-720DT-G48S4" and (fanout_port_config[port_name]['lanes'] | int) <= 24 %}
+            "autoneg": "on",
+    {% endif %}
     {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
             "fec" : "rs",
     {% endif %}
@@ -179,6 +182,7 @@
     {% endfor %}
     },
 {% endif %}
+{% if fanout_hwsku not in ("Nokia-7215", "Arista-720DT-G48S4") %}
     "BUFFER_QUEUE": {
     {% for port_name in fanout_port_config %}
          "{{ port_name }}|0-7": {
@@ -193,6 +197,7 @@
         }{% if not loop.last %},{% endif %}
     {% endfor %}
     },
+{% endif %}
 {% if fanout_hwsku in ("Nokia-7215", "Arista-720DT-G48S4") %}
 
     "FLEX_COUNTER_TABLE": {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix fanout switch config template:
1. For Arista-7260, fix the config template for breakout interface to 4x 10G.
2. For Arista-720DT, set autoneg=on for gbsyncd interface (1 <= lane <= 24). Otherwise, these interface cannot oper up.
3. For Arista-720DT and Nokia-7215, remove BUFFER_QUEUE and BUFFER_PG sections from config_db.json.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fix fanout switch config template:


#### How did you do it?
1. For Arista-7260, fix the config template for breakout interface to 4x 10G.
2. For Arista-720DT, set autoneg=on for gbsyncd interface (1 <= lane <= 24). Otherwise, these interface cannot oper up.
3. For Arista-720DT and Nokia-7215, remove BUFFER_QUEUE and BUFFER_PG sections from config_db.json.

#### How did you verify/test it?
Verified on physical fanout switch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
