### PR TITLE
[Smartswitch] Fix route perf test for smartswitch

### DIFF
--- a/tests/route/utils.py
+++ b/tests/route/utils.py
@@ -24,7 +24,7 @@ def generate_intf_neigh(asichost, num_neigh, ip_version, mg_facts=None, is_backe
     else:
         interfaces = asichost.show_interface(command="status")["ansible_facts"]["int_status"]
         for intf, values in list(interfaces.items()):
-            if values["admin_state"] == "up" and values["oper_state"] == "up":
+            if values["admin_state"] == "up" and values["oper_state"] == "up" and values["type"] != "DPU-NPU Data Port":
                 up_interfaces.append(intf)
         if not up_interfaces:
             raise Exception("DUT does not have up interfaces")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The DPU-NPU data ports should not be selected for test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix the test_route_perf test for smartswitch.
#### How did you do it?
Fix the method generate_intf_neigh in tests/route/utils.py. If the port type is "DPU-NPU Data Port", don't select it for the test.
#### How did you verify/test it?
Run the test on smartswitch test bed, it passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
