### PR TITLE
increase wait time for mocked T0 DToR TC failures due to config push delta

### DIFF
--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -25,7 +25,7 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_unselected_tor    # noqa: F401
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor        # noqa: F401
 from tests.common.helpers.assertions import pytest_require
-from tests.common.utilities import is_ipv4_address, wait_until
+from tests.common.utilities import is_ipv4_address, wait_until, wait
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder          # noqa: F401
 from tests.common.fixtures.ptfhost_utils import run_garp_service            # noqa: F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa: F401
@@ -118,7 +118,7 @@ def test_decap_active_tor(
 
     if is_t0_mocked_dualtor(tbinfo):        # noqa: F405
         request.getfixturevalue('apply_active_state_to_orchagent')
-        time.sleep(30)
+        wait(60, 'wait for config push/mux state change on mocked dualtor')
     else:
         request.getfixturevalue('toggle_all_simulator_ports_to_rand_selected_tor')
 


### PR DESCRIPTION
### Description of PR
Test fails because trigger happens before the mux toggle config is pushed from orchagent for all the ports and took effect from sairedis. ports are selected randomly hence the issue is intermittent(if the ports selected for that run has the config taken effect at sairedis by the time trigger happens). In case of T0 mocked DToR we can not check the mux status so we're relying on sleep to finish config.

This was observed with sonic mgmt 202311 after merging https://github.com/sonic-net/sonic-mgmt/pull/8363 which was missing in 202311

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Back port request
- [x] 202305
- [x] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
**#3 is happening before #2 in NOK run**
**1)when ansible command was executed(syslog)**
```
May 31 05:29:05.525247 mth-t0-64 INFO python[630593]: ansible-command Invoked with _raw_params=docker exec swss sh -c "swssconfig /muxactive.json" _uses_shell=True warn=True stdin_add_newline=True strip_empty_ends=True argv=None chdir=None executable=None creates=None removes=None stdin=None
May 31 05:29:49.005483 mth-t0-64 INFO python[631130]: ansible-command Invoked with _raw_params=docker exec swss sh -c "swssconfig /muxactive.json" _uses_shell=True warn=True stdin_add_newline=True strip_empty_ends=True argv=None chdir=None executable=None creates=None removes=None stdin=None 
```
**2)when it took effect from sairedis(sairedis.rec)**
```
2024-05-31.05:29:40.878793|c|SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:{"ip":"192.168.0.17","rif":"oid:0x600000000099c","switch_id":"oid:0x21000000000000"}|SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS=3C:FD:FE:B0:8D:1B
2024-05-31.05:29:40.879545|c|SAI_OBJECT_TYPE_NEXT_HOP:oid:0x4000000000ad9|SAI_NEXT_HOP_ATTR_TYPE=SAI
```
**3)when did trigger happen(test log)**
```
31/05/2024 05:29:34 testutils.verify_packet                  L3245 DEBUG  | Checking for pkt on device 0, port 27
```

#### How did you do it?
Introduced an additional delay of 30s between mux toggle on DUT and send packet from T1(PTF)

#### How did you verify/test it?
Verified that test packets are sent to DUT after config is finished and test case passes.

#### Any platform specific information?


#### Supported testbed topology if it's a new test case?

### Documentation