### PR TITLE
fix: support multi asic for config reload

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -158,6 +158,13 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
         time.sleep(wait)
 
     if wait_for_bgp:
-        bgp_neighbors = sonic_host.get_bgp_neighbors().keys()
-        pytest_assert(wait_until(120, 10, 0, sonic_host.check_bgp_session_state, bgp_neighbors),
-                      "Not all bgp sessions are established after config reload")
+        if sonic_host.is_multi_asic:
+            bgp_neighbors = sonic_host.get_bgp_neighbors_per_asic()
+            pytest_assert(
+                wait_until(120, 10, 0, sonic_host.check_bgp_session_state_all_asics, bgp_neighbors),
+                "Not all bgp sessions are established after config reload",
+            )
+        else:
+            bgp_neighbors = sonic_host.get_bgp_neighbors().keys()
+            pytest_assert(wait_until(120, 10, 0, sonic_host.check_bgp_session_state, bgp_neighbors),
+                          "Not all bgp sessions are established after config reload")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add multi asic support when `wait_for_bgp` is True in `tests/common/config_reload.py`

Summary:
Fixes # (issue) Microsoft ADO 28459397

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Currently, if `wait_for_bgp` is True [here](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/common/config_reload.py#L160) in `tests/common/config_reload.py`, a multi-asic Testbed might never meet the `check_bgp_session_state` check. This is due to the restrictions of the show ip bgp command. For example, we have the following output for the `show ip bgp summary -d all` command:

![image](https://github.com/sonic-net/sonic-mgmt/assets/49756587/1d6a75f7-d4bf-4e3a-9663-72a15838f883)

We can see there are multiple `3.3.3.3` neighbors in the output, and this is because `3.3.3.3` is the neighbor for each ASIC. However, when we try to get the `bgp_neighbors` [here](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/common/config_reload.py#L161) from the [get_bgp_neighbors()](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/common/devices/multi_asic.py#L522) function, we actually update the dictionary with all ASICs. Therefore, when we compare the length between `neigh_ips` and `neigh_ok` in [check_bgp_session_state()](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/common/devices/multi_asic.py#L558), they will never be equal, because `neigh_ips` doesn't contain duplicates while `neigh_ok` contains duplicates, for a mutli-asic testbed.

#### How did you do it?
I updated the `config_reload()` function with multi asic support within the `if wait_for_bgp:` statement.

#### How did you verify/test it?
I manually put `config_reload(..., wait_for_bgp=True)` in a random test case and ran this test case in a multi-asic testbed (a T2 device). I can confirm this time `config_reload(..., wait_for_bgp=True)` passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
