### PR TITLE
Validate /etc/resolv.conf in each docker container

### DIFF
--- a/tests/dns/test_dns_resolv_conf.py
+++ b/tests/dns/test_dns_resolv_conf.py
@@ -37,3 +37,44 @@ def test_dns_resolv_conf(duthost):
     pytest_assert(not (current_nameservers ^ expected_nameservers),
                   "Mismatch between expected and current nameservers! Expected: [{}]. Current: [{}].".format(
                   " ".join(expected_nameservers), " ".join(current_nameservers)))
+
+
+def test_dns_resolv_conf_container(duthost):
+    """verify that /etc/resolv.conf in container contains the expected nameservers
+
+    Args:
+        duthost: AnsibleHost instance for DUT
+    """
+
+    # If running a public image with sonic-mgmt-int, we can't say for sure whether we should expect there to not be any
+    # DNS servers configured in /etc/resolv.conf, or whether the internal DNS should be configured. This is becuase
+    # pretest configures the internal DNS server, but if there's some system reload/reboot, then this may go away/be
+    # overwritten.
+    #
+    # There are some changes that might improve the state of things (resolvconf, config_db support), but for now, just
+    # skip this combination.
+    if get_image_type(duthost) == "public":
+        pytest.skip("Inconsistent expectations for DNS server when running a public image with sonic-mgmt-int")
+
+    # Check SONiC image type and get expected nameservers in /etc/resolv.conf
+    expected_nameservers = set(RESOLV_CONF_NAMESERVERS[get_image_type(duthost=duthost)])
+
+    logger.info("expected nameservers: [{}]".format(" ".join(expected_nameservers)))
+
+    containers = duthost.get_running_containers()
+    for container in containers:
+        resolv_conf = duthost.shell("docker exec %s cat /etc/resolv.conf" % container, module_ignore_errors=True)
+        pytest_assert(resolv_conf["rc"] == 0, "Failed to read /etc/resolf.conf!")
+        current_nameservers = []
+        for resolver_line in resolv_conf["stdout_lines"]:
+            if not resolver_line.startswith("nameserver"):
+                continue
+            current_nameservers.append(resolver_line.split()[1])
+
+        current_nameservers = set(current_nameservers)
+
+        logger.info("{} container, current nameservers: [{}]".format(container, " ".join(current_nameservers)))
+
+        pytest_assert(not (current_nameservers ^ expected_nameservers),
+                    "Mismatch between expected and current nameservers for {}! Expected: [{}]. Current: [{}].".format(
+                    container, " ".join(expected_nameservers), " ".join(current_nameservers)))

--- a/tests/dns/test_dns_resolv_conf.py
+++ b/tests/dns/test_dns_resolv_conf.py
@@ -38,29 +38,6 @@ def test_dns_resolv_conf(duthost):
                   "Mismatch between expected and current nameservers! Expected: [{}]. Current: [{}].".format(
                   " ".join(expected_nameservers), " ".join(current_nameservers)))
 
-
-def test_dns_resolv_conf_container(duthost):
-    """verify that /etc/resolv.conf in container contains the expected nameservers
-
-    Args:
-        duthost: AnsibleHost instance for DUT
-    """
-
-    # If running a public image with sonic-mgmt-int, we can't say for sure whether we should expect there to not be any
-    # DNS servers configured in /etc/resolv.conf, or whether the internal DNS should be configured. This is becuase
-    # pretest configures the internal DNS server, but if there's some system reload/reboot, then this may go away/be
-    # overwritten.
-    #
-    # There are some changes that might improve the state of things (resolvconf, config_db support), but for now, just
-    # skip this combination.
-    if get_image_type(duthost) == "public":
-        pytest.skip("Inconsistent expectations for DNS server when running a public image with sonic-mgmt-int")
-
-    # Check SONiC image type and get expected nameservers in /etc/resolv.conf
-    expected_nameservers = set(RESOLV_CONF_NAMESERVERS[get_image_type(duthost=duthost)])
-
-    logger.info("expected nameservers: [{}]".format(" ".join(expected_nameservers)))
-
     containers = duthost.get_running_containers()
     for container in containers:
         resolv_conf = duthost.shell("docker exec %s cat /etc/resolv.conf" % container, module_ignore_errors=True)
@@ -76,5 +53,5 @@ def test_dns_resolv_conf_container(duthost):
         logger.info("{} container, current nameservers: [{}]".format(container, " ".join(current_nameservers)))
 
         pytest_assert(not (current_nameservers ^ expected_nameservers),
-                    "Mismatch between expected and current nameservers for {}! Expected: [{}]. Current: [{}].".format(
-                    container, " ".join(expected_nameservers), " ".join(current_nameservers)))
+                      "Mismatch between expected and current nameservers for {}! Expected: [{}]. Current: [{}].".format(
+                      container, " ".join(expected_nameservers), " ".join(current_nameservers)))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/8242

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
If /etc/resolv.conf is broken in docker container, some critical service may fail to start.

#### How did you do it?
Update test case to cover the validation of /etc/resolv.conf in each docker container.

#### How did you verify/test it?
Run DNS end to end test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
