### PR TITLE
[202205][Ansible] Skip package migrate when installing image (#13721)

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -172,6 +172,12 @@ def install_new_sonic_image(module, new_image_url, save_as=None):
         avail = get_disk_free_size(module, "/host")
         save_as = "/host/downloaded-sonic-image" if avail >= 2000 else "/tmp/tmpfs/downloaded-sonic-image"
 
+
+    skip_package_migrate_param = ""
+    _, output, _ = exec_command(module, cmd="sonic_installer install --help", ignore_error=True)
+    if "skip-package-migration" in output:
+        skip_package_migrate_param = "--skip-package-migration"
+
     if save_as.startswith("/tmp/tmpfs"):
         log("Create a tmpfs partition to download image to install")
         exec_command(module, cmd="mkdir -p /tmp/tmpfs", ignore_error=True)
@@ -186,7 +192,7 @@ def install_new_sonic_image(module, new_image_url, save_as=None):
         log("Running sonic_installer to install image at {}".format(save_as))
         rc, out, err = exec_command(
             module,
-            cmd="sonic_installer install {} -y".format(save_as),
+            cmd="sonic_installer install {} {} -y".format(save_as, skip_package_migrate_param),
             msg="installing new image", ignore_error=True
         )
         log("Done running sonic_installer to install image")
@@ -205,8 +211,8 @@ def install_new_sonic_image(module, new_image_url, save_as=None):
         log("Running sonic_installer to install image at {}".format(save_as))
         rc, out, err = exec_command(
             module,
-            cmd="sonic_installer install {} -y".format(
-                save_as),
+            cmd="sonic_installer install {} {} -y".format(
+                save_as, skip_package_migrate_param),
             msg="installing new image", ignore_error=True
         )
         log("Always remove the downloaded temp image inside /host/ before proceeding")


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Manually cherry-pick and resolve conflict of this PR: https://github.com/sonic-net/sonic-mgmt/pull/13721
Currently install image in sonic-mgmt is use default param, which would migrate sonic-extension-application package by default (dhcp_relay, macsec, dhcp_server) when install to a os version which doesn't contain them. This is un-clean install, should be fixed. Also, there is an issue with sonic_package_manager when migrate package sonic-net/sonic-buildimage#19633

#### How did you do it?
When installing image, check whether it support skip-package-migrate, if so, skip it.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
