### PR TITLE
Fix az login timeout issue while running test_plan.py

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -241,7 +241,9 @@ steps:
 
     displayName: "Trigger test"
     env:
-      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
+      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
+      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
+      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
 
   - task: AzureCLI@2
     inputs:
@@ -276,7 +278,9 @@ steps:
 
     displayName: "Lock testbed"
     env:
-      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
+      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
+      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
+      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
 
   - task: AzureCLI@2
     inputs:
@@ -312,7 +316,9 @@ steps:
 
     displayName: "Prepare testbed"
     env:
-      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
+      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
+      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
+      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
 
   - task: AzureCLI@2
     inputs:
@@ -348,7 +354,9 @@ steps:
     displayName: "Run test"
     timeoutInMinutes: ${{ parameters.MAX_RUN_TEST_MINUTES }}
     env:
-      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
+      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
+      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
+      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
 
   - ${{ if eq(parameters.DUMP_KVM_IF_FAIL, 'True') }}:
       - task: AzureCLI@2
@@ -375,7 +383,9 @@ steps:
         condition: succeededOrFailed()
         displayName: "KVM dump"
         env:
-          ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
+          SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
+          ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
+          SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
 
   - task: AzureCLI@2
     inputs:
@@ -393,4 +403,6 @@ steps:
     condition: always()
     displayName: "Finalize running test plan"
     env:
-      ELASTICTEST_MSAL_CLIENT_SECRET: $(ELASTICTEST_MSAL_CLIENT_SECRET)
+      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
+      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
+      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -238,7 +238,6 @@ class TestPlanManager(object):
 
         raise Exception("Failed to get token after {} attempts".format(MAX_GET_TOKEN_RETRY_TIMES))
 
-
     def create(self, topology, test_plan_name="my_test_plan", deploy_mg_extra_params="", kvm_build_id="",
                min_worker=None, max_worker=None, pr_id="unknown", output=None,
                common_extra_params="", **kwargs):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
The test_plan.py may run for over 24 hours polling test plan status if the test plan is in EXECUTING.

The test_plan.py script is wrapped in AzureCLI task which takes cares of az login. However, the az login session may expire after 24 hours. In this case, the test_plan.py script will fail to get access token for accessing Elastictest API to poll test plan status.

#### How did you do it?
The workaround is run "az login" every 12 hours in test_plan.py to ensure that long running tests won't fail with getting access token.

To support the az login session, need to pass some more environment variables to the test_plan.py. The run elastictest pipeline yaml has been updated accordingly.

New variable `SONIC_AUTOMATION_SERVICE_PRINCIPAL` has been added to variable group `SONiC-Elastictest` on Azure pipeline platform.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
