### PR TITLE
Add debug forced mgmt routes after fixture setup for MGMT IPv6 only

### DIFF
--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -72,14 +72,16 @@ def log_tacacs(duthosts, ptfhost):
             logging.debug(f"Checking ping_result [{ping_result}]")
 
         # Print debug info for mgmt interfaces and forced mgmt routes
-        mgmt_interface_keys = duthost.command("sonic-db-cli  CONFIG_DB keys 'MGMT_INTERFACE|eth0|*'")['stdout']
-        logging.debug("mgmt_interface_keys: {}".format(mgmt_interface_keys))
-        for interface_key in mgmt_interface_keys.split('\n'):
-            logging.debug("interface_key: {}".format(interface_key))
-            interface_address = interface_key.split('|')[2]
-            forced_mgmt_routes_cmd = "sonic-db-cli CONFIG_DB HGET '{}' forced_mgmt_routes@".format(interface_key)
-            forced_mgmt_routes = duthost.command(forced_mgmt_routes_cmd)['stdout']
-            logging.debug("forced_mgmt_routes: {}, interface address: {}".format(forced_mgmt_routes, interface_address))
+        mgmt_interface_keys = duthost.command("sonic-db-cli CONFIG_DB keys 'MGMT_INTERFACE|*'")['stdout']
+        logging.debug(f"mgmt_interface_keys: {mgmt_interface_keys}")
+        for intf_key in mgmt_interface_keys.split('\n'):
+            logging.debug(f"interface key: {intf_key}")
+            intf_values = intf_key.split('|')
+            if len(intf_values) != 3:
+                logging.debug(f"Unexpected interface key: {intf_key}")
+                continue
+            forced_mgmt_rte = duthost.command(f"sonic-db-cli CONFIG_DB HGET '{intf_key}' forced_mgmt_routes@")['stdout']
+            logging.debug(f"forced_mgmt_routes: {forced_mgmt_rte}, interface address: {intf_values[2]}")
 
 
 def test_bgp_facts_ipv6_only(duthosts, enum_frontend_dut_hostname, enum_asic_index,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add debug forced mgmt routes after fixture setup for MGMT IPv6 only
Fixes # (issue)
ADO: 28489789, 28451569
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [X] 202305
- [X] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
There're some random failures for MGMT IPv6 only TACACS test case, suspect the cause is unreachable ipv6 issue after fixture setup for MGMT IPv6 only.
```
Failed: Warning: Permanently added '2a01:111:e210:3000::a03:9289' (RSA) to the list of known hosts. Permission denied, please try again.
```
This PR is to check the issue's root cause along with ipv6 unreachable issue.

#### How did you do it?
Add debug log to check if forced mgmt routes config is missing after fixture setup

#### How did you verify/test it?
```
18/07/2024 18:05:08 base._run                                L0071 DEBUG  | /var/src/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#128: [strtk5-msn4600c-acs-02] AnsibleModule::command, args=["sonic-db-cli  CONFIG_DB keys 'MGMT_INTERFACE|eth0|*'"], kwargs={}
18/07/2024 18:05:08 base._run                                L0108 DEBUG  | /var/src/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#128: [strtk5-msn4600c-acs-02] AnsibleModule::command Result => {"changed": true, "stdout": "MGMT_INTERFACE|eth0|2603:10e2:140:3000::98/122", "stderr": "", "rc": 0, "cmd": ["sonic-db-cli", "CONFIG_DB", "keys", "MGMT_INTERFACE|eth0|*"], "start": "2024-07-18 18:05:08.542930", "end": "2024-07-18 18:05:08.561001", "delta": "0:00:00.018071", "msg": "", "invocation": {"module_args": {"_raw_params": "sonic-db-cli  CONFIG_DB keys 'MGMT_INTERFACE|eth0|*'", "_uses_shell": false, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["MGMT_INTERFACE|eth0|2603:10e2:140:3000::98/122"], "stderr_lines": [], "_ansible_no_log": null, "failed": false}
18/07/2024 18:05:08 test_mgmt_ipv6_only.log_tacacs           L0074 DEBUG  | mgmt_interface_keys: MGMT_INTERFACE|eth0|2603:10e2:140:3000::98/122
18/07/2024 18:05:08 test_mgmt_ipv6_only.log_tacacs           L0077 DEBUG  | interface_key: MGMT_INTERFACE|eth0|2603:10e2:140:3000::98/122
18/07/2024 18:05:08 base._run                                L0071 DEBUG  | /var/src/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#128: [strtk5-msn4600c-acs-02] AnsibleModule::command, args=["sonic-db-cli CONFIG_DB HGET 'MGMT_INTERFACE|eth0|2603:10e2:140:3000::98/122' forced_mgmt_routes@"], kwargs={}
18/07/2024 18:05:09 base._run                                L0108 DEBUG  | /var/src/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#128: [strtk5-msn4600c-acs-02] AnsibleModule::command Result => {"changed": true, "stdout": "2603:10b0:11d:1::400/118,2603:10b0:b17:18::400/118,2603:10e2:140:3000::101/122", "stderr": "", "rc": 0, "cmd": ["sonic-db-cli", "CONFIG_DB", "HGET", "MGMT_INTERFACE|eth0|2603:10e2:140:3000::98/122", "forced_mgmt_routes@"], "start": "2024-07-18 18:05:09.076085", "end": "2024-07-18 18:05:09.096777", "delta": "0:00:00.020692", "msg": "", "invocation": {"module_args": {"_raw_params": "sonic-db-cli CONFIG_DB HGET 'MGMT_INTERFACE|eth0|2603:10e2:140:3000::98/122' forced_mgmt_routes@", "_uses_shell": false, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["2603:10b0:11d:1::400/118,2603:10b0:b17:18::400/118,2603:10e2:140:3000::101/122"], "stderr_lines": [], "_ansible_no_log": null, "failed": false}
18/07/2024 18:05:09 test_mgmt_ipv6_only.log_tacacs           L0082 DEBUG  | forced_mgmt_routes: 2603:10b0:11d:1::400/118,2603:10b0:b17:18::400/118,2603:10e2:140:3000::101/122, interface address: 2603:10e2:140:3000::98/122
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
