### PR TITLE
[dhcp_server_test] Enable autorestart before test dhcp server container autorestart

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -36,11 +36,6 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname, tb
     dhcp_server_hosts = []
     # Enable autorestart for all features before the test begins
     for hostname in selected_rand_one_per_hwsku_hostname:
-        duthost = duthosts[hostname]
-        feature_list, _ = duthost.get_feature_status()
-        for feature, status in list(feature_list.items()):
-            if status == 'enabled':
-                duthost.shell("sudo config feature autorestart {} enabled".format(feature))
         # Enable dhcp_server feature for mx topo
         if tbinfo["topo"]["type"] == "mx" \
             and DHCP_SERVER in feature_list \
@@ -56,6 +51,12 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname, tb
                            "dhcp-relay:dhcprelayd"),
                 "dhcp-relay:dhcprelayd is not running"
             )
+        # Enable autorestart for all enabled features
+        duthost = duthosts[hostname]
+        feature_list, _ = duthost.get_feature_status()
+        for feature, status in list(feature_list.items()):
+            if status == 'enabled':
+                duthost.shell("sudo config feature autorestart {} enabled".format(feature))
     yield
     # Config reload should set the auto restart back to state before test started
     for hostname in selected_rand_one_per_hwsku_hostname:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
 test_pretest.py disables autorestart for all features, so if we want to test dhcp server autorestart we need to enable it.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
test_pretest.py disables autorestart for all features, so if we want to test dhcp server autorestart we need to enable it.

#### How did you do it?
Enable autorestart before test

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
