### PR TITLE
[Snappi][ECN] Changing the test and expectations for ECN dequeue testcases for DNX platform.

### DIFF
--- a/docs/testplan/ecn/ECN_Broadcom_DNX_Test_Cases.md
+++ b/docs/testplan/ecn/ECN_Broadcom_DNX_Test_Cases.md
@@ -1,6 +1,6 @@
-
-### ECN testcases for Broadcom-DNX platform
-- [Existing testcase](#existing-testcase) 
+### ECN testcases for Broadcom-DNX platform:
+- [Overview](#overview)
+- [Existing testcase](#existing-testcase)
 - [New Approach](#new-approach)
 - [Broadcom-DNX behavior](#broadcom-dnx-behavior)
 - [Test case verification](#test-case-verification)
@@ -12,7 +12,7 @@ Revision of the document:
 |:----------:|:-----------:|:-----------:|:----------------------:|
 |     01     | 10/01/2024  | Amit Pawar  |      First Draft       |
 
-Overview
+#### Overview:
 The testcase is applicable ONLY for Broadcom-DNX platforms and hence will be skipped for other platforms. The current testcase has a narrow range between Kmin and Kmax, making it challenging to verify the ECN marking probability. Furthermore, the Broadcom-DNX architecture results in slightly different behavior, as described below.
 
 #### Existing testcase:
@@ -39,23 +39,9 @@ There are three aspects associated with Broadcom-DNX behavior for ECN-marking of
 3. **Packets transferred to DRAM:**
 
     DNX platform enqueues the packets in the ingress asic’s VOQ until it gets the credit from egress asic. The VOQ consist of SRAM and DRAM buffers and it starts enqueuing in the SRAM buffer and once the SRAM buffer becomes scarce, packets are moved from SRAM to DRAM from the VOQ which are congested.  Multiple packets from same VOQ are dequeued from  SRAM and packed as 1 DRAM bundle and moved to DRAM. When ECN is marked, all the packets in that DRAM bundle are marked.
-    
-
 
 #### Test case verification:
-1. With packet-count less than Kmin (800 packets), NONE of the packets should be marked as ECN. 
+1. With packet-count less than Kmin (800 packets), NONE of the packets should be marked as ECN.
 2. With packet count between Kmin and Kmx (1600), packets between 800-1600 packets should be check for ECN-marking probability (Pmax).
 3. With packet count slightly above Kmax(2400), packets between Kmin and Kmax should be checked for ECN marking probability (Pmax).
 4. With packet count above Kmax (4000), all the packets from 267-4000 should be marked as ECN. This will be around 760-4000 for 400Gbps interface.
-
-
-
-
-
-
-
-
-
-
-
-        

--- a/docs/testplan/ecn/ECN_Broadcom_DNX_Test_Cases.md
+++ b/docs/testplan/ecn/ECN_Broadcom_DNX_Test_Cases.md
@@ -1,0 +1,61 @@
+
+### ECN testcases for Broadcom-DNX platform
+- [Existing testcase](#existing-testcase) 
+- [New Approach](#new-approach)
+- [Broadcom-DNX behavior](#broadcom-dnx-behavior)
+- [Test case verification](#test-case-verification)
+
+
+Revision of the document:
+
+|  Revision  |    Date     |   Author    |   Change Description   |
+|:----------:|:-----------:|:-----------:|:----------------------:|
+|     01     | 10/01/2024  | Amit Pawar  |      First Draft       |
+
+Overview
+The testcase is applicable ONLY for Broadcom-DNX platforms and hence will be skipped for other platforms. The current testcase has a narrow range between Kmin and Kmax, making it challenging to verify the ECN marking probability. Furthermore, the Broadcom-DNX architecture results in slightly different behavior, as described below.
+
+#### Existing testcase:
+
+The ECN-dequeue test-case has Kmin, Kmax and Pmax set to 50000 bytes, 51000 bytes and 100% respectively. The packet-size is set to 1024B. Test involved sending 100 packets and ensuring that  first packet is ECN-marked and last packet is not ECN-marked.
+
+However testing, with Broadcom-DNX platform, showed many issues with this approach. Setting of Kmin, Kmax and packet-size to 50000 bytes, 51000 bytes and 1024B respectively, meant that Kmin and Kmax were effectively set to around 50 and 51 packets, leaving window of just 1 packet. There is no verification to check the probability of the packets marked (as per Pmax) due to such a short window of Kmin and Kmax.
+
+#### New Approach:
+
+1. New ECN testcase for Broadcom-DNX platform sets Kmin and Kmax values to 800000 and 2000000 bytes respectively. With packet-size of 1024B, Kmin and Kmax translates to around 800 and 2000 packets.
+2. The Pmax value is parameterized to different values, example - 5, 25, 50 and 75 to check probability of packets marked as congested between Kmin and Kmax values.
+3. The packet-count is parameterized to different values, example - 800, 1600, 2400 and 4000 packets of 1024B each. Purpose is to have packet count less than Kmin (800), between Kmin and Kmax (1600), slightly above Kmax value (2400) and twice the value of Kmax (4000).
+
+#### Broadcom-DNX behavior:
+
+There are three aspects associated with Broadcom-DNX behavior for ECN-marking of the packets:
+1. **ECN-marking on De-queue:**
+
+    The packets are marked ECN upon the de-queue, so initial packets below the Kmin will also be ECN marked if the total number of packets are greater than Kmin value.
+2. **Egress credits:**
+
+   Even though there is congestion the egress side, the egress interface/asic assigns few credits to the ingress. These credits cause few packets to stay with egress queue and hence never ECN-marked. Typically, these packets range between 250-270 and 750-800 for 100 and 400Gbps interfaces respectively.
+3. **Packets transferred to DRAM:**
+
+    DNX platform enqueues the packets in the ingress asic’s VOQ until it gets the credit from egress asic. The VOQ consist of SRAM and DRAM buffers and it starts enqueuing in the SRAM buffer and once the SRAM buffer becomes scarce, packets are moved from SRAM to DRAM from the VOQ which are congested.  Multiple packets from same VOQ are dequeued from  SRAM and packed as 1 DRAM bundle and moved to DRAM. When ECN is marked, all the packets in that DRAM bundle are marked.
+    
+
+
+#### Test case verification:
+1. With packet-count less than Kmin (800 packets), NONE of the packets should be marked as ECN. 
+2. With packet count between Kmin and Kmx (1600), packets between 800-1600 packets should be check for ECN-marking probability (Pmax).
+3. With packet count slightly above Kmax(2400), packets between Kmin and Kmax should be checked for ECN marking probability (Pmax).
+4. With packet count above Kmax (4000), all the packets from 267-4000 should be marked as ECN. This will be around 760-4000 for 400Gbps interface.
+
+
+
+
+
+
+
+
+
+
+
+        

--- a/tests/snappi_tests/multidut/ecn/files/restpy_multidut_helper.py
+++ b/tests/snappi_tests/multidut/ecn/files/restpy_multidut_helper.py
@@ -1,0 +1,202 @@
+import logging
+import time
+import os
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts             # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
+     snappi_api                                                                                     # noqa: F401
+from tests.common.snappi_tests.snappi_helpers import get_dut_port_id
+from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, config_wred, \
+    enable_ecn, config_ingress_lossless_buffer_alpha, stop_pfcwd, disable_packet_aging, \
+    config_capture_pkt, traffic_flow_mode, calc_pfc_pause_flow_rate  # noqa: F401
+from tests.common.snappi_tests.read_pcap import get_ip_pkts
+from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, generate_test_flows, \
+    generate_pause_flows, run_traffic                                       # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+EXP_DURATION_SEC = 1
+DATA_START_DELAY_SEC = 0.2
+SNAPPI_POLL_DELAY_SEC = 2
+PAUSE_FLOW_NAME = 'Pause Storm'
+DATA_FLOW_NAME = 'Data Flow'
+
+
+def run_ecn_test(api,
+                 testbed_config,
+                 port_config_list,
+                 conn_data,
+                 fanout_data,
+                 dut_port,
+                 lossless_prio,
+                 prio_dscp_map,
+                 iters,
+                 snappi_extra_params=None):
+    """
+    Run multidut ECN test
+
+    Args:
+        api (obj): SNAPPI session
+        testbed_config (obj): testbed L1/L2/L3 configuration
+        port_config_list (list): list of port configuration
+        conn_data (dict): the dictionary returned by conn_graph_fact.
+        fanout_data (dict): the dictionary returned by fanout_graph_fact.
+        dut_port (str): DUT port to test
+        lossless_prio (int): lossless priority
+        prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
+
+    Returns:
+        Return captured IP packets (list of list)
+    """
+
+    if snappi_extra_params is None:
+        snappi_extra_params = SnappiTestParams()
+
+    # Traffic flow:
+    # tx_port (TGEN) --- ingress DUT --- egress DUT --- rx_port (TGEN)
+
+    rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
+    egress_duthost = rx_port['duthost']
+
+    tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
+    ingress_duthost = tx_port['duthost']
+
+    pytest_assert(testbed_config is not None, 'Failed to get L2/3 testbed config')
+
+    logger.info("Stopping PFC watchdog")
+    stop_pfcwd(egress_duthost)
+    stop_pfcwd(ingress_duthost)
+
+    logger.info("Disabling packet aging if necessary")
+    disable_packet_aging(egress_duthost, rx_port['asic_value'])
+    disable_packet_aging(ingress_duthost, tx_port['asic_value'])
+
+    # Configure WRED/ECN thresholds
+    logger.info("Configuring WRED and ECN thresholds")
+    config_result = config_wred(host_ans=ingress_duthost,
+                                kmin=snappi_extra_params.ecn_params["kmin"],
+                                kmax=snappi_extra_params.ecn_params["kmax"],
+                                pmax=snappi_extra_params.ecn_params["pmax"],
+                                asic_value=tx_port['asic_value'])
+    pytest_assert(config_result is True, 'Failed to configure WRED/ECN at the DUT')
+    config_result = config_wred(host_ans=egress_duthost,
+                                kmin=snappi_extra_params.ecn_params["kmin"],
+                                kmax=snappi_extra_params.ecn_params["kmax"],
+                                pmax=snappi_extra_params.ecn_params["pmax"],
+                                asic_value=rx_port['asic_value'])
+    pytest_assert(config_result is True, 'Failed to configure WRED/ECN at the DUT')
+
+    # Enable ECN marking
+    logger.info("Enabling ECN markings")
+    pytest_assert(enable_ecn(host_ans=egress_duthost, prio=lossless_prio, asic_value=rx_port['asic_value']),
+                  'Unable to enable ecn')
+    pytest_assert(enable_ecn(host_ans=ingress_duthost, prio=lossless_prio, asic_value=tx_port['asic_value']),
+                  'Unable to enable ecn')
+
+    # Get the ID of the port to test
+    port_id = get_dut_port_id(dut_hostname=egress_duthost.hostname,
+                              dut_port=dut_port,
+                              conn_data=conn_data,
+                              fanout_data=fanout_data)
+
+    logger.info('Got the port_id:{} for device:{} and interface: {}'.format(port_id, egress_duthost.hostname, dut_port))
+
+    speed_str = testbed_config.layer1[0].speed
+    speed_gbps = int(speed_str.split('_')[1])
+
+    # Generate base traffic config
+    port_id = 0
+    logger.info("Generating base flow config")
+    snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,
+                                                                     port_config_list=port_config_list,
+                                                                     port_id=port_id)
+
+    logger.info("Setting test flow config params")
+    snappi_extra_params.traffic_flow_config.data_flow_config.update({
+            "flow_name": DATA_FLOW_NAME,
+            "flow_rate_percent": 100,
+            "flow_delay_sec": DATA_START_DELAY_SEC,
+            "flow_traffic_type": traffic_flow_mode.FIXED_PACKETS
+        })
+
+    logger.info("Setting pause flow config params")
+    snappi_extra_params.traffic_flow_config.pause_flow_config = {
+        "flow_name": PAUSE_FLOW_NAME,
+        "flow_dur_sec": EXP_DURATION_SEC,
+        "flow_rate_percent": None,
+        "flow_rate_pps": calc_pfc_pause_flow_rate(speed_gbps),
+        "flow_rate_bps": None,
+        "flow_pkt_size": 64,
+        "flow_pkt_count": None,
+        "flow_delay_sec": 0,
+        "flow_traffic_type": traffic_flow_mode.FIXED_DURATION
+        }
+
+    # Generate traffic config of one test flow and one pause storm
+    logger.info("Generating test flows")
+    generate_test_flows(testbed_config=testbed_config,
+                        test_flow_prio_list=[lossless_prio],
+                        prio_dscp_map=prio_dscp_map,
+                        snappi_extra_params=snappi_extra_params)
+
+    logger.info("Generating pause flows")
+    generate_pause_flows(testbed_config=testbed_config,
+                         pause_prio_list=[lossless_prio],
+                         global_pause=False,
+                         snappi_extra_params=snappi_extra_params)
+
+    flows = testbed_config.flows
+
+    all_flow_names = [flow.name for flow in flows]
+    data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
+
+    logger.info("Setting packet capture port to {}".format(testbed_config.ports[port_id].name))
+    snappi_extra_params.packet_capture_ports = [testbed_config.ports[port_id].name]
+
+    result = []
+    snappi_extra_params.packet_capture_file = "ECN_cap"
+    config_capture_pkt(testbed_config=testbed_config,
+                       port_names=snappi_extra_params.packet_capture_ports,
+                       capture_type=snappi_extra_params.packet_capture_type,
+                       capture_name=snappi_extra_params.packet_capture_file)
+    api.set_config(testbed_config)
+    ixnetrestpy = api._ixnetwork
+    ixnetrestpy.Traffic.EnableMinFrameSize = True
+    cap_port = ixnetrestpy.Vport.find().Capture.find(HardwareEnabled=True)
+    cap_port.SliceSize = 32
+
+    logger.info("Running {} iteration(s)".format(iters))
+    trafficItem = ixnetrestpy.Traffic.TrafficItem.find()
+    trafficItem.Generate()
+    ixnetrestpy.Traffic.Apply()
+
+    logger.info("Running {} iteration(s)".format(iters))
+    for i in range(iters):
+        logger.info("Running iteration {}".format(i))
+        logger.info("Packet capture file: {}.pcapng".format(snappi_extra_params.packet_capture_file))
+
+        logger.info("Slicing Capture Disabled")
+        cap_port.update(HardwareEnabled=False, SoftwareEnabled=False)
+        time.sleep(1)
+
+        logger.info("Slicing Capture Enabled")
+        cap_port.update(HardwareEnabled=True, SoftwareEnabled=True)
+        time.sleep(1)
+
+        logger.info("Running traffic")
+        run_traffic(duthost=egress_duthost,
+                    api=api,
+                    config=testbed_config,
+                    data_flow_names=data_flow_names,
+                    all_flow_names=all_flow_names,
+                    exp_dur_sec=EXP_DURATION_SEC,
+                    snappi_extra_params=snappi_extra_params,
+                    is_ecn=True)
+
+        result.append(get_ip_pkts(snappi_extra_params.packet_capture_file + ".pcapng"))
+        os.rename(snappi_extra_params.packet_capture_file + ".pcapng",
+                  snappi_extra_params.packet_capture_file + "_{}.pcapng".format(i))
+        time.sleep(2)
+
+    return result

--- a/tests/snappi_tests/multidut/ecn/files/restpy_multidut_helper.py
+++ b/tests/snappi_tests/multidut/ecn/files/restpy_multidut_helper.py
@@ -9,7 +9,7 @@ from tests.common.snappi_tests.snappi_helpers import get_dut_port_id
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, config_wred, \
     enable_ecn, config_ingress_lossless_buffer_alpha, stop_pfcwd, disable_packet_aging, \
     config_capture_pkt, traffic_flow_mode, calc_pfc_pause_flow_rate  # noqa: F401
-from tests.common.snappi_tests.read_pcap import get_ip_pkts
+from tests.common.snappi_tests.read_pcap import get_ipv4_pkts
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, generate_test_flows, \
     generate_pause_flows, run_traffic                                       # noqa: F401
@@ -194,7 +194,7 @@ def run_ecn_test(api,
                     snappi_extra_params=snappi_extra_params,
                     is_ecn=True)
 
-        result.append(get_ip_pkts(snappi_extra_params.packet_capture_file + ".pcapng"))
+        result.append(get_ipv4_pkts(snappi_extra_params.packet_capture_file + ".pcapng"))
         os.rename(snappi_extra_params.packet_capture_file + ".pcapng",
                   snappi_extra_params.packet_capture_file + "_{}.pcapng".format(i))
         time.sleep(2)

--- a/tests/snappi_tests/multidut/ecn/files/restpy_multidut_helper.py
+++ b/tests/snappi_tests/multidut/ecn/files/restpy_multidut_helper.py
@@ -62,6 +62,9 @@ def run_ecn_test(api,
     tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
     ingress_duthost = tx_port['duthost']
 
+    snappi_extra_params.multi_dut_params.egress_duthosts.append(egress_duthost)
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost)
+
     pytest_assert(testbed_config is not None, 'Failed to get L2/3 testbed config')
 
     logger.info("Stopping PFC watchdog")
@@ -194,7 +197,7 @@ def run_ecn_test(api,
                     snappi_extra_params=snappi_extra_params,
                     is_ecn=True)
 
-        result.append(get_ipv4_pkts(snappi_extra_params.packet_capture_file + ".pcapng"))
+        result.append(get_ipv4_pkts(snappi_extra_params.packet_capture_file + ".pcapng", protocol_num=17))
         os.rename(snappi_extra_params.packet_capture_file + ".pcapng",
                   snappi_extra_params.packet_capture_file + "_{}.pcapng".format(i))
         time.sleep(2)

--- a/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_brcm_dnx.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_brcm_dnx.py
@@ -14,7 +14,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_
 from tests.snappi_tests.multidut.ecn.files.restpy_multidut_helper import run_ecn_test
 from tests.common.snappi_tests.read_pcap import is_ecn_marked
 from tests.snappi_tests.files.helper import skip_ecn_tests
-from tests.snappi_tests.new_variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.common.snappi_tests.common_helpers import packet_capture
 from tests.common.config_reload import config_reload
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams

--- a/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_brcm_dnx.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_brcm_dnx.py
@@ -1,0 +1,220 @@
+import pytest
+import random
+import logging
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
+    fanout_graph_facts_multidut                                                                     # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
+    snappi_api, snappi_dut_base_config, get_tgen_peer_ports, get_multidut_snappi_ports, \
+    get_multidut_tgen_peer_port_set, get_snappi_ports_for_rdma, get_snappi_ports, \
+    get_snappi_ports_multi_dut                                                                      # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list                # noqa: F401
+
+from tests.snappi_tests.multidut.ecn.files.restpy_multidut_helper import run_ecn_test
+from tests.common.snappi_tests.read_pcap import is_ecn_marked
+from tests.snappi_tests.files.helper import skip_ecn_tests
+from tests.snappi_tests.new_variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+from tests.common.snappi_tests.common_helpers import packet_capture
+from tests.common.config_reload import config_reload
+from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+logger = logging.getLogger(__name__)
+pytestmark = [pytest.mark.topology('multidut-tgen')]
+
+data_flow_pkt_count = [800, 1600, 2400]
+pmax_list = [25, 50, 75, 100]
+port_map = [[1, 100, 1, 100], [1, 400, 1, 400]]
+
+
+@pytest.mark.parametrize('data_flow_pkt_count', data_flow_pkt_count)
+@pytest.mark.parametrize('pmax', pmax_list)
+@pytest.mark.parametrize('port_map', port_map)
+@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
+def test_dequeue_ecn(request,
+                     snappi_api,                    # noqa: F811
+                     conn_graph_facts,              # noqa: F811
+                     fanout_graph_facts_multidut,   # noqa: F811
+                     duthosts,
+                     lossless_prio_list,            # noqa: F811
+                     get_snappi_ports,              # noqa: F811
+                     data_flow_pkt_count,
+                     tbinfo,
+                     port_map,
+                     pmax,
+                     multidut_port_info,
+                     get_multidut_snappi_ports,     # noqa: F811
+                     prio_dscp_map):                # noqa: F811
+    """
+    Test if the device under test (DUT) performs ECN marking at the egress.
+    Test uses has Kmix and Kmax set to 800000 and 2000000 respectively.
+    Test case checks ECN marking probability based on different value of Pmax and
+    for different packet counts. Test checks ECN probabilities for packet counts
+    - below Kmin, between Kmix and Kmax, slightly above Kmax and double of Kmax.
+
+    Args:
+        request (pytest fixture): pytest request object
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts_multidut (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        lossless_prio_list (fixture): list of lossless priorities
+        get_snappi_ports (fixture): list of snappi ports based on setup used
+        data_flow_pkt_count (list): various packet counts parameterized for the test.
+        tbinfo (string):  setup name as defined in testbed.csv
+        port_map (list): List with egress port, egress link speed, ingress port, ingress link speed format,
+        pmax (list): list with various values of Pmax parameterized.
+        multidut_port_info (list): Rx and Tx port choices defined in variables.py
+        get_multidut_snappi_ports (fixture): Select Rx and Tx ports for the test.
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+
+    Returns:
+        N/A
+    """
+
+    # Skip the test if the platform is NOT Broadcom-DNX.
+    if ("platform_asic" in duthosts[0].facts and duthosts[0].facts["platform_asic"] != "broadcom-dnx"):
+        pytest.skip("Test is specific to Broadcom-DNX platform. Skipping for other platforms.")
+
+    # Selecting Tx and Rx ports for the test based on port_map definitions.
+    for testbed_subtype, rdma_ports in multidut_port_info.items():
+        tx_port_count = port_map[0]
+        rx_port_count = port_map[2]
+        tmp_snappi_port_list = get_snappi_ports
+        snappi_port_list = []
+        for item in tmp_snappi_port_list:
+            if (int(item['speed']) == (port_map[1] * 1000)):
+                snappi_port_list.append(item)
+        pytest_assert(MULTIDUT_TESTBED == tbinfo['conf-name'],
+                      "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
+        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+
+        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
+                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
+                      testbed {}, subtype {} in variables.py'.
+                      format(MULTIDUT_TESTBED, testbed_subtype))
+
+        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
+                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
+                      testbed {}, subtype {} in variables.py'.
+                      format(MULTIDUT_TESTBED, testbed_subtype))
+        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+
+        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
+                                                                                snappi_ports,
+                                                                                snappi_api)
+
+    # Selecting lossless priority for the test.
+    lossless_prio = random.sample(lossless_prio_list, 1)[0]
+    logger.info('Selected lossless priority:{}'.format(lossless_prio))
+    skip_ecn_tests(snappi_ports[0]['duthost'])
+    skip_ecn_tests(snappi_ports[1]['duthost'])
+
+    # Defining snappi parameters for the test.
+    snappi_extra_params = SnappiTestParams()
+    snappi_extra_params.multi_dut_params.duthost1 = snappi_ports[0]['duthost']
+    snappi_extra_params.multi_dut_params.duthost2 = snappi_ports[1]['duthost']
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+    snappi_extra_params.packet_capture_type = packet_capture.IP_CAPTURE
+    snappi_extra_params.is_snappi_ingress_port_cap = True
+
+    # Creating dut_list for identifying unique duthosts to be used for the test.
+    dut_list = []
+    if (snappi_ports[0]['duthost'].hostname == snappi_ports[1]['duthost'].hostname):
+        dut_list.append(snappi_ports[0]['duthost'])
+    else:
+        dut_list = [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]
+
+    # Selecting Kmin, Kmax and Pmax for the test.
+    logger.info('Selecting different Kmin, Kmax and Pmax for DNX based platform')
+    snappi_extra_params.ecn_params = {'kmin': 800000, 'kmax': 2000000, 'pmax': pmax}
+    data_flow_pkt_size = 1024
+    kmin = snappi_extra_params.ecn_params['kmin']
+    kmax = snappi_extra_params.ecn_params['kmax']
+    pmax = snappi_extra_params.ecn_params['pmax']
+    logger.info('Running ECN dequeue test with params: {} and {} packets'.
+                format(snappi_extra_params.ecn_params, data_flow_pkt_count))
+
+    snappi_extra_params.traffic_flow_config.data_flow_config = {
+            "flow_pkt_size": data_flow_pkt_size,
+            "flow_pkt_count": data_flow_pkt_count
+        }
+
+    ip_pkts = run_ecn_test(api=snappi_api,
+                           testbed_config=testbed_config,
+                           port_config_list=port_config_list,
+                           conn_data=conn_graph_facts,
+                           fanout_data=fanout_graph_facts_multidut,
+                           dut_port=snappi_ports[0]['peer_port'],
+                           lossless_prio=lossless_prio,
+                           prio_dscp_map=prio_dscp_map,
+                           iters=1,
+                           snappi_extra_params=snappi_extra_params)[0]
+
+    logger.info("Running verification for ECN dequeue test")
+    # Check if all the packets are captured
+    pytest_assert(len(ip_pkts) == data_flow_pkt_count,
+                  'Only capture {}/{} IP packets'.format(len(ip_pkts), data_flow_pkt_count))
+
+    ecn_set = 0
+    logger.info('Analyzing PCAP with {} pkts'.format(data_flow_pkt_count))
+    pkts_mrk_bfr_kmin = 0
+    pkts_mrk_in_range = 0
+    pkts_mrk_aft_kmax = 0
+    for i in range(data_flow_pkt_count):
+        ecn_set_flag = False
+
+        # Identifying first packet ECN-marked.
+        if is_ecn_marked(ip_pkts[i]):
+            ecn_set_flag = True
+
+        if (ecn_set_flag and not ecn_set):
+            logger.info('First packet to be ECN-Marked:{}'.format(i+1))
+            ecn_set = 1
+
+        # Counting packets ECN marked - before Kmin, between Kmix-Kmax and after Kmax.
+        if (ecn_set_flag):
+            if (i < (kmin/data_flow_pkt_size)):
+                pkts_mrk_bfr_kmin += 1
+            if (i >= (kmin/data_flow_pkt_size) and (i < (kmax)/data_flow_pkt_size)):
+                pkts_mrk_in_range += 1
+            if (i >= (kmax/data_flow_pkt_size)):
+                pkts_mrk_aft_kmax += 1
+
+        # Identifying last packet ECN-marked.
+        if (not ecn_set_flag and ecn_set):
+            logger.info('Last packet to be ECN-Marked:{}'.format(i))
+            ecn_set = 0
+
+    logger.info('Result - Pkts marked before Kmin:{}'.format(pkts_mrk_bfr_kmin))
+    logger.info('Result - Pkts marked between Kmin and Kmax :{}'.format(pkts_mrk_in_range))
+    logger.info('Result - Pkts marked after Kmax:{}'.format(pkts_mrk_aft_kmax))
+
+    # Validation checks
+    # If packet count is less than Kmin, no packets should be ECN marked.
+    if (data_flow_pkt_count < (kmin/data_flow_pkt_size)):
+        pytest_assert(pkts_mrk_bfr_kmin == 0, 'If pkt_count is less than Kmin, no packets should be ECN-marked')
+
+    # If packet count is in range of Kmin and Kmax, ECN-marking should follow Pmax probability.
+    if ((data_flow_pkt_count > (kmin/data_flow_pkt_size)) and (data_flow_pkt_count < (kmax/data_flow_pkt_size + 500))):
+        pkts_ecn_range = (kmax - kmin)/data_flow_pkt_size
+        logger.info('ECN Marking range:{}'.format(pkts_ecn_range))
+        # Calculating probability of ECN marking between Kmin and Kmax.
+        pkts_marked_prob = round((float(pkts_mrk_in_range) / pkts_ecn_range * 100), 2)
+        logger.info('ECN Marking Probability between Kmin-Kmax for pmax of {} : {}%'.format(pmax, pkts_marked_prob))
+        pytest_assert(pkts_marked_prob <= pmax,
+                      'For packet count between Kmin-Kmax, ECN marking prob should be less than or equal to Pmax')
+
+    # If packet is way beyond Kmax value, then almost all packets should be ECN marked.
+    if ((data_flow_pkt_count > (kmax/data_flow_pkt_size + 1000))):
+        pkts_marked = round((pkts_mrk_bfr_kmin + pkts_mrk_in_range + pkts_mrk_aft_kmax) / data_flow_pkt_count * 100, 2)
+        logger.info('ECN Marking % with {} packets > Kmax of {} is {}'.
+                    format(data_flow_pkt_count, kmax/data_flow_pkt_size, pkts_marked))
+
+    # Teardown ECN config through a reload
+    logger.info("Reloading config to teardown ECN config")
+    for dut in dut_list:
+        logger.info('Reloading configDB for dut:{}'.format(dut.hostname))
+        config_reload(sonic_host=dut, config_source='config_db', safe_reload=True)

--- a/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_brcm_dnx.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_brcm_dnx.py
@@ -6,8 +6,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
     fanout_graph_facts_multidut                                                                     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-    snappi_api, snappi_dut_base_config, get_tgen_peer_ports, get_multidut_snappi_ports, \
-    get_multidut_tgen_peer_port_set, get_snappi_ports_for_rdma, get_snappi_ports, \
+    snappi_api, snappi_multi_base_config, get_snappi_ports_for_rdma, get_snappi_ports, \
     get_snappi_ports_multi_dut                                                                      # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list                # noqa: F401
 
@@ -42,7 +41,6 @@ def test_dequeue_ecn(request,
                      port_map,
                      pmax,
                      multidut_port_info,
-                     get_multidut_snappi_ports,     # noqa: F811
                      prio_dscp_map):                # noqa: F811
     """
     Test if the device under test (DUT) performs ECN marking at the egress.
@@ -102,9 +100,9 @@ def test_dequeue_ecn(request,
         snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
                                                  tx_port_count, rx_port_count, MULTIDUT_TESTBED)
 
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
+        testbed_config, port_config_list, snappi_ports = snappi_multi_base_config(duthosts,
+                                                                                  snappi_ports,
+                                                                                  snappi_api)
 
     # Selecting lossless priority for the test.
     lossless_prio = random.sample(lossless_prio_list, 1)[0]

--- a/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
@@ -87,15 +87,9 @@ def test_dequeue_ecn(request,
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
     snappi_extra_params.packet_capture_type = packet_capture.IP_CAPTURE
     snappi_extra_params.is_snappi_ingress_port_cap = True
-    if (("platform_asic" in duthost1.facts) and (duthost1.facts["platform_asic"] == "broadcom-dnx")):
-        logger.info('Selecting different Kmin, Kmax for DNX based platform')
-        snappi_extra_params.ecn_params = {'kmin': 200000, 'kmax': 400000, 'pmax': 100}
-        data_flow_pkt_count = 5000
-    else:
-        snappi_extra_params.ecn_params = {'kmin': 50000, 'kmax': 51000, 'pmax': 100}
-        data_flow_pkt_count = 101
-
+    snappi_extra_params.ecn_params = {'kmin': 50000, 'kmax': 51000, 'pmax': 100}
     data_flow_pkt_size = 1024
+    data_flow_pkt_count = 101
     num_iterations = 1
     logger.info("Running ECN dequeue test with params: {}".format(snappi_extra_params.ecn_params))
 
@@ -116,26 +110,12 @@ def test_dequeue_ecn(request,
                            snappi_extra_params=snappi_extra_params)[0]
 
     logger.info("Running verification for ECN dequeue test")
-
     # Check if all the packets are captured
     pytest_assert(len(ip_pkts) == data_flow_pkt_count,
                   'Only capture {}/{} IP packets'.format(len(ip_pkts), data_flow_pkt_count))
 
-    if (("platform_asic" in duthost1.facts) and (duthost1.facts["platform_asic"] == "broadcom-dnx")):
-        if (snappi_ports[0]['speed'] == '400000'):
-            # Check if 1000th packet is ECN marked for 400Gbps interface
-            pytest_assert(is_ecn_marked(ip_pkts[1000]), "The 1000th packet should be marked")
-        else:
-            # Check if the 300th packet is ECN marked for 100Gbps interface
-            pytest_assert(is_ecn_marked(ip_pkts[300]), "The 300th should be marked")
-
-        # Check if the 975th packet is not ECN marked
-        pytest_assert(is_ecn_marked(ip_pkts[4950]),
-                      "The 4950th packet should not be marked")
-
-    else:
-        # Check if the first packet is ECN marked
-        pytest_assert(is_ecn_marked(ip_pkts[0]), "The first packet should be marked")
+    # Check if the first packet is ECN marked
+    pytest_assert(is_ecn_marked(ip_pkts[0]), "The first packet should be marked")
 
     # Check if the last packet is not ECN marked
     pytest_assert(not is_ecn_marked(ip_pkts[-1]),

--- a/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
@@ -87,9 +87,15 @@ def test_dequeue_ecn(request,
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
     snappi_extra_params.packet_capture_type = packet_capture.IP_CAPTURE
     snappi_extra_params.is_snappi_ingress_port_cap = True
-    snappi_extra_params.ecn_params = {'kmin': 50000, 'kmax': 51000, 'pmax': 100}
+    if (("platform_asic" in duthost1.facts) and (duthost1.facts["platform_asic"] == "broadcom-dnx")):
+        logger.info('Selecting different Kmin, Kmax for DNX based platform')
+        snappi_extra_params.ecn_params = {'kmin': 200000, 'kmax': 400000, 'pmax': 100}
+        data_flow_pkt_count = 5000
+    else:
+        snappi_extra_params.ecn_params = {'kmin': 50000, 'kmax': 51000, 'pmax': 100}
+        data_flow_pkt_count = 101
+
     data_flow_pkt_size = 1024
-    data_flow_pkt_count = 101
     num_iterations = 1
     logger.info("Running ECN dequeue test with params: {}".format(snappi_extra_params.ecn_params))
 
@@ -110,12 +116,26 @@ def test_dequeue_ecn(request,
                            snappi_extra_params=snappi_extra_params)[0]
 
     logger.info("Running verification for ECN dequeue test")
+
     # Check if all the packets are captured
     pytest_assert(len(ip_pkts) == data_flow_pkt_count,
                   'Only capture {}/{} IP packets'.format(len(ip_pkts), data_flow_pkt_count))
 
-    # Check if the first packet is ECN marked
-    pytest_assert(is_ecn_marked(ip_pkts[0]), "The first packet should be marked")
+    if (("platform_asic" in duthost1.facts) and (duthost1.facts["platform_asic"] == "broadcom-dnx")):
+        if (snappi_ports[0]['speed'] == '400000'):
+            # Check if 1000th packet is ECN marked for 400Gbps interface
+            pytest_assert(is_ecn_marked(ip_pkts[1000]), "The 1000th packet should be marked")
+        else:
+            # Check if the 300th packet is ECN marked for 100Gbps interface
+            pytest_assert(is_ecn_marked(ip_pkts[300]), "The 300th should be marked")
+
+        # Check if the 975th packet is not ECN marked
+        pytest_assert(is_ecn_marked(ip_pkts[4950]),
+                      "The 4950th packet should not be marked")
+
+    else:
+        # Check if the first packet is ECN marked
+        pytest_assert(is_ecn_marked(ip_pkts[0]), "The first packet should be marked")
 
     # Check if the last packet is not ECN marked
     pytest_assert(not is_ecn_marked(ip_pkts[-1]),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Changing the test and test expectations for the ECN dequeue test for DNX platform.

Summary:
Fixes # (issue)
Issue #12903 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
The original ECN dequeue test case has Kmin and Kmax to 50k and 51k respectively. This leaves only a single packet gap between Kmin and Kmax values (with packet-size of 1024B), and hence difficult to test congestion testcases.

Based on discussion, we changed the test case setting of Kmin and Kmax to 800k and 2000k, Now the test will have different packet counts - namely 800, 1600, 2400 and 4000 packets of 1024B. 

New test case is specifically meant for Broadcom-DNX platform and ensures that packets in range of Kmin-Kmax have the ECN marking probability less than or equal to Pmax.

Test also uses range of Pmax values to ensure that different ECN marking probability works for different Pmax values.

There is an associated README file also created to explain in more detail about the testcase.

#### How did you do it?
Based on the platform - Broadcom-DNX, the kmin, kmax values are set to 800k and 2000k respectively and the packets are checked with offset for congestion.

Original ECN dequeue test is pristine and has no changes whatsoever. We will need another PR maybe to exclude it for the test runs on Broadcom-DNX platforms.

#### How did you verify/test it?
Verified on 100 and 400Gbps ports on multi-asic platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
