### PR TITLE
Fix flaky test_set_fans_speed when target speed is low

### DIFF
--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -240,9 +240,11 @@ class TestChassisFans(PlatformApiTestBase):
                 target_speed = random.randint(speed_minimum, speed_maximum)
 
             speed = fan.get_speed(platform_api_conn, i)
+            speed_delta = abs(speed-target_speed)
 
             speed_set = fan.set_speed(platform_api_conn, i, target_speed)       # noqa F841
-            time.sleep(self.get_fan_facts(duthost, i, 5, "speed", "delay"))
+            time_wait = 10 if speed_delta > 40 else 5
+            time.sleep(self.get_fan_facts(duthost, i, time_wait, "speed", "delay"))
 
             act_speed = fan.get_speed(platform_api_conn, i)
             under_speed = fan.is_under_speed(platform_api_conn, i)


### PR DESCRIPTION
### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR handles the flakyness in the testcase platform_tests/test_set_fans_speed caused when the testcase selects a very low or very high target speeds for the fans. The current wait time of 5 seconds is not enough for the fans to reduce their speed to reach the target speed value. 
#### How did you do it?
Added a check to see if the difference between the target speed and actual speed is more than a particular value (40). If the difference is large enough, then change the wait time to 10 seconds from 5.
#### How did you verify/test it?
Ran the testcase multiple times to see if the testcase passes.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation

