### PR TITLE
Ignore LA error unsupported operation for poller state 1

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -209,6 +209,9 @@ r, ".* NOTICE ntpd.*: ERR: ntpd exiting on signal 15.*"
 # Race condition while removing a vlan member, no functionality impact
 r, ". *ERR swss#orchagent: :- update: FdbOrch MOVE notification: Failed to get port by bridge port ID.*"
 
+#Orchagent code prints error message even in the case of trying to enable an already enabled sensor poller.
+r, ".* ERR swss\d*#orchagent:.*doCfgSensorsTableTask: ASIC sensors : unsupported operation for poller state 1.*"
+
 # https://github.com/sonic-net/sonic-buildimage/issues/7895
 # https://github.com/Azure/sonic-sairedis/issues/582
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed getting attrib SAI_BRIDGE_PORT_ATTR_ISOLATION_GROUP"
@@ -282,5 +285,3 @@ r, ".* INFO .*[duty_cycle_map]: illegal pwm value .*"
 r, ".* INFO .*command '/usr/sbin/smartctl' failed: [116] Stale file handle.*"
 r, ".* INFO healthd.*Key 'TEMPERATURE_INFO|ASIC' field 'high_threshold' unavailable in database 'STATE_DB'.*"
 r, ".* INFO healthd.*Key 'TEMPERATURE_INFO|ASIC' field 'temperature' unavailable in database 'STATE_DB'.*"
-r, ".* ERR swss\d*#orchagent:.*doCfgSensorsTableTask: ASIC sensors : unsupported operation for poller state 1.*"
-

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -282,3 +282,5 @@ r, ".* INFO .*[duty_cycle_map]: illegal pwm value .*"
 r, ".* INFO .*command '/usr/sbin/smartctl' failed: [116] Stale file handle.*"
 r, ".* INFO healthd.*Key 'TEMPERATURE_INFO|ASIC' field 'high_threshold' unavailable in database 'STATE_DB'.*"
 r, ".* INFO healthd.*Key 'TEMPERATURE_INFO|ASIC' field 'temperature' unavailable in database 'STATE_DB'.*"
+r, ".* ERR swss\d*#orchagent:.*doCfgSensorsTableTask: ASIC sensors : unsupported operation for poller state 1.*"
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Log analyzer failure ERR swss#orchagent: :- doCfgSensorsTableTask: ASIC sensors : unsupported operation for poller state 1 in cisco test_platform_overtemp_fault and  T1 run, it's a cosmetic issue in upstream code (in orchagent). Basically, the code prints error message even in the case of trying to enable an already enabled sensor poller. It makes more sense to either do no-op or print non-error message.

[sonic-swss/orchagent/switchorch.cpp at 0c620910ada929ac5154fd548d34aa4eca36b219 · sonic-net/sonic-swss](https://github.com/sonic-net/sonic-swss/blob/0c620910ada929ac5154fd548d34aa4eca36b219/orchagent/switchorch.cpp#L212)

Summary:
Fixes # (issue)

### Type of change
Adding this error part of LA error ignore list.
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [X] 202305
- [X] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
This is cosmetic error, that errored out the sonic-mgmt test.

#### How did you do it?

#### How did you verify/test it?
Ran sonic-mgmt test with the ignore list updated in the local sonic-mgmt repo.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
