### PR TITLE
Add script `test_snmp_psu.py` into T0 PR checker

### DIFF
--- a/tests/snmp/test_snmp_psu.py
+++ b/tests/snmp/test_snmp_psu.py
@@ -22,6 +22,8 @@ def test_snmp_numpsu(duthosts, enum_supervisor_dut_hostname, localhost, creds_al
         localhost, host=hostip, version="v2c",
         community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
     res = duthost.shell("psuutil numpsus", module_ignore_errors=True)
+
+    # For kvm testbed, we will get the expected return code 2 because of no chassis
     if duthost.facts["asic_type"] == "vs" and res['rc'] == 2:
         return
 
@@ -43,6 +45,7 @@ def test_snmp_psu_status(duthosts, enum_supervisor_dut_hostname, localhost, cred
     psus_on = 0
     msg = "Unexpected operstatus results {} != {} for PSU {}"
 
+    # For kvm testbed, there is no snmp psu info
     if duthost.facts["asic_type"] == "vs":
         return
 

--- a/tests/snmp/test_snmp_psu.py
+++ b/tests/snmp/test_snmp_psu.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 
@@ -25,6 +26,7 @@ def test_snmp_numpsu(duthosts, enum_supervisor_dut_hostname, localhost, creds_al
 
     # For kvm testbed, we will get the expected return code 2 because of no chassis
     if duthost.facts["asic_type"] == "vs" and res['rc'] == 2:
+        logging.info("Get expected return code 2 on kvm testbed.")
         return
 
     assert int(res['rc']) == 0, "Failed to get number of PSUs"
@@ -47,6 +49,7 @@ def test_snmp_psu_status(duthosts, enum_supervisor_dut_hostname, localhost, cred
 
     # For kvm testbed, there is no snmp psu info
     if duthost.facts["asic_type"] == "vs":
+        logging.info("No snmp psu info on kvm testbed.")
         return
 
     for psu_indx, operstatus in list(snmp_facts['snmp_psu'].items()):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In this PR, we optimize the script `test_snmp_psu.py` to support running on kvm testbed. 
- Command `psuutil numpsus` will get the expected return code 2 on kvm testbed because of no chassis. So, on kvm testbed, we will return in advance. 
- There is no snmp psu infomation of kvm testbed. So we return in advance to skip the following checks. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In this PR, we optimize the script `test_snmp_psu.py` to support running on kvm testbed. 
- Command `psuutil numpsus` will get the expected return code 2 on kvm testbed because of no chassis. So, on kvm testbed, we will return in advance. 
- There is no snmp psu infomation of kvm testbed. So we return in advance to skip the following checks. 

#### How did you do it?
Return in advance on kvm testbed to skip following checks. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
