### PR TITLE
Fix fwutil test issue when pdu_ctrl is not ready

### DIFF
--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -43,8 +43,7 @@ def get_hw_revision(duthost):
 
 
 def power_cycle(duthost=None, pdu_ctrl=None, delay_time=60):
-    if pdu_ctrl is None:
-        pytest.skip("No PSU controller for %s, skipping" % duthost.hostname)
+    assert pdu_ctrl, "pdu_ctrl is not ready, fail test"
 
     all_outlets = pdu_ctrl.get_outlet_status()
 
@@ -240,9 +239,13 @@ def call_fwutil(duthost, localhost, pdu_ctrl, fw_pkg, component=None, next_image
     # Only one chassis
     chassis = list(init_versions["chassis"].keys())[0]
     paths = get_install_paths(duthost, fw_pkg, init_versions, chassis, component)
-    current = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
     if component not in paths:
         pytest.skip("No available firmware to install on {}. Skipping".format(component))
+    boot_type = boot if boot else paths[component]["reboot"][0]
+    if boot_type == POWER_CYCLE:
+        assert pdu_ctrl, "pdu_ctrl is not ready, fail test"
+
+    current = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
 
     allure.step("Upload firmware to DUT")
     generate_config(duthost, paths, init_versions)
@@ -278,7 +281,6 @@ def call_fwutil(duthost, localhost, pdu_ctrl, fw_pkg, component=None, next_image
 
     logger.info("Running install command: {}".format(command))
     task, res = duthost.command(command, module_ignore_errors=True, module_async=True)
-    boot_type = boot if boot else paths[component]["reboot"][0]
 
     allure.step("Perform Neccesary Reboot")
     timeout = max([v.get("timeout", TIMEOUT) for k, v in list(paths.items())])


### PR DESCRIPTION
**Issue：**
The following code should not be placed in the midle of test body, because it has done some fwtuil operation. For instance, when upgrading the cpld, if we don't do power cycle due to pdu_ctrl is not ready. Later if we do power cycle, the cpld veresion will change to the tested cpld version, It will cause some confusion.

```
if pdu_ctrl is None:
        pytest.skip("No PSU controller for %s, skipping" % duthost.hostname)
```

**Fix solution:**
1. Move the code checking pdu_ctrl ready before doing any fwtuil operation
2. When pdu_ctr is not ready, fail test

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
