### PR TITLE
[Smartswitch] Fix lldp test for smart switch

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+from tests.common.platform.interface_utils import get_dpu_npu_ports_from_hwsku
 
 logger = logging.getLogger(__name__)
 
@@ -24,9 +25,10 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost,
 
     config_facts = duthost.asic_instance(
         enum_frontend_asic_index).config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    internal_port_list = get_dpu_npu_ports_from_hwsku(duthost)
     lldpctl_facts = duthost.lldpctl_facts(
         asic_instance_id=enum_frontend_asic_index,
-        skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"])['ansible_facts']
+        skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list)['ansible_facts']
     if not list(lldpctl_facts['lldpctl'].items()):
         pytest.fail("No LLDP neighbors received (lldpctl_facts are empty)")
     for k, v in list(lldpctl_facts['lldpctl'].items()):
@@ -57,9 +59,10 @@ def test_lldp_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname, loca
     res = duthost.shell(
         "docker exec -i lldp lldpcli show chassis | grep \"SysDescr:\" | sed -e 's/^\\s*SysDescr:\\s*//g'")
     dut_system_description = res['stdout']
+    internal_port_list = get_dpu_npu_ports_from_hwsku(duthost)
     lldpctl_facts = duthost.lldpctl_facts(
         asic_instance_id=enum_frontend_asic_index,
-        skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"])['ansible_facts']
+        skip_interface_pattern_list=["eth0", "Ethernet-BP", "Ethernet-IB"] + internal_port_list)['ansible_facts']
     config_facts = duthost.asic_instance(enum_frontend_asic_index).config_facts(host=duthost.hostname,
                                                                                 source="running")['ansible_facts']
     if not list(lldpctl_facts['lldpctl'].items()):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The lldp test should skip the internal NPU-DPU data ports.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix lldp test for smart switch.
#### How did you do it?
Add the internal ports to the skip_interface_pattern_list.
#### How did you verify/test it?
Run the test on smartswitch testbed, it passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
