### PR TITLE
Skip eventd-related testing for eventd disabled on slim image

### DIFF
--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -171,6 +171,11 @@ def test_eventd_healthy(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, set
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
+    status = duthost.get_feature_status()
+    platform = duthost.facts["platform"]
+    if platform in ['x86_64-arista_7060_cx32s'] and ('eventd' not in status or status['eventd'] == 'disabled'):
+        pytest.skip("eventd is not enabled in slim image")
+
     do_init(duthost)
 
     module = __import__("eventd_events")

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -172,9 +172,8 @@ def test_eventd_healthy(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, set
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     status = duthost.get_feature_status()
-    platform = duthost.facts["platform"]
-    if platform in ['x86_64-arista_7060_cx32s'] and ('eventd' not in status or status['eventd'] == 'disabled'):
-        pytest.skip("eventd is not enabled in slim image")
+    if 'eventd' not in status or status['eventd'] == 'disabled':
+        pytest.skip("eventd is disabled on the system")
 
     do_init(duthost)
 

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -171,8 +171,8 @@ def test_eventd_healthy(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, set
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-    status = duthost.get_feature_status()
-    if 'eventd' not in status or status['eventd'] == 'disabled':
+    features_dict, succeeded = duthost.get_feature_status()
+    if succeeded and ('eventd' not in features_dict or features_dict['eventd'] == 'disabled'):
         pytest.skip("eventd is disabled on the system")
 
     do_init(duthost)

--- a/tests/telemetry/events/event_utils.py
+++ b/tests/telemetry/events/event_utils.py
@@ -87,8 +87,8 @@ def verify_received_output(received_file, N):
 
 
 def restart_eventd(duthost):
-    status = duthost.get_feature_status()
-    if 'eventd' not in status or status['eventd'] == 'disabled':
+    features_dict, succeeded = duthost.get_feature_status()
+    if succeeded and ('eventd' not in features_dict or features_dict['eventd'] == 'disabled'):
         pytest.skip("eventd is disabled on the system")
 
     duthost.shell("systemctl reset-failed eventd")

--- a/tests/telemetry/events/event_utils.py
+++ b/tests/telemetry/events/event_utils.py
@@ -88,9 +88,8 @@ def verify_received_output(received_file, N):
 
 def restart_eventd(duthost):
     status = duthost.get_feature_status()
-    platform = duthost.facts["platform"]
-    if platform in ['x86_64-arista_7060_cx32s'] and ('eventd' not in status or status['eventd'] == 'disabled'):
-        pytest.skip("eventd is not enabled in slim image")
+    if 'eventd' not in status or status['eventd'] == 'disabled':
+        pytest.skip("eventd is disabled on the system")
 
     duthost.shell("systemctl reset-failed eventd")
     duthost.service(name="eventd", state="restarted")

--- a/tests/telemetry/events/event_utils.py
+++ b/tests/telemetry/events/event_utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pytest
 import json
 import re
 
@@ -86,6 +87,11 @@ def verify_received_output(received_file, N):
 
 
 def restart_eventd(duthost):
+    status = duthost.get_feature_status()
+    platform = duthost.facts["platform"]
+    if platform in ['x86_64-arista_7060_cx32s'] and ('eventd' not in status or status['eventd'] == 'disabled'):
+        pytest.skip("eventd is not enabled in slim image")
+
     duthost.shell("systemctl reset-failed eventd")
     duthost.service(name="eventd", state="restarted")
     pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "eventd"), "eventd not started")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip tests relying on eventd feature, which is disabled on slim image by https://github.com/sonic-net/sonic-buildimage/blob/202311/files/build_templates/init_cfg.json.j2#L63



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
