### PR TITLE
[Snappi] - fixing swss service restart logic for basic PFCWD testcases in multi-asic environment

### DIFF
--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
@@ -56,7 +56,7 @@ def test_pfcwd_basic_single_lossless_prio(snappi_api,                   # noqa: 
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if
@@ -133,7 +133,7 @@ def test_pfcwd_basic_multi_lossless_prio(snappi_api,                # noqa F811
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if
@@ -213,7 +213,7 @@ def test_pfcwd_basic_single_lossless_prio_reboot(snappi_api,                # no
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if
@@ -301,7 +301,7 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if
@@ -387,7 +387,7 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if
@@ -415,6 +415,8 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
         for k in ports_dict.keys():
             ports_dict[k] = list(set(ports_dict[k]))
 
+        logger.info('Line Card Choice:{}'.format(line_card_choice))
+        logger.info('Port dictionary:{}'.format(ports_dict))
         for duthost in dut_list:
             asic_list = ports_dict[duthost.hostname]
             for asic in asic_list:
@@ -493,7 +495,7 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts, 2)
+        dut_list = random.sample(list(duthosts), 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
         dut_list = [dut for dut in duthosts if
@@ -510,6 +512,7 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
     testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
                                                                             snappi_ports,
                                                                             snappi_api)
+
     if (duthost1.is_multi_asic):
         ports_dict = defaultdict(list)
         for port in snappi_ports:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The existing PFCWD basic testcases have restart SWSS service testcases.

However, these testcases do not address the multi-asic environment.  The pull-request addresses this.

Summary:
Fixes # (issue)
The fix finds out the DUT and interfaces used in the test and based on that selects swss@0 or swss@1 to restart. The fix first verifies if the platform field exists and if yes, is set to 'broadcom-dnx' field. If this is not true, then code executes the default testcase.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
To address the multi-asic environment scenario and select appropriate SWSS depending upon the DUT-interface selected for the test.

#### How did you do it?
- Finding the DUT-interface used in the test. 
- For Single line card - Single ASIC, the DUT will be same and interfaces will be from same ASIC. So only single swss is selected.
- For Single line card - Multi ASIC, DUT is same but interfaces will be from different ASIC and hence two SWSS instances are selected. Same logic for multiple line card scenario.

#### How did you verify/test it?
- Ran the test on local setup.

Logs for single line card single ASIC:
```
15:33:49 test_multidut_pfcwd_basic_with_snappi.te L0574 INFO   | Issuing a restart of service swss@0 on the dut ixre-egl-board72
15:35:15 test_multidut_pfcwd_basic_with_snappi.te L0577 INFO   | Wait until the system is stable

```

Logs for single line card multiple ASIC:
```
15:47:39 test_multidut_pfcwd_basic_with_snappi.te L0574 INFO   | Issuing a restart of service swss@1 on the dut ixre-egl-board71
15:48:59 test_multidut_pfcwd_basic_with_snappi.te L0577 INFO   | Wait until the system is stable
15:49:20 test_multidut_pfcwd_basic_with_snappi.te L0574 INFO   | Issuing a restart of service swss@0 on the dut ixre-egl-board71
15:50:39 test_multidut_pfcwd_basic_with_snappi.te L0577 INFO   | Wait until the system is stable
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
