### PR TITLE
Fix KVM get device conn graph error

### DIFF
--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -16,6 +16,8 @@ def fanout_graph_facts(localhost, duthosts, rand_one_dut_hostname, conn_graph_fa
     duthost = duthosts[rand_one_dut_hostname]
     facts = dict()
     dev_conn = conn_graph_facts.get('device_conn', {})
+    if not dev_conn:
+        return None
     for _, val in list(dev_conn[duthost.hostname].items()):
         fanout = val["peerdevice"]
         if fanout not in facts:
@@ -28,6 +30,8 @@ def enum_fanout_graph_facts(localhost, duthosts, enum_rand_one_per_hwsku_fronten
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     facts = dict()
     dev_conn = conn_graph_facts.get('device_conn', {})
+    if not dev_conn:
+        return None
     for _, val in list(dev_conn[duthost.hostname].items()):
         fanout = val["peerdevice"]
         if fanout not in facts:

--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -17,7 +17,7 @@ def fanout_graph_facts(localhost, duthosts, rand_one_dut_hostname, conn_graph_fa
     facts = dict()
     dev_conn = conn_graph_facts.get('device_conn', {})
     if not dev_conn:
-        return None
+        return facts
     for _, val in list(dev_conn[duthost.hostname].items()):
         fanout = val["peerdevice"]
         if fanout not in facts:
@@ -31,7 +31,7 @@ def enum_fanout_graph_facts(localhost, duthosts, enum_rand_one_per_hwsku_fronten
     facts = dict()
     dev_conn = conn_graph_facts.get('device_conn', {})
     if not dev_conn:
-        return None
+        return facts
     for _, val in list(dev_conn[duthost.hostname].items()):
         fanout = val["peerdevice"]
         if fanout not in facts:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
When we get conn_graph_facts in fanout_graph_facts function, it would return an empty dict for KVM testbed, and raise key error when we directly get dev_conn[duthost.hostname].items()
#### How did you do it?
Return fanout conn graph with None when we get an empty device conn graph facts
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
