### PR TITLE
xfail SAD upgrade test if not using ceos testbed

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -397,6 +397,9 @@ def load_basic_facts(session):
         if _facts:
             results.update(_facts)
 
+        # Load test options
+        results.update(vars(session.config.option))
+
         # Load possible other facts here
 
     return results

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1629,6 +1629,15 @@ test_pktgen.py:
     reason: "have known issue, skip for now"
 
 #######################################
+#####        upgrade_path         #####
+#######################################
+upgrade_path/test_upgrade_path.py::test_warm_upgrade_sad_path:
+  xfail:
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/13627
+      - "neighbor_type!='eos'"
+
+#######################################
 #####            vlan             #####
 #######################################
 vlan/test_vlan.py::test_vlan_tc7_tagged_qinq_switch_on_outer_tag:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -772,6 +772,13 @@ platform_tests/test_advanced_reboot.py::test_fast_reboot_from_other_vendor:
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/11007
 
+platform_tests/test_advanced_reboot.py::test_warm_reboot_sad:
+  xfail:
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/13627
+      - "neighbor_type!='eos'"
+
+
 #######################################
 ####        test_kdump.py         #####
 #######################################


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/13627

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
SAD upgrade test currently unsupported for non-ceos testbed (e.g. vsonic)

#### How did you do it?
Mark the test as xfail if using non-ceos testbed

#### How did you verify/test it?
Ran test on Arista platform and verified it failed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
