### PR TITLE
[Snappi] Support for DUT statistics - Interface counters, PFC counters, and Queue counters.

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -1056,7 +1056,7 @@ def start_pfcwd_fwd(duthost, asic_value=None):
         duthost.shell('sudo ip netns exec {} pfcwd start --action forward 200 --restoration-time 200'.
                       format(asic_value))
 
-        
+
 def clear_counters(duthost, port):
     """
     Clear PFC, Queuecounters, Drop and generic counters from SONiC CLI.
@@ -1148,7 +1148,7 @@ def get_queue_count(duthost, port):
     return queue_dict
 
 
-def get_pfc_count(duthost, port):
+def get_queue_count_all_prio(duthost, port):
     """
     Get the PFC frame count for a given port from SONiC CLI
     Args:

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -1140,12 +1140,15 @@ def get_queue_count_all_prio(duthost, port):
     Returns:
         queue_dict (dict): key-value with key=dut+port+prio and value=queue count
     """
-    queue_dict = {}
-    # Capturing queue counts for all priorities.
+    # Initializing nested dictionary queue_dict
+    queue_dict = defaultdict(dict)
+    queue_dict[duthost.hostname][port] = {}
+
+    # Preparing the dictionary for all 7 priority queues.
     for priority in range(7):
-        dut_key = (duthost.hostname+'_'+port+'_prio_'+str(priority)).lower()
         total_pkts, _ = get_egress_queue_count(duthost, port, priority)
-        queue_dict.update({dut_key: total_pkts})
+        queue_dict[duthost.hostname][port]['prio_' + str(priority)] = total_pkts
+
     return queue_dict
 
 

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -1128,7 +1128,7 @@ def interface_stats(duthost, port):
     return i_stats
 
 
-def get_queue_count(duthost, port):
+def get_queue_count_all_prio(duthost, port):
     """
     Get the egress queue count in packets and bytes for a given port and priority from SONiC CLI.
     This is the equivalent of the "show queue counters" command.
@@ -1148,7 +1148,7 @@ def get_queue_count(duthost, port):
     return queue_dict
 
 
-def get_queue_count_all_prio(duthost, port):
+def get_pfc_count(duthost, port):
     """
     Get the PFC frame count for a given port from SONiC CLI
     Args:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Support to pull the DUT statistics, namely interface counters, PFC counters and Queue counters. 

This support will enable users to pull the DUT statistics run-time and capture them in form of dictionary for further processing.


Summary:
Fixes # (issue)
#13843 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Currently, there is no one stop-place to fetch the DUT statistics and use them for verification, especially the SNAPPI testcases. There should be some way to pull the DUT statistics ( at least important ones) and use them for verification.

#### How did you do it?
Clear counters:
Common function to clear interface, PFC and queue counter stats.

Interface counters:
Ability to fetch the interface counters for a given DUT and port. Returns dictionary with keys - Rx and Tx packet count, Rx and Tx failures (Error + drops + ovr), and Rx and Tx throughput in Mbps.

PFC counters:
Ability to fetch the PFC counters for a given DUT and port. Returns dictionary with keys - Rx and Tx PFC for the given DUT, port and priority.

Queue counters:
Ability to fetch the Queue counters for a given DUT and port. Internally calls get_egress_queue_count for all the priorities. Returns dictionary with <dut>_<port>_<prio> as key with transmitted packets as counter. 

#### How did you verify/test it?
These functions are called as part of new testcases for PFC-ECN.

```
    for dut, port in dutport_list:
        f_stats = update_dict(m, f_stats, interface_stats(dut, port))
        f_stats = update_dict(m, f_stats, get_pfc_count(dut, port))
        f_stats = update_dict(m, f_stats, get_queue_count(dut, port))
```

These are then used to create CSV with raw DUT statistics and then to summarize the test in the end.


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
