### PR TITLE
[202311]Skip warmreboot on SN4700 t0 devices since it is currently not qualified.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -122,9 +122,9 @@ bgp/test_bgp_slb.py:
 
 bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot:
   skip:
-    reason: "Skip it on dual tor since it got stuck during warm reboot due to known issue on master and internal image"
+    reason: "Skip it on dual tor since it got stuck during warm reboot due to known issue on master and internal image; skip warmreboot on SN4700 since it is currently not qualified."
     conditions:
-      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56']"
+      - "(topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56']) or ('SN4700' in hwsku and 't0' in topo_type)"
       - https://github.com/sonic-net/sonic-mgmt/issues/9201
 
 bgp/test_bgp_speaker.py:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Skip warm reboot on SN4700 t0 devices since it is currently not qualified.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Warm reboot failed on SN4700 t0 devices.
#### How did you do it?
Skip warm reboot on SN4700.
#### How did you verify/test it?
`==================================================================== short test summary info =====================================================================
SKIPPED [2] bgp/test_bgp_slb.py:68: Skip it on dual tor since it got stuck during warm reboot due to known issue on master and internal image; skip warm-reboot on SN4700 since it is not currently meant to be qualified.`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
