### PR TITLE
Add PTF logs collection to post test step

### DIFF
--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import logging
 import time
@@ -88,3 +89,11 @@ def test_enable_startup_tsa_tsb_service(duthosts, localhost):
         else:
             logger.info("{} file does not exist in the specified path on dut {}".
                         format(backup_tsa_tsb_file_path, duthost.hostname))
+
+
+def test_collect_ptf_logs(ptfhost):
+    log_files = ptfhost.shell('ls /tmp/*.log')['stdout'].split()
+    if not os.path.exists('logs/ptf'):
+        os.makedirs('logs/ptf')
+    for log_file in log_files:
+        ptfhost.fetch(src=log_file, dest='logs/ptf', fail_on_missing=False)


### PR DESCRIPTION
### Description of PR

Add function to collect logs from PTF container.

Summary:
Fixes # Not applicable

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

Collecting PTF logs help debug issues that have failures in the PTF container. Flaky PTF tests result in intermittent errors in PTF nn can be observed with this change.

#### How did you do it?

Add a function for log collection from PTF host to post test step.

#### How did you verify/test it?

Run the post-test step individually and observed the PTF logs are collected.

#### Any platform specific information?

This change is not platform specific.

#### Supported testbed topology if it's a new test case?

Any

### Documentation

Not applicable