### PR TITLE
Use temporary fixture in duthost_utils to skip traffic test in vs platform

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -849,3 +849,15 @@ def assert_addr_in_output(addr_set: Dict[str, List], hostname: str,
             pytest_assert(addr not in cmd_output,
                           f"{hostname} {cmd_desc} still with addr {addr}")
             logger.info(f"{addr} not exists in the output of {cmd_desc} which is expected")
+
+
+# Currently, conditional mark would only match longest prefix,
+# so our mark in tests_mark_conditions_skip_traffic_test.yaml couldn't be matched.
+# Use a temporary work around to add skip_traffic_test fixture here,
+# once conditional mark support add all matches, will remove this code.
+@pytest.fixture(scope="module")
+def skip_traffic_test(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    if duthost.facts["asic_type"] == "vs":
+        return True
+    return False

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -21,8 +21,10 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # no
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test           # noqa F401
+# from tests.common.fixtures.ptfhost_utils import skip_traffic_test           # noqa F401
 from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test           # noqa F401
 from tests.common.fixtures.fib_utils import fib_info_files                  # noqa F401
 from tests.common.fixtures.fib_utils import single_fib_for_duts             # noqa F401
 from tests.ptf_runner import ptf_runner

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -378,18 +378,6 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
     time.sleep(60)
 
 
-# Currently, conditional mark would only match longest prefix,
-# so our mark in tests_mark_conditions_skip_traffic_test.yaml couldn't be matched.
-# Use a temporary work around to add skip_traffic_test fixture here,
-# once conditional mark support add all matches, will remove this code.
-@pytest.fixture(scope="module")
-def skip_traffic_test(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    if duthost.facts["asic_type"] == "vs":
-        return True
-    return False
-
-
 # TODO: This should be refactored to some common area of sonic-mgmt.
 def add_route(duthost, prefix, nexthop, namespace):
     """

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -11,9 +11,11 @@ from .everflow_test_utilities import TEMPLATE_DIR, EVERFLOW_RULE_CREATE_TEMPLATE
                                     DUT_RUN_DIR, EVERFLOW_RULE_CREATE_FILE, UP_STREAM
 from tests.common.helpers.assertions import pytest_require
 
-from .everflow_test_utilities import setup_info, EVERFLOW_DSCP_RULES, skip_traffic_test       # noqa: F401
+from .everflow_test_utilities import setup_info, EVERFLOW_DSCP_RULES    # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
 # from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa: F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test       # noqa: F401
 
 pytestmark = [
     pytest.mark.topology("any")

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -12,8 +12,9 @@ from .everflow_test_utilities import TARGET_SERVER_IP, BaseEverflowTest, DOWN_ST
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                 # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_acstests_directory                                 # noqa: F401
 # from tests.common.fixtures.ptfhost_utils import skip_traffic_test                                       # noqa: F401
-from .everflow_test_utilities import \
-    setup_info, setup_arp_responder, EVERFLOW_DSCP_RULES, skip_traffic_test                             # noqa: F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test                                       # noqa: F401
+from .everflow_test_utilities import setup_info, setup_arp_responder, EVERFLOW_DSCP_RULES               # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py                                   # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker. But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed.
Currently, we are using a fixture `skip_traffic_test` in `ptfhost_utils` and `tests_mark_conditions_skip_traffic_test.yaml` to add marker to tests, but conditional mark would only match longest prefix, so our mark in `tests_mark_conditions_skip_traffic_test.yaml` couldn't be matched.
#### How did you do it?
We will support to add all markers in conditional mark in the future, the plan is: if marks are different, all marks would be matched and added, if marks are the same, only the longest prefix would be matched and added.
Before conditional mark get optimized, use a temporary work around to add `skip_traffic_test` fixture in `duthost_utils` for all modules not only everflow, always return True if asic type is vs, once conditional mark support add all matches, will remove this code and change to fixture in `ptfhost_utils`.
#### How did you verify/test it?
Tested everflow and decap in KVM
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
