### PR TITLE
Fix Key Mismatch for T1 Skip Scripts in pr_test_skip_scripts.yaml and pr_test_scripts.yaml

### DIFF
--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -48,7 +48,7 @@ t0:
   # The tests in this script are all related to the above table
   - system_health/test_system_health.py
 
-t1:
+t1-lag:
   # KVM do not support bfd test
   - bfd/test_bfd.py
   # KVM do not support drop reason in testcase, and testcase would set drop reason in setup stage, can't do more test


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
We use pr_test_skip_scripts.yaml to identify scripts that should be completely skipped on different platforms during KVM tests, and store these scripts statically in .azure-pipelines/testscripts_analyse/.
However, T1 skip scripts were not being included in the calculations because of a key mismatch. In pr_test_scripts.yaml, the key used is "t1-lag," while in pr_test_skip_scripts.yaml, the key used is "t1." This inconsistency prevented the correct aggregation of the results. This pull request addresses the issue by ensuring consistent key usage across both files.
#### How did you do it?
Modify the key "t1" to "t1-lag" in pr_test_skip_scripts.yaml
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
