### PR TITLE
Set inner packet next header as TCP

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/generic_hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/generic_hash_test.py
@@ -508,7 +508,7 @@ class GenericHashTest(BaseTest):
                 self.L4_SRC_PORT
             dst_port = random.randint(0, 65535) if self.hash_field in ['L4_DST_PORT', 'INNER_L4_DST_PORT'] else \
                 self.L4_DST_PORT
-            ip_proto = self.get_ip_proto() if self.hash_field in ['IP_PROTOCOL', 'INNER_IP_PROTOCOL'] else 17
+            ip_proto = self.get_ip_proto() if self.hash_field in ['IP_PROTOCOL', 'INNER_IP_PROTOCOL'] else 6
 
             pkt, masked_expected_pkt, pkt_summary = self.generate_pkt(
                 src_ip, dst_ip, src_port, dst_port, ip_proto, inner_src_ip, inner_dst_ip)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Set the inner packet next header as TCP
In order to be compatible with the payload type

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Script enhancement
#### How did you do it?
Set inner packet next header as TCP
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
