### PR TITLE
Skip cancel test plan for "NIGHTLY" test plan type

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -162,13 +162,13 @@ steps:
             curl -u :$(MSSONIC-TOKEN) "${{ parameters.MGMT_URL }}&commitOrBranch=${{ parameters.MGMT_BRANCH }}&api-version=5.0-preview.1&path=.azure-pipelines%2Fpr_test_scripts.yaml" -o ./.azure-pipelines/pr_test_scripts.yaml
           fi
         displayName: "Download pr script"
-  - ${{ else }}:
-      - ${{ if ne(parameters.MGMT_BRANCH, 'master') }}:
-          - script: |
-              # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
-              set -ex
-              curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
-            displayName: "Download test plan script"
+  # - ${{ else }}:
+  #     - ${{ if ne(parameters.MGMT_BRANCH, 'master') }}:
+  #         - script: |
+  #             # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
+  #             set -ex
+  #             curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
+  #           displayName: "Download test plan script"
 
   - script: |
       # Check if azure cli is installed. If not, try to install it
@@ -240,10 +240,6 @@ steps:
         echo "##vso[task.setvariable variable=TEST_PLAN_ID_LIST_STRING]$TEST_PLAN_ID_LIST_STRING"
 
     displayName: "Trigger test"
-    env:
-      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
-      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
 
   - task: AzureCLI@2
     inputs:
@@ -277,10 +273,6 @@ steps:
         fi
 
     displayName: "Lock testbed"
-    env:
-      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
-      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
 
   - task: AzureCLI@2
     inputs:
@@ -315,10 +307,6 @@ steps:
         fi
 
     displayName: "Prepare testbed"
-    env:
-      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
-      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
 
   - task: AzureCLI@2
     inputs:
@@ -332,19 +320,31 @@ steps:
         echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
         IFS=',' read -ra TEST_PLAN_ID_LIST <<< "$TEST_PLAN_ID_LIST_STRING"
         failure_count=0
+        runtest_polling_timeout=0
         for TEST_PLAN_ID in "${TEST_PLAN_ID_LIST[@]}"
         do
             echo -e -n "\033[33mPlease visit Elastictest page \033[0m"
             echo -n "$(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID "
             echo -e "\033[33mfor detailed test plan progress \033[0m"
             # When "EXECUTING" finish, it changes into "KVMDUMP", "FAILED", "CANCELLED" or "FINISHED"
-            echo "[test_plan.py] poll EXECUTING status"
-            python ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state EXECUTING --expected-result ${{ parameters.EXPECTED_RESULT }}
+            echo "[test_plan.py] poll EXECUTING status, timeout 20 hours"
+            python ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state EXECUTING --expected-result ${{ parameters.EXPECTED_RESULT }} --timeout 72000
             RET=$?
             if [ $RET -ne 0 ]; then
+                echo "Test plan $TEST_PLAN_ID failed with RC $RET"
                 ((failure_count++))
             fi
+            if [ $RET -eq 2 ]; then
+                echo "Polling timeout, test plan: $TEST_PLAN_ID"
+                ((runtest_polling_timeout++))
+            fi
         done
+
+        # Set variable POLL_AGAIN to "YES" if polling timeout
+        if [ $runtest_polling_timeout -gt 0 ]; then
+            echo "Polling timeout happened, run the next Run test step to poll again"
+            echo "##vso[task.setvariable variable=POLL_AGAIN]YES"
+        fi
 
         if [ $failure_count -eq ${#TEST_PLAN_ID_LIST[@]} ]; then
             echo "All testplan failed, cancel following steps"
@@ -353,10 +353,49 @@ steps:
 
     displayName: "Run test"
     timeoutInMinutes: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-    env:
-      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
-      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
+
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: "SONiC-Automation"
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        set -o
+        echo "Run test2"
+
+        # Check if variable POLL_AGAIN is set and equals to "YES". If not, skip this step
+        if [ "$POLL_AGAIN" != "YES" ]; then
+            echo "Previous Run Test step did not fail with polling timeout. Skip this Run test2 step"
+            exit 0
+        fi
+
+        echo "Polling timeout happened in previous Run test step, run this Run test2 step to poll again"
+
+        echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
+        IFS=',' read -ra TEST_PLAN_ID_LIST <<< "$TEST_PLAN_ID_LIST_STRING"
+        failure_count=0
+        for TEST_PLAN_ID in "${TEST_PLAN_ID_LIST[@]}"
+        do
+            echo -e -n "\033[33mPlease visit Elastictest page \033[0m"
+            echo -n "$(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID "
+            echo -e "\033[33mfor detailed test plan progress \033[0m"
+            # When "EXECUTING" finish, it changes into "KVMDUMP", "FAILED", "CANCELLED" or "FINISHED"
+            echo "[test_plan.py] poll EXECUTING status, timeout 16 hours"
+            python ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state EXECUTING --expected-result ${{ parameters.EXPECTED_RESULT }} --timeout 57600
+            RET=$?
+            if [ $RET -ne 0 ]; then
+                echo "Test plan $TEST_PLAN_ID failed"
+                ((failure_count++))
+            fi
+        done
+
+        if [ $failure_count -eq ${#TEST_PLAN_ID_LIST[@]} ]; then
+            echo "All testplan failed, cancel following steps"
+            exit 3
+        fi
+    displayName: "Run test2"
+    condition: succeededOrFailed()
+    timeoutInMinutes: ${{ parameters.MAX_RUN_TEST_MINUTES }}
 
   - ${{ if eq(parameters.DUMP_KVM_IF_FAIL, 'True') }}:
       - task: AzureCLI@2
@@ -382,10 +421,6 @@ steps:
 
         condition: succeededOrFailed()
         displayName: "KVM dump"
-        env:
-          SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
-          ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
-          SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
 
   - task: AzureCLI@2
     inputs:
@@ -402,7 +437,3 @@ steps:
         done
     condition: always()
     displayName: "Finalize running test plan"
-    env:
-      SONIC_AUTOMATION_SERVICE_PRINCIPAL: $(SONIC_AUTOMATION_SERVICE_PRINCIPAL)
-      ELASTICTEST_MSAL_TENANT_ID: $(ELASTICTEST_MSAL_TENANT_ID)
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -320,31 +320,21 @@ steps:
         echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
         IFS=',' read -ra TEST_PLAN_ID_LIST <<< "$TEST_PLAN_ID_LIST_STRING"
         failure_count=0
-        runtest_polling_timeout=0
         for TEST_PLAN_ID in "${TEST_PLAN_ID_LIST[@]}"
         do
             echo -e -n "\033[33mPlease visit Elastictest page \033[0m"
             echo -n "$(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID "
             echo -e "\033[33mfor detailed test plan progress \033[0m"
             # When "EXECUTING" finish, it changes into "KVMDUMP", "FAILED", "CANCELLED" or "FINISHED"
-            echo "[test_plan.py] poll EXECUTING status, timeout 20 hours"
-            python ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state EXECUTING --expected-result ${{ parameters.EXPECTED_RESULT }} --timeout 72000
+            echo "[test_plan.py] poll EXECUTING status, timeout 22 hours"
+            python ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state EXECUTING --expected-result ${{ parameters.EXPECTED_RESULT }} --timeout 79200
             RET=$?
-            if [ $RET -ne 0 ]; then
+            # RC==2 means polling test plan timeout, do not consider it as failure so far
+            if [ $RET -ne 0 ] && [ $RET -ne 2 ]; then
                 echo "Test plan $TEST_PLAN_ID failed with RC $RET"
                 ((failure_count++))
             fi
-            if [ $RET -eq 2 ]; then
-                echo "Polling timeout, test plan: $TEST_PLAN_ID"
-                ((runtest_polling_timeout++))
-            fi
         done
-
-        # Set variable POLL_AGAIN to "YES" if polling timeout
-        if [ $runtest_polling_timeout -gt 0 ]; then
-            echo "Polling timeout happened, run the next Run test step to poll again"
-            echo "##vso[task.setvariable variable=POLL_AGAIN]YES"
-        fi
 
         if [ $failure_count -eq ${#TEST_PLAN_ID_LIST[@]} ]; then
             echo "All testplan failed, cancel following steps"
@@ -352,49 +342,6 @@ steps:
         fi
 
     displayName: "Run test"
-    timeoutInMinutes: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: "SONiC-Automation"
-      scriptType: 'bash'
-      scriptLocation: 'inlineScript'
-      inlineScript: |
-        set -o
-        echo "Run test2"
-
-        # Check if variable POLL_AGAIN is set and equals to "YES". If not, skip this step
-        if [ "$POLL_AGAIN" != "YES" ]; then
-            echo "Previous Run Test step did not fail with polling timeout. Skip this Run test2 step"
-            exit 0
-        fi
-
-        echo "Polling timeout happened in previous Run test step, run this Run test2 step to poll again"
-
-        echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
-        IFS=',' read -ra TEST_PLAN_ID_LIST <<< "$TEST_PLAN_ID_LIST_STRING"
-        failure_count=0
-        for TEST_PLAN_ID in "${TEST_PLAN_ID_LIST[@]}"
-        do
-            echo -e -n "\033[33mPlease visit Elastictest page \033[0m"
-            echo -n "$(FRONTEND_URL)/scheduler/testplan/$TEST_PLAN_ID "
-            echo -e "\033[33mfor detailed test plan progress \033[0m"
-            # When "EXECUTING" finish, it changes into "KVMDUMP", "FAILED", "CANCELLED" or "FINISHED"
-            echo "[test_plan.py] poll EXECUTING status, timeout 16 hours"
-            python ./.azure-pipelines/test_plan.py poll -i $TEST_PLAN_ID --expected-state EXECUTING --expected-result ${{ parameters.EXPECTED_RESULT }} --timeout 57600
-            RET=$?
-            if [ $RET -ne 0 ]; then
-                echo "Test plan $TEST_PLAN_ID failed"
-                ((failure_count++))
-            fi
-        done
-
-        if [ $failure_count -eq ${#TEST_PLAN_ID_LIST[@]} ]; then
-            echo "All testplan failed, cancel following steps"
-            exit 3
-        fi
-    displayName: "Run test2"
-    condition: succeededOrFailed()
     timeoutInMinutes: ${{ parameters.MAX_RUN_TEST_MINUTES }}
 
   - ${{ if eq(parameters.DUMP_KVM_IF_FAIL, 'True') }}:
@@ -430,6 +377,13 @@ steps:
       inlineScript: |
         set -e
         echo "Try to cancel test plan $TEST_PLAN_ID, cancelling finished test plan has no effect."
+
+        # If TEST_PLAN_TYPE is NIGHTLY, skip the cancel step
+        if [ "${{ parameters.TEST_PLAN_TYPE }}" == "NIGHTLY" ]; then
+            echo "TEST_PLAN_TYPE is NIGHTLY, skip the cancel step as a dirty workaround for az login timeout issue"
+            exit 0
+        fi
+
         IFS=',' read -ra TEST_PLAN_ID_LIST <<< "$TEST_PLAN_ID_LIST_STRING"
         for TEST_PLAN_ID in "${TEST_PLAN_ID_LIST[@]}"
         do

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -162,13 +162,13 @@ steps:
             curl -u :$(MSSONIC-TOKEN) "${{ parameters.MGMT_URL }}&commitOrBranch=${{ parameters.MGMT_BRANCH }}&api-version=5.0-preview.1&path=.azure-pipelines%2Fpr_test_scripts.yaml" -o ./.azure-pipelines/pr_test_scripts.yaml
           fi
         displayName: "Download pr script"
-  # - ${{ else }}:
-  #     - ${{ if ne(parameters.MGMT_BRANCH, 'master') }}:
-  #         - script: |
-  #             # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
-  #             set -ex
-  #             curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
-  #           displayName: "Download test plan script"
+  - ${{ else }}:
+      - ${{ if ne(parameters.MGMT_BRANCH, 'master') }}:
+          - script: |
+              # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
+              set -ex
+              curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
+            displayName: "Download test plan script"
 
   - script: |
       # Check if azure cli is installed. If not, try to install it


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
This change is to address the "az login" timeout after 24 hours issue.

#### How did you do it?
The previous fix to run az login again using System.AccessToken is not working. The reason is that the System.AccessToken has expired when "az login" is executed in test_plan.py.

This change takes advantage of the "timeout" argument of test_plan.py. If test_plan.py has been running for like 20 hours, exit early with a different return code.

In the pipeline yaml, check return code of test_plan.py. If it is 0 or 2 (polling timeout), consider it as success.

The cancel test plan step still run with condition "always()". This step is updated to check TEST_PLAN_TYPE, if it is nightly, exit early to skip cancel test plan because the test plan could still be running.

#### How did you verify/test it?.
Use draft PR to verify the change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
