### PR TITLE
enable test case "test_pfc_counters.py"  for other topology

### DIFF
--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -16,7 +16,7 @@ device under test (DUT). Then we check the SONiC PFC Rx counters.
 """
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('any')
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable qos/test_pfc_counters.py for all topologies.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Enable qos/test_pfc_counters.py for other topology.

#### How did you do it?

#### How did you verify/test it?
Test it the following topology in local testbed. All successful.
- t0
- t1-32-lag
- dualtor-aa-56
- t2

Logs can be found in MSFT internal ADO 28837311

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
