### PR TITLE
refactor: combine single and multi asic bgp check

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -158,13 +158,8 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
         time.sleep(wait)
 
     if wait_for_bgp:
-        if sonic_host.is_multi_asic:
-            bgp_neighbors = sonic_host.get_bgp_neighbors_per_asic()
-            pytest_assert(
-                wait_until(120, 10, 0, sonic_host.check_bgp_session_state_all_asics, bgp_neighbors),
-                "Not all bgp sessions are established after config reload",
-            )
-        else:
-            bgp_neighbors = sonic_host.get_bgp_neighbors().keys()
-            pytest_assert(wait_until(120, 10, 0, sonic_host.check_bgp_session_state, bgp_neighbors),
-                          "Not all bgp sessions are established after config reload")
+        bgp_neighbors = sonic_host.get_bgp_neighbors_per_asic()
+        pytest_assert(
+            wait_until(120, 10, 0, sonic_host.check_bgp_session_state_all_asics, bgp_neighbors),
+            "Not all bgp sessions are established after config reload",
+        )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Refactor the BGP check in `config_reload.py` to combine the single and multi asic scenarios into one.

Summary:
Fixes # (issue) Microsoft ADO 28459397

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
In the previous PR #13471, we added multi asic support when `wait_for_bgp` is True in `common/config_reload.py`. It turns out we don't need to differentiate the single and multi asic scenarios. For a single asic Testbed, we can also use the `sonic_host.get_bgp_neighbors_per_asic()` and `sonic_host.check_bgp_session_state_all_asics()` to confirm the BGP session status. 

One thing we need to be aware of is that `sonic_host.get_bgp_neighbors_per_asic()` will return a dictionary with `None` as the key for a single asic Testbed. This is because for a single asic Testbed, its default namespace is always `None`, but any hashable value is a valid Python dictionary key, so it should be fine to use `None` as the key.

#### How did you do it?

#### How did you verify/test it?
I manually ran the `config_reload(..., wait_for_bgp=True)` function in a single asic Testbed, and I can confirm it's working fine.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
