### PR TITLE
[Mx] Update `xcvr_skip_list` for Mx topo

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -58,7 +58,7 @@ def skip_on_simx(duthosts, rand_one_dut_hostname):
 
 
 @pytest.fixture(scope="module")
-def xcvr_skip_list(duthosts, dpu_npu_port_list):
+def xcvr_skip_list(duthosts, dpu_npu_port_list, tbinfo):
     intf_skip_list = {}
     for dut in duthosts:
         platform = dut.facts['platform']
@@ -86,6 +86,12 @@ def xcvr_skip_list(duthosts, dpu_npu_port_list):
         # No hwsku.json for Arista-7050-QX-32S/Arista-7050QX-32S-S4Q31
         if hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX-32S-S4Q31']:
             sfp_list = ['Ethernet0', 'Ethernet1', 'Ethernet2', 'Ethernet3']
+            logging.debug('Skipping sfp interfaces: {}'.format(sfp_list))
+            intf_skip_list[dut.hostname].extend(sfp_list)
+
+        # For Mx topo, skip the SFP interfaces because they are admin down
+        if tbinfo['topo']['name'] == "mx" and hwsku in ["Arista-720DT-G48S4", "Nokia-7215"]:
+            sfp_list = ['Ethernet48', 'Ethernet49', 'Ethernet50', 'Ethernet51']
             logging.debug('Skipping sfp interfaces: {}'.format(sfp_list))
             intf_skip_list[dut.hostname].extend(sfp_list)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
On Mx topo, testbed doesn't use SFP interfaces (these ports are admin down). We need to exclude these interfaces from SFP related tests to avoid test failure when there is no cable connected on DUT.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
On Mx topo, testbed doesn't use SFP interfaces (these ports are admin down). We need to exclude these interfaces from SFP related tests to avoid test failure when there is no cable connected on DUT.

#### How did you do it?
Update `xcvr_skip_list`, for Nokia-7215 and Arista-720DT Mx, add `Ethernet48`, `Ethernet49`, `Ethernet50`, `Ethernet51` to skip list.

#### How did you verify/test it?
Verified by running below testcases, all passed or skipped:
* platform_tests/sfp
* platform_tests/api/test_sfp.py
* platform_tests/test_xcvr_info_in_db.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
