### PR TITLE
Update skip condition of po2vlan test for sonic fanout

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -670,7 +670,7 @@ def skip_sonic_leaf_fanout(fanouthosts):
                 pytest.skip("OS Version of fanout is older than 202205, unsupported")
             asic_type = fanouthost.facts['asic_type']
             platform = fanouthost.facts["platform"]
-            if not (asic_type in ["broadcom"] or platform in ["armhf-nokia_ixs7215_52x-r0"]):
+            if not (asic_type in ["broadcom", "mellanox"] or platform in ["armhf-nokia_ixs7215_52x-r0"]):
                 pytest.skip("Not supporteds on SONiC leaf-fanout platform")
 
 

--- a/tests/common/helpers/portchannel_to_vlan.py
+++ b/tests/common/helpers/portchannel_to_vlan.py
@@ -400,7 +400,7 @@ def setup_po2vlan(duthosts, ptfhost, rand_one_dut_hostname, rand_selected_dut, p
                 pytest.skip("OS Version of fanout is older than 202205, unsupported")
             asic_type = fanouthost.facts['asic_type']
             platform = fanouthost.facts["platform"]
-            if not (asic_type in ["broadcom"] or platform in
+            if not (asic_type in ["broadcom", "mellanox"] or platform in
                     ["armhf-nokia_ixs7215_52x-r0", "arm64-nokia_ixs7215_52xb-r0"]):
                 pytest.skip("Not supporteds on SONiC leaf-fanout platform")
 


### PR DESCRIPTION

### Description of PR
Update skip condition of po2vlan test for sonic fanout
For mellanox sonic fanout switch, related cases could pass

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Update skip condition of po2vlan test for sonic fanout
For mellanox sonic fanout switch, related cases could pass
#### How did you do it?
Add "mellanox" asic type to support list
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
