### PR TITLE
[Test Gap] Cover all cacl protocols in GCU test_cacl

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -347,6 +347,7 @@ onboarding_t0:
 
 onboarding_t1:
   - decap/test_decap.py
+  - generic_config_updater/test_cacl.py
 
 specific_param:
   t0-sonic:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix the test gap https://github.com/sonic-net/sonic-mgmt/issues/12816

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Original test_cacl only covers parts of SNMP or SSH protocol test, https://github.com/sonic-net/sonic-host-services/pull/9 introduce EXTERNAL_CLIENT, we have to cover it in GCU test_cacl

#### How did you do it?
Enhance many functions to support different protocols and add a fixture cacl_protocol to test SSH, SNMP,NTP, EXTERNAL_CLIENT one by one.
Also add T1 topology in mark topology list.

Test steps:
TC1 cacl table:
1. Test to add a new cacl table, which should expect success
2. test add duplicated cacl table, which should expect success
3. Test replace some variable in existing cacl table, which should expect success
4. Test add invalid cacl table, which should expect failure
5. Test remove non-existed cacl table, which should expect failure
6. Test remove cacl table, , which should expect success,
7. Test previous steps for SSH, SNMP,NTP, EXTERNAL_CLIENT one by one

TC2 cacl rule:
1. Test to add a new cacl rule, which should expect success and iptables rules are expected
2. test add duplicated cacl rule, which should expect success and iptables rules are expected
3. Test replace some variable in existing cacl rule, which should expect success and iptables rules are expected
4. Test add cacl rule into non-existed cacl table, which should expect failure
5. Test remove cacl table which has cacl rules, which should expect failure
6. Test remove non-existed cacl rule, which should expect success,
7. Test remove ACL_RULE path, which should expect success and none of  unexpected iptables rules exists
8. Test previous steps for SSH, SNMP,NTP, EXTERNAL_CLIENT one by one

- workitem:

27868222
#### How did you verify/test it?

```
collected 8 items                                                                                                                                                                                                                        

generic_config_updater/test_cacl.py::test_cacl_tc1_acl_table_suite[SSH] PASSED                                                                                                                                                     [ 12%]
generic_config_updater/test_cacl.py::test_cacl_tc2_acl_rule_test[SSH] PASSED                                                                                                                                                       [ 25%]
generic_config_updater/test_cacl.py::test_cacl_tc1_acl_table_suite[NTP] PASSED                                                                                                                                                     [ 37%]
generic_config_updater/test_cacl.py::test_cacl_tc2_acl_rule_test[NTP] PASSED                                                                                                                                                       [ 50%]
generic_config_updater/test_cacl.py::test_cacl_tc1_acl_table_suite[SNMP] PASSED                                                                                                                                                    [ 62%]
generic_config_updater/test_cacl.py::test_cacl_tc2_acl_rule_test[SNMP] PASSED                                                                                                                                                      [ 75%]
generic_config_updater/test_cacl.py::test_cacl_tc1_acl_table_suite[EXTERNAL_CLIENT] PASSED                                                                                                                                         [ 87%]
generic_config_updater/test_cacl.py::test_cacl_tc2_acl_rule_test[EXTERNAL_CLIENT] PASSED                                                                                                                                           [100%]

============================================================================================================ warnings summary ============================================================================================================
```

#### Any platform specific information?
Run `tests/generic_config_updater/test_cacl.py`

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
