### PR TITLE
enable test_link_down on t0 and t1 devices

### DIFF
--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -19,7 +19,7 @@ from tests.common.reboot import reboot, wait_for_startup
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t2'),
+    pytest.mark.topology('t0', 't1', 't2'),
     pytest.mark.disable_loganalyzer,
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) [11671](https://github.com/sonic-net/sonic-mgmt/issues/11671)
This PR is used to enable the test_link_down script to test SONiC T0 and T1 devices. There was only one line of code change made to tests/platform_tests/test_link_down.py. 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fill the test gap.
#### How did you do it?
Change the test script
#### How did you verify/test it?
I tested it on T0, T1 and T2 DUTs in Microsoft's internal testbed and the new script works fine.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
