### PR TITLE
[decap] Fix `test_decap` by using new db schema

### DIFF
--- a/ansible/roles/test/templates/decap_conf.j2
+++ b/ansible/roles/test/templates/decap_conf.j2
@@ -1,6 +1,12 @@
 [
 {% if outer_ipv4 %}
         {
+                "TUNNEL_DECAP_TERM_TABLE:TEST_IPINIP_V4_TUNNEL:{{ lo_ip }}" : {
+                    "term_type":"P2MP"
+                },
+                "OP": "{{ op }}"
+        },
+        {
                 "TUNNEL_DECAP_TABLE:TEST_IPINIP_V4_TUNNEL" : {
                         "tunnel_type":"IPINIP",
                         "dscp_mode":"{{ dscp_mode }}",
@@ -8,17 +14,17 @@
                         "ttl_mode":"{{ ttl_mode }}"
                 },
                 "OP": "{{ op }}"
-        },
-        {
-                "TUNNEL_DECAP_TERM_TABLE:TEST_IPINIP_V4_TUNNEL:{{ lo_ip }}" : {
-                    "term_type":"P2MP"
-                },
-                "OP": "SET"
         }
 {% endif %}
 {% if outer_ipv6 and outer_ipv4 %} ,
 {% endif %}
 {% if outer_ipv6 %}
+        {
+                "TUNNEL_DECAP_TERM_TABLE:TEST_IPINIP_V6_TUNNEL:{{ lo_ipv6 }}" : {
+                    "term_type":"P2MP"
+                },
+                "OP": "{{ op }}"
+        },
         {
                 "TUNNEL_DECAP_TABLE:TEST_IPINIP_V6_TUNNEL" : {
                         "tunnel_type":"IPINIP",
@@ -27,12 +33,6 @@
                         "ttl_mode":"{{ ttl_mode }}"
                 },
                 "OP": "{{ op }}"
-        },
-        {
-                "TUNNEL_DECAP_TERM_TABLE:TEST_IPINIP_V6_TUNNEL:{{ lo_ipv6 }}" : {
-                    "term_type":"P2MP"
-                },
-                "OP": "SET"
         }
 {% endif %}
 ]

--- a/ansible/roles/test/templates/decap_conf.j2
+++ b/ansible/roles/test/templates/decap_conf.j2
@@ -3,12 +3,17 @@
         {
                 "TUNNEL_DECAP_TABLE:TEST_IPINIP_V4_TUNNEL" : {
                         "tunnel_type":"IPINIP",
-                        "dst_ip":"{{ lo_ip }}",
                         "dscp_mode":"{{ dscp_mode }}",
                         "ecn_mode":"{{ ecn_mode }}",
                         "ttl_mode":"{{ ttl_mode }}"
                 },
                 "OP": "{{ op }}"
+        },
+        {
+                "TUNNEL_DECAP_TERM_TABLE:TEST_IPINIP_V4_TUNNEL:{{ lo_ip }}" : {
+                    "term_type":"P2MP"
+                },
+                "OP": "SET"
         }
 {% endif %}
 {% if outer_ipv6 and outer_ipv4 %} ,
@@ -17,12 +22,17 @@
         {
                 "TUNNEL_DECAP_TABLE:TEST_IPINIP_V6_TUNNEL" : {
                         "tunnel_type":"IPINIP",
-                        "dst_ip":"{{ lo_ipv6 }}",
                         "dscp_mode":"{{ dscp_mode }}",
                         "ecn_mode":"{{ ecn_mode }}",
                         "ttl_mode":"{{ ttl_mode }}"
                 },
                 "OP": "{{ op }}"
+        },
+        {
+                "TUNNEL_DECAP_TERM_TABLE:TEST_IPINIP_V6_TUNNEL:{{ lo_ipv6 }}" : {
+                    "term_type":"P2MP"
+                },
+                "OP": "SET"
         }
 {% endif %}
 ]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes [#19381](https://github.com/sonic-net/sonic-buildimage/issues/19381)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
With the introduction of subnet decap, the decap related db schma is changed, adapt `test_decap` to follow the new schema.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Change the template to use the new schema.

#### How did you verify/test it?
```
decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=disable] PASSED                                                                                                                                                                                          [100%]'
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
