### PR TITLE
Add data plane route test to t1 PR test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -135,7 +135,6 @@ t0:
   - route/test_forced_mgmt_route.py
   - route/test_route_consistency.py
   - route/test_route_flap.py
-  - route/test_route_flow_counter.py
   - route/test_route_perf.py
   - route/test_static_route.py
   - scp/test_scp_copy.py
@@ -246,6 +245,8 @@ t1-lag:
   - process_monitoring/test_critical_process_monitoring.py
   - qos/test_buffer.py
   - route/test_default_route.py
+  - route/test_route_consistency.py
+  - route/test_route_flap.py
   - route/test_route_perf.py
   - scp/test_scp_copy.py
   - snmp/test_snmp_cpu.py

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -41,6 +41,8 @@ t0:
   - platform_tests/mellanox/test_reboot_cause.py
   # This script only supported on Mellanox
   - restapi/test_restapi.py
+  # Route flow counter is not supported on vs platform
+  - route/test_route_flow_counter.py
   - snmp/test_snmp_phy_entity.py
   # Remove from PR test in https://github.com/sonic-net/sonic-mgmt/pull/6073
   - cacl/test_ebtables_application.py
@@ -90,6 +92,8 @@ t1-lag:
   - platform_tests/mellanox/test_hw_management_service.py
   - platform_tests/mellanox/test_psu_power_threshold.py
   - platform_tests/mellanox/test_reboot_cause.py
+  # Route flow counter is not supported on vs platform
+  - route/test_route_flow_counter.py
   - snmp/test_snmp_phy_entity.py
   # Remove from PR test in https://github.com/sonic-net/sonic-mgmt/pull/6073
   - cacl/test_ebtables_application.py

--- a/tests/flow_counter/flow_counter_utils.py
+++ b/tests/flow_counter/flow_counter_utils.py
@@ -120,6 +120,7 @@ def is_route_flow_counter_supported(duthosts, tbinfo, enum_rand_one_per_hwsku_ho
     if rand_selected_dut.facts['asic_type'] == 'vs':
         # vs platform always set SAI capability to enabled, however, it does not really support all SAI atrributes.
         # Currently, vs platform does not support route flow counter.
+        logger.info('Route flow counter is not supported on vs platform')
         return False
     skip, _ = check_skip_release(rand_selected_dut, skip_versions)
     if skip:

--- a/tests/route/test_route_flow_counter.py
+++ b/tests/route/test_route_flow_counter.py
@@ -10,7 +10,8 @@ logger = logging.getLogger(__name__)
 allure.logger = logger
 
 pytestmark = [
-    pytest.mark.topology("any")
+    pytest.mark.topology("any"),
+    pytest.mark.device_type('physical')
 ]
 
 test_update_route_pattern_para = [


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
#### How did you do it?
1. Add data plane route test to t1 PR test
2. Remove route flow counter test from t0 PR test since it's always be skipped for not support on KVM platform
#### How did you verify/test it?
Verify in KVM test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
