### PR TITLE
Move some stable test scripts into T0 PR checker. 

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -193,6 +193,11 @@ t0:
   - generic_config_updater/test_pg_headroom_update.py
   - sub_port_interfaces/test_show_subinterface.py
   - pc/test_lag_member.py
+  - platform_tests/test_link_down.py
+  - gnmi/test_gnmi_countersdb.py
+  - sub_port_interfaces/test_sub_port_l2_forwarding.py
+  - snmp/test_snmp_psu.py
+  - platform_tests/cli/test_show_platform.py
 
 t0-2vlans:
   - dhcp_relay/test_dhcp_relay.py
@@ -328,20 +333,17 @@ onboarding_t0:
   - pfcwd/test_pfcwd_function.py
   - pfcwd/test_pfcwd_timer_accuracy.py
   - pfcwd/test_pfcwd_warm_reboot.py
-  - platform_tests/cli/test_show_platform.py
   # - platform_tests/test_advanced_reboot.py
   - platform_tests/test_cont_warm_reboot.py
   - platform_tests/test_reboot.py
   - platform_tests/test_reload_config.py
   - snmp/test_snmp_link_local.py
-  - snmp/test_snmp_psu.py
   - snmp/test_snmp_queue_counters.py
   - sub_port_interfaces/test_sub_port_interfaces.py
-  - sub_port_interfaces/test_sub_port_l2_forwarding.py
   - arp/test_unknown_mac.py
   - hash/test_generic_hash.py
-  - gnmi/test_gnmi_countersdb.py
-  - platform_tests/test_link_down.py
+
+
 
 onboarding_t1:
   - generic_config_updater/test_cacl.py
@@ -363,7 +365,6 @@ onboarding_dualtor:
   - dualtor_io/test_tor_failure.py
   - dualtor_mgmt/test_ingress_drop.py
   - dualtor_mgmt/test_dualtor_bgp_update_delay.py
-
 
 specific_param:
   t0-sonic:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Some scripts are stable enough after we fixing them. So in this PR, we move these stable scripts from onboarding T0 PR checker to T0 PR checker. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Some scripts are stable enough after we fixing them. So in this PR, we move these stable scripts from onboarding T0 PR checker to T0 PR checker. 

#### How did you do it?
Move some stable test scripts from onboarding T0 PR checker to T0 PR checker. 

#### How did you verify/test it?

TestbedName | FilePath | RunDate | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-t0 | gnmi/test_gnmi_countersdb.py | 2024-07-31 00:00:00.0000000 | 248 | 0 | 248 | 1
vms-kvm-t0 | platform_tests/cli/test_show_platform.py | 2024-07-31 00:00:00.0000000 | 310 | 0 | 310 | 1
vms-kvm-t0 | platform_tests/test_link_down.py | 2024-07-31 00:00:00.0000000 | 62 | 0 | 62 | 1
vms-kvm-t0 | snmp/test_snmp_psu.py | 2024-07-31 00:00:00.0000000 | 62 | 0 | 62 | 1
vms-kvm-t0 | sub_port_interfaces/test_sub_port_l2_forwarding.py | 2024-07-31 00:00:00.0000000 | 62 | 0 | 62 | 1
vms-kvm-t0 | gnmi/test_gnmi_countersdb.py | 2024-07-30 00:00:00.0000000 | 136 | 0 | 136 | 1
vms-kvm-t0 | platform_tests/cli/test_show_platform.py | 2024-07-30 00:00:00.0000000 | 170 | 0 | 170 | 1
vms-kvm-t0 | platform_tests/test_link_down.py | 2024-07-30 00:00:00.0000000 | 34 | 0 | 34 | 1
vms-kvm-t0 | snmp/test_snmp_psu.py | 2024-07-30 00:00:00.0000000 | 34 | 0 | 34 | 1
vms-kvm-t0 | sub_port_interfaces/test_sub_port_l2_forwarding.py | 2024-07-30 00:00:00.0000000 | 34 | 0 | 34 | 1
vms-kvm-t0 | gnmi/test_gnmi_countersdb.py | 2024-07-29 00:00:00.0000000 | 200 | 0 | 200 | 1
vms-kvm-t0 | platform_tests/cli/test_show_platform.py | 2024-07-29 00:00:00.0000000 | 250 | 0 | 250 | 1
vms-kvm-t0 | platform_tests/test_link_down.py | 2024-07-29 00:00:00.0000000 | 50 | 0 | 50 | 1
vms-kvm-t0 | snmp/test_snmp_psu.py | 2024-07-29 00:00:00.0000000 | 50 | 0 | 50 | 1
vms-kvm-t0 | sub_port_interfaces/test_sub_port_l2_forwarding.py | 2024-07-29 00:00:00.0000000 | 50 | 0 | 50 | 1

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
