### PR TITLE
[GCU] Update AAA test with recent setup

### DIFF
--- a/tests/generic_config_updater/test_aaa.py
+++ b/tests/generic_config_updater/test_aaa.py
@@ -431,6 +431,7 @@ def test_tc2_tacacs_global_suite(rand_selected_dut):
     """ This test is for default setting when configDB doesn't
         contian TACACS table. So we remove TACACS config at first.
     """
+    aaa_add_init_config_without_table(rand_selected_dut)
     tacacs_add_init_config_without_table(rand_selected_dut)
     tacacs_global_tc2_add_config(rand_selected_dut)
     tacacs_global_tc2_invalid_input(rand_selected_dut)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
ADO: 28386083
Summary: Make TACPLUS test independent with AAA setup
Fixes # (issue) 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Update GCU aaa test with recent setup. In recent setup, the tacacs+ is always ready in AAA|Authentication. If we remove TACPLUS passkey, it will result in YANG validation error. In this PR, we will only check TACPLUS test without AAA tacacs+ imapct.
#### How did you do it?
Remove AAA table before TACPLUS test
#### How did you verify/test it?
E2E test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
