### PR TITLE
[Snappi] Fix for crash in enable_packet_aging_after_test called during test cleanup

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -811,10 +811,19 @@ def enable_packet_aging(duthost, asic_value=None):
         duthost.command("docker exec syncd python /packets_aging.py enable")
         duthost.command("docker exec syncd rm -rf /packets_aging.py")
     elif "platform_asic" in duthost.facts and duthost.facts["platform_asic"] == "broadcom-dnx":
-        try:
-            duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog enable"'.format(asic_value))
-        except Exception:
-            duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog enable"'.format(asic_value[-1]))
+        # if asic_value is present, enable packet aging for specific asic_value.
+        if (asic_value):
+            try:
+                duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog enable"'.format(asic_value))
+            except Exception:
+                duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog enable"'.format(asic_value[-1]))
+        else:
+            # Enabling packet aging for all asics on given DUT.
+            for asic_value in duthost.facts['asics_present']:
+                try:
+                    duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog enable"'.format(asic_value))
+                except Exception:
+                    duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog enable"'.format(asic_value[-1]))
 
 
 def get_ipv6_addrs_in_subnet(subnet, number_of_ip):

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -790,10 +790,19 @@ def disable_packet_aging(duthost, asic_value=None):
         duthost.command("docker exec syncd python /packets_aging.py disable")
         duthost.command("docker exec syncd rm -rf /packets_aging.py")
     elif "platform_asic" in duthost.facts and duthost.facts["platform_asic"] == "broadcom-dnx":
-        try:
-            duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog disable"'.format(asic_value))
-        except Exception:
-            duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog disable"'.format(asic_value[-1]))
+        # if asic_value is present, disable packet aging for specific asic_value.
+        if (asic_value):
+            try:
+                duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog disable"'.format(asic_value))
+            except Exception:
+                duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog disable"'.format(asic_value[-1]))
+        else:
+            # Disabling packet aging for all asics on given DUT.
+            for asic_value in duthost.facts['asics_present']:
+                try:
+                    duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog disable"'.format(asic_value))
+                except Exception:
+                    duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog disable"'.format(asic_value[-1]))
 
 
 def enable_packet_aging(duthost, asic_value=None):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Function enable_packet_aging_after_test is defined in conf_test.py to be called as test-cleanup after test execution. This function calls enable_packet_aging defined in common/snappi_tests/common_helper.py. However, it does not pass the asic_value when calling this function. There is no check in enable_packet_aging function to handle this and it crashes.


Summary:
Fixes # (issue)
#13654 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
To fix the enable_packet_aging during the test-cleanup. There is no asic_value defined when this function is called during test-cleanup and function does not have any check to handle this.

#### How did you do it?
Added check to see if the asic_value is present or not. If the asic_value is present, then default code is executed. If the asic_value is not present, then function will enable packet aging for all ASICs present on the DUT.

Note - By default, packet aging is enabled on the DUT and hence enabling it on all ASICs during the cleanup should be ok.

#### How did you verify/test it?
Normal OC runs, the test clean up works fine. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
