### PR TITLE
Subject: add qos_params for th5 asic

### DIFF
--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -1,0 +1,320 @@
+qos_params:
+    th5:
+        topo-t0:
+            400000_5m:
+                pkts_num_leak_out: 109
+                pkts_num_egr_mem: 101
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 15152
+                    pkts_num_trig_ingr_drp: 16624
+                    pkts_num_margin: 4
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 15152
+                    pkts_num_trig_ingr_drp: 16624
+                    pkts_num_margin: 4
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [0, 2, 4, 6, 8, 10, 12, 14, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]
+                    dst_port_id: 29
+                    pgs_num: 37
+                    pkts_num_trig_pfc: 1856
+                    pkts_num_hdrm_full: 1472
+                    pkts_num_hdrm_partial: 552
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 15152
+                    pkts_num_trig_ingr_drp: 16624
+                    cell_size: 254
+                    pkts_num_margin: 2
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 15152
+                    pkts_num_dismiss_pfc: 13
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 15152
+                    pkts_num_dismiss_pfc: 13
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 50482
+                    pkts_num_margin: 5
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 10
+                    pkts_num_trig_pfc: 15152
+                    packet_size: 64
+                    cell_size: 254
+                    pkts_num_margin: 1
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_trig_egr_drp: 50482
+                    packet_size: 64
+                    cell_size: 254
+                    pkts_num_margin: 1
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 16624
+                    cell_size: 254
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 7
+                    pkts_num_trig_pfc: 15152
+                    pkts_num_trig_ingr_drp: 16624
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 254
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_trig_egr_drp: 50482
+                    cell_size: 254
+                wm_buf_pool_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    queue: 0
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_egr_drp: 50482
+                    pkts_num_fill_egr_min: 7
+                    cell_size: 254
+            ecn_1:
+                dscp: 8
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 254
+            ecn_2:
+                dscp: 8
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 254
+            ecn_3:
+                dscp: 0
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 254
+            ecn_4:
+                dscp: 0
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 254
+            wrr:
+                ecn: 1
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                q7_num_of_pkts: 140
+                limit: 80
+            wrr_chg:
+                ecn: 1
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                q7_num_of_pkts: 80
+                limit: 80
+                lossy_weight: 8
+                lossless_weight: 30
+            hdrm_pool_wm_multiplier: 1
+            cell_size: 254
+        topo-t0-256-l2vlan:
+            200000_5m:
+                pkts_num_leak_out: 109
+                pkts_num_egr_mem: 101
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 15152
+                    pkts_num_trig_ingr_drp: 16624
+                    pkts_num_margin: 4
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 15152
+                    pkts_num_trig_ingr_drp: 16624
+                    pkts_num_margin: 4
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [0, 2, 4, 6, 8, 10, 12, 14, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]
+                    dst_port_id: 29
+                    pgs_num: 37
+                    pkts_num_trig_pfc: 1856
+                    pkts_num_hdrm_full: 1472
+                    pkts_num_hdrm_partial: 552
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 15152
+                    pkts_num_trig_ingr_drp: 16624
+                    cell_size: 254
+                    pkts_num_margin: 2
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 15152
+                    pkts_num_dismiss_pfc: 13
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 15152
+                    pkts_num_dismiss_pfc: 13
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 50482
+                    pkts_num_margin: 5
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 10
+                    pkts_num_trig_pfc: 15152
+                    packet_size: 64
+                    cell_size: 254
+                    pkts_num_margin: 1
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_trig_egr_drp: 50482
+                    packet_size: 64
+                    cell_size: 254
+                    pkts_num_margin: 1
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 16624
+                    cell_size: 254
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 7
+                    pkts_num_trig_pfc: 15152
+                    pkts_num_trig_ingr_drp: 16624
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 254
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_trig_egr_drp: 50482
+                    cell_size: 254
+                wm_buf_pool_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    queue: 0
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_egr_drp: 50482
+                    pkts_num_fill_egr_min: 7
+                    cell_size: 254
+            ecn_1:
+                dscp: 8
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 254
+            ecn_2:
+                dscp: 8
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 254
+            ecn_3:
+                dscp: 0
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 254
+            ecn_4:
+                dscp: 0
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 254
+            wrr:
+                ecn: 1
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                q7_num_of_pkts: 140
+                limit: 80
+            wrr_chg:
+                ecn: 1
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                q7_num_of_pkts: 80
+                limit: 80
+                lossy_weight: 8
+                lossless_weight: 30
+            hdrm_pool_wm_multiplier: 1
+            cell_size: 254


### PR DESCRIPTION
Summary:

ASIC-specific qos_params.py files are needed in order for the qos tests to run against the associated ASICs. This change adds a qos_params file for the Tomahawk5 (th5) ASIC. Additional speed/cable length params can be subsequently
added to this file for the Tomahawk5 ASIC.

Fixes: https://github.com/aristanetworks/sonic-qual.msft/issues/159
Note: This PR works in conjunction with the **community** version of the qos_param_generator.py file to resolve the aforementioned issue.
Note: The values contained in this PR are experimental and have not been fully verified beyond simply resolving the aforementioned issue.


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

Eliminate instances of `KeyError: 'th5'` being thrown when running qos tests, such as was identified in: https://github.com/aristanetworks/sonic-qual.msft/issues/159

#### How did you do it?

Added a qos params file specific to TH5.

#### How did you verify/test it?

Manual tested against a run of `qos/test_qos_sai.py::TestQosSai` on the topologies listed below, to verify the fix.

#### Supported testbed topology if it's a new test case?

This patch covers only the following topology names (additional topologies can be added as desired):
- t0
- t0-256-l2vlan
