### PR TITLE
[Mellanox] Skip asic mock in test_device_checker for mellanox device

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -18,6 +18,7 @@ from tests.common.utilities import wait_until
 from jinja2 import Template
 from netaddr import valid_ipv4, valid_ipv6
 from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.mellanox_data import is_mellanox_device
 
 
 logger = logging.getLogger(__name__)
@@ -524,6 +525,15 @@ def dut_qos_maps_module(rand_selected_front_end_dut):
     """
     dut = rand_selected_front_end_dut
     return _dut_qos_map(dut)
+
+
+@pytest.fixture(scope='module')
+def is_support_mock_asic(duthosts, rand_one_dut_hostname):
+    """
+    Check if dut supports mock asic. For mellanox device, it doesn't support mock asic
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    return not is_mellanox_device(duthost)
 
 
 def separated_dscp_to_tc_map_on_uplink(dut_qos_maps_module):

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -12,6 +12,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.platform_tests.thermal_control_test_helper import disable_thermal_policy     # noqa F401
 from .device_mocker import device_mocker_factory        # noqa F401
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.duthost_utils import is_support_mock_asic    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -159,7 +160,7 @@ def test_service_checker_with_process_exit(duthosts, enum_rand_one_per_hwsku_hos
 
 @pytest.mark.disable_loganalyzer
 def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname,
-                        device_mocker_factory, disable_thermal_policy):     # noqa F811
+                        device_mocker_factory, disable_thermal_policy, is_support_mock_asic):     # noqa F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     device_mocker = device_mocker_factory(duthost)
     wait_system_health_boot_up(duthost)
@@ -168,7 +169,9 @@ def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname,
         fan_mock_result, fan_name = device_mocker.mock_fan_speed(False)
         fan_expect_value = EXPECT_FAN_INVALID_SPEED.format(fan_name)
 
-        asic_mock_result = device_mocker.mock_asic_temperature(False)
+        asic_mock_result = 'not support asic mock'
+        if is_support_mock_asic:
+            asic_mock_result = device_mocker.mock_asic_temperature(False)
         asic_expect_value = EXPECT_ASIC_HOT
 
         psu_mock_result, psu_name = device_mocker.mock_psu_presence(False)
@@ -185,17 +188,18 @@ def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname,
                 duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
             assert value and fan_expect_value in value,\
                 'Mock fan invalid speed, expect {}, but got {}'.format(fan_expect_value, value)
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, 'ASIC')
-            assert value and asic_expect_value in value,\
-                'Mock ASIC temperature overheated, expect {}, but got {}'.format(asic_expect_value, value)
+            if is_support_mock_asic:
+                value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, 'ASIC')
+                assert value and asic_expect_value in value,\
+                    'Mock ASIC temperature overheated, expect {}, but got {}'.format(asic_expect_value, value)
 
             value = redis_get_field_value(
                 duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name)
             assert value and psu_expect_value == value,\
                 'Mock PSU absence, expect {}, but got {}'.format(psu_expect_value, value)
         fan_mock_result, fan_name = device_mocker.mock_fan_speed(True)
-        asic_mock_result = device_mocker.mock_asic_temperature(True)
+        if is_support_mock_asic:
+            asic_mock_result = device_mocker.mock_asic_temperature(True)
         psu_mock_result, psu_name = device_mocker.mock_psu_presence(True)
         if fan_mock_result and asic_mock_result and psu_mock_result:
             logger.info('Mocked valid fan speed for {}'.format(fan_name))
@@ -209,10 +213,10 @@ def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname,
             assert not value or fan_expect_value not in value,\
                 'Mock fan valid speed, expect {}, but it still report invalid speed'.format(fan_expect_value)
 
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, 'ASIC')
-            assert not value or asic_expect_value not in value,\
-                'Mock ASIC normal temperature, but it is still overheated'
+            if is_support_mock_asic:
+                value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, 'ASIC')
+                assert not value or asic_expect_value not in value,\
+                    'Mock ASIC normal temperature, but it is still overheated'
 
             value = redis_get_field_value(
                 duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name)
@@ -356,7 +360,7 @@ def test_external_checker(duthosts, enum_rand_one_per_hwsku_hostname):
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('ignore_log_analyzer_by_vendor', [['mellanox']], indirect=True)
 def test_system_health_config(duthosts, enum_rand_one_per_hwsku_hostname,
-                              device_mocker_factory, ignore_log_analyzer_by_vendor):    # noqa F811
+                              device_mocker_factory, ignore_log_analyzer_by_vendor, is_support_mock_asic):    # noqa F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     device_mocker = device_mocker_factory(duthost)
     wait_system_health_boot_up(duthost)
@@ -375,16 +379,17 @@ def test_system_health_config(duthosts, enum_rand_one_per_hwsku_hostname,
 
     logger.info(
         'Ignore ASIC check, verify there is no error information about ASIC')
-    with ConfigFileContext(duthost, os.path.join(FILES_DIR, IGNORE_ASIC_CHECK_CONFIG_FILE)):
-        time.sleep(FAST_INTERVAL)
-        mock_result = device_mocker.mock_asic_temperature(False)
-        expect_value = EXPECT_ASIC_HOT
-        if mock_result:
-            time.sleep(THERMAL_CHECK_INTERVAL)
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, 'ASIC')
-            assert not value or expect_value not in value, 'ASIC check is still performed after it ' \
-                                                           'is configured to be ignored'
+    if is_support_mock_asic:
+        with ConfigFileContext(duthost, os.path.join(FILES_DIR, IGNORE_ASIC_CHECK_CONFIG_FILE)):
+            time.sleep(FAST_INTERVAL)
+            mock_result = device_mocker.mock_asic_temperature(False)
+            expect_value = EXPECT_ASIC_HOT
+            if mock_result:
+                time.sleep(THERMAL_CHECK_INTERVAL)
+                value = redis_get_field_value(
+                    duthost, STATE_DB, HEALTH_TABLE_NAME, 'ASIC')
+                assert not value or expect_value not in value, 'ASIC check is still performed after it ' \
+                                                               'is configured to be ignored'
 
     logger.info(
         'Ignore PSU check, verify there is no error information about psu')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
For mellanox device, skip asic mock, because the asic soft link has been moved to sdk sysfs, and there is no way to mock asic.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
Skip asic mock on mellanox device

#### How did you do it?
Skip asic mock when device is mellanox

#### How did you verify/test it?
Run test on mellanox device

#### Any platform specific information?
Mellanox

#### Supported testbed topology if it's a new test case?
Any

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
