### PR TITLE
Revert "Handle failure during dualtor setup deployment"

### DIFF
--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -147,10 +147,3 @@
     vm_names: "{{ VM_targets }}"
   become: yes
   when: vm_type is defined and vm_type=="ceos"
-
-- name: Reinsert 8021q module
-  vm_topology:
-    cmd: 'reinsert-8021q'
-    vm_names: "{{ VM_targets }}"
-  become: yes
-  when: vm_type is defined and vm_type=="ceos"


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#12958
Thanks to @saiarcot895's finding, the re-insert of vlan kernel model will leave other testbeds on the same server in an error state.