### PR TITLE
Remove xfail marker of ecmp/test_ecmp_sai_value.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -529,7 +529,7 @@ ecmp/inner_hashing/test_wr_inner_hashing_lag.py:
 
 ecmp/test_ecmp_sai_value.py:
   skip:
-    reason: "Only support Broadcom T1/T0 topology with 20230531 image, 7050cx3 T1 doesn't enable this feature"
+    reason: "Only support Broadcom T1/T0 topology with 20230531 and above image, 7050cx3 T1 doesn't enable this feature"
     conditions_logical_operator: or
     conditions:
       - "topo_type not in ['t1', 't0']"
@@ -537,11 +537,6 @@ ecmp/test_ecmp_sai_value.py:
       - "release in ['201911', '202012', '202205', '202211', 'master']"
       - "'internal' in build_version"
       - "topo_type in ['t1'] and hwsku in ['Arista-7050CX3-32S-C32']"
-  xfail:
-    reason: "This feature is not supported in 202311 as the code was not merged into 202311"
-    conditions:
-      - "release in ['202311']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/11310
 
 ecmp/test_fgnhg.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #11310 
LAG and ECMP hash offset support has merged in 202311 https://github.com/sonic-net/sonic-swss/pull/3138, remove the xfail marker of ecmp/test_ecmp_sai_value.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
After https://github.com/sonic-net/sonic-swss/pull/3138, configure hash_offset along with hash_seed attribute is enabled on 202311 onwards on Broadcom T1 platfrom.

#### How did you do it?
Remove the xfail marker of ecmp/test_ecmp_sai_value.py

#### How did you verify/test it?
Run ecmp/test_ecmp_sai_values.py on 7260 T1 DUT and passed.
https://dev.azure.com/mssonic/internal/_build/results?buildId=586225&view=results

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
