### PR TITLE
[Ansible] Skip package migrate when installing image

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -208,6 +208,11 @@ def install_new_sonic_image(module, new_image_url, save_as=None, required_space=
         )
         return
 
+    skip_package_migrate_param = ""
+    _, output, _ = exec_command(module, cmd="sonic_installer install --help", ignore_error=True)
+    if "skip-package-migration" in output:
+        skip_package_migrate_param = "--skip-package-migration"
+
     if save_as.startswith("/tmp/tmpfs"):
         log("Create a tmpfs partition to download image to install")
         exec_command(module, cmd="mkdir -p /tmp/tmpfs", ignore_error=True)
@@ -222,7 +227,7 @@ def install_new_sonic_image(module, new_image_url, save_as=None, required_space=
         log("Running sonic_installer to install image at {}".format(save_as))
         rc, out, err = exec_command(
             module,
-            cmd="sonic_installer install {} -y".format(save_as),
+            cmd="sonic_installer install {} {} -y".format(save_as, skip_package_migrate_param),
             msg="installing new image", ignore_error=True
         )
         log("Done running sonic_installer to install image")
@@ -241,8 +246,8 @@ def install_new_sonic_image(module, new_image_url, save_as=None, required_space=
         log("Running sonic_installer to install image at {}".format(save_as))
         rc, out, err = exec_command(
             module,
-            cmd="sonic_installer install {} -y".format(
-                save_as),
+            cmd="sonic_installer install {} {} -y".format(
+                save_as, skip_package_migrate_param),
             msg="installing new image", ignore_error=True
         )
         log("Always remove the downloaded temp image inside /host/ before proceeding")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 202012
- [x] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Currently install image in sonic-mgmt is use default param, which would migrate sonic-extension-application package by default (dhcp_relay, macsec, dhcp_server) when install to a os version which doesn't contain them. This is un-clean install, should be fixed.
Also, there is an issue with sonic_package_manager when migrate package https://github.com/sonic-net/sonic-buildimage/issues/19633

#### How did you do it?
When installing image, check whether it support skip-package-migrate, if so, skip it.

#### How did you verify/test it?
Use .azure-pipelines/upgrade_image.py to install image from os support package migrate and not support package migrate to a new version, not error

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
