### PR TITLE
feat: support BGP session flap test on T2 chassis

### DIFF
--- a/tests/bgp/test_bgp_session_flap.py
+++ b/tests/bgp/test_bgp_session_flap.py
@@ -28,7 +28,7 @@ cpuSpike = 10
 memSpike = 1.3
 
 pytestmark = [
-    pytest.mark.topology('t1')
+    pytest.mark.topology('t1', 't2')
 ]
 
 
@@ -56,23 +56,26 @@ def get_cpu_stats(dut):
 
 
 @pytest.fixture(scope='module')
-def setup(tbinfo, nbrhosts, duthosts, rand_one_dut_hostname, enum_rand_one_frontend_asic_index):
-    duthost = duthosts[rand_one_dut_hostname]
+def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_index):
+    duthost = duthosts[enum_frontend_dut_hostname]
     asic_index = enum_rand_one_frontend_asic_index
     namespace = duthost.get_namespace_from_asic_id(asic_index)
 
+    bgp_facts = duthost.bgp_facts(instance_id=asic_index)['ansible_facts']
+    neigh_keys = []
     tor_neighbors = dict()
-    tor1 = natsorted(nbrhosts.keys())[0]
-
-    skip_hosts = duthost.get_asic_namespace_list()
-
-    bgp_facts = duthost.bgp_facts(instance_id=enum_rand_one_frontend_asic_index)['ansible_facts']
     neigh_asn = dict()
     for k, v in bgp_facts['bgp_neighbors'].items():
-        if v['description'].lower() not in skip_hosts:
+        if 'asic' not in v['description'].lower():
+            neigh_keys.append(v['description'])
             neigh_asn[v['description']] = v['remote AS']
             tor_neighbors[v['description']] = nbrhosts[v['description']]["host"]
             assert v['state'] == 'established'
+
+    if not neigh_keys:
+        pytest.skip("No BGP neighbors found on ASIC {} of DUT {}".format(asic_index, duthost.hostname))
+
+    tor1 = natsorted(neigh_keys)[0]
 
     # verify sessions are established
     logger.info(duthost.shell('show ip bgp summary'))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Support `bgp/test_bgp_session_flap.py` test on T2 chassis

Summary:
Fixes # (issue) Microsoft ADO 28357414

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The `bgp/test_bgp_session_flap.py` test was running on T1 topology only. We wanted to run it on T2 topo as well.

#### How did you do it?
I made some changes to the `setup()` function to run the test for all Line Cards on a T2 chassis.

#### How did you verify/test it?
I ran the updated test on both T1 and T2 devices and I can confirm both passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
