### PR TITLE
update hwsku definitions in the port_utils.py file

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -319,15 +319,6 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku in ["Cisco-8101-O32", "Cisco-8111-C32", "Cisco-8111-O32"]:
             for i in range(0, 32):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 8)
-        elif hwsku in ["Cisco-8101-C48T8"]:
-            for i in range(0, 24, 2):
-                port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 4)
-                port_alias_to_name_map["etp%d" % (i+1)] = "Ethernet%d" % ((i+1) * 4)
-            for i in range(0, 8):
-                port_alias_to_name_map["etp%d" % (i+24)] = "Ethernet%d" % ((i+12) * 8)
-            for i in range(0, 24, 2):
-                port_alias_to_name_map["etp%d" % (i+32)] = "Ethernet%d" % ((i+40) * 4)
-                port_alias_to_name_map["etp%d" % (i+33)] = "Ethernet%d" % ((i+41) * 4)
         elif hwsku in ["Cisco-8111-O64"]:
             for i in range(0, 64):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 4)

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -316,7 +316,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku == "Cisco-8102-C64":
             for i in range(0, 64):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 4)
-        elif hwsku in ["Cisco-8101-T32", "Cisco-8101-O32", "Cisco-8111-C32", "Cisco-8111-O32"]:
+        elif hwsku in ["Cisco-8101-O32", "Cisco-8111-C32", "Cisco-8111-O32"]:
             for i in range(0, 32):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 8)
         elif hwsku in ["Cisco-8101-C48T8"]:

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -319,7 +319,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku in ["Cisco-8101-T32", "Cisco-8101-O32", "Cisco-8111-C32", "Cisco-8111-O32"]:
             for i in range(0, 32):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 8)
-        elif hwsku in ["Cisco-8101-C48T8", "Cisco-8101-O8C48"]:
+        elif hwsku in ["Cisco-8101-C48T8"]:
             for i in range(0, 24, 2):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 4)
                 port_alias_to_name_map["etp%d" % (i+1)] = "Ethernet%d" % ((i+1) * 4)
@@ -328,7 +328,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             for i in range(0, 24, 2):
                 port_alias_to_name_map["etp%d" % (i+32)] = "Ethernet%d" % ((i+40) * 4)
                 port_alias_to_name_map["etp%d" % (i+33)] = "Ethernet%d" % ((i+41) * 4)
-        elif hwsku in ["Cisco-8101-C64", "Cisco-8111-O64"]:
+        elif hwsku in ["Cisco-8111-O64"]:
             for i in range(0, 64):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 4)
         elif hwsku == "Cisco-8101-O8C48":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The file 'port_utils.py' has duplicate definition on both the Cisco-8101-O8C48 and Cisco-8101-C64 hardware SKUs, and remove Cisco-8101-T32 and Cisco-8101-C48T8.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To address the issue of duplicate definitions in the ‘port_utils.py’ file for both the Cisco-8101-O8C48 and Cisco-8101-C64 hardware SKUs. We will ensure a single, consistent definition.

#### How did you do it?
I updated the ‘port_utils.py’ file to eliminate the duplicate definitions, this was after reviewing the ‘port_config.ini’ on the device.

#### How did you verify/test it?
To verify the changes, ensure that the 'port_utils.py' file was consistent with the 'port_config.ini' on the device.

#### Any platform specific information?
Cisco-8000

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
