### PR TITLE
Add ixia and wan test to pr skip yml

### DIFF
--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -79,6 +79,10 @@ t2:
   - platform_tests/test_intf_fec.py
   - snmp/test_snmp_phy_entity.py
 
+dualtor:
+  # This test is only for Nvidia platforms.
+  - dualtor_mgmt/test_egress_drop_nvidia.py
+
 tgen:
   # Ixia test only support on physical ixia testbed
   - ixia/ecn/test_dequeue_ecn.py
@@ -124,7 +128,3 @@ wan:
   - wan/lacp/test_wan_lag_min_link.py
   - wan/lldp/test_wan_lldp.py
   - wan/traffic_test/test_traffic.py
-
-dualtor:
-  # This test is only for Nvidia platforms.
-  - dualtor_mgmt/test_egress_drop_nvidia.py

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -3,6 +3,21 @@ t0:
   - restapi/test_restapi.py
   # This script only supported on Mellanox
   - generic_config_updater/test_pfcwd_interval.py
+  # Ixia test only support on physical ixia testbed
+  - ixia/ecn/test_dequeue_ecn.py
+  - ixia/ecn/test_red_accuracy.py
+  - ixia/ixanvl/test_bgp_conformance.py
+  - ixia/pfc/test_global_pause.py
+  - ixia/pfc/test_pfc_congestion.py
+  - ixia/pfc/test_pfc_pause_lossless.py
+  - ixia/pfc/test_pfc_pause_lossy.py
+  - ixia/pfcwd/test_pfcwd_a2a.py
+  - ixia/pfcwd/test_pfcwd_basic.py
+  - ixia/pfcwd/test_pfcwd_burst_storm.py
+  - ixia/pfcwd/test_pfcwd_m2o.py
+  - ixia/pfcwd/test_pfcwd_runtime_traffic.py
+  - ixia/test_ixia_traffic.py
+  - ixia/test_tgen.py
   # There is no k8s in inventory file
   - k8s/test_config_reload.py
   - k8s/test_disable_flag.py
@@ -26,10 +41,52 @@ t0:
   - platform_tests/api/test_thermal.py
   - platform_tests/api/test_watchdog.py
   - snmp/test_snmp_phy_entity.py
+  # Wan test only support on wan topo
+  - wan/isis/test_isis_authentication.py
+  - wan/isis/test_isis_csnp_interval.py
+  - wan/isis/test_isis_database.py
+  - wan/isis/test_isis_dynamic_hostname.py
+  - wan/isis/test_isis_ecmp.py
+  - wan/isis/test_isis_hello_interval.py
+  - wan/isis/test_isis_hello_pad.py
+  - wan/isis/test_isis_holdtime.py
+  - wan/isis/test_isis_intf_passive.py
+  - wan/isis/test_isis_level_capacity.py
+  - wan/isis/test_isis_log_adjacency_change.py
+  - wan/isis/test_isis_lsp_fragment.py
+  - wan/isis/test_isis_lsp_gen_interval.py
+  - wan/isis/test_isis_lsp_lifetime.py
+  - wan/isis/test_isis_lsp_refresh.py
+  - wan/isis/test_isis_metric_wide.py
+  - wan/isis/test_isis_neighbor.py
+  - wan/isis/test_isis_overload_bit.py
+  - wan/isis/test_isis_redistribute.py
+  - wan/isis/test_isis_spf_default_interval.py
+  - wan/isis/test_isis_spf_ietf_interval.py
+  - wan/lacp/test_wan_lacp.py
+  - wan/lacp/test_wan_lag_member.py
+  - wan/lacp/test_wan_lag_min_link.py
+  - wan/lldp/test_wan_lldp.py
+  - wan/traffic_test/test_traffic.py
 
 t1:
   # This script only supported on Mellanox
   - generic_config_updater/test_pfcwd_interval.py
+  # Ixia test only support on physical ixia testbed
+  - ixia/ecn/test_dequeue_ecn.py
+  - ixia/ecn/test_red_accuracy.py
+  - ixia/ixanvl/test_bgp_conformance.py
+  - ixia/pfc/test_global_pause.py
+  - ixia/pfc/test_pfc_congestion.py
+  - ixia/pfc/test_pfc_pause_lossless.py
+  - ixia/pfc/test_pfc_pause_lossy.py
+  - ixia/pfcwd/test_pfcwd_a2a.py
+  - ixia/pfcwd/test_pfcwd_basic.py
+  - ixia/pfcwd/test_pfcwd_burst_storm.py
+  - ixia/pfcwd/test_pfcwd_m2o.py
+  - ixia/pfcwd/test_pfcwd_runtime_traffic.py
+  - ixia/test_ixia_traffic.py
+  - ixia/test_tgen.py
   # There is no k8s in inventory file
   - k8s/test_config_reload.py
   - k8s/test_disable_flag.py
@@ -54,11 +111,52 @@ t1:
   - snmp/test_snmp_phy_entity.py
   # Not supported port type
   - sub_port_interfaces/test_sub_port_l2_forwarding.py
-
+  # Wan test only support on wan topo
+  - wan/isis/test_isis_authentication.py
+  - wan/isis/test_isis_csnp_interval.py
+  - wan/isis/test_isis_database.py
+  - wan/isis/test_isis_dynamic_hostname.py
+  - wan/isis/test_isis_ecmp.py
+  - wan/isis/test_isis_hello_interval.py
+  - wan/isis/test_isis_hello_pad.py
+  - wan/isis/test_isis_holdtime.py
+  - wan/isis/test_isis_intf_passive.py
+  - wan/isis/test_isis_level_capacity.py
+  - wan/isis/test_isis_log_adjacency_change.py
+  - wan/isis/test_isis_lsp_fragment.py
+  - wan/isis/test_isis_lsp_gen_interval.py
+  - wan/isis/test_isis_lsp_lifetime.py
+  - wan/isis/test_isis_lsp_refresh.py
+  - wan/isis/test_isis_metric_wide.py
+  - wan/isis/test_isis_neighbor.py
+  - wan/isis/test_isis_overload_bit.py
+  - wan/isis/test_isis_redistribute.py
+  - wan/isis/test_isis_spf_default_interval.py
+  - wan/isis/test_isis_spf_ietf_interval.py
+  - wan/lacp/test_wan_lacp.py
+  - wan/lacp/test_wan_lag_member.py
+  - wan/lacp/test_wan_lag_min_link.py
+  - wan/lldp/test_wan_lldp.py
+  - wan/traffic_test/test_traffic.py
 
 t2:
   # This script only supported on Mellanox
   - generic_config_updater/test_pfcwd_interval.py
+  # Ixia test only support on physical ixia testbed
+  - ixia/ecn/test_dequeue_ecn.py
+  - ixia/ecn/test_red_accuracy.py
+  - ixia/ixanvl/test_bgp_conformance.py
+  - ixia/pfc/test_global_pause.py
+  - ixia/pfc/test_pfc_congestion.py
+  - ixia/pfc/test_pfc_pause_lossless.py
+  - ixia/pfc/test_pfc_pause_lossy.py
+  - ixia/pfcwd/test_pfcwd_a2a.py
+  - ixia/pfcwd/test_pfcwd_basic.py
+  - ixia/pfcwd/test_pfcwd_burst_storm.py
+  - ixia/pfcwd/test_pfcwd_m2o.py
+  - ixia/pfcwd/test_pfcwd_runtime_traffic.py
+  - ixia/test_ixia_traffic.py
+  - ixia/test_tgen.py
   # There is no k8s in inventory file
   - k8s/test_config_reload.py
   - k8s/test_disable_flag.py
@@ -79,3 +177,30 @@ t2:
   # Test is not supported on vs testbed
   - platform_tests/test_intf_fec.py
   - snmp/test_snmp_phy_entity.py
+  # Wan test only support on wan topo
+  - wan/isis/test_isis_authentication.py
+  - wan/isis/test_isis_csnp_interval.py
+  - wan/isis/test_isis_database.py
+  - wan/isis/test_isis_dynamic_hostname.py
+  - wan/isis/test_isis_ecmp.py
+  - wan/isis/test_isis_hello_interval.py
+  - wan/isis/test_isis_hello_pad.py
+  - wan/isis/test_isis_holdtime.py
+  - wan/isis/test_isis_intf_passive.py
+  - wan/isis/test_isis_level_capacity.py
+  - wan/isis/test_isis_log_adjacency_change.py
+  - wan/isis/test_isis_lsp_fragment.py
+  - wan/isis/test_isis_lsp_gen_interval.py
+  - wan/isis/test_isis_lsp_lifetime.py
+  - wan/isis/test_isis_lsp_refresh.py
+  - wan/isis/test_isis_metric_wide.py
+  - wan/isis/test_isis_neighbor.py
+  - wan/isis/test_isis_overload_bit.py
+  - wan/isis/test_isis_redistribute.py
+  - wan/isis/test_isis_spf_default_interval.py
+  - wan/isis/test_isis_spf_ietf_interval.py
+  - wan/lacp/test_wan_lacp.py
+  - wan/lacp/test_wan_lag_member.py
+  - wan/lacp/test_wan_lag_min_link.py
+  - wan/lldp/test_wan_lldp.py
+  - wan/traffic_test/test_traffic.py

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -3,21 +3,6 @@ t0:
   - restapi/test_restapi.py
   # This script only supported on Mellanox
   - generic_config_updater/test_pfcwd_interval.py
-  # Ixia test only support on physical ixia testbed
-  - ixia/ecn/test_dequeue_ecn.py
-  - ixia/ecn/test_red_accuracy.py
-  - ixia/ixanvl/test_bgp_conformance.py
-  - ixia/pfc/test_global_pause.py
-  - ixia/pfc/test_pfc_congestion.py
-  - ixia/pfc/test_pfc_pause_lossless.py
-  - ixia/pfc/test_pfc_pause_lossy.py
-  - ixia/pfcwd/test_pfcwd_a2a.py
-  - ixia/pfcwd/test_pfcwd_basic.py
-  - ixia/pfcwd/test_pfcwd_burst_storm.py
-  - ixia/pfcwd/test_pfcwd_m2o.py
-  - ixia/pfcwd/test_pfcwd_runtime_traffic.py
-  - ixia/test_ixia_traffic.py
-  - ixia/test_tgen.py
   # There is no k8s in inventory file
   - k8s/test_config_reload.py
   - k8s/test_disable_flag.py
@@ -41,52 +26,10 @@ t0:
   - platform_tests/api/test_thermal.py
   - platform_tests/api/test_watchdog.py
   - snmp/test_snmp_phy_entity.py
-  # Wan test only support on wan topo
-  - wan/isis/test_isis_authentication.py
-  - wan/isis/test_isis_csnp_interval.py
-  - wan/isis/test_isis_database.py
-  - wan/isis/test_isis_dynamic_hostname.py
-  - wan/isis/test_isis_ecmp.py
-  - wan/isis/test_isis_hello_interval.py
-  - wan/isis/test_isis_hello_pad.py
-  - wan/isis/test_isis_holdtime.py
-  - wan/isis/test_isis_intf_passive.py
-  - wan/isis/test_isis_level_capacity.py
-  - wan/isis/test_isis_log_adjacency_change.py
-  - wan/isis/test_isis_lsp_fragment.py
-  - wan/isis/test_isis_lsp_gen_interval.py
-  - wan/isis/test_isis_lsp_lifetime.py
-  - wan/isis/test_isis_lsp_refresh.py
-  - wan/isis/test_isis_metric_wide.py
-  - wan/isis/test_isis_neighbor.py
-  - wan/isis/test_isis_overload_bit.py
-  - wan/isis/test_isis_redistribute.py
-  - wan/isis/test_isis_spf_default_interval.py
-  - wan/isis/test_isis_spf_ietf_interval.py
-  - wan/lacp/test_wan_lacp.py
-  - wan/lacp/test_wan_lag_member.py
-  - wan/lacp/test_wan_lag_min_link.py
-  - wan/lldp/test_wan_lldp.py
-  - wan/traffic_test/test_traffic.py
 
 t1:
   # This script only supported on Mellanox
   - generic_config_updater/test_pfcwd_interval.py
-  # Ixia test only support on physical ixia testbed
-  - ixia/ecn/test_dequeue_ecn.py
-  - ixia/ecn/test_red_accuracy.py
-  - ixia/ixanvl/test_bgp_conformance.py
-  - ixia/pfc/test_global_pause.py
-  - ixia/pfc/test_pfc_congestion.py
-  - ixia/pfc/test_pfc_pause_lossless.py
-  - ixia/pfc/test_pfc_pause_lossy.py
-  - ixia/pfcwd/test_pfcwd_a2a.py
-  - ixia/pfcwd/test_pfcwd_basic.py
-  - ixia/pfcwd/test_pfcwd_burst_storm.py
-  - ixia/pfcwd/test_pfcwd_m2o.py
-  - ixia/pfcwd/test_pfcwd_runtime_traffic.py
-  - ixia/test_ixia_traffic.py
-  - ixia/test_tgen.py
   # There is no k8s in inventory file
   - k8s/test_config_reload.py
   - k8s/test_disable_flag.py
@@ -111,52 +54,10 @@ t1:
   - snmp/test_snmp_phy_entity.py
   # Not supported port type
   - sub_port_interfaces/test_sub_port_l2_forwarding.py
-  # Wan test only support on wan topo
-  - wan/isis/test_isis_authentication.py
-  - wan/isis/test_isis_csnp_interval.py
-  - wan/isis/test_isis_database.py
-  - wan/isis/test_isis_dynamic_hostname.py
-  - wan/isis/test_isis_ecmp.py
-  - wan/isis/test_isis_hello_interval.py
-  - wan/isis/test_isis_hello_pad.py
-  - wan/isis/test_isis_holdtime.py
-  - wan/isis/test_isis_intf_passive.py
-  - wan/isis/test_isis_level_capacity.py
-  - wan/isis/test_isis_log_adjacency_change.py
-  - wan/isis/test_isis_lsp_fragment.py
-  - wan/isis/test_isis_lsp_gen_interval.py
-  - wan/isis/test_isis_lsp_lifetime.py
-  - wan/isis/test_isis_lsp_refresh.py
-  - wan/isis/test_isis_metric_wide.py
-  - wan/isis/test_isis_neighbor.py
-  - wan/isis/test_isis_overload_bit.py
-  - wan/isis/test_isis_redistribute.py
-  - wan/isis/test_isis_spf_default_interval.py
-  - wan/isis/test_isis_spf_ietf_interval.py
-  - wan/lacp/test_wan_lacp.py
-  - wan/lacp/test_wan_lag_member.py
-  - wan/lacp/test_wan_lag_min_link.py
-  - wan/lldp/test_wan_lldp.py
-  - wan/traffic_test/test_traffic.py
 
 t2:
   # This script only supported on Mellanox
   - generic_config_updater/test_pfcwd_interval.py
-  # Ixia test only support on physical ixia testbed
-  - ixia/ecn/test_dequeue_ecn.py
-  - ixia/ecn/test_red_accuracy.py
-  - ixia/ixanvl/test_bgp_conformance.py
-  - ixia/pfc/test_global_pause.py
-  - ixia/pfc/test_pfc_congestion.py
-  - ixia/pfc/test_pfc_pause_lossless.py
-  - ixia/pfc/test_pfc_pause_lossy.py
-  - ixia/pfcwd/test_pfcwd_a2a.py
-  - ixia/pfcwd/test_pfcwd_basic.py
-  - ixia/pfcwd/test_pfcwd_burst_storm.py
-  - ixia/pfcwd/test_pfcwd_m2o.py
-  - ixia/pfcwd/test_pfcwd_runtime_traffic.py
-  - ixia/test_ixia_traffic.py
-  - ixia/test_tgen.py
   # There is no k8s in inventory file
   - k8s/test_config_reload.py
   - k8s/test_disable_flag.py
@@ -177,7 +78,26 @@ t2:
   # Test is not supported on vs testbed
   - platform_tests/test_intf_fec.py
   - snmp/test_snmp_phy_entity.py
-  # Wan test only support on wan topo
+
+tgen:
+  # Ixia test only support on physical ixia testbed
+  - ixia/ecn/test_dequeue_ecn.py
+  - ixia/ecn/test_red_accuracy.py
+  - ixia/ixanvl/test_bgp_conformance.py
+  - ixia/pfc/test_global_pause.py
+  - ixia/pfc/test_pfc_congestion.py
+  - ixia/pfc/test_pfc_pause_lossless.py
+  - ixia/pfc/test_pfc_pause_lossy.py
+  - ixia/pfcwd/test_pfcwd_a2a.py
+  - ixia/pfcwd/test_pfcwd_basic.py
+  - ixia/pfcwd/test_pfcwd_burst_storm.py
+  - ixia/pfcwd/test_pfcwd_m2o.py
+  - ixia/pfcwd/test_pfcwd_runtime_traffic.py
+  - ixia/test_ixia_traffic.py
+  - ixia/test_tgen.py
+
+wan:
+  # Currently PR test will not test wan topo
   - wan/isis/test_isis_authentication.py
   - wan/isis/test_isis_csnp_interval.py
   - wan/isis/test_isis_database.py

--- a/tests/ixia/ixanvl/test_bgp_conformance.py
+++ b/tests/ixia/ixanvl/test_bgp_conformance.py
@@ -5,7 +5,10 @@ import pytest
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F401
 from scp import SCPClient
 
-pytestmark = [pytest.mark.disable_loganalyzer]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.disable_loganalyzer
+]
 
 
 @pytest.fixture()

--- a/tests/ixia/test_ixia_traffic.py
+++ b/tests/ixia/test_ixia_traffic.py
@@ -26,8 +26,12 @@ from tests.common.ixia.common_helpers import get_vlan_subnet, get_addrs_in_subne
     get_peer_ixia_chassis
 
 
-@pytest.mark.disable_loganalyzer
-@pytest.mark.topology("tgen")
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.disable_loganalyzer
+]
+
+
 def test_testbed(conn_graph_facts, duthosts, rand_one_dut_hostname, fanout_graph_facts,     # noqa F811
                  ixia_api_server_session, fanouthosts):                                     # noqa F811
     duthost = duthosts[rand_one_dut_hostname]

--- a/tests/ixia/test_tgen.py
+++ b/tests/ixia/test_tgen.py
@@ -19,8 +19,12 @@ from abstract_open_traffic_generator.control import State, ConfigState, FlowTran
 from abstract_open_traffic_generator.result import FlowRequest
 
 
-@pytest.mark.topology("tgen")
-@pytest.mark.disable_loganalyzer
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.disable_loganalyzer
+]
+
+
 def __gen_all_to_all_traffic(testbed_config,
                              port_config_list,
                              dut_hostname,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Ixia test do not support on kvm testbed, and wan test do not support in PR test, need to add those test to pr test skip yml to explicitly skip in PR testing.
#### How did you do it?
Add ixia/wan test to PR test skip yml, and add pytest marker in ixia test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
