### PR TITLE
[Bugfix] Move `test_sub_port_l2_forwarding.py` from T0 skip list to onboarding list. 

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -320,6 +320,7 @@ onboarding_t0:
   - snmp/test_snmp_queue_counters.py
   - sub_port_interfaces/test_show_subinterface.py
   - sub_port_interfaces/test_sub_port_interfaces.py
+  - sub_port_interfaces/test_sub_port_l2_forwarding.py
   - system_health/test_system_health.py
   - test_pktgen.py
   - acl/test_acl_outer_vlan.py

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -42,6 +42,8 @@ t0:
   # This script only supported on Mellanox
   - restapi/test_restapi.py
   - snmp/test_snmp_phy_entity.py
+  # Not supported port type
+  - sub_port_interfaces/test_sub_port_l2_forwarding.py
 
 t1:
   # KVM do not support bfd test
@@ -86,8 +88,6 @@ t1:
   - platform_tests/mellanox/test_psu_power_threshold.py
   - platform_tests/mellanox/test_reboot_cause.py
   - snmp/test_snmp_phy_entity.py
-  # Not supported port type
-  - sub_port_interfaces/test_sub_port_l2_forwarding.py
 
 t2:
   # KVM do not support bfd test

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -42,8 +42,6 @@ t0:
   # This script only supported on Mellanox
   - restapi/test_restapi.py
   - snmp/test_snmp_phy_entity.py
-  # Not supported port type
-  - sub_port_interfaces/test_sub_port_l2_forwarding.py
 
 t1:
   # KVM do not support bfd test


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Script `sub_port_interfaces/test_sub_port_l2_forwarding.py` has two test cases
- sub_port_interfaces/test_sub_port_l2_forwarding.py::test_sub_port_l2_forwarding[port] 
- sub_port_interfaces/test_sub_port_l2_forwarding.py::test_sub_port_l2_forwarding[port_in_lag]

The first case can run on kvm testbed, and the second case will skip because of the reason `Not supported port type` marked in `tests_mark_conditions.yaml`. But in PR #13506, I added this script into T0 skip list by mistake, which will skip whole script. In this PR, I fix this issue, and the first case can run in the PR checker. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Script `sub_port_interfaces/test_sub_port_l2_forwarding.py` has two test cases
- sub_port_interfaces/test_sub_port_l2_forwarding.py::test_sub_port_l2_forwarding[port] 
- sub_port_interfaces/test_sub_port_l2_forwarding.py::test_sub_port_l2_forwarding[port_in_lag]

The first case can run on kvm testbed, and the second case will skip because of the reason `Not supported port type` marked in `tests_mark_conditions.yaml`. But in PR #13506, I added this script into T0 skip list by mistake, which will skip whole script. In this PR, I fix this issue, and the first case can run in the PR checker. 

#### How did you do it?
Move script  `sub_port_interfaces/test_sub_port_l2_forwarding.py` from T0 skip list to T0 onboarding list. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
