### PR TITLE
Update the dualtor condition in test_vlan_ping.py

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -228,8 +228,7 @@ def test_vlan_ping(vlan_ping_setup, duthosts, rand_one_dut_hostname,
     device2 = dict(list(ptfhost_info.items())[1:])
     device1 = dict(list(ptfhost_info.items())[:1])
     # use mac addr of vlan interface in case of dualtor
-    dualtor_topo = ["dualtor", "dualtor-aa"]
-    if tbinfo["topo"]["name"] in dualtor_topo:
+    if 'dualtor' in tbinfo["topo"]["name"]:
         vlan_table = duthost.get_running_config_facts()['VLAN']
         vlan_name = list(vlan_table.keys())[0]
         vlan_mac = duthost.get_dut_iface_mac(vlan_name)
@@ -246,7 +245,7 @@ def test_vlan_ping(vlan_ping_setup, duthosts, rand_one_dut_hostname,
     logger.info("Checking connectivity to ptf ports")
 
     for member in ptfhost_info:
-        if tbinfo["topo"]["name"] in dualtor_topo:
+        if 'dualtor' in tbinfo["topo"]["name"]:
             verify_icmp_packet(duthost.facts['router_mac'], ptfhost_info[member],
                                vmhost_info, ptfadapter, tbinfo, vlan_mac, dtor_ul=True)
             verify_icmp_packet(duthost.facts['router_mac'], vmhost_info, ptfhost_info[member],
@@ -270,7 +269,7 @@ def test_vlan_ping(vlan_ping_setup, duthosts, rand_one_dut_hostname,
     # Checking for connectivity
     logger.info("Check connectivity to both ptfhost")
     for member in ptfhost_info:
-        if tbinfo["topo"]["name"] in dualtor_topo:
+        if 'dualtor' in tbinfo["topo"]["name"]:
             verify_icmp_packet(duthost.facts['router_mac'], ptfhost_info[member],
                                vmhost_info, ptfadapter, tbinfo, vlan_mac, dtor_ul=True)
             verify_icmp_packet(duthost.facts['router_mac'], vmhost_info, ptfhost_info[member],


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Update the dualtor condition in test_vlan_ping.py
Fixes # (issue)
The PR #12306 updated `tests/vlan/test_vlan_ping.py`. It used a condition to check if it is a `dualtor` setup. But the dualtor topo name not only has `dualtor` or `dualtor-aa`, it also has other names such as `dualtor-64`. So we need to use a general check condition

```python
    dualtor_topo = ["dualtor", "dualtor-aa"]
    if tbinfo["topo"]["name"] in dualtor_topo:
        vlan_table = duthost.get_running_config_facts()['VLAN']
```

Due to PR #12306 has not merged to 202311 branch, so this fix not back port to 202311. I will merge it after PR #12306 merge to 202311

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
