### PR TITLE
Remove variable group GIT_SECRETS from PR testing pipeline yaml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,8 +24,6 @@ name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd
 
 stages:
 - stage: Pre_test
-  variables:
-  - group: GIT_SECRETS
   jobs:
   - job: static_analysis
     displayName: "Static Analysis"
@@ -52,7 +50,6 @@ stages:
     value: veos_vtb
   - name: testbed_file
     value: vtestbed.yaml
-  - group: GIT_SECRETS
   - name: BUILD_BRANCH
     ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
       value: $(System.PullRequest.TargetBranch)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Querying Github issue no longer requires authentication. The GIT_SECRETS variable group is not needed now.

#### How did you do it?
This change removed reference of the GIT_SECRETS variable group from azure pipeline yaml

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
