### PR TITLE
Move the skip for expired ttl test case logic to the conditional yaml file

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -113,6 +113,12 @@ drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv6-src]:
       - "asic_type in ['broadcom', 'cisco-8000']"
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
 
+drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl:
+  skip:
+    reason: "Not supported on Mellanox devices"
+    conditions:
+      - "asic_type in ['mellanox']"
+
 drop_packets/test_drop_counters.py::test_loopback_filter:
   # Test case is skipped, because SONiC does not have a control to adjust loop-back filter settings.
   # Default SONiC behavior is to forward the traffic, so loop-back filter does not triggers for IP packets.

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -144,7 +144,7 @@ EOF
     yield
 
     duthost.command("rm {} {}".format(copp_trap_group_json, copp_trap_rule_json))
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True)
 
 
 def is_mellanox_devices(hwsku):
@@ -923,9 +923,6 @@ def test_ip_pkt_with_expired_ttl(duthost, do_test, ptfadapter, setup, tx_dut_por
     """
     @summary: Create an IP packet with TTL=0.
     """
-    if "x86_64-mlnx_msn" in duthost.facts["platform"] or "x86_64-nvidia_sn" in duthost.facts["platform"]:
-        pytest.skip("Not supported on Mellanox devices")
-
     log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["src_mac"],
                    pkt_fields["ipv4_dst"], pkt_fields["ipv4_src"])
 


### PR DESCRIPTION
If the skip logic is in the test body, the fixture still need to be done, in this test case, even the test need to be skipped,still need to finish the teardown of configure_copp_drop_for_ttl_error, and in the fixture, it has config reload which will take 2 mins to finish, since the test case need to be skipped, no need to waste 2 mins on it.

At the same time, change the config reload to use safe reload

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
