### PR TITLE
Add debug message for debugging script `test_stress_routes.py`.

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -11,10 +11,8 @@ import sys
 import socket
 import random
 import time
-import logging
 from multiprocessing.pool import ThreadPool
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.debug_utils import config_module_logging
 
 if sys.version_info.major == 3:
     UNICODE_TYPE = str
@@ -52,7 +50,6 @@ EXAMPLES = '''
       ptf_ip: "192.168.1.10"
     delegate_to: localhost
 '''
-config_module_logging("announce_routes", log_path='../tests/logs')
 
 TOPO_FILE_FOLDER = 'vars/'
 TOPO_FILENAME_TEMPLATE = 'topo_{}.yml'
@@ -164,7 +161,7 @@ def change_routes(action, ptf_ip, port, routes):
             r = requests.post(url, data=data, timeout=360, proxies={"http": None, "https": None})
             break
         except Exception as e:
-            logging.debug("Got exception {}, will try to connect again".format(e))
+            print("Got exception {}, will try to connect again".format(e))
             time.sleep(0.01 * (i+1))
             if i == 4:
                 raise e

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1041,11 +1041,12 @@ def main():
             action=dict(required=False, type='str',
                         default='announce', choices=["announce", "withdraw"]),
             path=dict(required=False, type='str', default=''),
-            log_path=dict(required=False, type='str', default='/tmp')
+            log_path=dict(required=False, type='str', default='')
         ),
         supports_check_mode=False)
 
-    config_module_logging("announce_routes", log_path=module.params['log_path'])
+    if module.params['log_path']:
+        config_module_logging("announce_routes", log_path=module.params['log_path'])
 
     topo_name = module.params['topo_name']
     ptf_ip = module.params['ptf_ip']

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -52,7 +52,7 @@ EXAMPLES = '''
       ptf_ip: "192.168.1.10"
     delegate_to: localhost
 '''
-config_module_logging("announce_routes", log_path='../tests/logs')
+config_module_logging("announce_routes", log_path='../tests')
 
 TOPO_FILE_FOLDER = 'vars/'
 TOPO_FILENAME_TEMPLATE = 'topo_{}.yml'

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -10,8 +10,8 @@ import json
 import sys
 import socket
 import random
-import time
 import logging
+import time
 from multiprocessing.pool import ThreadPool
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.debug_utils import config_module_logging

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -11,8 +11,10 @@ import sys
 import socket
 import random
 import time
+import logging
 from multiprocessing.pool import ThreadPool
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.debug_utils import config_module_logging
 
 if sys.version_info.major == 3:
     UNICODE_TYPE = str
@@ -161,7 +163,7 @@ def change_routes(action, ptf_ip, port, routes):
             r = requests.post(url, data=data, timeout=360, proxies={"http": None, "https": None})
             break
         except Exception as e:
-            print("Got exception {}, will try to connect again".format(e))
+            logging.debug("Got exception {}, will try to connect again".format(e))
             time.sleep(0.01 * (i+1))
             if i == 4:
                 raise e
@@ -1038,9 +1040,12 @@ def main():
             ptf_ip=dict(required=True, type='str'),
             action=dict(required=False, type='str',
                         default='announce', choices=["announce", "withdraw"]),
-            path=dict(required=False, type='str', default='')
+            path=dict(required=False, type='str', default=''),
+            log_path=dict(required=False, type='str', default='/tmp')
         ),
         supports_check_mode=False)
+
+    config_module_logging("announce_routes", log_path=module.params['log_path'])
 
     topo_name = module.params['topo_name']
     ptf_ip = module.params['ptf_ip']

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -52,7 +52,7 @@ EXAMPLES = '''
       ptf_ip: "192.168.1.10"
     delegate_to: localhost
 '''
-config_module_logging("announce_routes", log_path='logs')
+config_module_logging("announce_routes", log_path='../tests/logs')
 
 TOPO_FILE_FOLDER = 'vars/'
 TOPO_FILENAME_TEMPLATE = 'topo_{}.yml'

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -52,7 +52,7 @@ EXAMPLES = '''
       ptf_ip: "192.168.1.10"
     delegate_to: localhost
 '''
-config_module_logging("announce_routes", log_path='../tests')
+config_module_logging("announce_routes", log_path='../tests/logs')
 
 TOPO_FILE_FOLDER = 'vars/'
 TOPO_FILENAME_TEMPLATE = 'topo_{}.yml'

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -11,8 +11,10 @@ import sys
 import socket
 import random
 import time
+import logging
 from multiprocessing.pool import ThreadPool
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.debug_utils import config_module_logging
 
 if sys.version_info.major == 3:
     UNICODE_TYPE = str
@@ -50,6 +52,7 @@ EXAMPLES = '''
       ptf_ip: "192.168.1.10"
     delegate_to: localhost
 '''
+config_module_logging("announce_routes", log_path='logs')
 
 TOPO_FILE_FOLDER = 'vars/'
 TOPO_FILENAME_TEMPLATE = 'topo_{}.yml'
@@ -160,7 +163,8 @@ def change_routes(action, ptf_ip, port, routes):
         try:
             r = requests.post(url, data=data, timeout=360, proxies={"http": None, "https": None})
             break
-        except ConnectionError as e:
+        except Exception as e:
+            logging.debug("Got exception {}, will try to connect again".format(e))
             time.sleep(0.01 * (i+1))
             if i == 4:
                 raise e

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -21,7 +21,8 @@ pytestmark = [
 
 def announce_withdraw_routes(duthost, namespace, localhost, ptf_ip, topo_name):
     logger.info("announce ipv4 and ipv6 routes")
-    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
+    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/",
+                              log_path="logs")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") is True)
 
@@ -30,7 +31,8 @@ def announce_withdraw_routes(duthost, namespace, localhost, ptf_ip, topo_name):
     sleep_to_wait(CRM_POLLING_INTERVAL * 5)
 
     logger.info("withdraw ipv4 and ipv6 routes")
-    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
+    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/",
+                              log_path="logs")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") is True)
     sleep_to_wait(CRM_POLLING_INTERVAL * 5)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We got flaky issue `ConnectionError(ProtocolError('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer')))` in script `test_stress_routes.py` in baseline test. We can not reproduce this issue in local environment. The logs of announcing routes are stored on DUT, in order to save these logs on test server and downloaded by elastictest, we use function `config_module_logging` to achieve this. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
We got flaky issue `ConnectionError(ProtocolError('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer')))` in script `test_stress_routes.py` in baseline test. We can not reproduce this issue in local environment. The logs of announcing routes are stored on DUT, in order to save these logs on test server and downloaded by elastictest, we use function `config_module_logging` to achieve this. 

#### How did you do it?
Use function `config_module_logging` to get the logs of announcing route ftom DUT to server, and store them in the folder `logs`. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
