### PR TITLE
Tolerate hash collision when adding entries in `test_stress_arp.py`

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -89,6 +89,8 @@ def test_ipv4_arp(duthost, garp_enabled, ip_and_intf_info, intfs_for_test,
             if not skip_traffic_test:
                 # There is a certain probability of hash collision, we set the percentage as 1% here
                 # The entries we add will not exceed 10000, so the number we tolerate is 100
+                logger.debug("Expected route number: {}, real route number {}"
+                             .format(arp_avaliable, get_fdb_dynamic_mac_count(duthost)))
                 pytest_assert(wait_until(20, 1, 0,
                                          lambda: abs(arp_avaliable - get_fdb_dynamic_mac_count(duthost)) < 100),
                               "ARP Table Add failed")
@@ -166,6 +168,8 @@ def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
             if not skip_traffic_test:
                 # There is a certain probability of hash collision, we set the percentage as 1% here
                 # The entries we add will not exceed 10000, so the number we tolerate is 100
+                logger.debug("Expected route number: {}, real route number {}"
+                             .format(nd_avaliable, get_fdb_dynamic_mac_count(duthost)))
                 pytest_assert(wait_until(20, 1, 0,
                                          lambda: abs(nd_avaliable - get_fdb_dynamic_mac_count(duthost)) < 100),
                               "Neighbor Table Add failed")

--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -88,6 +88,7 @@ def test_ipv4_arp(duthost, garp_enabled, ip_and_intf_info, intfs_for_test,
             add_arp(ptf_intf_ipv4_hosts, intf1_index, ptfadapter)
             if not skip_traffic_test:
                 # There is a certain probability of hash collision, we set the percentage as 1% here
+                # The entries we add will not exceed 10000, so the number we tolerate is 100
                 pytest_assert(wait_until(20, 1, 0,
                                          lambda: abs(arp_avaliable - get_fdb_dynamic_mac_count(duthost)) < 100),
                               "ARP Table Add failed")
@@ -164,6 +165,7 @@ def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
             add_nd(ptfadapter, ip_and_intf_info, ptf_intf_index, nd_avaliable)
             if not skip_traffic_test:
                 # There is a certain probability of hash collision, we set the percentage as 1% here
+                # The entries we add will not exceed 10000, so the number we tolerate is 100
                 pytest_assert(wait_until(20, 1, 0,
                                          lambda: abs(nd_avaliable - get_fdb_dynamic_mac_count(duthost)) < 100),
                               "Neighbor Table Add failed")

--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -87,7 +87,9 @@ def test_ipv4_arp(duthost, garp_enabled, ip_and_intf_info, intfs_for_test,
         try:
             add_arp(ptf_intf_ipv4_hosts, intf1_index, ptfadapter)
             if not skip_traffic_test:
-                pytest_assert(wait_until(20, 1, 0, lambda: get_fdb_dynamic_mac_count(duthost) >= arp_avaliable),
+                # There is a certain probability of hash collision, we set the percentage as 1% here
+                pytest_assert(wait_until(20, 1, 0,
+                                         lambda: abs(arp_avaliable - get_fdb_dynamic_mac_count(duthost)) < 100),
                               "ARP Table Add failed")
         finally:
             clear_dut_arp_cache(duthost)
@@ -161,7 +163,9 @@ def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
         try:
             add_nd(ptfadapter, ip_and_intf_info, ptf_intf_index, nd_avaliable)
             if not skip_traffic_test:
-                pytest_assert(wait_until(20, 1, 0, lambda: get_fdb_dynamic_mac_count(duthost) >= nd_avaliable),
+                # There is a certain probability of hash collision, we set the percentage as 1% here
+                pytest_assert(wait_until(20, 1, 0,
+                                         lambda: abs(nd_avaliable - get_fdb_dynamic_mac_count(duthost)) < 100),
                               "Neighbor Table Add failed")
         finally:
             clear_dut_arp_cache(duthost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In script `test_stress_arp.py`, we will add as much ipv4 arp entries and ipv6 nd entries as we can. We will get this number from crm. But in fact, there is a probability of hash collision, which means we can not add such number entries as we expected. So in this PR, we tolerate this possible and set the percentage of hash collision 1%

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In script `test_stress_arp.py`, we will add as much ipv4 arp entries and ipv6 nd entries as we can. We will get this number from crm. But in fact, there is a probability of hash collision, which means we can not add such number entries as we expected. So in this PR, we tolerate this possible and set the percentage of hash collision 1%

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
