### PR TITLE
Remove config_db.json for cold-reboot upgrade path test

### DIFF
--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -86,6 +86,12 @@ def setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
     # Install target image
     logger.info("Upgrading to {}".format(to_image))
     target_version = install_sonic(duthost, to_image, tbinfo)
+    # Remove config_db.json before cold-reboot to target image
+    # to ensure the new config_db.json is generated from minigraph
+    if "cold" in reboot_type \
+            and duthost.shell("ls /host/old_config/minigraph.xml", module_ignore_errors=True)['rc'] == 0:
+        logger.info("Remove config_db.json before cold reboot to target image")
+        duthost.shell("rm -f /host/old_config/config_db.json", module_ignore_errors=True)
 
     if allow_fail and modify_reboot_script:
         # add fail step to reboot script

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -89,9 +89,9 @@ def setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
     # Remove config_db.json before cold-reboot to target image
     # to ensure the new config_db.json is generated from minigraph
     if "cold" in reboot_type \
-            and duthost.shell("ls /host/old_config/minigraph.xml", module_ignore_errors=True)['rc'] == 0:
+            and duthost.command("ls /host/old_config/minigraph.xml", module_ignore_errors=True)['rc'] == 0:
         logger.info("Remove config_db.json before cold reboot to target image")
-        duthost.shell("rm -f /host/old_config/config_db.json", module_ignore_errors=True)
+        duthost.command("rm -f /host/old_config/config_db.json", module_ignore_errors=True)
 
     if allow_fail and modify_reboot_script:
         # add fail step to reboot script


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to remove `config_db.json` from old_config in upgrade path test when the reboot_type is cold reboot.
The change is needed because we always re-generate `config_db.json` from `minigraph.xml` for upgrade with cold-reboot.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
This PR is to remove `config_db.json` from old_config in upgrade path test when the reboot_type is cold reboot.

#### How did you do it?
Check the `reboot-type` and remove `config_db.json` if `reboot-type` contains `cold`.

#### How did you verify/test it?
The change is verified by running a pipeline tese.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
