### PR TITLE
Adding port mapping for new Arista Hardware SKUs

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -279,7 +279,7 @@
   - block:
       - name: Create new dictionary for my slot
         set_fact:
-          new_asic_topo_config : "{{ new_asic_topo_config | default( { slot_num  : asic_topo_config.slot0 }) }}"
+          new_asic_topo_config : "{{ new_asic_topo_config | default( { slot_num  : asic_topo_config[slot_num] }) }}"
 
       - name: set asic_topo_config to new dictionary
         set_fact:

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -279,7 +279,7 @@
   - block:
       - name: Create new dictionary for my slot
         set_fact:
-          new_asic_topo_config : "{{ new_asic_topo_config | default( { slot_num  : asic_topo_config[slot_num] }) }}"
+          new_asic_topo_config : "{{ new_asic_topo_config | default( { slot_num  : asic_topo_config.slot0 }) }}"
 
       - name: set asic_topo_config to new dictionary
         set_fact:

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -243,15 +243,16 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
                 sonic_name = "Ethernet%d" % ((i - 1) * 8)
                 port_alias_to_name_map["Ethernet{}/{}".format(i, 1)] = sonic_name
         elif hwsku == "Arista-7800R3A-36DM2-C72" or\
-             hwsku == "Arista-7800R3A-36D-C72" or\
-             hwsku == "Arista-7800R3A-36P-C72" or\
-             hwsku == "Arista-7800R3AK-36DM2-C72" or\
-             hwsku == "Arista-7800R3AK-36D2-C72" or\
-             hwsku == "Arista-7800R3A-36D2-C72":
+                hwsku == "Arista-7800R3A-36D-C72" or\
+                hwsku == "Arista-7800R3A-36P-C72" or\
+                hwsku == "Arista-7800R3AK-36DM2-C72" or\
+                hwsku == "Arista-7800R3AK-36D2-C72" or\
+                hwsku == "Arista-7800R3A-36D2-C72":
+
             intf_idx = 0
             for i in range(1, 37):
                 for j in [1, 5]:
-                    port_alias_to_name_map["Ethernet%d/%d" % ( i, j)] = "Ethernet%d" % intf_idx
+                    port_alias_to_name_map["Ethernet%d/%d" % (i, j)] = "Ethernet%d" % intf_idx
                     intf_idx += 4
         elif hwsku == "INGRASYS-S9100-C32":
             for i in range(1, 33):

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -236,10 +236,23 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku in ["Arista-7800R3-48CQ2-C48", "Arista-7800R3-48CQM2-C48"]:
             for i in range(1, 49):
                 port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
-        elif hwsku == "Arista-7800R3A-36DM2-C36" or hwsku == "Arista-7800R3A-36DM2-D36":
-            for i in range(1, 36):
+        elif hwsku in ["Arista-7800R3A-36DM2-C36",
+                       "Arista-7800R3AK-36DM2-C36",
+                       "Arista-7800R3A-36DM2-D36"]:
+            for i in range(1, 37):
                 sonic_name = "Ethernet%d" % ((i - 1) * 8)
                 port_alias_to_name_map["Ethernet{}/{}".format(i, 1)] = sonic_name
+        elif hwsku == "Arista-7800R3A-36DM2-C72" or\
+             hwsku == "Arista-7800R3A-36D-C72" or\
+             hwsku == "Arista-7800R3A-36P-C72" or\
+             hwsku == "Arista-7800R3AK-36DM2-C72" or\
+             hwsku == "Arista-7800R3AK-36D2-C72" or\
+             hwsku == "Arista-7800R3A-36D2-C72":
+            intf_idx = 0
+            for i in range(1, 37):
+                for j in [1, 5]:
+                    port_alias_to_name_map["Ethernet%d/%d" % ( i, j)] = "Ethernet%d" % intf_idx
+                    intf_idx += 4
         elif hwsku == "INGRASYS-S9100-C32":
             for i in range(1, 33):
                 port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
@@ -406,6 +419,8 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             for i in range(1, 33):
                 port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 8)
         else:
+            if "Arista-7800" in hwsku:
+                assert False, "Please add port_alias_to_name_map for new modular SKU %s." % hwsku
             for i in range(0, 128, 4):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Primiarly add support for various Arista 7800R3A SKUs s to port_utils.py. Also one minor tweak `config_sonic_basedon_testbed.yml` to parameterize `asic_topo_config` per slot.

Summary:

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR? How did you do it?
Support all 7800R3A SKU variants

#### How did you verify/test it?
Validated with sonic-mgmt runs against Arista 7800R3A linecards.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
This is not a new feature and hence does not require a Wiki change. 
