### PR TITLE
Add logic to handle err msg detected by loganalyzer

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -15,6 +15,13 @@ def pytest_addoption(parser):
                      help="do not fail the test if new bugs were found")
     parser.addoption("--loganalyzer_rotate_logs", action="store_true", default=True,
                      help="rotate log on all the dut engines at the beginning of the log analyzer fixture")
+    parser.addoption("--bug_handler_params", action="store", default=None,
+                     help="params that may needed in log_analyzer_bug_handler when err detected, "
+                          "log_analyzer_bug_handler is called in _post_err_msg_handler, "
+                          "vendor can implement their own logic in log_analyzer_bug_handler.")
+    parser.addoption("--force_load_err_list", action="store_true", default=False,
+                     help="Load the user defined err msgs which is not included in the common ignore file,"
+                          "even when disable_loganalyzer is true")
 
 
 @reset_ansible_local_tmp
@@ -60,7 +67,7 @@ def loganalyzer(duthosts, request):
     if should_rotate_log:
         parallel_run(analyzer_logrotate, [], {}, duthosts, timeout=120)
     for duthost in duthosts:
-        analyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name)
+        analyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=request.node.name, request=request)
         analyzer.load_common_config()
         analyzers[duthost.hostname] = analyzer
     markers = parallel_run(analyzer_add_marker, [analyzers], {}, duthosts, timeout=120)
@@ -73,4 +80,4 @@ def loganalyzer(duthosts, request):
         return
     logging.info("Starting to analyse on all DUTs")
     parallel_run(analyze_logs, [analyzers, markers], {'fail_test': fail_test, 'store_la_logs': store_la_logs},
-                 duthosts, timeout=120)
+                 duthosts, timeout=240)

--- a/tests/common/plugins/loganalyzer/bug_handler_helper.py
+++ b/tests/common/plugins/loganalyzer/bug_handler_helper.py
@@ -1,0 +1,16 @@
+
+def skip_loganalyzer_bug_handler(duthost, request):
+    """
+    return True if the bug handler will be skipped.
+    User could implement their own logic here.
+    """
+    return True
+
+
+def log_analyzer_bug_handler(duthost, request):
+    """
+    If the not skip bug handler after the loganalyzer, run this function to handle the err msg detected in the
+    loganalyzer.
+    User could implement their own logic here.
+    """
+    pass

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -9,6 +9,7 @@ from . import system_msg_handler
 
 from .system_msg_handler import AnsibleLogAnalyzer as ansible_loganalyzer
 from os.path import join, split
+from .bug_handler_helper import log_analyzer_bug_handler, skip_loganalyzer_bug_handler
 
 ANSIBLE_LOGANALYZER_MODULE = system_msg_handler.__file__.replace(r".pyc", ".py")
 COMMON_MATCH = join(split(__file__)[0], "loganalyzer_common_match.txt")
@@ -72,7 +73,8 @@ class LogAnalyzerError(Exception):
 
 
 class LogAnalyzer:
-    def __init__(self, ansible_host, marker_prefix, dut_run_dir="/tmp", start_marker=None, additional_files={}):
+    def __init__(self, ansible_host, marker_prefix, request=None, dut_run_dir="/tmp", start_marker=None,
+                 additional_files={}):
         self.ansible_host = ansible_host
         ansible_host.loganalyzer = self
         self.dut_run_dir = dut_run_dir
@@ -91,12 +93,13 @@ class LogAnalyzer:
 
         self.additional_files = list(additional_files.keys())
         self.additional_start_str = list(additional_files.values())
+        self.request = request
 
     def _add_end_marker(self, marker):
         """
         @summary: Add stop marker into syslog on the DUT.
 
-        @return: True for successfull execution False otherwise
+        @return: True for successful execution False otherwise
         """
         self.ansible_host.copy(src=ANSIBLE_LOGANALYZER_MODULE, dest=os.path.join(self.dut_run_dir, "loganalyzer.py"))
 
@@ -145,8 +148,8 @@ class LogAnalyzer:
                 raise LogAnalyzerError(err_parse + result_str)
 
             # if the number of expected matches is provided
-            if (self.expect_regex and (self.expected_matches_target > 0)
-               and result["total"]["expected_match"] != self.expected_matches_target):
+            if (self.expect_regex and (self.expected_matches_target > 0) and
+                    result["total"]["expected_match"] != self.expected_matches_target):
                 err_target = "Log analyzer expected {} messages but found only {}\n"\
                     .format(self.expected_matches_target, len(self.expect_regex))
                 raise LogAnalyzerError(err_target + result_str)
@@ -164,7 +167,8 @@ class LogAnalyzer:
             tmp_folder = "/tmp/loganalyzer/{}".format(self.ansible_host.hostname)
             os.makedirs(tmp_folder, exist_ok=True)
             cur_time = time.strftime("%d_%m_%Y_%H_%M_%S", time.gmtime())
-            file_path = os.path.join(tmp_folder, "log_error_{}_{}.json".format(self.marker_prefix, cur_time))
+            cleaned_marker_prefix = re.sub(r'[\\/\'"<>|]', '_', self.marker_prefix)
+            file_path = os.path.join(tmp_folder, "log_error_{}_{}.json".format(cleaned_marker_prefix, cur_time))
             logging.info("Log errors will be saved in file: {}".format(file_path))
             data = {'log_errors': log_errors}
             with open(file_path, "w+") as file:
@@ -209,7 +213,7 @@ class LogAnalyzer:
 
     def load_common_config(self):
         """
-        @summary: Load regular expressions from common files, which are localted in folder with legacy loganalyzer.
+        @summary: Load regular expressions from common files, which are located in folder with legacy loganalyzer.
                   Loaded regular expressions are used by "analyze" method
                   to match expected text in the downloaded log file.
         """
@@ -217,6 +221,11 @@ class LogAnalyzer:
         self.ignore_regex = self.ansible_loganalyzer.create_msg_regex([COMMON_IGNORE])[1]
         self.expect_regex = self.ansible_loganalyzer.create_msg_regex([COMMON_EXPECT])[1]
         logging.debug('Loaded common config.')
+
+        if self.request:
+            extended_ignore_list = self.request.session.config.cache.get("extended_ignore_list", [])
+            self.ignore_regex.extend(extended_ignore_list)
+            logging.info(f"Loaded extend ignore config: {extended_ignore_list}")
 
     def parse_regexp_file(self, src):
         """
@@ -250,7 +259,7 @@ class LogAnalyzer:
         """
         @summary: Add start marker into log files on the DUT.
 
-        @return: True for successfull execution False otherwise
+        @return: True for successful execution False otherwise
         """
         logging.debug("Loganalyzer init")
 
@@ -407,8 +416,16 @@ class LogAnalyzer:
 
         if fail:
             self._verify_log(analyzer_summary)
+        elif store_la_logs:
+            self._post_err_msg_handler(analyzer_summary)
         else:
             return analyzer_summary
+
+    def _post_err_msg_handler(self, analyzer_summary):
+        if skip_loganalyzer_bug_handler(self.ansible_host, self.request):
+            self._verify_log(analyzer_summary)
+        else:
+            log_analyzer_bug_handler(self.ansible_host, self.request)
 
     def save_extracted_log(self, dest):
         """


### PR DESCRIPTION
In this change it has following function:
1. Add ability to handle the err msg detected by loganalyzer
2. Do not run the loganalyzer in parallel if there is only 1 loganalyzer need to run
3. Increase the timeout from 120 to 240 for the parallel run of the loganalyzer since if lot of err msgs need to be handler, it will take more time to finish it.
4. When load the ignore regex list, also load the value of "extended_ignore_list" in the cache

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
