### PR TITLE
Easy-pdb support for ptf test cases

### DIFF
--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -49,7 +49,7 @@ def get_dut_type(host):
 def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                platform="remote", qlen=0, relax=True, debug_level="info",
                socket_recv_size=None, log_file=None, device_sockets=[], timeout=0, custom_options="",
-               module_ignore_errors=False, is_python3=False, async_mode=False):
+               module_ignore_errors=False, is_python3=False, async_mode=False, pdb=False):
     # Call virtual env ptf for migrated py3 scripts.
     # ptf will load all scripts under ptftests, it will throw error for py2 scripts.
     # So move migrated scripts to seperated py3 folder avoid impacting py2 scripts.
@@ -98,7 +98,7 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
     if device_sockets:
         cmd += " ".join(map(" --device-socket {}".format, device_sockets))
 
-    if timeout:
+    if timeout and not pdb:
         cmd += " --test-case-timeout {}".format(int(timeout))
 
     if custom_options:
@@ -111,6 +111,15 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
         host.create_macsec_info()
 
     try:
+        if pdb:
+            # Write command to file. Use short test name for simpler launch in ptf container.
+            script_name = "/tmp/" + testname.split(".")[-1] + ".sh"
+            with open(script_name, 'w') as f:
+                f.write(cmd)
+            host.copy(src=script_name, dest="/root/")
+            print("Run command from ptf: sh {}".format(script_name))
+            import pdb
+            pdb.set_trace()
         result = host.shell(cmd, chdir="/root", module_ignore_errors=module_ignore_errors, module_async=async_mode)
         if not async_mode:
             if log_file:

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -114,7 +114,7 @@ class QosBase:
 
         yield dut_test_params_qos
 
-    def runPtfTest(self, ptfhost, testCase='', testParams={}, relax=False):
+    def runPtfTest(self, ptfhost, testCase='', testParams={}, relax=False, pdb=False):
         """
             Runs QoS SAI test case on PTF host
 
@@ -148,7 +148,8 @@ class QosBase:
             relax=relax,
             timeout=1200,
             socket_recv_size=16384,
-            custom_options=custom_options
+            custom_options=custom_options,
+            pdb=pdb
         )
 
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adds a quality-of-life tool for PTF test case debugging. 
- User can add a simple `pdb=True` to the test case ptf run, e.g. in any test_qos_sai.py test. 
- The new feature will then copy the PTF command to a script, then copies the script into the PTF container. 
- The script is named against the given PTF test case name for easy readability. 
- Automatically pauses on PDB at the right time so the engineer can launch the created PTF script.
- Removes the timeout from the command since timeouts are not desirable during debugging. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
QoL improvement.

#### How did you do it?

#### How did you verify/test it?
Has saved lots of time with my test_qos_sai.py debugging efforts!

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
