### PR TITLE
Removed Python3 style f-strings

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/pfc_wd_background_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/pfc_wd_background_traffic.py
@@ -38,8 +38,8 @@ class PfcWdBackgroundTrafficTest(BaseTest):
             src_mac = self.dataplane.get_mac(0, src_port)
             dst_mac = self.dataplane.get_mac(0, dst_port)
             for queue in self.queues:
-                print(f"traffic from {src_port} to {dst_port}: {queue} ")
-                logging.info(f"traffic from {src_port} to {dst_port}: {queue} ")
+                print("traffic from {} to {}: {} ".format(src_port, dst_port, queue))
+                logging.info("traffic from {} to {}: {} ".format(src_port, dst_port, queue))
                 pkt = simple_udp_packet(
                     eth_src=src_mac,
                     eth_dst=self.router_mac,
@@ -51,8 +51,8 @@ class PfcWdBackgroundTrafficTest(BaseTest):
                 )
                 pkts_dict[src_port].append(pkt)
                 if self.bidirection:
-                    print(f"traffic from {dst_port} to {src_port}: {queue} ")
-                    logging.info(f"traffic from {dst_port} to {src_port}: {queue} ")
+                    print("traffic from {} to {}: {} ".format(dst_port, src_port, queue))
+                    logging.info("traffic from {} to {}: {} ".format(dst_port, src_port, queue))
                     pkt = simple_udp_packet(
                         eth_src=dst_mac,
                         eth_dst=self.router_mac,


### PR DESCRIPTION
Removed Python3 style f-strings so there will not be errors when imported by Python2-ran tests.

See https://github.com/sonic-net/sonic-mgmt/pull/13867#issuecomment-2257955500 for more context
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
