### PR TITLE
Skip snmp loopback tests for standalone topos

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1472,11 +1472,10 @@ snmp/test_snmp_link_local.py:
 
 snmp/test_snmp_loopback.py::test_snmp_loopback:
   skip:
-    reason: "Not supported topology backend."
+    reason: "Not supported topology backend. Not supported in standalone topologies."
+    conditions_logical_operator: or
     conditions:
       - "'backend' in topo_name"
-    reason: "Not supported in standalone topologies."
-    conditions:
       - "'standalone' in topo_name"
 
 snmp/test_snmp_pfc_counters.py:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1475,6 +1475,9 @@ snmp/test_snmp_loopback.py::test_snmp_loopback:
     reason: "Not supported topology backend."
     conditions:
       - "'backend' in topo_name"
+    reason: "Not supported in standalone topologies."
+    conditions:
+      - "'standalone' in topo_name"
 
 snmp/test_snmp_pfc_counters.py:
   skip:


### PR DESCRIPTION
### Description of PR
Summary:
snmp_loopback tests do not apply to standalone topologies and should be skipped. This patch skips this test.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The test attempts SNMP loopback with BGP peers, of which there are none in a standalone topology.

#### How did you do it?
Applied skip conditions to the applicable tests in the tests mark conditions yaml file in sonic-mgmt.

#### How did you verify/test it?
Ran the route test suite and confirmed that the desired tests are now skipped.

#### Any platform specific information?
Verified on Arista-7060X6-64DE-128x400G.