### PR TITLE
[QoS]SAI_PORT_STAT_IN/OUT_DROPPED_PKTS counters skipped read for dnx platform

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4309,7 +4309,6 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         src_port_vlan = self.test_params['src_port_vlan']
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
 
-
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
         pkts_num_fill_min = int(self.test_params['pkts_num_fill_min'])
         pkts_num_fill_shared = int(self.test_params['pkts_num_fill_shared'])
@@ -4936,7 +4935,6 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         src_port_ip = self.test_params['src_port_ip']
         src_port_vlan = self.test_params['src_port_vlan']
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
-
 
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
         pkts_num_fill_min = int(self.test_params['pkts_num_fill_min'])

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4316,7 +4316,6 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         hwsku = self.test_params['hwsku']
         internal_hdr_size = self.test_params.get('internal_hdr_size', 0)
 
-
         if 'packet_size' in list(self.test_params.keys()):
             packet_length = int(self.test_params['packet_size'])
         else:
@@ -4942,7 +4941,6 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         pkts_num_trig_drp = int(self.test_params['pkts_num_trig_drp'])
         cell_size = int(self.test_params['cell_size'])
         hwsku = self.test_params['hwsku']
-
 
         if 'packet_size' in list(self.test_params.keys()):
             packet_length = int(self.test_params['packet_size'])

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -559,11 +559,11 @@ def get_rx_port(dp, device_number, src_port_id, dst_mac, dst_ip, src_ip, src_vla
     return result.port
 
 
-def get_counter_names(sonic_version, asic_type=None):
+def get_counter_names(sonic_version, platform_asic=None):
     ingress_counters = [INGRESS_DROP]
     egress_counters = [EGRESS_DROP]
 
-    if '201811' not in sonic_version and asic_type not in ['broadcom']:
+    if '201811' not in sonic_version and platform_asic not in ['broadcom-dnx']:
         ingress_counters.append(INGRESS_PORT_BUFFER_DROP)
         egress_counters.append(EGRESS_PORT_BUFFER_DROP)
 
@@ -1669,7 +1669,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
 
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
         # get counter names to query
-        ingress_counters, egress_counters = get_counter_names(sonic_version, asic_type)
+        ingress_counters, egress_counters = get_counter_names(sonic_version, platform_asic)
 
         # get a snapshot of PG drop packets counter
         if '201811' not in sonic_version and ('mellanox' in asic_type or 'cisco-8000' in asic_type):
@@ -2377,7 +2377,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             margin = 1
 
         # get counter names to query
-        ingress_counters, egress_counters = get_counter_names(sonic_version, asic_type)
+        ingress_counters, egress_counters = get_counter_names(sonic_version, platform_asic)
 
         port_counter_indexes = [pg]
         port_counter_indexes += ingress_counters
@@ -2845,15 +2845,14 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         self.platform_asic = self.test_params['platform_asic']
         print(self.src_port_ips, file=sys.stderr)
         sys.stderr.flush()
-        self.asic_type = self.test_params['sonic_asic_type']
         # get counter names to query
         self.ingress_counters, self.egress_counters = get_counter_names(
-            self.sonic_version, self.asic_type)
+            self.sonic_version, self.platform_asic)
 
         self.dst_port_id = self.test_params['dst_port_id']
         self.dst_port_ip = self.test_params['dst_port_ip']
         self.pgs_num = self.test_params['pgs_num']
-
+        self.asic_type = self.test_params['sonic_asic_type']
         self.pkts_num_leak_out = self.test_params['pkts_num_leak_out']
         self.pkts_num_trig_pfc = self.test_params.get('pkts_num_trig_pfc')
         if not self.pkts_num_trig_pfc:
@@ -3851,7 +3850,7 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
         platform_asic = self.test_params['platform_asic']
 
         # get counter names to query
-        ingress_counters, egress_counters = get_counter_names(sonic_version, asic_type)
+        ingress_counters, egress_counters = get_counter_names(sonic_version, platform_asic)
 
         # prepare tcp packet data
         ttl = 64
@@ -4298,9 +4297,9 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         router_mac = self.test_params['router_mac']
         print("router_mac: %s" % (router_mac), file=sys.stderr)
         pg = int(self.test_params['pg'])
-        asic_type = self.test_params['sonic_asic_type']
+        platform_asic = self.test_params['platform_asic']
         ingress_counters, egress_counters = get_counter_names(
-            self.test_params['sonic_version'], asic_type)
+            self.test_params['sonic_version'], platform_asic)
         dst_port_id = int(self.test_params['dst_port_id'])
         dst_port_ip = self.test_params['dst_port_ip']
         dst_port_mac = self.dataplane.get_mac(0, dst_port_id)
@@ -4309,13 +4308,14 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         src_port_vlan = self.test_params['src_port_vlan']
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
 
+        asic_type = self.test_params['sonic_asic_type']
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
         pkts_num_fill_min = int(self.test_params['pkts_num_fill_min'])
         pkts_num_fill_shared = int(self.test_params['pkts_num_fill_shared'])
         cell_size = int(self.test_params['cell_size'])
         hwsku = self.test_params['hwsku']
         internal_hdr_size = self.test_params.get('internal_hdr_size', 0)
-        platform_asic = self.test_params['platform_asic']
+
 
         if 'packet_size' in list(self.test_params.keys()):
             packet_length = int(self.test_params['packet_size'])
@@ -4920,9 +4920,9 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         switch_init(self.clients)
 
         # Parse input parameters
-        asic_type = self.test_params['sonic_asic_type']
+        platform_asic = self.test_params['platform_asic']
         ingress_counters, egress_counters = get_counter_names(
-            self.test_params['sonic_version'], asic_type)
+            self.test_params['sonic_version'], platform_asic)
         dscp = int(self.test_params['dscp'])
         ecn = int(self.test_params['ecn'])
         router_mac = self.test_params['router_mac']
@@ -4936,12 +4936,13 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         src_port_vlan = self.test_params['src_port_vlan']
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
 
+        asic_type = self.test_params['sonic_asic_type']
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
         pkts_num_fill_min = int(self.test_params['pkts_num_fill_min'])
         pkts_num_trig_drp = int(self.test_params['pkts_num_trig_drp'])
         cell_size = int(self.test_params['cell_size'])
         hwsku = self.test_params['hwsku']
-        platform_asic = self.test_params['platform_asic']
+
 
         if 'packet_size' in list(self.test_params.keys()):
             packet_length = int(self.test_params['packet_size'])

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -559,11 +559,11 @@ def get_rx_port(dp, device_number, src_port_id, dst_mac, dst_ip, src_ip, src_vla
     return result.port
 
 
-def get_counter_names(sonic_version):
+def get_counter_names(sonic_version, asic_type=None):
     ingress_counters = [INGRESS_DROP]
     egress_counters = [EGRESS_DROP]
 
-    if '201811' not in sonic_version:
+    if '201811' not in sonic_version and asic_type not in ['broadcom']:
         ingress_counters.append(INGRESS_PORT_BUFFER_DROP)
         egress_counters.append(EGRESS_PORT_BUFFER_DROP)
 
@@ -1669,7 +1669,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
 
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
         # get counter names to query
-        ingress_counters, egress_counters = get_counter_names(sonic_version)
+        ingress_counters, egress_counters = get_counter_names(sonic_version, asic_type)
 
         # get a snapshot of PG drop packets counter
         if '201811' not in sonic_version and ('mellanox' in asic_type or 'cisco-8000' in asic_type):
@@ -2377,7 +2377,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             margin = 1
 
         # get counter names to query
-        ingress_counters, egress_counters = get_counter_names(sonic_version)
+        ingress_counters, egress_counters = get_counter_names(sonic_version, asic_type)
 
         port_counter_indexes = [pg]
         port_counter_indexes += ingress_counters
@@ -2845,14 +2845,15 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         self.platform_asic = self.test_params['platform_asic']
         print(self.src_port_ips, file=sys.stderr)
         sys.stderr.flush()
+        self.asic_type = self.test_params['sonic_asic_type']
         # get counter names to query
         self.ingress_counters, self.egress_counters = get_counter_names(
-            self.sonic_version)
+            self.sonic_version, self.asic_type)
 
         self.dst_port_id = self.test_params['dst_port_id']
         self.dst_port_ip = self.test_params['dst_port_ip']
         self.pgs_num = self.test_params['pgs_num']
-        self.asic_type = self.test_params['sonic_asic_type']
+
         self.pkts_num_leak_out = self.test_params['pkts_num_leak_out']
         self.pkts_num_trig_pfc = self.test_params.get('pkts_num_trig_pfc')
         if not self.pkts_num_trig_pfc:
@@ -3850,7 +3851,7 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
         platform_asic = self.test_params['platform_asic']
 
         # get counter names to query
-        ingress_counters, egress_counters = get_counter_names(sonic_version)
+        ingress_counters, egress_counters = get_counter_names(sonic_version, asic_type)
 
         # prepare tcp packet data
         ttl = 64
@@ -4297,8 +4298,9 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         router_mac = self.test_params['router_mac']
         print("router_mac: %s" % (router_mac), file=sys.stderr)
         pg = int(self.test_params['pg'])
+        asic_type = self.test_params['sonic_asic_type']
         ingress_counters, egress_counters = get_counter_names(
-            self.test_params['sonic_version'])
+            self.test_params['sonic_version'], asic_type)
         dst_port_id = int(self.test_params['dst_port_id'])
         dst_port_ip = self.test_params['dst_port_ip']
         dst_port_mac = self.dataplane.get_mac(0, dst_port_id)
@@ -4307,7 +4309,7 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         src_port_vlan = self.test_params['src_port_vlan']
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
 
-        asic_type = self.test_params['sonic_asic_type']
+
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
         pkts_num_fill_min = int(self.test_params['pkts_num_fill_min'])
         pkts_num_fill_shared = int(self.test_params['pkts_num_fill_shared'])
@@ -4919,8 +4921,9 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         switch_init(self.clients)
 
         # Parse input parameters
+        asic_type = self.test_params['sonic_asic_type']
         ingress_counters, egress_counters = get_counter_names(
-            self.test_params['sonic_version'])
+            self.test_params['sonic_version'], asic_type)
         dscp = int(self.test_params['dscp'])
         ecn = int(self.test_params['ecn'])
         router_mac = self.test_params['router_mac']
@@ -4934,7 +4937,7 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         src_port_vlan = self.test_params['src_port_vlan']
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
 
-        asic_type = self.test_params['sonic_asic_type']
+
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
         pkts_num_fill_min = int(self.test_params['pkts_num_fill_min'])
         pkts_num_trig_drp = int(self.test_params['pkts_num_trig_drp'])

--- a/tests/saitests/py3/switch.py
+++ b/tests/saitests/py3/switch.py
@@ -792,6 +792,9 @@ def sai_thrift_read_port_counters(client, asic_type, port):
     port_cnt_ids.append(SAI_PORT_STAT_IF_IN_UCAST_PKTS)
     port_cnt_ids.append(SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS)
     port_cnt_ids.append(SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS)
+    if asic_type == 'broadcom':
+        port_cnt_ids.remove(SAI_PORT_STAT_IN_DROPPED_PKTS)
+        port_cnt_ids.remove(SAI_PORT_STAT_OUT_DROPPED_PKTS)
     if asic_type != 'mellanox':
         port_cnt_ids.append(SAI_PORT_STAT_IF_OUT_QLEN)
 

--- a/tests/saitests/py3/switch.py
+++ b/tests/saitests/py3/switch.py
@@ -801,6 +801,9 @@ def sai_thrift_read_port_counters(client, asic_type, port):
     counters_results = []
     counters_results = client.sai_thrift_get_port_stats(
         port, port_cnt_ids, len(port_cnt_ids))
+    if asic_type == 'broadcom':
+        counters_results.insert(12, 0)
+        counters_results.insert(13, 0)
     if asic_type == 'mellanox':
         counters_results.append(0)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
SAI_PORT_STAT_IN/OUT_DROPPED_PKTS is not supported for DNX. #**CS00012344046**
Added a check in sonic-mgmt qos test for dnx , not to query this counter.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
The sai-thrift_read_port_counters function will update the list for dnx and then read the counters.

#### What is the motivation for this PR?

#### How did you do it?
The sai-thrift_read_port_counters function will update the list for dnx and then read the counters.
The test cases are updated accordingly in sai_qos_tests.py 
#### How did you verify/test it?
Executed the  qos test and verify the counters are read correctly.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
