### PR TITLE
Move stable test from onboarding test job to t0/t1-lag PR checker

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -2,6 +2,7 @@ t0:
   - acl/custom_acl_table/test_custom_acl_table.py
   - acl/null_route/test_null_route_helper.py
   - acl/test_acl.py
+  - acl/test_acl_outer_vlan.py
   - acl/test_stress_acl.py
   - arp/test_arp_extended.py
   - arp/test_neighbor_mac.py
@@ -29,6 +30,7 @@ t0:
   - container_hardening/test_container_hardening.py
   - database/test_db_config.py
   - database/test_db_scripts.py
+  - decap/test_decap.py
   - dhcp_relay/test_dhcp_pkt_recv.py
   - dhcp_relay/test_dhcp_relay.py
   - dhcp_relay/test_dhcpv6_relay.py
@@ -36,6 +38,10 @@ t0:
   - dns/static_dns/test_static_dns.py
   - dns/test_dns_resolv_conf.py
   - dualtor/test_orch_stress.py
+  - dualtor/test_orchagent_active_tor_downstream.py
+  - dualtor/test_orchagent_mac_move.py
+  - dualtor/test_orchagent_standby_tor_downstream.py
+  - dualtor/test_standby_tor_upstream_mux_toggle.py
   - dualtor_mgmt/test_server_failure.py
   - dualtor_mgmt/test_toggle_mux.py
   - dut_console/test_console_baud_rate.py
@@ -212,6 +218,7 @@ t1-lag:
   - bgp/test_traffic_shift.py
   - configlet/test_add_rack.py
   - container_checker/test_container_checker.py
+  - decap/test_decap.py
   - dhcp_relay/test_dhcp_pkt_fwd.py
   - everflow/test_everflow_ipv6.py
   - everflow/test_everflow_per_interface.py
@@ -323,17 +330,10 @@ onboarding_t0:
   - sub_port_interfaces/test_sub_port_interfaces.py
   - sub_port_interfaces/test_sub_port_l2_forwarding.py
   - test_pktgen.py
-  - acl/test_acl_outer_vlan.py
   - arp/test_unknown_mac.py
-  - decap/test_decap.py
   - hash/test_generic_hash.py
-  - dualtor/test_orchagent_active_tor_downstream.py
-  - dualtor/test_orchagent_mac_move.py
-  - dualtor/test_orchagent_standby_tor_downstream.py
-  - dualtor/test_standby_tor_upstream_mux_toggle.py
 
 onboarding_t1:
-  - decap/test_decap.py
   - generic_config_updater/test_cacl.py
   - hash/test_generic_hash.py
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
I have added some dataplane test scripts to PR test and put into optional onboarding job to test case performance, I calculated the success rate of test scripts in recent 1 week, I think I can move high success rate test scripts to t0/t1 job now
TestbedName | FilePath | RunDate | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-t0 | acl/test_acl_outer_vlan.py | 2024-07-21 00:00:00.0000000 | 64 | 0 | 64 | 1
vms-kvm-t1-lag | decap/test_decap.py | 2024-07-21 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t0 | decap/test_decap.py | 2024-07-21 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t0 | dualtor/test_orchagent_active_tor_downstream.py | 2024-07-21 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t0 | dualtor/test_orchagent_mac_move.py | 2024-07-21 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t0 | dualtor/test_orchagent_standby_tor_downstream.py | 2024-07-21 00:00:00.0000000 | 24 | 0 | 24 | 1
vms-kvm-t0 | dualtor/test_standby_tor_upstream_mux_toggle.py | 2024-07-21 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t0 | acl/test_acl_outer_vlan.py | 2024-07-20 00:00:00.0000000 | 256 | 0 | 256 | 1
vms-kvm-t1-lag | decap/test_decap.py | 2024-07-20 00:00:00.0000000 | 32 | 0 | 32 | 1
vms-kvm-t0 | decap/test_decap.py | 2024-07-20 00:00:00.0000000 | 32 | 0 | 32 | 1
vms-kvm-t0 | dualtor/test_orchagent_active_tor_downstream.py | 2024-07-20 00:00:00.0000000 | 32 | 0 | 32 | 1
vms-kvm-t0 | dualtor/test_orchagent_mac_move.py | 2024-07-20 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t0 | dualtor/test_orchagent_standby_tor_downstream.py | 2024-07-20 00:00:00.0000000 | 96 | 0 | 96 | 1
vms-kvm-t0 | dualtor/test_standby_tor_upstream_mux_toggle.py | 2024-07-20 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t0 | acl/test_acl_outer_vlan.py | 2024-07-19 00:00:00.0000000 | 576 | 0 | 576 | 1
vms-kvm-t1-lag | decap/test_decap.py | 2024-07-19 00:00:00.0000000 | 72 | 0 | 72 | 1
vms-kvm-t0 | decap/test_decap.py | 2024-07-19 00:00:00.0000000 | 72 | 0 | 72 | 1
vms-kvm-t0 | dualtor/test_orchagent_active_tor_downstream.py | 2024-07-19 00:00:00.0000000 | 72 | 0 | 72 | 1
vms-kvm-t0 | dualtor/test_orchagent_mac_move.py | 2024-07-19 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t0 | dualtor/test_orchagent_standby_tor_downstream.py | 2024-07-19 00:00:00.0000000 | 212 | 1 | 213 | 0.9953
vms-kvm-t0 | dualtor/test_standby_tor_upstream_mux_toggle.py | 2024-07-19 00:00:00.0000000 | 18 | 0 | 18 | 1
#### How did you do it?
Move test from onboarding job to t0/t1 job
#### How did you verify/test it?
Run PR test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
