### PR TITLE
Enhance the fwutil test

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -190,7 +190,7 @@ become_method='sudo'
 # ssh arguments to use
 # Leaving off ControlPersist will result in poor performance, so use
 # paramiko on older platforms rather than removing it
-ssh_args = -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=4
+ssh_args = -o ControlMaster=auto -o ControlPersist=120s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=40
 
 
 # The path to use for the ControlPath sockets. This defaults to

--- a/tests/platform_tests/fwutil/conftest.py
+++ b/tests/platform_tests/fwutil/conftest.py
@@ -3,7 +3,6 @@ import json
 import pytest
 import logging
 import os
-from random import randrange
 from fwutil_common import show_firmware
 
 logger = logging.getLogger(__name__)
@@ -81,13 +80,17 @@ def extract_fw_data(fw_pkg_path):
     return fw_data
 
 
-@pytest.fixture(scope='function')
-def random_component(duthost, fw_pkg):
-    chass = list(show_firmware(duthost)["chassis"].keys())[0]
-    components = list(fw_pkg["chassis"].get(chass, {}).get("component", {}).keys())
-    if len(components) == 0:
-        pytest.skip("No suitable components found in config file for platform {}.".format(duthost.facts['platform']))
-    return components[randrange(len(components))]
+@pytest.fixture(scope='function', params=["CPLD", "ONIE", "BIOS", "FPGA"])
+def component(request, duthost, fw_pkg):
+    component_type = request.param
+    chassis = list(show_firmware(duthost)["chassis"].keys())[0]
+    available_components = list(fw_pkg["chassis"].get(chassis, {}).get("component", {}).keys())
+    if len(available_components) > 0:
+        for component in available_components:
+            if component_type in component:
+                return component
+    pytest.skip(f"No suitable components found in config file for "
+                f"platform {duthost.facts['platform']}, firmware type {component_type}.")
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR contains the following enhancements:
1. Remove the randomization in selecting component, instead, parameterize the test by the components type.
2. Add the FPGA component for Nvidia sn4280 platform.
3. Increase the ServerAliveCountMax in ansible config to keep the ssh connection when buring the FPGA(it takes 15~20 mins with no data transferred in the channel).
4. When testing the install test cases, even if we only have one version of the component, still run the test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Enhance the fwutil test.
#### How did you do it?
See the summary.
#### How did you verify/test it?
Run the test on multiple testbeds, all passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
