### PR TITLE
[Snappi] Fix duthost port mapping in multidut snappi tests (PFCWD, ECN)

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -630,6 +630,7 @@ def get_multidut_snappi_ports(duthosts, conn_graph_facts, fanout_graph_facts):  
                         if port["peer_port"] in asic_port_map[asic] and hostname in port['peer_device']:
                             port['asic_value'] = asic
                             port['asic_type'] = host.facts["asic_type"]
+                            port['duthost'] = host
                             ports.append(port)
         return ports
     return _get_multidut_snappi_ports

--- a/tests/snappi_tests/multidut/ecn/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/ecn/files/multidut_helper.py
@@ -51,28 +51,32 @@ def run_ecn_test(api,
     if snappi_extra_params is None:
         snappi_extra_params = SnappiTestParams()
 
-    duthost1 = snappi_extra_params.multi_dut_params.duthost1
+    # Traffic flow:
+    # tx_port (TGEN) --- ingress DUT --- egress DUT --- rx_port (TGEN)
+
     rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
-    duthost2 = snappi_extra_params.multi_dut_params.duthost2
+    egress_duthost = rx_port['duthost']
+
     tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
+    ingress_duthost = tx_port['duthost']
 
     pytest_assert(testbed_config is not None, 'Failed to get L2/3 testbed config')
 
     logger.info("Stopping PFC watchdog")
-    stop_pfcwd(duthost1, rx_port['asic_value'])
-    stop_pfcwd(duthost2, tx_port['asic_value'])
+    stop_pfcwd(egress_duthost, rx_port['asic_value'])
+    stop_pfcwd(ingress_duthost, tx_port['asic_value'])
     logger.info("Disabling packet aging if necessary")
-    disable_packet_aging(duthost1)
-    disable_packet_aging(duthost2)
+    disable_packet_aging(egress_duthost)
+    disable_packet_aging(ingress_duthost)
 
     # Configure WRED/ECN thresholds
     logger.info("Configuring WRED and ECN thresholds")
-    config_result = config_wred(host_ans=duthost1,
+    config_result = config_wred(host_ans=egress_duthost,
                                 kmin=snappi_extra_params.ecn_params["kmin"],
                                 kmax=snappi_extra_params.ecn_params["kmax"],
                                 pmax=snappi_extra_params.ecn_params["pmax"])
     pytest_assert(config_result is True, 'Failed to configure WRED/ECN at the DUT')
-    config_result = config_wred(host_ans=duthost2,
+    config_result = config_wred(host_ans=ingress_duthost,
                                 kmin=snappi_extra_params.ecn_params["kmin"],
                                 kmax=snappi_extra_params.ecn_params["kmax"],
                                 pmax=snappi_extra_params.ecn_params["pmax"])
@@ -80,20 +84,20 @@ def run_ecn_test(api,
 
     # Enable ECN marking
     logger.info("Enabling ECN markings")
-    pytest_assert(enable_ecn(host_ans=duthost1, prio=lossless_prio), 'Unable to enable ecn')
-    pytest_assert(enable_ecn(host_ans=duthost2, prio=lossless_prio), 'Unable to enable ecn')
+    pytest_assert(enable_ecn(host_ans=egress_duthost, prio=lossless_prio), 'Unable to enable ecn')
+    pytest_assert(enable_ecn(host_ans=ingress_duthost, prio=lossless_prio), 'Unable to enable ecn')
 
-    config_result = config_ingress_lossless_buffer_alpha(host_ans=duthost1,
+    config_result = config_ingress_lossless_buffer_alpha(host_ans=egress_duthost,
                                                          alpha_log2=3)
 
     pytest_assert(config_result is True, 'Failed to configure PFC threshold to 8')
-    config_result = config_ingress_lossless_buffer_alpha(host_ans=duthost2,
+    config_result = config_ingress_lossless_buffer_alpha(host_ans=ingress_duthost,
                                                          alpha_log2=3)
 
     pytest_assert(config_result is True, 'Failed to configure PFC threshold to 8')
 
     # Get the ID of the port to test
-    port_id = get_dut_port_id(dut_hostname=duthost1.hostname,
+    port_id = get_dut_port_id(dut_hostname=egress_duthost.hostname,
                               dut_port=dut_port,
                               conn_data=conn_data,
                               fanout_data=fanout_data)
@@ -166,7 +170,7 @@ def run_ecn_test(api,
                            capture_name=snappi_extra_params.packet_capture_file)
 
         logger.info("Running traffic")
-        run_traffic(duthost=duthost1,
+        run_traffic(duthost=egress_duthost,
                     api=api,
                     config=testbed_config,
                     data_flow_names=data_flow_names,

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_burst_storm_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_burst_storm_helper.py
@@ -51,22 +51,27 @@ def run_pfcwd_burst_storm_test(api,
     if snappi_extra_params is None:
         snappi_extra_params = SnappiTestParams()
 
-    duthost1 = snappi_extra_params.multi_dut_params.duthost1
+    # Traffic flow:
+    # tx_port (TGEN) --- ingress DUT --- egress DUT --- rx_port (TGEN)
+
     rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
     rx_port_id = rx_port["port_id"]
-    duthost2 = snappi_extra_params.multi_dut_params.duthost2
+    egress_duthost = rx_port['duthost']
+
     tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
     tx_port_id = tx_port["port_id"]
+    ingress_duthost = tx_port['duthost']
 
     pytest_assert(testbed_config is not None, 'Fail to get L2/3 testbed config')
 
-    start_pfcwd(duthost1, rx_port['asic_value'])
-    enable_packet_aging(duthost1)
-    start_pfcwd(duthost2, tx_port['asic_value'])
-    enable_packet_aging(duthost2)
-    poll_interval_sec = get_pfcwd_poll_interval(duthost1, rx_port['asic_value']) / 1000.0
-    detect_time_sec = get_pfcwd_detect_time(host_ans=duthost1, intf=dut_port, asic_value=rx_port['asic_value']) / 1000.0        # noqa: E501
-    restore_time_sec = get_pfcwd_restore_time(host_ans=duthost1, intf=dut_port, asic_value=rx_port['asic_value']) / 1000.0      # noqa: E501
+    start_pfcwd(egress_duthost, rx_port['asic_value'])
+    enable_packet_aging(egress_duthost)
+    start_pfcwd(ingress_duthost, tx_port['asic_value'])
+    enable_packet_aging(ingress_duthost)
+
+    poll_interval_sec = get_pfcwd_poll_interval(egress_duthost, rx_port['asic_value']) / 1000.0
+    detect_time_sec = get_pfcwd_detect_time(host_ans=egress_duthost, intf=rx_port['peer_port'], asic_value=rx_port['asic_value']) / 1000.0        # noqa: E501
+    restore_time_sec = get_pfcwd_restore_time(host_ans=egress_duthost, intf=rx_port['peer_port'], asic_value=rx_port['asic_value']) / 1000.0      # noqa: E501
     burst_cycle_sec = poll_interval_sec + detect_time_sec + restore_time_sec + 0.1
     data_flow_dur_sec = ceil(burst_cycle_sec * BURST_EVENTS)
     pause_flow_dur_sec = poll_interval_sec * 0.5
@@ -108,7 +113,7 @@ def run_pfcwd_burst_storm_test(api,
     __verify_results(rows=flow_stats,
                      data_flow_prefix=DATA_FLOW_PREFIX,
                      pause_flow_prefix=PAUSE_FLOW_PREFIX,
-                     duthosts=[duthost1, duthost2])
+                     duthosts=[egress_duthost, ingress_duthost])
 
 
 def __gen_traffic(testbed_config,

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_runtime_traffic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_runtime_traffic_helper.py
@@ -48,16 +48,20 @@ def run_pfcwd_runtime_traffic_test(api,
     if snappi_extra_params is None:
         snappi_extra_params = SnappiTestParams()
 
-    duthost1 = snappi_extra_params.duthost1
-    rx_port = snappi_extra_params.rx_port
-    duthost2 = snappi_extra_params.duthost2
-    tx_port = snappi_extra_params.tx_port
+    # Traffic flow:
+    # tx_port (TGEN) --- ingress DUT --- egress DUT --- rx_port (TGEN)
+
+    rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
+    egress_duthost = rx_port['duthost']
     rx_port_id = snappi_extra_params.rx_port_id
+
+    tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
+    ingress_duthost = tx_port['duthost']
     tx_port_id = snappi_extra_params.tx_port_id
 
     pytest_assert(testbed_config is not None, 'Fail to get L2/3 testbed config')
-    stop_pfcwd(duthost1, rx_port['asic_value'])
-    stop_pfcwd(duthost2, tx_port['asic_value'])
+    stop_pfcwd(egress_duthost, rx_port['asic_value'])
+    stop_pfcwd(ingress_duthost, tx_port['asic_value'])
 
     __gen_traffic(testbed_config=testbed_config,
                   port_config_list=port_config_list,
@@ -75,7 +79,7 @@ def run_pfcwd_runtime_traffic_test(api,
 
     flow_stats = __run_traffic(api=api,
                                config=testbed_config,
-                               duthost=duthost1,
+                               duthost=egress_duthost,
                                port=rx_port,
                                all_flow_names=all_flow_names,
                                pfcwd_start_delay_sec=PFCWD_START_DELAY_SEC,

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_runtime_traffic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_runtime_traffic_helper.py
@@ -51,11 +51,11 @@ def run_pfcwd_runtime_traffic_test(api,
     # Traffic flow:
     # tx_port (TGEN) --- ingress DUT --- egress DUT --- rx_port (TGEN)
 
-    rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
+    rx_port = snappi_extra_params.rx_port
     egress_duthost = rx_port['duthost']
     rx_port_id = snappi_extra_params.rx_port_id
 
-    tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
+    tx_port = snappi_extra_params.tx_port
     ingress_duthost = tx_port['duthost']
     tx_port_id = snappi_extra_params.tx_port_id
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #13443 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix duthost and port mapping mismatch issue in multidut  PFCWD and ECN test cases.  PFC test cases will be changed in another PR to avoid large commit.

#### How did you do it?
Add 'duthost' into get_multidut_snappi_ports, so that we can retrieve duthost based on port information.

#### How did you verify/test it?
Test it manually. all PFCWD test cases can run successfully. There are test failures but are not related to this change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
