### PR TITLE
Move some stable scripts to T0 PR checker. 

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -183,6 +183,14 @@ t0:
   - vlan/test_vlan.py
   - vlan/test_vlan_ping.py
   - vxlan/test_vnet_route_leak.py
+  - bgp/test_bgp_peer_shutdown.py
+  - clock/test_clock.py
+  - generic_config_updater/test_pfcwd_status.py
+  - pfcwd/test_pfc_config.py
+  - platform_tests/link_flap/test_link_flap.py
+  - platform_tests/test_memory_exhaustion.py
+  - generic_config_updater/test_pg_headroom_update.py
+
 
 t0-2vlans:
   - dhcp_relay/test_dhcp_relay.py
@@ -309,22 +317,16 @@ dpu:
 
 onboarding_t0:
   # We will add a batch of T0 control plane cases and fix the failed cases later
-  - bgp/test_bgp_peer_shutdown.py
-  - clock/test_clock.py
   - generic_config_updater/test_dynamic_acl.py
-  - generic_config_updater/test_pfcwd_status.py
   - mvrf/test_mgmtvrf.py
   - pc/test_lag_member.py
-  - pfcwd/test_pfc_config.py
   - pfcwd/test_pfcwd_all_port_storm.py
   - pfcwd/test_pfcwd_function.py
   - pfcwd/test_pfcwd_timer_accuracy.py
   - pfcwd/test_pfcwd_warm_reboot.py
   - platform_tests/cli/test_show_platform.py
-  - platform_tests/link_flap/test_link_flap.py
   # - platform_tests/test_advanced_reboot.py
   - platform_tests/test_cont_warm_reboot.py
-  - platform_tests/test_memory_exhaustion.py
   - platform_tests/test_reboot.py
   - platform_tests/test_reload_config.py
   - snmp/test_snmp_link_local.py
@@ -340,7 +342,6 @@ onboarding_t0:
   - dualtor/test_orchagent_mac_move.py
   - dualtor/test_orchagent_standby_tor_downstream.py
   - dualtor/test_standby_tor_upstream_mux_toggle.py
-  - generic_config_updater/test_pg_headroom_update.py
 
 
 onboarding_t1:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In this PR, we move some stable test scripts from onboarding t0 PR checker to t0 PR checker. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In this PR, we move some stable test scripts from onboarding t0 PR checker to t0 PR checker. 

#### How did you do it?
Move some stable test scripts from onboarding t0 PR checker to t0 PR checker. 

#### How did you verify/test it?

TestbedName | FilePath | RunDate | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-t0 | bgp/test_bgp_peer_shutdown.py | 2024-07-25 00:00:00.0000000 | 1 | 0 | 1 | 1
vms-kvm-t0 | clock/test_clock.py | 2024-07-25 00:00:00.0000000 | 3 | 0 | 3 | 1
vms-kvm-t0 | generic_config_updater/test_pfcwd_status.py | 2024-07-25 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-t0 | generic_config_updater/test_pg_headroom_update.py | 2024-07-25 00:00:00.0000000 | 1 | 0 | 1 | 1
vms-kvm-t0 | pfcwd/test_pfc_config.py | 2024-07-25 00:00:00.0000000 | 9 | 0 | 9 | 1
vms-kvm-t0 | platform_tests/link_flap/test_link_flap.py | 2024-07-25 00:00:00.0000000 | 1 | 0 | 1 | 1
vms-kvm-t0 | platform_tests/test_memory_exhaustion.py | 2024-07-25 00:00:00.0000000 | 1 | 0 | 1 | 1
vms-kvm-t0 | bgp/test_bgp_peer_shutdown.py | 2024-07-24 00:00:00.0000000 | 35 | 1 | 36 | 0.9722
vms-kvm-t0 | clock/test_clock.py | 2024-07-24 00:00:00.0000000 | 111 | 0 | 111 | 1
vms-kvm-t0 | generic_config_updater/test_pfcwd_status.py | 2024-07-24 00:00:00.0000000 | 144 | 0 | 144 | 1
vms-kvm-t0 | generic_config_updater/test_pg_headroom_update.py | 2024-07-24 00:00:00.0000000 | 37 | 0 | 37 | 1
vms-kvm-t0 | pfcwd/test_pfc_config.py | 2024-07-24 00:00:00.0000000 | 324 | 0 | 324 | 1
vms-kvm-t0 | platform_tests/link_flap/test_link_flap.py | 2024-07-24 00:00:00.0000000 | 37 | 0 | 37 | 1
vms-kvm-t0 | platform_tests/test_memory_exhaustion.py | 2024-07-24 00:00:00.0000000 | 37 | 0 | 37 | 1
vms-kvm-t0 | bgp/test_bgp_peer_shutdown.py | 2024-07-23 00:00:00.0000000 | 25 | 0 | 25 | 1
vms-kvm-t0 | clock/test_clock.py | 2024-07-23 00:00:00.0000000 | 72 | 0 | 72 | 1
vms-kvm-t0 | generic_config_updater/test_pfcwd_status.py | 2024-07-23 00:00:00.0000000 | 100 | 0 | 100 | 1
vms-kvm-t0 | generic_config_updater/test_pg_headroom_update.py | 2024-07-23 00:00:00.0000000 | 24 | 0 | 24 | 1
vms-kvm-t0 | pfcwd/test_pfc_config.py | 2024-07-23 00:00:00.0000000 | 225 | 0 | 225 | 1
vms-kvm-t0 | platform_tests/link_flap/test_link_flap.py | 2024-07-23 00:00:00.0000000 | 24 | 0 | 24 | 1
vms-kvm-t0 | platform_tests/test_memory_exhaustion.py | 2024-07-23 00:00:00.0000000 | 24 | 0 | 24 | 1
vms-kvm-t0 | bgp/test_bgp_peer_shutdown.py | 2024-07-22 00:00:00.0000000 | 23 | 0 | 23 | 1
vms-kvm-t0 | clock/test_clock.py | 2024-07-22 00:00:00.0000000 | 69 | 0 | 69 | 1
vms-kvm-t0 | generic_config_updater/test_pfcwd_status.py | 2024-07-22 00:00:00.0000000 | 92 | 0 | 92 | 1
vms-kvm-t0 | generic_config_updater/test_pg_headroom_update.py | 2024-07-22 00:00:00.0000000 | 23 | 0 | 23 | 1
vms-kvm-t0 | pfcwd/test_pfc_config.py | 2024-07-22 00:00:00.0000000 | 207 | 0 | 207 | 1
vms-kvm-t0 | platform_tests/link_flap/test_link_flap.py | 2024-07-22 00:00:00.0000000 | 23 | 0 | 23 | 1
vms-kvm-t0 | platform_tests/test_memory_exhaustion.py | 2024-07-22 00:00:00.0000000 | 23 | 0 | 23 | 1


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
