### PR TITLE
Add option to skip certificates cleanup

### DIFF
--- a/tests/dash/conftest.py
+++ b/tests/dash/conftest.py
@@ -43,6 +43,12 @@ def pytest_addoption(parser):
         help="Skip dataplane checking"
     )
 
+    parser.addoption(
+        "--skip_cert_cleanup",
+        action="store_true",
+        help="Skip certificates cleanup after test"
+    )
+
 
 @pytest.fixture(scope="module")
 def config_only(request):
@@ -63,6 +69,9 @@ def skip_cleanup(request):
 def skip_dataplane_checking(request):
     return request.config.getoption("--skip_dataplane_checking")
 
+@pytest.fixture(scope="module")
+def skip_cert_cleanup(request):
+    return request.config.getoption("--skip_cert_cleanup")
 
 @pytest.fixture(scope="module")
 def config_facts(duthost):
@@ -244,7 +253,7 @@ def apply_direct_configs(dash_outbound_configs, apply_config):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost, ptfhost):
+def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost, ptfhost, skip_cert_cleanup):
     if not ENABLE_GNMI_API:
         yield
         return
@@ -253,7 +262,7 @@ def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost, ptfhost):
     generate_gnmi_cert(localhost, duthost)
     apply_gnmi_cert(duthost, ptfhost)
     yield
-    recover_gnmi_cert(localhost, duthost)
+    recover_gnmi_cert(localhost, duthost, skip_cert_cleanup)
 
 
 @pytest.fixture(scope="function")

--- a/tests/dash/conftest.py
+++ b/tests/dash/conftest.py
@@ -69,9 +69,11 @@ def skip_cleanup(request):
 def skip_dataplane_checking(request):
     return request.config.getoption("--skip_dataplane_checking")
 
+
 @pytest.fixture(scope="module")
 def skip_cert_cleanup(request):
     return request.config.getoption("--skip_cert_cleanup")
+
 
 @pytest.fixture(scope="module")
 def config_facts(duthost):

--- a/tests/dash/gnmi_utils.py
+++ b/tests/dash/gnmi_utils.py
@@ -197,7 +197,7 @@ def apply_gnmi_cert(duthost, ptfhost):
     time.sleep(env.gnmi_server_start_wait_time)
 
 
-def recover_gnmi_cert(localhost, duthost):
+def recover_gnmi_cert(localhost, duthost, skip_cert_cleanup):
     """
     Restart gnmi server to use default certificate
 
@@ -208,7 +208,8 @@ def recover_gnmi_cert(localhost, duthost):
     Returns:
     """
     env = GNMIEnvironment(duthost)
-    localhost.shell("rm -rf "+env.work_dir, module_ignore_errors=True)
+    if not skip_cert_cleanup:
+        localhost.shell("rm -rf "+env.work_dir, module_ignore_errors=True)
     dut_command = "docker exec %s supervisorctl status %s" % (env.gnmi_container, env.gnmi_program)
     output = duthost.command(dut_command, module_ignore_errors=True)['stdout'].strip()
     if 'RUNNING' in output:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Sometimes we need to keep gnmi certificates for further testing.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Sometimes we need to keep gnmi certificates for further testing.

#### How did you do it?
Add option to skip gnmi certificates cleanup.

#### How did you verify/test it?
I have manually run dash end2end test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
