### PR TITLE
Add debug unreachable ipv6 issue after fixture setup for MGMT IPv6 only

### DIFF
--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -62,6 +62,15 @@ def log_eth0_interface_info(duthosts):
         logging.debug(f"Checking host[{duthost.hostname}] ifconfig eth0:[{duthost_interface}] after fixture")
 
 
+def log_tacacs(duthosts, ptfhost):
+    for duthost in duthosts:
+        ptfhost_vars = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars
+        if 'ansible_hostv6' in ptfhost_vars:
+            tacacs_server_ip = ptfhost_vars['ansible_hostv6']
+            ping_result = duthost.shell("ping {} -c 1 -W 3".format(tacacs_server_ip), module_ignore_errors=True)["stdout"]
+            logging.debug(f"Checking ping_result [{ping_result}]")
+
+
 def test_bgp_facts_ipv6_only(duthosts, enum_frontend_dut_hostname, enum_asic_index,
                              convert_and_restore_config_db_to_ipv6_only): # noqa F811
     # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
@@ -134,6 +143,7 @@ def test_ro_user_ipv6_only(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku
     log_eth0_interface_info(duthosts)
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutipv6 = get_mgmt_ipv6(duthost)
+    log_tacacs(duthosts, ptfhost)
 
     res = ssh_remote_run_retry(localhost, dutipv6, ptfhost, tacacs_creds['tacacs_ro_user'],
                                tacacs_creds['tacacs_ro_user_passwd'], 'cat /etc/passwd')
@@ -148,6 +158,7 @@ def test_rw_user_ipv6_only(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku
     log_eth0_interface_info(duthosts)
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutipv6 = get_mgmt_ipv6(duthost)
+    log_tacacs(duthosts, ptfhost)
 
     res = ssh_remote_run_retry(localhost, dutipv6, ptfhost, tacacs_creds['tacacs_rw_user'],
                                tacacs_creds['tacacs_rw_user_passwd'], "cat /etc/passwd")

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -67,7 +67,7 @@ def log_tacacs(duthosts, ptfhost):
         ptfhost_vars = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars
         if 'ansible_hostv6' in ptfhost_vars:
             tacacs_server_ip = ptfhost_vars['ansible_hostv6']
-            ping_result = duthost.shell("ping {} -c 1 -W 3".format(tacacs_server_ip), module_ignore_errors=True)["stdout"]
+            ping_result = duthost.shell(f"ping {tacacs_server_ip} -c 1 -W 3", module_ignore_errors=True)["stdout"]
             logging.debug(f"Checking ping_result [{ping_result}]")
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add debug unreachable ipv6 issue after fixture setup for MGMT IPv6 only
Fixes # (issue)
ADO: 28489789, 28451569
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [X] 202305
- [X] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
There're some random failures for MGMT IPv6 only TACACS test case, suspect the cause is unreachable ipv6 issue after fixture setup for MGMT IPv6 only
```
Failed: Warning: Permanently added '2a01:111:e210:3000::a03:9289' (RSA) to the list of known hosts. Permission denied, please try again.
```
#### How did you do it?
Add debug log to check and confirm unreachable mgmt IPv6 issue
#### How did you verify/test it?
Failed case
```
15/07/2024 01:07:31 test_mgmt_ipv6_only.log_tacacs           L0070 DEBUG  | Checking ping_result [PING 2a01:111:e210:b000::a40:f691(2a01:111:e210:b000::a40:f691) 56 data bytes

--- 2a01:111:e210:b000::a40:f691 ping statistics ---
1 packets transmitted, 0 received, 100% packet loss, time 0ms]
15/07/2024 01:07:31 base._run                                L0071 DEBUG  | /var/src/sonic-mgmt-int/tests/tacacs/test_ro_user.py::ssh_remote_run#21: [localhost] AnsibleModule::shell, args=["sshpass -p 123456 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null test_rwuser@2a01:111:e210:3000::a03:9242 'cat /etc/passwd'"], kwargs={"module_ignore_errors": true}
15/07/2024 01:07:38 base._run                                L0108 DEBUG  | /var/src/sonic-mgmt-int/tests/tacacs/test_ro_user.py::ssh_remote_run#21: [localhost] AnsibleModule::shell Result => {"failed": true, "changed": true, "stdout": "", "stderr": "Warning: Permanently added '2a01:111:e210:3000::a03:9242' (RSA) to the list of known hosts.\r\nPermission denied, please try again.", "rc": 5, "cmd": "sshpass -p 123456 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null test_rwuser@2a01:111:e210:3000::a03:9242 'cat /etc/passwd'", "start": "2024-07-15 01:07:31.674903", "end": "2024-07-15 01:07:38.159599", "delta": "0:00:06.484696", "msg": "non-zero return code", "invocation": {"module_args": {"_raw_params": "sshpass -p 123456 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null test_rwuser@2a01:111:e210:3000::a03:9242 'cat /etc/passwd'", "_uses_shell": true, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": [], "stderr_lines": ["Warning: Permanently added '2a01:111:e210:3000::a03:9242' (RSA) to the list of known hosts.", "Permission denied, please try again."], "_ansible_no_log": null}
15/07/2024 01:07:38 base._run                                L0071 DEBUG  | /var/src/sonic-mgmt-int/tests/tacacs/utils.py::tacacs_running#37: [vms21-1] AnsibleModule::command, args=["service tacacs_plus status"], kwargs={"module_ignore_errors": true}
15/07/2024 01:07:38 base._run                                L0108 DEBUG  | /var/src/sonic-mgmt-int/tests/tacacs/utils.py::tacacs_running#37: [vms21-1] AnsibleModule::command Result => {"changed": true, "end": "2024-07-15 01:07:38.359980", "stdout": "Checking status of TACACS+ authentication daemon: tacacs+ running.", "cmd": ["service", "tacacs_plus", "status"], "start": "2024-07-15 01:07:38.277983", "delta": "0:00:00.081997", "stderr": "", "rc": 0, "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": false, "strip_empty_ends": true, "_raw_params": "service tacacs_plus status", "removes": null, "argv": null, "warn": false, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "msg": "", "stdout_lines": ["Checking status of TACACS+ authentication daemon: tacacs+ running."], "stderr_lines": [], "_ansible_no_log": null, "failed": false}
```
Successful case
```
15/07/2024 01:06:28 test_mgmt_ipv6_only.log_tacacs           L0070 DEBUG  | Checking ping_result [PING 2a01:111:e210:b000::a40:f691(2a01:111:e210:b000::a40:f691) 56 data bytes
64 bytes from 2a01:111:e210:b000::a40:f691: icmp_seq=1 ttl=60 time=0.838 ms

--- 2a01:111:e210:b000::a40:f691 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.838/0.838/0.838/0.000 ms]
15/07/2024 01:06:28 base._run                                L0071 DEBUG  | /var/src/sonic-mgmt-int/tests/tacacs/test_ro_user.py::ssh_remote_run#21: [localhost] AnsibleModule::shell, args=["sshpass -p 123456 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null test_rouser@2a01:111:e210:3000::a03:9242 'cat /etc/passwd'"], kwargs={"module_ignore_errors": true}
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
