### PR TITLE
Add script `generic_config_updater/test_pfcwd_status.py` into T0 PR checker.

### DIFF
--- a/tests/generic_config_updater/test_pfcwd_status.py
+++ b/tests/generic_config_updater/test_pfcwd_status.py
@@ -37,6 +37,12 @@ def ignore_expected_loganalyzer_exceptions(duthosts, loganalyzer):
                     '.*ERR syncd#syncd:.*SAI_API_SWITCH:sai_bulk_object_get_stats.* ',
                 ]
             )
+        if duthost.facts["asic_type"] == "vs":
+            loganalyzer[duthost.hostname].ignore_regex.extend(
+                [
+                    '.*ERR syncd#syncd: :- queryStatsCapability: failed to find switch oid:.* in switch state map'
+                ]
+            )
 
     return
 

--- a/tests/generic_config_updater/test_pfcwd_status.py
+++ b/tests/generic_config_updater/test_pfcwd_status.py
@@ -13,8 +13,7 @@ from tests.generic_config_updater.gu_utils import create_checkpoint, delete_chec
 from tests.generic_config_updater.gu_utils import is_valid_platform_and_version
 
 pytestmark = [
-    pytest.mark.topology('any'),
-    pytest.mark.device_type('physical')
+    pytest.mark.topology('any')
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR [#13220](https://github.com/sonic-net/sonic-mgmt/pull/13220), we add a batch of control plane test scripts into onboarding T0 PR checker, but some of them failed. For test script `generic_config_updater/test_pfcwd_status.py`, it will always have an error message `'.*ERR syncd#syncd: :- queryStatsCapability: failed to find switch oid:.* in switch state map'` in syslog, which I think is expected. So in this PR, we add this error message into ignore list. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In PR [#13220](https://github.com/sonic-net/sonic-mgmt/pull/13220), we add a batch of control plane test scripts into onboarding T0 PR checker, but some of them failed. For test script `generic_config_updater/test_pfcwd_status.py`, it will always have an error message `'.*ERR syncd#syncd: :- queryStatsCapability: failed to find switch oid:.* in switch state map'` in syslog, which I think is expected. So in this PR, we add this error message into ignore list. 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
