### PR TITLE
[Dualtor] Skip `test_ecmp_sai_value` on dualtor

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -527,6 +527,7 @@ ecmp/test_ecmp_sai_value.py:
     conditions_logical_operator: or
     conditions:
       - "topo_type not in ['t1', 't0']"
+      - "'dualtor' in topo_name"
       - "asic_type not in ['broadcom']"
       - "release in ['201911', '202012', '202205', '202211', 'master']"
       - "'internal' in build_version"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
As the subject.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
If the topo is dualtor, skip it.

#### How did you verify/test it?
Run over dualtor testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
