### PR TITLE
[Fanout] Update Arista-7260CX3 leaf fanout template for breakout 4x 10G interface

### DIFF
--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -70,7 +70,7 @@ interface {{ subintf }}
 interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-   switchport mode dot1q-tunnel 
+   switchport mode dot1q-tunnel
    spanning-tree portfast
    speed forced 50gfull
    no error-correction encoding

--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -52,7 +52,8 @@ vrf definition management
    no shutdown
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "10000" %}
 {%          for sub in range (1,5) %}
-{%             set subintf = 'Ethernet' + i|string + '/' + sub|string %}
+{%              set subintf = 'Ethernet' + i|string + '/' + sub|string %}
+{%              if subintf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][subintf]['mode'] != "Trunk" %}
    interface {{ subintf }}
    description {{ device_conn[inventory_hostname][subintf]['peerdevice'] }}-{{ device_conn[inventory_hostname][subintf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[inventory_hostname][subintf]['vlanids'] }}
@@ -61,6 +62,7 @@ vrf definition management
    speed forced 10gfull
    no shutdown
 !
+{%              endif %}
 {%          endfor %}
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "50000" %}
 interface {{ intf }}

--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -51,9 +51,9 @@ vrf definition management
    speed forced 40gfull
    no shutdown
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "10000" %}
-{%          for sub in range (1,5) %}
-{%              set subintf = 'Ethernet' + i|string + '/' + sub|string %}
-{%              if subintf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][subintf]['mode'] != "Trunk" %}
+{%         for sub in range (1,5) %}
+{%             set subintf = 'Ethernet' + i|string + '/' + sub|string %}
+{%             if subintf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][subintf]['mode'] != "Trunk" %}
    interface {{ subintf }}
    description {{ device_conn[inventory_hostname][subintf]['peerdevice'] }}-{{ device_conn[inventory_hostname][subintf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[inventory_hostname][subintf]['vlanids'] }}
@@ -62,8 +62,8 @@ vrf definition management
    speed forced 10gfull
    no shutdown
 !
-{%              endif %}
-{%          endfor %}
+{%             endif %}
+{%         endfor %}
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "50000" %}
 interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}

--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -70,7 +70,7 @@ interface {{ subintf }}
 interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-   switchport mode dot1q-tunnel
+   switchport mode dot1q-tunnel 
    spanning-tree portfast
    speed forced 50gfull
    no error-correction encoding

--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -53,8 +53,8 @@ vrf definition management
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "10000" %}
 {%         for sub in range (1,5) %}
 {%             set subintf = 'Ethernet' + i|string + '/' + sub|string %}
+interface {{ subintf }}
 {%             if subintf in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][subintf]['mode'] != "Trunk" %}
-   interface {{ subintf }}
    description {{ device_conn[inventory_hostname][subintf]['peerdevice'] }}-{{ device_conn[inventory_hostname][subintf]['peerport'] }}
    switchport access vlan {{ device_port_vlans[inventory_hostname][subintf]['vlanids'] }}
    switchport mode dot1q-tunnel
@@ -62,6 +62,8 @@ vrf definition management
    speed forced 10gfull
    no shutdown
 !
+{%             else %}
+   shutdown
 {%             endif %}
 {%         endfor %}
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "50000" %}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update Arista-7260CX3 leaf fanout configuration template for breakout 4x 10G interface.
Fix the template for situation that not all the 4 breakout interface are being used.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Update Arista-7260CX3 leaf fanout configuration template for breakout 4x 10G interface.
Fix the template for situation that not all the 4 breakout interface are being used.

#### How did you do it?
Update the j2 template file.

#### How did you verify/test it?
Verified on physical Arista-7260CX3 fanout switch.
Snippet of generated configuration:

```
...
interface Ethernet9/1
   description DUT-1-Ethernet51
   speed forced 10000full
   switchport access vlan 668
   switchport mode dot1q-tunnel
   spanning-tree portfast
!
interface Ethernet9/2
   shutdown
!
interface Ethernet9/3
   description DUT-2-Ethernet51
   speed forced 10000full
   switchport access vlan 772
   switchport mode dot1q-tunnel
   spanning-tree portfast
!
interface Ethernet9/4
   shutdown
!
...
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
