### PR TITLE
Various Fixes for Telemetry with Multi-Asic Support

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -285,6 +285,12 @@ class MultiAsicSonicHost(object):
         ns_cmd = cmd.replace('ip', 'ip -n {}'.format(namespace))
         return ns_cmd
 
+    def get_cli_cmd_for_namespace(self, cmd, namespace):
+        if not namespace:
+            return cmd
+        ns_cmd = cmd.replace('sonic-db-cli', 'sonic-db-cli -n {}'.format(namespace))
+        return ns_cmd
+
     @property
     def ttl_decr_value(self):
         """
@@ -532,6 +538,23 @@ class MultiAsicSonicHost(object):
         for asic in self.asics:
             bgp_info = asic.bgp_facts()
             bgp_neigh.update(bgp_info["ansible_facts"]["bgp_neighbors"])
+
+        return bgp_neigh
+
+    def get_bgp_neighbors_for_asic(self, namespace=None):
+        """
+        Get a diction of BGP neighbor states for asic with specific namespace
+
+        Args: None
+
+        Returns: dictionary { (neighbor_ip : info_dict)* }
+
+        """
+        bgp_neigh = {}
+        for asic in self.asics:
+            if asic.namespace == namespace:
+                bgp_info = asic.bgp_facts()
+                bgp_neigh.update(bgp_info["ansible_facts"]["bgp_neighbors"])
 
         return bgp_neigh
 

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1366,7 +1366,7 @@ default nhid 224 proto bgp src fc00:1::32 metric 20 pref medium
             if asic_id is None:
                 out = self.command("vtysh -c \"show bgp ipv6 neighbor {} json\"".format(neighbor_ip))
             else:
-                out = self.command("vtysh -n {} -c \"show bgp ipv6 neighbor {} json\"".format(asic_id, neighbor_ip))  
+                out = self.command("vtysh -n {} -c \"show bgp ipv6 neighbor {} json\"".format(asic_id, neighbor_ip))
 
         nbinfo = json.loads(re.sub(r"\\\"", '"', re.sub(r"\\n", "", out['stdout'])))
         logging.info("bgp neighbor {} info {}".format(neighbor_ip, nbinfo))
@@ -1823,7 +1823,7 @@ Totals               6450                 6449
 
     def get_interfaces_status(self, namespace=None):
         '''
-        Get interfaces status by running 'show interfaces status' or 'show interfaces status -n namespace' 
+        Get interfaces status by running 'show interfaces status' or 'show interfaces status -n namespace'
         on the DUT, and parse the result into a dict.
 
         Example output:
@@ -1859,7 +1859,7 @@ Totals               6450                 6449
         if namespace is None:
             return {x.get('interface'): x for x in self.show_and_parse('show interfaces status')}
         else:
-            return {x.get('interface'): x for x in 
+            return {x.get('interface'): x for x in
                     self.show_and_parse('show interfaces status -n {}'.format(namespace))}
 
     def get_crm_facts(self):

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1859,8 +1859,8 @@ Totals               6450                 6449
         if namespace is None:
             return {x.get('interface'): x for x in self.show_and_parse('show interfaces status')}
         else:
-            return {x.get('interface'): x for x in self.show_and_parse('show interfaces status -n {}'.format(namespace))}
-
+            return {x.get('interface'): x for x in 
+                    self.show_and_parse('show interfaces status -n {}'.format(namespace))}
 
     def get_crm_facts(self):
         """Run various 'crm show' commands and parse their output to gather CRM facts

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -38,7 +38,7 @@ class GNMIEnvironment(object):
                     self.gnmi_process = "gnmi"
                 else:
                     self.gnmi_process = "telemetry"
-                self.gnmi_port = 50052
+                self.gnmi_port = 8080
                 return True
             else:
                 pytest.fail("GNMI is not running")

--- a/tests/dash/gnmi_utils.py
+++ b/tests/dash/gnmi_utils.py
@@ -32,7 +32,7 @@ class GNMIEnvironment(object):
                 self.gnmi_config_table = "GNMI"
                 self.gnmi_container = "gnmi"
                 self.gnmi_program = "gnmi-native"
-                self.gnmi_port = 50052
+                self.gnmi_port = 8080
                 return
             else:
                 pytest.fail("GNMI is not running")

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -58,7 +58,7 @@ def check_gnmi_config(duthost):
 
 
 def create_gnmi_config(duthost):
-    cmd = "sonic-db-cli CONFIG_DB hset 'GNMI|gnmi' port 50052"
+    cmd = "sonic-db-cli CONFIG_DB hset 'GNMI|gnmi' port 8080"
     duthost.shell(cmd, module_ignore_errors=True)
     cmd = "sonic-db-cli CONFIG_DB hset 'GNMI|gnmi' client_auth true"
     duthost.shell(cmd, module_ignore_errors=True)

--- a/tests/telemetry/events/bgp_events.py
+++ b/tests/telemetry/events/bgp_events.py
@@ -40,7 +40,8 @@ def drop_tcp_packets(duthost):
         ret = duthost.shell("sudo ip netns exec {} iptables -L".format(ns))
         assert ret["rc"] == 0, "Unable to list iptables rules"
 
-        time.sleep(holdtime_timer_ms / 1000)  # Give time for hold timer expiry event, val from configured bgp neighbor info
+        # Give time for hold timer expiry event, val from configured bgp neighbor info
+        time.sleep(holdtime_timer_ms / 1000)
 
         ret = duthost.shell("sudo ip netns exec {} iptables -D INPUT -p tcp --dport 179 -j DROP".format(ns))
         assert ret["rc"] == 0, "Unable to remove DROP rule from iptables"
@@ -62,7 +63,8 @@ def drop_tcp_packets(duthost):
         ret = duthost.shell("iptables -L")
         assert ret["rc"] == 0, "Unable to list iptables rules"
 
-        time.sleep(holdtime_timer_ms / 1000)  # Give time for hold timer expiry event, val from configured bgp neighbor info
+        # Give time for hold timer expiry event, val from configured bgp neighbor info
+        time.sleep(holdtime_timer_ms / 1000)
 
         ret = duthost.shell("iptables -D INPUT -p tcp --dport 179 -j DROP")
         assert ret["rc"] == 0, "Unable to remove DROP rule from iptables"

--- a/tests/telemetry/events/bgp_events.py
+++ b/tests/telemetry/events/bgp_events.py
@@ -22,30 +22,53 @@ def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
 
 
 def drop_tcp_packets(duthost):
-    nslist = duthost.get_asic_namespace_list()
-    ns = random.choice(nslist)
-    asic_id = duthost.get_asic_id_from_namespace(ns)
-    bgp_neighbor = list(duthost.get_bgp_neighbors_for_asic(ns).keys())[0]
-    holdtime_timer_ms = duthost.get_bgp_neighbor_info(bgp_neighbor, asic_id)["bgpTimerConfiguredHoldTimeMsecs"]
+    if duthost.is_multi_asic:
+        nslist = duthost.get_asic_namespace_list()
+        ns = random.choice(nslist)
+        asic_id = duthost.get_asic_id_from_namespace(ns)
+        bgp_neighbor = list(duthost.get_bgp_neighbors_for_asic(ns).keys())[0]
+        holdtime_timer_ms = duthost.get_bgp_neighbor_info(bgp_neighbor, asic_id)["bgpTimerConfiguredHoldTimeMsecs"]
 
-    logger.info("Adding rule to drop TCP packets to test bgp-notification")
+        logger.info("Adding rule to drop TCP packets to test bgp-notification")
 
-    ret = duthost.shell("iptables -I INPUT -p tcp --dport 179 -j DROP")
-    assert ret["rc"] == 0, "Unable to add DROP rule to iptables"
+        ret = duthost.shell("sudo ip netns exec {} iptables -I INPUT -p tcp --dport 179 -j DROP".format(ns))
+        assert ret["rc"] == 0, "Unable to add DROP rule to iptables"
 
-    ret = duthost.shell("iptables -I INPUT -p tcp --sport 179 -j DROP")
-    assert ret["rc"] == 0, "Unable to add DROP rule to iptables"
+        ret = duthost.shell("sudo ip netns exec {} iptables -I INPUT -p tcp --sport 179 -j DROP".format(ns))
+        assert ret["rc"] == 0, "Unable to add DROP rule to iptables"
 
-    ret = duthost.shell("iptables -L")
-    assert ret["rc"] == 0, "Unable to list iptables rules"
+        ret = duthost.shell("sudo ip netns exec {} iptables -L".format(ns))
+        assert ret["rc"] == 0, "Unable to list iptables rules"
 
-    time.sleep(holdtime_timer_ms / 1000)  # Give time for hold timer expiry event, val from configured bgp neighbor info
+        time.sleep(holdtime_timer_ms / 1000)  # Give time for hold timer expiry event, val from configured bgp neighbor info
 
-    ret = duthost.shell("iptables -D INPUT -p tcp --dport 179 -j DROP")
-    assert ret["rc"] == 0, "Unable to remove DROP rule from iptables"
+        ret = duthost.shell("sudo ip netns exec {} iptables -D INPUT -p tcp --dport 179 -j DROP".format(ns))
+        assert ret["rc"] == 0, "Unable to remove DROP rule from iptables"
+        ret = duthost.shell("sudo ip netns exec {} iptables -D INPUT -p tcp --sport 179 -j DROP".format(ns))
+        assert ret["rc"] == 0, "Unable to remove DROP rule from iptables"
+    else:
+        bgp_neighbor = list(duthost.get_bgp_neighbors().keys())[0]
 
-    ret = duthost.shell("iptables -D INPUT -p tcp --sport 179 -j DROP")
-    assert ret["rc"] == 0, "Unable to remove DROP rule from iptables"
+        holdtime_timer_ms = duthost.get_bgp_neighbor_info(bgp_neighbor)["bgpTimerConfiguredHoldTimeMsecs"]
+
+        logger.info("Adding rule to drop TCP packets to test bgp-notification")
+
+        ret = duthost.shell("iptables -I INPUT -p tcp --dport 179 -j DROP")
+        assert ret["rc"] == 0, "Unable to add DROP rule to iptables"
+
+        ret = duthost.shell("iptables -I INPUT -p tcp --sport 179 -j DROP")
+        assert ret["rc"] == 0, "Unable to add DROP rule to iptables"
+
+        ret = duthost.shell("iptables -L")
+        assert ret["rc"] == 0, "Unable to list iptables rules"
+
+        time.sleep(holdtime_timer_ms / 1000)  # Give time for hold timer expiry event, val from configured bgp neighbor info
+
+        ret = duthost.shell("iptables -D INPUT -p tcp --dport 179 -j DROP")
+        assert ret["rc"] == 0, "Unable to remove DROP rule from iptables"
+
+        ret = duthost.shell("iptables -D INPUT -p tcp --sport 179 -j DROP")
+        assert ret["rc"] == 0, "Unable to remove DROP rule from iptables"
 
 
 def shutdown_bgp_neighbors(duthost):

--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -61,7 +61,7 @@ def shutdown_interface(duthost):
     if duthost.is_multi_asic:
         ret = duthost.shell("config interface -n {} shutdown {}".format(ns, if_state_test_port))
     else:
-        ret = duthost.shell("config interface shutdown {}".format(if_state_test_port))    
+        ret = duthost.shell("config interface shutdown {}".format(if_state_test_port))
     assert ret["rc"] == 0, "Failing to shutdown interface {}".format(if_state_test_port)
 
     # Wait until port goes down

--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -7,7 +7,7 @@ import re
 
 from run_events_test import run_test
 from tests.common.utilities import wait_until
-from tests.common.helpers.constants import NAMESPACE_PREFIX
+
 random.seed(10)
 logger = logging.getLogger(__name__)
 tag = "sonic-events-swss"

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -143,7 +143,7 @@ def generate_client_cli(duthost, gnxi_path, method=METHOD_GET, xpath="COUNTERS/E
     """ Generate the py_gnmicli command line based on the given params.
     """
     env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
-    cmdFormat = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m {2} -x {3} -xt {4} -o {5} -n'
+    cmdFormat = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m {2} -x {3} -xt {4} -o {5}'
     cmd = cmdFormat.format(duthost.mgmt_ip, env.gnmi_port, method, xpath, target, "ndastreamingservertest")
 
     if method == METHOD_SUBSCRIBE:

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -143,7 +143,7 @@ def generate_client_cli(duthost, gnxi_path, method=METHOD_GET, xpath="COUNTERS/E
     """ Generate the py_gnmicli command line based on the given params.
     """
     env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
-    cmdFormat = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m {2} -x {3} -xt {4} -o {5}'
+    cmdFormat = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m {2} -x {3} -xt {4} -o {5} -n'
     cmd = cmdFormat.format(duthost.mgmt_ip, env.gnmi_port, method, xpath, target, "ndastreamingservertest")
 
     if method == METHOD_SUBSCRIBE:

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -109,7 +109,7 @@ def listen_for_events(duthost, gnxi_path, ptfhost, filter_event_regex, op_file, 
                               submode=SUBMODE_ONCHANGE, update_count=update_count, xpath="all[heartbeat=2]",
                               target="EVENTS", filter_event_regex=filter_event_regex)
     results = [""]
-    event_thread = InterruptableThread(target=listen_for_event, args=(ptfhost, cmd, results,))
+    event_thread = InterruptableThread(target=listen_for_event, args=(ptfhost, cmd, results))
     event_thread.start()
     event_thread.join(thread_timeout)  # close thread after 30 sec, was not able to find event within reasonable time
     assert results[0] != "", "No output from PTF docker, thread timed out after {} seconds".format(thread_timeout)

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -39,7 +39,7 @@ def get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, iface, gnmi_port):
     for i in range(MAX_UC_CNT):
         cmd = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} \
             -p {1} -m get -x COUNTERS_QUEUE_NAME_MAP/{2}:{3} \
-            -xt COUNTERS_DB -o "ndastreamingservertest" -n \
+            -xt COUNTERS_DB -o "ndastreamingservertest" \
             '.format(dut_ip, gnmi_port, iface, i)
 
         cmd_output = ptfhost.shell(cmd, module_ignore_errors=True)
@@ -116,7 +116,7 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gn
     logger.info('start telemetry output testing')
     dut_ip = duthost.mgmt_ip
     cmd = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m get -x COUNTERS/Ethernet0 -xt \
-        COUNTERS_DB -o "ndastreamingservertest" -n'.format(dut_ip, env.gnmi_port)
+        COUNTERS_DB -o "ndastreamingservertest"'.format(dut_ip, env.gnmi_port)
     show_gnmi_out = ptfhost.shell(cmd)['stdout']
     logger.info("GNMI Server output")
     logger.info(show_gnmi_out)
@@ -205,7 +205,7 @@ def test_sysuptime(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_pat
     skip_201911_and_older(duthost)
     dut_ip = duthost.mgmt_ip
     cmd = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m get -x proc/uptime -xt OTHERS \
-           -o "ndastreamingservertest" -n'.format(dut_ip, env.gnmi_port)
+           -o "ndastreamingservertest"'.format(dut_ip, env.gnmi_port)
     system_uptime_info = ptfhost.shell(cmd)["stdout_lines"]
     system_uptime_1st = 0
     found_system_uptime_field = False

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -107,7 +107,8 @@ def test_telemetry_enabledbydefault(duthosts, enum_rand_one_per_hwsku_hostname):
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, gnxi_path):
+def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
+                         setup_streaming_telemetry, gnxi_path):
     """Run pyclient from ptfdocker and show gnmi server outputself.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -129,7 +130,8 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, se
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, gnxi_path):
+def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
+                                    setup_streaming_telemetry, gnxi_path):
     """
     Run pyclient from ptfdocker and check number of queue counters to check
     correctness of the feature of polling only configured port buffer queues.

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -39,7 +39,7 @@ def get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, iface, gnmi_port):
     for i in range(MAX_UC_CNT):
         cmd = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} \
             -p {1} -m get -x COUNTERS_QUEUE_NAME_MAP/{2}:{3} \
-            -xt COUNTERS_DB -o "ndastreamingservertest" \
+            -xt COUNTERS_DB -o "ndastreamingservertest" -n \
             '.format(dut_ip, gnmi_port, iface, i)
 
         cmd_output = ptfhost.shell(cmd, module_ignore_errors=True)
@@ -105,9 +105,7 @@ def test_telemetry_enabledbydefault(duthosts, enum_rand_one_per_hwsku_hostname):
             pytest_assert(str(v) == status_expected,
                           "Telemetry feature is not enabled")
 
-@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                         setup_streaming_telemetry, gnxi_path):
+def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
     """Run pyclient from ptfdocker and show gnmi server outputself.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -118,7 +116,7 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
     logger.info('start telemetry output testing')
     dut_ip = duthost.mgmt_ip
     cmd = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m get -x COUNTERS/Ethernet0 -xt \
-        COUNTERS_DB -o "ndastreamingservertest"'.format(dut_ip, env.gnmi_port)
+        COUNTERS_DB -o "ndastreamingservertest" -n'.format(dut_ip, env.gnmi_port)
     show_gnmi_out = ptfhost.shell(cmd)['stdout']
     logger.info("GNMI Server output")
     logger.info(show_gnmi_out)
@@ -128,9 +126,7 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
                   "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi_output")
 
 
-@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                                    setup_streaming_telemetry, gnxi_path):
+def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
     """
     Run pyclient from ptfdocker and check number of queue counters to check
     correctness of the feature of polling only configured port buffer queues.
@@ -182,8 +178,7 @@ def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, 
     pytest_assert(pre_del_cnt > post_del_cnt,
                   "Number of queue counters count differs from expected")
 
-@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_osbuild_version(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path, setup_streaming_telemetry):
+def test_osbuild_version(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
     """ Test osbuild/version query.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -198,8 +193,7 @@ def test_osbuild_version(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gn
     assert_equal(len(re.findall(r'SONiC\.NA', result, flags=re.IGNORECASE)),
                  0, "invalid build_version value at {0}".format(result))
 
-@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_sysuptime(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path, setup_streaming_telemetry):
+def test_sysuptime(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
     """
     @summary: Run pyclient from ptfdocker and test the dataset 'system uptime' to check
               whether the value of 'system uptime' was float number and whether the value was
@@ -211,7 +205,7 @@ def test_sysuptime(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_pat
     skip_201911_and_older(duthost)
     dut_ip = duthost.mgmt_ip
     cmd = 'python ' + gnxi_path + 'gnmi_cli_py/py_gnmicli.py -g -t {0} -p {1} -m get -x proc/uptime -xt OTHERS \
-           -o "ndastreamingservertest"'.format(dut_ip, env.gnmi_port)
+           -o "ndastreamingservertest" -n'.format(dut_ip, env.gnmi_port)
     system_uptime_info = ptfhost.shell(cmd)["stdout_lines"]
     system_uptime_1st = 0
     found_system_uptime_field = False
@@ -247,8 +241,7 @@ def test_sysuptime(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_pat
     if system_uptime_2nd - system_uptime_1st < 10:
         pytest.fail("The value of system uptime was not updated correctly.")
 
-@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_virtualdb_table_streaming(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path, setup_streaming_telemetry):
+def test_virtualdb_table_streaming(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
     """Run pyclient from ptfdocker to stream a virtual-db query multiple times.
     """
     logger.info('start virtual db sample streaming testing')
@@ -276,8 +269,7 @@ def invoke_py_cli_from_ptf(ptfhost, cmd, callback):
     assert ret["rc"] == 0, "PTF docker did not get a response"
     callback(ret["stdout"])
 
-@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path, setup_streaming_telemetry):
+def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
     logger.info("Testing on change update notifications")
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     if duthost.is_supervisor_node():
@@ -320,9 +312,8 @@ def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
     duthost.shell(cmd)
     client_thread.join(60)  # max timeout of 60s, expect update to come in <=30s
 
-@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 @pytest.mark.disable_loganalyzer
-def test_mem_spike(duthosts, rand_one_dut_hostname, ptfhost, gnxi_path, virtualdb_table_streaming):
+def test_mem_spike(duthosts, rand_one_dut_hostname, ptfhost, gnxi_path):
     """Test whether memory usage of telemetry container will exceed threshold
     if python gNMI client continuously creates channels with gNMI server.
     """

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -107,7 +107,7 @@ def test_telemetry_enabledbydefault(duthosts, enum_rand_one_per_hwsku_hostname):
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
+def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
                          setup_streaming_telemetry, gnxi_path):
     """Run pyclient from ptfdocker and show gnmi server outputself.
     """
@@ -130,7 +130,7 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
+def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
                                     setup_streaming_telemetry, gnxi_path):
     """
     Run pyclient from ptfdocker and check number of queue counters to check

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -303,7 +303,7 @@ def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
         try:
             assert result != "", "Did not get output from PTF client"
         finally:
-            ccmd = "sonic-db-cli STATE_DB HSET \"NEIGH_STATE_TABLE|{}\" \"state\" {}".format(bgp_neighbor, 
+            ccmd = "sonic-db-cli STATE_DB HSET \"NEIGH_STATE_TABLE|{}\" \"state\" {}".format(bgp_neighbor,
                                                                                              original_state)
             ccmd = duthost.get_cli_cmd_for_namespace(ccmd, ns)
             duthost.shell(ccmd)

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -104,8 +104,9 @@ def test_telemetry_enabledbydefault(duthosts, enum_rand_one_per_hwsku_hostname):
             status_expected = "enabled"
             pytest_assert(str(v) == status_expected,
                           "Telemetry feature is not enabled")
-
-def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
+            
+@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
+def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path, setup_streaming_telemetry):
     """Run pyclient from ptfdocker and show gnmi server outputself.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -125,8 +126,8 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gn
     pytest_assert(inerrors_match is not None,
                   "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi_output")
 
-
-def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
+@pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
+def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path, setup_streaming_telemetry):
     """
     Run pyclient from ptfdocker and check number of queue counters to check
     correctness of the feature of polling only configured port buffer queues.
@@ -178,6 +179,7 @@ def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, 
     pytest_assert(pre_del_cnt > post_del_cnt,
                   "Number of queue counters count differs from expected")
 
+
 def test_osbuild_version(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
     """ Test osbuild/version query.
     """
@@ -192,6 +194,7 @@ def test_osbuild_version(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gn
                  1, "build_version value at {0}".format(result))
     assert_equal(len(re.findall(r'SONiC\.NA', result, flags=re.IGNORECASE)),
                  0, "invalid build_version value at {0}".format(result))
+
 
 def test_sysuptime(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
     """
@@ -240,6 +243,7 @@ def test_sysuptime(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_pat
 
     if system_uptime_2nd - system_uptime_1st < 10:
         pytest.fail("The value of system uptime was not updated correctly.")
+
 
 def test_virtualdb_table_streaming(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
     """Run pyclient from ptfdocker to stream a virtual-db query multiple times.

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -104,9 +104,10 @@ def test_telemetry_enabledbydefault(duthosts, enum_rand_one_per_hwsku_hostname):
             status_expected = "enabled"
             pytest_assert(str(v) == status_expected,
                           "Telemetry feature is not enabled")
-            
+
+
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path, setup_streaming_telemetry):
+def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, gnxi_path):
     """Run pyclient from ptfdocker and show gnmi server outputself.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -126,8 +127,9 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gn
     pytest_assert(inerrors_match is not None,
                   "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi_output")
 
+
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path, setup_streaming_telemetry):
+def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, gnxi_path):
     """
     Run pyclient from ptfdocker and check number of queue counters to check
     correctness of the feature of polling only configured port buffer queues.

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -11,7 +11,6 @@ from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from telemetry_utils import assert_equal, get_list_stdout, get_dict_stdout, skip_201911_and_older
 from telemetry_utils import generate_client_cli, parse_gnmi_output, check_gnmi_cli_running
 from tests.common import config_reload
-from tests.common.helpers.constants import NAMESPACE_PREFIX
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -159,7 +158,7 @@ def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, 
     if ns is None:
         cmd = "sonic-cfggen -d --print-data > {}".format(ORIG_CFG_DB)
     else:
-        cmd  = "sonic-cfggen -n {} -d --print-data > {}".format(ns, ORIG_CFG_DB)
+        cmd = "sonic-cfggen -n {} -d --print-data > {}".format(ns, ORIG_CFG_DB)
     duthost.shell(cmd)
     data = json.loads(duthost.shell("cat {}".format(ORIG_CFG_DB),
                                     verbose=False)['stdout'])
@@ -277,6 +276,7 @@ def invoke_py_cli_from_ptf(ptfhost, cmd, callback):
     assert ret["rc"] == 0, "PTF docker did not get a response"
     callback(ret["stdout"])
 
+
 def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_path):
     logger.info("Testing on change update notifications")
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -303,8 +303,8 @@ def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
         try:
             assert result != "", "Did not get output from PTF client"
         finally:
-            ccmd = "sonic-db-cli STATE_DB HSET \"NEIGH_STATE_TABLE|{}\" \"state\" {}".format(bgp_neighbor,
-                                                                                                original_state)
+            ccmd = "sonic-db-cli STATE_DB HSET \"NEIGH_STATE_TABLE|{}\" \"state\" {}".format(bgp_neighbor, 
+                                                                                             original_state)
             ccmd = duthost.get_cli_cmd_for_namespace(ccmd, ns)
             duthost.shell(ccmd)
         ret = parse_gnmi_output(result, 1, bgp_neighbor)
@@ -315,10 +315,11 @@ def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
 
     wait_until(5, 1, 0, check_gnmi_cli_running, ptfhost)
     cmd = "sonic-db-cli STATE_DB HSET \"NEIGH_STATE_TABLE|{}\" \"state\" {}".format(bgp_neighbor,
-                                                                                            new_state)
+                                                                                    new_state)
     cmd = duthost.get_cli_cmd_for_namespace(cmd, ns)
     duthost.shell(cmd)
     client_thread.join(60)  # max timeout of 60s, expect update to come in <=30s
+
 
 @pytest.mark.disable_loganalyzer
 def test_mem_spike(duthosts, rand_one_dut_hostname, ptfhost, gnxi_path):


### PR DESCRIPTION
### Description of PR
Current telemetry test code on master does not take multi-asic into consideration. Which causes many test failures when testing against chassis with multi-asic. 

The commit is to add those missing multi-asic supports

Summary:
Fixes # 

### Type of change
- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Currently many test cases failure for telemetry. A significant of the failures are because of multi-asic handlings are missing in the code.
#### How did you do it?
Add multi-asic support and make sure all test passed with the changes
#### How did you verify/test it?
OC test for telemetry are passing with the changes against Nokia 7250 chassis (multi-asic)
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

