### PR TITLE
Add mock dualtor dataplane test to onboarding t0 job

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -335,6 +335,10 @@ onboarding_t0:
   - acl/test_acl_outer_vlan.py
   - arp/test_unknown_mac.py
   - decap/test_decap.py
+  - dualtor/test_orchagent_active_tor_downstream.py
+  - dualtor/test_orchagent_mac_move.py
+  - dualtor/test_orchagent_standby_tor_downstream.py
+  - dualtor/test_standby_tor_upstream_mux_toggle.py
 
 onboarding_t1:
   - decap/test_decap.py

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -849,7 +849,9 @@ def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip,
     Returns:
         None.
     """
-
+    if skip_traffic_test is True:
+        logging.info("Skip checking tunnel balance due to traffic test was skipped")
+        return
     HASH_KEYS = ["src-port", "dst-port", "src-ip"]
     params = {
         "server_ip": target_server_ip,
@@ -869,8 +871,6 @@ def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip,
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     log_file = "/tmp/ip_in_ip_tunnel_test.{}.log".format(timestamp)
     logging.info("PTF log file: %s" % log_file)
-    if skip_traffic_test is True:
-        return
     ptf_runner(ptfhost,
                "ptftests",
                "ip_in_ip_tunnel_test.IpinIPTunnelTest",
@@ -1116,6 +1116,7 @@ def check_nexthops_single_uplink(portchannel_ports, port_packet_count, expect_pa
         logging.info("Packets received on portchannel {}: {}".format(pc, count))
 
         if skip_traffic_test is True:
+            logging.info("Skip checking single uplink balance due to traffic test was skipped")
             continue
         if count > 0 and count != expect_packet_num:
             pytest.fail("Packets not sent up single standby port {}".format(pc))
@@ -1139,6 +1140,7 @@ def check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_add
     packets_to_send = generate_hashed_packet_to_server(ptfadapter, rand_selected_dut, HASH_KEYS, dst_server_addr,
                                                        expect_packet_num)
     if skip_traffic_test is True:
+        logging.info("Skip checking single downlink balance due to traffic test was skipped")
         return
     for send_packet, exp_pkt, exp_tunnel_pkt in packets_to_send:
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), send_packet, count=1)
@@ -1219,6 +1221,7 @@ def verify_upstream_traffic(host, ptfadapter, tbinfo, itfs, server_ip,
     logger.info("Verifying upstream traffic. packet number = {} interface = {} \
                 server_ip = {} expect_drop = {}".format(pkt_num, itfs, server_ip, drop))
     if skip_traffic_test is True:
+        logger.info("Skip verifying upstream traffic due to traffic test was skipped")
         return
     for i in range(0, pkt_num):
         ptfadapter.dataplane.flush()

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -831,7 +831,7 @@ def mux_cable_server_ip(dut):
 def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip,
                          standby_tor_ip, selected_port, target_server_ip,
                          target_server_ipv6, target_server_port, ptf_portchannel_indices,
-                         completeness_level, check_ipv6=False):
+                         completeness_level, check_ipv6=False, skip_traffic_test=False):
     """
     Function for testing traffic distribution among all avtive T1.
     A test script will be running on ptf to generate traffic to standby interface, and the traffic will be forwarded to
@@ -869,6 +869,8 @@ def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip,
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     log_file = "/tmp/ip_in_ip_tunnel_test.{}.log".format(timestamp)
     logging.info("PTF log file: %s" % log_file)
+    if skip_traffic_test is True:
+        return
     ptf_runner(ptfhost,
                "ptftests",
                "ip_in_ip_tunnel_test.IpinIPTunnelTest",
@@ -1104,7 +1106,7 @@ def check_nexthops_balance(rand_selected_dut, ptfadapter, dst_server_addr,
                     pc))
 
 
-def check_nexthops_single_uplink(portchannel_ports, port_packet_count, expect_packet_num):
+def check_nexthops_single_uplink(portchannel_ports, port_packet_count, expect_packet_num, skip_traffic_test=False):
     for pc, intfs in portchannel_ports.items():
         count = 0
         # Collect the packets count within a single portchannel
@@ -1113,13 +1115,15 @@ def check_nexthops_single_uplink(portchannel_ports, port_packet_count, expect_pa
             count = count + port_packet_count.get(uplink_int, 0)
         logging.info("Packets received on portchannel {}: {}".format(pc, count))
 
+        if skip_traffic_test is True:
+            continue
         if count > 0 and count != expect_packet_num:
             pytest.fail("Packets not sent up single standby port {}".format(pc))
 
 
 # verify nexthops are only sent to single active or standby mux
 def check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_addr,
-                                   tbinfo, downlink_ints):
+                                   tbinfo, downlink_ints, skip_traffic_test=False):
     HASH_KEYS = ["src-port", "dst-port", "src-ip"]
     expect_packet_num = 1000
     expect_packet_num_high = expect_packet_num * (0.90)
@@ -1134,6 +1138,8 @@ def check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_add
     port_packet_count = dict()
     packets_to_send = generate_hashed_packet_to_server(ptfadapter, rand_selected_dut, HASH_KEYS, dst_server_addr,
                                                        expect_packet_num)
+    if skip_traffic_test is True:
+        return
     for send_packet, exp_pkt, exp_tunnel_pkt in packets_to_send:
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), send_packet, count=1)
         # expect multi-mux nexthops to focus packets to one downlink
@@ -1155,10 +1161,11 @@ def check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_add
     if len(downlink_ints) == 0:
         # All nexthops are now connected to standby mux, and the packets will be sent towards a single portchanel int
         # Check if uplink distribution is towards a single portchannel
-        check_nexthops_single_uplink(portchannel_ports, port_packet_count, expect_packet_num)
+        check_nexthops_single_uplink(portchannel_ports, port_packet_count, expect_packet_num, skip_traffic_test)
 
 
-def verify_upstream_traffic(host, ptfadapter, tbinfo, itfs, server_ip, pkt_num=100, drop=False):
+def verify_upstream_traffic(host, ptfadapter, tbinfo, itfs, server_ip,
+                            pkt_num=100, drop=False, skip_traffic_test=False):
     """
     @summary: Helper function for verifying upstream packets
     @param host: The dut host
@@ -1211,6 +1218,8 @@ def verify_upstream_traffic(host, ptfadapter, tbinfo, itfs, server_ip, pkt_num=1
 
     logger.info("Verifying upstream traffic. packet number = {} interface = {} \
                 server_ip = {} expect_drop = {}".format(pkt_num, itfs, server_ip, drop))
+    if skip_traffic_test is True:
+        return
     for i in range(0, pkt_num):
         ptfadapter.dataplane.flush()
         testutils.send(ptfadapter, tx_port, pkt, count=1)

--- a/tests/common/dualtor/server_traffic_utils.py
+++ b/tests/common/dualtor/server_traffic_utils.py
@@ -50,7 +50,8 @@ class ServerTrafficMonitor(object):
     VLAN_INTERFACE_TEMPLATE = "{external_port}.{vlan_id}"
 
     def __init__(self, duthost, ptfhost, vmhost, tbinfo, dut_iface,
-                 conn_graph_facts, exp_pkt, existing=True, is_mocked=False):
+                 conn_graph_facts, exp_pkt, existing=True, is_mocked=False,
+                 skip_traffic_test=False):
         """
         @summary: Initialize the monitor.
 
@@ -75,6 +76,7 @@ class ServerTrafficMonitor(object):
         self.conn_graph_facts = conn_graph_facts
         self.captured_packets = []
         self.matched_packets = []
+        self.skip_traffic_test = skip_traffic_test
         if is_mocked:
             mg_facts = self.duthost.get_extended_minigraph_facts(self.tbinfo)
             ptf_iface = "eth%s" % mg_facts['minigraph_ptf_indices'][self.dut_iface]
@@ -120,6 +122,8 @@ class ServerTrafficMonitor(object):
         logging.info("the expected packet:\n%s", str(self.exp_pkt))
         self.matched_packets = [p for p in self.captured_packets if match_exp_pkt(self.exp_pkt, p)]
         logging.info("received %d matched packets", len(self.matched_packets))
+        if self.skip_traffic_test is True:
+            return
         if self.matched_packets:
             logging.info(
                 "display the most recent matched captured packet:\n%s",

--- a/tests/common/dualtor/server_traffic_utils.py
+++ b/tests/common/dualtor/server_traffic_utils.py
@@ -123,6 +123,7 @@ class ServerTrafficMonitor(object):
         self.matched_packets = [p for p in self.captured_packets if match_exp_pkt(self.exp_pkt, p)]
         logging.info("received %d matched packets", len(self.matched_packets))
         if self.skip_traffic_test is True:
+            logging.info("Skip matched_packets verify due to traffic test was skipped.")
             return
         if self.matched_packets:
             logging.info(

--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -250,7 +250,7 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
             return " ,".join(check_res)
 
         def __init__(self, standby_tor, active_tor=None, existing=True, inner_packet=None,
-                     check_items=("ttl", "tos", "queue"), packet_count=10):
+                     check_items=("ttl", "tos", "queue"), packet_count=10, skip_traffic_test=False):
             """
             Init the tunnel traffic monitor.
 
@@ -262,6 +262,7 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
             self.listen_ports = sorted(self._get_t1_ptf_port_indexes(standby_tor, tbinfo))
             self.ptfadapter = ptfadapter
             self.packet_count = packet_count
+            self.skip_traffic_test = skip_traffic_test
 
             standby_tor_cfg_facts = self.standby_tor.config_facts(
                 host=self.standby_tor.hostname, source="running"
@@ -293,6 +294,8 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
 
         def __exit__(self, *exc_info):
             if exc_info[0]:
+                return
+            if self.skip_traffic_test is True:
                 return
             try:
                 port_index, rec_pkt = testutils.verify_packet_any_port(

--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -296,6 +296,7 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
             if exc_info[0]:
                 return
             if self.skip_traffic_test is True:
+                logging.info("Skip tunnel traffic verify due to traffic test was skipped.")
                 return
             try:
                 port_index, rec_pkt = testutils.verify_packet_any_port(

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -64,12 +64,6 @@ decap/test_decap.py:
 #######################################
 #####           dualtor           #####
 #######################################
-dualtor/test_orch_stress.py:
-  skip_traffic_test:
-    reason: "Skip traffic test for KVM testbed"
-    conditions:
-      - "asic_type in ['vs']"
-
 dualtor/test_orchagent_active_tor_downstream.py:
   skip_traffic_test:
     reason: "Skip traffic test for KVM testbed"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -62,6 +62,39 @@ decap/test_decap.py:
       - "asic_type in ['vs']"
 
 #######################################
+#####           dualtor           #####
+#######################################
+dualtor/test_orch_stress.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+dualtor/test_orchagent_active_tor_downstream.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+dualtor/test_orchagent_mac_move.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+dualtor/test_orchagent_standby_tor_downstream.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+dualtor/test_standby_tor_upstream_mux_toggle.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
 #####             ecmp            #####
 #######################################
 ecmp/inner_hashing/test_inner_hashing.py:

--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -65,16 +65,17 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="module", autouse=True)
 def common_setup_teardown(rand_selected_dut, request, tbinfo, vmhost):
     # Skip dualtor test cases on unsupported platform
-    supported_platforms = ['broadcom_td3_hwskus', 'broadcom_th2_hwskus', 'cisco_hwskus', 'mellanox_dualtor_hwskus']
-    hostvars = get_host_visible_vars(rand_selected_dut.host.options['inventory'], rand_selected_dut.hostname)
-    hwsku = rand_selected_dut.facts['hwsku']
-    skip = True
-    for platform in supported_platforms:
-        supported_skus = hostvars.get(platform, [])
-        if hwsku in supported_skus:
-            skip = False
-            break
-    py_require(not skip, "Skip on unsupported platform")
+    if rand_selected_dut.facts['asic_type'] != 'vs':
+        supported_platforms = ['broadcom_td3_hwskus', 'broadcom_th2_hwskus', 'cisco_hwskus', 'mellanox_dualtor_hwskus']
+        hostvars = get_host_visible_vars(rand_selected_dut.host.options['inventory'], rand_selected_dut.hostname)
+        hwsku = rand_selected_dut.facts['hwsku']
+        skip = True
+        for platform in supported_platforms:
+            supported_skus = hostvars.get(platform, [])
+            if hwsku in supported_skus:
+                skip = False
+                break
+        py_require(not skip, "Skip on unsupported platform")
 
     if 'dualtor' in tbinfo['topo']['name']:
         request.getfixturevalue('run_garp_service')

--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -21,6 +21,9 @@ from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor    
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder                  # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_garp_service                    # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                # noqa F401
+# from tests.common.fixtures.ptfhost_utils import skip_traffic_test                   # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test                   # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 
@@ -67,7 +70,7 @@ def neighbor_reachable(duthost, neighbor_ip):
 def test_active_tor_remove_neighbor_downstream_active(
     conn_graph_facts, ptfadapter, ptfhost, testbed_setup,
     rand_selected_dut, tbinfo, set_crm_polling_interval,
-    tunnel_traffic_monitor, vmhost      # noqa F811
+    tunnel_traffic_monitor, vmhost, skip_traffic_test      # noqa F811
 ):
     """
     @Verify those two scenarios:
@@ -101,18 +104,18 @@ def test_active_tor_remove_neighbor_downstream_active(
         ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
         logging.info("send traffic to server %s from ptf t1 interface %s", server_ip, ptf_t1_intf)
         server_traffic_monitor = ServerTrafficMonitor(
-            tor, ptfhost, vmhost, tbinfo, test_port,
-            conn_graph_facts, exp_pkt, existing=True, is_mocked=is_mocked_dualtor(tbinfo)       # noqa F405
+            tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
+            existing=True, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test       # noqa F405
         )
-        tunnel_monitor = tunnel_traffic_monitor(tor, existing=False)
+        tunnel_monitor = tunnel_traffic_monitor(tor, existing=False, skip_traffic_test=skip_traffic_test)
         with crm_neighbor_checker(tor, ip_version, expect_change=ip_version == "ipv6"), \
                 tunnel_monitor, server_traffic_monitor:
             testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), pkt, count=10)
 
         logging.info("send traffic to server %s after removing neighbor entry", server_ip)
         server_traffic_monitor = ServerTrafficMonitor(
-            tor, ptfhost, vmhost, tbinfo, test_port,
-            conn_graph_facts, exp_pkt, existing=False, is_mocked=is_mocked_dualtor(tbinfo)      # noqa F405
+            tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
+            existing=False, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test      # noqa F405
         )
         remove_neighbor_ct = remove_neighbor(ptfhost, tor, server_ip, ip_version, removed_neighbor)
         with crm_neighbor_checker(tor, ip_version, expect_change=ip_version == "ipv6"), \
@@ -124,8 +127,8 @@ def test_active_tor_remove_neighbor_downstream_active(
 
         logging.info("send traffic to server %s after neighbor entry is restored", server_ip)
         server_traffic_monitor = ServerTrafficMonitor(
-            tor, ptfhost, vmhost, tbinfo, test_port,
-            conn_graph_facts, exp_pkt, existing=True, is_mocked=is_mocked_dualtor(tbinfo)       # noqa F405
+            tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
+            existing=True, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test       # noqa F405
         )
         with crm_neighbor_checker(tor, ip_version, expect_change=ip_version == "ipv6"), \
                 tunnel_monitor, server_traffic_monitor:
@@ -145,7 +148,7 @@ def test_active_tor_remove_neighbor_downstream_active(
 
 def test_downstream_ecmp_nexthops(
     ptfadapter, rand_selected_dut, tbinfo,
-    toggle_all_simulator_ports, tor_mux_intfs, ip_version   # noqa F811
+    toggle_all_simulator_ports, tor_mux_intfs, ip_version, skip_traffic_test   # noqa F811
 ):
     nexthops_count = 4
     set_mux_state(rand_selected_dut, tbinfo, 'active', tor_mux_intfs, toggle_all_simulator_ports)        # noqa F405
@@ -171,7 +174,7 @@ def test_downstream_ecmp_nexthops(
     try:
         logging.info("Verify traffic to this route destination is sent to single downlink or uplink")
         check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_addr,
-                                       tbinfo, nexthop_interfaces)
+                                       tbinfo, nexthop_interfaces, skip_traffic_test)
 
         nexthop_interfaces_copy = nexthop_interfaces.copy()
 
@@ -182,7 +185,9 @@ def test_downstream_ecmp_nexthops(
             nexthop_interfaces_copy.remove(interface)
             logging.info("Verify traffic to this route destination is sent to single downlink or uplink")
             check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_addr,
-                                           tbinfo, nexthop_interfaces_copy)
+                                           tbinfo, nexthop_interfaces_copy, skip_traffic_test)
+            if skip_traffic_test is True:
+                break
 
         # Revert two mux states to active
         for index, interface in reversed(list(enumerate(nexthop_interfaces))):
@@ -191,7 +196,9 @@ def test_downstream_ecmp_nexthops(
             nexthop_interfaces_copy.append(interface)
             logging.info("Verify traffic to this route destination is sent to single downlink or uplink")
             check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_addr,
-                                           tbinfo, nexthop_interfaces_copy)
+                                           tbinfo, nexthop_interfaces_copy, skip_traffic_test)
+            if skip_traffic_test is True:
+                break
     finally:
         # Remove the nexthop route
         remove_static_routes(rand_selected_dut, dst_server_addr)

--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -186,8 +186,6 @@ def test_downstream_ecmp_nexthops(
             logging.info("Verify traffic to this route destination is sent to single downlink or uplink")
             check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_addr,
                                            tbinfo, nexthop_interfaces_copy, skip_traffic_test)
-            if skip_traffic_test is True:
-                break
 
         # Revert two mux states to active
         for index, interface in reversed(list(enumerate(nexthop_interfaces))):
@@ -197,8 +195,6 @@ def test_downstream_ecmp_nexthops(
             logging.info("Verify traffic to this route destination is sent to single downlink or uplink")
             check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_addr,
                                            tbinfo, nexthop_interfaces_copy, skip_traffic_test)
-            if skip_traffic_test is True:
-                break
     finally:
         # Remove the nexthop route
         remove_static_routes(rand_selected_dut, dst_server_addr)

--- a/tests/dualtor/test_orchagent_mac_move.py
+++ b/tests/dualtor/test_orchagent_mac_move.py
@@ -13,6 +13,9 @@ from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor    
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder              # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_garp_service                # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses            # noqa F401
+# from tests.common.fixtures.ptfhost_utils import skip_traffic_test               # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test               # noqa F401
 from tests.common.utilities import dump_scapy_packet_show_output
 
 
@@ -84,7 +87,7 @@ def test_mac_move(
     announce_new_neighbor, apply_active_state_to_orchagent,
     conn_graph_facts, ptfadapter, ptfhost,
     rand_selected_dut, set_crm_polling_interval,
-    tbinfo, tunnel_traffic_monitor, vmhost          # noqa F811
+    tbinfo, tunnel_traffic_monitor, vmhost, skip_traffic_test          # noqa F811
 ):
     tor = rand_selected_dut
     ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
@@ -95,10 +98,10 @@ def test_mac_move(
     announce_new_neighbor.send(None)
     logging.info("let new neighbor learnt on active port %s", test_port)
     pkt, exp_pkt = build_packet_to_server(tor, ptfadapter, NEW_NEIGHBOR_IPV4_ADDR)
-    tunnel_monitor = tunnel_traffic_monitor(tor, existing=False)
+    tunnel_monitor = tunnel_traffic_monitor(tor, existing=False, skip_traffic_test=skip_traffic_test)
     server_traffic_monitor = ServerTrafficMonitor(
-        tor, ptfhost, vmhost, tbinfo, test_port,
-        conn_graph_facts, exp_pkt, existing=True, is_mocked=is_mocked_dualtor(tbinfo)   # noqa F405
+        tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
+        existing=True, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test   # noqa F405
     )
     with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
         testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)
@@ -108,10 +111,10 @@ def test_mac_move(
     announce_new_neighbor.send(lambda iface: set_dual_tor_state_to_orchagent(tor, "standby", [iface]))  # noqa F405
     logging.info("mac move to a standby port %s", test_port)
     pkt, exp_pkt = build_packet_to_server(tor, ptfadapter, NEW_NEIGHBOR_IPV4_ADDR)
-    tunnel_monitor = tunnel_traffic_monitor(tor, existing=True)
+    tunnel_monitor = tunnel_traffic_monitor(tor, existing=True, skip_traffic_test=skip_traffic_test)
     server_traffic_monitor = ServerTrafficMonitor(
-        tor, ptfhost, vmhost, tbinfo, test_port,
-        conn_graph_facts, exp_pkt, existing=False, is_mocked=is_mocked_dualtor(tbinfo)  # noqa F405
+        tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
+        existing=False, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test  # noqa F405
     )
     with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
         testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)
@@ -119,8 +122,8 @@ def test_mac_move(
     # standby forwarding check after fdb ageout/flush
     tor.shell("fdbclear")
     server_traffic_monitor = ServerTrafficMonitor(
-        tor, ptfhost, vmhost, tbinfo, test_port,
-        conn_graph_facts, exp_pkt, existing=False, is_mocked=is_mocked_dualtor(tbinfo)  # noqa F405
+        tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
+        existing=False, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test  # noqa F405
     )
     with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
         testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)
@@ -130,10 +133,10 @@ def test_mac_move(
     announce_new_neighbor.send(None)
     logging.info("mac move to another active port %s", test_port)
     pkt, exp_pkt = build_packet_to_server(tor, ptfadapter, NEW_NEIGHBOR_IPV4_ADDR)
-    tunnel_monitor = tunnel_traffic_monitor(tor, existing=False)
+    tunnel_monitor = tunnel_traffic_monitor(tor, existing=False, skip_traffic_test=skip_traffic_test)
     server_traffic_monitor = ServerTrafficMonitor(
-        tor, ptfhost, vmhost, tbinfo, test_port,
-        conn_graph_facts, exp_pkt, existing=True, is_mocked=is_mocked_dualtor(tbinfo)   # noqa F405
+        tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
+        existing=True, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test   # noqa F405
     )
     with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
         testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)
@@ -143,8 +146,8 @@ def test_mac_move(
     if not (tor.facts['asic_type'] == 'mellanox' or tor.facts['asic_type'] == 'cisco-8000'):
         tor.shell("fdbclear")
         server_traffic_monitor = ServerTrafficMonitor(
-            tor, ptfhost, vmhost, tbinfo, test_port,
-            conn_graph_facts, exp_pkt, existing=False, is_mocked=is_mocked_dualtor(tbinfo)  # noqa F405
+            tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
+            existing=False, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test  # noqa F405
         )
         with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
             testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)

--- a/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
+++ b/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
@@ -11,6 +11,9 @@ from tests.common.config_reload import config_reload
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses, run_garp_service, \
                                                 run_icmp_responder                  # noqa F401
+# from tests.common.fixtures.ptfhost_utils import skip_traffic_test                   # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test                   # noqa F401
 
 logger = logging.getLogger(__file__)
 
@@ -33,8 +36,8 @@ def test_cleanup(rand_selected_dut):
 
 
 def test_standby_tor_upstream_mux_toggle(
-    rand_selected_dut, tbinfo, ptfadapter, rand_selected_interface,     # noqa F811
-    toggle_all_simulator_ports, set_crm_polling_interval):              # noqa F811
+    rand_selected_dut, tbinfo, ptfadapter, rand_selected_interface,                     # noqa F811
+    toggle_all_simulator_ports, set_crm_polling_interval, skip_traffic_test):           # noqa F811
     itfs, ip = rand_selected_interface
     PKT_NUM = 100
     # Step 1. Set mux state to standby and verify traffic is dropped by ACL rule and drop counters incremented
@@ -49,7 +52,8 @@ def test_standby_tor_upstream_mux_toggle(
                             itfs=itfs,
                             server_ip=ip['server_ipv4'].split('/')[0],
                             pkt_num=PKT_NUM,
-                            drop=True)
+                            drop=True,
+                            skip_traffic_test=skip_traffic_test)
 
     time.sleep(5)
     # Step 2. Toggle mux state to active, and verify traffic is not dropped by ACL and fwd-ed to uplinks;
@@ -64,7 +68,8 @@ def test_standby_tor_upstream_mux_toggle(
                             itfs=itfs,
                             server_ip=ip['server_ipv4'].split('/')[0],
                             pkt_num=PKT_NUM,
-                            drop=False)
+                            drop=False,
+                            skip_traffic_test=skip_traffic_test)
 
     # Step 3. Toggle mux state to standby, and verify traffic is dropped by ACL;
     # verify CRM show and no nexthop objects are stale
@@ -78,7 +83,8 @@ def test_standby_tor_upstream_mux_toggle(
                             itfs=itfs,
                             server_ip=ip['server_ipv4'].split('/')[0],
                             pkt_num=PKT_NUM,
-                            drop=True)
+                            drop=True,
+                            skip_traffic_test=skip_traffic_test)
     crm_facts1 = rand_selected_dut.get_crm_facts()
     unmatched_crm_facts = compare_crm_facts(crm_facts0, crm_facts1)
     pt_assert(len(unmatched_crm_facts) == 0, 'Unmatched CRM facts: {}'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed
#### How did you do it?
Add mock dualtor dataplane test to onboarding t0 job and skip traffic test
#### How did you verify/test it?
Test in KVM platform
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
