### PR TITLE
[CI] Update elastictest template and test_plan.py not to use CLIENT secret

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -162,13 +162,13 @@ steps:
             curl -u :$(MSSONIC-TOKEN) "${{ parameters.MGMT_URL }}&commitOrBranch=${{ parameters.MGMT_BRANCH }}&api-version=5.0-preview.1&path=.azure-pipelines%2Fpr_test_scripts.yaml" -o ./.azure-pipelines/pr_test_scripts.yaml
           fi
         displayName: "Download pr script"
-  - ${{ else }}:
-      - ${{ if ne(parameters.MGMT_BRANCH, 'master') }}:
-          - script: |
-              # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
-              set -ex
-              curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
-            displayName: "Download test plan script"
+#  - ${{ else }}:
+#      - ${{ if ne(parameters.MGMT_BRANCH, 'master') }}:
+#          - script: |
+#              # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
+#              set -ex
+#              curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
+#            displayName: "Download test plan script"
 
   - script: |
       # Check if azure cli is installed. If not, try to install it

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -162,13 +162,13 @@ steps:
             curl -u :$(MSSONIC-TOKEN) "${{ parameters.MGMT_URL }}&commitOrBranch=${{ parameters.MGMT_BRANCH }}&api-version=5.0-preview.1&path=.azure-pipelines%2Fpr_test_scripts.yaml" -o ./.azure-pipelines/pr_test_scripts.yaml
           fi
         displayName: "Download pr script"
-#  - ${{ else }}:
-#      - ${{ if ne(parameters.MGMT_BRANCH, 'master') }}:
-#          - script: |
-#              # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
-#              set -ex
-#              curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
-#            displayName: "Download test plan script"
+  - ${{ else }}:
+      - ${{ if ne(parameters.MGMT_BRANCH, 'master') }}:
+          - script: |
+              # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
+              set -ex
+              curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
+            displayName: "Download test plan script"
 
   - script: |
       # Check if azure cli is installed. If not, try to install it

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -192,6 +192,9 @@ steps:
 
         rm -f new_test_plan_id.txt
 
+        accessToken=$(az account get-access-token --resource "$(ELASTICTEST_MSAL_CLIENT_ID)" --query accessToken -o tsv)
+        export ACCESS_TOKEN=$accessToken
+
         python ./.azure-pipelines/test_plan.py create \
         -t ${{ parameters.TOPOLOGY }} \
         -o new_test_plan_id.txt \
@@ -252,6 +255,9 @@ steps:
         set -o
         echo "Lock testbed"
 
+        accessToken=$(az account get-access-token --resource "$(ELASTICTEST_MSAL_CLIENT_ID)" --query accessToken -o tsv)
+        export ACCESS_TOKEN=$accessToken
+
         echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
         IFS=',' read -ra TEST_PLAN_ID_LIST <<< "$TEST_PLAN_ID_LIST_STRING"
         failure_count=0
@@ -288,6 +294,9 @@ steps:
         echo "Prepare testbed"
         echo "Preparing the testbed(add-topo, deploy-mg) may take 15-30 minutes. Before the testbed is ready, the progress of the test plan keeps displayed as 0, please be patient"
 
+        accessToken=$(az account get-access-token --resource "$(ELASTICTEST_MSAL_CLIENT_ID)" --query accessToken -o tsv)
+        export ACCESS_TOKEN=$accessToken
+
         echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
         IFS=',' read -ra TEST_PLAN_ID_LIST <<< "$TEST_PLAN_ID_LIST_STRING"
         failure_count=0
@@ -322,6 +331,9 @@ steps:
       inlineScript: |
         set -o
         echo "Run test"
+
+        accessToken=$(az account get-access-token --resource "$(ELASTICTEST_MSAL_CLIENT_ID)" --query accessToken -o tsv)
+        export ACCESS_TOKEN=$accessToken
 
         echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
         IFS=',' read -ra TEST_PLAN_ID_LIST <<< "$TEST_PLAN_ID_LIST_STRING"
@@ -360,6 +372,9 @@ steps:
             set -e
             echo "KVM dump"
 
+            accessToken=$(az account get-access-token --resource "$(ELASTICTEST_MSAL_CLIENT_ID)" --query accessToken -o tsv)
+            export ACCESS_TOKEN=$accessToken
+
             echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
             IFS=',' read -ra TEST_PLAN_ID_LIST <<< "$TEST_PLAN_ID_LIST_STRING"
             for TEST_PLAN_ID in "${TEST_PLAN_ID_LIST[@]}"
@@ -385,6 +400,10 @@ steps:
       inlineScript: |
         set -e
         echo "Try to cancel test plan $TEST_PLAN_ID, cancelling finished test plan has no effect."
+
+        accessToken=$(az account get-access-token --resource "$(ELASTICTEST_MSAL_CLIENT_ID)" --query accessToken -o tsv)
+        export ACCESS_TOKEN=$accessToken
+
         IFS=',' read -ra TEST_PLAN_ID_LIST <<< "$TEST_PLAN_ID_LIST_STRING"
         for TEST_PLAN_ID in "${TEST_PLAN_ID_LIST[@]}"
         do

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -171,6 +171,14 @@ class TestPlanManager(object):
             self.get_token()
 
     def get_token(self):
+
+        access_token = os.environ.get('ACCESS_TOKEN', None)
+        if access_token:
+            print("Got ACCESS_TOKEN from environment variable.")
+            return access_token
+
+        print("No ACCESS_TOKEN in environment variable, try to get token using client secrets.")
+
         token_generate_time_valid = \
             self._token_generate_time is not None and \
             (datetime.utcnow() - self._token_generate_time) < timedelta(hours=TOKEN_EXPIRE_HOURS)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,141 +74,141 @@ stages:
         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
         MGMT_BRANCH: $(BUILD_BRANCH)
 
-#  - job: t0_2vlans_elastictest
-#    displayName: "kvmtest-t0-2vlans by Elastictest"
-#    timeoutInMinutes: 240
-#    continueOnError: false
-#    pool: sonic-ubuntu-1c
-#    steps:
-#    - template: .azure-pipelines/run-test-elastictest-template.yml
-#      parameters:
-#        TOPOLOGY: t0
-#        TEST_SET: t0-2vlans
-#        MIN_WORKER: $(T0_2VLANS_INSTANCE_NUM)
-#        MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
-#        DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
-#        KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-#        MGMT_BRANCH: $(BUILD_BRANCH)
-#
-#  - job: t1_lag_elastictest
-#    displayName: "kvmtest-t1-lag by Elastictest"
-#    timeoutInMinutes: 240
-#    continueOnError: false
-#    pool: sonic-ubuntu-1c
-#    steps:
-#    - template: .azure-pipelines/run-test-elastictest-template.yml
-#      parameters:
-#        TOPOLOGY: t1-lag
-#        MIN_WORKER: $(T1_LAG_INSTANCE_NUM)
-#        MAX_WORKER: $(T1_LAG_INSTANCE_NUM)
-#        KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-#        MGMT_BRANCH: $(BUILD_BRANCH)
-#
-#  - job: dualtor_elastictest
-#    displayName: "kvmtest-dualtor-t0 by Elastictest"
+  - job: t0_2vlans_elastictest
+    displayName: "kvmtest-t0-2vlans by Elastictest"
+    timeoutInMinutes: 240
+    continueOnError: false
+    pool: sonic-ubuntu-1c
+    steps:
+    - template: .azure-pipelines/run-test-elastictest-template.yml
+      parameters:
+        TOPOLOGY: t0
+        TEST_SET: t0-2vlans
+        MIN_WORKER: $(T0_2VLANS_INSTANCE_NUM)
+        MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
+        DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
+        KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+        MGMT_BRANCH: $(BUILD_BRANCH)
+
+  - job: t1_lag_elastictest
+    displayName: "kvmtest-t1-lag by Elastictest"
+    timeoutInMinutes: 240
+    continueOnError: false
+    pool: sonic-ubuntu-1c
+    steps:
+    - template: .azure-pipelines/run-test-elastictest-template.yml
+      parameters:
+        TOPOLOGY: t1-lag
+        MIN_WORKER: $(T1_LAG_INSTANCE_NUM)
+        MAX_WORKER: $(T1_LAG_INSTANCE_NUM)
+        KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+        MGMT_BRANCH: $(BUILD_BRANCH)
+
+  - job: dualtor_elastictest
+    displayName: "kvmtest-dualtor-t0 by Elastictest"
+    timeoutInMinutes: 240
+    continueOnError: false
+    pool: sonic-ubuntu-1c
+    steps:
+      - template: .azure-pipelines/run-test-elastictest-template.yml
+        parameters:
+          TOPOLOGY: dualtor
+          MIN_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
+          MAX_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
+          COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          MGMT_BRANCH: $(BUILD_BRANCH)
+
+  - job: multi_asic_elastictest
+    displayName: "kvmtest-multi-asic-t1-lag by Elastictest"
+    timeoutInMinutes: 240
+    continueOnError: false
+    pool: sonic-ubuntu-1c
+    steps:
+      - template: .azure-pipelines/run-test-elastictest-template.yml
+        parameters:
+          TOPOLOGY: t1-8-lag
+          TEST_SET: multi-asic-t1-lag
+          MIN_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
+          MAX_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
+          NUM_ASIC: 4
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          MGMT_BRANCH: $(BUILD_BRANCH)
+
+  - job: sonic_t0_elastictest
+    displayName: "kvmtest-t0-sonic by Elastictest"
+    timeoutInMinutes: 240
+    continueOnError: false
+    pool: sonic-ubuntu-1c
+    steps:
+      - template: .azure-pipelines/run-test-elastictest-template.yml
+        parameters:
+          TOPOLOGY: t0-64-32
+          MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
+          MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
+          TEST_SET: t0-sonic
+          COMMON_EXTRA_PARAMS: "--neighbor_type=sonic "
+          VM_TYPE: vsonic
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          MGMT_BRANCH: $(BUILD_BRANCH)
+
+  - job: dpu_elastictest
+    displayName: "kvmtest-dpu by Elastictest"
+    timeoutInMinutes: 240
+    continueOnError: false
+    pool: sonic-ubuntu-1c
+    steps:
+      - template: .azure-pipelines/run-test-elastictest-template.yml
+        parameters:
+          TOPOLOGY: dpu
+          MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
+          MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          MGMT_BRANCH: $(BUILD_BRANCH)
+
+  - job: onboarding_elastictest_t0
+    displayName: "onboarding t0 testcases by Elastictest - optional"
+    timeoutInMinutes: 240
+    continueOnError: true
+    pool: sonic-ubuntu-1c
+    steps:
+      - template: .azure-pipelines/run-test-elastictest-template.yml
+        parameters:
+          TOPOLOGY: t0
+          STOP_ON_FAILURE: "False"
+          RETRY_TIMES: 0
+          MIN_WORKER: $(T0_ONBOARDING_SONIC_INSTANCE_NUM)
+          MAX_WORKER: $(T0_ONBOARDING_SONIC_INSTANCE_NUM)
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          MGMT_BRANCH: $(BUILD_BRANCH)
+          TEST_SET: onboarding_t0
+
+  - job: onboarding_elastictest_t1
+    displayName: "onboarding t1 testcases by Elastictest - optional"
+    timeoutInMinutes: 240
+    continueOnError: true
+    pool: sonic-ubuntu-1c
+    steps:
+      - template: .azure-pipelines/run-test-elastictest-template.yml
+        parameters:
+          TOPOLOGY: t1-lag
+          STOP_ON_FAILURE: "False"
+          RETRY_TIMES: 0
+          MIN_WORKER: $(T1_LAG_ONBOARDING_INSTANCE_NUM)
+          MAX_WORKER: $(T1_LAG_ONBOARDING_INSTANCE_NUM)
+          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+          MGMT_BRANCH: $(BUILD_BRANCH)
+          TEST_SET: onboarding_t1
+
+#  - job: wan_elastictest
+#    displayName: "kvmtest-wan by Elastictest"
 #    timeoutInMinutes: 240
 #    continueOnError: false
 #    pool: sonic-ubuntu-1c
 #    steps:
 #      - template: .azure-pipelines/run-test-elastictest-template.yml
 #        parameters:
-#          TOPOLOGY: dualtor
-#          MIN_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
-#          MAX_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
-#          COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
-#          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-#          MGMT_BRANCH: $(BUILD_BRANCH)
-#
-#  - job: multi_asic_elastictest
-#    displayName: "kvmtest-multi-asic-t1-lag by Elastictest"
-#    timeoutInMinutes: 240
-#    continueOnError: false
-#    pool: sonic-ubuntu-1c
-#    steps:
-#      - template: .azure-pipelines/run-test-elastictest-template.yml
-#        parameters:
-#          TOPOLOGY: t1-8-lag
-#          TEST_SET: multi-asic-t1-lag
-#          MIN_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
-#          MAX_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
-#          NUM_ASIC: 4
-#          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-#          MGMT_BRANCH: $(BUILD_BRANCH)
-#
-#  - job: sonic_t0_elastictest
-#    displayName: "kvmtest-t0-sonic by Elastictest"
-#    timeoutInMinutes: 240
-#    continueOnError: false
-#    pool: sonic-ubuntu-1c
-#    steps:
-#      - template: .azure-pipelines/run-test-elastictest-template.yml
-#        parameters:
-#          TOPOLOGY: t0-64-32
-#          MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
-#          MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
-#          TEST_SET: t0-sonic
-#          COMMON_EXTRA_PARAMS: "--neighbor_type=sonic "
-#          VM_TYPE: vsonic
-#          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-#          MGMT_BRANCH: $(BUILD_BRANCH)
-#
-#  - job: dpu_elastictest
-#    displayName: "kvmtest-dpu by Elastictest"
-#    timeoutInMinutes: 240
-#    continueOnError: false
-#    pool: sonic-ubuntu-1c
-#    steps:
-#      - template: .azure-pipelines/run-test-elastictest-template.yml
-#        parameters:
-#          TOPOLOGY: dpu
-#          MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
-#          MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
-#          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-#          MGMT_BRANCH: $(BUILD_BRANCH)
-#
-#  - job: onboarding_elastictest_t0
-#    displayName: "onboarding t0 testcases by Elastictest - optional"
-#    timeoutInMinutes: 240
-#    continueOnError: true
-#    pool: sonic-ubuntu-1c
-#    steps:
-#      - template: .azure-pipelines/run-test-elastictest-template.yml
-#        parameters:
-#          TOPOLOGY: t0
-#          STOP_ON_FAILURE: "False"
-#          RETRY_TIMES: 0
-#          MIN_WORKER: $(T0_ONBOARDING_SONIC_INSTANCE_NUM)
-#          MAX_WORKER: $(T0_ONBOARDING_SONIC_INSTANCE_NUM)
-#          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-#          MGMT_BRANCH: $(BUILD_BRANCH)
-#          TEST_SET: onboarding_t0
-#
-#  - job: onboarding_elastictest_t1
-#    displayName: "onboarding t1 testcases by Elastictest - optional"
-#    timeoutInMinutes: 240
-#    continueOnError: true
-#    pool: sonic-ubuntu-1c
-#    steps:
-#      - template: .azure-pipelines/run-test-elastictest-template.yml
-#        parameters:
-#          TOPOLOGY: t1-lag
-#          STOP_ON_FAILURE: "False"
-#          RETRY_TIMES: 0
-#          MIN_WORKER: $(T1_LAG_ONBOARDING_INSTANCE_NUM)
-#          MAX_WORKER: $(T1_LAG_ONBOARDING_INSTANCE_NUM)
-#          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-#          MGMT_BRANCH: $(BUILD_BRANCH)
-#          TEST_SET: onboarding_t1
-#
-##  - job: wan_elastictest
-##    displayName: "kvmtest-wan by Elastictest"
-##    timeoutInMinutes: 240
-##    continueOnError: false
-##    pool: sonic-ubuntu-1c
-##    steps:
-##      - template: .azure-pipelines/run-test-elastictest-template.yml
-##        parameters:
-##          TOPOLOGY: wan-pub
-##          MIN_WORKER: $(WAN_INSTANCE_NUM)
-##          MAX_WORKER: $(WAN_INSTANCE_NUM)
-##          COMMON_EXTRA_PARAMS: "--skip_sanity "
+#          TOPOLOGY: wan-pub
+#          MIN_WORKER: $(WAN_INSTANCE_NUM)
+#          MAX_WORKER: $(WAN_INSTANCE_NUM)
+#          COMMON_EXTRA_PARAMS: "--skip_sanity "

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,141 +74,141 @@ stages:
         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
         MGMT_BRANCH: $(BUILD_BRANCH)
 
-  - job: t0_2vlans_elastictest
-    displayName: "kvmtest-t0-2vlans by Elastictest"
-    timeoutInMinutes: 240
-    continueOnError: false
-    pool: sonic-ubuntu-1c
-    steps:
-    - template: .azure-pipelines/run-test-elastictest-template.yml
-      parameters:
-        TOPOLOGY: t0
-        TEST_SET: t0-2vlans
-        MIN_WORKER: $(T0_2VLANS_INSTANCE_NUM)
-        MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
-        DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
-        KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-        MGMT_BRANCH: $(BUILD_BRANCH)
-
-  - job: t1_lag_elastictest
-    displayName: "kvmtest-t1-lag by Elastictest"
-    timeoutInMinutes: 240
-    continueOnError: false
-    pool: sonic-ubuntu-1c
-    steps:
-    - template: .azure-pipelines/run-test-elastictest-template.yml
-      parameters:
-        TOPOLOGY: t1-lag
-        MIN_WORKER: $(T1_LAG_INSTANCE_NUM)
-        MAX_WORKER: $(T1_LAG_INSTANCE_NUM)
-        KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-        MGMT_BRANCH: $(BUILD_BRANCH)
-
-  - job: dualtor_elastictest
-    displayName: "kvmtest-dualtor-t0 by Elastictest"
-    timeoutInMinutes: 240
-    continueOnError: false
-    pool: sonic-ubuntu-1c
-    steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml
-        parameters:
-          TOPOLOGY: dualtor
-          MIN_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
-          MAX_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
-          COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-
-  - job: multi_asic_elastictest
-    displayName: "kvmtest-multi-asic-t1-lag by Elastictest"
-    timeoutInMinutes: 240
-    continueOnError: false
-    pool: sonic-ubuntu-1c
-    steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml
-        parameters:
-          TOPOLOGY: t1-8-lag
-          TEST_SET: multi-asic-t1-lag
-          MIN_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
-          MAX_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
-          NUM_ASIC: 4
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-
-  - job: sonic_t0_elastictest
-    displayName: "kvmtest-t0-sonic by Elastictest"
-    timeoutInMinutes: 240
-    continueOnError: false
-    pool: sonic-ubuntu-1c
-    steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml
-        parameters:
-          TOPOLOGY: t0-64-32
-          MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
-          MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
-          TEST_SET: t0-sonic
-          COMMON_EXTRA_PARAMS: "--neighbor_type=sonic "
-          VM_TYPE: vsonic
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-
-  - job: dpu_elastictest
-    displayName: "kvmtest-dpu by Elastictest"
-    timeoutInMinutes: 240
-    continueOnError: false
-    pool: sonic-ubuntu-1c
-    steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml
-        parameters:
-          TOPOLOGY: dpu
-          MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
-          MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-
-  - job: onboarding_elastictest_t0
-    displayName: "onboarding t0 testcases by Elastictest - optional"
-    timeoutInMinutes: 240
-    continueOnError: true
-    pool: sonic-ubuntu-1c
-    steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml
-        parameters:
-          TOPOLOGY: t0
-          STOP_ON_FAILURE: "False"
-          RETRY_TIMES: 0
-          MIN_WORKER: $(T0_ONBOARDING_SONIC_INSTANCE_NUM)
-          MAX_WORKER: $(T0_ONBOARDING_SONIC_INSTANCE_NUM)
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-          TEST_SET: onboarding_t0
-
-  - job: onboarding_elastictest_t1
-    displayName: "onboarding t1 testcases by Elastictest - optional"
-    timeoutInMinutes: 240
-    continueOnError: true
-    pool: sonic-ubuntu-1c
-    steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml
-        parameters:
-          TOPOLOGY: t1-lag
-          STOP_ON_FAILURE: "False"
-          RETRY_TIMES: 0
-          MIN_WORKER: $(T1_LAG_ONBOARDING_INSTANCE_NUM)
-          MAX_WORKER: $(T1_LAG_ONBOARDING_INSTANCE_NUM)
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-          TEST_SET: onboarding_t1
-
-#  - job: wan_elastictest
-#    displayName: "kvmtest-wan by Elastictest"
+#  - job: t0_2vlans_elastictest
+#    displayName: "kvmtest-t0-2vlans by Elastictest"
+#    timeoutInMinutes: 240
+#    continueOnError: false
+#    pool: sonic-ubuntu-1c
+#    steps:
+#    - template: .azure-pipelines/run-test-elastictest-template.yml
+#      parameters:
+#        TOPOLOGY: t0
+#        TEST_SET: t0-2vlans
+#        MIN_WORKER: $(T0_2VLANS_INSTANCE_NUM)
+#        MAX_WORKER: $(T0_2VLANS_INSTANCE_NUM)
+#        DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
+#        KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+#        MGMT_BRANCH: $(BUILD_BRANCH)
+#
+#  - job: t1_lag_elastictest
+#    displayName: "kvmtest-t1-lag by Elastictest"
+#    timeoutInMinutes: 240
+#    continueOnError: false
+#    pool: sonic-ubuntu-1c
+#    steps:
+#    - template: .azure-pipelines/run-test-elastictest-template.yml
+#      parameters:
+#        TOPOLOGY: t1-lag
+#        MIN_WORKER: $(T1_LAG_INSTANCE_NUM)
+#        MAX_WORKER: $(T1_LAG_INSTANCE_NUM)
+#        KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+#        MGMT_BRANCH: $(BUILD_BRANCH)
+#
+#  - job: dualtor_elastictest
+#    displayName: "kvmtest-dualtor-t0 by Elastictest"
 #    timeoutInMinutes: 240
 #    continueOnError: false
 #    pool: sonic-ubuntu-1c
 #    steps:
 #      - template: .azure-pipelines/run-test-elastictest-template.yml
 #        parameters:
-#          TOPOLOGY: wan-pub
-#          MIN_WORKER: $(WAN_INSTANCE_NUM)
-#          MAX_WORKER: $(WAN_INSTANCE_NUM)
-#          COMMON_EXTRA_PARAMS: "--skip_sanity "
+#          TOPOLOGY: dualtor
+#          MIN_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
+#          MAX_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
+#          COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
+#          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+#          MGMT_BRANCH: $(BUILD_BRANCH)
+#
+#  - job: multi_asic_elastictest
+#    displayName: "kvmtest-multi-asic-t1-lag by Elastictest"
+#    timeoutInMinutes: 240
+#    continueOnError: false
+#    pool: sonic-ubuntu-1c
+#    steps:
+#      - template: .azure-pipelines/run-test-elastictest-template.yml
+#        parameters:
+#          TOPOLOGY: t1-8-lag
+#          TEST_SET: multi-asic-t1-lag
+#          MIN_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
+#          MAX_WORKER: $(MULTI_ASIC_INSTANCE_NUM)
+#          NUM_ASIC: 4
+#          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+#          MGMT_BRANCH: $(BUILD_BRANCH)
+#
+#  - job: sonic_t0_elastictest
+#    displayName: "kvmtest-t0-sonic by Elastictest"
+#    timeoutInMinutes: 240
+#    continueOnError: false
+#    pool: sonic-ubuntu-1c
+#    steps:
+#      - template: .azure-pipelines/run-test-elastictest-template.yml
+#        parameters:
+#          TOPOLOGY: t0-64-32
+#          MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
+#          MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
+#          TEST_SET: t0-sonic
+#          COMMON_EXTRA_PARAMS: "--neighbor_type=sonic "
+#          VM_TYPE: vsonic
+#          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+#          MGMT_BRANCH: $(BUILD_BRANCH)
+#
+#  - job: dpu_elastictest
+#    displayName: "kvmtest-dpu by Elastictest"
+#    timeoutInMinutes: 240
+#    continueOnError: false
+#    pool: sonic-ubuntu-1c
+#    steps:
+#      - template: .azure-pipelines/run-test-elastictest-template.yml
+#        parameters:
+#          TOPOLOGY: dpu
+#          MIN_WORKER: $(T0_SONIC_INSTANCE_NUM)
+#          MAX_WORKER: $(T0_SONIC_INSTANCE_NUM)
+#          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+#          MGMT_BRANCH: $(BUILD_BRANCH)
+#
+#  - job: onboarding_elastictest_t0
+#    displayName: "onboarding t0 testcases by Elastictest - optional"
+#    timeoutInMinutes: 240
+#    continueOnError: true
+#    pool: sonic-ubuntu-1c
+#    steps:
+#      - template: .azure-pipelines/run-test-elastictest-template.yml
+#        parameters:
+#          TOPOLOGY: t0
+#          STOP_ON_FAILURE: "False"
+#          RETRY_TIMES: 0
+#          MIN_WORKER: $(T0_ONBOARDING_SONIC_INSTANCE_NUM)
+#          MAX_WORKER: $(T0_ONBOARDING_SONIC_INSTANCE_NUM)
+#          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+#          MGMT_BRANCH: $(BUILD_BRANCH)
+#          TEST_SET: onboarding_t0
+#
+#  - job: onboarding_elastictest_t1
+#    displayName: "onboarding t1 testcases by Elastictest - optional"
+#    timeoutInMinutes: 240
+#    continueOnError: true
+#    pool: sonic-ubuntu-1c
+#    steps:
+#      - template: .azure-pipelines/run-test-elastictest-template.yml
+#        parameters:
+#          TOPOLOGY: t1-lag
+#          STOP_ON_FAILURE: "False"
+#          RETRY_TIMES: 0
+#          MIN_WORKER: $(T1_LAG_ONBOARDING_INSTANCE_NUM)
+#          MAX_WORKER: $(T1_LAG_ONBOARDING_INSTANCE_NUM)
+#          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+#          MGMT_BRANCH: $(BUILD_BRANCH)
+#          TEST_SET: onboarding_t1
+#
+##  - job: wan_elastictest
+##    displayName: "kvmtest-wan by Elastictest"
+##    timeoutInMinutes: 240
+##    continueOnError: false
+##    pool: sonic-ubuntu-1c
+##    steps:
+##      - template: .azure-pipelines/run-test-elastictest-template.yml
+##        parameters:
+##          TOPOLOGY: wan-pub
+##          MIN_WORKER: $(WAN_INSTANCE_NUM)
+##          MAX_WORKER: $(WAN_INSTANCE_NUM)
+##          COMMON_EXTRA_PARAMS: "--skip_sanity "


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Update elastictest template and test_plan.py not to use CLIENT secret

This is part of the security wave 1 effort for eliminating CLIENT secrets.
The test_plan.py script has been improved to get ACCESS_TOKEN from environment variable.

Signed-off-by: Chun'ang Li <chunangli@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
