### PR TITLE
[ntp]: Enable iburst when testing with a custom server

### DIFF
--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -79,7 +79,8 @@ def _context_for_setup_ntp(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv
 
     duthost.command("config ntp add %s" % (ptfhost.mgmt_ipv6 if ptf_use_ipv6 else ptfhost.mgmt_ip))
 
-    duthost.command("sonic-db-cli CONFIG_DB HSET 'NTP_SERVER|%s' iburst true" % (ptfhost.mgmt_ipv6 if ptf_use_ipv6 else ptfhost.mgmt_ip))
+    duthost.command("sonic-db-cli CONFIG_DB HSET 'NTP_SERVER|%s' iburst true"
+                    % (ptfhost.mgmt_ipv6 if ptf_use_ipv6 else ptfhost.mgmt_ip))
     duthost.service(name="ntp-config", state="restarted")
 
     yield

--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -79,6 +79,9 @@ def _context_for_setup_ntp(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv
 
     duthost.command("config ntp add %s" % (ptfhost.mgmt_ipv6 if ptf_use_ipv6 else ptfhost.mgmt_ip))
 
+    duthost.command("sonic-db-cli CONFIG_DB HSET 'NTP_SERVER|%s' iburst true" % (ptfhost.mgmt_ipv6 if ptf_use_ipv6 else ptfhost.mgmt_ip))
+    duthost.service(name="ntp-config", state="restarted")
+
     yield
 
     # stop ntp server


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

202311 and newer images don't enable the iburst configuration for NTP servers by default. This means that if some packet happened to get lost or dropped, then NTP will take a long while to synchronize the time.

#### How did you do it?

Configure the iburst option manually here.

#### How did you verify/test it?

Tested on KVM, and added an iptables rule on my host manually to reject packets on UDP port 123. Then, verified to see that NTP sent out multiple client packets with the iburst option.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
