### PR TITLE
[QoS JR2] Clone J2C+ changes for new vsq thresholds

### DIFF
--- a/tests/qos/files/qos_params.jr2.yaml
+++ b/tests/qos/files/qos_params.jr2.yaml
@@ -114,15 +114,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 418781
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 418781
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -131,43 +131,43 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 35208
+                    pkts_num_trig_pfc: 415271
                     pkts_num_hdrm_full: 362
                     pkts_num_hdrm_partial: 182
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 418781
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_dismiss_pfc: 3243
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 35108
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_dismiss_pfc: 3243
                     pkts_num_margin: 150
                 lossy_queue_1:
-                    dscp: 7
+                    dscp: 8
                     ecn: 1
-                    pg: 1
+                    pg: 0
                     pkts_num_trig_egr_drp: 2396745
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_fill_min: 51
-                    pkts_num_trig_pfc: 9874
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 415271
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -175,7 +175,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_fill_min: 51
+                    pkts_num_fill_min: 0
                     pkts_num_trig_egr_drp: 2396745
                     packet_size: 64
                     cell_size: 4096
@@ -185,7 +185,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 38619
+                    pkts_num_trig_ingr_drp: 418781
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -220,15 +220,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 216064
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 593885
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 216064
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 593885
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -237,43 +237,43 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 37549
+                    pkts_num_trig_pfc: 415271
                     pkts_num_hdrm_full: 362
                     pkts_num_hdrm_partial: 182
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_trig_ingr_drp: 216064
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_ingr_drp: 593885
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 37449
-                    pkts_num_dismiss_pfc: 200
+                    pkts_num_trig_pfc: 415271
+                    pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 lossy_queue_1:
-                    dscp: 7
+                    dscp: 8
                     ecn: 1
-                    pg: 1
+                    pg: 0
                     pkts_num_trig_egr_drp: 2396745
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_fill_min: 51
-                    pkts_num_trig_pfc: 37449
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 415271
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -281,7 +281,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_fill_min: 51
+                    pkts_num_fill_min: 0
                     pkts_num_trig_egr_drp: 2396745
                     packet_size: 64
                     cell_size: 4096
@@ -291,7 +291,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 216064
+                    pkts_num_trig_ingr_drp: 593885
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3


### PR DESCRIPTION

### Description of PR
Cloned values from https://github.com/sonic-net/sonic-mgmt/pull/13069 for Jericho2.

Summary:
Copied values for Jericho2 as requested.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
