### PR TITLE
Move stable test scripts from onboarding test job to dualtor PR checker

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -197,6 +197,9 @@ t0-sonic:
 
 dualtor:
   - arp/test_arp_extended.py
+  - dualtor_mgmt/test_grpc_periodical_sync.py
+  - dualtor_mgmt/test_server_failure.py
+  - dualtor_mgmt/test_toggle_mux.py
 
 t1-lag:
   - acl/test_acl.py
@@ -339,11 +342,9 @@ onboarding_t1:
   - hash/test_generic_hash.py
 
 onboarding_dualtor:
-  - dualtor_mgmt/test_dualtor_bgp_update_delay.py
-  - dualtor_mgmt/test_grpc_periodical_sync.py
   - dualtor_mgmt/test_ingress_drop.py
-  - dualtor_mgmt/test_server_failure.py
-  - dualtor_mgmt/test_toggle_mux.py
+  - dualtor_mgmt/test_dualtor_bgp_update_delay.py
+
 
 specific_param:
   t0-sonic:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In this PR, we move some stable scripts from onboarding dualtor PR checker to dualtor PR checker. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In this PR, we move some stable scripts from onboarding dualtor PR checker to dualtor PR checker. 

#### How did you do it?

#### How did you verify/test it?
TestbedName | FilePath | RunDate | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-dual-t0 | dualtor_mgmt/test_grpc_periodical_sync.py | 2024-07-22 00:00:00.0000000 | 6 | 0 | 6 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_server_failure.py | 2024-07-22 00:00:00.0000000 | 6 | 0 | 6 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_toggle_mux.py | 2024-07-22 00:00:00.0000000 | 12 | 0 | 12 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_grpc_periodical_sync.py | 2024-07-21 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_server_failure.py | 2024-07-21 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_toggle_mux.py | 2024-07-21 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_grpc_periodical_sync.py | 2024-07-20 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_server_failure.py | 2024-07-20 00:00:00.0000000 | 16 | 0 | 16 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_toggle_mux.py | 2024-07-20 00:00:00.0000000 | 26 | 2 | 28 | 0.9286
vms-kvm-dual-t0 | dualtor_mgmt/test_grpc_periodical_sync.py | 2024-07-19 00:00:00.0000000 | 34 | 0 | 34 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_server_failure.py | 2024-07-19 00:00:00.0000000 | 34 | 1 | 35 | 0.9714
vms-kvm-dual-t0 | dualtor_mgmt/test_toggle_mux.py | 2024-07-19 00:00:00.0000000 | 58 | 4 | 62 | 0.9355
vms-kvm-dual-t0 | dualtor_mgmt/test_grpc_periodical_sync.py | 2024-07-18 00:00:00.0000000 | 48 | 0 | 48 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_server_failure.py | 2024-07-18 00:00:00.0000000 | 50 | 0 | 50 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_toggle_mux.py | 2024-07-18 00:00:00.0000000 | 80 | 5 | 85 | 0.9412
vms-kvm-dual-t0 | dualtor_mgmt/test_grpc_periodical_sync.py | 2024-07-17 00:00:00.0000000 | 46 | 0 | 46 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_server_failure.py | 2024-07-17 00:00:00.0000000 | 46 | 1 | 47 | 0.9787
vms-kvm-dual-t0 | dualtor_mgmt/test_toggle_mux.py | 2024-07-17 00:00:00.0000000 | 75 | 7 | 82 | 0.9146

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
