### PR TITLE
[Mellanox] Revert the set_speed function in https://github.com/sonic-net/sonic-mgmt/pull/11763

### DIFF
--- a/tests/common/devices/onyx.py
+++ b/tests/common/devices/onyx.py
@@ -189,19 +189,6 @@ class OnyxHost(AnsibleHostBase):
             speed = 'auto'
         else:
             speed = speed[:-3] + 'G'
-            # The speed support list for onyx is like '1G 10G 25G 40G 50Gx1 50Gx2 100Gx2 100Gx4 200Gx4'.
-            # We need to set the speed according to the speed support list.
-            # For example, when dut and fanout all support 50G,
-            # if support speed list of fanout just includes 50Gx1 not 50G,
-            # we need to set the speed with 50Gx1 instead of 50G, otherwise, the port can not be up.
-            all_support_speeds = self.get_supported_speeds(interface_name, raw_data=True)
-            for support_speed in all_support_speeds:
-                if speed in support_speed:
-                    logger.info("Speed {} find the matched support speed:{} ".format(speed, support_speed))
-                    speed = support_speed
-                    break
-            logger.info("set speed is {}".format(speed))
-
         if autoneg_mode or speed == 'auto':
             out = self.host.onyx_config(
                     lines=['shutdown', 'speed {}'.format(speed), 'no shutdown'],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
revert https://github.com/sonic-net/sonic-mgmt/pull/11763

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Revert the set_speed function in https://github.com/sonic-net/sonic-mgmt/pull/11763
For onyx fanout, we don't need to specify the lane number when setting speed. It will sync with dut automatically.
In https://github.com/sonic-net/sonic-mgmt/pull/11763, It will select the smallest lane 1, but some platforms don't support the smallest lane 1, so it will cause port not up. So we should let fanout sync with dut automatically.

#### How did you do it?
Revert it

#### How did you verify/test it?
Run it on setup with onyx

#### Any platform specific information?
mellanox

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
