### PR TITLE
Deprecate ceosimage_saskey for downloading cEOS image

### DIFF
--- a/ansible/group_vars/all/ceos.yml
+++ b/ansible/group_vars/all/ceos.yml
@@ -1,12 +1,11 @@
-# upgrade cEOS to 4.25.5.1M from 4.23.2F at 2021/09/24
-
-#ceos_image_filename: cEOS64-lab-4.23.2F.tar.xz
-#ceos_image_orig: ceosimage:4.23.2F
-#ceos_image: ceosimage:4.23.2F-1
-#ceos_image_filename: cEOS64-lab-4.25.5.1M.tar
-#ceos_image_orig: ceosimage:4.25.5.1M
-#ceos_image: ceosimage:4.25.5.1M-1
 ceos_image_filename: cEOS64-lab-4.29.3M.tar
 ceos_image_orig: ceosimage:4.29.3M
 ceos_image: ceosimage:4.29.3M-1
+# Please update ceos_image_url to the actual URL of the cEOS image file in your environment. If the cEOS image file
+# is not available on test server, the cEOS image file will be downloaded from this URL.
+# The ceos_image_url can be a string as single URL or a list of strings as multiple URLs. If it is a list, the code
+# logic will automatically try each URL in the list
+ceos_image_url:
+  - "http://example1.com/cEOS64-lab-4.29.3M.tar"
+  - "http://example2.com/cEOS64-lab-4.29.3M.tar"
 skip_ceos_image_downloading: false

--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -1,88 +1,97 @@
 - name: Check if cEOS docker image exists or not
   docker_image_info:
     name:
-      - "{{ ceos_image_orig }}"
       - "{{ ceos_image }}"
   become: yes
   register: ceos_docker_image_stat
 
-- name: Check if cEOS image file exists on the test server
-  stat:
-    path: "{{ root_path }}/images/{{ ceos_image_filename }}"
-  register: ceos_image_file_stat
-
-- name: Fail if cEOS docker image and cEOS image file do not exist, and downloading is not enabled
-  fail:
-    msg: "Failed, no ceos docker image, no ceos image file, and skip_ceos_image_downloading is false"
-  when:
-    - ceos_docker_image_stat.images | length == 0
-    - ceos_image_file_stat.stat.exists == false
-    - skip_ceos_image_downloading == true
-
-- name: Ensure that cEOS docker image is imported locally if not already imported
+- name: Prepare ceos_image if it does not exist
   block:
 
-  - name: Download ceos image if no local ceos image file and skip_ceos_image_downloading is false
-    block:
+    - name: Check if ceos_image_orig exists or not
+      docker_image_info:
+        name:
+          - "{{ ceos_image_orig }}"
+      become: yes
+      register: ceos_image_orig_stat
 
-    - name: Init ceos_image_urls when ceos_image_url value type is string
-      set_fact:
-        ceos_image_urls:
-          - "{{ ceos_image_url }}"
-      when: ceos_image_url | type_debug == 'string'
+    - name: Prepare ceos_image_orig if it does not exist
+      block:
+        - name: Check if local ceos image file exists or not
+          stat:
+            path: "{{ root_path }}/images/{{ ceos_image_filename }}"
+          register: ceos_image_file_stat
 
-    - name: Init ceos_image_urls when ceos_image_url value type is list
-      set_fact:
-        ceos_image_urls: "{{ ceos_image_url }}"
-      when: ceos_image_url | type_debug == 'list'
+        - name: Download cEOS image file if no local ceos image file exists
+          block:
+            - name: Fail if skip_ceos_image_downloading is true
+              fail:
+                msg: [
+                  "Failed, no ceos docker image, no ceos image file and skip_ceos_image_downloading is true",
+                  "Please manually put cEOS image to {{ root_path }}/images/{{ ceos_image_filename }}"
+                ]
+              when: skip_ceos_image_downloading == true
 
-    - name: Init working_ceos_image_urls list
-      set_fact:
-        working_ceos_image_urls: []
+            - name: Init ceos_image_urls when ceos_image_url value type is string
+              set_fact:
+                ceos_image_urls:
+                  - "{{ ceos_image_url }}"
+              when: ceos_image_url | type_debug == 'string'
 
-    - name: Loop ceos_image_urls to find out working URLs
-      include_tasks: probe_ceos_image_url.yml
-      loop: "{{ ceos_image_urls }}"
+            - name: Init ceos_image_urls when ceos_image_url value type is list
+              set_fact:
+                ceos_image_urls: "{{ ceos_image_url }}"
+              when: ceos_image_url | type_debug == 'list'
 
-    - name: Fail if no working ceos image download url is found
-      fail:
-        msg: [
-          "Failed, no working ceos image download URL is found. There are 2 options to fix it:",
-          "  1. Fix ceos_image_url defined in ansible/group_vars/all/ceos.yml",
-          "  2. Manually put cEOS image to {{ root_path }}/images/{{ ceos_image_filename }}",
-        ]
-      when: working_ceos_image_urls | length == 0
+            - name: Init working_ceos_image_urls list
+              set_fact:
+                working_ceos_image_urls: []
 
-    - name: Download cEOS image file from working ceos_image_urls using the first working URL
-      get_url:
-        url: "{{ working_ceos_image_urls[0] }}"
-        dest: "{{ root_path }}/images/{{ ceos_image_filename }}"
-      register: ceos_image_download_result
+            - name: Loop ceos_image_urls to find out working URLs
+              include_tasks: probe_ceos_image_url.yml
+              loop: "{{ ceos_image_urls }}"
 
-    when: ceos_image_file_stat.stat.exists == false and skip_ceos_image_downloading == false
+            - name: Fail if no working ceos image download url is found
+              fail:
+                msg: [
+                  "Failed, no working ceos image download URL is found. There are 2 options to fix it:",
+                  "  1. Fix ceos_image_url defined in ansible/group_vars/all/ceos.yml",
+                  "  2. Manually put cEOS image to {{ root_path }}/images/{{ ceos_image_filename }}",
+                ]
+              when: working_ceos_image_urls | length == 0
 
-  - name: Import cEOS image
-    become: yes
-    shell: "docker import {{ root_path }}/images/{{ ceos_image_filename }} {{ ceos_image_orig }}"
+            - name: Download cEOS image file from working ceos_image_urls using the first working URL
+              get_url:
+                url: "{{ working_ceos_image_urls[0] }}"
+                dest: "{{ root_path }}/images/{{ ceos_image_filename }}"
+              register: ceos_image_download_result
 
-  - name: create directory for build ceos image
-    become: yes
-    file:
-      path: "/tmp/ceosimage"
-      state: directory
+          when: ceos_image_file_stat.stat.exists == false
 
-  - name: copy the ceos image template
-    become: yes
-    template: src=ceos_dockerfile.j2 dest=/tmp/ceosimage/Dockerfile mode=0644
+        - name: Import ceos_image_orig docker image
+          become: yes
+          shell: "docker import {{ root_path }}/images/{{ ceos_image_filename }} {{ ceos_image_orig }}"
 
-  - name: Build the ceos image with increase inotify limit
-    become: yes
-    docker_image:
-      name: "{{ ceos_image }}"
-      build:
+      when: ceos_image_orig_stat.images | length == 0
+
+    - name: Create directory for building ceos docker image
+      become: yes
+      file:
         path: "/tmp/ceosimage"
-        pull: no
-      source: build
+        state: directory
+
+    - name: Copy the ceos image template
+      become: yes
+      template: src=ceos_dockerfile.j2 dest=/tmp/ceosimage/Dockerfile mode=0644
+
+    - name: Build the ceos image with increasing inotify limit
+      become: yes
+      docker_image:
+        name: "{{ ceos_image }}"
+        build:
+          path: "/tmp/ceosimage"
+          pull: no
+        source: build
 
   when: ceos_docker_image_stat.images | length == 0
 

--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -1,3 +1,91 @@
+- name: Check if cEOS docker image exists or not
+  docker_image_info:
+    name:
+      - "{{ ceos_image_orig }}"
+      - "{{ ceos_image }}"
+  become: yes
+  register: ceos_docker_image_stat
+
+- name: Check if cEOS image file exists on the test server
+  stat:
+    path: "{{ root_path }}/images/{{ ceos_image_filename }}"
+  register: ceos_image_file_stat
+
+- name: Fail if cEOS docker image and cEOS image file do not exist, and downloading is not enabled
+  fail:
+    msg: "Failed, no ceos docker image, no ceos image file, and skip_ceos_image_downloading is false"
+  when:
+    - ceos_docker_image_stat.images | length == 0
+    - ceos_image_file_stat.stat.exists == false
+    - skip_ceos_image_downloading == true
+
+- name: Ensure that cEOS docker image is imported locally if not already imported
+  block:
+
+  - name: Download ceos image if no local ceos image file and skip_ceos_image_downloading is false
+    block:
+
+    - name: Init ceos_image_urls when ceos_image_url value type is string
+      set_fact:
+        ceos_image_urls:
+          - "{{ ceos_image_url }}"
+      when: ceos_image_url | type_debug == 'string'
+
+    - name: Init ceos_image_urls when ceos_image_url value type is list
+      set_fact:
+        ceos_image_urls: "{{ ceos_image_url }}"
+      when: ceos_image_url | type_debug == 'list'
+
+    - name: Init working_ceos_image_urls list
+      set_fact:
+        working_ceos_image_urls: []
+
+    - name: Loop ceos_image_urls to find out working URLs
+      include_tasks: probe_ceos_image_url.yml
+      loop: "{{ ceos_image_urls }}"
+
+    - name: Fail if no working ceos image download url is found
+      fail:
+        msg: [
+          "Failed, no working ceos image download URL is found. There are 2 options to fix it:",
+          "  1. Fix ceos_image_url defined in ansible/group_vars/all/ceos.yml",
+          "  2. Manually put cEOS image to {{ root_path }}/images/{{ ceos_image_filename }}",
+        ]
+      when: working_ceos_image_urls | length == 0
+
+    - name: Download cEOS image file from working ceos_image_urls using the first working URL
+      get_url:
+        url: "{{ working_ceos_image_urls[0] }}"
+        dest: "{{ root_path }}/images/{{ ceos_image_filename }}"
+      register: ceos_image_download_result
+
+    when: ceos_image_file_stat.stat.exists == false and skip_ceos_image_downloading == false
+
+  - name: Import cEOS image
+    become: yes
+    shell: "docker import {{ root_path }}/images/{{ ceos_image_filename }} {{ ceos_image_orig }}"
+
+  - name: create directory for build ceos image
+    become: yes
+    file:
+      path: "/tmp/ceosimage"
+      state: directory
+
+  - name: copy the ceos image template
+    become: yes
+    template: src=ceos_dockerfile.j2 dest=/tmp/ceosimage/Dockerfile mode=0644
+
+  - name: Build the ceos image with increase inotify limit
+    become: yes
+    docker_image:
+      name: "{{ ceos_image }}"
+      build:
+        path: "/tmp/ceosimage"
+        pull: no
+      source: build
+
+  when: ceos_docker_image_stat.images | length == 0
+
 - name: Create VMs network
   become: yes
   vm_topology:
@@ -6,53 +94,6 @@
     fp_mtu:       "{{ fp_mtu_size }}"
     max_fp_num:   "{{ max_fp_num }}"
     topo: "{{ topology }}"
-
-- name: Check if cEOS image exists or not
-  docker_image_info:
-    name:
-      - "{{ ceos_image_orig }}"
-      - "{{ ceos_image }}"
-  become: yes
-  register: ceos_stat
-
-- name: Fail if cEOS image does not exist and downloading is not enabled
-  fail: msg="Please ensure that cEOS docker image {{ ceos_image_orig }} is imported locally in test server"
-  when: (ceos_stat.images | length == 0) and skip_ceos_image_downloading
-
-- include_vars: vars/azure_storage.yml
-
-- name: Download cEOS image
-  become: yes
-  get_url:
-    url: "{{ vm_images_url }}/{{ ceos_image_filename }}?{{ ceosimage_saskey }}"
-    dest: "{{ root_path }}/images/{{ ceos_image_filename }}"
-    timeout: 1800
-  environment: "{{ proxy_env | default({}) }}"
-  when: (ceos_stat.images | length == 0) and not skip_ceos_image_downloading
-
-- name: Import cEOS image
-  become: yes
-  shell: "docker import {{ root_path }}/images/{{ ceos_image_filename }} {{ ceos_image_orig }}"
-  when: (ceos_stat.images | length == 0) and not skip_ceos_image_downloading
-
-- name: create directory for build ceos image
-  become: yes
-  file:
-    path: "/tmp/ceosimage"
-    state: directory
-
-- name: copy the ceos image template
-  become: yes
-  template: src=ceos_dockerfile.j2 dest=/tmp/ceosimage/Dockerfile mode=0644
-
-- name: Build the ceos image with increase inotify limit
-  become: yes
-  docker_image:
-    name: "{{ ceos_image }}"
-    build:
-      path: "/tmp/ceosimage"
-      pull: no
-    source: build
 
 - name: Create net base containers
   become: yes

--- a/ansible/roles/vm_set/tasks/probe_ceos_image_url.yml
+++ b/ansible/roles/vm_set/tasks/probe_ceos_image_url.yml
@@ -1,0 +1,14 @@
+- name: Probe if the URL works
+  uri:
+    url: "{{ item }}"
+    method: HEAD
+    status_code: 200
+    return_content: no
+    timeout: 3
+  register: ceos_image_url_probe_result
+  failed_when: false
+
+- name: Append working URL to working_ceos_image_urls list
+  set_fact:
+    working_ceos_image_urls: "{{ working_ceos_image_urls + [ item ] }}"
+  when: ceos_image_url_probe_result.status == 200

--- a/ansible/vars/azure_storage.yml
+++ b/ansible/vars/azure_storage.yml
@@ -1,6 +1,5 @@
 ## saskey are treated as credential in Credscan
 vmimage_saskey: use_own_value
 cdimage_saskey: use_own_value
-ceosimage_saskey: use_own_value
 k8s_vmimage_saskey: use_own_value
 vciscoimage_saskey: use_own_value

--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -43,31 +43,31 @@ We currently support EOS-based or SONiC VMs to simulate neighboring devices in t
 2. Copy below image files to `~/veos-vm/images` on your testbed host:
    - `Aboot-veos-serial-8.0.0.iso`
    - `vEOS-lab-4.20.15M.vmdk`
-### Option 2: cEOS (container-based) image (experimental)
+### Option 2: cEOS (container-based) image (recommended)
 #### Option 2.1: Download and import cEOS image manually
-1. Download the [cEOS image from Arista](https://www.arista.com/en/support/software-download)
-2. Import the cEOS image (it will take several minutes to import, so please be patient!)
+Download the [cEOS image from Arista](https://www.arista.com/en/support/software-download). For example download file `cEOS64-lab-4.29.3M.tar`.
+Put the downloaded file under `~/veos-vm/images/` on your testbed host.
+The playbook will automatically look for the cEOS image file in the `~/veos-vm/images/` directory and import it into the testbed server.
 
-```
-docker import cEOS-lab-4.25.5.1M.tar.xz ceosimage:4.25.5.1M
-```
-After imported successfully, you can check it by 'docker images'
-```
-$ docker images
-REPOSITORY                                             TAG           IMAGE ID       CREATED         SIZE
-ceosimage                                              4.25.5.1M     fa0df4b01467   9 seconds ago   1.62GB
-```
 **Note**: *For time being, the image might be updated, in that case you can't download the same version of image as in the instruction,
 please download the corresponding version(following [Arista recommended release](https://www.arista.com/en/support/software-download#datatab300)) of image and import it to your local docker repository.
 The actual image version that is needed in the installation process is defined in the file [ansible/group_vars/all/ceos.yml](../../ansible/group_vars/all/ceos.yml), make sure you modify locally to keep it up with the image version you imported.*
 
 **Note**: *Please also notice the type of the bit for the image, in the example above, it is a standard 32-bit image. Please import the right image as your needs.*
 #### Option 2.2: Pull cEOS image automatically
-1. Alternatively, you can host the cEOS image on a http server. Specify `vm_images_url` for downloading the image [here](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/group_vars/vm_host/main.yml#L2).
+Alternatively, you can host the cEOS image on a http server. Specify `ceos_image_url` for downloading the image in file `ansible/group_vars/all/ceos.yml`. For example:
+```
+ceos_image_url: "http://example1.com/cEOS64-lab-4.29.3M.tar"
+```
+The `ceos_image_url` variable also can be a list of URLs, for example:
+```
+ceos_image_url:
+  - "http://example1.com/cEOS64-lab-4.29.3M.tar"
+  - "http://example2.com/cEOS64-lab-4.29.3M.tar"
+```
+The playbook will try to download the image from the URLs in the list one by one until it succeeds.
 
-2. If a SAS key is required for downloading the cEOS image, specify `ceosimage_saskey` in `sonic-mgmt/ansible/vars/azure_storage.yml`.
-
-If you want to skip downloading the image when the cEOS image is not imported locally, set `skip_ceos_image_downloading` to `true` in `sonic-mgmt/ansible/group_vars/all/ceos.yml`. Then, when the cEOS image is not locally available, the scripts will not try to download it and will fail with an error message. Please use option 1 to download and import the cEOS image manually.
+If you want to skip downloading the image when the cEOS image is not imported locally and image file is not available on testbed server, set `skip_ceos_image_downloading` to `true` in `ansible/group_vars/all/ceos.yml`. Then, when the cEOS image is not locally available, the scripts will not try to download it and will fail with an error message. Please use option 2.1 to download the cEOS image manually.
 
 ### Option 3: Use SONiC image as neighboring devices
 You need to prepare a sound SONiC image `sonic-vs.img` in `~/veos-vm/images/`. We don't support to download sound sonic image right now, but for testing, you can also follow the section [Download the sonic-vs image](##download-the-sonic-vs-image) to download an available image and put it into the directory `~/veos-vm/images`


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
To download cEOS image, the URL has to be composed using multiple components including ceosimage_saskey. This is complicated and unnecessary.

#### How did you do it?
This change simplified the configuration of URL for downloading cEOS image. Just configure variable `ceos_image_url` in `ansible/group_vars/all/ceos.yml` is enough.

This change also enhanced the code logic to support configuring `ceos_image_url` as a string or a list of strings. When it is a string, the value is considered as a single URL. When it is a list of strings, each item in the list is considered as a URL. Playbook will try the images URLs one by one until downloading is successful.

The related document is updated too.

#### How did you verify/test it?
Tested add-topo.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
