### PR TITLE
Move stable test from onboarding job to t0/t1 job

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -1,8 +1,14 @@
 t0:
+  - acl/custom_acl_table/test_custom_acl_table.py
+  - acl/null_route/test_null_route_helper.py
+  - acl/test_acl.py
+  - acl/test_stress_acl.py
   - arp/test_arp_extended.py
   - arp/test_neighbor_mac.py
   - arp/test_neighbor_mac_noptf.py
+  - arp/test_stress_arp.py
   - arp/test_tagged_arp.py
+  - arp/test_wr_arp.py
   # Due to the auto start fails on container restapi, comment this case temporarily
 #  - autorestart/test_container_autorestart.py
   - bgp/test_bgp_dual_asn.py
@@ -184,6 +190,8 @@ dualtor:
   - arp/test_arp_extended.py
 
 t1-lag:
+  - acl/test_acl.py
+  - acl/test_stress_acl.py
   - arp/test_arpall.py
   - arp/test_neighbor_mac_noptf.py
   - bgp/test_bgp_allow_list.py
@@ -338,18 +346,10 @@ onboarding_t0:
   - sub_port_interfaces/test_sub_port_l2_forwarding.py
   - system_health/test_system_health.py
   - test_pktgen.py
-  - acl/custom_acl_table/test_custom_acl_table.py
-  - acl/null_route/test_null_route_helper.py
-  - acl/test_acl.py
   - acl/test_acl_outer_vlan.py
-  - acl/test_stress_acl.py
-  - arp/test_stress_arp.py
   - arp/test_unknown_mac.py
-  - arp/test_wr_arp.py
 
 onboarding_t1:
-  - acl/test_acl.py
-  - acl/test_stress_acl.py
 
 specific_param:
   t0-sonic:

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -348,12 +348,10 @@ onboarding_t0:
   - test_pktgen.py
   - acl/test_acl_outer_vlan.py
   - arp/test_unknown_mac.py
-
-onboarding_t1:
-  - arp/test_wr_arp.py
   - decap/test_decap.py
 
-
+onboarding_t1:
+  - decap/test_decap.py
 
 specific_param:
   t0-sonic:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
I have added some dataplane test scripts to PR test and put into optional onboarding job to test case performance, I calculated the success rate of test scripts in recent 1 week, I think I can move high success rate test scripts to t0/t1 job now

TestbedName | ModulePath | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | --
vms-kvm-t1-lag | acl.test_acl.TestAclWithPortToggle | 3989 | 0 | 3989 | 1
vms-kvm-t1-lag | acl.test_acl.TestAclWithReboot | 4013 | 2 | 4015 | 0.9995
vms-kvm-t1-lag | acl.test_acl.TestBasicAcl | 3361 | 0 | 3361 | 1
vms-kvm-t1-lag | acl.test_acl.TestIncrementalAcl | 4008 | 0 | 4008 | 1
vms-kvm-t1-lag | acl.test_stress_acl | 59 | 0 | 59 | 1
vms-kvm-t0 | acl.custom_acl_table.test_custom_acl_table | 104 | 0 | 104 | 1
vms-kvm-t0 | acl.null_route.test_null_route_helper | 105 | 0 | 105 | 1
vms-kvm-t0 | acl.test_acl.TestAclWithPortToggle | 5215 | 0 | 5215 | 1
vms-kvm-t0 | acl.test_acl.TestAclWithReboot | 4920 | 1 | 4921 | 0.9998
vms-kvm-t0 | acl.test_acl.TestBasicAcl | 3063 | 0 | 3063 | 1
vms-kvm-t0 | acl.test_acl.TestIncrementalAcl | 3734 | 0 | 3734 | 1
vms-kvm-t0 | acl.test_stress_acl | 119 | 1 | 120 | 0.9917
vms-kvm-t0 | arp.test_stress_arp | 173 | 1 | 174 | 0.9943
vms-kvm-t0 | arp.test_wr_arp.TestWrArp | 154 | 0 | 154 | 1


#### How did you do it?
Move test from onboarding job to t0/t1 job
#### How did you verify/test it?
Run PR test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
