### PR TITLE
Revert "Fix test_qos_sai teardown for dualtor (#13363)"

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1275,7 +1275,7 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class')
     def stopServices(
-        self, duthosts, get_src_dst_asic_and_duts, dut_disable_ipv6,
+        self, duthosts, get_src_dst_asic_and_duts,
         swapSyncd_on_selected_duts, enable_container_autorestart, disable_container_autorestart, get_mux_status, # noqa F811
         tbinfo, upper_tor_host, lower_tor_host, toggle_all_simulator_ports):  # noqa F811
         """


### PR DESCRIPTION
This reverts commit 20c8cdff655a2f46412c1cab3e0dd675c9262e56.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

PR #13363  caused qos sai tests error

```
2024-06-24 09:53:49.7980000 | qos.test_qos_sai.TestQosSai.testParameter[single_asic] | 202305 | error | failed on setup with "Failed: Not all critical processes are healthy"
```

#### How did you do it?

reverty PR #13363 can help.

#### How did you verify/test it?

pass qos sai test on local after revert pr #13363 

#### Any platform specific information?

generic error

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
