### PR TITLE
Add ecmp inner hash test to PR test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -35,6 +35,10 @@ t0:
   - dut_console/test_console_baud_rate.py
   - dut_console/test_escape_character.py
   - dut_console/test_idle_timeout.py
+  - ecmp/inner_hashing/test_inner_hashing_lag.py
+  - ecmp/inner_hashing/test_inner_hashing.py
+  - ecmp/inner_hashing/test_wr_inner_hashing_lag.py
+  - ecmp/inner_hashing/test_wr_inner_hashing.py
   - everflow/test_everflow_ipv6.py
   - fdb/test_fdb.py
   - fdb/test_fdb_flush.py
@@ -347,10 +351,6 @@ onboarding_t0:
   - arp/test_unknown_mac.py
   - arp/test_wr_arp.py
   - decap/test_decap.py
-  - ecmp/inner_hashing/test_inner_hashing_lag.py
-  - ecmp/inner_hashing/test_inner_hashing.py
-  - ecmp/inner_hashing/test_wr_inner_hashing_lag.py
-  - ecmp/inner_hashing/test_wr_inner_hashing.py
 
 onboarding_t1:
   - acl/test_acl.py

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -347,6 +347,10 @@ onboarding_t0:
   - arp/test_unknown_mac.py
   - arp/test_wr_arp.py
   - decap/test_decap.py
+  - ecmp/inner_hashing/test_inner_hashing_lag.py
+  - ecmp/inner_hashing/test_inner_hashing.py
+  - ecmp/inner_hashing/test_wr_inner_hashing_lag.py
+  - ecmp/inner_hashing/test_wr_inner_hashing.py
 
 onboarding_t1:
   - acl/test_acl.py

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -483,9 +483,9 @@ ecmp/inner_hashing/test_inner_hashing.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox']"
+      - "asic_type not in ['mellanox', 'vs']"
       - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_inner_hashing_lag.py:
@@ -494,9 +494,9 @@ ecmp/inner_hashing/test_inner_hashing_lag.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox']"
+      - "asic_type not in ['mellanox', 'vs']"
       - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_wr_inner_hashing.py:
@@ -505,9 +505,9 @@ ecmp/inner_hashing/test_wr_inner_hashing.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox']"
+      - "asic_type not in ['mellanox', 'vs']"
       - "'dualtor' in topo_name"
 
 ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
@@ -516,9 +516,9 @@ ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
     reason: "PBH introduced in 202111 and skip this test on Mellanox 2700 platform. Test does not support dualtor topology."
     conditions:
       - "branch in ['201811', '201911', '202012', '202106']"
-      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0']"
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-kvm_x86_64-r0']"
       - "topo_type not in ['t0']"
-      - "asic_type not in ['mellanox']"
+      - "asic_type not in ['mellanox', 'vs']"
       - "'dualtor' in topo_name"
 
 ecmp/test_ecmp_sai_value.py:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -62,6 +62,41 @@ decap/test_decap.py:
       - "asic_type in ['vs']"
 
 #######################################
+#####             ecmp            #####
+#######################################
+ecmp/inner_hashing/test_inner_hashing.py:
+  skip_traffic_test:
+    conditions_logical_operator: or
+    reason: "Skip traffic test if not in mellanox platform."
+    conditions:
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0']"
+      - "asic_type not in ['mellanox']"
+
+ecmp/inner_hashing/test_inner_hashing_lag.py:
+  skip_traffic_test:
+    conditions_logical_operator: or
+    reason: "Skip traffic test if not in mellanox platform."
+    conditions:
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0']"
+      - "asic_type not in ['mellanox']"
+
+ecmp/inner_hashing/test_wr_inner_hashing.py:
+  skip_traffic_test:
+    conditions_logical_operator: or
+    reason: "Skip traffic test if not in mellanox platform."
+    conditions:
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0']"
+      - "asic_type not in ['mellanox']"
+
+ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
+  skip_traffic_test:
+    conditions_logical_operator: or
+    reason: "Skip traffic test if not in mellanox platform."
+    conditions:
+      - "platform not in ['x86_64-mlnx_msn3800-r0', 'x86_64-mlnx_msn4600c-r0']"
+      - "asic_type not in ['mellanox']"
+
+#######################################
 #####         everflow            #####
 #######################################
 everflow/test_everflow_ipv6.py:

--- a/tests/ecmp/inner_hashing/test_inner_hashing_lag.py
+++ b/tests/ecmp/inner_hashing/test_inner_hashing_lag.py
@@ -12,12 +12,12 @@ from retry.api import retry_call
 from tests.ptf_runner import ptf_runner
 from tests.ecmp.inner_hashing.conftest import get_src_dst_ip_range, FIB_INFO_FILE_DST,\
     VXLAN_PORT, PTF_QLEN, check_pbh_counters, OUTER_ENCAP_FORMATS, NVGRE_TNI, setup_lag_config, config_pbh_lag
+from tests.common.fixtures.ptfhost_utils import skip_traffic_test   # noqa F401
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0'),
-    pytest.mark.asic('mellanox')
+    pytest.mark.topology('t0')
 ]
 
 
@@ -33,7 +33,7 @@ class TestDynamicInnerHashingLag():
 
     def test_inner_hashing(self, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
                            vlan_ptf_ports, symmetric_hashing, duthost, lag_mem_ptf_ports_groups,
-                           get_function_completeness_level):
+                           get_function_completeness_level, skip_traffic_test):     # noqa F811
         logging.info("Executing dynamic inner hash test for outer {} and inner {} with symmetric_hashing set to {}"
                      .format(outer_ipver, inner_ipver, str(symmetric_hashing)))
         with allure.step('Run ptf test InnerHashTest'):
@@ -54,6 +54,8 @@ class TestDynamicInnerHashingLag():
                 balancing_test_times = 20
                 balancing_range = 0.5
 
+            if skip_traffic_test is True:
+                return
             ptf_runner(ptfhost,
                        "ptftests",
                        "inner_hash_test.InnerHashTest",

--- a/tests/ecmp/inner_hashing/test_wr_inner_hashing.py
+++ b/tests/ecmp/inner_hashing/test_wr_inner_hashing.py
@@ -9,13 +9,13 @@ from tests.common import reboot
 from tests.ecmp.inner_hashing.conftest import get_src_dst_ip_range, FIB_INFO_FILE_DST, VXLAN_PORT,\
     PTF_QLEN, OUTER_ENCAP_FORMATS, NVGRE_TNI, config_pbh
 from tests.ptf_runner import ptf_runner
+from tests.common.fixtures.ptfhost_utils import skip_traffic_test   # noqa F401
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('t0'),
-    pytest.mark.asic('mellanox')
+    pytest.mark.topology('t0')
 ]
 
 
@@ -29,7 +29,7 @@ class TestWRDynamicInnerHashing():
 
     def test_inner_hashing(self, duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
                            vlan_ptf_ports, symmetric_hashing, localhost, lag_mem_ptf_ports_groups,
-                           get_function_completeness_level):
+                           get_function_completeness_level, skip_traffic_test):     # noqa F811
         logging.info("Executing warm boot dynamic inner hash test for outer {} and inner {} with symmetric_hashing"
                      " set to {}".format(outer_ipver, inner_ipver, str(symmetric_hashing)))
         with allure.step('Run ptf test InnerHashTest and warm-reboot in parallel'):
@@ -57,6 +57,52 @@ class TestWRDynamicInnerHashing():
             reboot_thr = threading.Thread(target=reboot, args=(duthost, localhost, 'warm', 10, 0, 0, True, True,))
             reboot_thr.start()
 
+            if not skip_traffic_test:
+                ptf_runner(ptfhost,
+                           "ptftests",
+                           "inner_hash_test.InnerHashTest",
+                           platform_dir="ptftests",
+                           params={"fib_info": FIB_INFO_FILE_DST,
+                                   "router_mac": router_mac,
+                                   "src_ports": vlan_ptf_ports,
+                                   "exp_port_groups": lag_mem_ptf_ports_groups,
+                                   "hash_keys": hash_keys,
+                                   "vxlan_port": VXLAN_PORT,
+                                   "inner_src_ip_range": ",".join(inner_src_ip_range),
+                                   "inner_dst_ip_range": ",".join(inner_dst_ip_range),
+                                   "outer_src_ip_range": ",".join(outer_src_ip_range),
+                                   "outer_dst_ip_range": ",".join(outer_dst_ip_range),
+                                   "balancing_test_times": balancing_test_times,
+                                   "balancing_range": balancing_range,
+                                   "outer_encap_formats": outer_encap_format,
+                                   "nvgre_tni": NVGRE_TNI,
+                                   "symmetric_hashing": symmetric_hashing},
+                           log_file=log_file,
+                           qlen=PTF_QLEN,
+                           socket_recv_size=16384,
+                           is_python3=True)
+            reboot_thr.join()
+
+
+@pytest.mark.static_config
+class TestWRStaticInnerHashing():
+
+    def test_inner_hashing(self, duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
+                           vlan_ptf_ports, symmetric_hashing, localhost, lag_mem_ptf_ports_groups, skip_traffic_test):   # noqa F811
+        logging.info("Executing static inner hash test for outer {} and inner {} with symmetric_hashing set to {}"
+                     .format(outer_ipver, inner_ipver, str(symmetric_hashing)))
+        timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+        log_file = "/tmp/wr_inner_hash_test.StaticInnerHashTest.{}.{}.{}.log"\
+                   .format(outer_ipver, inner_ipver, timestamp)
+        logging.info("PTF log file: %s" % log_file)
+
+        outer_src_ip_range, outer_dst_ip_range = get_src_dst_ip_range(outer_ipver)
+        inner_src_ip_range, inner_dst_ip_range = get_src_dst_ip_range(inner_ipver)
+
+        reboot_thr = threading.Thread(target=reboot, args=(duthost, localhost, 'warm', 10, 0, 0, True, True,))
+        reboot_thr.start()
+
+        if not skip_traffic_test:
             ptf_runner(ptfhost,
                        "ptftests",
                        "inner_hash_test.InnerHashTest",
@@ -71,54 +117,10 @@ class TestWRDynamicInnerHashing():
                                "inner_dst_ip_range": ",".join(inner_dst_ip_range),
                                "outer_src_ip_range": ",".join(outer_src_ip_range),
                                "outer_dst_ip_range": ",".join(outer_dst_ip_range),
-                               "balancing_test_times": balancing_test_times,
-                               "balancing_range": balancing_range,
-                               "outer_encap_formats": outer_encap_format,
-                               "nvgre_tni": NVGRE_TNI,
+                               "outer_encap_formats": OUTER_ENCAP_FORMATS,
                                "symmetric_hashing": symmetric_hashing},
                        log_file=log_file,
                        qlen=PTF_QLEN,
                        socket_recv_size=16384,
                        is_python3=True)
-            reboot_thr.join()
-
-
-@pytest.mark.static_config
-class TestWRStaticInnerHashing():
-
-    def test_inner_hashing(self, duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
-                           vlan_ptf_ports, symmetric_hashing, localhost, lag_mem_ptf_ports_groups):
-        logging.info("Executing static inner hash test for outer {} and inner {} with symmetric_hashing set to {}"
-                     .format(outer_ipver, inner_ipver, str(symmetric_hashing)))
-        timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
-        log_file = "/tmp/wr_inner_hash_test.StaticInnerHashTest.{}.{}.{}.log"\
-                   .format(outer_ipver, inner_ipver, timestamp)
-        logging.info("PTF log file: %s" % log_file)
-
-        outer_src_ip_range, outer_dst_ip_range = get_src_dst_ip_range(outer_ipver)
-        inner_src_ip_range, inner_dst_ip_range = get_src_dst_ip_range(inner_ipver)
-
-        reboot_thr = threading.Thread(target=reboot, args=(duthost, localhost, 'warm', 10, 0, 0, True, True,))
-        reboot_thr.start()
-
-        ptf_runner(ptfhost,
-                   "ptftests",
-                   "inner_hash_test.InnerHashTest",
-                   platform_dir="ptftests",
-                   params={"fib_info": FIB_INFO_FILE_DST,
-                           "router_mac": router_mac,
-                           "src_ports": vlan_ptf_ports,
-                           "exp_port_groups": lag_mem_ptf_ports_groups,
-                           "hash_keys": hash_keys,
-                           "vxlan_port": VXLAN_PORT,
-                           "inner_src_ip_range": ",".join(inner_src_ip_range),
-                           "inner_dst_ip_range": ",".join(inner_dst_ip_range),
-                           "outer_src_ip_range": ",".join(outer_src_ip_range),
-                           "outer_dst_ip_range": ",".join(outer_dst_ip_range),
-                           "outer_encap_formats": OUTER_ENCAP_FORMATS,
-                           "symmetric_hashing": symmetric_hashing},
-                   log_file=log_file,
-                   qlen=PTF_QLEN,
-                   socket_recv_size=16384,
-                   is_python3=True)
         reboot_thr.join()

--- a/tests/ecmp/inner_hashing/test_wr_inner_hashing_lag.py
+++ b/tests/ecmp/inner_hashing/test_wr_inner_hashing_lag.py
@@ -9,13 +9,13 @@ from tests.common import reboot
 from tests.ecmp.inner_hashing.conftest import get_src_dst_ip_range, FIB_INFO_FILE_DST, VXLAN_PORT,\
     PTF_QLEN, OUTER_ENCAP_FORMATS, NVGRE_TNI, setup_lag_config, config_pbh_lag
 from tests.ptf_runner import ptf_runner
+from tests.common.fixtures.ptfhost_utils import skip_traffic_test   # noqa F401
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('t0'),
-    pytest.mark.asic('mellanox')
+    pytest.mark.topology('t0')
 ]
 
 
@@ -31,7 +31,7 @@ class TestWRDynamicInnerHashingLag():
 
     def test_inner_hashing(self, duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
                            vlan_ptf_ports, symmetric_hashing, localhost, lag_mem_ptf_ports_groups,
-                           get_function_completeness_level):
+                           get_function_completeness_level, skip_traffic_test):     # noqa F811
         logging.info("Executing warm boot dynamic inner hash test for outer {} and inner {} with symmetric_hashing"
                      " set to {}".format(outer_ipver, inner_ipver, str(symmetric_hashing)))
         timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
@@ -58,27 +58,28 @@ class TestWRDynamicInnerHashingLag():
         reboot_thr = threading.Thread(target=reboot, args=(duthost, localhost, 'warm', 10, 0, 0, True, True,))
         reboot_thr.start()
 
-        ptf_runner(ptfhost,
-                   "ptftests",
-                   "inner_hash_test.InnerHashTest",
-                   platform_dir="ptftests",
-                   params={"fib_info": FIB_INFO_FILE_DST,
-                           "router_mac": router_mac,
-                           "src_ports": vlan_ptf_ports,
-                           "exp_port_groups": lag_mem_ptf_ports_groups,
-                           "hash_keys": hash_keys,
-                           "vxlan_port": VXLAN_PORT,
-                           "inner_src_ip_range": ",".join(inner_src_ip_range),
-                           "inner_dst_ip_range": ",".join(inner_dst_ip_range),
-                           "outer_src_ip_range": ",".join(outer_src_ip_range),
-                           "outer_dst_ip_range": ",".join(outer_dst_ip_range),
-                           "balancing_test_times": balancing_test_times,
-                           "balancing_range": balancing_range,
-                           "outer_encap_formats": outer_encap_format,
-                           "nvgre_tni": NVGRE_TNI,
-                           "symmetric_hashing": symmetric_hashing},
-                   log_file=log_file,
-                   qlen=PTF_QLEN,
-                   socket_recv_size=16384,
-                   is_python3=True)
+        if not skip_traffic_test:
+            ptf_runner(ptfhost,
+                       "ptftests",
+                       "inner_hash_test.InnerHashTest",
+                       platform_dir="ptftests",
+                       params={"fib_info": FIB_INFO_FILE_DST,
+                               "router_mac": router_mac,
+                               "src_ports": vlan_ptf_ports,
+                               "exp_port_groups": lag_mem_ptf_ports_groups,
+                               "hash_keys": hash_keys,
+                               "vxlan_port": VXLAN_PORT,
+                               "inner_src_ip_range": ",".join(inner_src_ip_range),
+                               "inner_dst_ip_range": ",".join(inner_dst_ip_range),
+                               "outer_src_ip_range": ",".join(outer_src_ip_range),
+                               "outer_dst_ip_range": ",".join(outer_dst_ip_range),
+                               "balancing_test_times": balancing_test_times,
+                               "balancing_range": balancing_range,
+                               "outer_encap_formats": outer_encap_format,
+                               "nvgre_tni": NVGRE_TNI,
+                               "symmetric_hashing": symmetric_hashing},
+                       log_file=log_file,
+                       qlen=PTF_QLEN,
+                       socket_recv_size=16384,
+                       is_python3=True)
         reboot_thr.join()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed
#### How did you do it?
Add test to t0 job and skip traffic test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
