### PR TITLE
[Snappi]: Support for selecting buffer-sizes associated with ingress lossless profile with Nokia7250 platform.

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -107,13 +107,15 @@ def get_lossless_buffer_size(host_ans):
     """
     config_facts = host_ans.config_facts(host=host_ans.hostname,
                                          source="running")['ansible_facts']
-    # Fetching device_metadata for HWSKU info.
-    device_mtd = config_facts['DEVICE_METADATA']['localhost']['hwsku']
 
     is_cisco8000_platform = True if 'cisco-8000' in host_ans.facts['platform_asic'] else False
 
     # Checking if platform is Broadcom-DNX.
-    is_broadcom_dnx = True if "platform_asic" in host_ans.facts and host_ans.facts["platform_asic"] == "broadcom-dnx" else False
+    is_broadcom_dnx = (
+            True
+            if "platform_asic" in host_ans.facts and host_ans.facts["platform_asic"] == "broadcom-dnx"
+            else False
+            )
 
     if "BUFFER_POOL" not in list(config_facts.keys()):
         return None

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -107,13 +107,25 @@ def get_lossless_buffer_size(host_ans):
     """
     config_facts = host_ans.config_facts(host=host_ans.hostname,
                                          source="running")['ansible_facts']
+    # Fetching device_metadata for HWSKU info.
+    device_mtd = config_facts['DEVICE_METADATA']['localhost']['hwsku']
+
     is_cisco8000_platform = True if 'cisco-8000' in host_ans.facts['platform_asic'] else False
+
+    # Checking if platform is Nokia-7250
+    is_nokia7250_platform = True if ('Nokia' or 'nokia') and '7250' in device_mtd else False
 
     if "BUFFER_POOL" not in list(config_facts.keys()):
         return None
 
     buffer_pools = config_facts['BUFFER_POOL']
-    profile_name = 'ingress_lossless_pool' if is_cisco8000_platform else 'egress_lossless_pool'
+
+    # Added check to select ingress_lossles_pool for Nokia7250 platform.
+    profile_name = (
+            'ingress_lossless_pool'
+            if (is_cisco8000_platform or is_nokia7250_platform)
+            else 'egress_lossless_pool'
+            )
 
     if profile_name not in list(buffer_pools.keys()):
         return None

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -112,8 +112,8 @@ def get_lossless_buffer_size(host_ans):
 
     is_cisco8000_platform = True if 'cisco-8000' in host_ans.facts['platform_asic'] else False
 
-    # Checking if platform is Nokia-7250
-    is_nokia7250_platform = True if ('Nokia' or 'nokia') and '7250' in device_mtd else False
+    # Checking if platform is Broadcom-DNX.
+    is_broadcom_dnx = True if "platform_asic" in host_ans.facts and host_ans.facts["platform_asic"] == "broadcom-dnx" else False
 
     if "BUFFER_POOL" not in list(config_facts.keys()):
         return None
@@ -123,7 +123,7 @@ def get_lossless_buffer_size(host_ans):
     # Added check to select ingress_lossles_pool for Nokia7250 platform.
     profile_name = (
             'ingress_lossless_pool'
-            if (is_cisco8000_platform or is_nokia7250_platform)
+            if (is_cisco8000_platform or is_broadcom_dnx)
             else 'egress_lossless_pool'
             )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The current function returned buffer sizes for ingress lossless profile only for specific platforms and for rest, it returned buffer sizes associated with egress lossless profile. However, Nokia 7250 platform uses on ingress lossless profiles, check requires to include nokia 7250 platform to return buffer-sizes associated with ingress lossless profile.

Summary:
Fixes # (issue)
#13653 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
The function - get_lossless_buffer_size returns buffer size associated with either ingress or egress lossless profile. However, it is checking ingress lossless profile for specific platforms and using egress lossless profiles for rest.

Need to include Nokia 7250 platform in the list of the platforms to use ingress lossless profiles.

#### How did you do it?
Using device-metadata in config_facts for the host, to determine HWSKU. 

If the HWSKU contains 'nokia' and '7250' keyword, it will used to select ingress lossless profile for choosing buffer-size.

#### How did you verify/test it?
Used the function to see if the ingress lossless profile is used selecting buffer size.

#### Any platform specific information?
Code is specific to Cisco 8000 and Nokia7250 platform. It will be good for Cisco to check if the code is still working on their side.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
