### PR TITLE
Fix dhcp process name when called by supervisorctl

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -486,9 +486,10 @@ def ensure_process_is_running(duthost, container_name, critical_process):
     Returns:
         None.
     """
-    if container_name == "dhcp_relay" and (critical_process == "dhcp6relay" or critical_process == "dhcprelayd"):
+    if critical_process in ["dhcp6relay", "dhcprelayd"]:
         # For dhcp-relay container, the process name in supervisord started 'dhcp-relay: + the process name'
         critical_process = "dhcp-relay" + ":" + critical_process
+
     logger.info("Checking whether process '{}' in container '{}' is running..."
                 .format(critical_process, container_name))
     program_status, program_pid = get_program_info(duthost, container_name, critical_process)

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -486,6 +486,10 @@ def ensure_process_is_running(duthost, container_name, critical_process):
     Returns:
         None.
     """
+    if container_name == "dhcp_relay":
+        # For dhcp-relay container, the process name in supervisord started 'dhcp-relay: + the process name'
+        critical_process = "dhcp-relay" + ":" + critical_process
+
     logger.info("Checking whether process '{}' in container '{}' is running..."
                 .format(critical_process, container_name))
     program_status, program_pid = get_program_info(duthost, container_name, critical_process)

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -486,10 +486,9 @@ def ensure_process_is_running(duthost, container_name, critical_process):
     Returns:
         None.
     """
-    if container_name == "dhcp_relay":
+    if container_name == "dhcp_relay" and (critical_process == "dhcp6relay" or critical_process == "dhcprelayd"):
         # For dhcp-relay container, the process name in supervisord started 'dhcp-relay: + the process name'
         critical_process = "dhcp-relay" + ":" + critical_process
-
     logger.info("Checking whether process '{}' in container '{}' is running..."
                 .format(critical_process, container_name))
     program_status, program_pid = get_program_info(duthost, container_name, critical_process)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
To address the issue where the `dhcp6relay` and `dhcprelayd` processes are not running as expected within `dhcp_relay`, it is necessary to ensure that the correct prefix `dhcp-relay:` is included when attempting to start these processes using `supervisorctl`. This prefix is crucial for the supervisor to recognize and manage the processes correctly. By adding a condition to include the prefix, `supervisorctl` can be used effectively to start the `dhcp6relay` and `dhcprelayd` processes as intended.

Fixes # (issue)
{"changed": true, "cmd": "docker exec dhcp_relay supervisorctl start dhcp6relay", "delta": "0:00:00.381158", "end": "2024-06-19 03:45:44.319270", "failed": true, "msg": "non-zero return code", "rc": 1, "start": "2024-06-19 03:45:43.938112", "stderr": "", "stderr_lines": [], "stdout": "dhcp6relay: ERROR (no such process)", "stdout_lines": ["dhcp6relay: ERROR (no such process)"]}

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Make sure critical process can starts it if it was not running. 

#### How did you do it?
By adding a check on the container name the process name. And add the `dhcp-relay:` as necessary. 

#### How did you verify/test it?
Run with `docker exec` command on testbed.
We can see, before the change it will have the error "no such process" which is what we have been seeing in the test log, by adding the prefix will correctly lactated the process.

```
root@str3-msn4700-03:/etc/supervisor# supervisorctl start dhcp6relay
dhcp6relay: ERROR (no such process)
root@str3-msn4700-03:/etc/supervisor# supervisorctl start dhcp-relay:dhcp6relay
dhcp-relay:dhcp6relay: ERROR (already started)
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
