### PR TITLE
Fix dualtor sanity mux probe recovery

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -599,10 +599,14 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs):
             return False, err_msg, {}
 
     if not check_success:
-        if len(dut_wrong_mux_status_ports) == 0:
+        if len(dut_wrong_mux_status_ports) != 0:
             # NOTE: Let's probe here to see if those inconsistent mux ports could be
             # restored before using the recovery method.
-            _probe_mux_ports(duthosts, dut_wrong_mux_status_ports)
+            port_index_map = duts_minigraph_facts[duthosts[0].hostname][0][1]['minigraph_port_indices']
+            dut_wrong_mux_status_ports = set(dut_wrong_mux_status_ports)
+            inconsistent_mux_ports = [port for port, port_index in port_index_map.items()
+                                      if port_index in dut_wrong_mux_status_ports]
+            _probe_mux_ports(duthosts, inconsistent_mux_ports)
         if not wait_until(60, 10, 0, _check_mux_status_helper):
             if err_msg_from_mux_status:
                 err_msg = err_msg_from_mux_status[-1]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix the sanity check mux probe recovery.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Use the port name to probe instead of the port index.

#### How did you verify/test it?
Run `test_bgp_fact.py` on dualtor with inconsistent mux ports.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
