### PR TITLE
[QoS]Test_buffer_model test skip for Nokia platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1318,7 +1318,7 @@ qos/test_buffer.py::test_buffer_model_test:
     reason: "Running only on mellanox devices and covered by unit testing / M0/MX topo does not support qos"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox']"
+      - "asic_type in ['mellanox'] or platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
       - "topo_type in ['m0', 'mx']"
 
 qos/test_buffer_traditional.py:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1318,7 +1318,7 @@ qos/test_buffer.py::test_buffer_model_test:
     reason: "Running only on mellanox devices and covered by unit testing / M0/MX topo does not support qos"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox'] or platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
+      - "asic_type in ['mellanox'] or asic_subtype in ['broadcom-dnx']"
       - "topo_type in ['m0', 'mx']"
 
 qos/test_buffer_traditional.py:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Updating skip condition for test_buffer_model_test.py in conditional mark as this was overriding the base test skip condition for  nokia platform 'x86_64-nokia_ixr7250e_36x400g-r0'

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Test suite was executing skipped test.
#### How did you do it?
Updated the conditional mark skip condition
#### How did you verify/test it?
Executed the test and verify the results
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
