### PR TITLE
Xfail test_copp test_add_new_trap and test_remove_trap on 202311 for  Broadcom platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -213,12 +213,22 @@ copp/test_copp.py::TestCOPP::test_add_new_trap:
     reason: "Copp test_add_new_trap is not yet supported on multi-asic platform"
     conditions:
       - "is_multi_asic==True"
+  xfail:
+    reason: "Test failed due to known issue on broadcom platform, xfail it on 202311"
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/13560
+      - "asic_type in ['broadcom'] and release in ['202311']"
 
 copp/test_copp.py::TestCOPP::test_remove_trap:
   skip:
     reason: "Copp test_remove_trap is not yet supported on multi-asic platform"
     conditions:
       - "is_multi_asic==True"
+  xfail:
+    reason: "Test failed due to known issue on broadcom platform, xfail it on 202311"
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/13560
+      - "asic_type in ['broadcom'] and release in ['202311']"
 
 copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
   skip:


### PR DESCRIPTION
…broadcom platform

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
 test_copp 2 cases failed due to the issue:
https://github.com/sonic-net/sonic-mgmt/issues/13560

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Xfaile test_copp test_add_new_trap and test_remove_trap on 202311 for Broadcom platform.

#### How did you do it?
Add xfail section for these 2 cases in conditional mark file.

#### How did you verify/test it?
Run test_copp on Broadcom  testbeds against 202311 branch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
