### PR TITLE
[Snappi] Support to enable PFCWD in Forward Mode

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -1007,3 +1007,25 @@ def calc_pfc_pause_flow_rate(port_speed, oversubscription_ratio=2):
     pps = int(oversubscription_ratio / pause_dur)
 
     return pps
+
+
+def start_pfcwd_fwd(duthost, asic_value=None):
+    """
+    Start PFC watchdog in Forward mode.
+    Stops the PFCWD cleanly before restarting it in FORWARD mode.
+    Args:
+        duthost (AnsibleHost): Device Under Test (DUT)
+        asic_value: asic value of the host
+
+    Returns:
+        N/A
+    """
+
+    # Starting PFCWD in forward mode with detection and restoration duration of 200msec.
+    if asic_value is None:
+        stop_pfcwd(duthost)
+        duthost.shell('sudo pfcwd start --action forward 200 --restoration-time 200')
+    else:
+        stop_pfcwd(duthost, asic_value)
+        duthost.shell('sudo ip netns exec {} pfcwd start --action forward 200 --restoration-time 200'.
+                      format(asic_value))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Support to enable PFCWD in Forward mode.

Summary:
Fixes # (issue)
#13752 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Providing support to enable PFCWD in forward mode.

#### How did you do it?
Added a function 'start_pfcwd_fwd' with duthost and asic_value as parameters. If asic_value is not passed, then PFCWD in forward mode will be enabled in global mode.

Function first stops the PFCWD (in whatever mode it is operating), before enabling it in FORWARD mode.

#### How did you verify/test it?
Tested with function call with and without asic_value and checked if PFCWD was enabled on the DUT. If asic_value is passed, PFCWD is enabled for the specific ASIC in forward mode.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
