### PR TITLE
[202305 only]Skip test_drop_counters.py::test_acl_drop on Cisco 8111 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -302,6 +302,12 @@ drop_packets:
     conditions:
       - "topo_type in ['m0', 'mx']"
 
+drop_packets/test_drop_counters.py::test_acl_drop:
+  skip:
+    reason: "Cisco 8111 platform has known issue with test_acl_drop"
+    conditions:
+      - "platform in ['x86_64-8111_32eh_o-r0']"
+
 #######################################
 #####           dualtor           #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
There is known issue in test_drop_counters.py::test_acl_drop on Cisco 8111 platform

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
There is known issue in test_drop_counters.py::test_acl_drop on Cisco 8111 platform

#### How did you do it?
Skip the testcase in 202305 branch

#### How did you verify/test it?
======================================= short test summary info =======================================
SKIPPED [3] drop_packets/drop_packets.py: Cisco 8111 platform has known issue with test_acl_drop
=================================== 3 skipped, 1 warning in 34.96s ====================================

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
