### PR TITLE
Skip sonic-mgmt  HdrmPoolSizeTest for Nokia-IXR7250E hwsku

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1421,6 +1421,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
       and topo_type in ['t1-64-lag'] and hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox']
       and asic_type in ['cisco-8000']"
       - "topo_type in ['m0', 'mx']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/13503 and platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
   skip:
@@ -1431,10 +1432,17 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
          and asic_type in ['cisco-8000']
          and https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100'] and topo_type in ['t1-64-lag']"
       - "topo_type in ['m0', 'mx']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/13503 and platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
   xfail:
     reason: "Headroom pool size not supported."
     conditions:
       - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
+
+qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue:
+  skip:
+    reason: "LossyQueue test is not supported"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/13503 and platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1421,7 +1421,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
       and topo_type in ['t1-64-lag'] and hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox']
       and asic_type in ['cisco-8000']"
       - "topo_type in ['m0', 'mx']"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/13503 and platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/13503 and 't2' in topo_name and asic_subtype in ['broadcom-dnx']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
   skip:
@@ -1432,7 +1432,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
          and asic_type in ['cisco-8000']
          and https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100'] and topo_type in ['t1-64-lag']"
       - "topo_type in ['m0', 'mx']"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/13503 and platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/13503 and 't2' in topo_name and asic_subtype in ['broadcom-dnx']"
   xfail:
     reason: "Headroom pool size not supported."
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1432,7 +1432,6 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
          and asic_type in ['cisco-8000']
          and https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100'] and topo_type in ['t1-64-lag']"
       - "topo_type in ['m0', 'mx']"
-      - "'t2' in topo_name and asic_subtype in ['broadcom-dnx']"
   xfail:
     reason: "Headroom pool size not supported."
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1446,12 +1446,6 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
       - "asic_type not in ['cisco-8000'] or platform in ['x86_64-8122_64eh_o-r0']"
       - "topo_type in ['m0', 'mx']"
 
-qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue:
-  skip:
-    reason: "LossyQueue test is not supported"
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/13503 and platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
-
 qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq:
   skip:
     reason: "Lossy Queue Voq test is not supported / M0/MX topo does not support qos"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1421,7 +1421,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
       and topo_type in ['t1-64-lag'] and hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox']
       and asic_type in ['cisco-8000']"
       - "topo_type in ['m0', 'mx']"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/13503 and 't2' in topo_name and asic_subtype in ['broadcom-dnx']"
+      - "'t2' in topo_name and asic_subtype in ['broadcom-dnx']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
   skip:
@@ -1432,7 +1432,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
          and asic_type in ['cisco-8000']
          and https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100'] and topo_type in ['t1-64-lag']"
       - "topo_type in ['m0', 'mx']"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/13503 and 't2' in topo_name and asic_subtype in ['broadcom-dnx']"
+      - "'t2' in topo_name and asic_subtype in ['broadcom-dnx']"
   xfail:
     reason: "Headroom pool size not supported."
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1438,12 +1438,6 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
     conditions:
       - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
 
-qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue:
-  skip:
-    reason: "LossyQueue test is not supported"
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/13503 and platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
-
 qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
   skip:
     reason: "Lossless Voq test is not supported / M0/MX topo does not support qos"
@@ -1451,6 +1445,12 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform in ['x86_64-8122_64eh_o-r0']"
       - "topo_type in ['m0', 'mx']"
+
+qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue:
+  skip:
+    reason: "LossyQueue test is not supported"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/13503 and platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Below test cases are skipped for hwsku in Nokia-IXR7250E-36x400G & platform asic in ['x86_64-nokia_ixr7250e_36x400g-r0']
-testQosSaiHeadroomPoolSize
-testQosSaiHeadroomPoolWatermark


Issue : https://github.com/sonic-net/sonic-mgmt/issues/13503

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
set skip for hwsku in Nokia-IXR7250E-36x400G & platform asic in ['x86_64-nokia_ixr7250e_36x400g-r0']
#### How did you verify/test it?
Execute the qos test cases 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
