### PR TITLE
Use access token to connect kusto in report_data_storage

### DIFF
--- a/.azure-pipelines/testscripts_analyse/report_data_storage.py
+++ b/.azure-pipelines/testscripts_analyse/report_data_storage.py
@@ -37,18 +37,14 @@ class KustoConnector():
             by hosting a backup cluster, which is optional.
         """
         ingest_cluster = os.getenv("TEST_REPORT_INGEST_KUSTO_CLUSTER_BACKUP")
-        tenant_id = os.getenv("TEST_REPORT_AAD_TENANT_ID_BACKUP")
-        service_id = os.getenv("TEST_REPORT_AAD_CLIENT_ID_BACKUP")
-        service_key = os.getenv("TEST_REPORT_AAD_CLIENT_KEY_BACKUP")
+        access_token = os.getenv('ACCESS_TOKEN', None)
 
-        if not ingest_cluster or not tenant_id or not service_id or not service_key:
+        if not ingest_cluster or not access_token:
             raise RuntimeError(
                 "Could not load Kusto Credentials from environment")
         else:
             kcsb = KustoConnectionStringBuilder.with_aad_application_key_authentication(ingest_cluster,
-                                                                                        service_id,
-                                                                                        service_key,
-                                                                                        tenant_id)
+                                                                                        access_token)
             self._ingestion_client_backup = KustoIngestClient(kcsb)
 
     def upload_testscripts(self, test_scripts):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Use access token to connect kusto in report_data_storage

#### How did you do it?
Remove client id/client key/tenant id

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
