### PR TITLE
Remove TACACS fixture from none TACACS test cases

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -26,7 +26,6 @@ from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts # noqa F401
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.platform.interface_utils import check_all_interface_information
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -21,7 +21,6 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.utilities import check_skip_release
 from tests.common.utilities import get_neighbor_ptf_port_list
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -7,7 +7,6 @@ from ptf import mask, packet
 from collections import defaultdict
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa F401
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.fixtures.ptfhost_utils import skip_traffic_test   # noqa F401
 
 pytestmark = [

--- a/tests/arp/test_arp_dualtor.py
+++ b/tests/arp/test_arp_dualtor.py
@@ -15,7 +15,6 @@ from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, 
 from tests.common.dualtor.dual_tor_common import mux_config     # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_garp_service, \
     change_mac_addresses, run_icmp_responder, pause_garp_service  # noqa F401
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 from tests.common.utilities import wait_until
 

--- a/tests/arp/test_arp_extended.py
+++ b/tests/arp/test_arp_extended.py
@@ -7,7 +7,6 @@ import pytest
 
 from tests.arp.arp_utils import clear_dut_arp_cache, increment_ipv4_addr
 from tests.common.helpers.assertions import pytest_assert, pytest_require
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t0', 'dualtor')

--- a/tests/arp/test_arpall.py
+++ b/tests/arp/test_arpall.py
@@ -8,7 +8,6 @@ from tests.ptf_runner import ptf_runner
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa F401
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -3,7 +3,6 @@ import pytest
 import time
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -5,7 +5,6 @@ import time
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.config_reload import config_reload
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -9,7 +9,6 @@ from scapy.all import Ether, IPv6, ICMPv6ND_NS, ICMPv6NDOptSrcLLAddr, in6_getnsm
                       in6_getnsma, inet_pton, inet_ntop, socket
 from ipaddress import ip_address, ip_network
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.fixtures.ptfhost_utils import skip_traffic_test   # noqa F401
 
 ARP_BASE_IP = "172.16.0.1/16"

--- a/tests/arp/test_tagged_arp.py
+++ b/tests/arp/test_tagged_arp.py
@@ -17,7 +17,6 @@ from tests.common.helpers.portchannel_to_vlan import vlan_intfs_dict  # noqa F40
 from tests.common.helpers.portchannel_to_vlan import setup_po2vlan    # noqa F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses   # noqa F401
 from tests.common.helpers.portchannel_to_vlan import running_vlan_ports_list
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/arp/test_unknown_mac.py
+++ b/tests/arp/test_unknown_mac.py
@@ -19,7 +19,6 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 from tests.common.utilities import get_intf_by_sub_intf, wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -10,7 +10,6 @@ from tests.common.fixtures.ptfhost_utils import skip_traffic_test               
 from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies     # noqa F401
 from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 logger = logging.getLogger(__name__)

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -12,7 +12,6 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
 from tests.common import config_reload
 from tests.common.helpers.dut_utils import get_disabled_container_list
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -6,7 +6,6 @@ import logging
 
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 from tests.common.snappi_tests.common_helpers import get_egress_queue_count
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t1'),

--- a/tests/bfd/test_bfd_static_route.py
+++ b/tests/bfd/test_bfd_static_route.py
@@ -8,7 +8,6 @@ from tests.bfd.bfd_helpers import verify_static_route, select_src_dst_dut_with_a
     check_bgp_status, modify_all_bfd_sessions, find_bfd_peers_with_given_state, add_bfd, verify_bfd_state, delete_bfd, \
     extract_backend_portchannels
 from tests.common.config_reload import config_reload
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs  # noqa F401
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.reboot import reboot
 from tests.common.utilities import wait_until

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -17,7 +17,6 @@ from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEI
 from tests.common.helpers.parallel import reset_ansible_local_tmp
 from tests.common.helpers.parallel import parallel_run
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 DUT_TMP_DIR = os.path.join('tmp', os.path.basename(BASE_DIR))

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -24,7 +24,6 @@ from bgp_helpers import define_config, apply_default_bgp_config, DUT_TMP_DIR, TE
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common import constants
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 logger = logging.getLogger(__name__)

--- a/tests/bgp/test_bgp_allow_list.py
+++ b/tests/bgp/test_bgp_allow_list.py
@@ -11,7 +11,6 @@ from bgp_helpers import apply_allow_list, remove_allow_list, check_routes_on_fro
 from bgp_helpers import check_routes_on_neighbors_empty_allow_list, checkout_bgp_mon_routes, check_routes_on_neighbors
 # Fixtures
 from bgp_helpers import bgp_allow_list_setup, prepare_eos_routes    # noqa F401
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t1'),

--- a/tests/bgp/test_bgp_authentication.py
+++ b/tests/bgp/test_bgp_authentication.py
@@ -7,7 +7,6 @@ import time
 
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.config_reload import config_reload
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -21,7 +21,6 @@ from tests.common.helpers.parallel import parallel_run
 from tests.common.utilities import wait_until, delete_running_config
 from tests.generic_config_updater.gu_utils import apply_patch, expect_op_success
 from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/bgp/test_bgp_bounce.py
+++ b/tests/bgp/test_bgp_bounce.py
@@ -10,7 +10,6 @@ from tests.common.helpers.assertions import pytest_assert
 from bgp_helpers import apply_bgp_config
 from bgp_helpers import get_no_export_output
 from bgp_helpers import BGP_ANNOUNCE_TIME
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t1')

--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -21,7 +21,6 @@ from tests.generic_config_updater.gu_utils import (
     rollback_or_reload,
 )
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [pytest.mark.topology("t0")]

--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -1,5 +1,4 @@
 import pytest
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any'),

--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -7,7 +7,6 @@ import json
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.utilities import is_ipv4_address
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/bgp/test_bgp_multipath_relax.py
+++ b/tests/bgp/test_bgp_multipath_relax.py
@@ -1,7 +1,6 @@
 import pytest
 import logging
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t1')

--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -1,7 +1,6 @@
 import time
 import pytest
 import logging
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/bgp/test_bgp_sentinel.py
+++ b/tests/bgp/test_bgp_sentinel.py
@@ -13,7 +13,6 @@ from bgp_helpers import CONSTANTS_FILE, BGPSENTINEL_CONFIG_FILE
 from bgp_helpers import BGP_SENTINEL_PORT_V4, BGP_SENTINEL_NAME_V4
 from bgp_helpers import BGP_SENTINEL_PORT_V6, BGP_SENTINEL_NAME_V6
 from bgp_helpers import BGPMON_TEMPLATE_FILE, BGPMON_CONFIG_FILE, BGP_MONITOR_NAME
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/bgp/test_bgp_session_flap.py
+++ b/tests/bgp/test_bgp_session_flap.py
@@ -12,7 +12,6 @@ import time
 from tests.common.utilities import InterruptableThread
 import textfsm
 import traceback
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 from natsort import natsorted
 

--- a/tests/bgp/test_bgp_slb.py
+++ b/tests/bgp/test_bgp_slb.py
@@ -6,7 +6,6 @@ from tests.common.dualtor.mux_simulator_control import \
     toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m  # noqa F401
 from tests.common.utilities import wait_until, delete_running_config
 from tests.common.helpers.assertions import pytest_require
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -17,7 +17,6 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.utilities import wait_until
 from tests.flow_counter.flow_counter_utils import RouteFlowCounterTestContext, \
                                                   is_route_flow_counter_supported   # noqa F401
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -24,7 +24,6 @@ from tests.common.platform.interface_utils import check_interface_status_of_up_p
 from bgp_helpers import restart_bgp_session, get_eth_port, get_exabgp_port, get_vm_name_list, get_bgp_neighbor_ip, \
     check_route_install_status, validate_route_propagate_status, operate_orchagent, get_t2_ptf_intfs, \
     get_eth_name_from_ptf_port, check_bgp_neighbor, check_fib_route
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology("t1"),

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -22,7 +22,6 @@ from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_s
 from tests.common.dualtor.mux_simulator_control import mux_server_url  # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m # noqa F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/bgp/test_bgpmon.py
+++ b/tests/bgp/test_bgpmon.py
@@ -13,7 +13,6 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.utilities import wait_tcp_connection
 from bgp_helpers import BGPMON_TEMPLATE_FILE, BGPMON_CONFIG_FILE, BGP_MONITOR_NAME, BGP_MONITOR_PORT
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any'),

--- a/tests/bgp/test_bgpmon_v6.py
+++ b/tests/bgp/test_bgpmon_v6.py
@@ -14,7 +14,6 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.utilities import wait_tcp_connection
 from bgp_helpers import BGPMON_TEMPLATE_FILE, BGPMON_CONFIG_FILE, BGP_MONITOR_NAME, BGP_MONITOR_PORT
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t2'),

--- a/tests/bgp/test_ipv6_nlri_over_ipv4.py
+++ b/tests/bgp/test_ipv6_nlri_over_ipv4.py
@@ -11,7 +11,6 @@ from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/bgp/test_passive_peering.py
+++ b/tests/bgp/test_passive_peering.py
@@ -9,7 +9,6 @@ import pytest
 import time
 from tests.common.config_reload import config_reload
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -13,7 +13,6 @@ from tests.common.helpers.constants import DEFAULT_ASIC_ID
 from tests.common.helpers.parallel import parallel_run
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t1', 't2')

--- a/tests/bgp/test_traffic_shift_sup.py
+++ b/tests/bgp/test_traffic_shift_sup.py
@@ -5,7 +5,6 @@ import time
 from tests.common.helpers.assertions import pytest_assert
 from tests.common import config_reload
 from test_traffic_shift import get_traffic_shift_state
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t2')

--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -8,7 +8,6 @@ from tests.common.utilities import wait_until
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor  # noqa F401
 from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                  # noqa F401
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -3,7 +3,6 @@ import logging
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 from tests.common.utilities import get_data_acl, recover_acl_rule
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 try:
     import ntplib

--- a/tests/cacl/test_ebtables_application.py
+++ b/tests/cacl/test_ebtables_application.py
@@ -1,6 +1,5 @@
 import pytest
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer globally

--- a/tests/clock/test_clock.py
+++ b/tests/clock/test_clock.py
@@ -7,7 +7,6 @@ import datetime as dt
 
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any'),

--- a/tests/configlet/test_add_rack.py
+++ b/tests/configlet/test_add_rack.py
@@ -5,7 +5,6 @@ import sys
 from tests.common.utilities import skip_release
 from .util.base_test import do_test_add_rack, backup_minigraph, restore_orig_minigraph
 from .util.helpers import log_info
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
         pytest.mark.topology("t1")

--- a/tests/console/test_console_availability.py
+++ b/tests/console/test_console_availability.py
@@ -3,7 +3,6 @@ import pexpect
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology("any"),

--- a/tests/console/test_console_driver.py
+++ b/tests/console/test_console_driver.py
@@ -1,7 +1,6 @@
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any')

--- a/tests/console/test_console_loopback.py
+++ b/tests/console/test_console_loopback.py
@@ -2,7 +2,6 @@ import pytest
 import string
 import random
 from tests.common.helpers.console_helper import assert_expect_text, create_ssh_client, ensure_console_session_up
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any')

--- a/tests/console/test_console_reversessh.py
+++ b/tests/console/test_console_reversessh.py
@@ -3,7 +3,6 @@ import pexpect
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any')

--- a/tests/console/test_console_udevrule.py
+++ b/tests/console/test_console_udevrule.py
@@ -1,7 +1,6 @@
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any')

--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -15,7 +15,6 @@ from tests.common.helpers.dut_utils import is_container_running
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import get_disabled_container_list
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/container_hardening/test_container_hardening.py
+++ b/tests/container_hardening/test_container_hardening.py
@@ -3,7 +3,6 @@ import pytest
 import logging
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.helpers.dut_utils import is_container_running, get_disabled_container_list
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any'),

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -37,7 +37,6 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import find_duthost_on_role
 from tests.common.utilities import get_upstream_neigh_type
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 # Module-level fixtures
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -17,7 +17,6 @@ from tests.common.helpers.crm import get_used_percent, CRM_UPDATE_TIME, CRM_POLL
 from tests.common.fixtures.duthost_utils import disable_route_checker   # noqa F401
 from tests.common.fixtures.duthost_utils import disable_fdb_aging       # noqa F401
 from tests.common.utilities import wait_until, get_data_acl
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.mellanox_data import is_mellanox_device
 from tests.common.helpers.dut_utils import get_sai_sdk_dump_file
 

--- a/tests/dash/dash_acl.py
+++ b/tests/dash/dash_acl.py
@@ -11,7 +11,6 @@ from dash_utils import render_template
 from gnmi_utils import apply_gnmi_file
 import packets
 import ptf.testutils as testutils
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/dash/dash_utils.py
+++ b/tests/dash/dash_utils.py
@@ -5,7 +5,6 @@ from time import sleep
 from jinja2 import Template
 
 from constants import TEMPLATE_DIR
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/dash/gnmi_utils.py
+++ b/tests/dash/gnmi_utils.py
@@ -7,7 +7,6 @@ from functools import lru_cache
 import pytest
 
 import proto_utils
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/dash/packets.py
+++ b/tests/dash/packets.py
@@ -9,7 +9,6 @@ from constants import *  # noqa: F403
 import logging
 import sys
 import time
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from six import StringIO
 

--- a/tests/dash/proto_utils.py
+++ b/tests/dash/proto_utils.py
@@ -18,7 +18,6 @@ from dash_api.acl_out_pb2 import AclOut
 from dash_api.acl_in_pb2 import AclIn
 from dash_api.acl_rule_pb2 import AclRule, Action
 from dash_api.prefix_tag_pb2 import PrefixTag
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 ENABLE_PROTO = True

--- a/tests/dash/test_dash_acl.py
+++ b/tests/dash/test_dash_acl.py
@@ -6,7 +6,6 @@ import ptf.testutils as testutils
 from dash_acl import check_dataplane, acl_fields_test, acl_multi_stage_test, check_tcp_rst_dataplane, acl_tcp_rst_test # noqa: F401
 from dash_acl import acl_tag_test, acl_multi_tag_test, acl_tag_order_test, acl_multi_tag_order_test  # noqa: F401
 from dash_acl import acl_tag_update_ip_test, acl_tag_remove_ip_test, acl_tag_scale_test, acl_tag_not_exists_test  # noqa: F401
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/dash/test_dash_vnet.py
+++ b/tests/dash/test_dash_vnet.py
@@ -7,7 +7,6 @@ from constants import LOCAL_PTF_INTF, REMOTE_PTF_INTF, ENI
 from dash_acl import AclGroup, DEFAULT_ACL_GROUP, WAIT_AFTER_CONFIG, DefaultAclRule
 import packets
 import time
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/database/test_db_scripts.py
+++ b/tests/database/test_db_scripts.py
@@ -6,7 +6,6 @@ import pytest
 
 from tests.common.utilities import skip_release
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -33,7 +33,6 @@ from tests.common.dualtor.dual_tor_common import mux_config                     
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_random_side    # noqa F401
 from tests.common.dualtor.nic_simulator_control import mux_status_from_nic_simulator                # noqa F401
 from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/dhcp_relay/test_dhcp_pkt_fwd.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_fwd.py
@@ -6,7 +6,6 @@ import ipaddress
 
 import ptf.testutils as testutils
 import ptf.packet as scapy
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 from ptf.mask import Mask
 from socket import INADDR_ANY

--- a/tests/dhcp_relay/test_dhcp_pkt_recv.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_recv.py
@@ -7,7 +7,6 @@ from ptf import testutils
 from scapy.layers.dhcp6 import DHCP6_Solicit
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import capture_and_check_packet_on_dut
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology("t0", "m0", 'mx')

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -16,7 +16,6 @@ from tests.common.utilities import skip_release
 from tests.common import config_reload
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0'),

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -16,7 +16,6 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby                 # noqa F401
 from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup                        # noqa F401
 from tests.common.dualtor.dual_tor_common import active_active_ports                                        # noqa F401
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0', 'mx'),

--- a/tests/disk/test_disk_exhaustion.py
+++ b/tests/disk/test_disk_exhaustion.py
@@ -9,7 +9,6 @@ from paramiko.ssh_exception import AuthenticationException
 from ptf import mask, packet
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import paramiko_ssh
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/dns/test_dns_resolv_conf.py
+++ b/tests/dns/test_dns_resolv_conf.py
@@ -3,7 +3,6 @@ import logging
 from tests.common.constants import RESOLV_CONF_NAMESERVERS
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import get_image_type
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology("any")

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -15,7 +15,6 @@ from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common import config_reload
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 RX_DRP = "RX_DRP"
 RX_ERR = "RX_ERR"

--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -29,7 +29,6 @@ from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py       # no
 from tests.common.utilities import is_ipv4_address
 from tests.common import constants
 from tests.common import config_reload
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -22,7 +22,6 @@ from .drop_packets import L2_COL_KEY, L3_COL_KEY, RX_ERR, RX_DRP, ACL_COUNTERS_U
     test_acl_egress_drop  # noqa F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts  # noqa F401
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology("any")

--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -31,7 +31,6 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # no
 from tests.common.utilities import dump_scapy_packet_show_output
 from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby                 # noqa F401
 from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup                        # noqa F401
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology("t0")

--- a/tests/dualtor/test_orch_stress.py
+++ b/tests/dualtor/test_orch_stress.py
@@ -27,7 +27,6 @@ from tests.common.utilities import compare_crm_facts
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.dual_tor_utils import tor_mux_intfs       # noqa F401
 from tests.common.dualtor.dual_tor_mock import *                    # noqa F401
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology("t0")

--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -23,7 +23,6 @@ from tests.common.fixtures.ptfhost_utils import run_garp_service                
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor/test_orchagent_mac_move.py
+++ b/tests/dualtor/test_orchagent_mac_move.py
@@ -14,7 +14,6 @@ from tests.common.fixtures.ptfhost_utils import run_icmp_responder              
 from tests.common.fixtures.ptfhost_utils import run_garp_service                # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses            # noqa F401
 from tests.common.utilities import dump_scapy_packet_show_output
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor/test_orchagent_slb.py
+++ b/tests/dualtor/test_orchagent_slb.py
@@ -21,7 +21,6 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses            
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                             # noqa F401
 from tests.common.helpers import bgp
 from tests.common.utilities import is_ipv4_address
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor/test_orchagent_standby_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_standby_tor_downstream.py
@@ -25,7 +25,6 @@ from tests.common.dualtor.server_traffic_utils import ServerTrafficMonitor
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports   # noqa: F401
 from tests.common.dualtor.tor_failure_utils import shutdown_bgp_sessions            # noqa: F401
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
+++ b/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
@@ -11,7 +11,6 @@ from tests.common.config_reload import config_reload
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses, run_garp_service, \
                                                 run_icmp_responder                  # noqa F401
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__file__)
 

--- a/tests/dualtor/test_switchover_failure.py
+++ b/tests/dualtor/test_switchover_failure.py
@@ -11,7 +11,6 @@ from tests.common.dualtor.mux_simulator_control import (  # noqa: F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service  # noqa: F401
 from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_common import cable_type, CableType                                     # noqa F401
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -33,7 +33,6 @@ from tests.common.dualtor.tunnel_traffic_utils import derive_queue_id_from_dscp,
 from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby      # noqa F401
 from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup             # noqa F401
 from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology("dualtor")

--- a/tests/dualtor/test_tunnel_memory_leak.py
+++ b/tests/dualtor/test_tunnel_memory_leak.py
@@ -23,7 +23,6 @@ from tests.common.dualtor.dual_tor_utils import delete_neighbor
 from tests.common.helpers.dut_utils import get_program_info
 from tests.common.fixtures.ptfhost_utils import run_garp_service, run_icmp_responder  # noqa: F401
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor_io/test_grpc_server_failure.py
+++ b/tests/dualtor_io/test_grpc_server_failure.py
@@ -14,7 +14,6 @@ from tests.common.dualtor.dual_tor_common import cable_type                     
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.dualtor.nic_simulator_control import stop_nic_grpc_server         # noqa F401
 from tests.common.dualtor.nic_simulator_control import restart_nic_simulator        # noqa F401
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor_io/test_heartbeat_failure.py
+++ b/tests/dualtor_io/test_heartbeat_failure.py
@@ -12,7 +12,6 @@ from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_ser
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import cable_type                                     # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor_io/test_link_drop.py
+++ b/tests/dualtor_io/test_link_drop.py
@@ -24,7 +24,6 @@ from tests.common.dualtor.dual_tor_common import active_active_ports            
 from tests.common.dualtor.dual_tor_common import active_standby_ports                           # noqa F401
 from tests.common.dualtor.dual_tor_common import cable_type                                     # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -16,7 +16,6 @@ from tests.common.dualtor.dual_tor_common import active_active_ports            
 from tests.common.dualtor.dual_tor_common import cable_type                                         # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.config_reload import config_reload
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -17,7 +17,6 @@ from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_ser
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC, CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -15,7 +15,6 @@ from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor    
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import cable_type                                         # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -20,7 +20,6 @@ from tests.common.dualtor.dual_tor_common import ActiveActivePortID
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 logger = logging.getLogger(__name__)

--- a/tests/dualtor_mgmt/test_dualtor_bgp_update_delay.py
+++ b/tests/dualtor_mgmt/test_dualtor_bgp_update_delay.py
@@ -14,7 +14,6 @@ from scapy.contrib import bgp
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor_mgmt/test_egress_drop_nvidia.py
+++ b/tests/dualtor_mgmt/test_egress_drop_nvidia.py
@@ -15,7 +15,6 @@ from ptf import testutils
 from tests.common.utilities import wait_until
 from ptf.testutils import simple_tcp_packet, simple_ipv4ip_packet
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('dualtor')

--- a/tests/dualtor_mgmt/test_grpc_periodical_sync.py
+++ b/tests/dualtor_mgmt/test_grpc_periodical_sync.py
@@ -17,7 +17,6 @@ from tests.common.fixtures.ptfhost_utils import run_icmp_responder              
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor_mgmt/test_ingress_drop.py
+++ b/tests/dualtor_mgmt/test_ingress_drop.py
@@ -19,7 +19,6 @@ from tests.common.fixtures.ptfhost_utils import run_icmp_responder              
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor_mgmt/test_server_failure.py
+++ b/tests/dualtor_mgmt/test_server_failure.py
@@ -17,7 +17,6 @@ from tests.common.dualtor.nic_simulator_control import simulator_server_down_act
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses, run_garp_service, \
                                                 run_icmp_responder                                      # noqa: F401
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dualtor_mgmt/test_toggle_mux.py
+++ b/tests/dualtor_mgmt/test_toggle_mux.py
@@ -7,7 +7,6 @@ from tests.common.dualtor.dual_tor_common import active_standby_ports           
 from tests.common.dualtor.mux_simulator_control import check_mux_status, validate_check_result
 from tests.common.dualtor.dual_tor_utils import recover_linkmgrd_probe_interval, update_linkmgrd_probe_interval
 from tests.common.utilities import wait_until
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -3,7 +3,6 @@ import time
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.helpers.console_helper import assert_expect_text, create_ssh_client, ensure_console_session_up
 from tests.common.reboot import reboot
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 pytestmark = [

--- a/tests/dut_console/test_escape_character.py
+++ b/tests/dut_console/test_escape_character.py
@@ -1,6 +1,5 @@
 import logging
 import pytest
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 
 TOTAL_PACKETS = 100

--- a/tests/dut_console/test_idle_timeout.py
+++ b/tests/dut_console/test_idle_timeout.py
@@ -3,7 +3,6 @@ import time
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.tacacs import tacacs_creds, setup_tacacs    # noqa F401
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Remove TACACS fixture from none TACACS test cases

#### Why I did it
To improve TACACS feature coverage, will have a PR to enable TACACS on testbed for daily work and all test cases. before that change need remove TACACS fixture from none TACACS test cases first.

##### Work item tracking
- Microsoft ADO: 26156377

#### How I did it
Remove TACACS fixture from none TACACS test cases.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Remove TACACS fixture from none TACACS test cases

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

