### PR TITLE
feat: support BGP peer shutdown test on T2

### DIFF
--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -15,7 +15,7 @@ from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.utilities import wait_until, delete_running_config
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1'),
+    pytest.mark.topology('t0', 't1', 't2'),
 ]
 
 TEST_ITERATIONS = 5
@@ -156,11 +156,11 @@ def is_neighbor_session_down(duthost, neighbor):
             bgp_neighbors[neighbor.ip]["state"] == "idle")
 
 
-def get_bgp_down_timestamp(duthost, peer_ip, timestamp_before_teardown):
+def get_bgp_down_timestamp(duthost, namespace, peer_ip, timestamp_before_teardown):
     # get the bgp session down timestamp from syslog in the format of seconds (with ms precision) since the Unix Epoch
     cmd = (
-        "grep \"[b]gp#bgpcfgd: Peer 'default|{}' admin state is set to 'down'\" /var/log/syslog | tail -1"
-    ).format(peer_ip)
+        "grep \"[b]gp{}#bgpcfgd: Peer 'default|{}' admin state is set to 'down'\" /var/log/syslog | tail -1"
+    ).format(namespace.split("asic")[1] if namespace else "", peer_ip)
 
     bgp_down_msg_list = duthost.shell(cmd)['stdout'].split()
     try:
@@ -230,7 +230,7 @@ def test_bgp_peer_shutdown(
                     bgp_packet.show(dump=True),
                 )
 
-                bgp_session_down_time = get_bgp_down_timestamp(duthost, n0.ip, timestamp_before_teardown)
+                bgp_session_down_time = get_bgp_down_timestamp(duthost, n0.namespace, n0.ip, timestamp_before_teardown)
                 if not match_bgp_notification(bgp_packet, n0.ip, n0.peer_ip, "cease", bgp_session_down_time):
                     pytest.fail("BGP notification packet does not match expected values")
 

--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -163,6 +163,9 @@ def get_bgp_down_timestamp(duthost, namespace, peer_ip, timestamp_before_teardow
     ).format(namespace.split("asic")[1] if namespace else "", peer_ip)
 
     bgp_down_msg_list = duthost.shell(cmd)['stdout'].split()
+    if not bgp_down_msg_list:
+        pytest.fail("Could not find the BGP session down message in syslog")
+
     try:
         timestamp = " ".join(bgp_down_msg_list[1:4])
         timestamp_in_sec = float(duthost.shell("date -d \"{}\" +%s.%6N".format(timestamp))['stdout'])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Support `bgp/test_bgp_peer_shutdown.py` on T2 topology

Summary:
Fixes # (issue) Microsoft ADO 28837065

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
We want to support as more test cases as possible on T2 topology

#### How did you do it?

#### How did you verify/test it?
I ran the updated test on T0, T1 & T2, and I can confirm they all passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
