### PR TITLE
[Snappi] - Infra changes related to new testcases added for PFC, ECN.

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -762,6 +762,26 @@ def start_pfcwd(duthost, asic_value=None):
         duthost.shell('sudo ip netns exec {} pfcwd start_default'.format(asic_value))
 
 
+def start_pfcwd_fwd(duthost, asic_value=None):
+    """
+    Start PFC watchdog in Forward mode.
+    Args:
+        duthost (AnsibleHost): Device Under Test (DUT)
+        asic_value: asic value of the host
+
+    Returns:
+        N/A
+    """
+    # Stopping PFCWD cleanly.
+    stop_pfcwd(duthost, asic_value)
+
+    # Starting PFCWD in forward mode with detection and restoration duration of 200msec.
+    if asic_value is None:
+        duthost.shell('sudo pfcwd start --action forward 200 --restoration-time 200')
+    else:
+        duthost.shell('sudo ip netns exec {} pfcwd start --action forward 200 --restoration-time 200')
+
+
 def stop_pfcwd(duthost, asic_value=None):
     """
     Stop PFC watchdog

--- a/tests/common/snappi_tests/snappi_systest_params.py
+++ b/tests/common/snappi_tests/snappi_systest_params.py
@@ -1,0 +1,60 @@
+"""
+The SnappiTestParams module allows for modular pass through of test parameters for all Snappi based tests.
+"""
+
+from tests.common.snappi_tests.common_helpers import packet_capture
+from tests.common.snappi_tests.traffic_flow_config import TrafficFlowConfig
+from tests.common.snappi_tests.multi_dut_params import MultiDUTParams
+
+
+class SnappiSysTestParams():
+    def __init__(self):
+        """
+        Initialize the SnappiTestParams class
+
+        Params:
+            headroom_test_params (array): 2 element array if the associated pfc pause quanta
+                                    results in no packet drop [pfc_delay, headroom_result]
+            pfc_pause_src_mac (str): PFC pause source MAC address ex. '00:00:00:fa:ce:01'
+            set_pfc_class_enable_vec (bool): PFC class enable vector setting
+            packet_capture_type (ENUM): packet capture type ex. packet_capture.IP_CAPTURE
+            packet_capture_file (str): packet capture file ex. 'capture.pcapng'
+            packet_capture_ports (list): packet capture ports on ixia chassis ex. ['Port 1', 'Port 2']
+            is_snappi_ingress_port_cap (bool): whether or not the packet capture is on the tgen ingress port, if False,
+                                             then pcap is on the tgen egress port
+            base_flow_config (dict): base flow configuration
+            test_tx_frames (list): number of test frames transmitted for priorities to test ex. [2000, 3000]
+                                    for priorities 3 and 4
+            multi_dut_params (MultiDUTParams obj): contains details of duthost objects,
+                                                   multidut_ports and other parameters
+            test_iterations (int) : No of iterations in the test
+                for ex. priorities 3 and 4
+            gen_background_traffic (bool): whether or not to generate background traffic (default: True)
+            poll_device_runtime (bool): whether or not to poll the device for stats when traffic is running
+                                        (default: False)
+                for priorities 3 and 4
+            gen_background_traffic (bool): whether or not to generate background traffic (default: True)
+            ecn_params (dict): ECN parameters
+                Dict values:
+                    kmin: minimum ECN marking threshold
+                    kmax: maximum ECN marking threshold
+                    pmax: maximum ECN marking probability
+            traffic_flow_config (TrafficFlowConfig obj): traffic flow configuration object
+        """
+        self.headroom_test_params = None
+        self.pfc_pause_src_mac = None
+        self.set_pfc_class_enable_vec = True
+        self.packet_capture_type = packet_capture.NO_CAPTURE
+        self.packet_capture_file = None
+        self.packet_capture_ports = None
+        self.is_snappi_ingress_port_cap = True
+        # self.base_flow_config = None
+        # self.base_flow_config = [None] * 2
+        self.base_flow_config = []
+        self.test_tx_frames = 0
+        self.multi_dut_params = MultiDUTParams()
+        self.test_iterations = 1
+        self.gen_background_traffic = True
+        self.poll_device_runtime = True
+        self.ecn_params = None
+        self.traffic_flow_config = TrafficFlowConfig()

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -1245,11 +1245,20 @@ def run_sys_traffic(rx_duthost,
                         test_stats['dut_lossy_pkts'] += val
                     f.write('{}:{} \n'.format(key, val))
 
+        test_stats['lossless_tx_pfc'] = 0
+        test_stats['lossless_rx_pfc'] = 0
+        test_stats['lossy_rx_tx_pfc'] = 0
         f.write('Received or Transmitted PFC counts \n')
         for item in results:
             if ('egl-board' in item and 'pfc' in item):
                 if (df_t[item].max() != 0):
                     f.write('{} : {} \n'.format(item, df_t[item].max()))
+                    if (('tx_pfc_3' in item) or ('tx_pfc_4' in item)):
+                        test_stats['lossless_tx_pfc'] += int(df_t[item].max())
+                    elif (('rx_pfc_3' in item) or ('rx_pfc_4' in item)):
+                        test_stats['lossless_rx_pfc'] += int(df_t[item].max())
+                    else:
+                        test_stats['lossy_rx_tx_pfc'] += int(df_t[item].max())
 
     fname = fname + '.csv'
     logger.info('Writing statistics to file : {}'.format(fname))

--- a/tests/snappi_tests/multidut/systest/files/pfcwd_multidut_helper.py
+++ b/tests/snappi_tests/multidut/systest/files/pfcwd_multidut_helper.py
@@ -1,0 +1,373 @@
+import logging
+import time
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
+    fanout_graph_facts  # noqa F401
+from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector,\
+    get_lossless_buffer_size, get_pg_dropped_packets,\
+    stop_pfcwd, disable_packet_aging, sec_to_nanosec,\
+    get_pfc_frame_count, packet_capture, config_capture_pkt,\
+    start_pfcwd, enable_packet_aging, start_pfcwd_fwd, \
+    traffic_flow_mode, calc_pfc_pause_flow_rate      # noqa F401
+from tests.common.snappi_tests.traffic_generation import verify_pause_flow, \
+    verify_basic_test_flow, verify_background_flow, verify_pause_frame_count_dut, \
+    run_sys_traffic, new_base_traffic_config, \
+    generate_sys_test_flows, generate_sys_background_flows, generate_sys_pause_flows
+from tests.common.snappi_tests.snappi_systest_params import SnappiSysTestParams
+
+
+logger = logging.getLogger(__name__)
+
+dut_port_config = []
+PAUSE_FLOW_NAME = 'Pause Storm'
+TEST_FLOW_NAME = 'Test Flow'
+BG_FLOW_NAME = 'Background Flow'
+TOLERANCE_THRESHOLD = 0.1
+CONTINUOUS_MODE = -5
+ANSIBLE_POLL_DELAY_SEC = 4
+global DATA_FLOW_DURATION_SEC
+global data_flow_delay_sec
+
+
+def run_pfc_test(api,
+                 testbed_config,
+                 port_config_list,
+                 conn_data,
+                 fanout_data,
+                 global_pause,
+                 pause_prio_list,
+                 test_prio_list,
+                 bg_prio_list,
+                 prio_dscp_map,
+                 test_traffic_pause,
+                 test_def,
+                 snappi_extra_params=None):
+    """
+    Run a multidut PFC test
+    Args:
+        api (obj): snappi session
+        testbed_config (obj): testbed L1/L2/L3 configuration
+        port_config_list (list): list of port configuration
+        conn_data (dict): the dictionary returned by conn_graph_fact.
+        fanout_data (dict): the dictionary returned by fanout_graph_fact.
+        duthost (Ansible host instance): device under test
+        dut_port (str): DUT port to test
+        global_pause (bool): if pause frame is IEEE 802.3X pause
+        pause_prio_list (list): priorities to pause for pause frames
+        test_prio_list (list): priorities of test flows
+        bg_prio_list (list): priorities of background flows
+        prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
+        test_traffic_pause (bool): if test flows are expected to be paused
+        test_def['enable_pause'] (bool) : if test expects no pause flow traffic.
+        snappi_extra_params (SnappiSysTestParams obj): additional parameters for Snappi traffic
+
+    Returns:
+        N/A
+    """
+
+    TEST_FLOW_AGGR_RATE_PERCENT = test_def['TEST_FLOW_AGGR_RATE_PERCENT']
+    BG_FLOW_AGGR_RATE_PERCENT = test_def['BG_FLOW_AGGR_RATE_PERCENT']
+    data_flow_pkt_size = test_def['data_flow_pkt_size']
+    DATA_FLOW_DURATION_SEC = test_def['DATA_FLOW_DURATION_SEC']
+    data_flow_delay_sec = test_def['data_flow_delay_sec']
+    SNAPPI_POLL_DELAY_SEC = test_def['SNAPPI_POLL_DELAY_SEC']
+    PAUSE_FLOW_DUR_BASE_SEC = data_flow_delay_sec + DATA_FLOW_DURATION_SEC
+    if test_def['imix']:
+        fname = test_def['test_type'] + '_' + test_def['line_card_choice'] + '_' + 'IMIX'
+    else:
+        fname = test_def['test_type'] + '_' + test_def['line_card_choice'] + '_' + str(data_flow_pkt_size) + 'B'
+
+    port_map = test_def['port_map']
+
+    if snappi_extra_params is None:
+        snappi_extra_params = SnappiSysTestParams()
+
+    duthost1 = snappi_extra_params.multi_dut_params.duthost1
+    rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
+    duthost2 = snappi_extra_params.multi_dut_params.duthost2
+    tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[-1]
+    dut_list = []
+    dut_list.append(duthost1)
+    dut_list.append(duthost2)
+
+    tx_dut = duthost1
+    rx_dut = duthost2
+
+    if rx_port['peer_device'] == duthost1.hostname:
+        tx_dut = duthost2
+        rx_dut = duthost1
+
+    if (test_traffic_pause):
+        logger.info("PFC receiving DUT is {}".format(tx_dut.hostname))
+
+    pytest_assert(testbed_config is not None, 'Fail to get L2/3 testbed config')
+
+    if (test_def['enable_pfcwd_drop']):
+        start_pfcwd(rx_dut)
+        start_pfcwd(tx_dut)
+    elif (test_def['enable_pfcwd_fwd']):
+        start_pfcwd_fwd(rx_dut)
+        start_pfcwd_fwd(tx_dut)
+    else:
+        stop_pfcwd(rx_dut)
+        stop_pfcwd(tx_dut)
+
+    if (test_def['enable_credit_wd']):
+        enable_packet_aging(rx_dut, rx_port['asic_value'])
+        enable_packet_aging(tx_dut, tx_port['asic_value'])
+    else:
+        disable_packet_aging(rx_dut, rx_port['asic_value'])
+        disable_packet_aging(tx_dut, tx_port['asic_value'])
+
+    rx_port_id = 0
+
+    # Rate percent must be an integer
+    bg_flow_rate_percent = int(BG_FLOW_AGGR_RATE_PERCENT / len(bg_prio_list))
+    test_flow_rate_percent = int(TEST_FLOW_AGGR_RATE_PERCENT / len(test_prio_list))
+    # Generate base traffic config
+    if (port_map[0] == 2):
+        for i in range(port_map[0]):
+            rx_port_id = i
+            tx_port_id = 2
+            snappi_extra_params.base_flow_config.append(new_base_traffic_config(testbed_config=testbed_config,
+                                                                                port_config_list=port_config_list,
+                                                                                rx_port_id=rx_port_id,
+                                                                                tx_port_id=tx_port_id))
+    else:
+        rx_port_id = 0
+        for i in range(port_map[2]):
+            tx_port_id = i+1
+            snappi_extra_params.base_flow_config.append(new_base_traffic_config(testbed_config=testbed_config,
+                                                                                port_config_list=port_config_list,
+                                                                                rx_port_id=rx_port_id,
+                                                                                tx_port_id=tx_port_id))
+
+    speed_str = testbed_config.layer1[0].speed
+    speed_gbps = int(speed_str.split('_')[1])
+
+    if snappi_extra_params.headroom_test_params is not None:
+        DATA_FLOW_DURATION_SEC += 10
+        data_flow_delay_sec += 2
+
+        # Set up pfc delay parameter
+        l1_config = testbed_config.layer1[0]
+        pfc = l1_config.flow_control.ieee_802_1qbb
+        pfc.pfc_delay = snappi_extra_params.headroom_test_params[0]
+
+    if snappi_extra_params.poll_device_runtime:
+        # If the switch needs to be polled as traffic is running for stats,
+        # then the test runtime needs to be increased for the polling delay
+        DATA_FLOW_DURATION_SEC += ANSIBLE_POLL_DELAY_SEC
+        data_flow_delay_sec = ANSIBLE_POLL_DELAY_SEC
+
+    if snappi_extra_params.packet_capture_type != packet_capture.NO_CAPTURE:
+        # Setup capture config
+        if snappi_extra_params.is_snappi_ingress_port_cap:
+            # packet capture is required on the ingress snappi port
+            snappi_extra_params.packet_capture_ports = [snappi_extra_params.base_flow_config["rx_port_name"]]
+        else:
+            # packet capture will be on the egress snappi port
+            snappi_extra_params.packet_capture_ports = [snappi_extra_params.base_flow_config["tx_port_name"]]
+
+        snappi_extra_params.packet_capture_file = snappi_extra_params.packet_capture_type.value
+
+        config_capture_pkt(testbed_config=testbed_config,
+                           port_names=snappi_extra_params.packet_capture_ports,
+                           capture_type=snappi_extra_params.packet_capture_type,
+                           capture_name=snappi_extra_params.packet_capture_file)
+        logger.info("Packet capture file: {}.pcapng".format(snappi_extra_params.packet_capture_file))
+
+    # Set default traffic flow configs if not set
+    if snappi_extra_params.traffic_flow_config.data_flow_config is None:
+        snappi_extra_params.traffic_flow_config.data_flow_config = {
+            "flow_name": TEST_FLOW_NAME,
+            "flow_dur_sec": DATA_FLOW_DURATION_SEC,
+            "flow_rate_percent": test_flow_rate_percent,
+            "flow_rate_pps": None,
+            "flow_rate_bps": None,
+            "flow_pkt_count": None,
+            "flow_pkt_size": data_flow_pkt_size,
+            "flow_delay_sec": data_flow_delay_sec,
+            "flow_traffic_type": traffic_flow_mode.FIXED_DURATION
+        }
+
+    if snappi_extra_params.traffic_flow_config.background_flow_config is None and \
+       snappi_extra_params.gen_background_traffic:
+        snappi_extra_params.traffic_flow_config.background_flow_config = {
+            "flow_name": BG_FLOW_NAME,
+            "flow_dur_sec": DATA_FLOW_DURATION_SEC,
+            "flow_rate_percent": bg_flow_rate_percent,
+            "flow_rate_pps": None,
+            "flow_rate_bps": None,
+            "flow_pkt_size": data_flow_pkt_size,
+            "flow_pkt_count": None,
+            "flow_delay_sec": data_flow_delay_sec,
+            "flow_traffic_type": traffic_flow_mode.FIXED_DURATION
+        }
+
+    # PPS is high to ensure Storm is detected.
+    # traffic_flow_mode is changed to BURST
+    # Need to check how it works
+    if (test_traffic_pause):
+        if snappi_extra_params.traffic_flow_config.pause_flow_config is None:
+            snappi_extra_params.traffic_flow_config.pause_flow_config = {
+                "flow_name": PAUSE_FLOW_NAME,
+                "flow_dur_sec": DATA_FLOW_DURATION_SEC+60,
+                "flow_rate_percent": None,
+                "flow_rate_pps": calc_pfc_pause_flow_rate(speed_gbps),
+                "flow_rate_bps": None,
+                "flow_pkt_size": 64,
+                "flow_pkt_count": None,
+                "flow_delay_sec": 0,
+                "flow_traffic_type": traffic_flow_mode.FIXED_DURATION
+            }
+
+    if snappi_extra_params.packet_capture_type == packet_capture.PFC_CAPTURE:
+        # PFC pause frame capture is requested
+        valid_pfc_frame_test = True
+    else:
+        # PFC pause frame capture is not requested
+        valid_pfc_frame_test = False
+
+    if (test_traffic_pause):
+        if valid_pfc_frame_test:
+            snappi_extra_params.traffic_flow_config.pause_flow_config["flow_dur_sec"] = DATA_FLOW_DURATION_SEC + \
+                data_flow_delay_sec + SNAPPI_POLL_DELAY_SEC + PAUSE_FLOW_DUR_BASE_SEC
+            snappi_extra_params.traffic_flow_config.pause_flow_config["flow_traffic_type"] = \
+                traffic_flow_mode.FIXED_DURATION
+
+    # Generate test flow config
+    for m in range(port_map[2]):
+        generate_sys_test_flows(testbed_config=testbed_config,
+                                test_flow_prio_list=test_prio_list,
+                                prio_dscp_map=prio_dscp_map,
+                                snappi_extra_params=snappi_extra_params,
+                                snap_index=m)
+
+    if (test_def['background_traffic']):
+        for m in range(port_map[2]):
+            if snappi_extra_params.gen_background_traffic:
+                # Generate background flow config
+                generate_sys_background_flows(testbed_config=testbed_config,
+                                              bg_flow_prio_list=bg_prio_list,
+                                              prio_dscp_map=prio_dscp_map,
+                                              snappi_extra_params=snappi_extra_params,
+                                              snap_index=m)
+
+    # Generate pause storm config
+    if (test_traffic_pause):
+        for m in range(port_map[0]):
+            generate_sys_pause_flows(testbed_config=testbed_config,
+                                     pause_prio_list=pause_prio_list,
+                                     global_pause=global_pause,
+                                     snappi_extra_params=snappi_extra_params,
+                                     snap_index=m)
+
+    flows = testbed_config.flows
+
+    all_flow_names = [flow.name for flow in flows]
+    data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
+
+    # Clear PFC, queue and interface counters before traffic run
+    for dut in dut_list:
+        dut.command("pfcstat -c \n")
+        time.sleep(1)
+        dut.command("sonic-clear queuecounters \n")
+        time.sleep(1)
+        dut.command("sonic-clear counters \n")
+        time.sleep(1)
+
+    exp_dur_sec = DATA_FLOW_DURATION_SEC + data_flow_delay_sec
+
+    """ Run traffic """
+    tgen_flow_stats, switch_flow_stats, test_stats = run_sys_traffic(rx_duthost=rx_dut,
+                                                                     tx_duthost=tx_dut,
+                                                                     api=api,
+                                                                     config=testbed_config,
+                                                                     data_flow_names=data_flow_names,
+                                                                     all_flow_names=all_flow_names,
+                                                                     exp_dur_sec=exp_dur_sec,
+                                                                     port_map=test_def['port_map'],
+                                                                     fname=fname,
+                                                                     stats_interval=test_def['stats_interval'],
+                                                                     imix=test_def['imix'],
+                                                                     snappi_extra_params=snappi_extra_params)
+
+    test_check = test_def['test_check']
+    if (not test_check['loss_expected']):
+        # Check for loss packets on IXIA and DUT.
+        pytest_assert(test_stats['tgen_loss_pkts'] == 0, 'Loss seen on TGEN')
+        pytest_assert(test_stats['dut_loss_pkts'] == 0, 'Loss seen on DUT')
+
+        # Check for Tx and Rx packets on IXIA for lossless and lossy streams.
+        pytest_assert(test_stats['tgen_lossless_rx_pkts'] == test_stats['tgen_lossless_tx_pkts'],
+                      'Losses observed in lossless traffic streams')
+        pytest_assert(test_stats['tgen_lossy_rx_pkts'] == test_stats['tgen_lossy_tx_pkts'],
+                      'Losses observed in lossy traffic streams')
+
+        # Check for Rx packets between IXIA and DUT for lossy and lossless streams.
+        pytest_assert(test_stats['tgen_lossless_rx_pkts'] == test_stats['dut_lossless_pkts'],
+                      'Losses observed in lossless traffic streams on DUT Tx and IXIA Rx')
+        pytest_assert(test_stats['tgen_lossy_rx_pkts'] == test_stats['dut_lossy_pkts'],
+                      'Losses observed in lossy traffic streams on DUT Tx and IXIA Rx')
+    else:
+        # Check for lossless and lossy stream percentage drop for a given tolerance limit.
+        lossless_drop = round((1 - float(test_stats['tgen_lossless_rx_pkts']) / test_stats['tgen_lossless_tx_pkts']), 2)
+        lossy_drop = round((1 - float(test_stats['tgen_lossy_rx_pkts']) / test_stats['tgen_lossy_tx_pkts']), 2)
+        logger.info('Lossless Drop %:{}, Lossy Drop %:{}'.format(lossless_drop, lossy_drop))
+        pytest_assert((lossless_drop*100) <= test_check['lossless'], 'Lossless packet drop outside tolerance limit')
+        pytest_assert((lossy_drop*100) <= test_check['lossy'], 'Lossy packet drop outside tolerance limit')
+
+    # Checking if the actual line rate on egress is within tolerable limit of egress line speed.
+    pytest_assert(((1 - test_stats['tgen_rx_rate'] / float(port_map[0]*port_map[1]))*100) <= test_check['speed_tol'],
+                  'Egress speed beyond tolerance range')
+
+    # Checking for PFC counts on DUT
+    if (not test_check['pfc']):
+        pytest_assert(test_stats['lossless_tx_pfc'] == 0, 'Error:PFC transmitted by DUT for lossless priorities')
+        pytest_assert(test_stats['lossy_rx_tx_pfc'] == 0, 'Error:PFC transmitted by DUT for lossy priorities')
+    else:
+        if (test_stats['lossless_rx_pfc'] != 0 and
+                (test_def['enable_pfcwd_drop'] or test_def['enable_pfcwd_fwd'])):
+            pytest_assert(test_stats['lossless_tx_pfc'] == 0, 'Error:No Tx PFCs from DUT after receiving PFCs')
+        if (test_stats['lossless_rx_pfc'] != 0 and
+                (not test_def['enable_pfcwd_drop'] and not test_def['enable_pfcwd_fwd'])):
+            pytest_assert(test_stats['lossless_tx_pfc'] != 0, 'Error:Tx PFCs should sent from DUT after receiving PFCs')
+        pytest_assert(test_stats['lossy_rx_tx_pfc'] == 0, 'Error:Incorrect Rx/Tx PFCs on DUT for lossy priorities')
+
+    # Reset pfc delay parameter
+    pfc = testbed_config.layer1[0].flow_control.ieee_802_1qbb
+    pfc.pfc_delay = 0
+
+    for metric in tgen_flow_stats:
+        if "Pause" in metric.name:
+            PAUSE_FLW_NAME = metric.name
+
+    # Verify pause flows
+    if (test_traffic_pause):
+        verify_pause_flow(flow_metrics=tgen_flow_stats,
+                          pause_flow_name=PAUSE_FLW_NAME)
+
+    if (test_def['background_traffic'] and test_def['verify_flows']):
+        if snappi_extra_params.gen_background_traffic:
+            # Verify background flows
+            verify_background_flow(flow_metrics=tgen_flow_stats,
+                                   speed_gbps=speed_gbps,
+                                   tolerance=TOLERANCE_THRESHOLD,
+                                   snappi_extra_params=snappi_extra_params)
+
+    # Verify basic test flows metrics from ixia
+    if (test_def['verify_flows']):
+        verify_basic_test_flow(flow_metrics=tgen_flow_stats,
+                               speed_gbps=speed_gbps,
+                               tolerance=TOLERANCE_THRESHOLD,
+                               test_flow_pause=test_traffic_pause,
+                               snappi_extra_params=snappi_extra_params)
+
+    if (test_traffic_pause and test_def['verify_flows']):
+        verify_pause_frame_count_dut(rx_dut=rx_dut,
+                                     tx_dut=tx_dut,
+                                     test_traffic_pause=test_traffic_pause,
+                                     global_pause=global_pause,
+                                     snappi_extra_params=snappi_extra_params)

--- a/tests/snappi_tests/multidut/systest/files/sys_multidut_helper.py
+++ b/tests/snappi_tests/multidut/systest/files/sys_multidut_helper.py
@@ -1,0 +1,375 @@
+import logging
+import time
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
+    fanout_graph_facts  # noqa F401
+from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector,\
+    get_lossless_buffer_size, get_pg_dropped_packets,\
+    stop_pfcwd, disable_packet_aging, sec_to_nanosec,\
+    get_pfc_frame_count, packet_capture, config_capture_pkt,\
+    start_pfcwd, enable_packet_aging, \
+    traffic_flow_mode, calc_pfc_pause_flow_rate      # noqa F401
+from tests.common.snappi_tests.port import select_ports, select_tx_port  # noqa F401
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp  # noqa F401
+from tests.common.snappi_tests.traffic_generation import generate_pause_flows,  verify_pause_flow, \
+    verify_basic_test_flow, verify_background_flow, verify_pause_frame_count_dut, verify_sys_egress_queue_count, \
+    verify_unset_cev_pause_frame_count, verify_tx_frame_count_dut, \
+    verify_rx_frame_count_dut, run_sys_traffic, new_base_traffic_config, \
+    generate_sys_test_flows, generate_sys_background_flows
+from tests.common.snappi_tests.snappi_systest_params import SnappiSysTestParams
+from tests.common.snappi_tests.read_pcap import validate_pfc_frame
+
+logger = logging.getLogger(__name__)
+
+dut_port_config = []
+PAUSE_FLOW_NAME = 'Pause Storm'
+TEST_FLOW_NAME = 'Test Flow'
+BG_FLOW_NAME = 'Background Flow'
+TOLERANCE_THRESHOLD = 0.1
+CONTINUOUS_MODE = -5
+ANSIBLE_POLL_DELAY_SEC = 4
+global DATA_FLOW_DURATION_SEC
+global data_flow_delay_sec
+
+
+def run_pfc_test(api,
+                 testbed_config,
+                 port_config_list,
+                 conn_data,
+                 fanout_data,
+                 global_pause,
+                 pause_prio_list,
+                 test_prio_list,
+                 bg_prio_list,
+                 prio_dscp_map,
+                 test_traffic_pause,
+                 test_def,
+                 snappi_extra_params=None):
+    """
+    Run a multidut PFC test
+    Args:
+        api (obj): snappi session
+        testbed_config (obj): testbed L1/L2/L3 configuration
+        port_config_list (list): list of port configuration
+        conn_data (dict): the dictionary returned by conn_graph_fact.
+        fanout_data (dict): the dictionary returned by fanout_graph_fact.
+        duthost (Ansible host instance): device under test
+        dut_port (str): DUT port to test
+        global_pause (bool): if pause frame is IEEE 802.3X pause
+        pause_prio_list (list): priorities to pause for pause frames
+        test_prio_list (list): priorities of test flows
+        bg_prio_list (list): priorities of background flows
+        prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
+        test_traffic_pause (bool): if test flows are expected to be paused
+        test_def['enable_pause'] (bool) : if test expects no pause flow traffic.
+        snappi_extra_params (SnappiSysTestParams obj): additional parameters for Snappi traffic
+
+    Returns:
+        N/A
+    """
+
+    TEST_FLOW_AGGR_RATE_PERCENT = test_def['TEST_FLOW_AGGR_RATE_PERCENT']
+    BG_FLOW_AGGR_RATE_PERCENT = test_def['BG_FLOW_AGGR_RATE_PERCENT']
+    data_flow_pkt_size = test_def['data_flow_pkt_size']
+    DATA_FLOW_DURATION_SEC = test_def['DATA_FLOW_DURATION_SEC']
+    data_flow_delay_sec = test_def['data_flow_delay_sec']
+    SNAPPI_POLL_DELAY_SEC = test_def['SNAPPI_POLL_DELAY_SEC']
+    PAUSE_FLOW_DUR_BASE_SEC = data_flow_delay_sec + DATA_FLOW_DURATION_SEC
+    if test_def['imix']:
+        fname = test_def['test_type'] + '_' + test_def['line_card_choice'] + '_' + 'IMIX'
+    else:
+        fname = test_def['test_type'] + '_' + test_def['line_card_choice'] + '_' + str(data_flow_pkt_size) + 'B'
+    port_map = test_def['port_map']
+
+    if snappi_extra_params is None:
+        snappi_extra_params = SnappiSysTestParams()
+
+    duthost1 = snappi_extra_params.multi_dut_params.duthost1
+    rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
+    duthost2 = snappi_extra_params.multi_dut_params.duthost2
+    tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[-1]
+    dut_list = []
+    dut_list.append(duthost1)
+    dut_list.append(duthost2)
+
+    tx_dut = duthost1
+    rx_dut = duthost2
+    if (rx_port['peer_device'] == duthost1.hostname):
+        tx_dut = duthost2
+        rx_dut = duthost1
+
+    if (test_traffic_pause):
+        logger.info("PFC receiving DUT is {}".format(tx_dut.hostname))
+
+    pytest_assert(testbed_config is not None, 'Fail to get L2/3 testbed config')
+
+    if (test_def['enable_pfcwd']):
+        start_pfcwd(rx_dut)
+        start_pfcwd(tx_dut)
+    else:
+        stop_pfcwd(rx_dut)
+        stop_pfcwd(tx_dut)
+
+    if (test_def['enable_credit_wd']):
+        enable_packet_aging(rx_dut, rx_port['asic_value'])
+        enable_packet_aging(tx_dut, tx_port['asic_value'])
+    else:
+        disable_packet_aging(rx_dut, rx_port['asic_value'])
+        disable_packet_aging(tx_dut, tx_port['asic_value'])
+
+    # Port id of Rx port for traffic config
+    # rx_port_id and tx_port_id belong to IXIA chassis.
+    rx_port_id = 0
+
+    # Rate percent must be an integer
+    bg_flow_rate_percent = int(BG_FLOW_AGGR_RATE_PERCENT / len(bg_prio_list))
+    test_flow_rate_percent = int(TEST_FLOW_AGGR_RATE_PERCENT / len(test_prio_list))
+    # Generate base traffic config
+    for i in range(port_map[2]):
+        tx_port_id = i+1
+        snappi_extra_params.base_flow_config.append(new_base_traffic_config(testbed_config=testbed_config,
+                                                                            port_config_list=port_config_list,
+                                                                            rx_port_id=rx_port_id,
+                                                                            tx_port_id=tx_port_id))
+
+    speed_str = testbed_config.layer1[0].speed
+    speed_gbps = int(speed_str.split('_')[1])
+
+    if snappi_extra_params.headroom_test_params is not None:
+        DATA_FLOW_DURATION_SEC += 10
+        data_flow_delay_sec += 2
+
+        # Set up pfc delay parameter
+        l1_config = testbed_config.layer1[0]
+        pfc = l1_config.flow_control.ieee_802_1qbb
+        pfc.pfc_delay = snappi_extra_params.headroom_test_params[0]
+
+    if snappi_extra_params.poll_device_runtime:
+        # If the switch needs to be polled as traffic is running for stats,
+        # then the test runtime needs to be increased for the polling delay
+        DATA_FLOW_DURATION_SEC += ANSIBLE_POLL_DELAY_SEC
+        data_flow_delay_sec = ANSIBLE_POLL_DELAY_SEC
+
+    if snappi_extra_params.packet_capture_type != packet_capture.NO_CAPTURE:
+        # Setup capture config
+        if snappi_extra_params.is_snappi_ingress_port_cap:
+            # packet capture is required on the ingress snappi port
+            snappi_extra_params.packet_capture_ports = [snappi_extra_params.base_flow_config["rx_port_name"]]
+        else:
+            # packet capture will be on the egress snappi port
+            snappi_extra_params.packet_capture_ports = [snappi_extra_params.base_flow_config["tx_port_name"]]
+
+        snappi_extra_params.packet_capture_file = snappi_extra_params.packet_capture_type.value
+
+        config_capture_pkt(testbed_config=testbed_config,
+                           port_names=snappi_extra_params.packet_capture_ports,
+                           capture_type=snappi_extra_params.packet_capture_type,
+                           capture_name=snappi_extra_params.packet_capture_file)
+        logger.info("Packet capture file: {}.pcapng".format(snappi_extra_params.packet_capture_file))
+
+    # Set default traffic flow configs if not set
+    if snappi_extra_params.traffic_flow_config.data_flow_config is None:
+        snappi_extra_params.traffic_flow_config.data_flow_config = {
+            "flow_name": TEST_FLOW_NAME,
+            "flow_dur_sec": DATA_FLOW_DURATION_SEC,
+            "flow_rate_percent": test_flow_rate_percent,
+            "flow_rate_pps": None,
+            "flow_rate_bps": None,
+            "flow_pkt_count": None,
+            "flow_pkt_size": data_flow_pkt_size,
+            "flow_delay_sec": data_flow_delay_sec,
+            "flow_traffic_type": traffic_flow_mode.FIXED_DURATION
+        }
+
+    if snappi_extra_params.traffic_flow_config.background_flow_config is None and \
+       snappi_extra_params.gen_background_traffic:
+        snappi_extra_params.traffic_flow_config.background_flow_config = {
+            "flow_name": BG_FLOW_NAME,
+            "flow_dur_sec": DATA_FLOW_DURATION_SEC,
+            "flow_rate_percent": bg_flow_rate_percent,
+            "flow_rate_pps": None,
+            "flow_rate_bps": None,
+            "flow_pkt_size": data_flow_pkt_size,
+            "flow_pkt_count": None,
+            "flow_delay_sec": data_flow_delay_sec,
+            "flow_traffic_type": traffic_flow_mode.FIXED_DURATION
+        }
+
+    if (test_traffic_pause):
+        if snappi_extra_params.traffic_flow_config.pause_flow_config is None:
+            snappi_extra_params.traffic_flow_config.pause_flow_config = {
+                "flow_name": PAUSE_FLOW_NAME,
+                "flow_dur_sec": None,
+                "flow_rate_percent": None,
+                "flow_rate_pps": calc_pfc_pause_flow_rate(speed_gbps),
+                "flow_rate_bps": None,
+                "flow_pkt_size": 64,
+                "flow_pkt_count": None,
+                "flow_delay_sec": 0,
+                "flow_traffic_type": traffic_flow_mode.CONTINUOUS
+            }
+
+    if snappi_extra_params.packet_capture_type == packet_capture.PFC_CAPTURE:
+        # PFC pause frame capture is requested
+        valid_pfc_frame_test = True
+    else:
+        # PFC pause frame capture is not requested
+        valid_pfc_frame_test = False
+
+    if (test_traffic_pause):
+        if valid_pfc_frame_test:
+            snappi_extra_params.traffic_flow_config.pause_flow_config["flow_dur_sec"] = DATA_FLOW_DURATION_SEC + \
+                data_flow_delay_sec + SNAPPI_POLL_DELAY_SEC + PAUSE_FLOW_DUR_BASE_SEC
+            snappi_extra_params.traffic_flow_config.pause_flow_config["flow_traffic_type"] = \
+                traffic_flow_mode.FIXED_DURATION
+
+    # Generate test flow config based on number of ingress ports
+    # Every ingress port will be used as index. Example - test flow stream 0 - for first ingress.
+    for m in range(port_map[2]):
+        generate_sys_test_flows(testbed_config=testbed_config,
+                                test_flow_prio_list=test_prio_list,
+                                prio_dscp_map=prio_dscp_map,
+                                snappi_extra_params=snappi_extra_params,
+                                snap_index=m)
+
+    if (test_def['background_traffic']):
+        for m in range(port_map[2]):
+            if snappi_extra_params.gen_background_traffic:
+                # Generate background flow config
+                generate_sys_background_flows(testbed_config=testbed_config,
+                                              bg_flow_prio_list=bg_prio_list,
+                                              prio_dscp_map=prio_dscp_map,
+                                              snappi_extra_params=snappi_extra_params,
+                                              snap_index=m)
+
+    # Generate pause storm config
+    if (test_traffic_pause):
+        for m in range(port_map[0]):
+            generate_pause_flows(testbed_config=testbed_config,
+                                 pause_prio_list=pause_prio_list,
+                                 global_pause=global_pause,
+                                 snappi_extra_params=snappi_extra_params,
+                                 snap_index=m)
+
+    flows = testbed_config.flows
+
+    all_flow_names = [flow.name for flow in flows]
+    data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
+
+    # Clear PFC, queue and interface counters before traffic run
+    for dut in dut_list:
+        dut.command("pfcstat -c \n")
+        time.sleep(1)
+        dut.command("sonic-clear queuecounters \n")
+        time.sleep(1)
+        dut.command("sonic-clear counters \n")
+        time.sleep(1)
+
+    exp_dur_sec = DATA_FLOW_DURATION_SEC + data_flow_delay_sec
+
+    """ Run traffic """
+    tgen_flow_stats, switch_flow_stats, test_stats = run_sys_traffic(rx_duthost=rx_dut,
+                                                                     tx_duthost=tx_dut,
+                                                                     api=api,
+                                                                     config=testbed_config,
+                                                                     data_flow_names=data_flow_names,
+                                                                     all_flow_names=all_flow_names,
+                                                                     exp_dur_sec=exp_dur_sec,
+                                                                     port_map=test_def['port_map'],
+                                                                     fname=fname,
+                                                                     stats_interval=test_def['stats_interval'],
+                                                                     imix=test_def['imix'],
+                                                                     snappi_extra_params=snappi_extra_params)
+
+    test_check = test_def['test_check']
+    if (not test_check['loss_expected']):
+        # Check for loss packets on IXIA and DUT.
+        pytest_assert(test_stats['tgen_loss_pkts'] == 0, 'Loss seen on TGEN')
+        pytest_assert(test_stats['dut_loss_pkts'] == 0, 'Loss seen on DUT')
+
+        # Check for Tx and Rx packets on IXIA for lossless and lossy streams.
+        pytest_assert(test_stats['tgen_lossless_rx_pkts'] == test_stats['tgen_lossless_tx_pkts'],
+                      'Losses observed in lossless traffic streams')
+        pytest_assert(test_stats['tgen_lossy_rx_pkts'] == test_stats['tgen_lossy_tx_pkts'],
+                      'Losses observed in lossy traffic streams')
+
+        # Check for Rx packets between IXIA and DUT for lossy and lossless streams.
+        pytest_assert(test_stats['tgen_lossless_rx_pkts'] == test_stats['dut_lossless_pkts'],
+                      'Losses observed in lossless traffic streams on DUT Tx and IXIA Rx')
+        pytest_assert(test_stats['tgen_lossy_rx_pkts'] == test_stats['dut_lossy_pkts'],
+                      'Losses observed in lossy traffic streams on DUT Tx and IXIA Rx')
+    else:
+        # Check for lossless and lossy stream percentage drop for a given tolerance limit.
+        lossless_drop = (1 - test_stats['tgen_lossless_rx_pkts'] / test_stats['tgen_lossless_tx_pkts']) * 100
+        lossy_drop = (1 - test_stats['tgen_lossy_rx_pkts'] / test_stats['tgen_lossy_tx_pkts']) * 100
+        pytest_assert(lossless_drop < test_check['lossless'], 'Lossless packet drop outside tolerance limit')
+        pytest_assert(lossy_drop < test_check['lossy'], 'Lossy packet drop outside tolerance limit')
+
+    # Checking if the actual line rate on egress is within tolerable limit of egress line speed.
+    pytest_assert(((1 - test_stats['tgen_rx_rate'] / float(port_map[2]*port_map[3]))*100) < test_check['speed_tol'],
+                  'Egress speed beyond tolerance range')
+
+    # import pdb; pdb.set_trace()
+    # Reset pfc delay parameter
+    pfc = testbed_config.layer1[0].flow_control.ieee_802_1qbb
+    pfc.pfc_delay = 0
+
+    # Verify PFC pause frames
+    if (test_traffic_pause):
+        if valid_pfc_frame_test:
+            is_valid_pfc_frame = validate_pfc_frame(snappi_extra_params.packet_capture_file + ".pcapng")
+            pytest_assert(is_valid_pfc_frame, "PFC frames invalid")
+            return
+
+    # Verify pause flows
+    if (test_traffic_pause):
+        verify_pause_flow(flow_metrics=tgen_flow_stats,
+                          pause_flow_name=PAUSE_FLOW_NAME)
+
+    # Check for the flows ONLY if normal packet size (non-imix) is used.
+    if (test_def['background_traffic'] and test_def['verify_flows'] and not test_def['imix']):
+        if snappi_extra_params.gen_background_traffic:
+            # Verify background flows
+            verify_background_flow(flow_metrics=tgen_flow_stats,
+                                   speed_gbps=speed_gbps,
+                                   tolerance=TOLERANCE_THRESHOLD,
+                                   snappi_extra_params=snappi_extra_params)
+
+    # Verify basic test flows metrics from ixia
+    if (test_def['verify_flows'] and not test_def['imix']):
+        verify_basic_test_flow(flow_metrics=tgen_flow_stats,
+                               speed_gbps=speed_gbps,
+                               tolerance=TOLERANCE_THRESHOLD,
+                               test_flow_pause=test_traffic_pause,
+                               snappi_extra_params=snappi_extra_params)
+
+    if (test_traffic_pause and test_def['verify_flows']):
+        verify_pause_frame_count_dut(rx_dut=rx_dut,
+                                     tx_dut=tx_dut,
+                                     test_traffic_pause=test_traffic_pause,
+                                     global_pause=global_pause,
+                                     snappi_extra_params=snappi_extra_params)
+
+    # Verify in flight TX lossless packets do not leave the DUT when traffic is expected
+    # to be paused, or leave the DUT when the traffic is not expected to be paused
+    verify_sys_egress_queue_count(duthost=tx_dut,
+                                  switch_flow_stats=switch_flow_stats,
+                                  test_traffic_pause=test_traffic_pause,
+                                  snappi_extra_params=snappi_extra_params)
+
+    if test_traffic_pause:
+        # Verify zero pause frames are counted when the PFC class enable vector is not set
+        verify_unset_cev_pause_frame_count(duthost=tx_dut,
+                                           snappi_extra_params=snappi_extra_params)
+
+    if test_traffic_pause and not snappi_extra_params.gen_background_traffic:
+        # Verify TX frame count on the DUT when traffic is expected to be paused
+        # and only test traffic flows are generated
+        verify_tx_frame_count_dut(duthost=rx_dut,
+                                  snappi_extra_params=snappi_extra_params)
+
+        # Verify TX frame count on the DUT when traffic is expected to be paused
+        # and only test traffic flows are generated
+        verify_rx_frame_count_dut(duthost=tx_dut,
+                                  snappi_extra_params=snappi_extra_params)

--- a/tests/snappi_tests/multidut/systest/test_multiflow_pfcwd.py
+++ b/tests/snappi_tests/multidut/systest/test_multiflow_pfcwd.py
@@ -1,0 +1,758 @@
+import pytest
+from tests.common.helpers.assertions import pytest_require, pytest_assert                   # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
+    snappi_api, snappi_dut_base_config, get_tgen_peer_ports, get_multidut_snappi_ports, \
+    get_multidut_tgen_peer_port_set, new_get_multidut_tgen_peer_port_set, cleanup_config    # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
+        lossless_prio_list                                                                  # noqa: F401
+from tests.common.snappi_tests.common_helpers import get_pfcwd_stats
+from tests.snappi_tests.variables import config_set, line_card_choice
+from files.pfcwd_multidut_helper import run_pfc_test
+import logging
+from tests.common.snappi_tests.snappi_systest_params import SnappiSysTestParams
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.topology('multidut-tgen')]
+
+
+@pytest.mark.parametrize('linecard_configuration_set', [config_set])
+@pytest.mark.parametrize('line_card_choice', line_card_choice)
+def test_pfcwd_drop_90_10(snappi_api,                  # noqa: F811
+                          conn_graph_facts,            # noqa: F811
+                          fanout_graph_facts,          # noqa: F811
+                          duthosts,
+                          prio_dscp_map,               # noqa: F811
+                          lossless_prio_list,          # noqa: F811
+                          line_card_choice,
+                          linecard_configuration_set,
+                          get_multidut_snappi_ports):    # noqa: F811
+
+    """
+    Test with 1 ingress and egress. DUT should generate PFCs on congestion indication.
+
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        line_card_choice: Line card choice to be mentioned in the variable.py file
+        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
+    Returns:
+        N/A
+    Purpose of the test case is to enable PFCWD in drop mode and send 90% lossless traffic and 10%
+    lossy traffic and check the behavior. DUT is receiving pause storm on the egress port. DUT should
+    drop the lossless packets without generating any pause towards IXIA transmitter. No loss for lossy traffic.
+    """
+
+    test_pkt_size = 1024
+    # port_map is defined as port-speed combination.
+    # first two parameters are count of egress links and its speed.
+    # last two parameters are count of ingress links and its speed.
+    if '100Gbps' in line_card_choice:
+        port_map = [1, 100, 1, 100]
+    else:
+        port_map = [1, 400, 1, 400]
+
+    # Percentage drop expected for lossless and lossy traffic.
+    # speed_tol is speed tolerance between egress link speed and actual speed.
+    # loss_expected to check losses on DUT and TGEN.
+    test_check = {'lossless': 100, 'lossy': 0, 'speed_tol': 91, 'loss_expected': True, 'pfc': True}
+
+    test_def = {}
+    test_def = {'TEST_FLOW_AGGR_RATE_PERCENT': 90,
+                'BG_FLOW_AGGR_RATE_PERCENT': 10,
+                'data_flow_pkt_size': test_pkt_size,
+                'DATA_FLOW_DURATION_SEC': 300,
+                'data_flow_delay_sec': 1,
+                'SNAPPI_POLL_DELAY_SEC': 60,
+                'test_type': '/tmp/One_Ingress_Egress_pfcwd_drop_90_10_dist'+str(port_map[1])+'Gbps',
+                'line_card_choice': line_card_choice,
+                'port_map': port_map,
+                'enable_pfcwd_drop': True,
+                'enable_pfcwd_fwd': False,
+                'enable_credit_wd': True,
+                'stats_interval': 60,
+                'background_traffic': True,
+                'verify_flows': False,
+                'imix': False,
+                'test_check': test_check}
+
+    logger.info('Starting the test for line_card_choice : {}'.format(line_card_choice))
+    if line_card_choice not in linecard_configuration_set.keys():
+        assert False, "Invalid line_card_choice value passed in parameter"
+
+    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
+        dut_list = [dut for dut in duthosts
+                    if dut.hostname in linecard_configuration_set[line_card_choice]['hostname']]
+        duthost1, duthost2 = dut_list
+    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
+        dut_list = [dut for dut in duthosts
+                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
+        duthost1 = duthost2 = dut_list[0]
+    else:
+        assert False, "Hostname can't be an empty list"
+
+    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
+                                                 line_card_info=linecard_configuration_set[line_card_choice])
+
+    if len(snappi_port_list) < 2:
+        assert False, "Need Minimum of 2 ports for the test"
+
+    snappi_ports = new_get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, port_map)
+
+    if len(snappi_ports) < 2:
+        assert False, "Need Minimum of 2 ports for the test"
+
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+                                                                            snappi_ports,
+                                                                            snappi_api)
+
+    test_prio_list = lossless_prio_list
+    pause_prio_list = test_prio_list
+    bg_prio_list = [0, 1, 2]
+    logger.info("Snappi Ports : {}".format(snappi_ports))
+
+    logger.info('PFC-WD stats at the start of the test:')
+    for prio in test_prio_list:
+        for port in snappi_ports:
+            if len(dut_list) == 1:
+                if dut_list[0].hostname == port['peer_device']:
+                    logger.info('PFCWD stats for dut:{}, port:{},prio:{}'.
+                                format(dut_list[0].hostname, port['peer_port'], prio))
+                    pfcwd_stats = get_pfcwd_stats(dut_list[0], port['peer_port'], prio)
+                    logger.info('PFCWD Stats:{}'.format(pfcwd_stats))
+            else:
+                for dut in dut_list:
+                    if dut.hostname == port['peer_device']:
+                        logger.info('PFCWD stats for dut:{}, port:{},prio:{}'.
+                                    format(dut.hostname, port['peer_port'], prio))
+                        pfcwd_stats = get_pfcwd_stats(dut, port['peer_port'], prio)
+                        logger.info('PFCWD Stats::{}'.format(pfcwd_stats))
+
+    snappi_extra_params = SnappiSysTestParams()
+    snappi_extra_params.multi_dut_params.duthost1 = duthost1
+    snappi_extra_params.multi_dut_params.duthost2 = duthost2
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=True,
+                     test_def=test_def,
+                     snappi_extra_params=snappi_extra_params)
+
+        logger.info('PFC-WD stats at the end of the test:')
+        for prio in test_prio_list:
+            for port in snappi_ports:
+                if len(dut_list) == 1:
+                    if dut_list[0].hostname == port['peer_device']:
+                        pfcwd_stats = get_pfcwd_stats(dut_list[0], port['peer_port'], prio)
+                        logger.info('PFCWD Stats:for dut:{}, port:{},prio:{}, stats::{}'.
+                                    format(dut_list[0].hostname, port['peer_port'], prio, pfcwd_stats))
+                else:
+                    for dut in dut_list:
+                        if dut.hostname == port['peer_device']:
+                            pfcwd_stats = get_pfcwd_stats(dut, port['peer_port'], prio)
+                            logger.info('PFCWD Stats:for dut:{}, port:{},prio:{}, stats::{}'.
+                                        format(dut.hostname, port['peer_port'], prio, pfcwd_stats))
+
+    finally:
+        cleanup_config(dut_list, snappi_ports)
+
+
+@pytest.mark.parametrize('linecard_configuration_set', [config_set])
+@pytest.mark.parametrize('line_card_choice', line_card_choice)
+def test_pfcwd_frwd_90_10(snappi_api,                  # noqa: F811
+                          conn_graph_facts,            # noqa: F811
+                          fanout_graph_facts,          # noqa: F811
+                          duthosts,
+                          prio_dscp_map,               # noqa: F811
+                          lossless_prio_list,          # noqa: F811
+                          line_card_choice,
+                          linecard_configuration_set,
+                          get_multidut_snappi_ports):    # noqa: F811
+
+    """
+    Test with 1 ingress and egress. DUT should generate PFCs on congestion indication.
+
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        line_card_choice: Line card choice to be mentioned in the variable.py file
+        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
+    Returns:
+        N/A
+    Purpose of the test case is to check behavior of the DUT when PFCWD is enabled in FORWARD mode and egress port
+    is congested with PAUSE storm. DUT in this mode should forward the lossless packets irrespective of the pause
+    storm and not send any PAUSE frames towards IXIA transmitter. No effect on lossy traffic.
+    """
+
+    test_pkt_size = 1024
+    # port_map is defined as port-speed combination.
+    # first two parameters are count of egress links and its speed.
+    # last two parameters are count of ingress links and its speed.
+    if '100Gbps' in line_card_choice:
+        port_map = [1, 100, 1, 100]
+    else:
+        port_map = [1, 400, 1, 400]
+
+    # Percentage drop expected for lossless and lossy traffic.
+    # speed_tol is speed tolerance between egress link speed and actual speed.
+    # loss_expected to check losses on DUT and TGEN.
+    test_check = {'lossless': 0, 'lossy': 0, 'speed_tol': 3, 'loss_expected': False, 'pfc': True}
+
+    test_def = {}
+    test_def = {'TEST_FLOW_AGGR_RATE_PERCENT': 90,
+                'BG_FLOW_AGGR_RATE_PERCENT': 10,
+                'data_flow_pkt_size': test_pkt_size,
+                'DATA_FLOW_DURATION_SEC': 300,
+                'data_flow_delay_sec': 1,
+                'SNAPPI_POLL_DELAY_SEC': 60,
+                'test_type': '/tmp/One_Ingress_Egress_pfcwd_frwd_90_10_dist'+str(port_map[1])+'Gbps',
+                'line_card_choice': line_card_choice,
+                'port_map': port_map,
+                'enable_pfcwd_drop': False,
+                'enable_pfcwd_fwd': True,
+                'enable_credit_wd': True,
+                'stats_interval': 60,
+                'background_traffic': True,
+                'verify_flows': False,
+                'imix': False,
+                'test_check': test_check}
+
+    logger.info('Starting the test for line_card_choice : {}'.format(line_card_choice))
+    if line_card_choice not in linecard_configuration_set.keys():
+        assert False, "Invalid line_card_choice value passed in parameter"
+
+    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
+        dut_list = [dut for dut in duthosts
+                    if dut.hostname in linecard_configuration_set[line_card_choice]['hostname']]
+        duthost1, duthost2 = dut_list
+    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
+        dut_list = [dut for dut in duthosts
+                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
+        duthost1 = duthost2 = dut_list[0]
+    else:
+        assert False, "Hostname can't be an empty list"
+
+    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
+                                                 line_card_info=linecard_configuration_set[line_card_choice])
+
+    if len(snappi_port_list) < 2:
+        assert False, "Need Minimum of 2 ports for the test"
+
+    snappi_ports = new_get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, port_map)
+
+    if len(snappi_ports) < 2:
+        assert False, "Need Minimum of 2 ports for the test"
+
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+                                                                            snappi_ports,
+                                                                            snappi_api)
+
+    test_prio_list = lossless_prio_list
+    pause_prio_list = test_prio_list
+    bg_prio_list = [0, 1, 2]
+    logger.info("Snappi Ports : {}".format(snappi_ports))
+
+    logger.info('PFC-WD stats at the start of the test:')
+    for prio in test_prio_list:
+        for port in snappi_ports:
+            if len(dut_list) == 1:
+                if dut_list[0].hostname == port['peer_device']:
+                    logger.info('PFCWD stats for dut:{}, port:{},prio:{}'.
+                                format(dut_list[0].hostname, port['peer_port'], prio))
+                    pfcwd_stats = get_pfcwd_stats(dut_list[0], port['peer_port'], prio)
+                    logger.info('PFCWD Stats:{}'.format(pfcwd_stats))
+            else:
+                for dut in dut_list:
+                    if dut.hostname == port['peer_device']:
+                        logger.info('PFCWD stats for dut:{}, port:{},prio:{}'.
+                                    format(dut.hostname, port['peer_port'], prio))
+                        pfcwd_stats = get_pfcwd_stats(dut, port['peer_port'], prio)
+                        logger.info('PFCWD Stats::{}'.format(pfcwd_stats))
+
+    snappi_extra_params = SnappiSysTestParams()
+    snappi_extra_params.multi_dut_params.duthost1 = duthost1
+    snappi_extra_params.multi_dut_params.duthost2 = duthost2
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=True,
+                     test_def=test_def,
+                     snappi_extra_params=snappi_extra_params)
+
+        logger.info('PFC-WD stats at the end of the test:')
+        for prio in test_prio_list:
+            for port in snappi_ports:
+                if len(dut_list) == 1:
+                    if dut_list[0].hostname == port['peer_device']:
+                        pfcwd_stats = get_pfcwd_stats(dut_list[0], port['peer_port'], prio)
+                        logger.info('PFCWD Stats:for dut:{}, port:{},prio:{}, stats::{}'.
+                                    format(dut_list[0].hostname, port['peer_port'], prio, pfcwd_stats))
+                else:
+                    for dut in dut_list:
+                        if dut.hostname == port['peer_device']:
+                            pfcwd_stats = get_pfcwd_stats(dut, port['peer_port'], prio)
+                            logger.info('PFCWD Stats:for dut:{}, port:{},prio:{}, stats::{}'.
+                                        format(dut.hostname, port['peer_port'], prio, pfcwd_stats))
+
+    finally:
+        cleanup_config(dut_list, snappi_ports)
+
+
+@pytest.mark.parametrize('linecard_configuration_set', [config_set])
+@pytest.mark.parametrize('line_card_choice', line_card_choice)
+def test_pfcwd_drop_over_subs_40_09(snappi_api,                  # noqa: F811
+                                    conn_graph_facts,            # noqa: F811
+                                    fanout_graph_facts,          # noqa: F811
+                                    duthosts,
+                                    prio_dscp_map,               # noqa: F811
+                                    lossless_prio_list,          # noqa: F811
+                                    line_card_choice,
+                                    linecard_configuration_set,
+                                    get_multidut_snappi_ports):    # noqa: F811
+
+    """
+    Test with 1 ingress and egress. DUT should generate PFCs on congestion indication.
+
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        line_card_choice: Line card choice to be mentioned in the variable.py file
+        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
+    Returns:
+        N/A
+
+    Purpose of the testcase is to check PFCWD behavior in DROP mode with over-subscription.
+    Each ingress is sending 49% of link capacity traffic and DUT is receiving PAUSE storm on egress link.
+    DUT should drop lossless packets. No drop for lossy traffic.
+    """
+    test_pkt_size = 1024
+    # port_map is defined as port-speed combination.
+    # first two parameters are count of egress links and its speed.
+    # last two parameters are count of ingress links and its speed.
+    if '100Gbps' in line_card_choice:
+        port_map = [1, 100, 2, 100]
+    else:
+        port_map = [1, 400, 2, 400]
+
+    # Percentage drop expected for lossless and lossy traffic.
+    # speed_tol is speed tolerance between egress link speed and actual speed.
+    # loss_expected to check losses on DUT and TGEN.
+    test_check = {'lossless': 100, 'lossy': 0, 'speed_tol': 83, 'loss_expected': True, 'pfc': True}
+
+    test_def = {}
+    test_def = {'TEST_FLOW_AGGR_RATE_PERCENT': 40,
+                'BG_FLOW_AGGR_RATE_PERCENT': 9,
+                'data_flow_pkt_size': test_pkt_size,
+                'DATA_FLOW_DURATION_SEC': 300,
+                'data_flow_delay_sec': 1,
+                'SNAPPI_POLL_DELAY_SEC': 60,
+                'test_type': '/tmp/Two_Ingress_Single_Egress_pfcwd_drop_40_9_dist'+str(port_map[1])+'Gbps',
+                'line_card_choice': line_card_choice,
+                'port_map': port_map,
+                'enable_pfcwd_drop': True,
+                'enable_pfcwd_fwd': False,
+                'enable_credit_wd': True,
+                'stats_interval': 60,
+                'background_traffic': True,
+                'verify_flows': False,
+                'imix': False,
+                'test_check': test_check}
+
+    logger.info('Starting the test for line_card_choice : {}'.format(line_card_choice))
+    if line_card_choice not in linecard_configuration_set.keys():
+        assert False, "Invalid line_card_choice value passed in parameter"
+
+    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
+        dut_list = [dut for dut in duthosts
+                    if dut.hostname in linecard_configuration_set[line_card_choice]['hostname']]
+        duthost1, duthost2 = dut_list
+    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
+        dut_list = [dut for dut in duthosts
+                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
+        duthost1 = duthost2 = dut_list[0]
+    else:
+        assert False, "Hostname can't be an empty list"
+
+    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
+                                                 line_card_info=linecard_configuration_set[line_card_choice])
+
+    if len(snappi_port_list) < 3:
+        assert False, "Need Minimum of 3 ports for the test"
+
+    snappi_ports = new_get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, port_map)
+
+    if len(snappi_ports) < 3:
+        assert False, "Need Minimum of 3 ports for the test"
+
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+                                                                            snappi_ports,
+                                                                            snappi_api)
+
+    test_prio_list = lossless_prio_list
+    pause_prio_list = test_prio_list
+    bg_prio_list = [0, 1, 2]
+    logger.info("Snappi Ports : {}".format(snappi_ports))
+
+    logger.info('PFC-WD stats at the start of the test:')
+    for prio in test_prio_list:
+        for port in snappi_ports:
+            if len(dut_list) == 1:
+                if dut_list[0].hostname == port['peer_device']:
+                    logger.info('PFCWD stats for dut:{}, port:{},prio:{}'.
+                                format(dut_list[0].hostname, port['peer_port'], prio))
+                    pfcwd_stats = get_pfcwd_stats(dut_list[0], port['peer_port'], prio)
+                    logger.info('PFCWD Stats:{}'.format(pfcwd_stats))
+            else:
+                for dut in dut_list:
+                    if dut.hostname == port['peer_device']:
+                        logger.info('PFCWD stats for dut:{}, port:{},prio:{}'.
+                                    format(dut.hostname, port['peer_port'], prio))
+                        pfcwd_stats = get_pfcwd_stats(dut, port['peer_port'], prio)
+                        logger.info('PFCWD Stats::{}'.format(pfcwd_stats))
+
+    snappi_extra_params = SnappiSysTestParams()
+    snappi_extra_params.multi_dut_params.duthost1 = duthost1
+    snappi_extra_params.multi_dut_params.duthost2 = duthost2
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=True,
+                     test_def=test_def,
+                     snappi_extra_params=snappi_extra_params)
+
+        logger.info('PFC-WD stats at the end of the test:')
+        for prio in test_prio_list:
+            for port in snappi_ports:
+                if len(dut_list) == 1:
+                    if dut_list[0].hostname == port['peer_device']:
+                        pfcwd_stats = get_pfcwd_stats(dut_list[0], port['peer_port'], prio)
+                        logger.info('PFCWD Stats:for dut:{}, port:{},prio:{}, stats::{}'.
+                                    format(dut_list[0].hostname, port['peer_port'], prio, pfcwd_stats))
+                else:
+                    for dut in dut_list:
+                        if dut.hostname == port['peer_device']:
+                            pfcwd_stats = get_pfcwd_stats(dut, port['peer_port'], prio)
+                            logger.info('PFCWD Stats:for dut:{}, port:{},prio:{}, stats::{}'.
+                                        format(dut.hostname, port['peer_port'], prio, pfcwd_stats))
+    finally:
+        cleanup_config(dut_list, snappi_ports)
+
+
+@pytest.mark.parametrize('linecard_configuration_set', [config_set])
+@pytest.mark.parametrize('line_card_choice', line_card_choice)
+def test_pfcwd_frwd_over_subs_40_09(snappi_api,                  # noqa: F811
+                                    conn_graph_facts,            # noqa: F811
+                                    fanout_graph_facts,          # noqa: F811
+                                    duthosts,
+                                    prio_dscp_map,               # noqa: F811
+                                    lossless_prio_list,          # noqa: F811
+                                    line_card_choice,
+                                    linecard_configuration_set,
+                                    get_multidut_snappi_ports):    # noqa: F811
+
+    """
+    Test with 1 ingress and egress. DUT should generate PFCs on congestion indication.
+
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        line_card_choice: Line card choice to be mentioned in the variable.py file
+        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
+    Returns:
+        N/A
+    Purpose of testcase is to test behavior of DUT in PFCWD-FORWARD mode in oversubscription mode.
+    Each ingress is sending 49% of link capacity traffic and DUT is receiving PAUSE storm on egress link.
+    DUT should forward for both lossy and lossless traffic without generating PAUSE frames towards IXIA
+    transmitter.
+    """
+
+    test_pkt_size = 1024
+    # port_map is defined as port-speed combination.
+    # first two parameters are count of egress links and its speed.
+    # last two parameters are count of ingress links and its speed.
+    if '100Gbps' in line_card_choice:
+        port_map = [1, 100, 2, 100]
+    else:
+        port_map = [1, 400, 2, 400]
+
+    # Percentage drop expected for lossless and lossy traffic.
+    # speed_tol is speed tolerance between egress link speed and actual speed.
+    # loss_expected to check losses on DUT and TGEN.
+    test_check = {'lossless': 0, 'lossy': 0, 'speed_tol': 3, 'loss_expected': False, 'pfc': True}
+
+    test_def = {}
+    test_def = {'TEST_FLOW_AGGR_RATE_PERCENT': 40,
+                'BG_FLOW_AGGR_RATE_PERCENT': 9,
+                'data_flow_pkt_size': test_pkt_size,
+                'DATA_FLOW_DURATION_SEC': 300,
+                'data_flow_delay_sec': 1,
+                'SNAPPI_POLL_DELAY_SEC': 60,
+                'test_type': '/tmp/Two_Ingress_Single_Egress_pfcwd_frwd_40_9_dist'+str(port_map[1])+'Gbps',
+                'line_card_choice': line_card_choice,
+                'port_map': port_map,
+                'enable_pfcwd_drop': False,
+                'enable_pfcwd_fwd': True,
+                'enable_credit_wd': True,
+                'stats_interval': 60,
+                'background_traffic': True,
+                'verify_flows': False,
+                'imix': False,
+                'test_check': test_check}
+
+    logger.info('Starting the test for line_card_choice : {}'.format(line_card_choice))
+    if line_card_choice not in linecard_configuration_set.keys():
+        assert False, "Invalid line_card_choice value passed in parameter"
+
+    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
+        dut_list = [dut for dut in duthosts
+                    if dut.hostname in linecard_configuration_set[line_card_choice]['hostname']]
+        duthost1, duthost2 = dut_list
+    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
+        dut_list = [dut for dut in duthosts
+                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
+        duthost1 = duthost2 = dut_list[0]
+    else:
+        assert False, "Hostname can't be an empty list"
+
+    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
+                                                 line_card_info=linecard_configuration_set[line_card_choice])
+
+    if len(snappi_port_list) < 3:
+        assert False, "Need Minimum of 3 ports for the test"
+
+    snappi_ports = new_get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, port_map)
+
+    if len(snappi_ports) < 3:
+        assert False, "Need Minimum of 3 ports for the test"
+
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+                                                                            snappi_ports,
+                                                                            snappi_api)
+
+    test_prio_list = lossless_prio_list
+    pause_prio_list = test_prio_list
+    bg_prio_list = [0, 1, 2]
+    logger.info("Snappi Ports : {}".format(snappi_ports))
+
+    logger.info('PFC-WD stats at the start of the test:')
+    for prio in test_prio_list:
+        for port in snappi_ports:
+            if len(dut_list) == 1:
+                if dut_list[0].hostname == port['peer_device']:
+                    logger.info('PFCWD stats for dut:{}, port:{},prio:{}'.
+                                format(dut_list[0].hostname, port['peer_port'], prio))
+                    pfcwd_stats = get_pfcwd_stats(dut_list[0], port['peer_port'], prio)
+                    logger.info('PFCWD Stats:{}'.format(pfcwd_stats))
+            else:
+                for dut in dut_list:
+                    if dut.hostname == port['peer_device']:
+                        logger.info('PFCWD stats for dut:{}, port:{},prio:{}'.
+                                    format(dut.hostname, port['peer_port'], prio))
+                        pfcwd_stats = get_pfcwd_stats(dut, port['peer_port'], prio)
+                        logger.info('PFCWD Stats::{}'.format(pfcwd_stats))
+
+    snappi_extra_params = SnappiSysTestParams()
+    snappi_extra_params.multi_dut_params.duthost1 = duthost1
+    snappi_extra_params.multi_dut_params.duthost2 = duthost2
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=True,
+                     test_def=test_def,
+                     snappi_extra_params=snappi_extra_params)
+
+        logger.info('PFC-WD stats at the end of the test:')
+        for prio in test_prio_list:
+            for port in snappi_ports:
+                if len(dut_list) == 1:
+                    if dut_list[0].hostname == port['peer_device']:
+                        pfcwd_stats = get_pfcwd_stats(dut_list[0], port['peer_port'], prio)
+                        logger.info('PFCWD Stats:for dut:{}, port:{},prio:{}, stats::{}'.
+                                    format(dut_list[0].hostname, port['peer_port'], prio, pfcwd_stats))
+                else:
+                    for dut in dut_list:
+                        if dut.hostname == port['peer_device']:
+                            pfcwd_stats = get_pfcwd_stats(dut, port['peer_port'], prio)
+                            logger.info('PFCWD Stats:for dut:{}, port:{},prio:{}, stats::{}'.
+                                        format(dut.hostname, port['peer_port'], prio, pfcwd_stats))
+    finally:
+        cleanup_config(dut_list, snappi_ports)
+
+
+@pytest.mark.parametrize('linecard_configuration_set', [config_set])
+@pytest.mark.parametrize('line_card_choice', line_card_choice)
+def test_pfcwd_disable_pause_cngtn(snappi_api,                  # noqa: F811
+                                   conn_graph_facts,            # noqa: F811
+                                   fanout_graph_facts,          # noqa: F811
+                                   duthosts,
+                                   prio_dscp_map,                # noqa: F811
+                                   line_card_choice,
+                                   linecard_configuration_set,
+                                   get_multidut_snappi_ports):    # noqa: F811
+
+    """
+    Test with single ingress and egress with uniform traffic across  multiple lossless priorities for 100Gbps line-rate
+
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        line_card_choice: Line card choice to be mentioned in the variable.py file
+        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
+    Returns:
+        N/A
+    Purpose of the test case is to test oversubscription with two ingresses and single ingress.
+    Traffic pattern has 18% lossless priority and 27% lossy priority traffic.
+    Total ingress link is sending only 45% link capacity and hence egress will not be congested.
+    No losses for both lossless and lossy priority traffic.
+    """
+
+    # port_map is defined as port-speed combination.
+    # first two parameters are count of egress links and its speed.
+    # last two parameters are count of ingress links and its speed.
+    if '100Gbps' in line_card_choice:
+        port_map = [1, 100, 1, 100]
+    else:
+        port_map = [1, 400, 1, 400]
+
+    # pkt_size of 1024B will be used unless imix flag is set.
+    # With imix flag set, the traffic_generation.py uses IMIX profile.
+    pkt_size = 1024
+
+    # Percentage drop expected for lossless and lossy traffic.
+    # speed_tol is speed tolerance between egress link speed and actual speed.
+    # loss_expected to check losses on DUT and TGEN.
+    test_check = {'lossless': 0, 'lossy': 0, 'speed_tol': 41, 'loss_expected': False, 'pfc': True}
+
+    test_def = {'TEST_FLOW_AGGR_RATE_PERCENT': 40,
+                'BG_FLOW_AGGR_RATE_PERCENT': 60,
+                'data_flow_pkt_size': pkt_size,
+                'DATA_FLOW_DURATION_SEC': 300,
+                'data_flow_delay_sec': 1,
+                'SNAPPI_POLL_DELAY_SEC': 60,
+                'test_type': '/tmp/Single_Ingress_Single_Egress_pause_cngstn_'+str(port_map[1])+'Gbps',
+                'line_card_choice': line_card_choice,
+                'port_map': port_map,
+                'enable_pfcwd_drop': False,
+                'enable_pfcwd_fwd': False,
+                'enable_credit_wd': False,
+                'stats_interval': 60,
+                'background_traffic': True,
+                'verify_flows': False,
+                'imix': False,
+                'test_check': test_check}
+
+    logger.info('Starting the test for line_card_choice : {}'.format(line_card_choice))
+    if line_card_choice not in linecard_configuration_set.keys():
+        assert False, "Invalid line_card_choice value passed in parameter"
+
+    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
+        dut_list = [dut for dut in duthosts
+                    if dut.hostname in linecard_configuration_set[line_card_choice]['hostname']]
+        duthost1, duthost2 = dut_list
+    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
+        dut_list = [dut for dut in duthosts
+                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
+        duthost1 = duthost2 = dut_list[0]
+    else:
+        assert False, "Hostname can't be an empty list"
+
+    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
+                                                 line_card_info=linecard_configuration_set[line_card_choice])
+
+    if len(snappi_port_list) < 2:
+        assert False, "snappi_port_list: Need Minimum of 2 ports for the test"
+
+    # port_map is read as egress port_map[0] links of port_map[1] speed
+    # and ingress port_map[2] links of port_map[3] speed
+    port_map = test_def['port_map']
+
+    snappi_ports = new_get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, port_map)
+
+    if len(snappi_ports) < 2:
+        assert False, "snappi_ports: Need Minimum of 2 ports for the test"
+
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+                                                                            snappi_ports,
+                                                                            snappi_api)
+
+    test_prio_list = [3, 4]
+    pause_prio_list = test_prio_list
+    bg_prio_list = [0, 1, 2]
+    logger.info("Snappi Ports : {}".format(snappi_ports))
+
+    snappi_extra_params = SnappiSysTestParams()
+    snappi_extra_params.multi_dut_params.duthost1 = duthost1
+    snappi_extra_params.multi_dut_params.duthost2 = duthost2
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=True,
+                     test_def=test_def,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(dut_list, snappi_ports)

--- a/tests/snappi_tests/multidut/systest/test_non_congestion_imix.py
+++ b/tests/snappi_tests/multidut/systest/test_non_congestion_imix.py
@@ -1,0 +1,377 @@
+import pytest
+from tests.common.helpers.assertions import pytest_require, pytest_assert                   # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
+    snappi_api, snappi_dut_base_config, get_multidut_snappi_ports, \
+    new_get_multidut_tgen_peer_port_set, cleanup_config    # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map        # noqa: F401
+from tests.snappi_tests.variables import config_set, line_card_choice
+from files.sys_multidut_helper import run_pfc_test
+from tests.common.snappi_tests.snappi_systest_params import SnappiSysTestParams
+
+import logging
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.topology('multidut-tgen')]
+
+
+@pytest.mark.parametrize('linecard_configuration_set', [config_set])
+@pytest.mark.parametrize('line_card_choice', line_card_choice)
+def test_multiple_prio_diff_dist(snappi_api,                  # noqa: F811
+                                 conn_graph_facts,            # noqa: F811
+                                 fanout_graph_facts,          # noqa: F811
+                                 duthosts,
+                                 prio_dscp_map,                # noqa: F811
+                                 line_card_choice,
+                                 linecard_configuration_set,
+                                 get_multidut_snappi_ports):    # noqa: F811
+
+    """
+    Test if PFC can pause multiple lossless priorities for 100Gbps line-rate
+
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        line_card_choice: Line card choice to be mentioned in the variable.py file
+        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
+    Returns:
+        N/A
+    """
+
+    # port_map is defined as port-speed combination.
+    # first two parameters are count of egress links and its speed.
+    # last two parameters are count of ingress links and its speed.
+    if '100Gbps' in line_card_choice:
+        port_map = [1, 100, 1, 100]
+    else:
+        port_map = [1, 400, 1, 400]
+
+    # pkt_size of 1024B will be used unless imix flag is set.
+    # With imix flag set, the traffic_generation.py uses IMIX profile.
+    pkt_size = 1024
+
+    # Percentage drop expected for lossless and lossy traffic.
+    # speed_tol is speed tolerance between egress link speed and actual speed.
+    # loss_expected to check losses on DUT and TGEN.
+    test_check = {'lossless': 0, 'lossy': 0, 'speed_tol': 3, 'loss_expected': False}
+    test_def = {'TEST_FLOW_AGGR_RATE_PERCENT': 88,
+                'BG_FLOW_AGGR_RATE_PERCENT': 12,
+                'data_flow_pkt_size': pkt_size,
+                'DATA_FLOW_DURATION_SEC': 300,
+                'data_flow_delay_sec': 0,
+                'SNAPPI_POLL_DELAY_SEC': 60,
+                'test_type': '/tmp/Single_Ingress_Egress_diff_dist_'+str(port_map[1])+'Gbps',
+                'line_card_choice': line_card_choice,
+                'port_map': port_map,
+                'enable_pfcwd': True,
+                'enable_credit_wd': True,
+                'stats_interval': 60,
+                'background_traffic': True,
+                'imix': True,
+                'test_check': test_check,
+                'verify_flows': True}
+
+    logger.info('Starting the test for line_card_choice : {}'.format(line_card_choice))
+    if line_card_choice not in linecard_configuration_set.keys():
+        assert False, "Invalid line_card_choice value passed in parameter"
+
+    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
+        dut_list = [dut for dut in duthosts
+                    if dut.hostname in linecard_configuration_set[line_card_choice]['hostname']]
+        duthost1, duthost2 = dut_list
+    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
+        dut_list = [dut for dut in duthosts
+                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
+        duthost1 = duthost2 = dut_list[0]
+    else:
+        assert False, "Hostname can't be an empty list"
+
+    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
+                                                 line_card_info=linecard_configuration_set[line_card_choice])
+
+    if len(snappi_port_list) < 2:
+        assert False, "Need Minimum of 2 ports for the test"
+
+    snappi_ports = new_get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, port_map)
+
+    if len(snappi_ports) < 2:
+        assert False, "Need Minimum of 2 ports for the test"
+
+    logger.info("Snappi Ports : {}".format(snappi_ports))
+
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+                                                                            snappi_ports,
+                                                                            snappi_api)
+
+    test_prio_list = [3, 4]
+    pause_prio_list = test_prio_list
+    bg_prio_list = [0, 1, 2]
+
+    snappi_extra_params = SnappiSysTestParams()
+    snappi_extra_params.multi_dut_params.duthost1 = duthost1
+    snappi_extra_params.multi_dut_params.duthost2 = duthost2
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=False,
+                     test_def=test_def,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(dut_list, snappi_ports)
+
+
+@pytest.mark.parametrize('linecard_configuration_set', [config_set])
+@pytest.mark.parametrize('line_card_choice', line_card_choice)
+def test_multiple_prio_uni_dist(snappi_api,                  # noqa: F811
+                                conn_graph_facts,            # noqa: F811
+                                fanout_graph_facts,          # noqa: F811
+                                duthosts,
+                                prio_dscp_map,                # noqa: F811
+                                line_card_choice,
+                                linecard_configuration_set,
+                                get_multidut_snappi_ports):    # noqa: F811
+
+    """
+    Test with single ingress and egress with uniform traffic across  multiple lossless priorities for 100Gbps line-rate
+
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        line_card_choice: Line card choice to be mentioned in the variable.py file
+        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
+    Returns:
+        N/A
+    """
+
+    # port_map is defined as port-speed combination.
+    # first two parameters are count of egress links and its speed.
+    # last two parameters are count of ingress links and its speed.
+    if '100Gbps' in line_card_choice:
+        port_map = [1, 100, 1, 100]
+    else:
+        port_map = [1, 400, 1, 400]
+
+    # pkt_size of 1024B will be used unless imix flag is set.
+    # With imix flag set, the traffic_generation.py uses IMIX profile.
+    pkt_size = 1024
+
+    # Percentage drop expected for lossless and lossy traffic.
+    # speed_tol is speed tolerance between egress link speed and actual speed.
+    # loss_expected to check losses on DUT and TGEN.
+    test_check = {'lossless': 0, 'lossy': 0, 'speed_tol': 3, 'loss_expected': False}
+
+    test_def = {'TEST_FLOW_AGGR_RATE_PERCENT': 40,
+                'BG_FLOW_AGGR_RATE_PERCENT': 60,
+                'data_flow_pkt_size': pkt_size,
+                'DATA_FLOW_DURATION_SEC': 300,
+                'data_flow_delay_sec': 0,
+                'SNAPPI_POLL_DELAY_SEC': 60,
+                'test_type': '/tmp/Single_Ingress_Egress_uni_dist_'+str(port_map[1])+'Gbps',
+                'line_card_choice': line_card_choice,
+                'port_map': port_map,
+                'enable_pfcwd': True,
+                'enable_credit_wd': True,
+                'stats_interval': 60,
+                'background_traffic': True,
+                'imix': True,
+                'test_check': test_check,
+                'verify_flows': True}
+
+    logger.info('Starting the test for line_card_choice : {}'.format(line_card_choice))
+    if line_card_choice not in linecard_configuration_set.keys():
+        assert False, "Invalid line_card_choice value passed in parameter"
+
+    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
+        dut_list = [dut for dut in duthosts
+                    if dut.hostname in linecard_configuration_set[line_card_choice]['hostname']]
+        duthost1, duthost2 = dut_list
+    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
+        dut_list = [dut for dut in duthosts
+                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
+        duthost1 = duthost2 = dut_list[0]
+    else:
+        assert False, "Hostname can't be an empty list"
+
+    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
+                                                 line_card_info=linecard_configuration_set[line_card_choice])
+
+    if len(snappi_port_list) < 2:
+        assert False, "Need Minimum of 2 ports for the test"
+
+    # port_map is read as egress port_map[0] links of port_map[1] speed
+    # and ingress port_map[2] links of port_map[3] speed
+    port_map = test_def['port_map']
+
+    snappi_ports = new_get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, port_map)
+
+    if len(snappi_ports) < 2:
+        assert False, "Need Minimum of 2 ports for the test"
+
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+                                                                            snappi_ports,
+                                                                            snappi_api)
+
+    test_prio_list = [3, 4]
+    pause_prio_list = test_prio_list
+    bg_prio_list = [0, 1, 2]
+    logger.info("Snappi Ports : {}".format(snappi_ports))
+
+    snappi_extra_params = SnappiSysTestParams()
+    snappi_extra_params.multi_dut_params.duthost1 = duthost1
+    snappi_extra_params.multi_dut_params.duthost2 = duthost2
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=False,
+                     test_def=test_def,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(dut_list, snappi_ports)
+
+
+@pytest.mark.parametrize('linecard_configuration_set', [config_set])
+@pytest.mark.parametrize('line_card_choice', line_card_choice)
+def test_single_lossless_prio(snappi_api,                  # noqa: F811
+                              conn_graph_facts,            # noqa: F811
+                              fanout_graph_facts,          # noqa: F811
+                              duthosts,
+                              prio_dscp_map,                # noqa: F811
+                              line_card_choice,
+                              linecard_configuration_set,
+                              get_multidut_snappi_ports):    # noqa: F811
+
+    """
+    Test for single ingress and egress with single lossless priority for 100Gbps line-rate
+
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        line_card_choice: Line card choice to be mentioned in the variable.py file
+        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
+    Returns:
+        N/A
+    """
+
+    # port_map is defined as port-speed combination.
+    # first two parameters are count of egress links and its speed.
+    # last two parameters are count of ingress links and its speed.
+    if '100Gbps' in line_card_choice:
+        port_map = [1, 100, 1, 100]
+    else:
+        port_map = [1, 400, 1, 400]
+
+    # pkt_size of 1024B will be used unless imix flag is set.
+    # With imix flag set, the traffic_generation.py uses IMIX profile.
+    pkt_size = 1024
+
+    # Percentage drop expected for lossless and lossy traffic.
+    # speed_tol is speed tolerance between egress link speed and actual speed.
+    # loss_expected to check losses on DUT and TGEN.
+    test_check = {'lossless': 0, 'lossy': 0, 'speed_tol': 3, 'loss_expected': False}
+    test_def = {'TEST_FLOW_AGGR_RATE_PERCENT': 100,
+                'BG_FLOW_AGGR_RATE_PERCENT': 50,
+                'data_flow_pkt_size': pkt_size,
+                'DATA_FLOW_DURATION_SEC': 300,
+                'data_flow_delay_sec': 0,
+                'SNAPPI_POLL_DELAY_SEC': 60,
+                'test_type': '/tmp/Single_Ingress_Egress_1Prio_linerate_'+str(port_map[1])+'Gbps',
+                'line_card_choice': line_card_choice,
+                'port_map': port_map,
+                'enable_pfcwd': True,
+                'enable_credit_wd': True,
+                'stats_interval': 60,
+                'background_traffic': False,
+                'imix': True,
+                'test_check': test_check,
+                'verify_flows': True}
+
+    logger.info('Starting the test for line_card_choice : {}'.format(line_card_choice))
+
+    if line_card_choice not in linecard_configuration_set.keys():
+        assert False, "Invalid line_card_choice value passed in parameter"
+    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
+        dut_list = [dut for dut in duthosts
+                    if dut.hostname in linecard_configuration_set[line_card_choice]['hostname']]
+        duthost1, duthost2 = dut_list
+    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
+        dut_list = [dut for dut in duthosts
+                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
+        duthost1 = duthost2 = dut_list[0]
+    else:
+        assert False, "Hostname can't be an empty list"
+
+    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
+                                                 line_card_info=linecard_configuration_set[line_card_choice])
+
+    if len(snappi_port_list) < 2:
+        assert False, "Need Minimum of 2 ports for the test"
+
+    # port_map is read as egress port_map[0] links of port_map[1] speed
+    # and ingress port_map[2] links of port_map[3] speed
+    port_map = test_def['port_map']
+
+    snappi_ports = new_get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, port_map)
+
+    if len(snappi_ports) < 2:
+        assert False, "Need Minimum of 2 ports for the test"
+
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+                                                                            snappi_ports,
+                                                                            snappi_api)
+
+    test_prio_list = [3]
+    logger.info('Selected Test Prio:{}'.format(test_prio_list))
+    pause_prio_list = test_prio_list
+    bg_prio_list = [0, 1, 2]
+    logger.info("Pkt Size:{}, Current port_map:{} and Snappi Ports : {}".format(pkt_size, port_map, snappi_ports))
+
+    snappi_extra_params = SnappiSysTestParams()
+    snappi_extra_params.multi_dut_params.duthost1 = duthost1
+    snappi_extra_params.multi_dut_params.duthost2 = duthost2
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=False,
+                     test_def=test_def,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(dut_list, snappi_ports)

--- a/tests/snappi_tests/multidut/systest/test_over_subscription_imix.py
+++ b/tests/snappi_tests/multidut/systest/test_over_subscription_imix.py
@@ -40,18 +40,18 @@ def test_multiple_prio_diff_dist(snappi_api,                  # noqa: F811
     Returns:
         N/A
 
-    Purpose of the test-case is to ensure that link speed is achieved with 90% lossless priority traffic
-    and 10% lossy priority traffic.
-    No drops are seen.
+    Purpose of the test case is to test oversubscription with two ingresses and single ingress.
+    Traffic pattern has 90% lossless priority and 10% lossy priority traffic.
+    No losses for both lossless and lossy priority traffic.
     """
 
     # port_map is defined as port-speed combination.
     # first two parameters are count of egress links and its speed.
     # last two parameters are count of ingress links and its speed.
     if '100Gbps' in line_card_choice:
-        port_map = [1, 100, 1, 100]
+        port_map = [1, 100, 2, 100]
     else:
-        port_map = [1, 400, 1, 400]
+        port_map = [1, 400, 2, 400]
 
     # pkt_size of 1024B will be used unless imix flag is set.
     # With imix flag set, the traffic_generation.py uses IMIX profile.
@@ -60,14 +60,14 @@ def test_multiple_prio_diff_dist(snappi_api,                  # noqa: F811
     # Percentage drop expected for lossless and lossy traffic.
     # speed_tol is speed tolerance between egress link speed and actual speed.
     # loss_expected to check losses on DUT and TGEN.
-    test_check = {'lossless': 0, 'lossy': 0, 'speed_tol': 3, 'loss_expected': False, 'pfc': False}
+    test_check = {'lossless': 0, 'lossy': 0, 'speed_tol': 3, 'loss_expected': False, 'pfc': True}
     test_def = {'TEST_FLOW_AGGR_RATE_PERCENT': 88,
                 'BG_FLOW_AGGR_RATE_PERCENT': 12,
                 'data_flow_pkt_size': pkt_size,
                 'DATA_FLOW_DURATION_SEC': 300,
                 'data_flow_delay_sec': 0,
                 'SNAPPI_POLL_DELAY_SEC': 60,
-                'test_type': '/tmp/Single_Ingress_Egress_diff_dist_'+str(port_map[1])+'Gbps',
+                'test_type': '/tmp/Two_Ingress_Single_Egress_diff_dist_'+str(port_map[1])+'Gbps',
                 'line_card_choice': line_card_choice,
                 'port_map': port_map,
                 'enable_pfcwd': True,
@@ -76,7 +76,7 @@ def test_multiple_prio_diff_dist(snappi_api,                  # noqa: F811
                 'background_traffic': True,
                 'imix': True,
                 'test_check': test_check,
-                'verify_flows': True}
+                'verify_flows': False}
 
     logger.info('Starting the test for line_card_choice : {}'.format(line_card_choice))
     if line_card_choice not in linecard_configuration_set.keys():
@@ -96,13 +96,13 @@ def test_multiple_prio_diff_dist(snappi_api,                  # noqa: F811
     snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
                                                  line_card_info=linecard_configuration_set[line_card_choice])
 
-    if len(snappi_port_list) < 2:
-        assert False, "Need Minimum of 2 ports for the test"
+    if len(snappi_port_list) < 3:
+        assert False, "snappi_port_list: Need Minimum of 3 ports for the test"
 
     snappi_ports = new_get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, port_map)
 
-    if len(snappi_ports) < 2:
-        assert False, "Need Minimum of 2 ports for the test"
+    if len(snappi_ports) < 3:
+        assert False, "snappi_port: Need Minimum of 3 ports for the test"
 
     logger.info("Snappi Ports : {}".format(snappi_ports))
 
@@ -113,6 +113,133 @@ def test_multiple_prio_diff_dist(snappi_api,                  # noqa: F811
     test_prio_list = [3, 4]
     pause_prio_list = test_prio_list
     bg_prio_list = [0, 1, 2]
+
+    snappi_extra_params = SnappiSysTestParams()
+    snappi_extra_params.multi_dut_params.duthost1 = duthost1
+    snappi_extra_params.multi_dut_params.duthost2 = duthost2
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=False,
+                     test_def=test_def,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(dut_list, snappi_ports)
+
+
+@pytest.mark.parametrize('linecard_configuration_set', [config_set])
+@pytest.mark.parametrize('line_card_choice', line_card_choice)
+def test_multiple_prio_uni_dist_full(snappi_api,                  # noqa: F811
+                                     conn_graph_facts,            # noqa: F811
+                                     fanout_graph_facts,          # noqa: F811
+                                     duthosts,
+                                     prio_dscp_map,                # noqa: F811
+                                     line_card_choice,
+                                     linecard_configuration_set,
+                                     get_multidut_snappi_ports):    # noqa: F811
+
+    """
+    Test with single ingress and egress with uniform traffic across  multiple lossless priorities for 100Gbps line-rate
+
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        line_card_choice: Line card choice to be mentioned in the variable.py file
+        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
+    Returns:
+        N/A
+
+    Purpose of the test case is to test oversubscription with two ingresses and single ingress.
+    Traffic pattern has 24% lossless priority and 36% lossy priority traffic.
+    Each priority carries equal 12% of traffic.
+    No losses for lossless priority traffic. Some loss expected for lossy priority traffic.
+    """
+
+    # port_map is defined as port-speed combination.
+    # first two parameters are count of egress links and its speed.
+    # last two parameters are count of ingress links and its speed.
+    if '100Gbps' in line_card_choice:
+        port_map = [1, 100, 2, 100]
+    else:
+        port_map = [1, 400, 2, 400]
+
+    # pkt_size of 1024B will be used unless imix flag is set.
+    # With imix flag set, the traffic_generation.py uses IMIX profile.
+    pkt_size = 1024
+
+    # Percentage drop expected for lossless and lossy traffic.
+    # speed_tol is speed tolerance between egress link speed and actual speed.
+    # loss_expected to check losses on DUT and TGEN.
+    test_check = {'lossless': 0, 'lossy': 51, 'speed_tol': 51, 'loss_expected': True, 'pfc': True}
+
+    test_def = {'TEST_FLOW_AGGR_RATE_PERCENT': 40,
+                'BG_FLOW_AGGR_RATE_PERCENT': 60,
+                'data_flow_pkt_size': pkt_size,
+                'DATA_FLOW_DURATION_SEC': 300,
+                'data_flow_delay_sec': 0,
+                'SNAPPI_POLL_DELAY_SEC': 60,
+                'test_type': '/tmp/Two_Ingress_Single_Egress_uni_dist_full'+str(port_map[1])+'Gbps',
+                'line_card_choice': line_card_choice,
+                'port_map': port_map,
+                'enable_pfcwd': True,
+                'enable_credit_wd': True,
+                'stats_interval': 60,
+                'background_traffic': True,
+                'imix': True,
+                'test_check': test_check,
+                'verify_flows': False}
+
+    logger.info('Starting the test for line_card_choice : {}'.format(line_card_choice))
+    if line_card_choice not in linecard_configuration_set.keys():
+        assert False, "Invalid line_card_choice value passed in parameter"
+
+    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
+        dut_list = [dut for dut in duthosts
+                    if dut.hostname in linecard_configuration_set[line_card_choice]['hostname']]
+        duthost1, duthost2 = dut_list
+    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
+        dut_list = [dut for dut in duthosts
+                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
+        duthost1 = duthost2 = dut_list[0]
+    else:
+        assert False, "Hostname can't be an empty list"
+
+    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
+                                                 line_card_info=linecard_configuration_set[line_card_choice])
+
+    if len(snappi_port_list) < 3:
+        assert False, "snappi_port_list: Need Minimum of 3 ports for the test"
+
+    # port_map is read as egress port_map[0] links of port_map[1] speed
+    # and ingress port_map[2] links of port_map[3] speed
+    port_map = test_def['port_map']
+
+    snappi_ports = new_get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, port_map)
+
+    if len(snappi_ports) < 3:
+        assert False, "snappi_ports: Need Minimum of 3 ports for the test"
+
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+                                                                            snappi_ports,
+                                                                            snappi_api)
+
+    test_prio_list = [3, 4]
+    pause_prio_list = test_prio_list
+    bg_prio_list = [0, 1, 2]
+    logger.info("Snappi Ports : {}".format(snappi_ports))
 
     snappi_extra_params = SnappiSysTestParams()
     snappi_extra_params.multi_dut_params.duthost1 = duthost1
@@ -162,17 +289,21 @@ def test_multiple_prio_uni_dist(snappi_api,                  # noqa: F811
     Returns:
         N/A
 
-    Purpose of the test-case is to ensure that link speed is achieved with uniform lossless and lossy priority traffic.
-    No drops are seen.
+    Purpose of the test case is to test oversubscription with two ingresses and single ingress.
+    Traffic pattern has 24% lossless priority and 36% lossy priority traffic.
+    Each priority carries equal 12% of traffic.
+    No losses for lossless priority traffic. Some loss expected for lossy priority traffic.
     """
+    if (line_card_choice == 'chassis_slcsa_400Gbps'):
+        pytest.skip('Not enough 400Gbps ports on Single LC Single ASICs')
 
     # port_map is defined as port-speed combination.
     # first two parameters are count of egress links and its speed.
     # last two parameters are count of ingress links and its speed.
     if '100Gbps' in line_card_choice:
-        port_map = [1, 100, 1, 100]
+        port_map = [1, 100, 2, 100]
     else:
-        port_map = [1, 400, 1, 400]
+        port_map = [1, 400, 2, 400]
 
     # pkt_size of 1024B will be used unless imix flag is set.
     # With imix flag set, the traffic_generation.py uses IMIX profile.
@@ -181,15 +312,15 @@ def test_multiple_prio_uni_dist(snappi_api,                  # noqa: F811
     # Percentage drop expected for lossless and lossy traffic.
     # speed_tol is speed tolerance between egress link speed and actual speed.
     # loss_expected to check losses on DUT and TGEN.
-    test_check = {'lossless': 0, 'lossy': 0, 'speed_tol': 3, 'loss_expected': False, 'pfc': False}
+    test_check = {'lossless': 0, 'lossy': 15, 'speed_tol': 3, 'loss_expected': True, 'pfc': True}
 
-    test_def = {'TEST_FLOW_AGGR_RATE_PERCENT': 40,
-                'BG_FLOW_AGGR_RATE_PERCENT': 60,
+    test_def = {'TEST_FLOW_AGGR_RATE_PERCENT': 24,
+                'BG_FLOW_AGGR_RATE_PERCENT': 36,
                 'data_flow_pkt_size': pkt_size,
                 'DATA_FLOW_DURATION_SEC': 300,
                 'data_flow_delay_sec': 0,
                 'SNAPPI_POLL_DELAY_SEC': 60,
-                'test_type': '/tmp/Single_Ingress_Egress_uni_dist_'+str(port_map[1])+'Gbps',
+                'test_type': '/tmp/Two_Ingress_Single_Egress_uni_dist_'+str(port_map[1])+'Gbps',
                 'line_card_choice': line_card_choice,
                 'port_map': port_map,
                 'enable_pfcwd': True,
@@ -198,7 +329,7 @@ def test_multiple_prio_uni_dist(snappi_api,                  # noqa: F811
                 'background_traffic': True,
                 'imix': True,
                 'test_check': test_check,
-                'verify_flows': True}
+                'verify_flows': False}
 
     logger.info('Starting the test for line_card_choice : {}'.format(line_card_choice))
     if line_card_choice not in linecard_configuration_set.keys():
@@ -218,8 +349,8 @@ def test_multiple_prio_uni_dist(snappi_api,                  # noqa: F811
     snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
                                                  line_card_info=linecard_configuration_set[line_card_choice])
 
-    if len(snappi_port_list) < 2:
-        assert False, "Need Minimum of 2 ports for the test"
+    if len(snappi_port_list) < 3:
+        assert False, "snappi_port_list: Need Minimum of 3 ports for the test"
 
     # port_map is read as egress port_map[0] links of port_map[1] speed
     # and ingress port_map[2] links of port_map[3] speed
@@ -227,8 +358,8 @@ def test_multiple_prio_uni_dist(snappi_api,                  # noqa: F811
 
     snappi_ports = new_get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, port_map)
 
-    if len(snappi_ports) < 2:
-        assert False, "Need Minimum of 2 ports for the test"
+    if len(snappi_ports) < 3:
+        assert False, "snappi_ports: Need Minimum of 3 ports for the test"
 
     testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
                                                                             snappi_ports,
@@ -264,17 +395,17 @@ def test_multiple_prio_uni_dist(snappi_api,                  # noqa: F811
 
 @pytest.mark.parametrize('linecard_configuration_set', [config_set])
 @pytest.mark.parametrize('line_card_choice', line_card_choice)
-def test_single_lossless_prio(snappi_api,                  # noqa: F811
-                              conn_graph_facts,            # noqa: F811
-                              fanout_graph_facts,          # noqa: F811
-                              duthosts,
-                              prio_dscp_map,                # noqa: F811
-                              line_card_choice,
-                              linecard_configuration_set,
-                              get_multidut_snappi_ports):    # noqa: F811
+def test_multiple_prio_non_cngtn(snappi_api,                  # noqa: F811
+                                 conn_graph_facts,            # noqa: F811
+                                 fanout_graph_facts,          # noqa: F811
+                                 duthosts,
+                                 prio_dscp_map,                # noqa: F811
+                                 line_card_choice,
+                                 linecard_configuration_set,
+                                 get_multidut_snappi_ports):    # noqa: F811
 
     """
-    Test for single ingress and egress with single lossless priority for 100Gbps line-rate
+    Test with single ingress and egress with uniform traffic across  multiple lossless priorities for 100Gbps line-rate
 
     Args:
         snappi_api (pytest fixture): SNAPPI session
@@ -286,17 +417,21 @@ def test_single_lossless_prio(snappi_api,                  # noqa: F811
         linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
     Returns:
         N/A
-    Purpose of the test is to send single lossless priority at link speed. No background traffic sent.
-    No losses expected.
+    Purpose of the test case is to test oversubscription with two ingresses and single ingress.
+    Traffic pattern has 18% lossless priority and 27% lossy priority traffic.
+    Total ingress link is sending only 45% link capacity and hence egress will not be congested.
+    No losses for both lossless and lossy priority traffic.
     """
+    if (line_card_choice == 'chassis_slcsa_400Gbps'):
+        pytest.skip('Not enough 400Gbps ports on Single LC Single ASICs')
 
     # port_map is defined as port-speed combination.
     # first two parameters are count of egress links and its speed.
     # last two parameters are count of ingress links and its speed.
     if '100Gbps' in line_card_choice:
-        port_map = [1, 100, 1, 100]
+        port_map = [1, 100, 2, 100]
     else:
-        port_map = [1, 400, 1, 400]
+        port_map = [1, 400, 2, 400]
 
     # pkt_size of 1024B will be used unless imix flag is set.
     # With imix flag set, the traffic_generation.py uses IMIX profile.
@@ -305,28 +440,29 @@ def test_single_lossless_prio(snappi_api,                  # noqa: F811
     # Percentage drop expected for lossless and lossy traffic.
     # speed_tol is speed tolerance between egress link speed and actual speed.
     # loss_expected to check losses on DUT and TGEN.
-    test_check = {'lossless': 0, 'lossy': 0, 'speed_tol': 3, 'loss_expected': False, 'pfc': False}
-    test_def = {'TEST_FLOW_AGGR_RATE_PERCENT': 100,
-                'BG_FLOW_AGGR_RATE_PERCENT': 50,
+    test_check = {'lossless': 0, 'lossy': 0, 'speed_tol': 14, 'loss_expected': False, 'pfc': False}
+
+    test_def = {'TEST_FLOW_AGGR_RATE_PERCENT': 18,
+                'BG_FLOW_AGGR_RATE_PERCENT': 27,
                 'data_flow_pkt_size': pkt_size,
                 'DATA_FLOW_DURATION_SEC': 300,
                 'data_flow_delay_sec': 0,
                 'SNAPPI_POLL_DELAY_SEC': 60,
-                'test_type': '/tmp/Single_Ingress_Egress_1Prio_linerate_'+str(port_map[1])+'Gbps',
+                'test_type': '/tmp/Two_Ingress_Single_Egress_non_cngstn_'+str(port_map[1])+'Gbps',
                 'line_card_choice': line_card_choice,
                 'port_map': port_map,
                 'enable_pfcwd': True,
                 'enable_credit_wd': True,
                 'stats_interval': 60,
-                'background_traffic': False,
+                'background_traffic': True,
                 'imix': True,
                 'test_check': test_check,
-                'verify_flows': True}
+                'verify_flows': False}
 
     logger.info('Starting the test for line_card_choice : {}'.format(line_card_choice))
-
     if line_card_choice not in linecard_configuration_set.keys():
         assert False, "Invalid line_card_choice value passed in parameter"
+
     if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
         dut_list = [dut for dut in duthosts
                     if dut.hostname in linecard_configuration_set[line_card_choice]['hostname']]
@@ -341,8 +477,8 @@ def test_single_lossless_prio(snappi_api,                  # noqa: F811
     snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
                                                  line_card_info=linecard_configuration_set[line_card_choice])
 
-    if len(snappi_port_list) < 2:
-        assert False, "Need Minimum of 2 ports for the test"
+    if len(snappi_port_list) < 3:
+        assert False, "snappi_port_list: Need Minimum of 3 ports for the test"
 
     # port_map is read as egress port_map[0] links of port_map[1] speed
     # and ingress port_map[2] links of port_map[3] speed
@@ -350,18 +486,17 @@ def test_single_lossless_prio(snappi_api,                  # noqa: F811
 
     snappi_ports = new_get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, port_map)
 
-    if len(snappi_ports) < 2:
-        assert False, "Need Minimum of 2 ports for the test"
+    if len(snappi_ports) < 3:
+        assert False, "snappi_ports: Need Minimum of 3 ports for the test"
 
     testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
                                                                             snappi_ports,
                                                                             snappi_api)
 
-    test_prio_list = [3]
-    logger.info('Selected Test Prio:{}'.format(test_prio_list))
+    test_prio_list = [3, 4]
     pause_prio_list = test_prio_list
     bg_prio_list = [0, 1, 2]
-    logger.info("Pkt Size:{}, Current port_map:{} and Snappi Ports : {}".format(pkt_size, port_map, snappi_ports))
+    logger.info("Snappi Ports : {}".format(snappi_ports))
 
     snappi_extra_params = SnappiSysTestParams()
     snappi_extra_params.multi_dut_params.duthost1 = duthost1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
PR - 13215 details the list of the new test-cases that were to be added to test PFC and ECN.

This PR is for the purpose of adding the necessary infrastructure for the same. Additionally, a single test case to test line-rate (for both 100Gbps and 400Gbps) is added.

Summary:
Fixes # (issue)
#13654 
#13653 
#13215 
#13752 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Pull request is for specifically providing infrastructure to run the additional testcases.


#### How did you do it?

1.
Test case has dictionary called test_def which defines various testcases parameters necessary to run the testcase. An example of this, is packet-size (default is IMIX but can be changed to 1024B), test-duration, stats capture, file log at the end of the test.

Similarly, there is test_check which passes test-case uses for verification info. By default, lossless prio's 3 and 4 are used and lossy prio 0,1 and 2 are used.

2.
Most important change comes in form of port_map definition. Port map is a list with first two parameters defining the egress port count and egress speed. Last two parameters define the ingress port count and ingress speed. Example - [1, 100, 2 , 100] defines single egress port of speed 100Gbps and 2 ingress ports of 100Gbps.

This definition is important because, multi-speed ingress and egress ports needs to be supported. Example - [1, 100, 1, 400] will define single ingress and egress of 400Gbps and 100Gbps respectively.

3.
A new function is provided to capture snappi_ports. This will pick the line-card choice from variable.py and choose the ports as defined in port_map. In case of single line-card multiple asic and multiple line-card scenario, if the ports cannot be fitted in existing line-cards, it will try and swap to see if they can be still fitted.

4. 
New gen_sys flows are used to generate test, background and pause flows. These are called upon by multidut_helper file. The creation of flows and number of flows (depending upon ingress and egress), and verification is done here. 

The multi_dut calls run_sys test in traffic_generation file and expects test_stats file in return. The test_stats contains summary of test execution results from both IXIA and DUT.

The rest_py is used to generate the imix custom profile.

4.
Depending upon the test_duration and test_interval defined in test_def of the test, the test-case will be executed.
At every test_interval, the statistics from IXIA and DUT are pulled in form of dictionary, where date-timestamp is primary key.

Important parameters from IXIA like Tx and Rx throughput, number of packets, latency etc are captured with each interval. 

From DUT side, the Rx and Tx packets, loss packets (combination of failures, drops and errors), PFC count, queue counts are captured. Additional functions like - get_pfc_count, get_ingerface_stats etc are defined in the common/snappi_test helper files to assist with the same.

At the end of the test, a CSV is created as raw data for the test-case execution. Summary of the test-case is generated in form of text file with same name. 

5.
Additional checks are present in multi_dut helper file, depending upon the type of the test. The test passes the verification parameters in test_check in dictionary format.

6.
There is important change in variables.py file. The line_card_choice is sent as type of list from variables.py, which then is parameterized in the test. Depending upon the type of line_card_choice, the tests are ran for that specific line_card choice and speed.

Example - line_card_choice = ['chassis_slcsa_100Gbps','chassis_mlcma_100Gbps','chassis_slcma_400Gbps']
will specifically run the test for single 100Gbps line card single asic 100Gbps, multiple 100Gbps line card multiple asic and single 400Gbps line card of multiple asic.


Additional support added in infrastructure:

#13654
There is pytest module function to enable credit watchdog as the test finishes. This function does not pass any asic_value. However function definition expects asic_value to be passed. Addressed this issue by enabling packet_aging on all available asics.

#13653 
The function to get lossless buffer packets is checking ingress lossless buffer profile for Cisco platform. Added Nokia specific code to return the ingress lossless buffer values for Nokia 7250 Broadcom DNX platform as well.

#13752 
Added support to enable PFCWD in Forwarding mode.

#### How did you verify/test it?
The test was executed on local setup in local clone.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
