### PR TITLE
Fix testQosSaiPfcXonLimit in 202205 branch

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2111,7 +2111,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                 src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, dst_port_id, src_port_vlan
             )
             pkt2 = construct_ip_pkt(packet_length,
-                                    pkt_dst_mac,
+                                    pkt_dst_mac2,
                                     src_port_mac,
                                     src_port_ip,
                                     dst_port_2_ip,
@@ -2120,7 +2120,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                                     ecn=ecn,
                                     ttl=ttl)
             dst_port_2_id = self.get_rx_port(
-                src_port_id, pkt_dst_mac, dst_port_2_ip, src_port_ip, dst_port_2_id, src_port_vlan
+                src_port_id, pkt_dst_mac2, dst_port_2_ip, src_port_ip, dst_port_2_id, src_port_vlan
             )
             pkt3 = construct_ip_pkt(packet_length,
                                     pkt_dst_mac3,
@@ -2132,7 +2132,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                                     ecn=ecn,
                                     ttl=ttl)
             dst_port_3_id = self.get_rx_port(
-                src_port_id, pkt_dst_mac, dst_port_3_ip, src_port_ip, dst_port_3_id, src_port_vlan
+                src_port_id, pkt_dst_mac3, dst_port_3_ip, src_port_ip, dst_port_3_id, src_port_vlan
             )
 
         # For TH3/Cisco-8000, some packets stay in egress memory and doesn't show up in shared buffer or leakout


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix `testQosSaiPfcXonLimit` in 202205 branch.
Basically, this PR is to backport PR https://github.com/sonic-net/sonic-mgmt/pull/12649 and https://github.com/sonic-net/sonic-mgmt/pull/12151 into 202205 branch to fix test regression.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
This PR is to fix `testQosSaiPfcXonLimit` in 202205 branch.

#### How did you do it?
Backport PR https://github.com/sonic-net/sonic-mgmt/pull/12649 and https://github.com/sonic-net/sonic-mgmt/pull/12151 into 202205 branch.

#### How did you verify/test it?
The change is verified on a T0 testbed.
```
^HPASSED                                                                                                                [  8%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2] PASSED                                                                                                                [ 16%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_3] SKIPPED                                                                                                               [ 25%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_4] SKIPPED                                                                                                               [ 33%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_dut_multi_asic-xon_1]  ^HSKIPPED                                                                                                     [ 41%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_dut_multi_asic-xon_2] SKIPPED                                                                                                     [ 50%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_dut_multi_asic-xon_3] SKIPPED                                                                                                     [ 58%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_dut_multi_asic-xon_4] SKIPPED                                                                                                     [ 66%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut-xon_1] SKIPPED                                                                                                                 [ 75%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut-xon_2] SKIPPED                                                                                                                 [ 83%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut-xon_3] SKIPPED                                                                                                                 [ 91%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut-xon_4] SKIPPED                                                                                                                 [100%]

```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
