### PR TITLE
Fix test_ecmp_hash_seed_value failure on 202311

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -524,8 +524,7 @@ ecmp/test_ecmp_sai_value.py:
     conditions:
       - "topo_type not in ['t1', 't0']"
       - "asic_type not in ['broadcom']"
-      - "release in ['201911', '202012', '202205', '202211', 'master']"
-      - "'internal' in build_version"
+      - "release in ['201911', '202012', '202205', '202211']"
       - "topo_type in ['t1'] and hwsku in ['Arista-7050CX3-32S-C32']"
 
 ecmp/test_fgnhg.py:

--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -280,7 +280,7 @@ def test_ecmp_offset_value(localhost, duthosts, tbinfo, enum_rand_one_per_hwsku_
     elif parameter == "reload":
         logging.info("Run config reload on DUT")
         config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
-        check_hash_seed_value(duthost, asic_name, topo_type)
+        check_ecmp_offset_value(duthost, asic_name, topo_type)
     elif parameter == "reboot":
         logging.info("Run cold reboot on DUT")
         reboot(duthost, localhost, reboot_type=REBOOT_TYPE_COLD, reboot_helper=None,

--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -126,10 +126,14 @@ def check_config_bcm_file(duthost, topo_type):
             logging.info("sai_hash_seed_config_hash_offset_enable={}".format(value))
         else:
             logging.info("sai_hash_seed_config_hash_offset_enable not found in the file.")
-        if topo_type == "t0":
-            pytest_assert(not cat_output, "sai_hash_seed_config_hash_offset_enable should not set for T0")
-        if topo_type == "t1":
-            pytest_assert(cat_output and value == "1", "sai_hash_seed_config_hash_offset_enable is not set to 1")
+        # with code change https://github.com/sonic-net/sonic-buildimage/pull/18912,
+        # the sai_hash_seed_config_hash_offset_enable is not set in config.bcm,
+        # it's set by swss config on 202311 and later image
+        if "20230531" in duthost.os_version:
+            if topo_type == "t0":
+                pytest_assert(not cat_output, "sai_hash_seed_config_hash_offset_enable should not set for T0")
+            if topo_type == "t1":
+                pytest_assert(cat_output and value == "1", "sai_hash_seed_config_hash_offset_enable is not set to 1")
     else:
         pytest.fail("Config bcm file not found.")
 

--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -280,7 +280,7 @@ def test_ecmp_offset_value(localhost, duthosts, tbinfo, enum_rand_one_per_hwsku_
     elif parameter == "reload":
         logging.info("Run config reload on DUT")
         config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
-        check_ecmp_offset_value(duthost, asic_name, topo_type)
+        check_ecmp_offset_value(duthost, asic_name, topo_type, hwsku)
     elif parameter == "reboot":
         logging.info("Run cold reboot on DUT")
         reboot(duthost, localhost, reboot_type=REBOOT_TYPE_COLD, reboot_helper=None,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
After code change https://github.com/sonic-net/sonic-buildimage/pull/18912 and https://github.com/sonic-net/sonic-mgmt/pull/13538, test_ecmp_sai_value is not xfailed on 202311, but test_ecmp_hash_seed_value consistently failed on 202311, since the sai_hash_seed_config_hash_offset_enable is not set in config.bcm, it's set by swss config on 202311 and later image.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
1) Fix test_ecmp_hash_seed_value failure on 202311
2) fix one function mistake in case.
3) remove internal and master from skip list, internal and master should support this case now


#### How did you do it?
Only check if sai_hash_seed_config_hash_offset_enable exists in config.bcm for 202305 branch, will skip this check for other branches.

#### How did you verify/test it?
run test_ecmp_sai_value against 202311.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
