### PR TITLE
[dualtor-aa] Fix flakiness of arp/test_unknown_mac.py

### DIFF
--- a/tests/arp/test_unknown_mac.py
+++ b/tests/arp/test_unknown_mac.py
@@ -69,6 +69,8 @@ def unknownMacSetup(duthosts, rand_one_dut_hostname, tbinfo):
         servers = mux_cable_server_ip(duthost)
         for ips in list(servers.values()):
             server_ips.append(ips['server_ipv4'].split('/')[0])
+            if 'soc_ipv4' in ips:
+                server_ips.append(ips['soc_ipv4'].split('/')[0])
 
     # populate vlan info
     vlan = dict()
@@ -153,7 +155,8 @@ def flushArpFdb(duthosts, rand_one_dut_hostname):
 
 @pytest.fixture(autouse=True)
 def populateArp(unknownMacSetup, flushArpFdb, ptfhost, duthosts, rand_one_dut_hostname,
-                toggle_all_simulator_ports_to_rand_selected_tor_m):     # noqa F811
+                toggle_all_simulator_ports_to_rand_selected_tor_m,           # noqa F811
+                setup_standby_ports_on_rand_unselected_tor_unconditionally): # noqa F811
     """
     Fixture to populate ARP entry on the DUT for the traffic destination
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Updating the test to avoid using ip address that's already assinged to NIC interface (`soc_ipv4`).

Fixes # [aristanetworks/sonic-qual.msft#184](https://github.com/aristanetworks/sonic-qual.msft/issues/184)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Currently test is picking an ip address that isn't being used for server/ptf interfaces, and assigning this ip address to the ptf interface before pinigng the dut vlan. This will cause dut ARP and MAC tables to be populated for the relevant ip. 

In case of dualtor active-active topologies we have concept of nic-simulator, where we'll have an ip address for server nic as well (`soc_ipv4` field in 'show mux config') along with ptf interface ip (`server_ipv4`). And there will be gRPC traffic flowing b/w sonic dut and nic (with soc_ipv4). 

So updating the test to skip assigning an ip address for a ptf interface (used to ping vlan ip of dut), that's already assigned to nic interfaces (soc_ipv4), as gRPC traffic can override the ARP table entry that is learned during ping from ptf to sonic dut.

And test is failing sometimes with `Failed: Drop counters failed to increment`, as the traffic is getting permitted because of MAC table entry (populated due to gRPC traffic).

#### How did you do it?

#### How did you verify/test it?
Ran the test with fix on Arista-7260CX3-D108C8 and test is passing.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
