### PR TITLE
Update link flap test to use common port candidate function. 

### DIFF
--- a/tests/platform_tests/link_flap/test_link_flap.py
+++ b/tests/platform_tests/link_flap/test_link_flap.py
@@ -4,17 +4,16 @@ Tests the link flap in SONiC.
 import logging
 import pytest
 
-from tests.platform_tests.link_flap.link_flap_utils import toggle_one_link, check_orch_cpu_utilization
-from tests.common.platform.device_utils import fanout_switch_port_lookup
-from tests.common.helpers.assertions import pytest_assert
+from tests.platform_tests.link_flap.link_flap_utils import toggle_one_link, \
+    check_orch_cpu_utilization, build_test_candidates
+from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('any'),
-    pytest.mark.device_type('physical')
+    pytest.mark.topology('any')
 ]
 
 
@@ -49,12 +48,8 @@ def test_link_flap(request, duthosts, rand_one_dut_hostname, tbinfo, fanouthosts
 
     loop_times = get_loop_times
 
-    port_lists = get_port_list(duthost, tbinfo)
-
-    candidates = []
-    for port in port_lists:
-        fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, duthost.hostname, port)
-        candidates.append((port, fanout, fanout_port))
+    candidates = build_test_candidates(duthost, fanouthosts, 'all_ports')
+    pytest_require(candidates, "Didn't find any port that is admin up and present in the connection graph")
 
     for loop_time in range(0, loop_times):
         watch = False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
There is a more comprehensive function in `platform_tests/link_flap/link_flap_utils.py` to get port candidates for link flap test. In this PR, we use this common function to replace previous function. And in this PR, we also add the `pytest_require` after getting the port candidates. If there is no expected port candidates, we will skip this test. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
There is a more comprehensive function in `platform_tests/link_flap/link_flap_utils.py` to get port candidates for link flap test. In this PR, we use this common function to replace previous function. And in this PR, we also add the `pytest_require` after getting the port candidates. If there is no expected port candidates, we will skip this test. 

#### How did you do it?
Use function in `platform_tests/link_flap/link_flap_utils.py`  to replace previous function. And add the `pytest_require` after getting the port candidates to skip the scenario such like no expected port candidates.

#### How did you verify/test it?
```
=========================== short test summary info ============================
SKIPPED [1] common/helpers/assertions.py:16: Didn't find any port that is admin up and present in the connection graph
=================== 1 skipped, 1 warning in 64.03s (0:01:04) ===================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
