### PR TITLE
Improve the step for installing azure-cli in template

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -171,8 +171,13 @@ steps:
             displayName: "Download test plan script"
 
   - script: |
-      # Ensure that azure-cli apt package is installed
-      curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      # Check if azure cli is installed. If not, try to install it
+      if ! command -v az; then
+        echo "Azure CLI is not installed. Trying to install it..."
+        # curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      else
+        echo "Azure CLI is already installed"
+      fi
     displayName: "Install azure-cli"
 
   - task: AzureCLI@2

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -174,7 +174,7 @@ steps:
       # Check if azure cli is installed. If not, try to install it
       if ! command -v az; then
         echo "Azure CLI is not installed. Trying to install it..."
-        # curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
       else
         echo "Azure CLI is already installed"
       fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
On some agents, the azure cli package is already installed, it's unnecessary to try installing it again.

#### How did you do it?
This change improved the step for installing azure cli to check if the az command is available. If no, try to install azure-cli. If yes, skip this step.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
