### PR TITLE
Add a sonic-mgmt test case to validate FEC stat counters

### DIFF
--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -18,6 +18,7 @@ SUPPORTED_SPEEDS = [
     "100G", "200G", "400G", "800G", "1600G"
 ]
 
+
 @pytest.fixture(autouse=True)
 def is_supported_platform(duthost):
     if any(platform in duthost.facts['platform'] for platform in SUPPORTED_PLATFORMS):
@@ -127,9 +128,10 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
         fec_symbol_err = intf.get('fec_symbol_err', '').lower()
         # Check if fec_corr, fec_uncorr, and fec_symbol_err are valid integers
         try:
-            fec_corr_value = int(fec_corr)
-            fec_uncorr_value = int(fec_uncorr)
-            fec_symbol_err_value = int(fec_symbol_err)
+            int(fec_corr)
+            int(fec_uncorr)
+            int(fec_symbol_err)
         except ValueError:
-            pytest.fail("FEC stat counters are not valid integers for interface {}, fec_corr {} fec_uncorr {} fec_symbol_err {}"
+            pytest.fail("FEC stat counters are not valid integers for interface {}, \
+                        fec_corr {} fec_uncorr {} fec_symbol_err {}"
                         .format(intf_name, fec_corr, fec_uncorr, fec_symbol_err))

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -111,6 +111,7 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
                                    enum_frontend_asic_index, conn_graph_facts):
     """
     @Summary: Verify the FEC stats counters are valid
+    Also, check for any uncorrectable FEC errors
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
@@ -129,9 +130,14 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
         # Check if fec_corr, fec_uncorr, and fec_symbol_err are valid integers
         try:
             int(fec_corr)
-            int(fec_uncorr)
+            fec_uncorr_int = int(fec_uncorr)
             int(fec_symbol_err)
         except ValueError:
             pytest.fail("FEC stat counters are not valid integers for interface {}, \
-                        fec_corr {} fec_uncorr {} fec_symbol_err {}"
+                        fec_corr: {} fec_uncorr: {} fec_symbol_err: {}"
                         .format(intf_name, fec_corr, fec_uncorr, fec_symbol_err))
+
+        # Check for uncorrectable FEC errors
+        if fec_uncorr_int > 0:
+            pytest.fail("FEC uncorrectable errors are non-zero for interface {}: {}"
+                        .format(intf_name, fec_uncorr_int))

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -19,6 +19,15 @@ SUPPORTED_SPEEDS = [
 ]
 
 
+def is_supported_platform(duthost):
+    if any(platform in duthost.facts['platform'] for platform in SUPPORTED_PLATFORMS):
+        skip_release(duthost, ["201811", "201911", "202012", "202205", "202211", "202305"])
+        return True
+    else:
+        pytest.skip("DUT has platform {}, test is not supported".format(duthost.facts['platform']))
+        return False
+
+
 def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                               enum_frontend_asic_index, conn_graph_facts):
     """
@@ -27,11 +36,8 @@ def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-    if any(platform in duthost.facts['platform'] for platform in SUPPORTED_PLATFORMS):
-        # Not supported on 202305 and older releases
-        skip_release(duthost, ["201811", "201911", "202012", "202205", "202211", "202305"])
-    else:
-        pytest.skip("DUT has platform {}, test is not supported".format(duthost.facts['platform']))
+    if not is_supported_platform(duthost):
+        return
 
     logging.info("Get output of '{}'".format("show interface status"))
     intf_status = duthost.show_and_parse("show interface status")
@@ -61,11 +67,8 @@ def test_config_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-    if any(platform in duthost.facts['platform'] for platform in SUPPORTED_PLATFORMS):
-        # Not supported on 202305 and older releases
-        skip_release(duthost, ["201811", "201911", "202012", "202205", "202211", "202305"])
-    else:
-        pytest.skip("DUT has platform {}, test is not supported".format(duthost.facts['platform']))
+    if not is_supported_platform(duthost):
+        return
 
     logging.info("Get output of '{}'".format("show interface status"))
     intf_status = duthost.show_and_parse("show interface status")
@@ -100,11 +103,8 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-    if any(platform in duthost.facts['platform'] for platform in SUPPORTED_PLATFORMS):
-        # Not supported on 202305 and older releases
-        skip_release(duthost, ["201811", "201911", "202012", "202205", "202211", "202305"])
-    else:
-        pytest.skip("DUT has platform {}, test is not supported".format(duthost.facts['platform']))
+    if not is_supported_platform(duthost):
+        return
 
     logging.info("Get output of '{}'".format("show interfaces counters fec-stats"))
     intf_status = duthost.show_and_parse("show interfaces counters fec-stats")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

sonic-mgmt: Adding a test case to verify FEC stat counters are valid for all the interfaces with SFP status present.
Additionally, fail the test for non-zero uncorrectable FEC errors.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Use the command "show interfaces counters fec-stats" command to retrieve FEC stat counters

#### How did you verify/test it?
Verified on the lab devices with HWSku Mellanox 2700 and Mellanox 4600.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->