### PR TITLE
fix: enable safe reboot on supervisor card

### DIFF
--- a/tests/platform_tests/test_kdump.py
+++ b/tests/platform_tests/test_kdump.py
@@ -64,12 +64,7 @@ class TestKernelPanic:
         if "Enabled" not in out["stdout"]:
             pytest.skip('DUT {}: Skip test since kdump is not enabled'.format(hostname))
 
-        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_KERNEL_PANIC, safe_reboot=duthost.is_supervisor_node())
-
-        # Wait until all critical processes are healthy. Skip if DUT is supervisor node since we have
-        # already confirmed the critical processes for a supervisor node in above reboot function.
-        if not duthost.is_supervisor_node():
-            wait_critical_processes(duthost)
+        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_KERNEL_PANIC, safe_reboot=True)
 
         check_interfaces_and_services(duthost, conn_graph_facts["device_conn"][hostname],
                                       xcvr_skip_list, reboot_type=REBOOT_TYPE_KERNEL_PANIC)

--- a/tests/platform_tests/test_kdump.py
+++ b/tests/platform_tests/test_kdump.py
@@ -64,10 +64,13 @@ class TestKernelPanic:
         if "Enabled" not in out["stdout"]:
             pytest.skip('DUT {}: Skip test since kdump is not enabled'.format(hostname))
 
-        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_KERNEL_PANIC)
+        reboot(duthost, localhost, reboot_type=REBOOT_TYPE_KERNEL_PANIC, safe_reboot=duthost.is_supervisor_node())
 
-        # Wait until all critical processes are healthy.
-        wait_critical_processes(duthost)
+        # Wait until all critical processes are healthy. Skip if DUT is supervisor node since we have
+        # already confirmed the critical processes for a supervisor node in above reboot function.
+        if not duthost.is_supervisor_node():
+            wait_critical_processes(duthost)
+
         check_interfaces_and_services(duthost, conn_graph_facts["device_conn"][hostname],
                                       xcvr_skip_list, reboot_type=REBOOT_TYPE_KERNEL_PANIC)
         self.wait_lc_healthy_if_sup(duthost, duthosts, localhost, conn_graph_facts, xcvr_skip_list)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The `platform_tests/test_kdump.py` test keeps failing on the supervisor card. The reason is that a supervisor card needs more time to become fully available after reboot, because most of them have many dockers that need to come up. Luckily, if we set `safe_reboot` to True, the `reboot()` function will wait for all the critical processes to be up before continuing.

Therefore, we should enable safe reboot on supervisor card as well as all other cards so we can make sure that the DUT is fully ready before running any command/task on it. 

Summary:
Fixes # (issue): Microsoft ADO 28165196

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
I ran the updated  `platform_tests/test_kdump.py` test on a T2 chassis and I can confirm it passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
