### PR TITLE
Update test_bgp_scalability.py with 256k_ipv4_v6 and 64k_ipv4_v6 test…

### DIFF
--- a/tests/snappi_tests/bgp/test_bgp_scalability.py
+++ b/tests/snappi_tests/bgp/test_bgp_scalability.py
@@ -1,16 +1,16 @@
-from tests.common.snappi_tests.snappi_fixtures import (                           # noqa F401
+import pytest
+from tests.common.fixtures.conn_graph_facts import (  # noqa F401
+    conn_graph_facts, fanout_graph_facts)
+from tests.common.snappi_tests.snappi_fixtures import (  # noqa F401
     cvg_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
 from tests.snappi_tests.bgp.files.bgp_test_gap_helper import duthost_bgp_scalability_config, \
     run_bgp_scalability_v4_v6, cleanup_config
-from tests.common.fixtures.conn_graph_facts import (                        # noqa F401
-    conn_graph_facts, fanout_graph_facts)
-import pytest
 
 pytestmark = [pytest.mark.topology('tgen')]
 
 
 @pytest.mark.parametrize('multipath', [1])
-def test_duthost_bgp_scalability_config(duthost, tgen_ports, multipath):        # noqa F811
+def test_duthost_bgp_scalability_config(duthost, tgen_ports, multipath):  # noqa F811
     duthost_bgp_scalability_config(duthost, tgen_ports, multipath)
 
 
@@ -18,15 +18,14 @@ def test_duthost_bgp_scalability_config(duthost, tgen_ports, multipath):        
 @pytest.mark.parametrize('ipv4_routes', [16000])
 @pytest.mark.parametrize('ipv6_routes', [1])
 @pytest.mark.parametrize('ipv6_prefix', [64])
-def test_bgp_scalability_16k_v4_routes(cvg_api,             # noqa F811
+def test_bgp_scalability_16k_v4_routes(cvg_api,  # noqa F811
                                        duthost,
                                        localhost,
-                                       tgen_ports,          # noqa F811
+                                       tgen_ports,  # noqa F811
                                        multipath,
                                        ipv4_routes,
                                        ipv6_routes,
                                        ipv6_prefix):
-
     run_bgp_scalability_v4_v6(cvg_api,
                               duthost,
                               localhost,
@@ -41,15 +40,14 @@ def test_bgp_scalability_16k_v4_routes(cvg_api,             # noqa F811
 @pytest.mark.parametrize('ipv4_routes', [1])
 @pytest.mark.parametrize('ipv6_routes', [8000])
 @pytest.mark.parametrize('ipv6_prefix', [64])
-def test_bgp_scalability_8k_v6_routes(cvg_api,              # noqa F811
+def test_bgp_scalability_8k_v6_routes(cvg_api,  # noqa F811
                                       duthost,
                                       localhost,
-                                      tgen_ports,           # noqa F811
+                                      tgen_ports,  # noqa F811
                                       multipath,
                                       ipv4_routes,
                                       ipv6_routes,
                                       ipv6_prefix):
-
     run_bgp_scalability_v4_v6(cvg_api,
                               duthost,
                               localhost,
@@ -64,15 +62,14 @@ def test_bgp_scalability_8k_v6_routes(cvg_api,              # noqa F811
 @pytest.mark.parametrize('ipv4_routes', [1])
 @pytest.mark.parametrize('ipv6_routes', [256])
 @pytest.mark.parametrize('ipv6_prefix', [128])
-def test_bgp_scalability_256_v6_routes(cvg_api,             # noqa F811
+def test_bgp_scalability_256_v6_routes(cvg_api,  # noqa F811
                                        duthost,
                                        localhost,
-                                       tgen_ports,          # noqa F811
+                                       tgen_ports,  # noqa F811
                                        multipath,
                                        ipv4_routes,
                                        ipv6_routes,
                                        ipv6_prefix):
-
     run_bgp_scalability_v4_v6(cvg_api,
                               duthost,
                               localhost,
@@ -87,15 +84,58 @@ def test_bgp_scalability_256_v6_routes(cvg_api,             # noqa F811
 @pytest.mark.parametrize('ipv4_routes', [8000])
 @pytest.mark.parametrize('ipv6_routes', [4000])
 @pytest.mark.parametrize('ipv6_prefix', [64])
-def test_bgp_scalability_8kv4_4kv6_routes(cvg_api,          # noqa F811
+def test_bgp_scalability_8kv4_4kv6_routes(cvg_api,  # noqa F811
                                           duthost,
                                           localhost,
-                                          tgen_ports,       # noqa F811
+                                          tgen_ports,  # noqa F811
                                           multipath,
                                           ipv4_routes,
                                           ipv6_routes,
                                           ipv6_prefix):
+    run_bgp_scalability_v4_v6(cvg_api,
+                              duthost,
+                              localhost,
+                              tgen_ports,
+                              multipath,
+                              ipv4_routes,
+                              ipv6_routes,
+                              ipv6_prefix)
 
+
+@pytest.mark.parametrize('multipath', [1])
+@pytest.mark.parametrize('ipv4_routes', [64000])
+@pytest.mark.parametrize('ipv6_routes', [64000])
+@pytest.mark.parametrize('ipv6_prefix', [64])
+def test_bgp_scalability_64kv4_64kv6_routes(cvg_api,  # noqa F811
+                                            duthost,
+                                            localhost,
+                                            tgen_ports,  # noqa F811
+                                            multipath,
+                                            ipv4_routes,
+                                            ipv6_routes,
+                                            ipv6_prefix):
+    run_bgp_scalability_v4_v6(cvg_api,
+                              duthost,
+                              localhost,
+                              tgen_ports,
+                              multipath,
+                              ipv4_routes,
+                              ipv6_routes,
+                              ipv6_prefix)
+
+
+@pytest.mark.parametrize('multipath', [1])
+@pytest.mark.parametrize('ipv4_routes', [256000])
+@pytest.mark.parametrize('ipv6_routes', [256000])
+@pytest.mark.parametrize('ipv6_prefix', [64])
+def test_bgp_scalability_256kv4_256kv6_routes(cvg_api,  # noqa F811
+                                              duthost,
+                                              localhost,
+                                              tgen_ports,  # noqa F811
+                                              multipath,
+                                              ipv4_routes,
+                                              ipv6_routes,
+                                              ipv6_prefix):
     run_bgp_scalability_v4_v6(cvg_api,
                               duthost,
                               localhost,
@@ -110,15 +150,36 @@ def test_bgp_scalability_8kv4_4kv6_routes(cvg_api,          # noqa F811
 @pytest.mark.parametrize('ipv4_routes', [100000])
 @pytest.mark.parametrize('ipv6_routes', [25000])
 @pytest.mark.parametrize('ipv6_prefix', [64])
-def test_bgp_scalability_100kv4_25kv6_routes(cvg_api,       # noqa F811
+def test_bgp_scalability_100kv4_25kv6_routes(cvg_api,  # noqa F811
                                              duthost,
                                              localhost,
-                                             tgen_ports,    # noqa F811
+                                             tgen_ports,  # noqa F811
                                              multipath,
                                              ipv4_routes,
                                              ipv6_routes,
                                              ipv6_prefix):
+    run_bgp_scalability_v4_v6(cvg_api,
+                              duthost,
+                              localhost,
+                              tgen_ports,
+                              multipath,
+                              ipv4_routes,
+                              ipv6_routes,
+                              ipv6_prefix)
 
+
+@pytest.mark.parametrize('multipath', [1])
+@pytest.mark.parametrize('ipv4_routes', [64000])
+@pytest.mark.parametrize('ipv6_routes', [1])
+@pytest.mark.parametrize('ipv6_prefix', [64])
+def test_bgp_scalability_64k_v4_routes(cvg_api,  # noqa F811
+                                          duthost,
+                                          localhost,
+                                          tgen_ports,  # noqa F811
+                                          multipath,
+                                          ipv4_routes,
+                                          ipv6_routes,
+                                          ipv6_prefix):
     run_bgp_scalability_v4_v6(cvg_api,
                               duthost,
                               localhost,


### PR DESCRIPTION
…cases

Update test_bgp_scalability.py with 256k_ipv4_v6 and 64k_ipv4_v6 testcases

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
