### PR TITLE
Fix lag test

### DIFF
--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -100,7 +100,7 @@ def test_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
             break
 
     if not portchannel:
-        pytest.skip( 'Can not get PortChannel interface for test' )
+        pytest.skip('Can not get PortChannel interface for test')
 
     pytest_assert(portchannel_members, 'Can not get PortChannel interface for test')
 

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -99,6 +99,9 @@ def test_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
             portchannel_members = port_channels_data[portchannel]
             break
 
+    if not portchannel:
+        pytest.skip( 'Can not get PortChannel interface for test' )
+
     pytest_assert(portchannel and portchannel_members, 'Can not get PortChannel interface for test')
 
     tmp_portchannel = "PortChannel999"

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -102,7 +102,7 @@ def test_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     if not portchannel:
         pytest.skip( 'Can not get PortChannel interface for test' )
 
-    pytest_assert(portchannel and portchannel_members, 'Can not get PortChannel interface for test')
+    pytest_assert(portchannel_members, 'Can not get PortChannel interface for test')
 
     tmp_portchannel = "PortChannel999"
     # Initialize portchannel_ip and portchannel_members


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Skip the lag test if portchannel is None.

Summary:

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
We wish to skip the test instead of throwing an assertion when portchannel is not available.

#### How did you do it?
We add a check for portchannel

#### How did you verify/test it?
NA

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
This is not a new feature or test case that requires documentation
