### PR TITLE
[Snappi] random.sample exception in multidut snappi test cases.

### DIFF
--- a/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
@@ -54,7 +54,7 @@ def test_dequeue_ecn(request,
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if

--- a/tests/snappi_tests/multidut/ecn/test_multidut_red_accuracy_with_snappi.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_red_accuracy_with_snappi.py
@@ -59,7 +59,7 @@ def test_red_accuracy(request,
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]      # noqa: E501

--- a/tests/snappi_tests/multidut/pfc/test_lossless_response_to_external_pause_storms.py
+++ b/tests/snappi_tests/multidut/pfc/test_lossless_response_to_external_pause_storms.py
@@ -60,7 +60,7 @@ def test_lossless_response_to_external_pause_storms_test(snappi_api,            
     if line_card_choice not in linecard_configuration_set.keys():
         assert False, "Invalid line_card_choice value passed in parameter"
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if

--- a/tests/snappi_tests/multidut/pfc/test_lossless_response_to_throttling_pause_storms.py
+++ b/tests/snappi_tests/multidut/pfc/test_lossless_response_to_throttling_pause_storms.py
@@ -62,7 +62,7 @@ def test_lossless_response_to_throttling_pause_storms(snappi_api,               
     if line_card_choice not in linecard_configuration_set.keys():
         pytest_assert(False, "Invalid line_card_choice value passed in parameter")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if

--- a/tests/snappi_tests/multidut/pfc/test_m2o_fluctuating_lossless.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_fluctuating_lossless.py
@@ -60,7 +60,7 @@ def test_m2o_fluctuating_lossless(snappi_api,                  # noqa: F811
     if line_card_choice not in linecard_configuration_set.keys():
         pytest_assert(False, "Invalid line_card_choice value passed in parameter")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if

--- a/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless.py
@@ -60,7 +60,7 @@ def test_m2o_oversubscribe_lossless(snappi_api,                              # n
     if line_card_choice not in linecard_configuration_set.keys():
         pytest_assert(False, "Invalid line_card_choice value passed in parameter")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if

--- a/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless_lossy.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless_lossy.py
@@ -59,7 +59,7 @@ def test_m2o_oversubscribe_lossless_lossy(snappi_api,                   # noqa: 
     if line_card_choice not in linecard_configuration_set.keys():
         assert False, "Invalid line_card_choice value passed in parameter"
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if

--- a/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossy.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossy.py
@@ -57,7 +57,7 @@ def test_m2o_oversubscribe_lossy(snappi_api,                                  # 
     if line_card_choice not in linecard_configuration_set.keys():
         pytest_assert(False, "Invalid line_card_choice value passed in parameter")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if

--- a/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
@@ -49,7 +49,7 @@ def test_global_pause(snappi_api,                                   # noqa: F811
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]      # noqa: E501

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -56,7 +56,7 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts
@@ -135,7 +135,7 @@ def test_pfc_pause_multi_lossless_prio(snappi_api,                  # noqa: F811
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts
@@ -217,7 +217,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts
@@ -313,7 +313,7 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noq
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -58,7 +58,7 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts
@@ -136,7 +136,7 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts
@@ -218,7 +218,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts
@@ -313,7 +313,7 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_a2a_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_a2a_with_snappi.py
@@ -50,7 +50,7 @@ def test_multidut_pfcwd_all_to_all(snappi_api,                  # noqa: F811
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
@@ -54,7 +54,7 @@ def test_pfcwd_basic_single_lossless_prio(snappi_api,                   # noqa: 
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if
@@ -131,7 +131,7 @@ def test_pfcwd_basic_multi_lossless_prio(snappi_api,                # noqa F811
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if
@@ -211,7 +211,7 @@ def test_pfcwd_basic_single_lossless_prio_reboot(snappi_api,                # no
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if
@@ -299,7 +299,7 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if
@@ -385,7 +385,7 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if
@@ -471,7 +471,7 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_burst_storm_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_burst_storm_with_snappi.py
@@ -49,7 +49,7 @@ def test_pfcwd_burst_storm_single_lossless_prio(snappi_api,             # noqa: 
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_m2o_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_m2o_with_snappi.py
@@ -51,7 +51,7 @@ def test_pfcwd_many_to_one(snappi_api,              # noqa: F811
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_runtime_traffic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_runtime_traffic_with_snappi.py
@@ -43,7 +43,7 @@ def test_pfcwd_runtime_traffic(snappi_api,                  # noqa: F811
     pytest_assert(line_card_choice in linecard_configuration_set.keys(), "Invalid line_card_choice in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]      # noqa: E501

--- a/tests/snappi_tests/test_multidut_snappi.py
+++ b/tests/snappi_tests/test_multidut_snappi.py
@@ -111,7 +111,7 @@ def test_snappi(request,
         assert False, "Invalid line_card_choice value passed in parameter"
 
     if len(linecard_configuration_set[line_card_choice]['hostname']) > 1:
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
     elif len(linecard_configuration_set[line_card_choice]['hostname']) == 1:
         dut_list = [dut for dut in duthosts
                     if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes random.sample error in multidut test cases.

```
snappi_tests/multidut/pfcwd/test_multidut_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all[linecard_configuration_set0-chassis_multi_line_card_multi_asic-False]
-------------------------------- live log call ---------------------------------
12:09:41 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 1788, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 501, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 119, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 138, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 102, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/data/sonic-mgmt-int/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_a2a_with_snappi.py", line 53, in test_multidut_pfcwd_all_to_all
    dut_list = random.sample(duthosts, 2)
  File "/usr/lib/python3.8/random.py", line 359, in sample
    raise TypeError("Population must be a sequence or set.  For dicts, use list(d).")
TypeError: Population must be a sequence or set.  For dicts, use list(d).
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix random.sample exception in multidut snappi test cases.

#### How did you do it?
use list(duthosts)

#### How did you verify/test it?
Run it manually 

#### Any platform specific information?
Should only see in multiple host names.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
