### PR TITLE
Add test_pfc_config.py script to t0 and t1-lag PR test set

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -93,6 +93,7 @@ t0:
   - pc/test_lag_2.py
   - pc/test_po_cleanup.py
   - pc/test_po_update.py
+  - pfcwd/test_pfc_config.py
   - platform_tests/broadcom/test_ser.py
   - platform_tests/counterpoll/test_counterpoll_watermark.py
   - platform_tests/fwutil/test_fwutil.py
@@ -229,6 +230,7 @@ t1-lag:
   - override_config_table/test_override_config_table.py
   - pc/test_lag_2.py
   - pc/test_po_update.py
+  - pfcwd/test_pfc_config.py
   - platform_tests/test_cpu_memory_usage.py
   - process_monitoring/test_critical_process_monitoring.py
   - qos/test_buffer.py

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -107,7 +107,7 @@ def setup_pfc_test(
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     port_list = list(mg_facts['minigraph_ports'].keys())
-    neighbors = conn_graph_facts['device_conn'][duthost.hostname]
+    neighbors = conn_graph_facts['device_conn'].get(duthost.hostname, {})
     dut_eth0_ip = duthost.mgmt_ip
     vlan_nw = None
 

--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -104,21 +104,22 @@ class TrafficPorts(object):
                     if item['peer_addr'] == pfc_wd_test_port_addr:
                         pfc_wd_test_neighbor_addr = item['addr']
 
-                self.test_ports[pfc_wd_test_port] = {'test_neighbor_addr': pfc_wd_test_neighbor_addr,
-                                                     'rx_port': [self.pfc_wd_rx_port],
-                                                     'rx_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
-                                                     'peer_device': self.neighbors[pfc_wd_test_port]['peerdevice'],
-                                                     'test_port_id': pfc_wd_test_port_id,
-                                                     'rx_port_id': [self.pfc_wd_rx_port_id],
-                                                     'test_port_type': 'interface'
-                                                     }
+                self.test_ports[pfc_wd_test_port] = {
+                    'test_neighbor_addr': pfc_wd_test_neighbor_addr,
+                    'rx_port': [self.pfc_wd_rx_port],
+                    'rx_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
+                    'peer_device': self.neighbors.get(pfc_wd_test_port, {}).get('peerdevice', ''),
+                    'test_port_id': pfc_wd_test_port_id,
+                    'rx_port_id': [self.pfc_wd_rx_port_id],
+                    'test_port_type': 'interface'
+                    }
             # populate info for the first port
             if first_pair:
                 self.test_ports[self.pfc_wd_rx_port] = {
                     'test_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
                     'rx_port': [pfc_wd_test_port],
                     'rx_neighbor_addr': pfc_wd_test_neighbor_addr,
-                    'peer_device': self.neighbors[self.pfc_wd_rx_port]['peerdevice'],
+                    'peer_device': self.neighbors.get(self.pfc_wd_rx_port, {}).get('peerdevice', ''),
                     'test_port_id': self.pfc_wd_rx_port_id,
                     'rx_port_id': [pfc_wd_test_port_id],
                     'test_port_type': 'interface'
@@ -173,7 +174,7 @@ class TrafficPorts(object):
                     self.test_ports[port] = {'test_neighbor_addr': pfc_wd_test_neighbor_addr,
                                              'rx_port': self.pfc_wd_rx_port,
                                              'rx_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
-                                             'peer_device': self.neighbors[port]['peerdevice'],
+                                             'peer_device': self.neighbors.get(port, {}).get('peerdevice', ''),
                                              'test_port_id': self.port_idx_info[port],
                                              'rx_port_id': self.pfc_wd_rx_port_id,
                                              'test_portchannel_members': pfc_wd_test_port_id,
@@ -185,7 +186,7 @@ class TrafficPorts(object):
                     self.test_ports[port] = {'test_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
                                              'rx_port': pfc_wd_test_port,
                                              'rx_neighbor_addr': pfc_wd_test_neighbor_addr,
-                                             'peer_device': self.neighbors[port]['peerdevice'],
+                                             'peer_device': self.neighbors.get(port, {}).get('peerdevice', ''),
                                              'test_port_id': self.port_idx_info[port],
                                              'rx_port_id': pfc_wd_test_port_id,
                                              'test_portchannel_members': self.pfc_wd_rx_port_id,
@@ -222,7 +223,7 @@ class TrafficPorts(object):
             temp_ports[item] = {'test_neighbor_addr': self.vlan_nw,
                                 'rx_port': rx_port,
                                 'rx_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
-                                'peer_device': self.neighbors[item]['peerdevice'],
+                                'peer_device': self.neighbors.get(item, {}).get('peerdevice', ''),
                                 'test_port_id': self.port_idx_info[item],
                                 'rx_port_id': rx_port_id,
                                 'test_port_type': 'vlan'
@@ -267,23 +268,24 @@ class TrafficPorts(object):
                     if item['peer_addr'] == pfc_wd_test_port_addr:
                         pfc_wd_test_neighbor_addr = item['addr']
 
-                self.test_ports[pfc_wd_test_port] = {'test_neighbor_addr': pfc_wd_test_neighbor_addr,
-                                                     'rx_port': [self.pfc_wd_rx_port],
-                                                     'rx_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
-                                                     'peer_device': self.neighbors[pfc_wd_test_port]['peerdevice'],
-                                                     'test_port_id': pfc_wd_test_port_id,
-                                                     'rx_port_id': [self.pfc_wd_rx_port_id],
-                                                     'rx_port_vlan_id': self.pfc_wd_rx_port_vlan_id,
-                                                     'test_port_vlan_id': vlan_id,
-                                                     'test_port_type': 'interface'
-                                                     }
+                self.test_ports[pfc_wd_test_port] = {
+                    'test_neighbor_addr': pfc_wd_test_neighbor_addr,
+                    'rx_port': [self.pfc_wd_rx_port],
+                    'rx_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
+                    'peer_device': self.neighbors.get(pfc_wd_test_port, {}).get('peerdevice', ''),
+                    'test_port_id': pfc_wd_test_port_id,
+                    'rx_port_id': [self.pfc_wd_rx_port_id],
+                    'rx_port_vlan_id': self.pfc_wd_rx_port_vlan_id,
+                    'test_port_vlan_id': vlan_id,
+                    'test_port_type': 'interface'
+                    }
             # populate info for the first port
             if first_pair:
                 self.test_ports[self.pfc_wd_rx_port] = {
                     'test_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
                     'rx_port': [pfc_wd_test_port],
                     'rx_neighbor_addr': pfc_wd_test_neighbor_addr,
-                    'peer_device': self.neighbors[self.pfc_wd_rx_port]['peerdevice'],
+                    'peer_device': self.neighbors.get(self.pfc_wd_rx_port, {}).get('peerdevice', ''),
                     'test_port_id': self.pfc_wd_rx_port_id,
                     'rx_port_id': [pfc_wd_test_port_id],
                     'rx_port_vlan_id': vlan_id,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
When we get conn_graph_facts in pfcwd module, it would return an empty dict for KVM testbed, and raise key error when we get neighbors by directly get conn_graph_facts['device_conn'][duthost.hostname]
#### How did you do it?
Use get method to pass variables, and pass empty dict or string if conn_graph_facts is empty
#### How did you verify/test it?
Run KVM test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
