### PR TITLE
Fix test_acl_outer_vlan teardown error.

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -105,17 +105,7 @@ def remove_dataacl_table(rand_selected_dut):
     logger.info("Removing ACL table {}".format(TABLE_NAME))
     rand_selected_dut.shell(cmd="config acl remove table {}".format(TABLE_NAME))
     yield
-    # Recover DATAACL
-    config_db_json = "/etc/sonic/config_db.json"
-    output = rand_selected_dut.shell("sonic-cfggen -j {} --var-json \"ACL_TABLE\"".format(config_db_json))['stdout']
-    try:
-        entry = json.loads(output)[TABLE_NAME]
-        cmd_create_table = "config acl add table {} {} -p {} -s {}"\
-            .format(TABLE_NAME, entry['type'], ",".join(entry['ports']), entry['stage'])
-        logger.info("Restoring ACL table {}".format(TABLE_NAME))
-        rand_selected_dut.shell(cmd_create_table)
-    except Exception as e:
-        pytest.fail(str(e))
+    # Recover DATAACL table by teardown()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Summary: Fix test_acl_outer_vlan teardown error.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [X] 202205
- [X] 202305
- [X] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
During teardown, remove_dataacl_table() will attempt to add back the DATAACL, but the table has already been recovered by another function in teardown().

#### How did you do it?
Remove the code to recover the DATAACL table.

#### How did you verify/test it?
Run the "test_acl_outer_vlan", the test result do not show any error message.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
No

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
