### PR TITLE
Enhance the test_ro_user test case to check for user permissions errors.

### DIFF
--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -45,7 +45,7 @@ def ssh_remote_allow_run(localhost, remote_ip, username, password, cmd):
     # Verify that the command is allowed
     logger.info("check command \"{}\" rc={}".format(cmd, res['rc']))
     expected = "Make sure your account has RW permission to current device" not in res['stderr'] \
-            and "Permission denied" not in res['stderr']
+        and "Permission denied" not in res['stderr']
     if not expected:
         logger.error("error output=\"{}\"".format(res["stderr"]))
     return expected

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -44,7 +44,8 @@ def ssh_remote_allow_run(localhost, remote_ip, username, password, cmd):
     res = ssh_remote_run(localhost, remote_ip, username, password, cmd)
     # Verify that the command is allowed
     logger.info("check command \"{}\" rc={}".format(cmd, res['rc']))
-    expected = "Make sure your account has RW permission to current device" not in res['stderr']
+    expected = "Make sure your account has RW permission to current device" not in res['stderr'] \
+            and "Permission denied" not in res['stderr']
     if not expected:
         logger.error("error output=\"{}\"".format(res["stderr"]))
     return expected


### PR DESCRIPTION
### Description of PR

The PR fixes the test case test_ro_user.py to check if the command fails due to inadequate permissions. 
We see the following error .e.g. when the show command permission is changed to be for root user only..

root@m64-tor-0:/home/cisco# chmod 744 /usr/local/bin/show
root@m64-tor-0:/home/cisco# ls -l /usr/local/bin/show
-rwxr--r-- 1 root root 206 May 3 16:13 /usr/local/bin/show

Following is seen in the log, but the test case passes as it is looking for a different string.

21/05/2024 16:56:37 base._run L0104 DEBUG | /data/tests/tacacs/test_ro_user.py::ssh_remote_run#21: [localhost] AnsibleModule::shell Result => {"failed": true, "msg": "non-zero return code", "cmd": "sshpass -p 123456 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null test_rouser@1.74.23.15 show version", "stdout": "", "stderr": "Warning: Permanently added '1.74.23.15' (RSA) to the list of known hosts.\r\nbash: line 1: /usr/local/bin/show: **Permission denied**", "rc": 126, "start": "2024-05-21 16:56:37.449193", "end": "2024-05-21 16:56:37.794768", "delta": "0:00:00.345575", "changed": true, "invocation": {"module_args": {"_raw_params": "sshpass -p 123456 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null test_rouser@1.74.23.15 show version", "_uses_shell": true, "warn": true, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": [], "stderr_lines": ["Warning: Permanently added '1.74.23.15' (RSA) to the list of known hosts.", "bash: line 1: /usr/local/bin/show: Permission denied"], "_ansible_no_log": false}
21/05/2024 16:56:37 test_ro_user.ssh_remote_allow_run L0046 INFO | check command "show version" rc=126

Summary:

Changed the test case to look for a generic error string.
Same test above fails and error is caught.

FAILED tacacs/test_ro_user.py::test_ro_user_allowed_command[m64-tor-0] - Failed: command 'show version' not authorized
=============================================== 1 failed, 3 passed, 1 skipped, 1 warning in 206.51s (0:03:26) ================================================

### Type of change
- [x] Bug fix

