### PR TITLE
Fix hash collision in arp/test_stress_arp.py

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -73,7 +73,7 @@ def test_ipv4_arp(duthost, garp_enabled, ip_and_intf_info, intfs_for_test,
         get_crm_resources(duthost, "fdb_entry", "used")
     pytest_assert(ipv4_avaliable > 0 and fdb_avaliable > 0, "Entries have been filled")
 
-    arp_avaliable = min(min(ipv4_avaliable, fdb_avaliable), ENTRIES_NUMBERS)
+    arp_avaliable = int(min(min(ipv4_avaliable, fdb_avaliable), ENTRIES_NUMBERS) / 3 * 2)
 
     pytest_require(garp_enabled, 'Gratuitous ARP not enabled for this device')
     ptf_intf_ipv4_hosts = genrate_ipv4_ip()

--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -154,7 +154,7 @@ def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
         get_crm_resources(duthost, "fdb_entry", "used")
     pytest_assert(ipv6_avaliable > 0 and fdb_avaliable > 0, "Entries have been filled")
 
-    nd_avaliable = int(min(ipv6_avaliable, ENTRIES_NUMBERS) * 2 / 3)
+    nd_avaliable = int(min(ipv6_avaliable, ENTRIES_NUMBERS) / 3 * 2)
 
     while loop_times > 0:
         loop_times -= 1

--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -154,7 +154,7 @@ def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
         get_crm_resources(duthost, "fdb_entry", "used")
     pytest_assert(ipv6_avaliable > 0 and fdb_avaliable > 0, "Entries have been filled")
 
-    nd_avaliable = min(min(ipv6_avaliable, fdb_avaliable), ENTRIES_NUMBERS)
+    nd_avaliable = int(min(ipv6_avaliable, ENTRIES_NUMBERS) * 2 / 3)
 
     while loop_times > 0:
         loop_times -= 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
For stress testing arp related tables, only stress up to 2/3 of the tables instead of 100%. This is because they are hash tables and it is unrealistic to fill it all up as there will be hash collisions. These collisions will cause entries to not be added and will make the test fail.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change
Stress the tables up to 2/3 of the available space instead of 100%. 2/3 of the available space is okay (not 2/3 of the overall) because the number of entries already in the table be significantly smaller than overall available space.
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
