### PR TITLE
Generate IPv6 SSH configuration to devices with IPv6 address configured

### DIFF
--- a/ansible/ssh_session_gen.py
+++ b/ansible/ssh_session_gen.py
@@ -61,7 +61,7 @@ class SSHInfoSolver(object):
             "PTF": {"user": ptf_user, "pass": ptf_pass},
         }
 
-    def get_ssh_cred(self, device: DeviceInfo) -> Tuple[str, str, str]:
+    def get_ssh_cred(self, device: DeviceInfo) -> Tuple[str, str, str, str]:
         """
         Get SSH info for a testbed node.
 
@@ -72,6 +72,7 @@ class SSHInfoSolver(object):
             tuple: SSH IP, user and password.
         """
         ssh_ip = device.management_ip
+        ssh_ipv6 = None
         ssh_user = (
             self.ssh_overrides[device.device_type]["user"]
             if device.device_type in self.ssh_overrides
@@ -83,11 +84,12 @@ class SSHInfoSolver(object):
             else ""
         )
 
-        if not ssh_ip or not ssh_user or not ssh_pass:
+        if not ssh_ip or not ssh_user or not ssh_pass or not ssh_ipv6:
             try:
                 host_vars = self.ansible_hosts.get_host_vars(device.hostname)
 
                 ssh_ip = host_vars["ansible_host"] if not ssh_ip else ssh_ip
+                ssh_ipv6 = host_vars["ansible_hostv6"] if not ssh_ipv6 and "ansible_hostv6" in host_vars else ssh_ipv6
                 ssh_user = host_vars["creds"]["username"] if not ssh_user else ssh_user
                 ssh_pass = (
                     host_vars["creds"]["password"][-1] if not ssh_pass else ssh_pass
@@ -98,10 +100,11 @@ class SSHInfoSolver(object):
                 )
 
         ssh_ip = "" if ssh_ip is None else ssh_ip
+        ssh_ipv6 = "" if ssh_ipv6 is None else ssh_ipv6
         ssh_user = "" if ssh_user is None else ssh_user
         ssh_pass = "" if ssh_pass is None else ssh_pass
 
-        return ssh_ip, ssh_user, ssh_pass
+        return ssh_ip, ssh_ipv6, ssh_user, ssh_pass
 
 
 class DeviceSshSessionRepoGenerator(object):
@@ -121,8 +124,8 @@ class DeviceSshSessionRepoGenerator(object):
         if not device.is_ssh_supported():
             return
 
-        ssh_ip, ssh_user, ssh_pass = self.ssh_info_solver.get_ssh_cred(device)
-        if ssh_ip is None:
+        ssh_ip, ssh_ipv6, ssh_user, ssh_pass = self.ssh_info_solver.get_ssh_cred(device)
+        if not ssh_ip and not ssh_ipv6:
             print(
                 f"WARNING: Management IP is not specified for testbed node, skipped: {device.hostname}"
             )
@@ -138,6 +141,7 @@ class DeviceSshSessionRepoGenerator(object):
         self.repo_generator.generate(
             session_path,
             ssh_ip,
+            ssh_ipv6,
             ssh_user,
             ssh_pass,
         )


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

Currently, the SSH configuration uses the IPv4 address of a device. However, devices may also have an IPv6 address available, and some tests may configure the device to only have an IPv6 address on eth0.

#### How did you do it?

Modify the SSH config generation to support generating a separate entry with the IPv6 address instead of the IPv4 address. These entries will have a suffix of `-v6`.

A separate entry approach was chosen partly because OpenSSH's config doesn't support using multiple literal IP addresses.

#### How did you verify/test it?

Tested the OpenSSH config generation, and it looks file. Have not tested the SecureCRT config generation.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
