### PR TITLE
Change pytest mark of script `test_pktgen`. 

### DIFF
--- a/tests/test_pktgen.py
+++ b/tests/test_pktgen.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('any'),
-    pytest.mark.device_type('cisco-8000')
+    pytest.mark.asic('cisco-8000')
 ]
 
 ignoreRegex = [

--- a/tests/test_pktgen.py
+++ b/tests/test_pktgen.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('any'),
-    pytest.mark.device_type('vs')
+    pytest.mark.device_type('cisco-8000')
 ]
 
 ignoreRegex = [


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
As @XuChen-MSFT mentioned, this script was aimed at running on cisco testbeds only, but not sure why it was added the mark `pytest.mark.device_type('vs')` in PR [#10164](https://github.com/sonic-net/sonic-mgmt/pull/10164). So in this PR, we fix this issue by changing the pytest mark. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
As @XuChen-MSFT mentioned, this script was aimed at running on cisco testbeds only, but not sure why it was added the mark `pytest.mark.device_type('vs')` in PR [#10164](https://github.com/sonic-net/sonic-mgmt/pull/10164). So in this PR, we fix this issue by changing the pytest mark. 

#### How did you do it?
Change the pytest mark from `pytest.mark.device_type('vs')` to `pytest.mark.asic('cisco-8000')`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
