### PR TITLE
Fix SyntaxError in pfc_wd_background_traffic.py when running test_no_pfc testcase

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/pfc_wd_background_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/pfc_wd_background_traffic.py
@@ -37,8 +37,8 @@ class PfcWdBackgroundTrafficTest(BaseTest):
             src_mac = self.dataplane.get_mac(0, src_port)
             dst_mac = self.dataplane.get_mac(0, dst_port)
             for queue in self.queues:
-                print(f"traffic from {src_port} to {dst_port}: {queue} ")
-                logging.info(f"traffic from {src_port} to {dst_port}: {queue} ")
+                print("traffic from {} to {}: {}".format(src_port, dst_port, queue))
+                logging.info("traffic from {} to {}: {}".format(src_port, dst_port, queue))
                 pkt = simple_ip_packet(
                     eth_src=src_mac,
                     eth_dst=self.router_mac,
@@ -50,8 +50,8 @@ class PfcWdBackgroundTrafficTest(BaseTest):
                 )
                 pkts_dict[src_port].append(pkt)
                 if self.bidirection:
-                    print(f"traffic from {dst_port} to {src_port}: {queue} ")
-                    logging.info(f"traffic from {dst_port} to {src_port}: {queue} ")
+                    print("traffic from {} to {}: {}".format(dst_port, src_port, queue))
+                    logging.info("traffic from {} to {}: {}".format(dst_port, src_port, queue))
                     pkt = simple_ip_packet(
                         eth_src=dst_mac,
                         eth_dst=self.router_mac,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix SyntaxError of pfc_wd_background_traffic.py introduced in PR#12733

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
The PTF test still uses PY2 instead of PY3. PY2 does not support f-string.

See SyntaxError in nightly test:
```
Traceback (most recent call last):
  File \"/usr/bin/ptf\", line 522, in <module>
    test_modules = load_test_modules(config)
  File \"/usr/bin/ptf\", line 413, in load_test_modules
    mod = imp.load_module(modname, *imp.find_module(modname, [root]))
  File \"/root/ptftests/py3/pfc_wd_background_traffic.py\", line 40
    print(f\"traffic from {src_port} to {dst_port}: {queue} \")
                                                           ^
SyntaxError: invalid syntax",
```

#### How did you do it?
Change the print() and logger.info() call.

#### How did you verify/test it?
Test with physical testbed.
```
---------------------------------------------------------------------- live log call ----------------------------------------------------------------------
08:45:13 test_pfc_pause.test_no_pfc               L0334 INFO   | Testing dscp: [3] and background dscp: 4
08:45:14 test_pfc_pause.run_test                  L0173 INFO   | Running test: src intf: Ethernet24 dest intf: Ethernet28
08:45:39 test_pfc_pause.run_test                  L0173 INFO   | Running test: src intf: Ethernet28 dest intf: Ethernet32
08:46:04 test_pfc_pause.test_no_pfc               L0334 INFO   | Testing dscp: [3] and background dscp: 0
08:46:05 test_pfc_pause.run_test                  L0173 INFO   | Running test: src intf: Ethernet24 dest intf: Ethernet28
08:46:30 test_pfc_pause.run_test                  L0173 INFO   | Running test: src intf: Ethernet28 dest intf: Ethernet32
08:46:55 test_pfc_pause.test_no_pfc               L0334 INFO   | Testing dscp: [3] and background dscp: 1
08:46:56 test_pfc_pause.run_test                  L0173 INFO   | Running test: src intf: Ethernet24 dest intf: Ethernet28
08:47:20 test_pfc_pause.run_test                  L0173 INFO   | Running test: src intf: Ethernet28 dest intf: Ethernet32
PASSED                                                                                                                                              [ 50%]
qos/test_pfc_pause.py::test_no_pfc[str3-8111-04|4] 
--------------------------------------------------------------------- live log setup ----------------------------------------------------------------------
08:47:45 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
08:47:45 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
08:47:45 __init__.loganalyzer                     L0045 INFO   | Log analyzer is disabled
08:47:45 mux_simulator_control.toggle_all_simulat L0610 INFO   | Skipping toggle on non-dualtor testbed or active-active dualtor topo.
---------------------------------------------------------------------- live log call ----------------------------------------------------------------------
08:47:45 test_pfc_pause.test_no_pfc               L0334 INFO   | Testing dscp: [4] and background dscp: 3
08:47:46 test_pfc_pause.run_test                  L0173 INFO   | Running test: src intf: Ethernet24 dest intf: Ethernet28
08:48:11 test_pfc_pause.run_test                  L0173 INFO   | Running test: src intf: Ethernet28 dest intf: Ethernet32
08:48:35 test_pfc_pause.test_no_pfc               L0334 INFO   | Testing dscp: [4] and background dscp: 0
08:48:36 test_pfc_pause.run_test                  L0173 INFO   | Running test: src intf: Ethernet24 dest intf: Ethernet28
08:49:01 test_pfc_pause.run_test                  L0173 INFO   | Running test: src intf: Ethernet28 dest intf: Ethernet32
08:49:26 test_pfc_pause.test_no_pfc               L0334 INFO   | Testing dscp: [4] and background dscp: 1
08:49:27 test_pfc_pause.run_test                  L0173 INFO   | Running test: src intf: Ethernet24 dest intf: Ethernet28
08:49:51 test_pfc_pause.run_test                  L0173 INFO   | Running test: src intf: Ethernet28 dest intf: Ethernet32
PASSED                                                                                                                                              [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
