### PR TITLE
Subject: Skip some route tests for standalone topo

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1403,6 +1403,12 @@ restapi/test_restapi_vxlan_ecmp.py:
 #######################################
 #####           route             #####
 #######################################
+route/test_default_route.py:
+  skip:
+    reason: "Does not apply to standalone topos."
+    conditions:
+      - "'standalone' in topo_name"
+
 route/test_route_flap.py:
   skip:
     reason: "Test case has issue on the t0-56-povlan and dualtor-64 topo."
@@ -1410,12 +1416,24 @@ route/test_route_flap.py:
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/11323 and 't0-56-po2vlan' in topo_name"
       - "https://github.com/sonic-net/sonic-mgmt/issues/11324 and 'dualtor-64' in topo_name"
+    reason: "Does not apply to standalone topos."
+    conditions:
+      - "'standalone' in topo_name"
+
+route/test_route_perf.py:
+  skip:
+    reason: "Does not apply to standalone topos."
+    conditions:
+      - "'standalone' in topo_name"
 
 route/test_static_route.py:
   skip:
     reason: "Test not supported for 201911 images or older."
     conditions:
       - "release in ['201811', '201911']"
+    reason: "Does not apply to standalone topos."
+    conditions:
+      - "'standalone' in topo_name"
 
 route/test_static_route.py::test_static_route_ecmp_ipv6:
   # This test case may fail due to a known issue https://github.com/sonic-net/sonic-buildimage/issues/4930.

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1411,13 +1411,11 @@ route/test_default_route.py:
 
 route/test_route_flap.py:
   skip:
-    reason: "Test case has issue on the t0-56-povlan and dualtor-64 topo."
+    reason: "Test case has issue on the t0-56-povlan and dualtor-64 topo. Does not apply to standalone topos."
     conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/11323 and 't0-56-po2vlan' in topo_name"
       - "https://github.com/sonic-net/sonic-mgmt/issues/11324 and 'dualtor-64' in topo_name"
-    reason: "Does not apply to standalone topos."
-    conditions:
       - "'standalone' in topo_name"
 
 route/test_route_perf.py:
@@ -1428,11 +1426,10 @@ route/test_route_perf.py:
 
 route/test_static_route.py:
   skip:
-    reason: "Test not supported for 201911 images or older."
+    reason: "Test not supported for 201911 images or older. Does not apply to standalone topos."
+    conditions_logical_operator: OR
     conditions:
       - "release in ['201811', '201911']"
-    reason: "Does not apply to standalone topos."
-    conditions:
       - "'standalone' in topo_name"
 
 route/test_static_route.py::test_static_route_ecmp_ipv6:


### PR DESCRIPTION
### Description of PR
Summary:

Some route tests do not apply to standalone
topologies and should be skipped. This patch skips such tests.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Some route tests are not applicable to t0 topos and should be skipped rather than failing unecessarily, negatively impacting pass rate.

#### How did you do it?
Applied skip conditions to the applicable tests in the tests mark conditions yaml file in sonic-mgmt.

#### How did you verify/test it?
Ran the route test suite and confirmed that the desired tests are now skipped.

#### Any platform specific information?
Verified on Arista-7060X6-64PE-256x200G.