### PR TITLE
Add ip/radv test to pr test yml and mclag/nat/sflow test to skip yml

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -233,6 +233,7 @@ t1-lag:
   - http/test_http_copy.py
   - iface_namingmode/test_iface_namingmode.py
   - ip/test_ip_packet.py
+  - ip/test_mgmt_ipv6_only.py
   - ipfwd/test_dip_sip.py
   - ipfwd/test_mtu.py
   - lldp/test_lldp.py
@@ -244,6 +245,7 @@ t1-lag:
   - platform_tests/test_cpu_memory_usage.py
   - process_monitoring/test_critical_process_monitoring.py
   - qos/test_buffer.py
+  - radv/test_radv_restart.py
   - route/test_default_route.py
   - route/test_route_consistency.py
   - route/test_route_flap.py

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -9,7 +9,7 @@ t0:
   - k8s/test_join_available_master.py
   # Mclag test only support on t0-mclag platform which is not in PR test
   - mclag/test_mclag_l3.py
-  # Nat feature is not enabled in current image
+  # Nat feature is default disabled on both KVM and physical platforms
   - nat/test_dynamic_nat.py
   - nat/test_static_nat.py
   # Neighbor type must be sonic
@@ -48,7 +48,7 @@ t0:
   - restapi/test_restapi.py
   # Route flow counter is not supported on vs platform
   - route/test_route_flow_counter.py
-  # Sflow feature is not supported on vs platform
+  # Sflow feature is default disabled on vs platform
   - sflow/test_sflow.py
   - snmp/test_snmp_phy_entity.py
   # Remove from PR test in https://github.com/sonic-net/sonic-mgmt/pull/6073

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -7,6 +7,11 @@ t0:
   - k8s/test_config_reload.py
   - k8s/test_disable_flag.py
   - k8s/test_join_available_master.py
+  # Mclag test only support on t0-mclag platform which is not in PR test
+  - mclag/test_mclag_l3.py
+  # Nat feature is not enabled in current image
+  - nat/test_dynamic_nat.py
+  - nat/test_static_nat.py
   # Neighbor type must be sonic
   - ospf/test_ospf.py
   - ospf/test_ospf_bfd.py
@@ -43,6 +48,8 @@ t0:
   - restapi/test_restapi.py
   # Route flow counter is not supported on vs platform
   - route/test_route_flow_counter.py
+  # Sflow feature is not supported on vs platform
+  - sflow/test_sflow.py
   - snmp/test_snmp_phy_entity.py
   # Remove from PR test in https://github.com/sonic-net/sonic-mgmt/pull/6073
   - cacl/test_ebtables_application.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
#### How did you do it?
Add ip/radv test to pr test yml and mclag/nat/sflow test to skip yml
#### How did you verify/test it?
Test in KVM
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
