### PR TITLE
Disabled test_critical_process_monitoring.py::test_orchagent_heartbeat for T1 devices

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1148,6 +1148,15 @@ platform_tests/test_secure_upgrade.py:
       - "'sn2' in platform or 'sn3' in platform or 'sn4' in platform"
 
 #######################################
+#####     process_monitoring      #####
+#######################################
+process_monitoring/test_critical_process_monitoring.py::test_orchagent_heartbeat:
+  skip:
+    reason: This test is intended for Orchagent freeze scenario during warm-reboot. It is not required for T1 devices.
+    conditions:
+      - "'t1' in topo_name"
+
+#######################################
 #####           qos               #####
 #######################################
 qos:


### PR DESCRIPTION
This test is intened for Warm boot scenario which does not apply to T1s.
Disabling this test for T1 devices.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change
Test fox
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)
ADO: 27894767

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [X] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
