### PR TITLE
[Snappi]: Corrections in calling get_pfcwd_config_attr function and new PFCWD stats function to capture PFCWD statistics.

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -32,7 +32,7 @@ def increment_ip_address(ip, incr=1):
     ipaddress = ipaddr.IPv4Address(ip)
     ipaddress = ipaddress + incr
     return_value = ipaddress._string_from_ip_int(ipaddress._ip)
-    return(return_value)
+    return return_value
 
 
 def ansible_stdout_to_str(ansible_stdout):

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -644,7 +644,8 @@ def get_pfcwd_poll_interval(host_ans, asic_value=None):
         val = get_pfcwd_config_attr(host_ans=host_ans,
                                     config_scope='GLOBAL',
                                     attr='POLL_INTERVAL',
-                                    namespace=asic_value)
+                                    #namespace=asic_value)
+                                    asic_value=asic_value)
 
     if val is not None:
         return int(val)
@@ -671,7 +672,8 @@ def get_pfcwd_detect_time(host_ans, intf, asic_value=None):
         val = get_pfcwd_config_attr(host_ans=host_ans,
                                     config_scope=intf,
                                     attr='detection_time',
-                                    namespace=asic_value)
+                                    #namespace=asic_value)
+                                    asic_value=asic_value)
 
     if val is not None:
         return int(val)
@@ -698,13 +700,48 @@ def get_pfcwd_restore_time(host_ans, intf, asic_value=None):
         val = get_pfcwd_config_attr(host_ans=host_ans,
                                     config_scope=intf,
                                     attr='restoration_time',
-                                    namespace=asic_value)
+                                    #namespace=asic_value)
+                                    asic_value=asic_value)
 
     if val is not None:
         return int(val)
 
     return None
 
+
+def get_pfcwd_stats(duthost, port, prio, asic_value=None):
+    """
+    Get PFC watchdog statistics for given interface:prio
+    Args:
+        duthost		: Ansible host instance of the device
+	port		: Port for which stats needs to be gathered.
+	prio		: Lossless priority for which stats needs to be captured.
+        asic_value	: asic value of the host
+
+    Returns:
+        Dictionary with PFCWD statistics as key-value pair.
+	If the entry is not present, then values are returned as zero.
+    """
+
+    pfcwd_stats = {}
+    if asic_value is None:
+        raw_out = duthost.shell("show pfcwd stats | grep -E 'QUEUE|{}:{}'".format(port, prio))['stdout']
+    else:
+        raw_out = duthost.shell("sudo ip netns exec {} show pfcwd stats | grep -E 'QUEUE|{}:{}'".format(asic_value, port, prio))['stdout']
+
+    val_list = []
+    key_list = []
+    for line in raw_out.split('\n'):
+        if ('QUEUE' in line):
+                key_list = (re.sub(r"(\w) (\w)", r"\1_\2", line)).split()
+        else:
+                val_list = line.split()
+    if val_list:
+        for key, val in zip(key_list, val_list): pfcwd_stats[key]=val
+    else:
+        pfcwd_stats = {key: '0/0' if '/' in key else 0 for key in key_list}
+
+    return pfcwd_stats
 
 def start_pfcwd(duthost, asic_value=None):
     """

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -644,7 +644,6 @@ def get_pfcwd_poll_interval(host_ans, asic_value=None):
         val = get_pfcwd_config_attr(host_ans=host_ans,
                                     config_scope='GLOBAL',
                                     attr='POLL_INTERVAL',
-                                    #namespace=asic_value)
                                     asic_value=asic_value)
 
     if val is not None:
@@ -672,7 +671,6 @@ def get_pfcwd_detect_time(host_ans, intf, asic_value=None):
         val = get_pfcwd_config_attr(host_ans=host_ans,
                                     config_scope=intf,
                                     attr='detection_time',
-                                    #namespace=asic_value)
                                     asic_value=asic_value)
 
     if val is not None:
@@ -700,7 +698,6 @@ def get_pfcwd_restore_time(host_ans, intf, asic_value=None):
         val = get_pfcwd_config_attr(host_ans=host_ans,
                                     config_scope=intf,
                                     attr='restoration_time',
-                                    #namespace=asic_value)
                                     asic_value=asic_value)
 
     if val is not None:
@@ -714,34 +711,37 @@ def get_pfcwd_stats(duthost, port, prio, asic_value=None):
     Get PFC watchdog statistics for given interface:prio
     Args:
         duthost		: Ansible host instance of the device
-	port		: Port for which stats needs to be gathered.
-	prio		: Lossless priority for which stats needs to be captured.
+        port		: Port for which stats needs to be gathered.
+        prio		: Lossless priority for which stats needs to be captured.
         asic_value	: asic value of the host
 
     Returns:
         Dictionary with PFCWD statistics as key-value pair.
-	If the entry is not present, then values are returned as zero.
+        If the entry is not present, then values are returned as zero.
     """
 
     pfcwd_stats = {}
     if asic_value is None:
         raw_out = duthost.shell("show pfcwd stats | grep -E 'QUEUE|{}:{}'".format(port, prio))['stdout']
     else:
-        raw_out = duthost.shell("sudo ip netns exec {} show pfcwd stats | grep -E 'QUEUE|{}:{}'".format(asic_value, port, prio))['stdout']
+        comm = "sudo ip netns exec {} show pfcwd stats | grep -E 'QUEUE|{}:{}'".format(asic_value, port, prio)
+        raw_out = duthost.shell(comm)['stdout']
 
     val_list = []
     key_list = []
     for line in raw_out.split('\n'):
         if ('QUEUE' in line):
-                key_list = (re.sub(r"(\w) (\w)", r"\1_\2", line)).split()
+            key_list = (re.sub(r"(\w) (\w)", r"\1_\2", line)).split()
         else:
-                val_list = line.split()
+            val_list = line.split()
     if val_list:
-        for key, val in zip(key_list, val_list): pfcwd_stats[key]=val
+        for key, val in zip(key_list, val_list):
+            pfcwd_stats[key] = val
     else:
         pfcwd_stats = {key: '0/0' if '/' in key else 0 for key in key_list}
 
     return pfcwd_stats
+
 
 def start_pfcwd(duthost, asic_value=None):
     """

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
@@ -62,14 +62,16 @@ def run_pfcwd_basic_test(api,
     tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
     pytest_assert(testbed_config is not None, 'Fail to get L2/3 testbed config')
 
-    start_pfcwd(duthost1, rx_port['asic_value'])
-    start_pfcwd(duthost2, tx_port['asic_value'])
-    if ("platform_asic" in duthost1.facts and duthost1.facts["platform_asic"] == "broadcom-dnx"):
+    if (duthost1.is_multi_asic):
         enable_packet_aging(duthost1, rx_port['asic_value'])
         enable_packet_aging(duthost2, tx_port['asic_value'])
+        start_pfcwd(duthost1, rx_port['asic_value'])
+        start_pfcwd(duthost2, tx_port['asic_value'])
     else:
         enable_packet_aging(duthost1)
         enable_packet_aging(duthost2)
+        start_pfcwd(duthost1)
+        start_pfcwd(duthost2)
 
     ini_stats = {}
     for prio in prio_list:

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
@@ -7,7 +7,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_grap
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                              # noqa: F401
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, \
     get_pfcwd_poll_interval, get_pfcwd_detect_time, get_pfcwd_restore_time, \
-    enable_packet_aging, start_pfcwd, sec_to_nanosec                                              # noqa: F401
+    enable_packet_aging, start_pfcwd, sec_to_nanosec, get_pfcwd_stats                             # noqa: F401
 from tests.common.snappi_tests.port import select_ports, select_tx_port                           # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp                                 # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
@@ -63,9 +63,17 @@ def run_pfcwd_basic_test(api,
     pytest_assert(testbed_config is not None, 'Fail to get L2/3 testbed config')
 
     start_pfcwd(duthost1, rx_port['asic_value'])
-    enable_packet_aging(duthost1)
     start_pfcwd(duthost2, tx_port['asic_value'])
-    enable_packet_aging(duthost2)
+    if ("platform_asic" in duthost1.facts and duthost1.facts["platform_asic"] == "broadcom-dnx"):
+        enable_packet_aging(duthost1, rx_port['asic_value'])
+        enable_packet_aging(duthost2, tx_port['asic_value'])
+    else:
+        enable_packet_aging(duthost1)
+        enable_packet_aging(duthost2)
+
+    ini_stats = {}
+    for prio in prio_list: 
+        ini_stats.update(get_stats(duthost1, rx_port['peer_port'], prio))
 
     # Set appropriate pfcwd loss deviation - these values are based on empirical testing
     DEVIATION = 0.35 if duthost1.facts['asic_type'] in ["broadcom"] or \
@@ -136,10 +144,46 @@ def run_pfcwd_basic_test(api,
                                all_flow_names=all_flow_names,
                                exp_dur_sec=exp_dur_sec)
 
+    fin_stats = {}
+    for prio in prio_list: 
+        fin_stats.update(get_stats(duthost1, rx_port['peer_port'], prio))
+
+    loss_packets = 0
+    for k in fin_stats.keys():
+        logger.info('Parameter:{}, Initial Value:{}, Final Value:{}'.format(k, ini_stats[k], fin_stats[k]))
+        if 'DROP' in k: loss_packets += (int(fin_stats[k]) - int(ini_stats[k]))
+
+    logger.info('Total PFCWD drop packets before and after the test:{}'.format(loss_packets))
+
     __verify_results(rows=flow_stats,
                      data_flow_name_list=[DATA_FLOW1_NAME, DATA_FLOW2_NAME],
                      data_flow_min_loss_rate_list=[flow1_min_loss_rate, 0],
-                     data_flow_max_loss_rate_list=[flow1_max_loss_rate, 0])
+                     #data_flow_max_loss_rate_list=[flow1_max_loss_rate, 0])
+                     data_flow_max_loss_rate_list=[flow1_max_loss_rate, 0],
+                     loss_packets=loss_packets)
+
+
+def get_stats(duthost, port, prio):
+    """
+    Returns the PFCWD stats for Tx Ok, Tx drop, Storm detected and restored.
+
+    Args:
+	duthost (obj): DUT
+	port (string): Port on the DUT
+	prio (int):    Priority
+
+    Returns:
+	Dictionary with prio_'parameter' as key and associated value 
+
+    """
+    my_dict = {}
+    new_dict = {}
+    init_pfcwd = get_pfcwd_stats(duthost, port, prio)
+    key_list = ['TX_OK/DROP', 'STORM_DETECTED/RESTORED']
+    for keys in key_list: my_dict[keys] = init_pfcwd[keys]
+    new_dict = {str(prio)+'_'+k: v for key, value in my_dict.items() for k, v in zip(key.split('/'), value.split('/'))}
+
+    return new_dict
 
 
 def __gen_traffic(testbed_config,
@@ -336,7 +380,8 @@ def __run_traffic(api, config, all_flow_names, exp_dur_sec):
 def __verify_results(rows,
                      data_flow_name_list,
                      data_flow_min_loss_rate_list,
-                     data_flow_max_loss_rate_list):
+                     data_flow_max_loss_rate_list,
+                     loss_packets):
     """
     Verify if we get expected experiment results
 
@@ -363,7 +408,9 @@ def __verify_results(rows,
                 data_flow_tx_frames_list[i] += tx_frames
                 data_flow_rx_frames_list[i] += rx_frames
 
+    tgen_loss_packets = 0
     for i in range(num_data_flows):
+        tgen_loss_packets += data_flow_tx_frames_list[i] - data_flow_rx_frames_list[i]
         loss_rate = 1 - \
             float(data_flow_rx_frames_list[i]) / data_flow_tx_frames_list[i]
         min_loss_rate = data_flow_min_loss_rate_list[i]
@@ -372,3 +419,6 @@ def __verify_results(rows,
         pytest_assert(loss_rate <= max_loss_rate and loss_rate >= min_loss_rate,
                       'Loss rate of {} ({}) should be in [{}, {}]'.format(
                           data_flow_name_list[i], loss_rate, min_loss_rate, max_loss_rate))
+
+    logger.info('TGEN Loss packets:{}'.format(tgen_loss_packets))
+

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
@@ -72,7 +72,7 @@ def run_pfcwd_basic_test(api,
         enable_packet_aging(duthost2)
 
     ini_stats = {}
-    for prio in prio_list: 
+    for prio in prio_list:
         ini_stats.update(get_stats(duthost1, rx_port['peer_port'], prio))
 
     # Set appropriate pfcwd loss deviation - these values are based on empirical testing
@@ -145,20 +145,20 @@ def run_pfcwd_basic_test(api,
                                exp_dur_sec=exp_dur_sec)
 
     fin_stats = {}
-    for prio in prio_list: 
+    for prio in prio_list:
         fin_stats.update(get_stats(duthost1, rx_port['peer_port'], prio))
 
     loss_packets = 0
     for k in fin_stats.keys():
         logger.info('Parameter:{}, Initial Value:{}, Final Value:{}'.format(k, ini_stats[k], fin_stats[k]))
-        if 'DROP' in k: loss_packets += (int(fin_stats[k]) - int(ini_stats[k]))
+        if 'DROP' in k:
+            loss_packets += (int(fin_stats[k]) - int(ini_stats[k]))
 
     logger.info('Total PFCWD drop packets before and after the test:{}'.format(loss_packets))
 
     __verify_results(rows=flow_stats,
                      data_flow_name_list=[DATA_FLOW1_NAME, DATA_FLOW2_NAME],
                      data_flow_min_loss_rate_list=[flow1_min_loss_rate, 0],
-                     #data_flow_max_loss_rate_list=[flow1_max_loss_rate, 0])
                      data_flow_max_loss_rate_list=[flow1_max_loss_rate, 0],
                      loss_packets=loss_packets)
 
@@ -168,19 +168,20 @@ def get_stats(duthost, port, prio):
     Returns the PFCWD stats for Tx Ok, Tx drop, Storm detected and restored.
 
     Args:
-	duthost (obj): DUT
-	port (string): Port on the DUT
-	prio (int):    Priority
+        duthost (obj): DUT
+        port (string): Port on the DUT
+        prio (int):    Priority
 
     Returns:
-	Dictionary with prio_'parameter' as key and associated value 
+        Dictionary with prio_'parameter' as key and associated value.
 
     """
     my_dict = {}
     new_dict = {}
     init_pfcwd = get_pfcwd_stats(duthost, port, prio)
     key_list = ['TX_OK/DROP', 'STORM_DETECTED/RESTORED']
-    for keys in key_list: my_dict[keys] = init_pfcwd[keys]
+    for keys in key_list:
+        my_dict[keys] = init_pfcwd[keys]
     new_dict = {str(prio)+'_'+k: v for key, value in my_dict.items() for k, v in zip(key.split('/'), value.split('/'))}
 
     return new_dict
@@ -421,4 +422,3 @@ def __verify_results(rows,
                           data_flow_name_list[i], loss_rate, min_loss_rate, max_loss_rate))
 
     logger.info('TGEN Loss packets:{}'.format(tgen_loss_packets))
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
PFCWD testcases should capture PFCWD statistics before and after the test.

The function get_pfcwd_config_attr was defined with one of the arguments as 'asic_value' but while calling the function, 'namespace' was being used.  Corrected to use 'asic_value" while calling the get_pfcwd_config_attr function.



Summary:
Fixes # (issue)
Github issue #12900 
Github issue #12987 


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?

The PFCWD statistics should be captured before and after the testcases to ensure that storm detected/restored is incremented during the test. 

Similarly, the PFCWD drop counters should be also checked before and after the test to confirm the count of packets dropped during the test.

#### How did you do it?
Defined a function in tests/common/snappi_tests/common_helper.py to capture PFCWD stats for a given DUT, interface and priority. The function returns back all variables in form of a dictionary. If the stats are not present, then values are returned as zero for all the attributes.

The tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py calls this function before and after the test and calculates the 'loss_packets' on the DUT, which is difference of TX_DROPS returned via PFCWD statistics.

The 'loss_packets' is sent as one of parameters for function 'verify_results'. The 'tgen_loss_packets' is capturing the loss packets which is difference of Tx - Rx packets on IXIA.

We can further enhance this to fail the testcase if the drops do not match.

#### How did you verify/test it?
Ran the testcases on local T2 chassis setup.

Truncated Code output:
| Parameter:4_STORM_DETECTED, Initial Value:5, Final Value:5
| Parameter:4_RESTORED, Initial Value:5, Final Value:5
| Parameter:4_DROP, Initial Value:14092468, Final Value:14092468
| Parameter:4_TX_OK, Initial Value:20241318, Final Value:20241318
| Total PFCWD drop packets before and after the test:0
| TGEN Loss packets:0
`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
