### PR TITLE
[Snappi] support T2 testbed definition for multidut test cases

### DIFF
--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -12,8 +12,8 @@ def conn_graph_facts(duthosts, localhost):
 
 
 @pytest.fixture(scope="module")
-def fanout_graph_facts(localhost, duthosts, rand_one_dut_hostname, conn_graph_facts):
-    duthost = duthosts[rand_one_dut_hostname]
+def fanout_graph_facts(localhost, duthosts, rand_one_tgen_dut_hostname, conn_graph_facts):
+    duthost = duthosts[rand_one_tgen_dut_hostname]
     facts = dict()
     dev_conn = conn_graph_facts.get('device_conn', {})
     if not dev_conn:

--- a/tests/common/snappi_tests/port.py
+++ b/tests/common/snappi_tests/port.py
@@ -24,6 +24,15 @@ class SnappiPortConfig:
         self.type = port_type
         self.peer_port = peer_port
 
+    def __str__(self):
+        return "<SnappiPortConfig id: {}, ip: {}, mac: {}, gw: {}, gw_mac: {}, \
+                prefix_len: {}, type: {}, peer_port: {}>".format(
+                self.id, self.ip, self.mac, self.gateway, self.gateway_mac,
+                self.prefix_len, self.type, self.peer_port)
+
+    def __repr__(self):
+        return self.__str__()
+
 
 def select_ports(port_config_list, pattern, rx_port_id):
     """

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -8,7 +8,7 @@ import sys
 import random
 import snappi_convergence
 from ipaddress import ip_address, IPv4Address, IPv6Address
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts
 from tests.common.snappi_tests.common_helpers import get_addrs_in_subnet, get_peer_snappi_chassis, \
     get_ipv6_addrs_in_subnet
 from tests.common.snappi_tests.snappi_helpers import SnappiFanoutManager, get_snappi_port_location

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -8,7 +8,7 @@ import sys
 import random
 import snappi_convergence
 from ipaddress import ip_address, IPv4Address, IPv6Address
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
 from tests.common.snappi_tests.common_helpers import get_addrs_in_subnet, get_peer_snappi_chassis, \
     get_ipv6_addrs_in_subnet
 from tests.common.snappi_tests.snappi_helpers import SnappiFanoutManager, get_snappi_port_location

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -435,6 +435,7 @@ def rand_one_dut_front_end_hostname(request):
     logger.info("Randomly select dut {} for testing".format(dut_hostnames[0]))
     return dut_hostnames[0]
 
+
 @pytest.fixture(scope="module")
 def rand_one_tgen_dut_hostname(request, tbinfo, rand_one_dut_front_end_hostname, rand_one_dut_hostname):
     """
@@ -444,6 +445,7 @@ def rand_one_tgen_dut_hostname(request, tbinfo, rand_one_dut_front_end_hostname,
     if 't2' in tbinfo['topo']['name']:
         return rand_one_dut_front_end_hostname
     return rand_one_dut_hostname
+
 
 @pytest.fixture(scope="module")
 def rand_selected_front_end_dut(duthosts, rand_one_dut_front_end_hostname):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -435,6 +435,15 @@ def rand_one_dut_front_end_hostname(request):
     logger.info("Randomly select dut {} for testing".format(dut_hostnames[0]))
     return dut_hostnames[0]
 
+@pytest.fixture(scope="module")
+def rand_one_tgen_dut_hostname(request, tbinfo, rand_one_dut_front_end_hostname, rand_one_dut_hostname):
+    """
+    Return the randomly selected duthost for TGEN test cases
+    """
+    # For T2, we need to skip supervisor, only use linecards.
+    if 't2' in tbinfo['topo']['name']:
+        return rand_one_dut_front_end_hostname
+    return rand_one_dut_hostname
 
 @pytest.fixture(scope="module")
 def rand_selected_front_end_dut(duthosts, rand_one_dut_front_end_hostname):

--- a/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
@@ -54,10 +54,10 @@ def test_dequeue_ecn(request,
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:

--- a/tests/snappi_tests/multidut/ecn/test_multidut_red_accuracy_with_snappi.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_red_accuracy_with_snappi.py
@@ -59,10 +59,11 @@ def test_red_accuracy(request,
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]      # noqa: E501
+        dut_list = [dut for dut in duthosts.frontend_nodes if
+                    linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]      # noqa: E501
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:
         pytest_require(False, "Hostname can't be an empty list")

--- a/tests/snappi_tests/multidut/pfc/test_lossless_response_to_external_pause_storms.py
+++ b/tests/snappi_tests/multidut/pfc/test_lossless_response_to_external_pause_storms.py
@@ -60,10 +60,10 @@ def test_lossless_response_to_external_pause_storms_test(snappi_api,            
     if line_card_choice not in linecard_configuration_set.keys():
         assert False, "Invalid line_card_choice value passed in parameter"
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:

--- a/tests/snappi_tests/multidut/pfc/test_lossless_response_to_throttling_pause_storms.py
+++ b/tests/snappi_tests/multidut/pfc/test_lossless_response_to_throttling_pause_storms.py
@@ -62,10 +62,10 @@ def test_lossless_response_to_throttling_pause_storms(snappi_api,               
     if line_card_choice not in linecard_configuration_set.keys():
         pytest_assert(False, "Invalid line_card_choice value passed in parameter")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:

--- a/tests/snappi_tests/multidut/pfc/test_m2o_fluctuating_lossless.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_fluctuating_lossless.py
@@ -60,10 +60,10 @@ def test_m2o_fluctuating_lossless(snappi_api,                  # noqa: F811
     if line_card_choice not in linecard_configuration_set.keys():
         pytest_assert(False, "Invalid line_card_choice value passed in parameter")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:

--- a/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless.py
@@ -60,10 +60,10 @@ def test_m2o_oversubscribe_lossless(snappi_api,                              # n
     if line_card_choice not in linecard_configuration_set.keys():
         pytest_assert(False, "Invalid line_card_choice value passed in parameter")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:

--- a/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless_lossy.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless_lossy.py
@@ -59,10 +59,10 @@ def test_m2o_oversubscribe_lossless_lossy(snappi_api,                   # noqa: 
     if line_card_choice not in linecard_configuration_set.keys():
         assert False, "Invalid line_card_choice value passed in parameter"
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:

--- a/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossy.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossy.py
@@ -57,10 +57,10 @@ def test_m2o_oversubscribe_lossy(snappi_api,                                  # 
     if line_card_choice not in linecard_configuration_set.keys():
         pytest_assert(False, "Invalid line_card_choice value passed in parameter")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:

--- a/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
@@ -49,10 +49,11 @@ def test_global_pause(snappi_api,                                   # noqa: F811
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]      # noqa: E501
+        dut_list = [dut for dut in duthosts.frontend_nodes if
+                    linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]      # noqa: E501
         duthost1, duthost2 = dut_list[0], dut_list[0]
 
     snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -56,10 +56,10 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts
+        dut_list = [dut for dut in duthosts.frontend_nodes
                     if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1 = duthost2 = dut_list[0]
 

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -58,10 +58,10 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts
+        dut_list = [dut for dut in duthosts.frontend_nodes
                     if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
 
@@ -136,10 +136,10 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts
+        dut_list = [dut for dut in duthosts.frontend_nodes
                     if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
 
@@ -218,10 +218,10 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts
+        dut_list = [dut for dut in duthosts.frontend_nodes
                     if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
 
@@ -313,10 +313,10 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
     pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
                    "Hostname can't be an empty list")
     if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts
+        dut_list = [dut for dut in duthosts.frontend_nodes
                     if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
 

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_a2a_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_a2a_with_snappi.py
@@ -36,7 +36,7 @@ def test_multidut_pfcwd_all_to_all(snappi_api,                  # noqa: F811
         snappi_api (pytest fixture): SNAPPI session
         conn_graph_facts (pytest fixture): connection graph
         fanout_graph_facts (pytest fixture): fanout graph
-        duthosts (pytest fixture): list of DUTs
+        frontend_duthosts (pytest fixture): list of frontend DUTs.
         rand_one_dut_lossless_prio (str): lossless priority to test, e.g., 's6100-1|3'
         lossy_prio_list (pytest fixture): list of lossy priorities
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority)
@@ -46,14 +46,15 @@ def test_multidut_pfcwd_all_to_all(snappi_api,                  # noqa: F811
     Returns:
         N/A
     """
+
     if line_card_choice not in linecard_configuration_set.keys():
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
@@ -56,10 +56,10 @@ def test_pfcwd_basic_single_lossless_prio(snappi_api,                   # noqa: 
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:
@@ -133,10 +133,10 @@ def test_pfcwd_basic_multi_lossless_prio(snappi_api,                # noqa F811
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:
@@ -213,10 +213,10 @@ def test_pfcwd_basic_single_lossless_prio_reboot(snappi_api,                # no
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:
@@ -301,10 +301,10 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:
@@ -387,10 +387,10 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:
@@ -495,10 +495,10 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_burst_storm_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_burst_storm_with_snappi.py
@@ -49,10 +49,10 @@ def test_pfcwd_burst_storm_single_lossless_prio(snappi_api,             # noqa: 
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_m2o_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_m2o_with_snappi.py
@@ -51,10 +51,10 @@ def test_pfcwd_many_to_one(snappi_api,              # noqa: F811
         pytest_require(False, "Invalid line_card_choice value passed in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if
+        dut_list = [dut for dut in duthosts.frontend_nodes if
                     linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
         duthost1, duthost2 = dut_list[0], dut_list[0]
     else:

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_runtime_traffic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_runtime_traffic_with_snappi.py
@@ -43,10 +43,11 @@ def test_pfcwd_runtime_traffic(snappi_api,                  # noqa: F811
     pytest_assert(line_card_choice in linecard_configuration_set.keys(), "Invalid line_card_choice in parameter")
 
     if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(list(duthosts), 2)
+        dut_list = random.sample(duthosts.frontend_nodes, 2)
         duthost1, duthost2 = dut_list
     elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]      # noqa: E501
+        dut_list = [dut for dut in duthosts.frontend_nodes if
+                    linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]      # noqa: E501
         duthost1, duthost2 = dut_list[0], dut_list[0]
     elif len(linecard_configuration_set[line_card_choice]['hostname']) == 0:
         assert False, "Hostname can't be an empty list"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

For T2 testbed definition, the testbed DUTs will have both LCs and sup card:
```
- conf-name: vms-chassis-packet-dut
  ......
  dut:
    - lab-msft-lc0-1
    - lab-msft-lc1-1
    - lab-msft-lc2-1
    - lab-msft-sup-1
  comment: Chasiss Testbed
```
However, to run multidut cases, the testbed DUTs can only have LCs defined as the following:
```
- conf-name: vms-chassis-packet-dut-ixia
  ......
  dut:
    - lab-msft-lc0-1
    - lab-msft-lc1-1
    - lab-msft-lc2-1
  comment: Chasiss Testbed
```
So, for same testbed, we have to define two testbed DUTs in testbed.yml:
- one with supervisor card for deploy-mg
- one without supervisor card for running multidut test cases.

When running multidut cases directly for T2 testbed, it has following issues.
```
1. fanout_graph_facts may be empty if supervisor is selected. That results in empty snappi ports selected.
2. current dut selection in test cases may select supervisor card.
```

This change is to fix the above issues and make the multidut cases can be run on T2 testbed definition directly. So that we don't need to use different testbed definition for multidut cases separately.

After this fix, users can use T2 testbed DUT definition for both deploy-mg and multidut test cases. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
support T2 testbed definition for multidut test cases

#### How did you do it?
Add the following changes:
1. add rand_one_tgen_dut_hostname: it will select front end dut for T2 testbed.
2. change fanout_graph_facts to use rand_one_tgen_dut_hostname 
4. Use only frontend duthosts for multidut PFC/PFCWD/ECN test cases
5. Also add more debug for SnapPortConfig

#### How did you verify/test it?
Ran it manually in physical testbed. passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
