### PR TITLE
Set Xfail test_reload_configuration_checks for Cisco platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1079,6 +1079,12 @@ platform_tests/test_reboot.py::test_warm_reboot:
     conditions:
       - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-buildimage/issues/16502"
 
+platform_tests/test_reload_config.py::test_reload_configuration_checks:
+  xfail:
+    reason: "Known testcase issue in Cisco platforms."
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
 #######################################
 #####           qos               #####
 #######################################


### PR DESCRIPTION
…g issue

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Set Xfail test_reload_configuration_checks for Cisco platform in 202311 branch.
No need for other branch.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
There is a timing issue which will cause test_reload_configuration_checks fail in Cisco platform.

#### How did you do it?
Set xfail to test_reload_configuration_checks for Cisco platform

#### How did you verify/test it?
Run with physical testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
