### PR TITLE
Fix arp/test_unknown_mac by disabling arp_update

### DIFF
--- a/tests/arp/test_unknown_mac.py
+++ b/tests/arp/test_unknown_mac.py
@@ -41,6 +41,7 @@ def initClassVars(func):
         func(self, *args)
     return wrapper
 
+
 @pytest.fixture(autouse=True, scope="module")
 def dut_disable_arp_update(rand_selected_dut):
     """
@@ -50,11 +51,14 @@ def dut_disable_arp_update(rand_selected_dut):
         rand_selected_dut(AnsibleHost) : dut instance
     """
     duthost = rand_selected_dut
-    assert duthost.shell("docker exec -t swss supervisorctl stop arp_update")['stdout_lines'][0] == 'arp_update: stopped'
+    assert duthost.shell("docker exec -t swss supervisorctl stop arp_update")['stdout_lines'][0] \
+        == 'arp_update: stopped'
 
     yield
 
-    assert duthost.shell("docker exec -t swss supervisorctl start arp_update")['stdout_lines'][0] == 'arp_update: started'
+    assert duthost.shell("docker exec -t swss supervisorctl start arp_update")['stdout_lines'][0] \
+        == 'arp_update: started'
+
 
 @pytest.fixture(autouse=True, scope="module")
 def unknownMacSetup(duthosts, rand_one_dut_hostname, tbinfo):

--- a/tests/arp/test_unknown_mac.py
+++ b/tests/arp/test_unknown_mac.py
@@ -41,6 +41,20 @@ def initClassVars(func):
         func(self, *args)
     return wrapper
 
+@pytest.fixture(autouse=True, scope="module")
+def dut_disable_arp_update(rand_selected_dut):
+    """
+    Fixture to disable arp update before the test and re-enable it afterwards
+
+    Args:
+        rand_selected_dut(AnsibleHost) : dut instance
+    """
+    duthost = rand_selected_dut
+    assert duthost.shell("docker exec -t swss supervisorctl stop arp_update")['stdout_lines'][0] == 'arp_update: stopped'
+
+    yield
+
+    assert duthost.shell("docker exec -t swss supervisorctl start arp_update")['stdout_lines'][0] == 'arp_update: started'
 
 @pytest.fixture(autouse=True, scope="module")
 def unknownMacSetup(duthosts, rand_one_dut_hostname, tbinfo):

--- a/tests/arp/test_unknown_mac.py
+++ b/tests/arp/test_unknown_mac.py
@@ -51,8 +51,9 @@ def dut_disable_arp_update(rand_selected_dut):
         rand_selected_dut(AnsibleHost) : dut instance
     """
     duthost = rand_selected_dut
-    assert duthost.shell("docker exec -t swss supervisorctl stop arp_update")['stdout_lines'][0] \
-        == 'arp_update: stopped'
+    if duthost.shell("docker exec -t swss supervisorctl stop arp_update")['stdout_lines'][0] \
+            == 'arp_update: ERROR (not running)':
+        logger.warning("arp_update not running, already disabled")
 
     yield
 


### PR DESCRIPTION
### Description of PR
The DUT will occasionally (~5 mins) send a echo request through IPv6 to the PTF container. When the PTF container replies, it populates the fdb table. This is bad because the test expects the fdb table to be empty.

~Temporarily disabling IPv6 on the PTF container during the test will eliminate the problem.~
Temporarily disabling `arp_update` on the DUT during the test will eliminate the problem.

Summary:
Fixes #

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Test was flaky. Monitoring tcpdump on the PTF container and the DUT's fdb table shows IPv6 echo is causing mac addresses to be learned on the DUT even though it was previously flushed.

#### How did you do it?
Disable IPv6.

#### How did you verify/test it?
Disabling IPv6 will allow the test to consistently past. If IPv6 is re-enabled during the test and packets are sent, it immediately fails.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
