### PR TITLE
increase wait time for verifying dynamic bgp neigh

### DIFF
--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -280,7 +280,7 @@ def bgp_speaker_announce_routes_common(common_setup_teardown, tbinfo, duthost,
     announce_route(ptfip, lo_addr, peer_range, vlan_ips[0].ip, port_num[2])
 
     logger.info("Wait some time to make sure routes announced to dynamic bgp neighbors")
-    assert wait_until(90, 10, 0, is_all_neighbors_learned, duthost, speaker_ips), \
+    assert wait_until(120, 10, 0, is_all_neighbors_learned, duthost, speaker_ips), \
         "Not all dynamic neighbors were learned"
 
     logger.info("Verify nexthops and nexthop interfaces for accepted prefixes of the dynamic neighbors")


### PR DESCRIPTION
### Description of PR
We see that test_bgp_speaker_announce_routes and test_bgp_speaker_announce_routes_v6 in test_bgp_speaker.py are flaky wherein sometimes it takes more than 90s for BGP prefix exchange between the DUT and exabgp on PTF. The test asserts after 90s. This PR Increases the wait time before verifying accepted prefixes of the dynamic neighbors

Summary:
Increased the wait time before verifying accepted prefixes of the dynamic neighbors

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
test_bgp_speaker_announce_routes often fails, because wait time is not enough to announce dynamic bgp neighbors.

#### How did you do it?
increased the wait time

#### How did you verify/test it?
Verified that the tests are passing consistently

NOK log excerpts:
```
06/05/2024 01:54:10 utilities.wait_until                     L0156 DEBUG  | is_all_neighbors_learned is still False after 90 seconds, exit with False
06/05/2024 01:54:10 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 1788, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 501, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 119, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 138, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 102, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/var/src/sonic-mgmt_vms63-t0-8111-05_649d4810167b56701a640827/tests/bgp/test_bgp_speaker.py", line 373, in test_bgp_speaker_announce_routes_v6
    bgp_speaker_announce_routes_common(common_setup_teardown, tbinfo, duthost, ptfhost, ipv4, ipv6,
  File "/var/src/sonic-mgmt_vms63-t0-8111-05_649d4810167b56701a640827/tests/bgp/test_bgp_speaker.py", line 283, in bgp_speaker_announce_routes_common
    assert wait_until(90, 10, 0, is_all_neighbors_learned, duthost, speaker_ips), \
AssertionError: Not all dynamic neighbors were learned
…

UT:
```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
---------------------- generated xml file: /run_logs/ananshar/bgp/test_bgp_speaker_2024-06-27-05-45-16.xml -----------------------
INFO:root:Can not get Allure report URL. Please check logs
----------------------------------------------------- live log sessionfinish -----------------------------------------------------
05:48:59 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
============================================ 3 passed, 1 warning in 221.82s (0:03:41) ============================================
```

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
NA