### PR TITLE
[dhcp_server_test] wait lease to be wrote in state_db before check and ignore log error

### DIFF
--- a/tests/dhcp_server/dhcp_server_test_common.py
+++ b/tests/dhcp_server/dhcp_server_test_common.py
@@ -76,9 +76,9 @@ def clean_dhcp_server_config(duthost):
 def verify_lease(duthost, dhcp_interface, client_mac, exp_ip, exp_lease_time):
     pytest_assert(
         wait_until(
-            30,
-            3,
+            11,
             1,
+            3,
             lambda _dh, _di, _cm: len(_dh.shell(
                     "sonic-db-cli STATE_DB KEYS 'DHCP_SERVER_IPV4_LEASE|{}|{}'".format(_di, _cm)
                 )['stdout']) > 0,

--- a/tests/dhcp_server/dhcp_server_test_common.py
+++ b/tests/dhcp_server/dhcp_server_test_common.py
@@ -6,8 +6,7 @@ import logging
 import pytest
 import ptf.packet as scapy
 import ptf.testutils as testutils
-import time
-from tests.common.utilities import capture_and_check_packet_on_dut
+from tests.common.utilities import capture_and_check_packet_on_dut, wait_until
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 
 
@@ -75,7 +74,20 @@ def clean_dhcp_server_config(duthost):
 
 
 def verify_lease(duthost, dhcp_interface, client_mac, exp_ip, exp_lease_time):
-    time.sleep(5)  # wait for dhcp server to update lease info
+    pytest_assert(
+        wait_until(
+            30,
+            3,
+            1,
+            lambda _dh, _di, _cm: len(_dh.shell(
+                    "sonic-db-cli STATE_DB KEYS 'DHCP_SERVER_IPV4_LEASE|{}|{}'".format(_di, _cm)
+                )['stdout']) > 0,
+            duthost,
+            dhcp_interface,
+            client_mac
+        ),
+        'state db doesnt have lease info for client {}'.format(client_mac)
+    )
     lease_start = duthost.shell("sonic-db-cli STATE_DB HGET 'DHCP_SERVER_IPV4_LEASE|{}|{}' '{}'"
                                 .format(dhcp_interface, client_mac, STATE_DB_KEY_LEASE_START))['stdout']
     lease_end = duthost.shell("sonic-db-cli STATE_DB HGET 'DHCP_SERVER_IPV4_LEASE|{}|{}' '{}'"

--- a/tests/dhcp_server/dhcp_server_test_common.py
+++ b/tests/dhcp_server/dhcp_server_test_common.py
@@ -76,7 +76,7 @@ def clean_dhcp_server_config(duthost):
 def verify_lease(duthost, dhcp_interface, client_mac, exp_ip, exp_lease_time):
     pytest_assert(
         wait_until(
-            11,
+            11, # it's by design that there is a latency around 0~11 seconds for updating state db
             1,
             3,
             lambda _dh, _di, _cm: len(_dh.shell(

--- a/tests/dhcp_server/dhcp_server_test_common.py
+++ b/tests/dhcp_server/dhcp_server_test_common.py
@@ -76,7 +76,7 @@ def clean_dhcp_server_config(duthost):
 def verify_lease(duthost, dhcp_interface, client_mac, exp_ip, exp_lease_time):
     pytest_assert(
         wait_until(
-            11, # it's by design that there is a latency around 0~11 seconds for updating state db
+            11,  # it's by design that there is a latency around 0~11 seconds for updating state db
             1,
             3,
             lambda _dh, _di, _cm: len(_dh.shell(

--- a/tests/dhcp_server/test_dhcp_server.py
+++ b/tests/dhcp_server/test_dhcp_server.py
@@ -641,11 +641,13 @@ def test_dhcp_server_config_vlan_member_change(
     duthost,
     ptfhost,
     ptfadapter,
-    parse_vlan_setting_from_running_config
+    parse_vlan_setting_from_running_config,
+    loganalyzer
 ):
     """
         Test if config change on dhcp interface status can take effect
     """
+    loganalyzer[duthost.hostname].ignore_regex.append(".*Failed to get port by bridge port.*")
     test_xid = 11
     vlan_name, gateway, net_mask, vlan_hosts, vlan_members_with_ptf_idx = parse_vlan_setting_from_running_config
     expected_assigned_ip = random.choice(vlan_hosts)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
We should wait lease to wrote in the state_db before check and we should ignore error in pattern`.*Failed to get port by bridge port.*`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The test case failed because lease was not updated to state_db, we need to wait on it.
#### How did you do it?
Wait on lease to be wrote to state db
#### How did you verify/test it?
Run test on DUT
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
