### PR TITLE
Skip reboot acl test in t1-lag PR test for test time too long

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -17,8 +17,9 @@ from tests.common import reboot, port_toggle
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.config_reload import config_reload
-from tests.common.fixtures.ptfhost_utils import \
-    copy_arp_responder_py, run_garp_service, change_mac_addresses, skip_traffic_test   # noqa F401
+from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py, run_garp_service, change_mac_addresses   # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test       # noqa F401
 from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr # noqa F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1268,8 +1268,6 @@ class TestAclWithReboot(TestBasicAcl):
             populate_vlan_arp_entries: A fixture to populate ARP/FDB tables for VLAN interfaces.
 
         """
-        if dut.get_facts()['asic_type'] == 'vs' and 't1' in tbinfo['topo']['name']:
-            pytest.skip("Skip ACL test for t1 topology with vs platform")
         dut.command("config save -y")
         reboot(dut, localhost, wait=240)
         # We need some additional delay on e1031

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1268,6 +1268,8 @@ class TestAclWithReboot(TestBasicAcl):
             populate_vlan_arp_entries: A fixture to populate ARP/FDB tables for VLAN interfaces.
 
         """
+        if dut.get_facts()['asic_type'] == 'vs' and 't1' in tbinfo['topo']['name']:
+            pytest.skip("Skip ACL test for t1 topology with vs platform")
         dut.command("config save -y")
         reboot(dut, localhost, wait=240)
         # We need some additional delay on e1031

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_acl.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_acl.yaml
@@ -250,12 +250,22 @@ acl/test_acl.py::TestAclWithPortToggle::test_udp_source_ip_match_dropped[ipv6-eg
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
 
+acl/test_acl.py::TestAclWithReboot:
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
+
 acl/test_acl.py::TestAclWithReboot::test_dest_ip_match_dropped[ipv6-egress-uplink->downlink-default-Vlan1000]:
   xfail:
     reason: "Egress issue in Nokia"
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_dest_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan1000]:
   xfail:
@@ -263,6 +273,10 @@ acl/test_acl.py::TestAclWithReboot::test_dest_ip_match_dropped[ipv6-egress-uplin
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_dest_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan2000]:
   xfail:
@@ -270,6 +284,10 @@ acl/test_acl.py::TestAclWithReboot::test_dest_ip_match_dropped[ipv6-egress-uplin
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_icmp_match_forwarded[ipv6-egress-uplink->downlink-default-Vlan1000]:
   xfail:
@@ -277,6 +295,10 @@ acl/test_acl.py::TestAclWithReboot::test_icmp_match_forwarded[ipv6-egress-uplink
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_icmp_match_forwarded[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan1000]:
   xfail:
@@ -284,6 +306,10 @@ acl/test_acl.py::TestAclWithReboot::test_icmp_match_forwarded[ipv6-egress-uplink
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_icmp_match_forwarded[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan2000]:
   xfail:
@@ -291,6 +317,10 @@ acl/test_acl.py::TestAclWithReboot::test_icmp_match_forwarded[ipv6-egress-uplink
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_icmp_source_ip_match_dropped[ipv6-egress-uplink->downlink-default-Vlan1000]:
   xfail:
@@ -298,6 +328,10 @@ acl/test_acl.py::TestAclWithReboot::test_icmp_source_ip_match_dropped[ipv6-egres
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_icmp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan1000]:
   xfail:
@@ -305,6 +339,10 @@ acl/test_acl.py::TestAclWithReboot::test_icmp_source_ip_match_dropped[ipv6-egres
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_icmp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan2000]:
   xfail:
@@ -312,6 +350,10 @@ acl/test_acl.py::TestAclWithReboot::test_icmp_source_ip_match_dropped[ipv6-egres
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-default-Vlan1000]:
   xfail:
@@ -319,6 +361,10 @@ acl/test_acl.py::TestAclWithReboot::test_ip_proto_match_dropped[ipv6-egress-upli
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan1000]:
   xfail:
@@ -326,6 +372,10 @@ acl/test_acl.py::TestAclWithReboot::test_ip_proto_match_dropped[ipv6-egress-upli
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_ip_proto_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan2000]:
   xfail:
@@ -333,6 +383,10 @@ acl/test_acl.py::TestAclWithReboot::test_ip_proto_match_dropped[ipv6-egress-upli
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-default-Vlan1000]:
   xfail:
@@ -340,6 +394,10 @@ acl/test_acl.py::TestAclWithReboot::test_l4_dport_match_dropped[ipv6-egress-upli
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan1000]:
   xfail:
@@ -347,6 +405,10 @@ acl/test_acl.py::TestAclWithReboot::test_l4_dport_match_dropped[ipv6-egress-upli
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_l4_dport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan2000]:
   xfail:
@@ -354,6 +416,10 @@ acl/test_acl.py::TestAclWithReboot::test_l4_dport_match_dropped[ipv6-egress-upli
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-default-Vlan1000]:
   xfail:
@@ -361,6 +427,10 @@ acl/test_acl.py::TestAclWithReboot::test_l4_dport_range_match_dropped[ipv6-egres
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan1000]:
   xfail:
@@ -368,7 +438,10 @@ acl/test_acl.py::TestAclWithReboot::test_l4_dport_range_match_dropped[ipv6-egres
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_l4_dport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan2000]:
   xfail:
@@ -376,6 +449,10 @@ acl/test_acl.py::TestAclWithReboot::test_l4_dport_range_match_dropped[ipv6-egres
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-default-Vlan1000]:
   xfail:
@@ -383,6 +460,10 @@ acl/test_acl.py::TestAclWithReboot::test_l4_sport_match_dropped[ipv6-egress-upli
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan1000]:
   xfail:
@@ -390,6 +471,10 @@ acl/test_acl.py::TestAclWithReboot::test_l4_sport_match_dropped[ipv6-egress-upli
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_l4_sport_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan2000]:
   xfail:
@@ -397,6 +482,10 @@ acl/test_acl.py::TestAclWithReboot::test_l4_sport_match_dropped[ipv6-egress-upli
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-default-Vlan1000]:
   xfail:
@@ -404,6 +493,10 @@ acl/test_acl.py::TestAclWithReboot::test_l4_sport_range_match_dropped[ipv6-egres
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan1000]:
   xfail:
@@ -411,6 +504,10 @@ acl/test_acl.py::TestAclWithReboot::test_l4_sport_range_match_dropped[ipv6-egres
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_l4_sport_range_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan2000]:
   xfail:
@@ -418,6 +515,10 @@ acl/test_acl.py::TestAclWithReboot::test_l4_sport_range_match_dropped[ipv6-egres
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_rules_priority_dropped[ipv6-egress-uplink->downlink-default-Vlan1000]:
   xfail:
@@ -425,6 +526,10 @@ acl/test_acl.py::TestAclWithReboot::test_rules_priority_dropped[ipv6-egress-upli
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_rules_priority_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan1000]:
   xfail:
@@ -432,6 +537,10 @@ acl/test_acl.py::TestAclWithReboot::test_rules_priority_dropped[ipv6-egress-upli
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_rules_priority_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan2000]:
   xfail:
@@ -439,6 +548,10 @@ acl/test_acl.py::TestAclWithReboot::test_rules_priority_dropped[ipv6-egress-upli
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-default-Vlan1000]:
   xfail:
@@ -446,6 +559,10 @@ acl/test_acl.py::TestAclWithReboot::test_source_ip_match_dropped[ipv6-egress-upl
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan1000]:
   xfail:
@@ -453,12 +570,21 @@ acl/test_acl.py::TestAclWithReboot::test_source_ip_match_dropped[ipv6-egress-upl
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
+
 acl/test_acl.py::TestAclWithReboot::test_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan2000]:
   xfail:
     reason: "Egress issue in Nokia"
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-default-Vlan1000]:
   xfail:
@@ -466,6 +592,10 @@ acl/test_acl.py::TestAclWithReboot::test_tcp_flags_match_dropped[ipv6-egress-upl
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan1000]:
   xfail:
@@ -473,6 +603,10 @@ acl/test_acl.py::TestAclWithReboot::test_tcp_flags_match_dropped[ipv6-egress-upl
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_tcp_flags_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan2000]:
   xfail:
@@ -480,6 +614,10 @@ acl/test_acl.py::TestAclWithReboot::test_tcp_flags_match_dropped[ipv6-egress-upl
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-default-Vlan1000]:
   xfail:
@@ -487,6 +625,10 @@ acl/test_acl.py::TestAclWithReboot::test_udp_source_ip_match_dropped[ipv6-egress
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan1000]:
   xfail:
@@ -494,7 +636,10 @@ acl/test_acl.py::TestAclWithReboot::test_udp_source_ip_match_dropped[ipv6-egress
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
-
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestAclWithReboot::test_udp_source_ip_match_dropped[ipv6-egress-uplink->downlink-m0_vlan_scenario-Vlan2000]:
   xfail:
@@ -502,6 +647,10 @@ acl/test_acl.py::TestAclWithReboot::test_udp_source_ip_match_dropped[ipv6-egress
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8639
+  skip:
+    reason: "Skip in t1-lag KVM test due to test time too long and t0 would cover this testbeds"
+    conditions:
+      - "topo_type in ['t1'] and asic_type in ['vs']"
 
 acl/test_acl.py::TestBasicAcl::test_dest_ip_match_dropped[ipv6-egress-uplink->downlink-default-Vlan1000]:
   xfail:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In t1-lag PR test, reboot acl test took about 2 hours to finish, which took too much time to finish, and it's not needed since traffic test are skipped in acl test, and previous setup steps are tested in t0 PR test.
#### How did you do it?
Skip reboot acl test in t1-lag PR test with a pytest.skip, once conditional mark could support all matches, would switch to use conditional mark skip to save more time
#### How did you verify/test it?
Run test on t1-lag KVM
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
