### PR TITLE
Use DefaultAzureCredential to get token in test_plan.py

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -162,13 +162,13 @@ steps:
             curl -u :$(MSSONIC-TOKEN) "${{ parameters.MGMT_URL }}&commitOrBranch=${{ parameters.MGMT_BRANCH }}&api-version=5.0-preview.1&path=.azure-pipelines%2Fpr_test_scripts.yaml" -o ./.azure-pipelines/pr_test_scripts.yaml
           fi
         displayName: "Download pr script"
-  - ${{ else }}:
-      - ${{ if ne(parameters.MGMT_BRANCH, 'master') }}:
-          - script: |
-              # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
-              set -ex
-              curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
-            displayName: "Download test plan script"
+  # - ${{ else }}:
+  #     - ${{ if ne(parameters.MGMT_BRANCH, 'master') }}:
+  #         - script: |
+  #             # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
+  #             set -ex
+  #             curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
+  #           displayName: "Download test plan script"
 
   - script: |
       # Check if azure cli is installed. If not, try to install it
@@ -240,10 +240,6 @@ steps:
         echo "##vso[task.setvariable variable=TEST_PLAN_ID_LIST_STRING]$TEST_PLAN_ID_LIST_STRING"
 
     displayName: "Trigger test"
-    env:
-      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
-      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
 
   - task: AzureCLI@2
     inputs:
@@ -277,10 +273,6 @@ steps:
         fi
 
     displayName: "Lock testbed"
-    env:
-      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
-      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
 
   - task: AzureCLI@2
     inputs:
@@ -315,10 +307,6 @@ steps:
         fi
 
     displayName: "Prepare testbed"
-    env:
-      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
-      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
 
   - task: AzureCLI@2
     inputs:
@@ -353,10 +341,6 @@ steps:
 
     displayName: "Run test"
     timeoutInMinutes: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-    env:
-      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
-      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
 
   - ${{ if eq(parameters.DUMP_KVM_IF_FAIL, 'True') }}:
       - task: AzureCLI@2
@@ -382,10 +366,6 @@ steps:
 
         condition: succeededOrFailed()
         displayName: "KVM dump"
-        env:
-          SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
-          ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
-          SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
 
   - task: AzureCLI@2
     inputs:
@@ -402,7 +382,3 @@ steps:
         done
     condition: always()
     displayName: "Finalize running test plan"
-    env:
-      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
-      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -178,7 +178,15 @@ steps:
       else
         echo "Azure CLI is already installed"
       fi
-    displayName: "Install azure-cli"
+
+      # Check if azure-identity is installed. If not, try to install it
+      if ! python -c "import azure.identity" 2>/dev/null; then
+        echo "azure-identity is not installed. Trying to install it..."
+        pip install azure-identity
+      else
+        echo "azure-identity is already installed"
+      fi
+    displayName: "Install packages"
 
   - task: AzureCLI@2
     inputs:

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -5,10 +5,8 @@ import ast
 import json
 import os
 import sys
-import subprocess
 import copy
 import time
-from datetime import datetime, timedelta
 
 import requests
 import yaml
@@ -147,7 +145,6 @@ def parse_list_from_str(s):
 class TestPlanManager(object):
 
     def __init__(self, url, frontend_url, client_id):
-        self.last_login_time = datetime.now()
         self.url = url
         self.frontend_url = frontend_url
         self.client_id = client_id


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
It turns out that DefaultAzureCredential of azure identity package works in AzureCLI@2 task of Azure Pipeline. 

#### How did you do it?
This change simplified the test_plan.py script to use DefaultAzureCredential to get access token.
Since all Elastictest APIs require authentication, this change also removed the unnecessary logic of `with_auth`.

#### How did you verify/test it?
Create draft PR to test this change.
After draft PR passed, need to uncomment the lines for downloading test_plan.py for non-master branches.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
