### PR TITLE
Add dualtor io dataplane test to onboarding dualtor PR test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -353,6 +353,12 @@ onboarding_dualtor:
   - dualtor/test_switchover_failure.py
   - dualtor/test_tor_ecn.py
   - dualtor/test_tunnel_memory_leak.py
+  - dualtor_io/test_heartbeat_failure.py
+  - dualtor_io/test_link_drop.py
+  - dualtor_io/test_link_failure.py
+  - dualtor_io/test_normal_op.py
+  - dualtor_io/test_tor_bgp_failure.py
+  - dualtor_io/test_tor_failure.py
   - dualtor_mgmt/test_ingress_drop.py
   - dualtor_mgmt/test_dualtor_bgp_update_delay.py
 

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -161,6 +161,8 @@ t2:
   - mvrf/test_mgmtvrf.py
 
 dualtor:
+  # This test only support on dualtor-aa testbed
+  - dualtor_io/test_grpc_server_failure.py
   # This test is only for Nvidia platforms.
   - dualtor_mgmt/test_egress_drop_nvidia.py
 

--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -40,7 +40,8 @@ def arp_setup(ptfhost):
     ptfhost.shell("supervisorctl reread && supervisorctl update")
 
 
-def validate_traffic_results(tor_IO, allowed_disruption, delay, allow_disruption_before_traffic=False):
+def validate_traffic_results(tor_IO, allowed_disruption, delay,
+                             allow_disruption_before_traffic=False):
     """
     Generates a report (dictionary) of I/O metrics that were calculated as part
     of the dataplane test. This report is to be used by testcases to verify the
@@ -148,7 +149,8 @@ def _validate_long_disruption(disruptions, allowed_disruption, delay):
     return False
 
 
-def verify_and_report(tor_IO, verify, delay, allowed_disruption, allow_disruption_before_traffic=False):
+def verify_and_report(tor_IO, verify, delay, allowed_disruption,
+                      allow_disruption_before_traffic=False):
     # Wait for the IO to complete before doing checks
     if verify:
         validate_traffic_results(tor_IO, allowed_disruption=allowed_disruption, delay=delay,
@@ -236,7 +238,8 @@ def save_pcap(request, pytestconfig):
 
 
 @pytest.fixture
-def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type, vmhost, save_pcap):       # noqa F811
+def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
+                                  cable_type, vmhost, save_pcap, skip_traffic_test=False):       # noqa F811
     """
     Starts IO test from T1 router to server.
     As part of IO test the background thread sends and sniffs packets.
@@ -258,7 +261,8 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_t
 
     def t1_to_server_io_test(activehost, tor_vlan_port=None,
                              delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.1,
-                             stop_after=None, allow_disruption_before_traffic=False):
+                             stop_after=None, allow_disruption_before_traffic=False,
+                             skip_traffic_test=False):
         """
         Helper method for `send_t1_to_server_with_action`.
         Starts sender and sniffer before performing the action on the tor host.
@@ -293,6 +297,9 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_t
         if delay and not allowed_disruption:
             allowed_disruption = 1
 
+        if skip_traffic_test is True:
+            logging.info("Skipping traffic test")
+            return
         return verify_and_report(tor_IO, verify, delay, allowed_disruption, allow_disruption_before_traffic)
 
     yield t1_to_server_io_test
@@ -301,7 +308,8 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_t
 
 
 @pytest.fixture
-def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type, vmhost, save_pcap):   # noqa F811
+def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
+                                  cable_type, vmhost, save_pcap, skip_traffic_test=False):   # noqa F811
     """
     Starts IO test from server to T1 router.
     As part of IO test the background thread sends and sniffs packets.
@@ -324,7 +332,7 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_t
 
     def server_to_t1_io_test(activehost, tor_vlan_port=None,
                              delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.01,
-                             stop_after=None):
+                             stop_after=None, skip_traffic_test=False):
         """
         Helper method for `send_server_to_t1_with_action`.
         Starts sender and sniffer before performing the action on the tor host.
@@ -358,6 +366,9 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_t
         if delay and not allowed_disruption:
             allowed_disruption = 1
 
+        if skip_traffic_test is True:
+            logging.info("Skipping traffic test")
+            return
         return verify_and_report(tor_IO, verify, delay, allowed_disruption)
 
     yield server_to_t1_io_test
@@ -366,13 +377,14 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_t
 
 
 @pytest.fixture
-def send_soc_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type, vmhost, save_pcap):      # noqa F811
+def send_soc_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
+                               cable_type, vmhost, save_pcap, skip_traffic_test=False):      # noqa F811
 
     arp_setup(ptfhost)
 
     def soc_to_t1_io_test(activehost, tor_vlan_port=None,
                           delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.01,
-                          stop_after=None):
+                          stop_after=None, skip_traffic_test=False):
 
         tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
                           action, tbinfo, tor_vlan_port, send_interval,
@@ -382,6 +394,9 @@ def send_soc_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type
         if delay and not allowed_disruption:
             allowed_disruption = 1
 
+        if skip_traffic_test is True:
+            logging.info("Skipping traffic test")
+            return
         return verify_and_report(tor_IO, verify, delay, allowed_disruption)
 
     yield soc_to_t1_io_test
@@ -390,13 +405,14 @@ def send_soc_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type
 
 
 @pytest.fixture
-def send_t1_to_soc_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type, vmhost, save_pcap):      # noqa F811
+def send_t1_to_soc_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
+                               cable_type, vmhost, save_pcap, skip_traffic_test=False):      # noqa F811
 
     arp_setup(ptfhost)
 
     def t1_to_soc_io_test(activehost, tor_vlan_port=None,
                           delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.01,
-                          stop_after=None):
+                          stop_after=None, skip_traffic_test=False):
 
         tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
                           action, tbinfo, tor_vlan_port, send_interval,
@@ -408,6 +424,9 @@ def send_t1_to_soc_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type
         if delay and not allowed_disruption:
             allowed_disruption = 1
 
+        if skip_traffic_test is True:
+            logging.info("Skipping traffic test")
+            return
         return verify_and_report(tor_IO, verify, delay, allowed_disruption)
 
     yield t1_to_soc_io_test
@@ -432,13 +451,14 @@ def select_test_mux_ports(active_active_ports, active_standby_ports):           
 
 
 @pytest.fixture
-def send_server_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cable_type, vmhost, save_pcap):   # noqa F811
+def send_server_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
+                                      cable_type, vmhost, save_pcap, skip_traffic_test=False):   # noqa F811
 
     arp_setup(ptfhost)
 
     def server_to_server_io_test(activehost, test_mux_ports, delay=0,
                                  allowed_disruption=0, action=None,
-                                 verify=False, send_interval=0.01, stop_after=None):
+                                 verify=False, send_interval=0.01, stop_after=None, skip_traffic_test=False):
         tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
                           action, tbinfo, test_mux_ports, send_interval,
                           traffic_direction="server_to_server", stop_after=stop_after,
@@ -449,6 +469,9 @@ def send_server_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo, cab
         if delay and not allowed_disruption:
             allowed_disruption = 1
 
+        if skip_traffic_test is True:
+            logging.info("Skipping traffic test")
+            return
         return verify_and_report(tor_IO, verify, delay, allowed_disruption)
 
     yield server_to_server_io_test

--- a/tests/dualtor_io/test_heartbeat_failure.py
+++ b/tests/dualtor_io/test_heartbeat_failure.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 
 from tests.common.dualtor.control_plane_utils import verify_tor_states
 from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, \
@@ -9,6 +10,8 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.dualtor.tor_failure_utils import shutdown_tor_heartbeat                       # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
                                                 copy_ptftests_directory, change_mac_addresses   # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test                               # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import cable_type                                     # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
@@ -35,15 +38,17 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
 
 def test_active_tor_heartbeat_failure_upstream(
     toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,     # noqa F811
-    send_server_to_t1_with_action, shutdown_tor_heartbeat, cable_type           # noqa F811
+    send_server_to_t1_with_action, shutdown_tor_heartbeat, cable_type, skip_traffic_test        # noqa F811
 ):
     """
     Send upstream traffic and stop the LinkProber module on the active ToR.
     Confirm switchover and disruption lasts < 1 second.
     """
+    logging.info("skip_traffic_test: {}".format(skip_traffic_test))
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=lambda: shutdown_tor_heartbeat(upper_tor_host)
+        action=lambda: shutdown_tor_heartbeat(upper_tor_host),
+        skip_traffic_test=skip_traffic_test
     )
 
     if cable_type == CableType.active_standby:
@@ -64,7 +69,7 @@ def test_active_tor_heartbeat_failure_upstream(
 @pytest.mark.enable_active_active
 def test_active_tor_heartbeat_failure_downstream_active(
     toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa F811
-    send_t1_to_server_with_action, shutdown_tor_heartbeat, cable_type           # noqa F811
+    send_t1_to_server_with_action, shutdown_tor_heartbeat, cable_type, skip_traffic_test        # noqa F811
 ):
     """
     Send downstream traffic from T1 to the active ToR and stop the LinkProber module on the active ToR.
@@ -72,7 +77,8 @@ def test_active_tor_heartbeat_failure_downstream_active(
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=lambda: shutdown_tor_heartbeat(upper_tor_host)
+        action=lambda: shutdown_tor_heartbeat(upper_tor_host),
+        skip_traffic_test=skip_traffic_test
     )
 
     if cable_type == CableType.active_standby:
@@ -92,14 +98,15 @@ def test_active_tor_heartbeat_failure_downstream_active(
 
 def test_active_tor_heartbeat_failure_downstream_standby(
     toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa F811
-    send_t1_to_server_with_action, shutdown_tor_heartbeat):                     # noqa F811
+    send_t1_to_server_with_action, shutdown_tor_heartbeat, skip_traffic_test):                     # noqa F811
     """
     Send downstream traffic from T1 to the standby ToR and stop the LinkProber module on the active ToR.
     Confirm switchover and disruption lasts < 1 second.
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=lambda: shutdown_tor_heartbeat(upper_tor_host)
+        action=lambda: shutdown_tor_heartbeat(upper_tor_host),
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -109,14 +116,15 @@ def test_active_tor_heartbeat_failure_downstream_standby(
 
 def test_standby_tor_heartbeat_failure_upstream(
     toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa F811
-    send_server_to_t1_with_action, shutdown_tor_heartbeat):                     # noqa F811
+    send_server_to_t1_with_action, shutdown_tor_heartbeat, skip_traffic_test):                     # noqa F811
     """
     Send upstream traffic and stop the LinkProber module on the standby ToR.
     Confirm no switchover and no disruption.
     """
     send_server_to_t1_with_action(
         upper_tor_host, verify=True,
-        action=lambda: shutdown_tor_heartbeat(lower_tor_host)
+        action=lambda: shutdown_tor_heartbeat(lower_tor_host),
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -126,14 +134,15 @@ def test_standby_tor_heartbeat_failure_upstream(
 
 def test_standby_tor_heartbeat_failure_downstream_active(
     toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa F811
-    send_t1_to_server_with_action, shutdown_tor_heartbeat):                     # noqa F811
+    send_t1_to_server_with_action, shutdown_tor_heartbeat, skip_traffic_test):                     # noqa F811
     """
     Send downstream traffic from T1 to the active ToR and stop the LinkProber module on the standby ToR.
     Confirm no switchover and no disruption.
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True,
-        action=lambda: shutdown_tor_heartbeat(lower_tor_host)
+        action=lambda: shutdown_tor_heartbeat(lower_tor_host),
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -143,14 +152,15 @@ def test_standby_tor_heartbeat_failure_downstream_active(
 
 def test_standby_tor_heartbeat_failure_downstream_standby(
     toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa F811
-    send_t1_to_server_with_action, shutdown_tor_heartbeat):                     # noqa F811
+    send_t1_to_server_with_action, shutdown_tor_heartbeat, skip_traffic_test):                     # noqa F811
     """
     Send downstream traffic from T1 to the standby ToR and stop the LinkProber module on the standby ToR.
     Confirm no switchover and no disruption.
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True,
-        action=lambda: shutdown_tor_heartbeat(lower_tor_host)
+        action=lambda: shutdown_tor_heartbeat(lower_tor_host),
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,

--- a/tests/dualtor_io/test_link_drop.py
+++ b/tests/dualtor_io/test_link_drop.py
@@ -18,6 +18,8 @@ from tests.common.dualtor.nic_simulator_control import TrafficDirection
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service            # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                            # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                         # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test                               # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import ActiveActivePortID
 from tests.common.dualtor.dual_tor_common import active_active_ports                            # noqa F401
@@ -96,7 +98,7 @@ def drop_flow_upper_tor_active_active(active_active_ports, set_drop_active_activ
 def test_active_link_drop_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, drop_flow_upper_tor_all,   # noqa F811
-    drop_flow_upper_tor_active_active, cable_type                       # noqa F811
+    drop_flow_upper_tor_active_active, cable_type, skip_traffic_test    # noqa F811
 ):
     """
     Send traffic from servers to T1 and remove the flow between the servers and the active ToR.
@@ -108,7 +110,8 @@ def test_active_link_drop_upstream(
             verify=True,
             delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=3,
-            action=drop_flow_upper_tor_all
+            action=drop_flow_upper_tor_all,
+            skip_traffic_test=skip_traffic_test
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -123,7 +126,8 @@ def test_active_link_drop_upstream(
             verify=True,
             delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=1,
-            action=drop_flow_upper_tor_active_active
+            action=drop_flow_upper_tor_active_active,
+            skip_traffic_test=skip_traffic_test
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -138,7 +142,7 @@ def test_active_link_drop_upstream(
 def test_active_link_drop_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, drop_flow_upper_tor_all,   # noqa F811
-    drop_flow_upper_tor_active_active, cable_type                       # noqa F811
+    drop_flow_upper_tor_active_active, cable_type, skip_traffic_test    # noqa F811
 ):
     """
     Send traffic from the T1s to the servers via the active Tor and remove the flow between the
@@ -151,7 +155,8 @@ def test_active_link_drop_downstream_active(
             verify=True,
             delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=3,
-            action=drop_flow_upper_tor_all
+            action=drop_flow_upper_tor_all,
+            skip_traffic_test=skip_traffic_test
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -166,7 +171,8 @@ def test_active_link_drop_downstream_active(
             verify=True,
             delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=1,
-            action=drop_flow_upper_tor_active_active
+            action=drop_flow_upper_tor_active_active,
+            skip_traffic_test=skip_traffic_test
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -179,7 +185,8 @@ def test_active_link_drop_downstream_active(
 
 def test_active_link_drop_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
-    toggle_all_simulator_ports_to_upper_tor, drop_flow_upper_tor_all    # noqa F811
+    toggle_all_simulator_ports_to_upper_tor, drop_flow_upper_tor_all,   # noqa F811
+    skip_traffic_test                                                   # noqa F811
 ):
     """
     Send traffic from the T1s to the servers via the standby Tor and remove the flow between the
@@ -191,7 +198,8 @@ def test_active_link_drop_downstream_standby(
         verify=True,
         delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         allowed_disruption=3,
-        action=drop_flow_upper_tor_all
+        action=drop_flow_upper_tor_all,
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -203,7 +211,7 @@ def test_active_link_drop_downstream_standby(
 def test_standby_link_drop_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     check_simulator_flap_counter, drop_flow_lower_tor_all,              # noqa F811
-    toggle_all_simulator_ports_to_upper_tor                             # noqa F811
+    toggle_all_simulator_ports_to_upper_tor, skip_traffic_test          # noqa F811
 ):
     """
     Send traffic from servers to T1 and remove the flow between the servers and the standby ToR.
@@ -214,7 +222,8 @@ def test_standby_link_drop_upstream(
         verify=True,
         delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         allowed_disruption=2,
-        action=drop_flow_lower_tor_all
+        action=drop_flow_lower_tor_all,
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -227,7 +236,7 @@ def test_standby_link_drop_upstream(
 def test_standby_link_drop_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     check_simulator_flap_counter, drop_flow_lower_tor_all,              # noqa F811
-    toggle_all_simulator_ports_to_upper_tor                             # noqa F811
+    toggle_all_simulator_ports_to_upper_tor, skip_traffic_test          # noqa F811
 ):
     """
     Send traffic from the T1s to the servers via the active Tor and remove the flow between the
@@ -239,7 +248,8 @@ def test_standby_link_drop_downstream_active(
         verify=True,
         delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         allowed_disruption=2,
-        action=drop_flow_lower_tor_all
+        action=drop_flow_lower_tor_all,
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -252,7 +262,7 @@ def test_standby_link_drop_downstream_active(
 def test_standby_link_drop_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     check_simulator_flap_counter, drop_flow_lower_tor_all,              # noqa F811
-    toggle_all_simulator_ports_to_upper_tor                             # noqa F811
+    toggle_all_simulator_ports_to_upper_tor, skip_traffic_test          # noqa F811
 ):
     """
     Send traffic from the T1s to the servers via the standby Tor and remove the flow between the
@@ -264,7 +274,8 @@ def test_standby_link_drop_downstream_standby(
         verify=True,
         delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         allowed_disruption=2,
-        action=drop_flow_lower_tor_all
+        action=drop_flow_lower_tor_all,
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -11,6 +11,8 @@ from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter    
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor      # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
                                                 copy_ptftests_directory, change_mac_addresses       # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test                                   # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import active_active_ports                                # noqa F401
 from tests.common.dualtor.dual_tor_common import cable_type                                         # noqa F401
@@ -27,7 +29,7 @@ pytestmark = [
 def test_active_link_down_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_fanout_upper_tor_intfs, cable_type                         # noqa F811
+    shutdown_fanout_upper_tor_intfs, cable_type, skip_traffic_test      # noqa F811
 ):
     """
     Send traffic from server to T1 and shutdown the active ToR link.
@@ -36,7 +38,8 @@ def test_active_link_down_upstream(
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=1, action=shutdown_fanout_upper_tor_intfs
+            allowed_disruption=1, action=shutdown_fanout_upper_tor_intfs,
+            skip_traffic_test=skip_traffic_test
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -49,7 +52,8 @@ def test_active_link_down_upstream(
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
+            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs,
+            skip_traffic_test=skip_traffic_test
         )
 
         verify_tor_states(
@@ -64,7 +68,7 @@ def test_active_link_down_upstream(
 def test_active_link_down_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_fanout_upper_tor_intfs, cable_type                         # noqa F811
+    shutdown_fanout_upper_tor_intfs, cable_type, skip_traffic_test      # noqa F811
 ):
     """
     Send traffic from T1 to active ToR and shutdown the active ToR link.
@@ -73,7 +77,8 @@ def test_active_link_down_downstream_active(
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
+            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs,
+            skip_traffic_test=skip_traffic_test
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -84,7 +89,8 @@ def test_active_link_down_downstream_active(
     if cable_type == CableType.active_active:
         send_t1_to_server_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=1, action=shutdown_fanout_upper_tor_intfs
+            allowed_disruption=1, action=shutdown_fanout_upper_tor_intfs,
+            skip_traffic_test=skip_traffic_test
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -98,7 +104,7 @@ def test_active_link_down_downstream_active(
 def test_active_link_down_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_fanout_upper_tor_intfs                                     # noqa F811
+    shutdown_fanout_upper_tor_intfs, skip_traffic_test                  # noqa F811
 ):
     """
     Send traffic from T1 to standby ToR and shutdown the active ToR link.
@@ -106,7 +112,8 @@ def test_active_link_down_downstream_standby(
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
+        allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs,
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -118,7 +125,7 @@ def test_active_link_down_downstream_standby(
 def test_standby_link_down_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_fanout_lower_tor_intfs                                     # noqa F811
+    shutdown_fanout_lower_tor_intfs, skip_traffic_test                  # noqa F811
 ):
     """
     Send traffic from server to T1 and shutdown the standby ToR link.
@@ -126,7 +133,8 @@ def test_standby_link_down_upstream(
     """
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs
+        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs,
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -138,7 +146,7 @@ def test_standby_link_down_upstream(
 def test_standby_link_down_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_fanout_lower_tor_intfs                                     # noqa F811
+    shutdown_fanout_lower_tor_intfs, skip_traffic_test                  # noqa F811
 ):
     """
     Send traffic from T1 to active ToR and shutdown the standby ToR link.
@@ -146,7 +154,8 @@ def test_standby_link_down_downstream_active(
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs
+        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs,
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -158,7 +167,7 @@ def test_standby_link_down_downstream_active(
 def test_standby_link_down_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_fanout_lower_tor_intfs                                     # noqa F811
+    shutdown_fanout_lower_tor_intfs, skip_traffic_test                  # noqa F811
 ):
     """
     Send traffic from T1 to standby ToR and shutdwon the standby ToR link.
@@ -166,7 +175,8 @@ def test_standby_link_down_downstream_standby(
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs
+        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs,
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -178,7 +188,7 @@ def test_standby_link_down_downstream_standby(
 def test_active_tor_downlink_down_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_upper_tor_downlink_intfs                                   # noqa F811
+    shutdown_upper_tor_downlink_intfs, skip_traffic_test                # noqa F811
 ):
     """
     Send traffic from server to T1 and shutdown the active ToR downlink on DUT.
@@ -186,7 +196,8 @@ def test_active_tor_downlink_down_upstream(
     """
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs
+        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs,
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -198,7 +209,7 @@ def test_active_tor_downlink_down_upstream(
 def test_active_tor_downlink_down_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_upper_tor_downlink_intfs                                   # noqa F811
+    shutdown_upper_tor_downlink_intfs, skip_traffic_test                # noqa F811
 ):
     """
     Send traffic from T1 to active ToR and shutdown the active ToR downlink on DUT.
@@ -206,7 +217,8 @@ def test_active_tor_downlink_down_downstream_active(
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs
+        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs,
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -218,7 +230,7 @@ def test_active_tor_downlink_down_downstream_active(
 def test_active_tor_downlink_down_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_upper_tor_downlink_intfs                                   # noqa F811
+    shutdown_upper_tor_downlink_intfs, skip_traffic_test                # noqa F811
 ):
     """
     Send traffic from T1 to standby ToR and shutdown the active ToR downlink on DUT.
@@ -226,7 +238,8 @@ def test_active_tor_downlink_down_downstream_standby(
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs
+        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs,
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -238,7 +251,7 @@ def test_active_tor_downlink_down_downstream_standby(
 def test_standby_tor_downlink_down_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_lower_tor_downlink_intfs                                   # noqa F811
+    shutdown_lower_tor_downlink_intfs, skip_traffic_test                # noqa F811
 ):
     """
     Send traffic from server to T1 and shutdown the standby ToR downlink on DUT.
@@ -246,7 +259,8 @@ def test_standby_tor_downlink_down_upstream(
     """
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs
+        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs,
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -258,7 +272,7 @@ def test_standby_tor_downlink_down_upstream(
 def test_standby_tor_downlink_down_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_lower_tor_downlink_intfs                                   # noqa F811
+    shutdown_lower_tor_downlink_intfs, skip_traffic_test                # noqa F811
 ):
     """
     Send traffic from T1 to active ToR and shutdown the standby ToR downlink on DUT.
@@ -266,7 +280,8 @@ def test_standby_tor_downlink_down_downstream_active(
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs
+        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs,
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -278,7 +293,7 @@ def test_standby_tor_downlink_down_downstream_active(
 def test_standby_tor_downlink_down_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_lower_tor_downlink_intfs                                   # noqa F811
+    shutdown_lower_tor_downlink_intfs, skip_traffic_test                # noqa F811
 ):
     """
     Send traffic from T1 to standby ToR and shutdwon the standby ToR downlink on DUT.
@@ -286,7 +301,8 @@ def test_standby_tor_downlink_down_downstream_standby(
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs
+        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs,
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -14,6 +14,8 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter                        # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
                                                 copy_ptftests_directory, change_mac_addresses       # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test                                   # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC, CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
@@ -28,16 +30,19 @@ pytestmark = [
 def test_normal_op_upstream(upper_tor_host, lower_tor_host,             # noqa F811
                             send_server_to_t1_with_action,              # noqa F811
                             toggle_all_simulator_ports_to_upper_tor,    # noqa F811
-                            cable_type):                                # noqa F811
+                            cable_type,                                 # noqa F811
+                            skip_traffic_test):                         # noqa F811
     """Send upstream traffic and confirm no disruption or switchover occurs"""
     if cable_type == CableType.active_standby:
-        send_server_to_t1_with_action(upper_tor_host, verify=True, stop_after=60)
+        send_server_to_t1_with_action(upper_tor_host, verify=True,
+                                      stop_after=60, skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host,
                           skip_tunnel_route=False)
 
     if cable_type == CableType.active_active:
-        send_server_to_t1_with_action(upper_tor_host, verify=True, stop_after=60)
+        send_server_to_t1_with_action(upper_tor_host, verify=True,
+                                      stop_after=60, skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type,
@@ -48,18 +53,21 @@ def test_normal_op_upstream(upper_tor_host, lower_tor_host,             # noqa F
 def test_normal_op_downstream_upper_tor(upper_tor_host, lower_tor_host,             # noqa F811
                                         send_t1_to_server_with_action,              # noqa F811
                                         toggle_all_simulator_ports_to_upper_tor,    # noqa F811
-                                        cable_type):                                # noqa F811
+                                        cable_type,                                 # noqa F811
+                                        skip_traffic_test):                         # noqa F811
     """
     Send downstream traffic to the upper ToR and confirm no disruption or
     switchover occurs
     """
     if cable_type == CableType.active_standby:
-        send_t1_to_server_with_action(upper_tor_host, verify=True, stop_after=60)
+        send_t1_to_server_with_action(upper_tor_host, verify=True,
+                                      stop_after=60, skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host)
 
     if cable_type == CableType.active_active:
-        send_t1_to_server_with_action(upper_tor_host, verify=True, stop_after=60)
+        send_t1_to_server_with_action(upper_tor_host, verify=True,
+                                      stop_after=60, skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type)
@@ -67,20 +75,23 @@ def test_normal_op_downstream_upper_tor(upper_tor_host, lower_tor_host,         
 
 @pytest.mark.enable_active_active
 def test_normal_op_downstream_lower_tor(upper_tor_host, lower_tor_host,             # noqa F811
-                                        send_t1_to_server_with_action,             # noqa F811
-                                        toggle_all_simulator_ports_to_upper_tor,   # noqa F811
-                                        cable_type):                               # noqa F811
+                                        send_t1_to_server_with_action,              # noqa F811
+                                        toggle_all_simulator_ports_to_upper_tor,    # noqa F811
+                                        cable_type,                                 # noqa F811
+                                        skip_traffic_test):                         # noqa F811
     """
     Send downstream traffic to the lower ToR and confirm no disruption or
     switchover occurs
     """
     if cable_type == CableType.active_standby:
-        send_t1_to_server_with_action(lower_tor_host, verify=True, stop_after=60)
+        send_t1_to_server_with_action(lower_tor_host, verify=True,
+                                      stop_after=60, skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host)
 
     if cable_type == CableType.active_active:
-        send_t1_to_server_with_action(lower_tor_host, verify=True, stop_after=60)
+        send_t1_to_server_with_action(lower_tor_host, verify=True,
+                                      stop_after=60, skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type)
@@ -91,7 +102,8 @@ def test_normal_op_active_server_to_active_server(upper_tor_host, lower_tor_host
                                                   send_server_to_server_with_action,            # noqa F811
                                                   toggle_all_simulator_ports_to_upper_tor,      # noqa F811
                                                   cable_type,                                   # noqa F811
-                                                  select_test_mux_ports):                       # noqa F811
+                                                  select_test_mux_ports,                        # noqa F811
+                                                  skip_traffic_test):                           # noqa F811
     """
     Send server to server traffic in active-active setup and confirm no disruption or switchover occurs.
     """
@@ -99,13 +111,15 @@ def test_normal_op_active_server_to_active_server(upper_tor_host, lower_tor_host
     test_mux_ports = select_test_mux_ports(cable_type, 2)
 
     if cable_type == CableType.active_standby:
-        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True,
+                                          stop_after=60, skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host,
                           skip_tunnel_route=False)
 
     if cable_type == CableType.active_active:
-        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True,
+                                          stop_after=60, skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type,
@@ -117,7 +131,8 @@ def test_normal_op_active_server_to_standby_server(upper_tor_host, lower_tor_hos
                                                    send_server_to_server_with_action,               # noqa F811
                                                    toggle_all_simulator_ports_to_upper_tor,         # noqa F811
                                                    cable_type, force_standby_tor,                   # noqa F811
-                                                   select_test_mux_ports):                          # noqa F811
+                                                   select_test_mux_ports,                           # noqa F811
+                                                   skip_traffic_test):                              # noqa F811
     """
     Send server to server traffic in active-standby setup and confirm no disruption or switchover occurs.
     """
@@ -133,10 +148,12 @@ def test_normal_op_active_server_to_standby_server(upper_tor_host, lower_tor_hos
                   "failed to toggle mux port %s to standby on DUT %s" % (tx_mux_port, upper_tor_host.hostname))
 
     if cable_type == CableType.active_standby:
-        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True,
+                                          stop_after=60, skip_traffic_test=skip_traffic_test)
 
     if cable_type == CableType.active_active:
-        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True,
+                                          stop_after=60, skip_traffic_test=skip_traffic_test)
 
     # TODO: Add per-port db check
 
@@ -146,7 +163,8 @@ def test_normal_op_active_server_to_standby_server(upper_tor_host, lower_tor_hos
 def test_upper_tor_config_reload_upstream(upper_tor_host, lower_tor_host,               # noqa F811
                                           send_server_to_t1_with_action,                # noqa F811
                                           toggle_all_simulator_ports_to_upper_tor,      # noqa F811
-                                          cable_type):                                  # noqa F811
+                                          cable_type,                                   # noqa F811
+                                          skip_traffic_test):                           # noqa F811
     """
     Send upstream traffic and `config reload` the active ToR.
     Confirm switchover occurs and disruption lasted < 1 second for active-standby ports.
@@ -154,13 +172,15 @@ def test_upper_tor_config_reload_upstream(upper_tor_host, lower_tor_host,       
     """
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(upper_tor_host, verify=True, delay=CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: config_reload(upper_tor_host, wait=0))
+                                      action=lambda: config_reload(upper_tor_host, wait=0),
+                                      skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host)
 
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: config_reload(upper_tor_host, wait=0))
+                                      action=lambda: config_reload(upper_tor_host, wait=0),
+                                      skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type)
@@ -170,14 +190,16 @@ def test_upper_tor_config_reload_upstream(upper_tor_host, lower_tor_host,       
 def test_lower_tor_config_reload_upstream(upper_tor_host, lower_tor_host,               # noqa F811
                                           send_server_to_t1_with_action,                # noqa F811
                                           toggle_all_simulator_ports_to_upper_tor,      # noqa F811
-                                          cable_type):                                  # noqa F811
+                                          cable_type,                                   # noqa F811
+                                          skip_traffic_test):                           # noqa F811
     """
     Send upstream traffic and `config reload` the lower ToR.
     Confirm no switchover occurs and no disruption.
     """
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(upper_tor_host, verify=True,
-                                      action=lambda: config_reload(lower_tor_host, wait=0))
+                                      action=lambda: config_reload(lower_tor_host, wait=0),
+                                      skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host)
 
@@ -187,20 +209,23 @@ def test_lower_tor_config_reload_upstream(upper_tor_host, lower_tor_host,       
 def test_lower_tor_config_reload_downstream_upper_tor(upper_tor_host, lower_tor_host,           # noqa F811
                                                       send_t1_to_server_with_action,            # noqa F811
                                                       toggle_all_simulator_ports_to_upper_tor,  # noqa F811
-                                                      cable_type):                              # noqa F811
+                                                      cable_type,                               # noqa F811
+                                                      skip_traffic_test):                       # noqa F811
     """
     Send downstream traffic to the upper ToR and `config reload` the lower ToR.
     Confirm no switchover occurs and no disruption
     """
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(upper_tor_host, verify=True,
-                                      action=lambda: config_reload(lower_tor_host, wait=0))
+                                      action=lambda: config_reload(lower_tor_host, wait=0),
+                                      skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host)
 
     if cable_type == CableType.active_active:
         send_t1_to_server_with_action(upper_tor_host, verify=True,
-                                      action=lambda: config_reload(lower_tor_host, wait=0))
+                                      action=lambda: config_reload(lower_tor_host, wait=0),
+                                      skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type)
@@ -210,7 +235,8 @@ def test_lower_tor_config_reload_downstream_upper_tor(upper_tor_host, lower_tor_
 def test_upper_tor_config_reload_downstream_lower_tor(upper_tor_host, lower_tor_host,           # noqa F811
                                                       send_t1_to_server_with_action,            # noqa F811
                                                       toggle_all_simulator_ports_to_upper_tor,  # noqa F811
-                                                      cable_type):                              # noqa F811
+                                                      cable_type,                               # noqa F811
+                                                      skip_traffic_test):                       # noqa F811
     """
     Send downstream traffic to the lower ToR and `config reload` the upper ToR.
     Confirm switchover occurs and disruption lasts < 1 second for active-standby ports.
@@ -218,7 +244,8 @@ def test_upper_tor_config_reload_downstream_lower_tor(upper_tor_host, lower_tor_
     """
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(lower_tor_host, verify=True, delay=CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: config_reload(upper_tor_host, wait=0))
+                                      action=lambda: config_reload(upper_tor_host, wait=0),
+                                      skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host)
 
@@ -228,7 +255,8 @@ def test_tor_switch_upstream(upper_tor_host, lower_tor_host,                # no
                              send_server_to_t1_with_action,                 # noqa F811
                              toggle_all_simulator_ports_to_upper_tor,       # noqa F811
                              force_active_tor, force_standby_tor,           # noqa F811
-                             cable_type):                                   # noqa F811
+                             cable_type,                                    # noqa F811
+                             skip_traffic_test):                            # noqa F811
     """
     Send upstream traffic and perform switchover via CLI.
     Confirm switchover occurs and disruption lasts < 1 second for active-standby ports.
@@ -236,13 +264,15 @@ def test_tor_switch_upstream(upper_tor_host, lower_tor_host,                # no
     """
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_active_tor(lower_tor_host, 'all'))
+                                      action=lambda: force_active_tor(lower_tor_host, 'all'),
+                                      skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host)
 
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_standby_tor(upper_tor_host, 'all'))
+                                      action=lambda: force_standby_tor(upper_tor_host, 'all'),
+                                      skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host,
                           expected_standby_health="healthy",
@@ -254,7 +284,8 @@ def test_tor_switch_downstream_active(upper_tor_host, lower_tor_host,           
                                       send_t1_to_server_with_action,                # noqa F811
                                       toggle_all_simulator_ports_to_upper_tor,      # noqa F811
                                       force_active_tor, force_standby_tor,          # noqa F811
-                                      cable_type):                                  # noqa F811
+                                      cable_type,                                   # noqa F811
+                                      skip_traffic_test):                           # noqa F811
     """
     Send downstream traffic to the upper ToR and perform switchover via CLI.
     Confirm switchover occurs and disruption lasts < 1 second for active-standby ports.
@@ -262,13 +293,15 @@ def test_tor_switch_downstream_active(upper_tor_host, lower_tor_host,           
     """
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_active_tor(lower_tor_host, 'all'))
+                                      action=lambda: force_active_tor(lower_tor_host, 'all'),
+                                      skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host)
 
     if cable_type == CableType.active_active:
         send_t1_to_server_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_standby_tor(upper_tor_host, 'all'))
+                                      action=lambda: force_standby_tor(upper_tor_host, 'all'),
+                                      skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host,
                           expected_standby_health="healthy",
@@ -280,7 +313,8 @@ def test_tor_switch_downstream_standby(upper_tor_host, lower_tor_host,          
                                        send_t1_to_server_with_action,               # noqa F811
                                        toggle_all_simulator_ports_to_upper_tor,     # noqa F811
                                        force_active_tor, force_standby_tor,         # noqa F811
-                                       cable_type):                                 # noqa F811
+                                       cable_type,                                  # noqa F811
+                                       skip_traffic_test):                          # noqa F811
     """
     Send downstream traffic to the lower ToR and perform switchover via CLI.
     Confirm switchover occurs and disruption lasts < 1 second for active-standby ports.
@@ -288,13 +322,15 @@ def test_tor_switch_downstream_standby(upper_tor_host, lower_tor_host,          
     """
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_active_tor(lower_tor_host, 'all'))
+                                      action=lambda: force_active_tor(lower_tor_host, 'all'),
+                                      skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host)
 
     if cable_type == CableType.active_active:
         send_t1_to_server_with_action(lower_tor_host, verify=True,
-                                      action=lambda: force_standby_tor(upper_tor_host, 'all'))
+                                      action=lambda: force_standby_tor(upper_tor_host, 'all'),
+                                      skip_traffic_test=skip_traffic_test)
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host,
                           expected_standby_health="healthy",
@@ -322,7 +358,7 @@ def test_mux_port_switch_active_server_to_active_server(upper_tor_host, lower_to
         send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True,
                                           action=lambda: force_standby_tor(upper_tor_host, [tx_mux_port]),
                                           send_interval=0.0035,
-                                          stop_after=60)
+                                          stop_after=60,)
 
         pytest_assert(_is_mux_port_standby(upper_tor_host, tx_mux_port),
                       "mux port %s on DUT %s failed to toggle to standby" % (upper_tor_host.hostname, tx_mux_port))

--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -11,6 +11,8 @@ from tests.common.dualtor.tor_failure_utils import shutdown_bgp_sessions        
 from tests.common.dualtor.tor_failure_utils import shutdown_bgp_sessions_on_duthost
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
                                                 copy_ptftests_directory, change_mac_addresses       # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test                                   # noqa F401
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor                        # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import cable_type                                         # noqa F401
@@ -75,7 +77,7 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
 
 def test_active_tor_kill_bgpd_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
-    toggle_all_simulator_ports_to_upper_tor, kill_bgpd):                # noqa F811
+    toggle_all_simulator_ports_to_upper_tor, kill_bgpd, skip_traffic_test):                # noqa F811
     '''
     Case: Server -> ToR -> T1 (Active ToR BGP Down)
     Action: Shutdown all BGP sessions on the active ToR
@@ -87,7 +89,8 @@ def test_active_tor_kill_bgpd_upstream(
     '''
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=lambda: kill_bgpd(upper_tor_host)
+        action=lambda: kill_bgpd(upper_tor_host),
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -97,7 +100,7 @@ def test_active_tor_kill_bgpd_upstream(
 
 def test_standby_tor_kill_bgpd_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
-    toggle_all_simulator_ports_to_upper_tor, kill_bgpd):                # noqa F811
+    toggle_all_simulator_ports_to_upper_tor, kill_bgpd, skip_traffic_test):                # noqa F811
     '''
     Case: Server -> ToR -> T1 (Standby ToR BGP Down)
     Action: Shutdown all BGP sessions on the standby ToR
@@ -108,7 +111,8 @@ def test_standby_tor_kill_bgpd_upstream(
     '''
     send_server_to_t1_with_action(
         upper_tor_host, verify=True,
-        action=lambda: kill_bgpd(lower_tor_host)
+        action=lambda: kill_bgpd(lower_tor_host),
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -119,7 +123,7 @@ def test_standby_tor_kill_bgpd_upstream(
 def test_standby_tor_kill_bgpd_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, kill_bgpd,                 # noqa F811
-    tunnel_traffic_monitor):                                            # noqa F811
+    tunnel_traffic_monitor, skip_traffic_test):                         # noqa F811
     '''
     Case: T1 -> Active ToR -> Server (Standby ToR BGP Down)
     Action: Shutdown all BGP sessions on the standby ToR
@@ -130,7 +134,8 @@ def test_standby_tor_kill_bgpd_downstream_active(
     with tunnel_traffic_monitor(lower_tor_host, existing=False):
         send_t1_to_server_with_action(
             upper_tor_host, verify=True,
-            action=lambda: kill_bgpd(lower_tor_host)
+            action=lambda: kill_bgpd(lower_tor_host),
+            skip_traffic_test=skip_traffic_test
         )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -141,7 +146,7 @@ def test_standby_tor_kill_bgpd_downstream_active(
 def test_active_tor_kill_bgpd_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, kill_bgpd,                 # noqa F811
-    tunnel_traffic_monitor):                                            # noqa F811
+    tunnel_traffic_monitor, skip_traffic_test):                         # noqa F811
     '''
     Case: T1 -> Standby ToR -> Server (Active ToR BGP Down)
     Action: Shutdown all BGP sessions on the active ToR
@@ -152,7 +157,8 @@ def test_active_tor_kill_bgpd_downstream_standby(
     '''
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=lambda: kill_bgpd(upper_tor_host)
+        action=lambda: kill_bgpd(upper_tor_host),
+        skip_traffic_test=skip_traffic_test
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -164,7 +170,7 @@ def test_active_tor_kill_bgpd_downstream_standby(
 def test_active_tor_shutdown_bgp_sessions_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_bgp_sessions, cable_type                                   # noqa F811
+    shutdown_bgp_sessions, cable_type, skip_traffic_test                # noqa F811
 ):
     """
     Case: Server -> ToR -> T1 (Active ToR BGP Down)
@@ -178,13 +184,15 @@ def test_active_tor_shutdown_bgp_sessions_upstream(
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            action=lambda: shutdown_bgp_sessions(upper_tor_host)
+            action=lambda: shutdown_bgp_sessions(upper_tor_host),
+            skip_traffic_test=skip_traffic_test
         )
 
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            action=lambda: shutdown_bgp_sessions(upper_tor_host)
+            action=lambda: shutdown_bgp_sessions(upper_tor_host),
+            skip_traffic_test=skip_traffic_test
         )
 
     if cable_type == CableType.active_active:

--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -10,6 +10,8 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.dualtor.tor_failure_utils import reboot_tor, tor_blackhole_traffic, wait_for_device_reachable     # noqa F401
 from tests.common.dualtor.tor_failure_utils import wait_for_mux_container, wait_for_pmon_container                  # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, change_mac_addresses          # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test                                                   # noqa F401
 from tests.common.dualtor.nic_simulator_control import mux_status_from_nic_simulator                                # noqa F401
 from tests.common.dualtor.nic_simulator_control import ForwardingState
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor                                        # noqa F401
@@ -61,7 +63,7 @@ def test_active_tor_reboot_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_upper_tor_pdu,      # noqa F811
     wait_for_device_reachable, wait_for_mux_container, cable_type,      # noqa F811
-    wait_for_pmon_container                                             # noqa F811
+    wait_for_pmon_container, skip_traffic_test                          # noqa F811
 ):
     """
     Send upstream traffic and reboot the active ToR. Confirm switchover
@@ -71,7 +73,8 @@ def test_active_tor_reboot_upstream(
                      marker_prefix="test_active_tor_reboot_upstream"):
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            action=toggle_upper_tor_pdu, stop_after=60
+            action=toggle_upper_tor_pdu, stop_after=60,
+            skip_traffic_test=skip_traffic_test
         )
         wait_for_device_reachable(upper_tor_host)
         wait_for_mux_container(upper_tor_host)
@@ -96,7 +99,7 @@ def test_active_tor_reboot_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_upper_tor_pdu,      # noqa F811
     wait_for_device_reachable, wait_for_mux_container,                  # noqa F811
-    wait_for_pmon_container                                             # noqa F811
+    wait_for_pmon_container, skip_traffic_test                          # noqa F811
 ):
     """
     Send downstream traffic to the standby ToR and reboot the active ToR.
@@ -106,7 +109,8 @@ def test_active_tor_reboot_downstream_standby(
                      marker_prefix="test_active_tor_reboot_downstream_standby"):
         send_t1_to_server_with_action(
             lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            action=toggle_upper_tor_pdu, stop_after=60
+            action=toggle_upper_tor_pdu, stop_after=60,
+            skip_traffic_test=skip_traffic_test
         )
         wait_for_device_reachable(upper_tor_host)
         wait_for_mux_container(upper_tor_host)
@@ -122,7 +126,7 @@ def test_standby_tor_reboot_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_lower_tor_pdu,      # noqa F811
     wait_for_device_reachable, wait_for_mux_container,                  # noqa F811
-    wait_for_pmon_container                                             # noqa F811
+    wait_for_pmon_container, skip_traffic_test                          # noqa F811
 ):
     """
     Send upstream traffic and reboot the standby ToR. Confirm no switchover
@@ -132,7 +136,8 @@ def test_standby_tor_reboot_upstream(
                      marker_prefix="test_standby_tor_reboot_upstream"):
         send_server_to_t1_with_action(
             upper_tor_host, verify=True,
-            action=toggle_lower_tor_pdu, stop_after=60
+            action=toggle_lower_tor_pdu, stop_after=60,
+            skip_traffic_test=skip_traffic_test
         )
         wait_for_device_reachable(lower_tor_host)
         wait_for_mux_container(lower_tor_host)
@@ -148,7 +153,7 @@ def test_standby_tor_reboot_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_lower_tor_pdu,      # noqa F811
     wait_for_device_reachable, wait_for_mux_container,                  # noqa F811
-    wait_for_pmon_container                                             # noqa F811
+    wait_for_pmon_container, skip_traffic_test                          # noqa F811
 ):
     """
     Send downstream traffic to the active ToR and reboot the standby ToR.
@@ -158,7 +163,8 @@ def test_standby_tor_reboot_downstream_active(
                      marker_prefix="test_standby_tor_reboot_downstream_active"):
         send_t1_to_server_with_action(
             upper_tor_host, verify=True,
-            action=toggle_lower_tor_pdu, stop_after=60
+            action=toggle_lower_tor_pdu, stop_after=60,
+            skip_traffic_test=skip_traffic_test
         )
         wait_for_device_reachable(lower_tor_host)
         wait_for_mux_container(lower_tor_host)

--- a/tests/dualtor_mgmt/test_ingress_drop.py
+++ b/tests/dualtor_mgmt/test_ingress_drop.py
@@ -16,6 +16,8 @@ from tests.common.dualtor.nic_simulator_control import ForwardingState
 from tests.common.dualtor.nic_simulator_control import mux_status_from_nic_simulator    # noqa F401
 from tests.common.dualtor.nic_simulator_control import stop_nic_simulator               # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder                      # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test                       # noqa F401
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
@@ -103,7 +105,7 @@ def selected_mux_port(cable_type, active_active_ports, active_standby_ports):   
 
 
 @pytest.mark.enable_active_active
-def test_ingress_drop(cable_type, ptfadapter, setup_mux, tbinfo, selected_mux_port, upper_tor_host):    # noqa F811
+def test_ingress_drop(cable_type, ptfadapter, setup_mux, tbinfo, selected_mux_port, upper_tor_host, skip_traffic_test):    # noqa F811
     """
     Aims to verify if orchagent installs ingress drop ACL when the port comes to standby.
 
@@ -130,7 +132,7 @@ def test_ingress_drop(cable_type, ptfadapter, setup_mux, tbinfo, selected_mux_po
 
     if cable_type == CableType.active_active:
         verify_upstream_traffic(upper_tor_host, ptfadapter, tbinfo, selected_mux_port,
-                                server_ip, pkt_num=10, drop=False)
+                                server_ip, pkt_num=10, drop=False, skip_traffic_test=skip_traffic_test)
     elif cable_type == CableType.active_standby:
         verify_upstream_traffic(upper_tor_host, ptfadapter, tbinfo, selected_mux_port,
-                                server_ip, pkt_num=10, drop=True)
+                                server_ip, pkt_num=10, drop=True, skip_traffic_test=skip_traffic_test)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed
#### How did you do it?
Add dualtor_io data plane test to onboarding dualtor job and skip traffic test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
