### PR TITLE
Add GCU mgmt-interface test case

### DIFF
--- a/tests/generic_config_updater/test_mgmt_interface.py
+++ b/tests/generic_config_updater/test_mgmt_interface.py
@@ -65,7 +65,8 @@ def update_forced_mgmt_route(duthost, interface_address, interface_key, routes):
         delete_tmpfile(duthost, tmpfile)
 
 
-def update_and_check_forced_mgmt_routes(duthost, forced_mgmt_routes, interface_address, interface_key, ip_type, test_route, expect_exist):
+def update_and_check_forced_mgmt_routes(duthost, forced_mgmt_routes, interface_address, interface_key,
+                                        ip_type, test_route, expect_exist):
     # Update forced mgmt routes with new route address
     wait_for_file_changed(
                         duthost,

--- a/tests/generic_config_updater/test_mgmt_interface.py
+++ b/tests/generic_config_updater/test_mgmt_interface.py
@@ -39,7 +39,7 @@ def update_forced_mgmt_route(duthost, routes):
     json_patch = [
         {
             "path": create_path(["MGMT_INTERFACE",
-                                 "eth0|{}".format(interface_address.replace("/", "~1"),
+                                 "eth0|{}".format(interface_address.replace("/", "~1")),
                                  "forced_mgmt_routes"])
         }
     ]

--- a/tests/generic_config_updater/test_mgmt_interface.py
+++ b/tests/generic_config_updater/test_mgmt_interface.py
@@ -39,7 +39,7 @@ def update_forced_mgmt_route(duthost, interface_address, interface_key, routes):
     json_patch = [
         {
             "path": create_path(["MGMT_INTERFACE",
-                                 "eth0|{}".format(interface_address.replace("/", "~1")),
+                                 "eth0|{}".format(interface_address),
                                  "forced_mgmt_routes"])
         }
     ]

--- a/tests/generic_config_updater/test_mgmt_interface.py
+++ b/tests/generic_config_updater/test_mgmt_interface.py
@@ -1,0 +1,132 @@
+import ipaddress
+import logging
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.generic_config_updater.gu_utils import apply_patch
+from tests.generic_config_updater.gu_utils import generate_tmpfile, delete_tmpfile
+from tests.generic_config_updater.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
+from tests.route.test_forced_mgmt_route import FORCED_MGMT_ROUTE_PRIORITY, wait_for_file_changed
+
+pytestmark = [
+    pytest.mark.topology('any'),
+]
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def ensure_dut_readiness(duthost):
+    """
+    Setup/teardown fixture for pg headroom update test
+
+    Args:
+        duthost: DUT host object
+    """
+    create_checkpoint(duthost)
+
+    yield
+
+    try:
+        logger.info("Rolled back to original checkpoint")
+        rollback_or_reload(duthost)
+    finally:
+        delete_checkpoint(duthost)
+
+
+def test_forced_mgmt_routes_update(duthost, ensure_dut_readiness):
+    # Get interface and check config generate correct
+    mgmt_interface_keys = duthost.command("sonic-db-cli  CONFIG_DB keys 'MGMT_INTERFACE|eth0|*'")['stdout']
+    logging.debug("mgmt_interface_keys: {}".format(mgmt_interface_keys))
+
+    for interface_key in mgmt_interface_keys.split('\n'):
+        logging.debug("interface_key: {}".format(interface_key))
+        interface_address = interface_key.split('|')[2]
+
+        # Get current forced mgmt routes
+        forced_mgmt_routes_config = duthost.command("sonic-db-cli CONFIG_DB HGET '{}' forced_mgmt_routes@"
+                                                      .format(interface_key))['stdout']
+
+        original_forced_mgmt_routes = []
+        if forced_mgmt_routes_config != "":
+            original_forced_mgmt_routes = forced_mgmt_routes_config.split(",")
+
+        # Prepare new forced mgmt routes
+        test_route = "1::2:3:4/64"
+        ip_type = "-6"
+        if type(ipaddress.ip_network(interface_address, False)) == ipaddress.IPv4Network:
+            test_route = "1.2.3.4/24"
+            ip_type = "-4"
+
+        updated_forced_mgmt_routes = original_forced_mgmt_routes.copy()
+        updated_forced_mgmt_routes.append(test_route)
+        logging.debug("interface address: {}, original_forced_mgmt_routes: {}, updated_forced_mgmt_routes: {}"
+                      .format(interface_address, original_forced_mgmt_routes, updated_forced_mgmt_routes))
+
+        def update_forced_mgmt_route(duthost, routes):
+            current_forced_mgmt_routes_config = duthost.command("sonic-db-cli CONFIG_DB HGET '{}' forced_mgmt_routes@"
+                                                                                        .format(interface_key))['stdout']
+            operation = "add"
+            if current_forced_mgmt_routes_config != "":
+                operation = "replace"
+
+            # Escape '/' in interface key
+            mgmt_interface_path = "/MGMT_INTERFACE/eth0|{}/forced_mgmt_routes".format(interface_address.replace("/", "~1"))
+            json_patch = None
+            if len(routes) == 0:
+                json_patch = [
+                    {
+                        "op": "remove",
+                        "path": mgmt_interface_path
+                    }
+                 ]
+            else:
+                json_patch = [
+                    {
+                        "op": operation,
+                        "path": mgmt_interface_path,
+                        "value": routes
+                    }
+                ]
+
+            tmpfile = generate_tmpfile(duthost)
+            try:
+                output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+                logging.debug("json_patch: {}".format(json_patch))
+                logging.debug("apply_patch result: {}".format(output))
+            finally:
+                delete_tmpfile(duthost, tmpfile)
+
+        # Update forced mgmt routes with new route address
+        wait_for_file_changed(
+                            duthost,
+                            "/etc/network/interfaces",
+                            update_forced_mgmt_route,
+                            duthost,
+                            updated_forced_mgmt_routes)
+
+        # Check /etc/network/interfaces generate correct
+        interfaces = duthost.command("cat /etc/network/interfaces")['stdout']
+        logging.debug("interfaces: {}".format(interfaces))
+
+        pytest_assert("up ip {} rule add pref {} to {} table default"
+                      .format(ip_type, FORCED_MGMT_ROUTE_PRIORITY, test_route) in interfaces)
+        pytest_assert("pre-down ip {} rule delete pref {} to {} table default"
+                      .format(ip_type, FORCED_MGMT_ROUTE_PRIORITY, test_route) in interfaces)
+
+        # Revert change and check again
+        wait_for_file_changed(
+                            duthost,
+                            "/etc/network/interfaces",
+                            update_forced_mgmt_route,
+                            duthost,
+                            original_forced_mgmt_routes)
+
+        # Check /etc/network/interfaces generate correct
+        interfaces = duthost.command("cat /etc/network/interfaces")['stdout']
+        logging.debug("interfaces: {}".format(interfaces))
+
+        pytest_assert("up ip {} rule add pref {} to {} table default"
+                      .format(ip_type, FORCED_MGMT_ROUTE_PRIORITY, test_route) not in interfaces)
+        pytest_assert("pre-down ip {} rule delete pref {} to {} table default"
+                      .format(ip_type, FORCED_MGMT_ROUTE_PRIORITY, test_route) not in interfaces)


### PR DESCRIPTION
Add GCU mgmt-interface test case

#### Why I did it
Need verify GCU update forced_mgmt_routes scenario.

##### Work item tracking
- Microsoft ADO: 28707715

#### How I did it
Add GCU mgmt-interface test case.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Add GCU mgmt-interface test case.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

