### PR TITLE
Add `is_lldp_disabled` method for fanout devices

### DIFF
--- a/tests/common/devices/aos.py
+++ b/tests/common/devices/aos.py
@@ -170,8 +170,11 @@ class AosHost(AnsibleHostBase):
 
     def is_lldp_disabled(self):
         """
-        TODO: Add support
-        Return False always
+        TODO: Add support for AOS device when access to
+        AOS fanout becomes available.
+
+        Return False always. If AOS device is found as a
+        fanout the pretest will fail until this check is implemented.
         """
         return False
 

--- a/tests/common/devices/aos.py
+++ b/tests/common/devices/aos.py
@@ -168,6 +168,13 @@ class AosHost(AnsibleHostBase):
                 parents='interface %s' % interface_name)
         return not self._has_cli_cmd_failed(out)
 
+    def is_lldp_disabled(self):
+        """
+        TODO: Add support
+        Return False always
+        """
+        return False
+
 
 def speed_gb_to_mb(speed):
     res = re.search(r'(\d+)(\w)', speed)

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -102,6 +102,20 @@ class EosHost(AnsibleHostBase):
         intf_str = ','.join(interfaces)
         return self.no_shutdown(intf_str)
 
+    def is_lldp_disabled(self):
+        """
+        Checks if LLDP is enabled by neighbors
+        Returns True if disabled (i.e. neighbors absent)
+        Returns False if enabled (i.e. found neighbors)
+        """
+        command = 'show lldp neighbors | json'
+        output = self.eos_command(commands=[command])['stdout']
+        logger.debug(f'lldp neighbors returned: {output}')
+        # check for empty output -> ['']
+        if output is None or (len(output) == 1 and len(output[0]) == 0):
+            return True
+        return False
+
     def check_intf_link_state(self, interface_name):
         """
         This function returns link oper status

--- a/tests/common/devices/fanout.py
+++ b/tests/common/devices/fanout.py
@@ -211,7 +211,7 @@ class FanoutHost(object):
     def set_port_fec(self, interface_name, mode):
         self.host.set_port_fec(interface_name, mode)
 
-    def is_lldb_disabled(self):
+    def is_lldp_disabled(self):
         """Check global LLDP status on the device
         Returns:
             True: if LLDP is disabled

--- a/tests/common/devices/fanout.py
+++ b/tests/common/devices/fanout.py
@@ -210,3 +210,11 @@ class FanoutHost(object):
 
     def set_port_fec(self, interface_name, mode):
         self.host.set_port_fec(interface_name, mode)
+
+    def is_lldb_disabled(self):
+        """Check global LLDP status on the device
+        Returns:
+            True: if LLDP is disabled
+            False: if LLDP is enabled
+        """
+        return self.host.is_lldp_disabled()

--- a/tests/common/devices/ixia.py
+++ b/tests/common/devices/ixia.py
@@ -57,3 +57,10 @@ class IxiaHost (AnsibleHostBase):
         """
         if (self.os == 'ixia'):
             eval(cmd)
+
+    def is_lldp_disabled(self):
+        """
+        TODO: Add support
+        Return False always
+        """
+        return False

--- a/tests/common/devices/ixia.py
+++ b/tests/common/devices/ixia.py
@@ -60,7 +60,10 @@ class IxiaHost (AnsibleHostBase):
 
     def is_lldp_disabled(self):
         """
-        TODO: Add support
-        Return False always
+        TODO: Add support for IXIA device when access to
+        IXIA fanout becomes available.
+
+        Return False always. If IXIA device is found as a
+        fanout the pretest will fail until this check is implemented.
         """
         return False

--- a/tests/common/devices/onyx.py
+++ b/tests/common/devices/onyx.py
@@ -309,3 +309,10 @@ class OnyxHost(AnsibleHostBase):
             is not supported or failed.
         """
         return self.fanout_helper.restore_drop_counter_config()
+
+    def is_lldp_disabled(self):
+        """
+        TODO: Add support
+        Return False always
+        """
+        return False

--- a/tests/common/devices/onyx.py
+++ b/tests/common/devices/onyx.py
@@ -312,7 +312,10 @@ class OnyxHost(AnsibleHostBase):
 
     def is_lldp_disabled(self):
         """
-        TODO: Add support
-        Return False always
+        TODO: Add support for Onyx device when access to
+        Onyx fanout becomes available.
+
+        Return False always. If Onyx device is found as a
+        fanout the pretest will fail until this check is implemented.
         """
         return False

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1150,6 +1150,22 @@ class SonicHost(AnsibleHostBase):
             intf_str = ','.join(ifnames)
             return self.no_shutdown(intf_str)
 
+    def is_lldp_disabled(self):
+        """
+        Checks LLDP feature status
+        Returns True if disabled
+        Returns False if enabled
+        """
+        # get lldp status without table header
+        lldp_status_output = self.command('show feature status lldp | tail -n +3')["stdout_lines"][0]
+        if lldp_status_output is not None:
+            fields = lldp_status_output.split()
+            # State is the second field
+            state = fields[1]
+            if state == "enabled":
+                return False
+            return True
+
     def get_ip_route_info(self, dstip, ns=""):
         """
         @summary: return route information for a destionation. The destination could an ip address or ip prefix.

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -405,12 +405,6 @@ def test_backend_acl_load(duthosts, enum_dut_hostname, tbinfo):
             pytest.fail("Backend acl not installed succesfully: {}".format(rule))
 
 
-# TODO may need to move this to health check
-def test_lldp_disabled_on_fanout(fanouthosts):
-    for fanout_name, fanouthost in fanouthosts.items():
-        assert fanouthost.is_lldp_disabled() is True
-
-
 # This one is special. It is public, but we need to ensure that it is the last one executed in pre-test.
 def test_generate_running_golden_config(duthosts):
     """

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -405,6 +405,12 @@ def test_backend_acl_load(duthosts, enum_dut_hostname, tbinfo):
             pytest.fail("Backend acl not installed succesfully: {}".format(rule))
 
 
+# TODO may need to move this to health check
+def test_lldp_disabled_on_fanout(fanouthosts):
+    for fanout_name, fanouthost in fanouthosts.items():
+        assert fanouthost.is_lldp_disabled() is True
+
+
 # This one is special. It is public, but we need to ensure that it is the last one executed in pre-test.
 def test_generate_running_golden_config(duthosts):
     """


### PR DESCRIPTION
### Description of PR

This PR adds a pre-test check to ensure the fanout switches for the DUT have LLDP disabled on them before starting the tests.

Summary:
Fixes # N/A

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

There have been incidents of fanout switches having LLDP enabled on them which leads to flaky test results due to unexpected entries in neighbor tables.

#### How did you do it?

Implemented checks to ensure LLDP is disabled on fanout hosts for `eos` and `sonic` OSes.

#### How did you verify/test it?

Ran the test on `eos` fanout switches for testbeds.

#### Any platform specific information?

Supports fanout switches that run `eos` and `sonic` only.

#### Supported testbed topology if it's a new test case?

Not applicable

### Documentation

Not applicable
