### PR TITLE
Adjust test to only check queue counter of active ports

### DIFF
--- a/tests/snmp/test_snmp_queue.py
+++ b/tests/snmp/test_snmp_queue.py
@@ -70,8 +70,8 @@ def test_snmp_queues(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
                     for k, v in list(snmp_facts['snmp_interfaces'].items()) if v['name'] in alias_port_name_map]
 
     for intf in q_interfaces:
-        assert intf in snmp_ifnames, "Port {} with QUEUE config is not present in snmp interfaces".format(intf)    
-    
+        assert intf in snmp_ifnames, "Port {} with QUEUE config is not present in snmp interfaces".format(intf)
+
     for k, v in snmp_facts['snmp_interfaces'].items():
         # v['name'] is  alias for example Ethernet1/1
         if v['name'] in alias_port_name_map and is_port_active(v):

--- a/tests/snmp/test_snmp_queue.py
+++ b/tests/snmp/test_snmp_queue.py
@@ -7,6 +7,10 @@ pytestmark = [
 ]
 
 
+def is_port_active(v):
+    return v['adminstatus'] == 'up' and v['operstatus'] == 'up'
+
+
 def test_snmp_queues(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_all_duts,
                      collect_techsupport_all_duts):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -66,11 +70,11 @@ def test_snmp_queues(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cred
                     for k, v in list(snmp_facts['snmp_interfaces'].items()) if v['name'] in alias_port_name_map]
 
     for intf in q_interfaces:
-        assert intf in snmp_ifnames, "Port {} with QUEUE config is not present in snmp interfaces".format(intf)
-
+        assert intf in snmp_ifnames, "Port {} with QUEUE config is not present in snmp interfaces".format(intf)    
+    
     for k, v in snmp_facts['snmp_interfaces'].items():
         # v['name'] is  alias for example Ethernet1/1
-        if v['name'] in alias_port_name_map:
+        if v['name'] in alias_port_name_map and is_port_active(v):
             intf = alias_port_name_map[v['name']]
 
             # Expect all interfaces to have queue counters


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adjusted the test to skip validation of queue counter on inactive ports.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Adjust test to only check queue counter of active ports
#### How did you do it?
Check that a port is up before validating its queue counter.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
