### PR TITLE
Align the test case to use mask in dotted decimal notation

### DIFF
--- a/tests/hash/generic_hash_helper.py
+++ b/tests/hash/generic_hash_helper.py
@@ -3,6 +3,7 @@ import json
 import time
 import logging
 import pytest
+import ipaddress
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
@@ -552,6 +553,17 @@ def get_encap_type_from_option(encap_type_option):
         return [encap_type_option]
 
 
+def format_ip_mask(ip_network, strict=False):
+    """
+    Format the full mask notation to the mask in dotted decimal notation
+    """
+    ip_addr = ipaddress.ip_network(ip_network, strict=strict)
+    if ip_addr.version == 4:
+        return str(ip_addr)
+    else:
+        return ip_network
+
+
 def remove_ip_interface_and_config_vlan(duthost, mg_facts, tbinfo, downlink_interface, uplink_interfaces, hash_field):
     """
     Re-configure the interface and vlan on dut to enable switching of L2 traffic.
@@ -579,23 +591,25 @@ def remove_ip_interface_and_config_vlan(duthost, mg_facts, tbinfo, downlink_inte
         # if topology is t1, remove the ip address on downlink interface
         for ip_interface in mg_facts['minigraph_interfaces']:
             if ip_interface['attachto'] == downlink_interface:
-                duthost.shell(f"config interface ip remove {ip_interface['attachto']} "
-                              f"{ip_interface['addr']}/{ip_interface['mask']}")
+                formatted_ip_addr = format_ip_mask(f"{ip_interface['addr']}/{ip_interface['mask']}")
+                duthost.shell(f"config interface ip remove {ip_interface['attachto']} {formatted_ip_addr}")
                 ip_interface_to_restore.append(ip_interface)
                 l2_ports.add(downlink_interface)
         for portchannel in mg_facts['minigraph_portchannels'].values():
             if downlink_interface in portchannel['members']:
                 for portchannel_ip_interface in mg_facts['minigraph_portchannel_interfaces']:
                     if portchannel_ip_interface['attachto'] == portchannel['name']:
-                        duthost.shell(f"config interface ip remove {portchannel_ip_interface['attachto']} "
-                                      f"{portchannel_ip_interface['addr']}/{portchannel_ip_interface['mask']}")
+                        formatted_ip_addr = format_ip_mask(
+                            f"{portchannel_ip_interface['addr']}/{portchannel_ip_interface['mask']}")
+                        duthost.shell(
+                            f"config interface ip remove {portchannel_ip_interface['attachto']} {formatted_ip_addr}")
                         ip_interface_to_restore.append(portchannel_ip_interface)
                         l2_ports.add(portchannel_ip_interface['attachto'])
     # re-config the uplink interfaces, remove the ip address on the egress portchannel interfaces
     for ip_interface in mg_facts['minigraph_portchannel_interfaces']:
         if ip_interface['attachto'] in uplink_interfaces:
-            duthost.shell(f"config interface ip remove {ip_interface['attachto']} "
-                          f"{ip_interface['addr']}/{ip_interface['mask']}")
+            formatted_ip_addr = format_ip_mask(f"{ip_interface['addr']}/{ip_interface['mask']}")
+            duthost.shell(f"config interface ip remove {ip_interface['attachto']} {formatted_ip_addr}")
             ip_interface_to_restore.append(ip_interface)
             l2_ports.add(ip_interface['attachto'])
     # Configure VLANs for VLAN_ID test


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This is a code align for github issue #18766
Currently, CLI/SWSS doesn't have a way to normalize the IP mask notation regardless of what was provided by user.
The code change here is to only use dotted decimal notation when removing ip address.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Currently, CLI/SWSS doesn't have a way to normalize the IP mask notation regardless of what was provided by user.
#### How did you do it?
The code change here is to only use dotted decimal notation when removing ip address.
#### How did you verify/test it?
Run it in internal regression.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
