### PR TITLE
Increase post-PDU state change delay to allow all PSUs to react

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -27,6 +27,8 @@ CMD_PLATFORM_PSUSTATUS_JSON = "{} --json".format(CMD_PLATFORM_PSUSTATUS)
 CMD_PLATFORM_FANSTATUS = "show platform fan"
 CMD_PLATFORM_TEMPER = "show platform temperature"
 
+PDU_WAIT_TIME = 20
+
 THERMAL_CONTROL_TEST_WAIT_TIME = 65
 THERMAL_CONTROL_TEST_CHECK_INTERVAL = 5
 
@@ -209,8 +211,7 @@ def turn_all_outlets_on(pdu_ctrl):
     for outlet in all_outlet_status:
         if not outlet["outlet_on"]:
             pdu_ctrl.turn_on_outlet(outlet)
-            time.sleep(5)
-    time.sleep(5)
+    time.sleep(PDU_WAIT_TIME)
 
 
 def check_all_psu_on(dut, psu_test_results):
@@ -296,7 +297,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
 
         logging.info("Turn off outlet {}".format(outlet))
         pdu_ctrl.turn_off_outlet(outlet)
-        time.sleep(10)
+        time.sleep(PDU_WAIT_TIME)
 
         cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
         for line in cli_psu_status["stdout_lines"][2:]:
@@ -310,7 +311,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
 
         logging.info("Turn on outlet {}".format(outlet))
         pdu_ctrl.turn_on_outlet(outlet)
-        time.sleep(10)
+        time.sleep(PDU_WAIT_TIME)
 
         cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
         for line in cli_psu_status["stdout_lines"][2:]:

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -211,7 +211,8 @@ def turn_all_outlets_on(pdu_ctrl):
     for outlet in all_outlet_status:
         if not outlet["outlet_on"]:
             pdu_ctrl.turn_on_outlet(outlet)
-    time.sleep(PDU_WAIT_TIME)
+            time.sleep(5)
+    time.sleep(5)
 
 
 def check_all_psu_on(dut, psu_test_results):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Increase delay between PDU state change and reading PSU details to 10 seconds (previously 5).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

10 second delay between PDU state change and accessing PSU details is not always enough. The time needed depends on PDU hardware, psud update interval, and PSU hardware. Increasing to 20 seconds allows extra time for the PDU to apply a state change and PSU to reflect it, which MSFT has validated and found sufficient.

#### How did you do it?

Increase post-PDU state change delays to 20 seconds (previously 10 seconds). This is especially important anywhere the PDU state is changed to "on".

#### How did you verify/test it?

MSFT verified by setting the delay to 20 seconds since Cisco was unable to reproduce with our PDU hardware.