### PR TITLE
Multi-asic support for snmp_queue_counters test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -413,6 +413,7 @@ multi-asic-t1-lag:
   - snmp/test_snmp_loopback.py
   - snmp/test_snmp_pfc_counters.py
   - snmp/test_snmp_queue.py
+  - snmp/test_snmp_queue_counters.py
   - tacacs/test_accounting.py
   - tacacs/test_authorization.py
   - tacacs/test_jit_user.py

--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -24,9 +24,29 @@ def get_queue_ctrs(duthost, cmd):
     return len(duthost.shell(cmd)["stdout_lines"])
 
 
+def get_queue_cntrs_oid(duthost, asic):
+    """
+    @summary: Returns queue_cntrs_oid value based on the single/multi-asic sonic host.
+              In case of multi-asic, for asic0 returns oid value for Ethernet0 port and
+              for asic1, returns oid value for Ethernet144
+    Args:
+        duthost: Ansible object DuT.
+        asic: SonicAsic object
+    Returns:
+        queue_cntrs_oid
+    """
+    # Ethernet0 port OID, chosen arbitrary
+    queue_cntrs_oid = '1.3.6.1.4.1.9.9.580.1.5.5.1.4.1'
+    if duthost.sonichost.is_multi_asic and asic is not None:
+        queue_cntrs_oid = '1.3.6.1.4.1.9.9.580.1.5.5.1.4.1' if asic.namespace == 'asic0' \
+            else '1.3.6.1.4.1.9.9.580.1.5.5.1.4.145'   # Ethernet144 asic1 port OID, chosen arbitrary
+
+    return queue_cntrs_oid
+
+
 def test_snmp_queue_counters(duthosts,
-                             enum_rand_one_per_hwsku_frontend_hostname,
-                             creds_all_duts):
+                             enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_asic_index,
+                             creds_all_duts, teardown):
     """
     Test SNMP queue counters
       - Set "create_only_config_db_buffers" to true in config db, to create
@@ -41,17 +61,20 @@ def test_snmp_queue_counters(duthosts,
     """
 
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    global ORIG_CFG_DB, CFG_DB_PATH
     hostip = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_host']
-    Ethernet0_queue_cntrs_oid = '1.3.6.1.4.1.9.9.580.1.5.5.1.4.1'
+    asic = duthost.asic_instance(enum_rand_one_asic_index)
+    queue_cntrs_oid = get_queue_cntrs_oid(duthost, asic)
     get_bfr_queue_cntrs_cmd \
         = "docker exec snmp snmpwalk -v2c -c {} {} {}".format(
             creds_all_duts[duthost.hostname]['snmp_rocommunity'], hostip,
-            Ethernet0_queue_cntrs_oid)
+            queue_cntrs_oid)
     # Generate sonic-cfggen commands for multi-asic and single-asic duts
-    nslist = duthost.get_asic_namespace_list()
-    if duthost.sonichost.is_multi_asic and nslist is not None:
-        cmd = "sonic-cfggen -n asic0 -d --print-data > {}".format(ORIG_CFG_DB)
+    if duthost.sonichost.is_multi_asic and asic is not None:
+        ORIG_CFG_DB = "/etc/sonic/orig_config_db{}.json".format(asic.asic_index)
+        CFG_DB_PATH = "/etc/sonic/config_db{}.json".format(asic.asic_index)
+        cmd = "sonic-cfggen -n {} -d --print-data > {}".format(asic.namespace, ORIG_CFG_DB)
     else:
         cmd = "sonic-cfggen -d --print-data > {}".format(ORIG_CFG_DB)
 
@@ -59,13 +82,13 @@ def test_snmp_queue_counters(duthosts,
     data = json.loads(duthost.shell("cat {}".format(ORIG_CFG_DB),
                                     verbose=False)['stdout'])
     buffer_queue_to_del = None
-    # Get appropriate buffer queue value to delete for Ethernet0|3-4 in case of multi-asic
+    # Get appropriate buffer queue value to delete in case of multi-asic
     if duthost.sonichost.is_multi_asic:
         buffer_queues = list(data['BUFFER_QUEUE'].keys())
         iface_to_check = buffer_queues[0].split('|')[0]
         iface_buffer_queues = [bq for bq in buffer_queues if any(val in iface_to_check for val in bq.split('|'))]
         for queue in iface_buffer_queues:
-            if 'asic0' in queue and queue.split('|')[-1] == '3-4':
+            if asic.namespace in queue and queue.split('|')[-1] == '3-4':
                 buffer_queue_to_del = queue
                 break
     else:
@@ -85,14 +108,22 @@ def test_snmp_queue_counters(duthosts,
     load_new_cfg(duthost, data)
     queue_counters_cnt_post = get_queue_ctrs(duthost, get_bfr_queue_cntrs_cmd)
 
-    unicast_expected_diff = BUFFER_QUEUES_REMOVED * UNICAST_CTRS
-    multicast_expected_diff = unicast_expected_diff + (BUFFER_QUEUES_REMOVED
-                                                       * MULTICAST_CTRS)
-    pytest_assert((queue_counters_cnt_pre - queue_counters_cnt_post)
-                  in [unicast_expected_diff, multicast_expected_diff],
-                  "Queue counters actual count {} differs from expected values {}, {}".
-                  format(queue_counters_cnt_post, (queue_counters_cnt_pre - unicast_expected_diff),
-                         (queue_counters_cnt_pre - multicast_expected_diff)))
+    # For broadcom-dnx voq chassis, number of voq are fixed (static), which cannot be modified dynamically
+    # Hence, make sure the queue counters before deletion and after deletion are same for broadcom-dnx voq chassis
+    if duthost.facts.get("platform_asic") == "broadcom-dnx" and duthost.sonichost.is_multi_asic:
+        pytest_assert((queue_counters_cnt_pre == queue_counters_cnt_post),
+                      "Queue counters actual count {} differs from expected values {}".
+                      format(queue_counters_cnt_post, queue_counters_cnt_pre))
+    # check for other duts
+    else:
+        unicast_expected_diff = BUFFER_QUEUES_REMOVED * UNICAST_CTRS
+        multicast_expected_diff = unicast_expected_diff + (BUFFER_QUEUES_REMOVED
+                                                           * MULTICAST_CTRS)
+        pytest_assert((queue_counters_cnt_pre - queue_counters_cnt_post)
+                      in [unicast_expected_diff, multicast_expected_diff],
+                      "Queue counters actual count {} differs from expected values {}, {}".
+                      format(queue_counters_cnt_post, (queue_counters_cnt_pre - unicast_expected_diff),
+                             (queue_counters_cnt_pre - multicast_expected_diff)))
 
 
 @pytest.fixture(scope="module")
@@ -103,5 +134,5 @@ def teardown(duthost):
     """
     yield
     # Cleanup
-    duthost.copy(src=ORIG_CFG_DB, dest=CFG_DB_PATH)
+    duthost.copy(src=ORIG_CFG_DB, dest=CFG_DB_PATH, remote_src=True)
     config_reload(duthost, config_source='config_db', safe_reload=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- Added multi-asic support for the test '_test_snmp_queue_counters_' under snmp

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

-  Currently, 'test_snmp_queue_counters' test doesn't have multi-asic support and the test is failing for multi-asic chassis due to the lack of support.

#### How did you do it?

- Added multi-asic support for test '_test_snmp_queue_counters_' and made sure the current test logic is not affected.

#### How did you verify/test it?

- Ran the above-mentioned test case on a T2 chassis and verified.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
