### PR TITLE
[dhcp_server_test] Fix log errors caused by dhcp server tests

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -2512,50 +2512,6 @@ Totals               6450                 6449
         sfp_type = re.search(r'[QO]?SFP-?[\d\w]{0,3}', out["stdout_lines"][0]).group()
         return sfp_type
 
-    def get_switch_hash_capabilities(self):
-        out = self.shell('show switch-hash capabilities --json')
-        assert_exit_non_zero(out)
-        return SonicHost._parse_hash_fields(out)
-
-    def get_switch_hash_configurations(self):
-        out = self.shell('show switch-hash global  --json')
-        assert_exit_non_zero(out)
-        return SonicHost._parse_hash_fields(out)
-
-    def set_switch_hash_global(self, hash_type, fields, validate=True):
-        cmd = 'config switch-hash global {}-hash'.format(hash_type)
-        for field in fields:
-            cmd += ' ' + field
-        out = self.shell(cmd, module_ignore_errors=True)
-        if validate:
-            assert_exit_non_zero(out)
-        return out
-
-    def set_switch_hash_global_algorithm(self, hash_type, algorithm, validate=True):
-        cmd = 'config switch-hash global {}-hash-algorithm {}'.format(hash_type, algorithm)
-        out = self.shell(cmd, module_ignore_errors=True)
-        if validate:
-            assert_exit_non_zero(out)
-        return out
-
-    @staticmethod
-    def _parse_hash_fields(cli_output):
-        ecmp_hash_fields = []
-        lag_hash_fields = []
-        ecmp_hash_algorithm = lag_hash_algorithm = ''
-        if "No configuration is present in CONFIG DB" in cli_output['stdout']:
-            logger.info("No configuration is present in CONFIG DB")
-        else:
-            out_json = json.loads(cli_output['stdout'])
-            ecmp_hash_fields = out_json["ecmp"]["hash_field"]
-            lag_hash_fields = out_json["lag"]["hash_field"]
-            ecmp_hash_algorithm = out_json["ecmp"]["algorithm"]
-            lag_hash_algorithm = out_json["lag"]["algorithm"]
-        return {'ecmp': ecmp_hash_fields,
-                'lag': lag_hash_fields,
-                'ecmp_algo': ecmp_hash_algorithm,
-                'lag_algo': lag_hash_algorithm}
-
     def get_counter_poll_status(self):
         result_dict = {}
         output = self.shell("counterpoll show")["stdout_lines"][2::]

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -57,17 +57,17 @@ class SonicHost(AnsibleHostBase):
             vm = self.host.options['variable_manager']
             sonic_conn = vm.get_vars(
                 host=im.get_hosts(pattern='sonic')[0]
-            )['ansible_connection']
+                )['ansible_connection']
             hostvars = vm.get_vars(host=im.get_host(hostname=self.hostname))
             # parse connection options and reset those options with
             # passed credentials
             connection_loader.get(sonic_conn, class_only=True)
             user_def = ansible_constants.config.get_configuration_definition(
                 "remote_user", "connection", sonic_conn
-            )
+                )
             pass_def = ansible_constants.config.get_configuration_definition(
                 "password", "connection", sonic_conn
-            )
+                )
             for user_var in (_['name'] for _ in user_def['vars']):
                 if user_var in hostvars:
                     vm.extra_vars.update({user_var: shell_user})
@@ -251,9 +251,9 @@ class SonicHost(AnsibleHostBase):
         py_res = self.shell("python -c \"import sonic_platform\"", module_ignore_errors=True)
         if py_res["failed"]:
             out = self.shell(
-                "python3 -c \"import sonic_platform.platform as P; \
+                             "python3 -c \"import sonic_platform.platform as P; \
                              print(P.Platform().get_chassis().is_modular_chassis()); exit()\"",
-                module_ignore_errors=True)
+                             module_ignore_errors=True)
         else:
             out = self.shell(
                 "python -c \"import sonic_platform.platform as P; \
@@ -329,8 +329,8 @@ class SonicHost(AnsibleHostBase):
             except Exception:
                 # if platform.json does not exist, then it's not added currently for certain platforms
                 # eventually all the platforms should have the platform.json
-                logging.debug("platform.json is not available for this platform, " +
-                              "DUT facts will not contain complete platform information.")
+                logging.debug("platform.json is not available for this platform, "
+                              + "DUT facts will not contain complete platform information.")
 
         return result
 
@@ -1564,9 +1564,9 @@ Totals               6450                 6449
         for idx, line in enumerate(output_lines):
             if sep_line_pattern.match(line):
                 sep_line_found = True
-                header_lines = output_lines[idx - header_len:idx]
+                header_lines = output_lines[idx-header_len:idx]
                 sep_line = output_lines[idx]
-                content_lines = output_lines[idx + 1:]
+                content_lines = output_lines[idx+1:]
                 break
 
         if not sep_line_found:

--- a/tests/dhcp_server/conftest.py
+++ b/tests/dhcp_server/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.helpers.assertions import pytest_require as py_require
+from dhcp_server_test_common import clean_dhcp_server_config
 
 DHCP_RELAY_CONTAINER_NAME = "dhcp_relay"
 DHCP_SERVER_CONTAINER_NAME = "dhcp_server"
@@ -43,3 +44,11 @@ def dhcp_server_setup_teardown(duthost):
         duthost.shell("config feature state dhcp_server disabled", module_ignore_errors=True)
         duthost.shell("sudo systemctl restart dhcp_relay.service")
         duthost.shell("docker rm dhcp_server", module_ignore_errors=True)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def clean_dhcp_server_config_after_test(duthost):
+
+    yield
+
+    clean_dhcp_server_config(duthost)

--- a/tests/dhcp_server/dhcp_server_test_common.py
+++ b/tests/dhcp_server/dhcp_server_test_common.py
@@ -38,6 +38,20 @@ DHCP_SERVER_SUPPORTED_OPTION_ID = (
 )
 
 
+def vlan_i2n(vlan_id):
+    """
+        Convert vlan id to vlan name
+    """
+    return "Vlan%s" % vlan_id
+
+
+def vlan_n2i(vlan_name):
+    """
+        Convert vlan name to vlan id
+    """
+    return vlan_name.replace("Vlan", "")
+
+
 def clean_fdb_table(duthost):
     duthost.shell("sonic-clear fdb all")
 
@@ -48,8 +62,16 @@ def ping_dut_refresh_fdb(ptfhost, interface):
 
 def clean_dhcp_server_config(duthost):
     keys = duthost.shell("sonic-db-cli CONFIG_DB KEYS DHCP_SERVER_IPV4*")
-    for key in keys["stdout_lines"]:
-        duthost.shell("sonic-db-cli CONFIG_DB DEL '{}'".format(key))
+    clean_order = [
+        "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS",
+        "DHCP_SERVER_IPV4_RANGE",
+        "DHCP_SERVER_IPV4_PORT",
+        "DHCP_SERVER_IPV4"
+    ]
+    for key in clean_order:
+        for line in keys['stdout_lines']:
+            if line.startswith(key + '|'):
+                duthost.shell("sonic-db-cli CONFIG_DB DEL '{}'".format(line))
 
 
 def verify_lease(duthost, dhcp_interface, client_mac, exp_ip, exp_lease_time):
@@ -127,11 +149,14 @@ def empty_config_patch(customized_options=None):
         }
     ]
     if customized_options:
-        ret_empty_patch.append({
-            "op": "add",
-            "path": "/DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS",
-            "value": {}
-        })
+        ret_empty_patch.insert(
+            0,
+            {
+                "op": "add",
+                "path": "/DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS",
+                "value": {}
+            }
+        )
     return ret_empty_patch
 
 
@@ -145,12 +170,13 @@ def append_common_config_patch(
     customized_options=None
 ):
     pytest_require(len(dut_ports) == len(ip_ranges), "Invalid input, dut_ports and ip_ranges should have same length")
-    new_patch = generate_dhcp_interface_config_patch(vlan_name, gateway, net_mask, customized_options)
+    new_patch = []
+    if customized_options:
+        new_patch += generate_dhcp_custom_option_config_patch(customized_options)
+    new_patch += generate_dhcp_interface_config_patch(vlan_name, gateway, net_mask, customized_options)
     range_names = ["range_" + ip_range[0] for ip_range in ip_ranges]
     new_patch += generate_dhcp_range_config_patch(ip_ranges, range_names)
     new_patch += generate_dhcp_port_config_patch(vlan_name, dut_ports, range_names)
-    if customized_options:
-        new_patch += generate_dhcp_custom_option_config_patch(customized_options)
     config_patch += new_patch
 
 

--- a/tests/dhcp_server/test_dhcp_server.py
+++ b/tests/dhcp_server/test_dhcp_server.py
@@ -6,7 +6,7 @@ import time
 from tests.common.helpers.assertions import pytest_assert
 from dhcp_server_test_common import DHCP_SERVER_CONFIG_TOOL_GCU, DHCP_SERVER_CONFIG_TOOL_CLI, \
     create_common_config_patch, generate_common_config_cli_commands, dhcp_server_config, \
-    validate_dhcp_server_pkts_custom_option, verify_lease, clean_dhcp_server_config, \
+    validate_dhcp_server_pkts_custom_option, verify_lease, \
     verify_discover_and_request_then_release, send_and_verify, DHCP_MESSAGE_TYPE_DISCOVER_NUM, \
     DHCP_SERVER_SUPPORTED_OPTION_ID, DHCP_MESSAGE_TYPE_REQUEST_NUM, DHCP_DEFAULT_LEASE_TIME, \
     apply_dhcp_server_config_gcu, create_dhcp_client_packet, vlan_n2i
@@ -554,7 +554,6 @@ def test_dhcp_server_config_change_dhcp_interface(
         server_id=gateway,
         net_mask=net_mask
     )
-    clean_dhcp_server_config(duthost)
 
 
 def test_dhcp_server_config_change_common(
@@ -636,7 +635,6 @@ def test_dhcp_server_config_change_common(
         net_mask=net_mask,
         exp_lease_time=changed_lease_time
     )
-    clean_dhcp_server_config(duthost)
 
 
 def test_dhcp_server_config_vlan_member_change(
@@ -694,7 +692,6 @@ def test_dhcp_server_config_vlan_member_change(
         server_id=gateway,
         net_mask=net_mask
     )
-    clean_dhcp_server_config(duthost)
 
 
 def test_dhcp_server_lease_config_change(
@@ -741,7 +738,6 @@ def test_dhcp_server_lease_config_change(
     apply_dhcp_server_config_gcu(duthost, change_to_apply)
     client_mac = ptfadapter.dataplane.get_mac(0, ptf_port_index).decode('utf-8')
     verify_lease(duthost, vlan_name, client_mac, expected_assigned_ip, DHCP_DEFAULT_LEASE_TIME)
-    clean_dhcp_server_config(duthost)
 
 
 def test_dhcp_server_config_vlan_intf_change(
@@ -818,4 +814,3 @@ def test_dhcp_server_config_vlan_intf_change(
         server_id=gateway_1,
         net_mask=net_mask_1
     )
-    clean_dhcp_server_config(duthost)

--- a/tests/dhcp_server/test_dhcp_server_multi_vlans.py
+++ b/tests/dhcp_server/test_dhcp_server_multi_vlans.py
@@ -5,7 +5,7 @@ import random
 from tests.common.helpers.assertions import pytest_assert
 from dhcp_server_test_common import create_common_config_patch, append_common_config_patch, \
     verify_discover_and_request_then_release, apply_dhcp_server_config_gcu, empty_config_patch, \
-    vlan_n2i, clean_dhcp_server_config
+    vlan_n2i
 
 
 pytestmark = [
@@ -237,7 +237,6 @@ def test_single_ip_assignment(
             server_id=gateway,
             net_mask=net_mask
         )
-    clean_dhcp_server_config(duthost)
 
 
 def test_range_ip_assignment(
@@ -319,4 +318,3 @@ def test_range_ip_assignment(
         server_id=gateway_2,
         net_mask=net_mask_2
     )
-    clean_dhcp_server_config(duthost)

--- a/tests/dhcp_server/test_dhcp_server_multi_vlans.py
+++ b/tests/dhcp_server/test_dhcp_server_multi_vlans.py
@@ -4,7 +4,8 @@ import pytest
 import random
 from tests.common.helpers.assertions import pytest_assert
 from dhcp_server_test_common import create_common_config_patch, append_common_config_patch, \
-    verify_discover_and_request_then_release, apply_dhcp_server_config_gcu, empty_config_patch
+    verify_discover_and_request_then_release, apply_dhcp_server_config_gcu, empty_config_patch, \
+    vlan_n2i, clean_dhcp_server_config
 
 
 pytestmark = [
@@ -113,20 +114,6 @@ def generate_four_vlans_config_patch(vlan_name, vlan_info, vlan_member_with_ptf_
             + [remove_vlan_member_patch(new_vlan_name, member)[0] for member, _ in new_members_with_ptf_idx]
 
     return four_vlans_info, patch_setup, patch_restore
-
-
-def vlan_i2n(vlan_id):
-    """
-        Convert vlan id to vlan name
-    """
-    return "Vlan%s" % vlan_id
-
-
-def vlan_n2i(vlan_name):
-    """
-        Convert vlan name to vlan id
-    """
-    return vlan_name.replace("Vlan", "")
 
 
 def add_vlan_patch(vlan_name):
@@ -250,6 +237,7 @@ def test_single_ip_assignment(
             server_id=gateway,
             net_mask=net_mask
         )
+    clean_dhcp_server_config(duthost)
 
 
 def test_range_ip_assignment(
@@ -331,3 +319,4 @@ def test_range_ip_assignment(
         server_id=gateway_2,
         net_mask=net_mask_2
     )
+    clean_dhcp_server_config(duthost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
When updating config db, there are some invalid references modeled by yang model.

For example: ERR sonic_yang: Data Loading Failed:Leafref "/sonic-dhcp-server-ipv4:sonic-dhcp-server-ipv4/sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE/sonic-dhcp-server-ipv4:DHCP_SERVER_IPV4_RANGE_LIST/sonic-dhcp-server-ipv4:name" of value "range_192.168.0.91" points to a non-existing leaf.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
When updating config db, there are some invalid references modeled by yang model.

we can adjust the order of applying patches to avoid invalid status.

#### How did you do it?
Adjust the order of config patches

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
