### PR TITLE
Add decap test to PR test and skip traffic test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -346,10 +346,12 @@ onboarding_t0:
   - arp/test_stress_arp.py
   - arp/test_unknown_mac.py
   - arp/test_wr_arp.py
+  - decap/test_decap.py
 
 onboarding_t1:
   - acl/test_acl.py
   - acl/test_stress_acl.py
+  - decap/test_decap.py
 
 specific_param:
   t0-sonic:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -53,6 +53,15 @@ arp/test_wr_arp.py:
       - "asic_type in ['vs']"
 
 #######################################
+#####           decap             #####
+#######################################
+decap/test_decap.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
 #####         everflow            #####
 #######################################
 everflow/test_everflow_ipv6.py:

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -21,6 +21,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # no
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa F401
+from tests.common.fixtures.ptfhost_utils import skip_traffic_test           # noqa F401
 from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active
 from tests.common.fixtures.fib_utils import fib_info_files                  # noqa F401
 from tests.common.fixtures.fib_utils import single_fib_for_duts             # noqa F401
@@ -179,7 +180,8 @@ def simulate_vxlan_teardown(duthosts, ptfhost, tbinfo):
 
 def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,                                   # noqa F811
                toggle_all_simulator_ports_to_random_side, supported_ttl_dscp_params, ip_ver, loopback_ips,  # noqa F811
-               duts_running_config_facts, duts_minigraph_facts, mux_status_from_nic_simulator):             # noqa F811
+               duts_running_config_facts, duts_minigraph_facts, mux_status_from_nic_simulator,              # noqa F811
+               skip_traffic_test):                                                                          # noqa F811
     setup_info = setup_teardown
     asic_type = duthosts[0].facts["asic_type"]
     ecn_mode = "copy_from_outer"
@@ -203,6 +205,8 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,       
             wait(30, 'Wait some time for mux active/standby state to be stable after toggled mux state')
 
         log_file = "/tmp/decap.{}.log".format(datetime.now().strftime('%Y-%m-%d-%H:%M:%S'))
+        if skip_traffic_test:
+            return
         ptf_runner(ptfhost,
                    "ptftests",
                    "IP_decap_test.DecapPacketTest",

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -201,12 +201,13 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,       
         else:
             apply_decap_cfg(duthosts, ip_ver, loopback_ips, ttl_mode, dscp_mode, ecn_mode, 'SET')
 
+        if skip_traffic_test:
+            return
+
         if 'dualtor' in tbinfo['topo']['name']:
             wait(30, 'Wait some time for mux active/standby state to be stable after toggled mux state')
 
         log_file = "/tmp/decap.{}.log".format(datetime.now().strftime('%Y-%m-%d-%H:%M:%S'))
-        if skip_traffic_test:
-            return
         ptf_runner(ptfhost,
                    "ptftests",
                    "IP_decap_test.DecapPacketTest",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed
#### How did you do it?
Add decap to PR test and skip traffic test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
