### PR TITLE
Use config load_minigraph -y command for images which does not support "--override_config"

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -543,13 +543,15 @@
       - name: execute cli "config load_minigraph --override_config -y" to apply new minigraph
         become: true
         shell: config load_minigraph --override_config -y
-        register: load_minigraph_rc
-        failed_when: load_minigraph_rc.rc != 0 and load_minigraph_rc.rc != 2
+        register: load_minigraph_result
+        failed_when:
+          - load_minigraph_result.rc != 0
+          - "'no such option: --override_config' not in load_minigraph_result.stderr"
 
       - name: execute cli "config load_minigraph -y" to apply new minigraph
         become: true
         shell: config load_minigraph -y
-        when: load_minigraph_rc.rc == 2
+        when: "'no such option: --override_config' in load_minigraph_result.stderr"
 
       - name: Wait for switch to become reachable again
         become: false

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -544,12 +544,12 @@
         become: true
         shell: config load_minigraph --override_config -y
         register: load_minigraph_rc
-        ignore_errors: yes
+        failed_when: load_minigraph_rc.rc != 0 and load_minigraph_rc.rc != 2
 
       - name: execute cli "config load_minigraph -y" to apply new minigraph
         become: true
         shell: config load_minigraph -y
-        when: load_minigraph_rc.rc != 0
+        when: load_minigraph_rc.rc == 2
 
       - name: Wait for switch to become reachable again
         become: false

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -543,6 +543,13 @@
       - name: execute cli "config load_minigraph --override_config -y" to apply new minigraph
         become: true
         shell: config load_minigraph --override_config -y
+        register: load_minigraph_rc
+        ignore_errors: yes
+
+      - name: execute cli "config load_minigraph -y" to apply new minigraph
+        become: true
+        shell: config load_minigraph -y
+        when: load_minigraph_rc.rc != 0
 
       - name: Wait for switch to become reachable again
         become: false


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
Images below 202111 don't support command "--override_config", we need still use `config load_minigraph -y`  to deploy minigraph for devices who has image below 202111. Add a condition here if it failed to use `config load_minigraph --override_config -y`, then switch to old command `config load_minigraph -y`.
<!--

-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Devices with images below 202111 fail to deploy minigraph due to command issue.
#### How did you do it?
If it failed, switch to use old command.
#### How did you verify/test it
Test on a device with 201911 image:
```
TASK [execute cli "config load_minigraph --override_config -y" to apply new minigraph] ***
Thursday 15 August 2024  18:40:35 +0000 (0:00:00.643)       0:02:00.380 ******* 
changed: [str-msn2700-20]

TASK [Print stderr] ************************************************************
Thursday 15 August 2024  18:40:36 +0000 (0:00:01.265)       0:02:01.645 ******* 
ok: [str-msn2700-20] => {
    "msg": "stderr : Error: no such option: --override_config"
}

TASK [execute cli "config load_minigraph -y" to apply new minigraph] ***********
Thursday 15 August 2024  18:40:36 +0000 (0:00:00.129)       0:02:01.774 ******* 
changed: [str-msn2700-20]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
