### PR TITLE
Add dualtor data plane test to onboarding dualtor job

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -348,6 +348,11 @@ onboarding_t1:
   - hash/test_generic_hash.py
 
 onboarding_dualtor:
+  - dualtor/test_ipinip.py
+  - dualtor/test_orchagent_slb.py
+  - dualtor/test_switchover_failure.py
+  - dualtor/test_tor_ecn.py
+  - dualtor/test_tunnel_memory_leak.py
   - dualtor_mgmt/test_ingress_drop.py
   - dualtor_mgmt/test_dualtor_bgp_update_delay.py
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -64,6 +64,12 @@ decap/test_decap.py:
 #######################################
 #####           dualtor           #####
 #######################################
+dualtor/test_ipinip.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
 dualtor/test_orchagent_active_tor_downstream.py:
   skip_traffic_test:
     reason: "Skip traffic test for KVM testbed"
@@ -76,6 +82,12 @@ dualtor/test_orchagent_mac_move.py:
     conditions:
       - "asic_type in ['vs']"
 
+dualtor/test_orchagent_slb.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
 dualtor/test_orchagent_standby_tor_downstream.py:
   skip_traffic_test:
     reason: "Skip traffic test for KVM testbed"
@@ -83,6 +95,18 @@ dualtor/test_orchagent_standby_tor_downstream.py:
       - "asic_type in ['vs']"
 
 dualtor/test_standby_tor_upstream_mux_toggle.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+dualtor/test_tor_ecn.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+dualtor/test_tunnel_memory_leak.py:
   skip_traffic_test:
     reason: "Skip traffic test for KVM testbed"
     conditions:

--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -28,6 +28,8 @@ from tests.common.utilities import is_ipv4_address, wait_until
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder          # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_garp_service            # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test           # noqa F401
 from tests.common.utilities import dump_scapy_packet_show_output
 from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby                 # noqa F401
 from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup                        # noqa F401
@@ -104,7 +106,7 @@ def build_expected_packet_to_server(encapsulated_packet, decrease_ttl=False):
 def test_decap_active_tor(
     build_encapsulated_packet, request, ptfhost,
     rand_selected_interface, ptfadapter,                    # noqa F401
-    tbinfo, rand_selected_dut, tunnel_traffic_monitor):     # noqa F401
+    tbinfo, rand_selected_dut, tunnel_traffic_monitor, skip_traffic_test):  # noqa F811
 
     @contextlib.contextmanager
     def stop_garp(ptfhost):
@@ -128,6 +130,9 @@ def test_decap_active_tor(
 
     ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
     logging.info("send encapsulated packet from ptf t1 interface %s", ptf_t1_intf)
+    if skip_traffic_test is True:
+        logging.info("Skip following traffic test")
+        return
     with stop_garp(ptfhost):
         ptfadapter.dataplane.flush()
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), encapsulated_packet)
@@ -137,7 +142,7 @@ def test_decap_active_tor(
 def test_decap_standby_tor(
     build_encapsulated_packet, request,
     rand_selected_interface, ptfadapter,                    # noqa F401
-    tbinfo, rand_selected_dut, tunnel_traffic_monitor       # noqa F401
+    tbinfo, rand_selected_dut, tunnel_traffic_monitor, skip_traffic_test       # noqa F401
 ):
 
     def verify_downstream_packet_to_server(ptfadapter, port, exp_pkt):
@@ -166,6 +171,9 @@ def test_decap_standby_tor(
 
     ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
     logging.info("send encapsulated packet from ptf t1 interface %s", ptf_t1_intf)
+    if skip_traffic_test is True:
+        logging.info("Skip following traffic test")
+        return
     with tunnel_traffic_monitor(tor, existing=False):
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), encapsulated_packet, count=10)
         time.sleep(2)
@@ -295,7 +303,7 @@ def setup_active_active_ports(active_active_ports, rand_selected_dut, rand_unsel
 def test_encap_with_mirror_session(rand_selected_dut, rand_selected_interface,              # noqa F811
                                    ptfadapter, tbinfo, setup_mirror_session,
                                    toggle_all_simulator_ports_to_rand_unselected_tor,       # noqa F811
-                                   tunnel_traffic_monitor,                                  # noqa F811
+                                   tunnel_traffic_monitor, skip_traffic_test,               # noqa F811
                                    setup_standby_ports_on_rand_selected_tor):               # noqa F811
     """
     A test case to verify the bounced back packet from Standby ToR to T1 doesn't have an unexpected vlan id (4095)
@@ -314,5 +322,8 @@ def test_encap_with_mirror_session(rand_selected_dut, rand_selected_interface,  
     logging.info("Sending packet from ptf t1 interface {}".format(src_port_id))
     inner_packet = pkt_to_server[scapy.all.IP].copy()
     inner_packet[IP].ttl -= 1
+    if skip_traffic_test is True:
+        logging.info("Skip following traffic test")
+        return
     with tunnel_traffic_monitor(rand_selected_dut, inner_packet=inner_packet, check_items=()):
         testutils.send(ptfadapter, src_port_id, pkt_to_server)

--- a/tests/dualtor/test_orchagent_slb.py
+++ b/tests/dualtor/test_orchagent_slb.py
@@ -2,6 +2,7 @@ import ipaddress
 import pytest
 import random
 import time
+import logging
 import scapy.all as scapyall
 
 from ptf import testutils
@@ -19,6 +20,8 @@ from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor    
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder                                  # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                                # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                             # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test                                   # noqa F401
 from tests.common.helpers import bgp
 from tests.common.utilities import is_ipv4_address
 
@@ -215,7 +218,7 @@ def test_orchagent_slb(
     force_active_tor, upper_tor_host, lower_tor_host,       # noqa F811
     ptfadapter, ptfhost, setup_interfaces,
     toggle_all_simulator_ports_to_upper_tor, tbinfo,        # noqa F811
-    tunnel_traffic_monitor, vmhost                          # noqa F811
+    tunnel_traffic_monitor, vmhost, skip_traffic_test       # noqa F811
 ):
 
     def verify_bgp_session(duthost, bgp_neighbor):
@@ -233,7 +236,11 @@ def test_orchagent_slb(
         else:
             assert len(existing_route["nexthops"]) == 0
 
-    def verify_traffic(duthost, connection, route, is_duthost_active=True, is_route_existed=True):
+    def verify_traffic(duthost, connection, route, is_duthost_active=True, is_route_existed=True,
+                       skip_traffic_test=skip_traffic_test):
+        if skip_traffic_test is True:
+            logging.info("Skip traffic test.")
+            return
         prefix = ipaddress.ip_network(route["prefix"])
         dst_host = str(next(prefix.hosts()))
         pkt, exp_pkt = build_packet_to_server(duthost, ptfadapter, dst_host)
@@ -288,11 +295,11 @@ def test_orchagent_slb(
         # STEP 3: verify the route by sending some downstream traffic
         verify_traffic(
             upper_tor_host, connections["upper_tor"], constants.route,
-            is_duthost_active=True, is_route_existed=True
+            is_duthost_active=True, is_route_existed=True, skip_traffic_test=skip_traffic_test
         )
         verify_traffic(
             lower_tor_host, connections["lower_tor"], constants.route,
-            is_duthost_active=False, is_route_existed=True
+            is_duthost_active=False, is_route_existed=True, skip_traffic_test=skip_traffic_test
         )
 
         # STEP 4: withdraw the announced route to both ToRs
@@ -307,11 +314,11 @@ def test_orchagent_slb(
         # STEP 5: verify the route is removed by verifying that downstream traffic is dropped
         verify_traffic(
             upper_tor_host, connections["upper_tor"], constants.route,
-            is_duthost_active=True, is_route_existed=False
+            is_duthost_active=True, is_route_existed=False, skip_traffic_test=skip_traffic_test
         )
         verify_traffic(
             lower_tor_host, connections["lower_tor"], constants.route,
-            is_duthost_active=False, is_route_existed=False
+            is_duthost_active=False, is_route_existed=False, skip_traffic_test=skip_traffic_test
         )
 
         # STEP 6: toggle mux state change
@@ -334,11 +341,11 @@ def test_orchagent_slb(
         # STEP 8: verify the route by sending some downstream traffic
         verify_traffic(
             upper_tor_host, connections["upper_tor"], constants.route,
-            is_duthost_active=False, is_route_existed=True
+            is_duthost_active=False, is_route_existed=True, skip_traffic_test=skip_traffic_test
         )
         verify_traffic(
             lower_tor_host, connections["lower_tor"], constants.route,
-            is_duthost_active=True, is_route_existed=True
+            is_duthost_active=True, is_route_existed=True, skip_traffic_test=skip_traffic_test
         )
 
         # STEP 9: verify teardown

--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -28,6 +28,8 @@ from tests.common.utilities import is_ipv4_address
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder              # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_garp_service                # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses            # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test               # noqa F401
 from tests.common.utilities import dump_scapy_packet_show_output
 from tests.common.dualtor.tunnel_traffic_utils import derive_queue_id_from_dscp, derive_out_dscp_from_inner_dscp
 from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby      # noqa F401
@@ -275,7 +277,7 @@ def test_dscp_to_queue_during_decap_on_active(
     inner_dscp, ptfhost, setup_dualtor_tor_active,
     request, rand_selected_interface, ptfadapter,           # noqa F811
     tbinfo, rand_selected_dut, tunnel_traffic_monitor,      # noqa F811
-    duthosts, rand_one_dut_hostname
+    duthosts, rand_one_dut_hostname, skip_traffic_test      # noqa F811
 ):
     """
     Test if DSCP to Q mapping for inner header is matching with outer header during decap on active
@@ -295,6 +297,9 @@ def test_dscp_to_queue_during_decap_on_active(
     duthost.shell('sonic-clear queuecounters')
     logging.info("Clearing queue counters before starting traffic")
 
+    if skip_traffic_test is True:
+        logging.info("Skip following test due traffic test skipped")
+        return
     with stop_garp(ptfhost):
         ptfadapter.dataplane.flush()
         ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
@@ -346,7 +351,8 @@ def test_dscp_to_queue_during_encap_on_standby(
     duthosts,
     rand_one_dut_hostname,
     write_standby,
-    setup_standby_ports_on_rand_selected_tor        # noqa F811
+    setup_standby_ports_on_rand_selected_tor,       # noqa F811
+    skip_traffic_test                               # noqa F811
 ):
     """
     Test if DSCP to Q mapping for outer header is matching with inner header during encap on standby
@@ -367,6 +373,9 @@ def test_dscp_to_queue_during_encap_on_standby(
     ptfadapter.dataplane.flush()
     ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
     logging.info("send IP packet from ptf t1 interface %s", ptf_t1_intf)
+    if skip_traffic_test is True:
+        logging.info("Skip following test due traffic test skipped")
+        return
     with tunnel_traffic_monitor(tor, existing=True, packet_count=PACKET_NUM):
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), non_encapsulated_packet, count=PACKET_NUM)
 
@@ -375,7 +384,8 @@ def test_dscp_to_queue_during_encap_on_standby(
 def test_ecn_during_decap_on_active(
     inner_dscp, ptfhost, setup_dualtor_tor_active,
     request, rand_selected_interface, ptfadapter,           # noqa F811
-    tbinfo, rand_selected_dut, tunnel_traffic_monitor       # noqa F811
+    tbinfo, rand_selected_dut, tunnel_traffic_monitor,      # noqa F811
+    skip_traffic_test                                       # noqa F811
 ):
     """
     Test if the ECN stamping on inner header is matching with outer during decap on active
@@ -395,6 +405,10 @@ def test_ecn_during_decap_on_active(
 
     exp_tos = encapsulated_packet[IP].payload[IP].tos
     exp_ecn = exp_tos & 3
+
+    if skip_traffic_test is True:
+        logging.info("Skip following test due traffic test skipped")
+        return
     with stop_garp(ptfhost):
         tor.shell("portstat -c")
         tor.shell("show arp")
@@ -411,7 +425,8 @@ def test_ecn_during_encap_on_standby(
     rand_selected_interface, ptfadapter,                    # noqa F811
     tbinfo, rand_selected_dut, tunnel_traffic_monitor,      # noqa F811
     write_standby,
-    setup_standby_ports_on_rand_selected_tor                # noqa F811
+    setup_standby_ports_on_rand_selected_tor,               # noqa F811
+    skip_traffic_test                                       # noqa F811
 ):
     """
     Test if the ECN stamping on outer header is matching with inner during encap on standby
@@ -426,5 +441,8 @@ def test_ecn_during_encap_on_standby(
 
     ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
     logging.info("send IP packet from ptf t1 interface %s", ptf_t1_intf)
+    if skip_traffic_test is True:
+        logging.info("Skip following test due traffic test skipped")
+        return
     with tunnel_traffic_monitor(tor, existing=True, packet_count=PACKET_NUM):
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), non_encapsulated_packet, count=PACKET_NUM)

--- a/tests/dualtor/test_tunnel_memory_leak.py
+++ b/tests/dualtor/test_tunnel_memory_leak.py
@@ -11,9 +11,9 @@ import random
 import time
 import contextlib
 from ptf import testutils
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor  # noqa: F401
-from tests.common.dualtor.dual_tor_common import cable_type  # noqa: F401
-from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host  # noqa: F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor  # noqa F401
+from tests.common.dualtor.dual_tor_common import cable_type  # noqa F401
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host  # noqa F401
 from tests.common.dualtor.server_traffic_utils import ServerTrafficMonitor
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
@@ -21,7 +21,9 @@ from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.dual_tor_utils import build_packet_to_server
 from tests.common.dualtor.dual_tor_utils import delete_neighbor
 from tests.common.helpers.dut_utils import get_program_info
-from tests.common.fixtures.ptfhost_utils import run_garp_service, run_icmp_responder  # noqa: F401
+from tests.common.fixtures.ptfhost_utils import run_garp_service, run_icmp_responder    # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test                       # noqa F401
 from tests.common.utilities import wait_until
 
 
@@ -114,8 +116,9 @@ def check_memory_leak(duthost, target_mem_percent, delay=10, timeout=15, interva
     return not wait_until(timeout, interval, delay, _check_memory, duthost)
 
 
-def test_tunnel_memory_leak(toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,  # noqa: F811
-                            ptfhost, ptfadapter, conn_graph_facts, tbinfo, vmhost, run_arp_responder):  # noqa: F811
+def test_tunnel_memory_leak(toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa F811
+                            ptfhost, ptfadapter, conn_graph_facts, tbinfo, vmhost, run_arp_responder,   # noqa F811
+                            skip_traffic_test):                                                         # noqa F811
     """
     Test if there is memory leak for service tunnel_packet_handler.
     Send ip packets from standby TOR T1 to Server, standby TOR will
@@ -169,6 +172,9 @@ def test_tunnel_memory_leak(toggle_all_simulator_ports_to_upper_tor, upper_tor_h
 
             pkt, exp_pkt = build_packet_to_server(lower_tor_host, ptfadapter, server_ipv4)
 
+            if skip_traffic_test is True:
+                logging.info("Skip traffic test.")
+                continue
             server_traffic_monitor = ServerTrafficMonitor(
                 upper_tor_host, ptfhost, vmhost, tbinfo, iface,
                 conn_graph_facts, exp_pkt, existing=True, is_mocked=False
@@ -182,9 +188,11 @@ def test_tunnel_memory_leak(toggle_all_simulator_ports_to_upper_tor, upper_tor_h
                     mem_usage, mem_limit, mem_percent = get_memory_info(upper_tor_host)
                     logging.info(
                         "SWSS MEM USAGE:{} LIMIT:{} PERCENT:{}".format(mem_usage, mem_limit, mem_percent))
-                    pytest_assert(validate_neighbor_entry_exist(upper_tor_host, server_ipv4),
-                                  "The server ip {} doesn't exist in neighbor table on dut {}. \
-                                  tunnel_packet_handler isn't triggered.".format(server_ipv4, upper_tor_host.hostname))
+                    if not skip_traffic_test:
+                        pytest_assert(validate_neighbor_entry_exist(upper_tor_host, server_ipv4),
+                                      "The server ip {} doesn't exist in neighbor table on dut {}. \
+                                      tunnel_packet_handler isn't triggered."
+                                      .format(server_ipv4, upper_tor_host.hostname))
             except Exception as e:
                 logging.error("Capture exception {}, continue the process.".format(repr(e)))
             if len(server_traffic_monitor.matched_packets) == 0:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed
#### How did you do it?
Add dualtor data plane test to onboarding dualtor job and skip traffic test
#### How did you verify/test it?
Test on KVM
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
