### PR TITLE
Reduce the temp file size to verify logrotate for small_size test

### DIFF
--- a/tests/syslog/test_logrotate.py
+++ b/tests/syslog/test_logrotate.py
@@ -139,7 +139,7 @@ def multiply_with_unit(logrotate_threshold, num):
     return str(int(logrotate_threshold[:-1]) * num) + logrotate_threshold[-1]
 
 
-def validate_logrotate_function(duthost, logrotate_threshold):
+def validate_logrotate_function(duthost, logrotate_threshold, small_size):
     """
     Validate logrotate function
     :param duthost: DUT host object
@@ -152,7 +152,10 @@ def validate_logrotate_function(duthost, logrotate_threshold):
             logrotate_threshold)):
         syslog_number_origin = get_syslog_file_count(duthost)
         logger.info('There are {} syslog gz files'.format(syslog_number_origin))
-        create_temp_syslog_file(duthost, multiply_with_unit(logrotate_threshold, 0.9))
+        if small_size:
+            create_temp_syslog_file(duthost, multiply_with_unit(logrotate_threshold, 0.5))
+        else:
+            create_temp_syslog_file(duthost, multiply_with_unit(logrotate_threshold, 0.9))
         run_logrotate(duthost)
         syslog_number_no_rotate = get_syslog_file_count(duthost)
         logger.info('There are {} syslog gz files after running logrotate'.format(syslog_number_no_rotate))
@@ -206,7 +209,7 @@ def test_logrotate_normal_size(rand_selected_dut):
         if get_var_log_size(duthost) < 200 * 1024:
             pytest.skip('{} size is lower than 200MB, skip this test'.format(LOG_FOLDER))
     rotate_large_threshold = get_threshold_based_on_memory(duthost)
-    validate_logrotate_function(duthost, rotate_large_threshold)
+    validate_logrotate_function(duthost, rotate_large_threshold, False)
 
 
 @pytest.mark.disable_loganalyzer
@@ -218,7 +221,7 @@ def test_logrotate_small_size(rand_selected_dut, simulate_small_var_log_partitio
     Execute config reload to active the mount
     Stop logrotate cron job, make sure no logrotate executes during this test
     Check current syslog.x file number and save it
-    Create a temp file with size of rotate_size * 90%, and rename it as 'syslog', run logrotate command
+    Create a temp file with size of rotate_size * 50%, and rename it as 'syslog', run logrotate command
     There would be no logrotate happens - by checking the 'syslog.x' file number not increased
     Create a temp file with size of rotate_size * 110%, and rename it as 'syslog', run logrotate command
     There would be logrotate happens - by checking the 'syslog.x' file number increased by 1
@@ -229,7 +232,7 @@ def test_logrotate_small_size(rand_selected_dut, simulate_small_var_log_partitio
     """
     duthost = rand_selected_dut
     rotate_small_threshold = get_threshold_based_on_memory(duthost)
-    validate_logrotate_function(duthost, rotate_small_threshold)
+    validate_logrotate_function(duthost, rotate_small_threshold, True)
 
 
 def get_pending_entries(duthost, ignore_list=None):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/13451

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
On a chatty device, when the file size reaches 0.9 times the threshold, it quickly exceeds the limit, causing a false positive error by triggering log rotation.

#### How did you do it?
Create a temporary file at half the threshold size to ensure ample space is available before the actual log rotation occurs.

#### How did you verify/test it?
Verified the test Mellanox 4700 testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
