### PR TITLE
skip dip_link_local test for cisco platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -8,6 +8,7 @@ drop_packets/test_configurable_drop_counters.py::test_dip_link_local:
     reason: "Some mlx platforms does not drop DIP link local packets"
     conditions:
       - "'Mellanox' in hwsku"
+      - asic_type=="cisco-8000"
 
 drop_packets/test_configurable_drop_counters.py::test_sip_link_local:
   skip:


### PR DESCRIPTION
### Description of PR
drop_packets.test_configurable_drop_counters.test_dip_link_local Test failed as the configured dropcounters were not incremented on some of Cisco platforms. There is a functional gap that we are working on. We are skipping this test until that is complete.

Summary:
Skip drop_packets.test_configurable_drop_counters.test_dip_link_local for all Cisco platforms until the implementation is complete for all of them.

### Type of change
- [] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Skip drop_packets.test_configurable_drop_counters.test_dip_link_local for all Cisco platforms until the implementation is complete for all of them.

#### How did you do it?
Skip the test

#### How did you verify/test it?
Verified that the test is being skipped
```
------------------------------------------- live log sessionfinish -------------------------------------------
13:26:07 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
========================================== short test summary info ===========================================
SKIPPED [2] drop_packets/test_configurable_drop_counters.py:359: Drop reasons not supported on target DUT
================================== 2 skipped, 1 warning in 86.23s (0:01:26) ==================================
sonic@sonic-ucs-m6-8:/data/tests$
```

#### Any platform specific information?
Cisco-8000

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
