### PR TITLE
Avoid KeyError in script `test_generic_hash.py` on kvm testbed. 

### DIFF
--- a/tests/hash/generic_hash_helper.py
+++ b/tests/hash/generic_hash_helper.py
@@ -431,7 +431,7 @@ def get_asic_type(request):
     else:
         # Always get the asic type from the first dut
         dut_info = metadata[list(metadata.keys())[0]]
-        asic_type = dut_info['asic_type']
+        asic_type = dut_info.get('asic_type', "")
     return asic_type
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In sciprt `hash/test_generic_hash.py`, it needs to get asic type from the dict `dut_info`. But on kvm testbed, this dict doesn't have the key `asic_type`, which will cause the KeyError. In this PR, we use the function `get` to get the value in a dict, and if the key doesn't exist, we will return an empty string. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In sciprt `hash/test_generic_hash.py`, it needs to get asic type from the dict `dut_info`. But on kvm testbed, this dict doesn't have the key `asic_type`, which will cause the KeyError. In this PR, we use the function `get` to get the value in a dict, and if the key doesn't exist, we will return an empty string. 

#### How did you do it?
Use the function `get` to get the value in a dict, and if the key doesn't exist, we will return an empty string. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
