### PR TITLE
Skip forced mgmt route test if intf is invalid

### DIFF
--- a/tests/route/test_forced_mgmt_route.py
+++ b/tests/route/test_forced_mgmt_route.py
@@ -128,9 +128,14 @@ def test_forced_mgmt_route_add_and_remove_by_mgmt_port_status(
     config_db_mgmt_interface = config_db_json["MGMT_INTERFACE"]
     config_db_port = config_db_json["MGMT_PORT"]
 
-    # Skip multi-asic because override_config format are different.
+    # Skip if port does not exist
+    output = duthost.command("ip link show eth1", module_ignore_errors=True)
+    if output["failed"]:
+        pytest.skip("Skip test_forced_mgmt_route_add_and_remove_by_mgmt_port_status, port does not exist")
+
+    # Skip if port is already in use
     if 'eth1' in config_db_port:
-        pytest.skip("Skip test_forced_mgmt_route_add_and_remove_by_mgmt_port_status for multi-mgmt device")
+        pytest.skip("Skip test_forced_mgmt_route_add_and_remove_by_mgmt_port_status, port in use")
 
     # Add eth1 to mgmt interface and port
     ipv4_forced_mgmt_address = "172.17.1.1/24"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #169

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

Skip `test_forced_mgmt_route_add_and_remove_by_mgmt_port_status` in `route/test_forced_mgmt_route.py` if `eth1` does not exist or is being used. This test was failing on Arista platforms when interface `eth1` did not exist.

#### How did you do it?

Added a check to see if `eth1` does not exist, and skips the test if so.

#### How did you verify/test it?

Tested on a `t0` setup on a `Arista-7260`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
