### PR TITLE
Skip ROUTE_TABLE and NEIGH_RESOLVE_TABLE entries for test_add_rack.py

### DIFF
--- a/tests/configlet/util/common.py
+++ b/tests/configlet/util/common.py
@@ -99,6 +99,12 @@ scan_dbs = {
                 "NEIGH_TABLE:eth0",
                 "NEIGH_TABLE_DEL_SET",
                 "ROUTE_TABLE:fe80:",
+                "ROUTE_TABLE:192.168.0.128/25",
+                "ROUTE_TABLE:20c0:a800::/64",
+                "ROUTE_TABLE:2064:100::11",
+                "ROUTE_TABLE:192.168.0.0/25",
+                "ROUTE_TABLE:100.1.0.17",
+                "ROUTE_TABLE:20c0:a800:0:80::/64",
                 "ROUTE_TABLE:FE80:",
                 "TUNNEL_DECAP_TABLE",
                 # BUFFER_PG.*3-4 is an auto created entry by buffermgr
@@ -107,7 +113,8 @@ scan_dbs = {
                 # Diff in TUNNEL_DECAP_TERM_TABLE is expected because router port
                 # is set admin down in the test, which leads to tunnel term change
                 "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL",
-                "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL"
+                "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL",
+                "NEIGH_RESOLVE_TABLE*"
                 },
             "keys_skip_val_comp": {
                 "last_up_time",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
For T1 topo on boot there are some route table entries that already exist for Ethernet128 (test_add_rack uses this intf explicitly).

test_add_rack takes a snapshot of the DB at this point and after applying patch_add.json to config. It compares the two and succeeds.

test_add_rack now applies patch_rm.json. This removes the BGP_NEIGHBOUR and /INTERFACE/Ethernet128 entries. Once this happens, APPL_DB will purge it's ROUTE table entries for Ethernet128. Fix is to skip these entries for APPL_DB comparison. We also see the same issue for NEIGH_RESOLVE_TABLE entries; @wen587 confirmed we can skip these too.

The missing entries are:
```
ROUTE_TABLE:100.1.0.17
ROUTE_TABLE:20c0:a800::/64
ROUTE_TABLE:192.168.0.128/25
ROUTE_TABLE:2064:100::11
ROUTE_TABLE:192.168.0.0/25
ROUTE_TABLE:20c0:a800:0:80::/64
```
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To get this test passing on master, 202405, 202311

#### How did you do it?
Skip the APPL_DB comparison entries

#### How did you verify/test it?
The test passes on all branches on Arista SKUs now

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
