### PR TITLE
[202405] BBR disabled by default test.

### DIFF
--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -9,7 +9,6 @@ from collections import namedtuple
 
 import pytest
 import requests
-import yaml
 import ipaddr as ipaddress
 
 from jinja2 import Template
@@ -161,9 +160,7 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts):
     if not constants_stat['stat']['exists']:
         pytest.skip('No file {} on DUT, BBR is not supported')
 
-    constants = yaml.safe_load(duthost.shell('cat {}'.format(CONSTANTS_FILE))['stdout'])
     bbr_default_state = 'disabled'
-
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     tor_neighbors = natsorted([neighbor for neighbor in list(nbrhosts.keys()) if neighbor.endswith('T0')])
@@ -417,8 +414,7 @@ def test_bbr_disabled_constants_yml_default(duthosts, rand_one_dut_hostname, set
     if bbr_config != '(empty array)':
         # remove the BBR config. we want to see the default behavior.
         duthost.shell("redis-cli -n 4 hset 'BGP_BBR|all' 'status' 'disabled'")
-        duthost.shell("sudo config save -y")   
+        duthost.shell("sudo config save -y")
     config_reload(duthost)
-    is_bbr_enabled = duthost.shell("show runningconfiguration bgp | grep allowas",module_ignore_errors=True)['stdout']
+    is_bbr_enabled = duthost.shell("show runningconfiguration bgp | grep allowas", module_ignore_errors=True)['stdout']
     pytest_assert(is_bbr_enabled == "", "BBR is not disabled by default.")
-


### PR DESCRIPTION
This test ensures that BBR remains disabled by default. If this test fails, it would imply that BBR has been enabled as default option which is not a desired outcome.
Ref: (https://github.com/sonic-net/sonic-buildimage/pull/19716)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [X] 202305
- [X] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
