### PR TITLE
Add script `platform_tests/test_reboot.py` into T0 PR checker. 

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -353,6 +353,11 @@ def check_reboot_cause(dut, reboot_cause_expected):
     @param dut: The AnsibleHost object of DUT.
     @param reboot_cause_expected: The expected reboot cause.
     """
+    # For kvm testbed, command `show reboot-cause` will return Unknown.
+    # So, return in advance if this check is running on kvm testbed.
+    if dut.facts["asic_type"] == "vs":
+        return True
+
     reboot_cause_got = get_reboot_cause(dut)
     logger.debug("dut {} last reboot-cause {}".format(dut.hostname, reboot_cause_got))
     return reboot_cause_got == reboot_cause_expected
@@ -451,6 +456,11 @@ def check_reboot_cause_history(dut, reboot_type_history_queue):
     reboot_cause_history_got = dut.show_and_parse("show reboot-cause history")
     logger.debug("dut {} reboot-cause history {}. reboot type history queue is {}".format(
         dut.hostname, reboot_cause_history_got, reboot_type_history_queue))
+
+    # For kvm testbed, command `show reboot-cause history` will return None
+    # So, return in advance if this check is running on kvm.
+    if dut.facts["asic_type"] == "vs":
+        return True
 
     logger.info("Verify reboot-cause history title")
     if reboot_cause_history_got:

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -354,9 +354,9 @@ def check_reboot_cause(dut, reboot_cause_expected):
     @param reboot_cause_expected: The expected reboot cause.
     """
     # For kvm testbed, command `show reboot-cause` will return Unknown.
-    # So, return in advance if this check is running on kvm testbed.
+    # So, overwrite the reboot_cause_expected as `Unknown`
     if dut.facts["asic_type"] == "vs":
-        return True
+        reboot_cause_expected = "Unknown"
 
     reboot_cause_got = get_reboot_cause(dut)
     logger.debug("dut {} last reboot-cause {}".format(dut.hostname, reboot_cause_got))

--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -76,7 +76,13 @@ def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     portmap, dev_conn = get_dev_conn(
         duthost, conn_graph_facts, enum_frontend_asic_index)
-    sfp_lpmode = duthost.command(cmd_sfp_lpmode)
+    sfp_lpmode = duthost.command(cmd_sfp_lpmode, module_ignore_errors=True)
+
+    # For vs testbed, we will get expected Error code `ERROR_CHASSIS_LOAD = 2` here.
+    if duthost.facts["asic_type"] == "vs" and sfp_lpmode['rc'] == 2:
+        return
+    assert sfp_lpmode['rc'] == 0, "Run command '{}' failed".format(cmd_sfp_presence)
+
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
             assert validate_transceiver_lpmode(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR [#13220](https://github.com/sonic-net/sonic-mgmt/pull/13220), we add a batch of control plane test scripts into onboarding T0 PR checker, but some of them failed. In this PR, we fix the failed test script `platform_tests/test_reboot.py` and let it run successfully in T0 PR checker. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In PR [#13220](https://github.com/sonic-net/sonic-mgmt/pull/13220), we add a batch of control plane test scripts into onboarding T0 PR checker, but some of them failed. In this PR, we fix the failed test script `platform_tests/test_reboot.py` and let it run successfully in T0 PR checker. 

#### How did you do it?

#### How did you verify/test it?
```
=========================== short test summary info ============================
SKIPPED [1] platform_tests/test_reboot.py: Skip test_soft_reboot for m0/mx and test is supported only on S6100 hwsku
SKIPPED [1] platform_tests/test_reboot.py:247: Watchdog is not supported on this DUT, skip this test case
============= 4 passed, 2 skipped, 1 warning in 1836.16s (0:30:36) =============
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
