### PR TITLE
Skip advanced reboot on vms20-t0-7050cx3-2 since failures to session teardown

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1080,6 +1080,11 @@ platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset:
       - "(platform in ['x86_64-cel_e1031-r0'] or 't2' in topo_name) and https://github.com/sonic-net/sonic-mgmt/issues/6218"
       - "asic_type in ['nvidia-bluefield']"
 
+platform_tests/test_advanced_reboot.py:
+  skip:
+    reason: "Skip advanced reboot on vms20-t0-7050cx3-2 since no SSD on this device and failures to session teardown"
+    conditions: "topo_name in 'vms20-t0-7050cx3-2'"
+
 platform_tests/test_auto_negotiation.py:
   skip:
     reason: "auto negotiation test highly depends on test enviroments, file issue to track and skip for now"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1080,11 +1080,6 @@ platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset:
       - "(platform in ['x86_64-cel_e1031-r0'] or 't2' in topo_name) and https://github.com/sonic-net/sonic-mgmt/issues/6218"
       - "asic_type in ['nvidia-bluefield']"
 
-platform_tests/test_advanced_reboot.py:
-  skip:
-    reason: "Skip advanced reboot on vms20-t0-7050cx3-2 since no SSD on this device and failures to session teardown"
-    conditions: "topo_name in 'vms20-t0-7050cx3-2'"
-
 platform_tests/test_auto_negotiation.py:
   skip:
     reason: "auto negotiation test highly depends on test enviroments, file issue to track and skip for now"

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -16,6 +16,7 @@ from tests.common.dualtor.mux_simulator_control import get_mux_status, check_mux
     toggle_all_simulator_ports, toggle_simulator_port_to_upper_tor              # noqa F401
 from tests.common.dualtor.constants import LOWER_TOR
 from tests.common.utilities import wait_until
+from tests.conftest import get_tbinfo
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -32,6 +33,9 @@ logger = logging.getLogger()
 @pytest.fixture(scope="module", params=[SINGLE_TOR_MODE, DUAL_TOR_MODE])
 def testing_config(request, tbinfo):
     testing_mode = request.param
+    tbname, _ = get_tbinfo(request)
+    if tbname == "vms20-t0-7050cx3-2":
+        pytest.skip("skip advanced reboot on vms20-t0-7050cx3-2 since the failure to lacp session teardown")
     if 'dualtor' in tbinfo['topo']['name']:
         if testing_mode == SINGLE_TOR_MODE:
             pytest.skip("skip SINGLE_TOR_MODE tests on Dual ToR testbeds")

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -30,12 +30,29 @@ DUAL_TOR_MODE = 'dual'
 logger = logging.getLogger()
 
 
+def check_if_ssd(duthost):
+    try:
+        output = duthost.command("lsblk -d -o NAME,ROTA")
+        lines = output['stdout'].strip().split('\n')
+        for line in lines[1:]:
+            name, rota = line.split()
+            if name.startswith('sd') and int(rota) == 0:
+                return True
+        return False
+    except Exception as e:
+        logger.error(f"Error while checking SSD: {e}")
+        return False
+
+
 @pytest.fixture(scope="module", params=[SINGLE_TOR_MODE, DUAL_TOR_MODE])
-def testing_config(request, tbinfo):
+def testing_config(request, duthosts, rand_one_dut_hostname, tbinfo):
     testing_mode = request.param
+    duthost = duthosts[rand_one_dut_hostname]
     tbname, _ = get_tbinfo(request)
-    if tbname == "vms20-t0-7050cx3-2":
-        pytest.skip("skip advanced reboot on vms20-t0-7050cx3-2 since the failure to lacp session teardown")
+    is_ssd = check_if_ssd(duthost)
+    neighbor_type = request.config.getoption("--neighbor_type")
+    if '7050' in tbname and not is_ssd and neighbor_type == 'eos':
+        pytest.skip("skip advanced reboot tests on 7050 devices without SSD")
     if 'dualtor' in tbinfo['topo']['name']:
         if testing_mode == SINGLE_TOR_MODE:
             pytest.skip("skip SINGLE_TOR_MODE tests on Dual ToR testbeds")

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -16,7 +16,6 @@ from tests.common.dualtor.mux_simulator_control import get_mux_status, check_mux
     toggle_all_simulator_ports, toggle_simulator_port_to_upper_tor              # noqa F401
 from tests.common.dualtor.constants import LOWER_TOR
 from tests.common.utilities import wait_until
-from tests.conftest import get_tbinfo
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -48,10 +47,9 @@ def check_if_ssd(duthost):
 def testing_config(request, duthosts, rand_one_dut_hostname, tbinfo):
     testing_mode = request.param
     duthost = duthosts[rand_one_dut_hostname]
-    tbname, _ = get_tbinfo(request)
     is_ssd = check_if_ssd(duthost)
     neighbor_type = request.config.getoption("--neighbor_type")
-    if '7050' in tbname and not is_ssd and neighbor_type == 'eos':
+    if duthost.facts['platform'] == 'x86_64-arista_7050cx3_32s' and not is_ssd and neighbor_type == 'eos':
         pytest.skip("skip advanced reboot tests on 7050 devices without SSD")
     if 'dualtor' in tbinfo['topo']['name']:
         if testing_mode == SINGLE_TOR_MODE:


### PR DESCRIPTION
…e and failures to session teardown

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Skip advanced reboot on 7050 devices which has eos neighbors but no SSD due to failures of session teardown.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Advanced reboot failed on vms20-t0-7050cx3-2 / vms28-t0-7050-13.
#### How did you do it?
Skip advanced reboot on it.
#### How did you verify/test it?
Ran advanced_reboot on `vms28-t0-7050-13` test bed and result is:
`================================================ short test summary info =================================================
SKIPPED [1] platform_tests/test_advanced_reboot.py: skip test_fast_reboot_from_other_vendor due to knonw issue, if xfail it, it will block other test cases
SKIPPED [2] platform_tests/test_advanced_reboot.py:115: skip advanced reboot tests on 7050 devices without SSD`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
