### PR TITLE
No exporting client secrets in run test template yaml

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -240,8 +240,6 @@ steps:
         echo "##vso[task.setvariable variable=TEST_PLAN_ID_LIST_STRING]$TEST_PLAN_ID_LIST_STRING"
 
     displayName: "Trigger test"
-    env:
-      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
 
   - task: AzureCLI@2
     inputs:
@@ -275,8 +273,6 @@ steps:
         fi
 
     displayName: "Lock testbed"
-    env:
-      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
 
   - task: AzureCLI@2
     inputs:
@@ -311,8 +307,6 @@ steps:
         fi
 
     displayName: "Prepare testbed"
-    env:
-      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
 
   - task: AzureCLI@2
     inputs:
@@ -347,8 +341,6 @@ steps:
 
     displayName: "Run test"
     timeoutInMinutes: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-    env:
-      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
 
   - ${{ if eq(parameters.DUMP_KVM_IF_FAIL, 'True') }}:
       - task: AzureCLI@2
@@ -374,8 +366,6 @@ steps:
 
         condition: succeededOrFailed()
         displayName: "KVM dump"
-        env:
-          ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
 
   - task: AzureCLI@2
     inputs:
@@ -392,5 +382,3 @@ steps:
         done
     condition: always()
     displayName: "Finalize running test plan"
-    env:
-      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
We have deprecated usage of client secret for authentication. The code for exporting client secret in run test template yaml is no longer needed.

#### How did you do it?
This change cleaned up the code for exporting client secret in the run test template yaml file.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
