### PR TITLE
add http_proxy/https_proxy testbed setup information

### DIFF
--- a/docs/testbed/README.testbed.Setup.md
+++ b/docs/testbed/README.testbed.Setup.md
@@ -219,6 +219,7 @@ Once you are in the docker container, you need to modify the testbed configurati
         ```
         ansible -m ping -i veos vm_host_1
         ```
+    - (Optional) if your environment is under a proxy to you can setup it in [`absible/group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
 
 - VMs
     - Update /ansible/group_vars/vm_host/main.yml with the location of the veos files or veos file name if you downloaded a different version
@@ -239,7 +240,7 @@ Once you are in the docker container, you need to modify the testbed configurati
     ceos_image: ceosimage:4.25.10M
     skip_ceos_image_downloading: true
     ```
-    **NOTE: We are using local ceos image, hence the skip ceos image downloading should be set as true.
+    **NOTE**: We are using local ceos image, hence the skip ceos image downloading should be set as true.
 
 
 ## Deploy physical Fanout Switch VLAN

--- a/docs/testbed/README.testbed.Setup.md
+++ b/docs/testbed/README.testbed.Setup.md
@@ -219,7 +219,7 @@ Once you are in the docker container, you need to modify the testbed configurati
         ```
         ansible -m ping -i veos vm_host_1
         ```
-    - (Optional) If your organization uses a proxy server (e.g Squid Proxy) to connect to the internet, you may need to configure the Docker daemon to use the proxy server. You can configure it in [`ansible /group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
+    - (Optional) The connectivity to the public internet is necessary during the setup, if the lab env of your organization requires http/https proxy server to reach out to the internet, you need to configure to use the proxy server. It will automatically be leveraged on required steps (e.g. Docker daemon config for image pulling, APT configuration for installing packages). You can configure it in [`ansible/group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
 
 - VMs
     - Update /ansible/group_vars/vm_host/main.yml with the location of the veos files or veos file name if you downloaded a different version

--- a/docs/testbed/README.testbed.Setup.md
+++ b/docs/testbed/README.testbed.Setup.md
@@ -219,7 +219,7 @@ Once you are in the docker container, you need to modify the testbed configurati
         ```
         ansible -m ping -i veos vm_host_1
         ```
-    - (Optional) if your environment is under a proxy to you can setup it in [`absible/group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
+    - (Optional) If your organization uses a proxy server (e.g Squid Proxy) to connect to the internet, you may need to configure the Docker daemon to use the proxy server. You can configure it in [`ansible /group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
 
 - VMs
     - Update /ansible/group_vars/vm_host/main.yml with the location of the veos files or veos file name if you downloaded a different version

--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -114,25 +114,7 @@ cd sonic-mgmt
 ```
 
 
-
-3. (Optional) Set up proxy: if you get the error `ERROR: unable to find a usable default docker image, please specify one manually` you might need to setup proxy to pull docker image.
-
-   Follows the steps in [Configure docker daemon proxy](https://docs.docker.com/config/daemon/proxy/#daemon-configuration) to setup proxies. You can add these configuration in `etc/docker/daemon.json` and then run `sudo systemctl restart docker` to take effect.
-
-   ```json
-   {
-        ...
-        "proxies": {
-                "http-proxy": "http://proxy.example.com:3128",
-                "https-proxy": "https://proxy.example.com:3129",
-                "no-proxy": "*.test.example.com,.example.org,127.0.0.0/8"
-        }
-   }
-   ```
-
-
-
-4. From now on, **all steps are running inside the sonic-mgmt docker**, unless otherwise specified.
+3. From now on, **all steps are running inside the sonic-mgmt docker**, unless otherwise specified.
 
 
 You can enter your sonic-mgmt container with the following command:
@@ -341,8 +323,7 @@ cd /data/sonic-mgmt/ansible
 ## Deploy minigraph on the DUT
 Once the topology has been created, we need to give the DUT an initial configuration.
 
-(Optional) If your organization uses a proxy server (e.g Squid Proxy) to connect to the internet, you may need to configure the Docker daemon to use the proxy server. You can configure it in [`ansible /group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
-
+(Optional) The connectivity to the public internet is necessary during the setup, if the lab env of your organization requires http/https proxy server to reach out to the internet, you need to configure to use the proxy server. It will automatically be leveraged on required steps (e.g. Docker daemon config for image pulling, APT configuration for installing packages). You can configure it in [`ansible/group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
 
 1. Deploy the `minigraph.xml` to the DUT and save the configuration:
 

--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -96,10 +96,11 @@ All testbed configuration steps and tests are run from a `sonic-mgmt` docker con
 
 1. Run the `setup-container.sh` in the root directory of the sonic-mgmt repository:
 
-```
+```bash
 cd sonic-mgmt
 ./setup-container.sh -n <container name> -d /data
 ```
+
 
 2. (Required for IPv6 test cases): Follow the steps [IPv6 for docker default bridge](https://docs.docker.com/config/daemon/ipv6/#use-ipv6-for-the-default-bridge-network) to enable IPv6 for container. For example, edit the Docker daemon configuration file located at `/etc/docker/daemon.json` with the following parameters to use ULA address if no special requirement. Then restart docker daemon by running `sudo systemctl restart docker` to take effect.
 
@@ -112,7 +113,26 @@ cd sonic-mgmt
 }
 ```
 
-3. From now on, **all steps are running inside the sonic-mgmt docker**, unless otherwise specified.
+
+
+3. (Optional) Set up proxy: if you get the error `ERROR: unable to find a usable default docker image, please specify one manually` you might need to setup proxy to pull docker image.
+
+   Follows the steps in [Configure docker daemon proxy](https://docs.docker.com/config/daemon/proxy/#daemon-configuration) to setup proxies. You can add these configuration in `etc/docker/daemon.json` and then run `sudo systemctl restart docker` to take effect.
+
+   ```json
+   {
+        ...
+        "proxies": {
+                "http-proxy": "http://proxy.example.com:3128",
+                "https-proxy": "https://proxy.example.com:3129",
+                "no-proxy": "*.test.example.com,.example.org,127.0.0.0/8"
+        }
+   }
+   ```
+
+
+
+4. From now on, **all steps are running inside the sonic-mgmt docker**, unless otherwise specified.
 
 
 You can enter your sonic-mgmt container with the following command:
@@ -320,6 +340,9 @@ cd /data/sonic-mgmt/ansible
 
 ## Deploy minigraph on the DUT
 Once the topology has been created, we need to give the DUT an initial configuration.
+
+(Optional) if your environment needs proxy running `testbed-cli.sh` you can setup it in [`absible/group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
+
 
 1. Deploy the `minigraph.xml` to the DUT and save the configuration:
 

--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -341,7 +341,7 @@ cd /data/sonic-mgmt/ansible
 ## Deploy minigraph on the DUT
 Once the topology has been created, we need to give the DUT an initial configuration.
 
-(Optional) if your environment needs proxy running `testbed-cli.sh` you can setup it in [`absible/group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
+(Optional) If your organization uses a proxy server (e.g Squid Proxy) to connect to the internet, you may need to configure the Docker daemon to use the proxy server. You can configure it in [`ansible /group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
 
 
 1. Deploy the `minigraph.xml` to the DUT and save the configuration:

--- a/docs/testbed/README.testbed.WANSetup.md
+++ b/docs/testbed/README.testbed.WANSetup.md
@@ -147,7 +147,7 @@ In order to configure the testbed on your host automatically, Ansible needs to b
 ## Deploy multiple devices topology
 Now we're finally ready to deploy the topology for our testbed! Run the following command:
 
-(Optional) If your organization uses a proxy server (e.g Squid Proxy) to connect to the internet, you may need to configure the Docker daemon to use the proxy server. You can configure it in [`ansible /group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
+(Optional) The connectivity to the public internet is necessary during the setup, if the lab env of your organization requires http/https proxy server to reach out to the internet, you need to configure to use the proxy server. It will automatically be leveraged on required steps (e.g. Docker daemon config for image pulling, APT configuration for installing packages). You can configure it in [`ansible/group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
 
 ### cEOS
    ```

--- a/docs/testbed/README.testbed.WANSetup.md
+++ b/docs/testbed/README.testbed.WANSetup.md
@@ -147,6 +147,7 @@ In order to configure the testbed on your host automatically, Ansible needs to b
 ## Deploy multiple devices topology
 Now we're finally ready to deploy the topology for our testbed! Run the following command:
 
+(Optional) if your environment needs proxy running `testbed-cli.sh` you can setup it in [`absible/group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
 
 ### cEOS
    ```

--- a/docs/testbed/README.testbed.WANSetup.md
+++ b/docs/testbed/README.testbed.WANSetup.md
@@ -147,7 +147,7 @@ In order to configure the testbed on your host automatically, Ansible needs to b
 ## Deploy multiple devices topology
 Now we're finally ready to deploy the topology for our testbed! Run the following command:
 
-(Optional) if your environment needs proxy running `testbed-cli.sh` you can setup it in [`absible/group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
+(Optional) If your organization uses a proxy server (e.g Squid Proxy) to connect to the internet, you may need to configure the Docker daemon to use the proxy server. You can configure it in [`ansible /group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
 
 ### cEOS
    ```

--- a/docs/testbed/sai_quality/DeploySAITestTopologyWithSONiC-MGMT.md
+++ b/docs/testbed/sai_quality/DeploySAITestTopologyWithSONiC-MGMT.md
@@ -5,7 +5,7 @@ This section of the document described how to build a sonic-mgmt docker
 https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testbed/README.testbed.VsSetup.md#setup-sonic-mgmt-docker
 
 
-(Optional) if your environment is under a proxy to you can setup it in [`absible/group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
+(Optional) If your organization uses a proxy server (e.g Squid Proxy) to connect to the internet, you may need to configure the Docker daemon to use the proxy server. You can configure it in [`ansible /group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
 
 1. install the sonic image in the DUT(device under test)
 for example

--- a/docs/testbed/sai_quality/DeploySAITestTopologyWithSONiC-MGMT.md
+++ b/docs/testbed/sai_quality/DeploySAITestTopologyWithSONiC-MGMT.md
@@ -3,6 +3,10 @@ In this article, you will get to know how to use the sonic-mgmt docker to set up
 **Those commands need to be run within a sonic-mgmt docker, or you need to run them within a similar environment.**
 This section of the document described how to build a sonic-mgmt docker
 https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testbed/README.testbed.VsSetup.md#setup-sonic-mgmt-docker
+
+
+(Optional) if your environment is under a proxy to you can setup it in [`absible/group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
+
 1. install the sonic image in the DUT(device under test)
 for example
 ```
@@ -41,6 +45,7 @@ For example, we want to use the config `vms-sn2700-t1-lag`, then we need to chan
 **for the topo, if it ends with 64, then the topo should be ptf64, please change it according to the actual device port.**
 
 4. deploy the new topology
+
 ```
 ./testbed-cli.sh -t testbed.yaml add-topo vms-sn2700-t1 password.txt
 ```

--- a/docs/testbed/sai_quality/DeploySAITestTopologyWithSONiC-MGMT.md
+++ b/docs/testbed/sai_quality/DeploySAITestTopologyWithSONiC-MGMT.md
@@ -5,7 +5,8 @@ This section of the document described how to build a sonic-mgmt docker
 https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testbed/README.testbed.VsSetup.md#setup-sonic-mgmt-docker
 
 
-(Optional) If your organization uses a proxy server (e.g Squid Proxy) to connect to the internet, you may need to configure the Docker daemon to use the proxy server. You can configure it in [`ansible /group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
+
+(Optional) The connectivity to the public internet is necessary during the setup, if the lab env of your organization requires http/https proxy server to reach out to the internet, you need to configure to use the proxy server. It will automatically be leveraged on required steps (e.g. Docker daemon config for image pulling, APT configuration for installing packages). You can configure it in [`ansible/group_vars/all/env.yml`](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/all/env.yml)
 
 1. install the sonic image in the DUT(device under test)
 for example


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

This PR adds documentation for setting up http_proxy/https_proxy for different type of testbeds.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

Some users run into the issues when setting up the testbed because the environment is under a proxy. The current documentation does not implicitly mention how to adjust the proxy settings when running a test bed.

#### How did you verify/test it?

Verified the proxy settings on [virtual switch test bed setup](https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testbed/README.testbed.VsSetup.md)
