### PR TITLE
Add functionality to save techsupport on vSONiC neighbors, and use it for retry count

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -867,7 +867,7 @@ def collect_techsupport_all_duts(request, duthosts):
 def collect_techsupport_all_nbrs(request, nbrhosts):
     yield
     if request.config.getoption("neighbor_type") == "sonic":
-        [collect_techsupport_on_dut(request, nbrhost) for nbrhost in nbrhosts]
+        [collect_techsupport_on_dut(request, nbrhosts[nbrhost]['host']) for nbrhost in nbrhosts]
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -863,6 +863,13 @@ def collect_techsupport_all_duts(request, duthosts):
     [collect_techsupport_on_dut(request, a_dut) for a_dut in duthosts]
 
 
+@pytest.fixture
+def collect_techsupport_all_nbrs(request, nbrhosts):
+    yield
+    if request.config.getoption("neighbor_type") == "sonic":
+        [collect_techsupport_on_dut(request, nbrhost) for nbrhost in nbrhosts]
+
+
 @pytest.fixture(scope="session", autouse=True)
 def tag_test_report(request, pytestconfig, tbinfo, duthost, record_testsuite_property):
     if not request.config.getoption("--junit-xml"):

--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -291,7 +291,7 @@ class TestNeighborRetryCount:
                 pytest_assert(not status["runner"]["selected"], "lag member is still up")
 
 
-def test_peer_retry_count_disabled(duthost, nbrhosts, higher_retry_count_on_peers, disable_retry_count_on_peer):
+def test_peer_retry_count_disabled(duthost, nbrhosts, higher_retry_count_on_peers, disable_retry_count_on_peer, collect_techsupport_all_nbrs):
     """
     Test that peers reset the retry count to 3 when the feature is disabled
     """
@@ -364,7 +364,7 @@ class TestDutRetryCount:
                 pytest_assert(not status["runner"]["selected"], "lag member is still up")
 
 
-def test_dut_retry_count_disabled(duthost, nbrhosts, higher_retry_count_on_dut, disable_retry_count_on_dut):
+def test_dut_retry_count_disabled(duthost, nbrhosts, higher_retry_count_on_dut, disable_retry_count_on_dut, collect_techsupport_all_nbrs):
     """
     Test that DUT resets the retry count to 3 when the feature is disabled
     """

--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -291,7 +291,8 @@ class TestNeighborRetryCount:
                 pytest_assert(not status["runner"]["selected"], "lag member is still up")
 
 
-def test_peer_retry_count_disabled(duthost, nbrhosts, higher_retry_count_on_peers, disable_retry_count_on_peer, collect_techsupport_all_nbrs):
+def test_peer_retry_count_disabled(duthost, nbrhosts, higher_retry_count_on_peers, disable_retry_count_on_peer,
+                                   collect_techsupport_all_nbrs):
     """
     Test that peers reset the retry count to 3 when the feature is disabled
     """
@@ -364,7 +365,8 @@ class TestDutRetryCount:
                 pytest_assert(not status["runner"]["selected"], "lag member is still up")
 
 
-def test_dut_retry_count_disabled(duthost, nbrhosts, higher_retry_count_on_dut, disable_retry_count_on_dut, collect_techsupport_all_nbrs):
+def test_dut_retry_count_disabled(duthost, nbrhosts, higher_retry_count_on_dut, disable_retry_count_on_dut,
+                                  collect_techsupport_all_nbrs):
     """
     Test that DUT resets the retry count to 3 when the feature is disabled
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

For test cases where there is some configuration done on the neighbor devices, or some state is checked on the neighbor devices, if there is a test case failure, it would be useful to get the logs on that device for debugging purposes. However, there's no fixture currently that does this (there is a fixture that automatically collects techsupport on the DUT itself).

#### How did you do it?

Add a fixture to collect the techsupport from neighbor VMs if they are vSONiC neighbors if the test case fails. Also, modify two test cases in `tests/pc/test_retry_count.py` to have it collect information from the neighbors if it fails. This information will be extremely helpful in debugging failures.

#### How did you verify/test it?

Modified the test function to always collect techsupport, then run it on a KVM t0-116 topo with vSONIC neighbors, and verify that techsupport got collected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
