### PR TITLE
fix: correct show bgp summary output typo references

### DIFF
--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -381,12 +381,12 @@ Peers 4, using 87264 KiB of memory
 Peer groups 4, using 256 bytes of memory
 
 
-Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
------------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
-10.0.0.57      4  64600       3792       3792         0      0       0  00:29:24             6400  ARISTA01T1
-10.0.0.59      4  64600       3792       3795         0      0       0  00:29:24             6400  ARISTA02T1
-10.0.0.61      4  64600       3792       3792         0      0       0  00:29:24             6400  ARISTA03T1
-10.0.0.63      4  64600       3795       3796         0      0       0  00:29:24             6400  ARISTA04T1
+Neighbor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
+----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
+10.0.0.57     4  64600       3792       3792         0      0       0  00:29:24             6400  ARISTA01T1
+10.0.0.59     4  64600       3792       3795         0      0       0  00:29:24             6400  ARISTA02T1
+10.0.0.61     4  64600       3792       3792         0      0       0  00:29:24             6400  ARISTA03T1
+10.0.0.63     4  64600       3795       3796         0      0       0  00:29:24             6400  ARISTA04T1
 
 Total number of neighbors 4
 ```
@@ -404,12 +404,12 @@ Peers 4, using 83680 KiB of memory
 Peer groups 4, using 256 bytes of memory
 
 
-Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
------------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
-10.0.0.57      4  64600          8          8         0      0       0  00:00:10   3               ARISTA01T1
-10.0.0.59      4  64600          0          0         0      0       0  00:00:10   3               ARISTA02T1
-10.0.0.61      4  64600          0          0         0      0       0  00:00:11   3               ARISTA03T1
-10.0.0.63      4  64600          0          0         0      0       0  00:00:11   3               ARISTA04T1
+Neighbor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
+----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
+10.0.0.57     4  64600          8          8         0      0       0  00:00:10   3               ARISTA01T1
+10.0.0.59     4  64600          0          0         0      0       0  00:00:10   3               ARISTA02T1
+10.0.0.61     4  64600          0          0         0      0       0  00:00:11   3               ARISTA03T1
+10.0.0.63     4  64600          0          0         0      0       0  00:00:11   3               ARISTA04T1
 
 ```
 

--- a/tests/route/test_route_flow_counter.py
+++ b/tests/route/test_route_flow_counter.py
@@ -214,4 +214,9 @@ class TestRouteCounter:
         else:
             cmd = 'show ip bgp summary'
         parse_result = duthost.show_and_parse(cmd)
-        return parse_result[0]['neighbor']
+        if "neighbor" in parse_result[0]:
+            return parse_result[0]['neighbor']
+        elif "neighbhor" in parse_result[0]:
+            return parse_result[0]['neighbhor']
+        else:
+            raise ValueError("Unexpected neighbor key in bgp summary output")

--- a/tests/route/test_route_flow_counter.py
+++ b/tests/route/test_route_flow_counter.py
@@ -214,4 +214,4 @@ class TestRouteCounter:
         else:
             cmd = 'show ip bgp summary'
         parse_result = duthost.show_and_parse(cmd)
-        return parse_result[0]['neighbhor']
+        return parse_result[0]['neighbor']

--- a/tests/stress/utils.py
+++ b/tests/stress/utils.py
@@ -22,8 +22,15 @@ def check_queue_status(duthost, queue):
     bgp_neighbors = duthost.show_and_parse(SHOW_BGP_SUMMARY_CMD)
     bgp_neighbor_addr_regex = re.compile(r"^([0-9]{1,3}\.){3}[0-9]{1,3}")
     for neighbor in bgp_neighbors:
-        if bgp_neighbor_addr_regex.match(neighbor["neighbor"]) and int(neighbor[queue]) != 0:
-            return False
+        if "neighbor" in neighbor:
+            if bgp_neighbor_addr_regex.match(neighbor["neighbor"]) and int(neighbor[queue]) != 0:
+                return False
+        elif "neighbhor" in neighbor:
+            if bgp_neighbor_addr_regex.match(neighbor["neighbhor"]) and int(neighbor[queue]) != 0:
+                return False
+        else:
+            raise ValueError("Unexpected neighbor key in bgp summary output")
+
     return True
 
 

--- a/tests/stress/utils.py
+++ b/tests/stress/utils.py
@@ -22,7 +22,7 @@ def check_queue_status(duthost, queue):
     bgp_neighbors = duthost.show_and_parse(SHOW_BGP_SUMMARY_CMD)
     bgp_neighbor_addr_regex = re.compile(r"^([0-9]{1,3}\.){3}[0-9]{1,3}")
     for neighbor in bgp_neighbors:
-        if bgp_neighbor_addr_regex.match(neighbor["neighbhor"]) and int(neighbor[queue]) != 0:
+        if bgp_neighbor_addr_regex.match(neighbor["neighbor"]) and int(neighbor[queue]) != 0:
             return False
     return True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We have a PR https://github.com/sonic-net/sonic-utilities/pull/3375 in `sonic-utilities` that fixes the 'Neighbhor' typo of the `show [ip|ipv6] bgp summary` command. Therefore, we need to correct all the 'Neighbhor' typo references in this repo

Summary:
Fixes # (issue) Microsoft ADO 28482605

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Correct the bgp summary output typo references to let it sync with the `sonic-utilities` repo

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
