### PR TITLE
Adjust packet size for testQosSaiLossyQueueVoqMultiSrc

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -343,7 +343,7 @@ class QosParamCisco(object):
                       "pg": 0,
                       "pkts_num_trig_egr_drp": self.max_depth // self.buffer_size,
                       "pkts_num_margin": 4,
-                      "packet_size": 64,
+                      "packet_size": 1350,
                       "cell_size": self.buffer_size}
             self.write_params("lossy_queue_voq_3", params)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
For multi flows, packet count of packet size 64B exceeds G100 packet descriptor limit.
G100 voq size is 64k buffers, compared to Q200 voq size 16k buffers.

Summary:
Fixes # (issue)
Increase packet size for MultiSrc case.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fix case testQosSaiLossyQueueVoqMultiSrc failure in G100.

#### How did you do it?
Increase packet size.

#### How did you verify/test it?
Verified it on 8111 testbed.
============================================================================================= PASSES ==============================================================================================
_____________________________________________________________________ TestQosSai.testQosSaiLossyQueueVoqMultiSrc[single_asic] _____________________________________________________________________
---------------------------------- generated xml file: /data/tests/logs/qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc_2024-06-19-05-15-18.xml ----------------------------------
------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
05:27:10 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
===================================================================================== short test summary info =====================================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc[single_asic]
SKIPPED [1] qos/qos_sai_base.py:624: single_dut_multi_asic is not supported on T0 topologies
SKIPPED [1] qos/qos_sai_base.py:642: multi-dut is not supported on T0 topologies
======================================================================= 1 passed, 2 skipped, 1 warning in 710.59s (0:11:50) =======================================================================
INFO:root:Can not get Allure report URL. Please check logs

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
