### PR TITLE
Added Multi ASICs support to test_counterpoll_queue_watermark_pg_drop

### DIFF
--- a/tests/common/helpers/sonic_db.py
+++ b/tests/common/helpers/sonic_db.py
@@ -545,7 +545,7 @@ class SonicDbNoCommandOutput(Exception):
     pass
 
 
-def redis_get_keys(duthost, db_id, pattern):
+def redis_get_keys(duthost, db_id, pattern, asic_id=None):
     """
     Get all keys for a given pattern in given redis database
     :param duthost: DUT host object
@@ -553,7 +553,11 @@ def redis_get_keys(duthost, db_id, pattern):
     :param pattern: Redis key pattern
     :return: A list of key name in string
     """
-    cmd = 'sonic-db-cli {} KEYS \"{}\"'.format(db_id, pattern)
+    if asic_id is not None:
+        cmd = 'sonic-db-cli -n asic{} {} KEYS \"{}\"'.format(asic_id, db_id, pattern)
+    else:
+        cmd = 'sonic-db-cli {} KEYS \"{}\"'.format(db_id, pattern)
+
     logger.debug('Getting keys from redis by command: {}'.format(cmd))
     output = duthost.shell(cmd)
     content = output['stdout'].strip()


### PR DESCRIPTION
### Description of PR
Added Multi ASICs support to test_counterpoll_queue_watermark_pg_drop

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
1. To Add Multi ASICs support to test_counterpoll_queue_watermark_pg_drop
This testcase will fail for multi ASICs chassis if the support is missing.
2. Since the testcase randomly choses one of the (type[watermark,queue,pg-drop]), unexpected types will always exist.
Because of this reason the check of unexpected_type of counterpoll has to be removed.
 
#### How did you do it?
1. Added Muti ASICs support
2.  Removed checking of unexpected_type of the counterpoll. 
 
#### How did you verify/test it?
Tested on a multi cards, multi ASICs chassis.
 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
