### PR TITLE
Add tgen/snappi/ptf test scripts to PR test skip yml

### DIFF
--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -167,6 +167,55 @@ tgen:
   - ixia/pfcwd/test_pfcwd_runtime_traffic.py
   - ixia/test_ixia_traffic.py
   - ixia/test_tgen.py
+  # Snappi test only support on physical tgen testbed
+  - snappi_tests/bgp/test_bgp_convergence_performance.py
+  - snappi_tests/bgp/test_bgp_local_link_failover.py
+  - snappi_tests/bgp/test_bgp_remote_link_failover.py
+  - snappi_tests/bgp/test_bgp_rib_in_capacity.py
+  - snappi_tests/bgp/test_bgp_rib_in_convergence.py
+  - snappi_tests/bgp/test_bgp_scalability.py
+  - snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
+  - snappi_tests/ecn/test_red_accuracy_with_snappi.py
+  - snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
+  - snappi_tests/multidut/ecn/test_multidut_red_accuracy_with_snappi.py
+  - snappi_tests/multidut/pfc/test_lossless_response_to_external_pause_storms.py
+  - snappi_tests/multidut/pfc/test_lossless_response_to_throttling_pause_storms.py
+  - snappi_tests/multidut/pfc/test_m2o_fluctuating_lossless.py
+  - snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless.py
+  - snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless_lossy.py
+  - snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossy.py
+  - snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
+  - snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+  - snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+  - snappi_tests/multidut/pfcwd/test_multidut_pfcwd_a2a_with_snappi.py
+  - snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
+  - snappi_tests/multidut/pfcwd/test_multidut_pfcwd_burst_storm_with_snappi.py
+  - snappi_tests/multidut/pfcwd/test_multidut_pfcwd_m2o_with_snappi.py
+  - snappi_tests/lacp/test_add_remove_link_from_dut.py
+  - snappi_tests/lacp/test_add_remove_link_physically.py
+  - snappi_tests/lacp/test_lacp_timers_effect.py
+  - snappi_tests/pfc/test_global_pause_with_snappi.py
+  - snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
+  - snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
+  - snappi_tests/pfc/test_pfc_pause_response_with_snappi.py
+  - snappi_tests/pfc/test_pfc_pause_unset_bit_enable_vector.py
+  - snappi_tests/pfc/test_pfc_pause_zero_mac.py
+  - snappi_tests/pfc/test_valid_pfc_frame_with_snappi.py
+  - snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py
+  - snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
+  - snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py
+  - snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py
+  - snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py
+  - snappi_tests/qos/test_ipip_packet_reorder_with_snappi.py
+
+snappi:
+  # Snappi test only support on physical snappi testbed
+  - snappi_tests/reboot/test_cold_reboot.py
+  - snappi_tests/reboot/test_fast_reboot.py
+  - snappi_tests/reboot/test_soft_reboot.py
+  - snappi_tests/reboot/test_warm_reboot.py
+  - snappi_tests/test_multidut_snappi.py
+  - snappi_tests/test_snappi.py
 
 wan-pub:
   # Currently PR test will not test wan topo
@@ -196,3 +245,11 @@ wan-pub:
   - wan/lacp/test_wan_lag_min_link.py
   - wan/lldp/test_wan_lldp.py
   - wan/traffic_test/test_traffic.py
+
+ptf:
+  # PTF test do not support on physical testbed
+  - sai_qualify/test_brcm_t0.py
+  - sai_qualify/test_community.py
+  - sai_qualify/test_sai_ptf.py
+  - sai_qualify/test_sai_ptf_warm_reboot.py
+  - sai_qualify/test_sai_t0_warm_reboot.py

--- a/tests/snappi_tests/bgp/test_bgp_local_link_failover.py
+++ b/tests/snappi_tests/bgp/test_bgp_local_link_failover.py
@@ -5,6 +5,8 @@ from tests.common.fixtures.conn_graph_facts import (                        # no
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
+pytestmark = [pytest.mark.topology('tgen')]
+
 
 @pytest.mark.parametrize('multipath', [2])
 @pytest.mark.parametrize('convergence_test_iterations', [1])

--- a/tests/snappi_tests/bgp/test_bgp_remote_link_failover.py
+++ b/tests/snappi_tests/bgp/test_bgp_remote_link_failover.py
@@ -5,6 +5,8 @@ from tests.common.fixtures.conn_graph_facts import (                        # no
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
+pytestmark = [pytest.mark.topology('tgen')]
+
 
 @pytest.mark.parametrize('multipath', [2])
 @pytest.mark.parametrize('convergence_test_iterations', [1])

--- a/tests/snappi_tests/bgp/test_bgp_rib_in_capacity.py
+++ b/tests/snappi_tests/bgp/test_bgp_rib_in_capacity.py
@@ -5,6 +5,8 @@ from tests.common.fixtures.conn_graph_facts import (                        # no
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
+pytestmark = [pytest.mark.topology('tgen')]
+
 
 @pytest.mark.parametrize('multipath', [2])
 @pytest.mark.parametrize('start_value', [1000])

--- a/tests/snappi_tests/bgp/test_bgp_rib_in_convergence.py
+++ b/tests/snappi_tests/bgp/test_bgp_rib_in_convergence.py
@@ -5,6 +5,8 @@ from tests.common.fixtures.conn_graph_facts import (                        # no
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
+pytestmark = [pytest.mark.topology('tgen')]
+
 
 @pytest.mark.parametrize('multipath', [2])
 @pytest.mark.parametrize('convergence_test_iterations', [1])

--- a/tests/snappi_tests/lacp/test_add_remove_link_from_dut.py
+++ b/tests/snappi_tests/lacp/test_add_remove_link_from_dut.py
@@ -6,6 +6,8 @@ from tests.common.fixtures.conn_graph_facts import (                    # noqa F
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
+pytestmark = [pytest.mark.topology('tgen')]
+
 
 @pytest.mark.parametrize('port_count', [4])
 @pytest.mark.parametrize('number_of_routes', [1000])

--- a/tests/snappi_tests/lacp/test_add_remove_link_physically.py
+++ b/tests/snappi_tests/lacp/test_add_remove_link_physically.py
@@ -6,6 +6,8 @@ from tests.common.fixtures.conn_graph_facts import (                # noqa F401
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
+pytestmark = [pytest.mark.topology('tgen')]
+
 
 @pytest.mark.parametrize('port_count', [4])
 @pytest.mark.parametrize('number_of_routes', [1000])

--- a/tests/snappi_tests/lacp/test_lacp_timers_effect.py
+++ b/tests/snappi_tests/lacp/test_lacp_timers_effect.py
@@ -6,6 +6,8 @@ from tests.common.fixtures.conn_graph_facts import (            # noqa F401
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
+pytestmark = [pytest.mark.topology('tgen')]
+
 
 @pytest.mark.parametrize('port_count', [4])
 @pytest.mark.parametrize('number_of_routes', [1000])

--- a/tests/snappi_tests/test_multidut_snappi.py
+++ b/tests/snappi_tests/test_multidut_snappi.py
@@ -12,8 +12,9 @@ from tests.snappi_tests.variables import config_set, line_card_choice
 
 SNAPPI_POLL_DELAY_SEC = 2
 
+pytestmark = [pytest.mark.topology('snappi')]
 
-@pytest.mark.topology("snappi")
+
 @pytest.mark.disable_loganalyzer
 def __gen_all_to_all_traffic(testbed_config,
                              port_config_list,

--- a/tests/snappi_tests/test_snappi.py
+++ b/tests/snappi_tests/test_snappi.py
@@ -12,8 +12,9 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map  # noqa F401
 
 SNAPPI_POLL_DELAY_SEC = 2
 
+pytestmark = [pytest.mark.topology('snappi')]
 
-@pytest.mark.topology("snappi")
+
 @pytest.mark.disable_loganalyzer
 def __gen_all_to_all_traffic(testbed_config,
                              port_config_list,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
Meanwhile, we are using `.azure-pipelines/testscripts_analyse/` to static test scripts have been added or not, if a test script need to skip in KVM test, need to add it to `.azure-pipelines/pr_test_skip_scripts.yaml` and we would mark it as checked/covered.
Based on that, tgen/snappi/ptf test could not run on KVM platform, so need to add these tests to `.azure-pipelines/pr_test_skip_scripts.yaml`
#### How did you do it?
Add tgen/snappi/ptf test scripts to `.azure-pipelines/pr_test_skip_scripts.yaml`
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
