### PR TITLE
Optimize `test_platform_serial_no` to handle module sonic_platform variations. 

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -115,10 +115,13 @@ def test_platform_serial_no(duthosts, enum_rand_one_per_hwsku_hostname, dut_vars
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     cmd = "sudo decode-syseeprom -s"
     get_serial_no_cmd = duthost.command(cmd, module_ignore_errors=True)
-    # For kvm testbed, command `sudo decode-syseeprom -s` will return the expected Error
-    # `ModuleNotFoundError: No module named 'sonic_platform'`
+    # For kvm testbed, when executing command `sudo decode-syseeprom -s`
+    # On some images, it will return the expected Error `ModuleNotFoundError: No module named 'sonic_platform'`
+    # and get the expected return code 2
+    # On some images, it will return the expected Error `Failed to read system EEPROM info in syseeprom on 'vlab-01'`
+    # and get the expected return code 0
     # So let this function return in advance
-    if duthost.facts["asic_type"] == "vs" and get_serial_no_cmd["rc"] == 1:
+    if duthost.facts["asic_type"] == "vs" and (get_serial_no_cmd["rc"] == 1 or get_serial_no_cmd["rc"] == 0):
         return
     assert get_serial_no_cmd['rc'] == 0, "Run command '{}' failed".format(cmd)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #13424, we have optimized the code to fit for kvm testbed. But I notice that, in some kvm images, it includes the module `sonic_platform`, but in other images, they doesn't include. This will generate different return code while executing some commands. In this PR, we optimize the code to cover both situations.  

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In PR #13424, we have optimized the code to fit for kvm testbed. But I notice that, in some kvm images, it includes the module `sonic_platform`, but in other images, they doesn't include. This will generate different return code while executing some commands. In this PR, we optimize the code to cover both situations.  

#### How did you do it?
Optimize the code to cover different situations. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
