### PR TITLE
Add everflow test to PR test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -346,10 +346,14 @@ onboarding_t0:
   - arp/test_stress_arp.py
   - arp/test_unknown_mac.py
   - arp/test_wr_arp.py
+  - everflow/test_everflow_per_interface.py
+  - everflow/test_everflow_testbed.py
 
 onboarding_t1:
   - acl/test_acl.py
   - acl/test_stress_acl.py
+  - everflow/test_everflow_per_interface.py
+  - everflow/test_everflow_testbed.py
 
 specific_param:
   t0-sonic:

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -42,6 +42,8 @@ t0:
   - dut_console/test_escape_character.py
   - dut_console/test_idle_timeout.py
   - everflow/test_everflow_ipv6.py
+  - everflow/test_everflow_per_interface.py
+  - everflow/test_everflow_testbed.py
   - fdb/test_fdb.py
   - fdb/test_fdb_flush.py
   - fdb/test_fdb_mac_expire.py
@@ -205,6 +207,9 @@ t1-lag:
   - configlet/test_add_rack.py
   - container_checker/test_container_checker.py
   - dhcp_relay/test_dhcp_pkt_fwd.py
+  - everflow/test_everflow_ipv6.py
+  - everflow/test_everflow_per_interface.py
+  - everflow/test_everflow_testbed.py
   - fdb/test_fdb_flush.py
   - generic_config_updater/test_mmu_dynamic_threshold_config_update.py
   - http/test_http_copy.py
@@ -349,13 +354,9 @@ onboarding_t0:
   - acl/test_acl_outer_vlan.py
   - arp/test_unknown_mac.py
   - decap/test_decap.py
-  - everflow/test_everflow_per_interface.py
-  - everflow/test_everflow_testbed.py
 
 onboarding_t1:
   - decap/test_decap.py
-  - everflow/test_everflow_per_interface.py
-  - everflow/test_everflow_testbed.py
 
 specific_param:
   t0-sonic:

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -36,6 +36,8 @@ t0:
   - dut_console/test_escape_character.py
   - dut_console/test_idle_timeout.py
   - everflow/test_everflow_ipv6.py
+  - everflow/test_everflow_per_interface.py
+  - everflow/test_everflow_testbed.py
   - fdb/test_fdb.py
   - fdb/test_fdb_flush.py
   - fdb/test_fdb_mac_expire.py
@@ -197,6 +199,8 @@ t1-lag:
   - configlet/test_add_rack.py
   - container_checker/test_container_checker.py
   - dhcp_relay/test_dhcp_pkt_fwd.py
+  - everflow/test_everflow_per_interface.py
+  - everflow/test_everflow_testbed.py
   - fdb/test_fdb_flush.py
   - generic_config_updater/test_mmu_dynamic_threshold_config_update.py
   - http/test_http_copy.py
@@ -346,14 +350,10 @@ onboarding_t0:
   - arp/test_stress_arp.py
   - arp/test_unknown_mac.py
   - arp/test_wr_arp.py
-  - everflow/test_everflow_per_interface.py
-  - everflow/test_everflow_testbed.py
 
 onboarding_t1:
   - acl/test_acl.py
   - acl/test_stress_acl.py
-  - everflow/test_everflow_per_interface.py
-  - everflow/test_everflow_testbed.py
 
 specific_param:
   t0-sonic:

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -36,8 +36,6 @@ t0:
   - dut_console/test_escape_character.py
   - dut_console/test_idle_timeout.py
   - everflow/test_everflow_ipv6.py
-  - everflow/test_everflow_per_interface.py
-  - everflow/test_everflow_testbed.py
   - fdb/test_fdb.py
   - fdb/test_fdb_flush.py
   - fdb/test_fdb_mac_expire.py
@@ -199,8 +197,6 @@ t1-lag:
   - configlet/test_add_rack.py
   - container_checker/test_container_checker.py
   - dhcp_relay/test_dhcp_pkt_fwd.py
-  - everflow/test_everflow_per_interface.py
-  - everflow/test_everflow_testbed.py
   - fdb/test_fdb_flush.py
   - generic_config_updater/test_mmu_dynamic_threshold_config_update.py
   - http/test_http_copy.py
@@ -350,10 +346,14 @@ onboarding_t0:
   - arp/test_stress_arp.py
   - arp/test_unknown_mac.py
   - arp/test_wr_arp.py
+  - everflow/test_everflow_per_interface.py
+  - everflow/test_everflow_testbed.py
 
 onboarding_t1:
   - acl/test_acl.py
   - acl/test_stress_acl.py
+  - everflow/test_everflow_per_interface.py
+  - everflow/test_everflow_testbed.py
 
 specific_param:
   t0-sonic:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -60,3 +60,15 @@ everflow/test_everflow_ipv6.py:
     reason: "Skip traffic test for KVM testbed"
     conditions:
       - "asic_type in ['vs']"
+
+everflow/test_everflow_per_interface.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+everflow/test_everflow_testbed.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -378,6 +378,18 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
     time.sleep(60)
 
 
+# Currently, conditional mark would only match longest prefix,
+# so our mark in tests_mark_conditions_skip_traffic_test.yaml couldn't be matched.
+# Use a temporary work around to add skip_traffic_test fixture here,
+# once conditional mark support add all matches, will remove this code.
+@pytest.fixture(scope="module")
+def skip_traffic_test(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    if duthost.facts["asic_type"] == "vs":
+        return True
+    return False
+
+
 # TODO: This should be refactored to some common area of sonic-mgmt.
 def add_route(duthost, prefix, nexthop, namespace):
     """

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -13,6 +13,7 @@ from tests.common.helpers.assertions import pytest_require
 
 from .everflow_test_utilities import setup_info, EVERFLOW_DSCP_RULES       # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
+from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa: F401
 
 pytestmark = [
     pytest.mark.topology("any")
@@ -180,7 +181,8 @@ def send_and_verify_packet(ptfadapter, packet, expected_packet, tx_port, rx_port
 
 
 def test_everflow_per_interface(ptfadapter, setup_info, apply_acl_rule, tbinfo,                 # noqa F811
-                                toggle_all_simulator_ports_to_rand_selected_tor, ip_ver):       # noqa F811
+                                toggle_all_simulator_ports_to_rand_selected_tor, ip_ver,        # noqa F811
+                                skip_traffic_test):                                             # noqa F811
     """Verify packet ingress from candidate ports are captured by EVERFLOW, while packets
     ingress from unselected ports are not captured
     """
@@ -189,6 +191,9 @@ def test_everflow_per_interface(ptfadapter, setup_info, apply_acl_rule, tbinfo, 
                                                  everflow_config['mirror_session_info'],
                                                  setup_info[UP_STREAM]['ingress_router_mac'], setup_info, ip_ver)
     uplink_ports = everflow_config["monitor_port_ptf_ids"]
+
+    if skip_traffic_test:
+        return
 
     # Verify that packet ingressed from INPUT_PORTS (candidate ports) are mirrored
     for port, ptf_idx in list(everflow_config['candidate_ports'].items()):

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -11,9 +11,9 @@ from .everflow_test_utilities import TEMPLATE_DIR, EVERFLOW_RULE_CREATE_TEMPLATE
                                     DUT_RUN_DIR, EVERFLOW_RULE_CREATE_FILE, UP_STREAM
 from tests.common.helpers.assertions import pytest_require
 
-from .everflow_test_utilities import setup_info, EVERFLOW_DSCP_RULES       # noqa: F401
+from .everflow_test_utilities import setup_info, EVERFLOW_DSCP_RULES, skip_traffic_test       # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa: F401
+# from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa: F401
 
 pytestmark = [
     pytest.mark.topology("any")

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -11,7 +11,8 @@ from .everflow_test_utilities import TARGET_SERVER_IP, BaseEverflowTest, DOWN_ST
 # Module-level fixtures
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                 # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_acstests_directory                                 # noqa: F401
-from .everflow_test_utilities import setup_info, setup_arp_responder, EVERFLOW_DSCP_RULES                # noqa: F401
+from tests.common.fixtures.ptfhost_utils import skip_traffic_test                                       # noqa: F401
+from .everflow_test_utilities import setup_info, setup_arp_responder, EVERFLOW_DSCP_RULES               # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py                                   # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
 
@@ -130,7 +131,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
     def test_everflow_basic_forwarding(self, setup_info, setup_mirror_session,              # noqa F811
                                        dest_port_type, ptfadapter, tbinfo,
                                        toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                                       setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa F811
+                                       setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
+                                       skip_traffic_test):    # noqa F811
         """
         Verify basic forwarding scenarios for the Everflow feature.
 
@@ -164,7 +166,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             [tx_port_ptf_id],
-            dest_port_type
+            dest_port_type,
+            skip_traffic_test=skip_traffic_test
         )
 
         # Add a (better) unresolved route to the mirror session destination IP
@@ -181,7 +184,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             [tx_port_ptf_id],
-            dest_port_type
+            dest_port_type,
+            skip_traffic_test=skip_traffic_test
         )
 
         # Remove the unresolved route
@@ -204,7 +208,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             [tx_port_ptf_id],
-            dest_port_type
+            dest_port_type,
+            skip_traffic_test=skip_traffic_test
         )
 
         # Remove the better route.
@@ -221,7 +226,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             [tx_port_ptf_id],
-            dest_port_type
+            dest_port_type,
+            skip_traffic_test=skip_traffic_test
         )
 
         remote_dut.shell(remote_dut.get_vtysh_cmd_for_namespace(
@@ -231,7 +237,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
     def test_everflow_neighbor_mac_change(self, setup_info, setup_mirror_session,               # noqa F811
                                           dest_port_type, ptfadapter, tbinfo,
                                           toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
-                                          setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa F811
+                                          setup_standby_ports_on_rand_unselected_tor_unconditionally,   # noqa F811
+                                          skip_traffic_test):    # noqa F811
         """Verify that session destination MAC address is changed after neighbor MAC address update."""
 
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
@@ -254,7 +261,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             [tx_port_ptf_id],
-            dest_port_type
+            dest_port_type,
+            skip_traffic_test=skip_traffic_test
         )
 
         # Update the MAC on the neighbor interface for the route we installed
@@ -274,7 +282,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
                 everflow_dut,
                 rx_port_ptf_id,
                 [tx_port_ptf_id],
-                dest_port_type
+                dest_port_type,
+                skip_traffic_test=skip_traffic_test
             )
 
         finally:
@@ -295,13 +304,15 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             [tx_port_ptf_id],
-            dest_port_type
+            dest_port_type,
+            skip_traffic_test=skip_traffic_test
         )
 
     def test_everflow_remove_unused_ecmp_next_hop(self, setup_info, setup_mirror_session,               # noqa F811
                                                   dest_port_type, ptfadapter, tbinfo,
                                                   toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
-                                                  setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa F811
+                                                  setup_standby_ports_on_rand_unselected_tor_unconditionally,   # noqa F811
+                                                  skip_traffic_test):    # noqa F811
         """Verify that session is still active after removal of next hop from ECMP route that was not in use."""
 
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
@@ -333,7 +344,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             tx_port_ptf_ids,
-            dest_port_type
+            dest_port_type,
+            skip_traffic_test=skip_traffic_test
         )
 
         # Remaining Scenario not applicable for this topology
@@ -358,7 +370,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             [tx_port_ptf_id],
             dest_port_type,
             expect_recv=False,
-            valid_across_namespace=False
+            valid_across_namespace=False,
+            skip_traffic_test=skip_traffic_test
         )
 
         # Remove the extra hop
@@ -376,7 +389,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             [tx_port_ptf_id],
             dest_port_type,
             expect_recv=False,
-            valid_across_namespace=False
+            valid_across_namespace=False,
+            skip_traffic_test=skip_traffic_test
         )
 
         # Verify that mirrored traffic is still sent to one of the original next hops
@@ -387,13 +401,15 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             tx_port_ptf_ids,
-            dest_port_type
+            dest_port_type,
+            skip_traffic_test=skip_traffic_test
         )
 
     def test_everflow_remove_used_ecmp_next_hop(self, setup_info, setup_mirror_session,                 # noqa F811
                                                 dest_port_type, ptfadapter, tbinfo,
                                                 toggle_all_simulator_ports_to_rand_selected_tor,        # noqa F811
-                                                setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa F811
+                                                setup_standby_ports_on_rand_unselected_tor_unconditionally,     # noqa F811
+                                                skip_traffic_test):    # noqa F811
         """Verify that session is still active after removal of next hop from ECMP route that was in use."""
 
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
@@ -424,7 +440,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             [tx_port_ptf_id],
-            dest_port_type
+            dest_port_type,
+            skip_traffic_test=skip_traffic_test
         )
 
         # Add two new ECMP next hops
@@ -448,7 +465,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             rx_port_ptf_id,
             [tx_port_ptf_id],
             dest_port_type,
-            valid_across_namespace=False
+            valid_across_namespace=False,
+            skip_traffic_test=skip_traffic_test
         )
 
         # Verify that traffic is not sent along either of the new next hops
@@ -465,7 +483,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             tx_port_ptf_ids,
             dest_port_type,
             expect_recv=False,
-            valid_across_namespace=False
+            valid_across_namespace=False,
+            skip_traffic_test=skip_traffic_test
         )
 
         # Remove the original next hop
@@ -482,7 +501,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             rx_port_ptf_id,
             [tx_port_ptf_id],
             dest_port_type,
-            expect_recv=False
+            expect_recv=False,
+            skip_traffic_test=skip_traffic_test
         )
 
         # Verify that mirrored traffis is now sent along either of the new next hops
@@ -493,7 +513,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             tx_port_ptf_ids,
-            dest_port_type
+            dest_port_type,
+            skip_traffic_test=skip_traffic_test
         )
 
     def test_everflow_dscp_with_policer(
@@ -506,6 +527,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             tbinfo,
             toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
             setup_standby_ports_on_rand_unselected_tor_unconditionally,    # noqa F811
+            skip_traffic_test                                   # noqa F811
     ):
         """Verify that we can rate-limit mirrored traffic from the MIRROR_DSCP table.
         This tests single rate three color policer mode and specifically checks CIR value
@@ -591,6 +613,9 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                        config_method,
                                        rules=EVERFLOW_DSCP_RULES)
 
+            if skip_traffic_test is True:
+                return
+
             # Run test with expected CIR/CBS in packets/sec and tolerance %
             partial_ptf_runner(setup_info,
                                dest_port_type,
@@ -606,7 +631,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                cir=rate_limit,
                                cbs=rate_limit,
                                send_time=send_time,
-                               tolerance=everflow_tolerance)
+                               tolerance=everflow_tolerance,
+                               skip_traffic_test=skip_traffic_test)
         finally:
             # Clean up ACL rules and routes
             BaseEverflowTest.remove_acl_rule_config(everflow_dut, table_name, config_method)
@@ -619,7 +645,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                         setup_info[default_tarffic_port_type]["remote_namespace"])
 
     def _run_everflow_test_scenarios(self, ptfadapter, setup, mirror_session, duthost, rx_port,
-                                     tx_ports, direction, expect_recv=True, valid_across_namespace=True):
+                                     tx_ports, direction, expect_recv=True, valid_across_namespace=True,
+                                     skip_traffic_test=False):      # noqa F811
         # FIXME: In the ptf_runner version of these tests, LAGs were passed down to the tests
         # as comma-separated strings of LAG member port IDs (e.g. portchannel0001 -> "2,3").
         # Because the DSCP test is still using ptf_runner we will preserve this for now,
@@ -658,6 +685,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                 dest_ports=tx_port_ids,
                 expect_recv=expect_recv,
                 valid_across_namespace=valid_across_namespace,
+                skip_traffic_test=skip_traffic_test,
             )
 
     def _base_tcp_packet(

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -11,8 +11,9 @@ from .everflow_test_utilities import TARGET_SERVER_IP, BaseEverflowTest, DOWN_ST
 # Module-level fixtures
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                 # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_acstests_directory                                 # noqa: F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test                                       # noqa: F401
-from .everflow_test_utilities import setup_info, setup_arp_responder, EVERFLOW_DSCP_RULES               # noqa: F401
+# from tests.common.fixtures.ptfhost_utils import skip_traffic_test                                       # noqa: F401
+from .everflow_test_utilities import \
+    setup_info, setup_arp_responder, EVERFLOW_DSCP_RULES, skip_traffic_test                             # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py                                   # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed
#### How did you do it?
Add everflow test to T0 and T1 PR test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
