### PR TITLE
Skip test_dip_link_local 202311 branch

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -5,7 +5,7 @@
 #Hence, it is not dropped by default in Cisco-8000. For dropping link local address, it should be done through security/DATA ACL
 drop_packets/test_configurable_drop_counters.py::test_dip_link_local:
   skip:
-    reason: "Some mlx platforms does not drop DIP link local packets"
+    reason: "Cisco 8000 platform and some mlx platforms does not drop DIP link local packets"
     conditions_logical_operator: or
     conditions:
       - "'Mellanox' in hwsku"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -6,8 +6,10 @@
 drop_packets/test_configurable_drop_counters.py::test_dip_link_local:
   skip:
     reason: "Some mlx platforms does not drop DIP link local packets"
+    conditions_logical_operator: or
     conditions:
       - "'Mellanox' in hwsku"
+      - "asic_type=='cisco-8000'"
 
 drop_packets/test_configurable_drop_counters.py::test_sip_link_local:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The following testcase is not supported in Cisco platform:

drop_packets.test_configurable_drop_counters.test_dip_link_local

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
The testcase is not supported in Cisco platform

#### How did you do it?
Skip the testcase.

#### How did you verify/test it?
N/A

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
