### PR TITLE
 [Snappi] Fixes for T2 ixia test cases: Traffic MAC address, peer_ports, SnappiFanout 

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -794,6 +794,7 @@ def get_multidut_tgen_peer_port_set(line_card_choice, ports, config_set, number_
     """
     linecards = {}
     try:
+        from itertools import product
         from itertools import izip_longest as zip_longest
     except ImportError:
         from itertools import zip_longest

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -617,7 +617,7 @@ def get_multidut_snappi_ports(duthosts, conn_graph_facts, fanout_graph_facts):  
         ports = []
         for index, host in enumerate(duthosts):
             snappi_fanout_list = SnappiFanoutManager(fanout_graph_facts)
-            for i in range(0, 3):
+            for i in range(len(snappi_fanout_list.fanout_list)):
                 try:
                     snappi_fanout_list.get_fanout_device_details(i)
                 except Exception:
@@ -771,7 +771,7 @@ def __intf_config_multidut(config, port_config_list, duthost, snappi_ports):
                                         ip=tgenIp,
                                         mac=mac,
                                         gw=dutIp,
-                                        gw_mac=str(duthost.facts['router_mac']),
+                                        gw_mac=duthost.get_dut_iface_mac(port['peer_port']),
                                         prefix_len=prefix_length,
                                         port_type=SnappiPortType.IPInterface,
                                         peer_port=port['peer_port']
@@ -850,8 +850,9 @@ def get_multidut_tgen_peer_port_set(line_card_choice, ports, config_set, number_
     elif line_card_choice in ['chassis_multi_line_card_multi_asic']:
         # Different line card and minimum one port from different asic number
         if len(linecards.keys()) >= 2:
-            host_asic = list(zip(config_set[line_card_choice]['hostname'], config_set[line_card_choice]['asic']))
-            peer_ports = list(zip_longest(*[linecards[host][asic] for host, asic in host_asic]))
+            host_asic = list(product(config_set[line_card_choice]['hostname'], config_set[line_card_choice]['asic']))
+            peer_ports = list(zip_longest(*[linecards[host][asic]
+                              for host, asic in host_asic if asic in linecards[host]]))
             peer_ports = [item for sublist in peer_ports for item in sublist]
             peer_ports = list(filter(None, peer_ports))
             return peer_ports[:number_of_tgen_peer_ports]

--- a/tests/common/snappi_tests/snappi_helpers.py
+++ b/tests/common/snappi_tests/snappi_helpers.py
@@ -80,7 +80,9 @@ class SnappiFanoutManager():
         self.ip_address = '0.0.0.0'
 
         for fanout in list(fanout_data.keys()):
-            self.fanout_list.append(fanout_data[fanout])
+            # only snappi fanout, skip other fanout type(eos, sonic, etc.)
+            if fanout_data[fanout]['device_info']['HwSku'] in ('SNAPPI-tester', 'IXIA-tester'):
+                self.fanout_list.append(fanout_data[fanout])
 
     def __parse_fanout_connections__(self):
         device_conn = self.last_device_connection_details
@@ -94,7 +96,7 @@ class SnappiFanoutManager():
                 format(self.ip_address, fanout_port, peer_port, peer_device, speed)
             retval.append(string)
 
-        return(retval)
+        return (retval)
 
     def get_fanout_device_details(self, device_number):
         """With the help of this function you can select the chassis you want
@@ -145,7 +147,7 @@ class SnappiFanoutManager():
         Returns:
             Details of the chassis connection as dictionary format.
         """
-        return(self.last_device_connection_details)
+        return (self.last_device_connection_details)
 
     def get_chassis_ip(self):
         """This function returns IP address of a particular chassis

--- a/tests/snappi_tests/variables.py
+++ b/tests/snappi_tests/variables.py
@@ -49,13 +49,13 @@ config_set = {
                 }
             }
 
-dut_ip_start = '20.1.1.1'
-snappi_ip_start = '20.1.1.2'
-prefix_length = 8
+dut_ip_start = '20.1.1.0'
+snappi_ip_start = '20.1.1.1'
+prefix_length = 31
 
 dut_ipv6_start = '2000:1::1'
 snappi_ipv6_start = '2000:1::2'
-v6_prefix_length = 16
+v6_prefix_length = 126
 
 pfcQueueGroupSize = 8  # can have values 4 or 8
 pfcQueueValueDict = {0: 0,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes :
1. Chose gateway MAC based on port, as the gateway MAC maybe different on packet chassis.
2. change peer_ports calculation in get_multidut_tgen_peer_port_set to cover all the dut/asic combination.
3. SnappiFanoutManager only supports Snappi chassis, so ignore other type of fanout switches during initialization.
4. change the default prefix length to /31 (ipv4), /126(ipv6). as these are the default prefix length that will be advertised in SONiC BGP for connected routes.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fixes needed to run test_multidut_pfcwd_a2a_with_snappi.py

#### How did you do it?
1. Chose gateway MAC based on port, as the gateway MAC maybe different on packet chassis.
2. change peer_ports calculation in get_multidut_tgen_peer_port_set to cover all the dut/asic combination.
3. SnappiFanoutManager only supports Snappi chassis, so ignore other type of fanout switches during initialization.

#### How did you verify/test it?
Run test manually.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
