### PR TITLE
stop_and_start_lldpmgrd should be tested for lldp0/lldp1 since lldp was removed from the host

### DIFF
--- a/tests/monit/test_monit_status.py
+++ b/tests/monit/test_monit_status.py
@@ -4,6 +4,7 @@ Test the running status and format of alerting message of Monit service.
 import logging
 
 import pytest
+import random
 
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
@@ -31,33 +32,24 @@ def stop_and_start_lldpmgrd(duthosts, enum_rand_one_per_hwsku_frontend_hostname)
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-    logger.info("Stopping 'lldpmgrd' process in 'lldp' container ...")
-    stop_command_result = duthost.command("docker exec lldp supervisorctl stop lldpmgrd")
-    exit_code = stop_command_result["rc"]
-    pytest_assert(exit_code == 0, "Failed to stop 'lldpmgrd' process in 'lldp' container!")
-    logger.info("'lldpmgrd' process in 'lldp' container is stopped.")
-
     if duthost.is_multi_asic:
-        logger.info("Stopping 'lldpmgrd' process in 'lldp0' container ...")
-        stop_command_result = duthost.command("docker exec lldp0 supervisorctl stop lldpmgrd")
-        exit_code = stop_command_result["rc"]
-        pytest_assert(exit_code == 0, "Failed to stop 'lldpmgrd' process in 'lldp0' container!")
-        logger.info("'lldpmgrd' process in 'lldp0' container is stopped.")
+        process = random.choice(["lldp0", "lldp1"])
+    else:
+        process = "lldp"
+
+    logger.info("Stopping 'lldpmgrd' process in {} container ...".format(process))
+    stop_command_result = duthost.command("docker exec {} supervisorctl stop lldpmgrd".format(process))
+    exit_code = stop_command_result["rc"]
+    pytest_assert(exit_code == 0, "Failed to stop 'lldpmgrd' process in {} container!".format(process))
+    logger.info("'lldpmgrd' process in {} container is stopped.".format(process))
 
     yield
 
-    logger.info("Starting 'lldpmgrd' process in 'lldp' container ...")
-    start_command_result = duthost.command("docker exec lldp supervisorctl start lldpmgrd")
+    logger.info("Starting 'lldpmgrd' process in {} container ...".format(process))
+    start_command_result = duthost.command("docker exec {} supervisorctl start lldpmgrd".format(process))
     exit_code = start_command_result["rc"]
-    pytest_assert(exit_code == 0, "Failed to start 'lldpmgrd' process in 'lldp' container!")
-    logger.info("'lldpmgrd' process in 'lldp' container is started.")
-
-    if duthost.is_multi_asic:
-        logger.info("Starting 'lldpmgrd' process in 'lldp0' container ...")
-        start_command_result = duthost.command("docker exec lldp0 supervisorctl start lldpmgrd")
-        exit_code = start_command_result["rc"]
-        pytest_assert(exit_code == 0, "Failed to start 'lldpmgrd' process in 'lldp0' container!")
-        logger.info("'lldpmgrd' process in 'lldp0' container is started.")
+    pytest_assert(exit_code == 0, "Failed to start 'lldpmgrd' process in {} container!".format(process))
+    logger.info("'lldpmgrd' process in {} container is started.".format(process))
 
 
 def check_monit_last_output(duthost):


### PR DESCRIPTION

### Description of PR
Since lldp docker was removed from the host on a multi ASIC chassis, stop_and_start_lldpmgrd fails for lldp.
lldp0/lldp1 should be used instead of lldp.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To use lldp0/lldp1 instead of lldp for stop_and_start_lldpmgrd. 
Since lldp was removed from the host for multi ASICs chassis, this fails if we check lldp.

#### How did you do it?
Randomly choose either lldp0 or lldp1 for stop_and_start_lldpmgrd if the chassis is a multi ASICs.

#### How did you verify/test it?
Tested on a Multi ASICs chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
