### PR TITLE
Add drop_packets/vrf/hash/sub_port/gcu/span data plane test to onboarding PR test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -352,9 +352,6 @@ onboarding_t1:
   - hash/test_generic_hash.py
   - gnmi/test_gnmi_countersdb.py
   - platform_tests/test_link_down.py
-  - arp/test_neighbor_mac.py
-  - copp/test_copp.py
-  - crm/test_crm.py
   - stress/test_stress_routes.py
   - drop_packets/test_drop_counters.py
   - sub_port_interfaces/test_sub_port_interfaces.py

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -342,14 +342,25 @@ onboarding_t0:
   - hash/test_generic_hash.py
   - gnmi/test_gnmi_countersdb.py
   - platform_tests/test_link_down.py
+  - span/test_port_mirroring.py
+  - drop_packets/test_drop_counters.py
+  - vrf/test_vrf.py
+  - vrf/test_vrf_attr.py
 
 onboarding_t1:
   - generic_config_updater/test_cacl.py
   - hash/test_generic_hash.py
   - gnmi/test_gnmi_countersdb.py
   - platform_tests/test_link_down.py
+  - arp/test_neighbor_mac.py
+  - copp/test_copp.py
+  - crm/test_crm.py
+  - stress/test_stress_routes.py
+  - drop_packets/test_drop_counters.py
+  - sub_port_interfaces/test_sub_port_interfaces.py
 
 onboarding_dualtor:
+  - arp/test_arp_dualtor.py
   - dualtor/test_ipinip.py
   - dualtor/test_orchagent_slb.py
   - dualtor/test_switchover_failure.py

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -70,6 +70,8 @@ t1-lag:
   - k8s/test_config_reload.py
   - k8s/test_disable_flag.py
   - k8s/test_join_available_master.py
+  # Mpls test only support on t1 platform not t1-lag
+  - mpls/test_mpls.py
   # Neighbor type must be sonic
   - ospf/test_ospf_bfd.py
   # Test is not supported on vs testbed

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -721,21 +721,27 @@ hash/test_generic_hash.py::test_ecmp_and_lag_hash:
 
 hash/test_generic_hash.py::test_lag_member_flap:
   skip:
-    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm'
+    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm, for other platforms, skipping until the issue is addressed'
+    conditions_logical_operator: "OR"
     conditions:
       - "asic_gen == 'spc1'"
+      - https://github.com/sonic-net/sonic-mgmt/issues/13919
 
 hash/test_generic_hash.py::test_lag_member_remove_add:
   skip:
-    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm'
+    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm, for other platforms, skipping until the issue is addressed'
+    conditions_logical_operator: "OR"
     conditions:
       - "asic_gen == 'spc1'"
+      - https://github.com/sonic-net/sonic-mgmt/issues/13919
 
 hash/test_generic_hash.py::test_nexthop_flap:
   skip:
-    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm'
+    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm, for other platforms, skipping until the issue is addressed'
+    conditions_logical_operator: "OR"
     conditions:
       - "asic_gen == 'spc1'"
+      - https://github.com/sonic-net/sonic-mgmt/issues/13919
 
 hash/test_generic_hash.py::test_reboot:
   skip:
@@ -1695,6 +1701,12 @@ vrf/test_vrf.py::TestVrfAclRedirect:
     reason: "Switch does not support ACL REDIRECT_ACTION."
     conditions:
       - "len([capabilities for capabilities in switch.values() if 'REDIRECT_ACTION' in capabilities]) == 0"
+
+vrf/test_vrf.py::TestVrfLoopbackIntf::test_bgp_with_loopback:
+  skip:
+    reason: "VS platform can't get ptf speaker ip as ipv4 unicast peer."
+    conditions:
+      - "asic_type in ['vs']"
 
 #######################################
 #####           vrf_attr          #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -62,6 +62,15 @@ decap/test_decap.py:
       - "asic_type in ['vs']"
 
 #######################################
+#####         drop_packets        #####
+#######################################
+drop_packets/test_drop_counters.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
 #####           dualtor           #####
 #######################################
 dualtor/test_ipinip.py:
@@ -178,6 +187,24 @@ fib/test_fib.py:
       - "asic_type in ['vs']"
 
 #######################################
+#####   generic_config_updater    #####
+#######################################
+generic_config_updater/test_dynamic_acl.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
+#####           hash              #####
+#######################################
+hash/test_generic_hash.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
 #####            ip               #####
 #######################################
 ip/test_ip_packet.py:
@@ -190,6 +217,39 @@ ip/test_ip_packet.py:
 #####            ipfwd            #####
 #######################################
 ipfwd/test_dir_bcast.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
+#####            span             #####
+#######################################
+span/test_port_mirroring.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
+#####     sub_port_interfaces     #####
+#######################################
+sub_port_interfaces/test_sub_port_interfaces.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
+#####             vrf             #####
+#######################################
+vrf/test_vrf.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+vrf/test_vrf_attr.py:
   skip_traffic_test:
     reason: "Skip traffic test for KVM testbed"
     conditions:

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -15,6 +15,8 @@ from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common import config_reload
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test       # noqa F401
 
 RX_DRP = "RX_DRP"
 RX_ERR = "RX_ERR"
@@ -549,7 +551,7 @@ def send_packets(pkt, ptfadapter, ptf_tx_port_id, num_packets=1):
 
 
 def test_equal_smac_dmac_drop(do_test, ptfadapter, setup, fanouthost,
-                              pkt_fields, ports_info, enum_fanout_graph_facts):      # noqa F811
+                              pkt_fields, ports_info, enum_fanout_graph_facts, skip_traffic_test):      # noqa F811
     """
     @summary: Create a packet with equal SMAC and DMAC.
     """
@@ -587,7 +589,8 @@ def test_equal_smac_dmac_drop(do_test, ptfadapter, setup, fanouthost,
     )
 
     group = "L2"
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], comparable_pkt=comparable_pkt)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            comparable_pkt=comparable_pkt, skip_traffic_test=skip_traffic_test)
 
 
 def test_multicast_smac_drop(do_test, ptfadapter, setup, fanouthost,
@@ -631,11 +634,11 @@ def test_multicast_smac_drop(do_test, ptfadapter, setup, fanouthost,
 
     group = "L2"
     do_test(group, pkt, ptfadapter, ports_info,
-            setup["neighbor_sniff_ports"], comparable_pkt=comparable_pkt)
+            setup["neighbor_sniff_ports"], comparable_pkt=comparable_pkt, skip_traffic_test=skip_traffic_test)
 
 
 def test_not_expected_vlan_tag_drop(do_test, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                    ptfadapter, setup, pkt_fields, ports_info):
+                                    ptfadapter, setup, pkt_fields, ports_info, skip_traffic_test):
     """
     @summary: Create a VLAN tagged packet which VLAN ID does not match ingress port VLAN ID.
     """
@@ -668,10 +671,11 @@ def test_not_expected_vlan_tag_drop(do_test, duthosts, enum_rand_one_per_hwsku_f
         )
 
     group = "L2"
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"])
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            skip_traffic_test=skip_traffic_test)
 
 
-def test_dst_ip_is_loopback_addr(do_test, ptfadapter, setup, pkt_fields, tx_dut_ports, ports_info):
+def test_dst_ip_is_loopback_addr(do_test, ptfadapter, setup, pkt_fields, tx_dut_ports, ports_info, skip_traffic_test):
     """
     @summary: Create a packet with loopback destination IP adress.
     """
@@ -689,10 +693,11 @@ def test_dst_ip_is_loopback_addr(do_test, ptfadapter, setup, pkt_fields, tx_dut_
         tcp_dport=pkt_fields["tcp_dport"])
 
     group = "L3"
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
-def test_src_ip_is_loopback_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info):
+def test_src_ip_is_loopback_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, skip_traffic_test):
     """
     @summary: Create a packet with loopback source IP adress.
     """
@@ -710,10 +715,11 @@ def test_src_ip_is_loopback_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_f
         tcp_dport=pkt_fields["tcp_dport"])
 
     group = "L3"
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
-def test_dst_ip_absent(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info):
+def test_dst_ip_absent(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, skip_traffic_test):
     """
     @summary: Create a packet with absent destination IP address.
     """
@@ -741,11 +747,13 @@ def test_dst_ip_absent(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, por
 
     group = "L3"
     print(("msm group {}, setup {}".format(group, setup)))
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
 @pytest.mark.parametrize("ip_addr", ["ipv4", "ipv6"])
-def test_src_ip_is_multicast_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ip_addr, ports_info):
+def test_src_ip_is_multicast_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ip_addr,
+                                  ports_info, skip_traffic_test):
     """
     @summary: Create a packet with multicast source IP adress.
     """
@@ -778,11 +786,12 @@ def test_src_ip_is_multicast_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_
                    ports_info["src_mac"], pkt_fields["ipv4_dst"], ip_src)
 
     group = "L3"
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports, ip_ver=ip_addr)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, ip_ver=ip_addr, skip_traffic_test=skip_traffic_test)
 
 
 def test_src_ip_is_class_e(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                           setup, tx_dut_ports, pkt_fields, ports_info):
+                           setup, tx_dut_ports, pkt_fields, ports_info, skip_traffic_test):
     """
     @summary: Create a packet with source IP address in class E.
     """
@@ -805,12 +814,14 @@ def test_src_ip_is_class_e(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsk
             tcp_dport=pkt_fields["tcp_dport"])
 
         group = "L3"
-        do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+        do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+                tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
 @pytest.mark.parametrize("addr_type, addr_direction", [("ipv4", "src"), ("ipv6", "src"),
                                                        ("ipv4", "dst"), ("ipv6", "dst")])
-def test_ip_is_zero_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, addr_type, addr_direction, ports_info):
+def test_ip_is_zero_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, addr_type, addr_direction,
+                         ports_info, skip_traffic_test):
     """
     @summary: Create a packet with "0.0.0.0" source or destination IP address.
     """
@@ -857,11 +868,11 @@ def test_ip_is_zero_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, a
         pytest.skip("Src IP zero packets are not dropped on Broadcom DNX platform currently")
 
     do_test(group, pkt, ptfadapter, ports_info, list(setup["dut_to_ptf_port_map"].values()), tx_dut_ports,
-            ip_ver=addr_type)
+            ip_ver=addr_type, skip_traffic_test=skip_traffic_test)
 
 
 def test_dst_ip_link_local(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                           setup, tx_dut_ports, pkt_fields, ports_info):
+                           setup, tx_dut_ports, pkt_fields, ports_info, skip_traffic_test):
     """
     @summary: Create a packet with link-local address "169.254.0.0/16".
     """
@@ -884,10 +895,11 @@ def test_dst_ip_link_local(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsk
     group = "L3"
 
     logger.info(pkt_params)
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
-def test_loopback_filter(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info):
+def test_loopback_filter(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, skip_traffic_test):
     """
     @summary: Create a packet drops by loopback-filter. Loop-back filter means that route to the host
               with DST IP of received packet exists on received interface
@@ -915,11 +927,13 @@ def test_loopback_filter(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, p
 
     group = "L3"
 
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
 def test_ip_pkt_with_expired_ttl(duthost, do_test, ptfadapter, setup, tx_dut_ports, pkt_fields,
-                                 ports_info, sai_acl_drop_adj_enabled, configure_copp_drop_for_ttl_error):
+                                 ports_info, sai_acl_drop_adj_enabled, configure_copp_drop_for_ttl_error,
+                                 skip_traffic_test):
     """
     @summary: Create an IP packet with TTL=0.
     """
@@ -940,12 +954,12 @@ def test_ip_pkt_with_expired_ttl(duthost, do_test, ptfadapter, setup, tx_dut_por
 
     group = "L3"
     do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
-            tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
+            tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled, skip_traffic_test=skip_traffic_test)
 
 
 @pytest.mark.parametrize("pkt_field, value", [("version", 1), ("chksum", 10), ("ihl", 1)])
 def test_broken_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, pkt_field,
-                          value, ports_info, sai_acl_drop_adj_enabled):
+                          value, ports_info, sai_acl_drop_adj_enabled, skip_traffic_test):
     """
     @summary: Create a packet with broken IP header.
     """
@@ -964,10 +978,11 @@ def test_broken_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, 
 
     group = "L3"
     do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
-            tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
+            tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled, skip_traffic_test=skip_traffic_test)
 
 
-def test_absent_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, sai_acl_drop_adj_enabled):
+def test_absent_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info,
+                          sai_acl_drop_adj_enabled, skip_traffic_test):
     """
     @summary: Create packets with absent IP header.
     """
@@ -990,12 +1005,12 @@ def test_absent_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, 
     group = "L3"
 
     do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
-            tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
+            tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled, skip_traffic_test=skip_traffic_test)
 
 
 @pytest.mark.parametrize("eth_dst", ["01:00:5e:00:01:02", "ff:ff:ff:ff:ff:ff"])
 def test_unicast_ip_incorrect_eth_dst(do_test, ptfadapter, setup, tx_dut_ports,
-                                      pkt_fields, eth_dst, ports_info):
+                                      pkt_fields, eth_dst, ports_info, skip_traffic_test):
     """
     @summary: Create packets with multicast/broadcast ethernet dst.
     """
@@ -1015,14 +1030,15 @@ def test_unicast_ip_incorrect_eth_dst(do_test, ptfadapter, setup, tx_dut_ports,
         )
 
     group = "L3"
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
 @pytest.mark.parametrize("igmp_version,msg_type", [("v1", "general_query"), ("v3", "general_query"),
                                                    ("v1", "membership_report"), ("v2", "membership_report"),
                                                    ("v3", "membership_report"), ("v2", "leave_group")])
 def test_non_routable_igmp_pkts(do_test, ptfadapter, setup, fanouthost, tx_dut_ports,
-                                pkt_fields, igmp_version, msg_type, ports_info):
+                                pkt_fields, igmp_version, msg_type, ports_info, skip_traffic_test):
     """
     @summary: Create an IGMP non-routable packets.
     """
@@ -1107,11 +1123,12 @@ def test_non_routable_igmp_pkts(do_test, ptfadapter, setup, fanouthost, tx_dut_p
                    pkt.getlayer("IP").dst, pkt_fields["ipv4_src"])
 
     group = "L3"
-    do_test(group, pkt, ptfadapter, ports_info, list(setup["dut_to_ptf_port_map"].values()), tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, list(setup["dut_to_ptf_port_map"].values()),
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
 def test_acl_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                  setup, tx_dut_ports, pkt_fields, acl_ingress, ports_info):
+                  setup, tx_dut_ports, pkt_fields, acl_ingress, ports_info, skip_traffic_test):
     """
         @summary: Verify that DUT drops packet with SRC IP 20.0.0.0/24 matched by ingress ACL
     """
@@ -1135,11 +1152,12 @@ def test_acl_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_fronten
         tcp_dport=pkt_fields["tcp_dport"]
     )
 
-    do_test("ACL", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test("ACL", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
 def test_acl_egress_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                         setup, tx_dut_ports, pkt_fields, acl_egress, ports_info):
+                         setup, tx_dut_ports, pkt_fields, acl_egress, ports_info, skip_traffic_test):
     """
         @summary: Verify that DUT drops packet with DST IP 192.168.144.1/24
         matched by egress ACL and ACL drop counter incremented
@@ -1165,4 +1183,5 @@ def test_acl_egress_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_
         ip_ttl=64
     )
     do_test(discard_group="ACL", pkt=pkt, ptfadapter=ptfadapter, ports_info=ports_info,
-            sniff_ports=setup["neighbor_sniff_ports"], tx_dut_ports=tx_dut_ports, drop_information="OUTDATAACL")
+            sniff_ports=setup["neighbor_sniff_ports"], tx_dut_ports=tx_dut_ports, drop_information="OUTDATAACL",
+            skip_traffic_test=skip_traffic_test)

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -22,6 +22,8 @@ from .drop_packets import L2_COL_KEY, L3_COL_KEY, RX_ERR, RX_DRP, ACL_COUNTERS_U
     test_acl_egress_drop  # noqa F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts  # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test       # noqa F401
 
 pytestmark = [
     pytest.mark.topology("any")
@@ -116,8 +118,9 @@ def handle_backend_acl(duthost, tbinfo):
         duthost.shell('systemctl restart backend-acl')
 
 
-def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info,   # noqa F811
-                      tx_dut_ports=None, skip_counter_check=False, drop_information=None):  # noqa F811
+def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info,     # noqa F811
+                      tx_dut_ports=None, skip_counter_check=False, drop_information=None,   # noqa F811
+                      skip_traffic_test=False):  # noqa F811
     """
     Base test function for verification of L2 or L3 packet drops. Verification type depends on 'discard_group' value.
     Supported 'discard_group' values: 'L2', 'L3', 'ACL', 'NO_DROPS'
@@ -136,6 +139,9 @@ def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, port
     # Some test cases will not increase the drop counter consistently on certain platforms
     if skip_counter_check:
         logger.info("Skipping counter check")
+        return None
+    if skip_traffic_test is True:
+        logger.info("Skipping traffic test")
         return None
 
     if discard_group == "L2":
@@ -269,7 +275,8 @@ def check_if_skip():
 @pytest.fixture(scope='module')
 def do_test(duthosts):
     def do_counters_test(discard_group, pkt, ptfadapter, ports_info, sniff_ports, tx_dut_ports=None,    # noqa F811
-                         comparable_pkt=None, skip_counter_check=False, drop_information=None, ip_ver='ipv4'):
+                         comparable_pkt=None, skip_counter_check=False, drop_information=None, ip_ver='ipv4',
+                         skip_traffic_test=False):      # noqa F811
         """
         Execute test - send packet, check that expected discard counters were incremented and packet was dropped
         @param discard_group: Supported 'discard_group' values: 'L2', 'L3', 'ACL', 'NO_DROPS'
@@ -283,18 +290,22 @@ def do_test(duthosts):
         check_if_skip()
         asic_index = ports_info["asic_index"]
         base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info, tx_dut_ports,
-                          skip_counter_check=skip_counter_check, drop_information=drop_information)
+                          skip_counter_check=skip_counter_check, drop_information=drop_information,
+                          skip_traffic_test=skip_traffic_test)
 
         # Verify packets were not egresed the DUT
         if discard_group != "NO_DROPS":
             exp_pkt = expected_packet_mask(pkt, ip_ver=ip_ver)
+            if skip_traffic_test is True:
+                logger.info("Skipping traffic test")
+                return
             testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=sniff_ports)
 
     return do_counters_test
 
 
 def test_reserved_dmac_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                            setup, fanouthost, pkt_fields, ports_info):  # noqa F811
+                            setup, fanouthost, pkt_fields, ports_info, skip_traffic_test):  # noqa F811
     """
     @summary: Verify that packet with reserved DMAC is dropped and L2 drop counter incremented
     @used_mac_address:
@@ -328,10 +339,12 @@ def test_reserved_dmac_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hws
         )
 
         group = "L2"
-        do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"])
+        do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+                skip_traffic_test=skip_traffic_test)
 
 
-def test_no_egress_drop_on_down_link(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, rif_port_down, ports_info):  # noqa F811
+def test_no_egress_drop_on_down_link(do_test, ptfadapter, setup, tx_dut_ports,                      # noqa F811
+                                     pkt_fields, rif_port_down, ports_info, skip_traffic_test):     # noqa F811
     """
     @summary: Verify that packets on ingress port are not dropped
               when egress RIF link is down and check that drop counters not incremented
@@ -349,11 +362,12 @@ def test_no_egress_drop_on_down_link(do_test, ptfadapter, setup, tx_dut_ports, p
         tcp_dport=pkt_fields["tcp_dport"]
         )
 
-    do_test("NO_DROPS", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test("NO_DROPS", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
 def test_src_ip_link_local(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                           setup, tx_dut_ports, pkt_fields, ports_info):  # noqa F811
+                           setup, tx_dut_ports, pkt_fields, ports_info, skip_traffic_test):  # noqa F811
     """
     @summary: Verify that packet with link-local address "169.254.0.0/16" is dropped and L3 drop counter incremented
     """
@@ -376,10 +390,12 @@ def test_src_ip_link_local(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsk
     pkt = testutils.simple_tcp_packet(**pkt_params)
 
     logger.info(pkt_params)
-    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
-def test_ip_pkt_with_exceeded_mtu(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, mtu_config, ports_info):  # noqa F811
+def test_ip_pkt_with_exceeded_mtu(do_test, ptfadapter, setup, tx_dut_ports,                 # noqa F811
+                                  pkt_fields, mtu_config, ports_info, skip_traffic_test):   # noqa F811
     """
     @summary: Verify that IP packet with exceeded MTU is dropped and L3 drop counter incremented
     """
@@ -409,6 +425,7 @@ def test_ip_pkt_with_exceeded_mtu(do_test, ptfadapter, setup, tx_dut_ports, pkt_
     )
     L2_COL_KEY = RX_ERR
     try:
-        do_test("L2", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"])
+        do_test("L2", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+                skip_traffic_test=skip_traffic_test)
     finally:
         L2_COL_KEY = RX_DRP

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -35,7 +35,8 @@ from tests.generic_config_updater.gu_utils import expect_acl_table_match_multipl
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa F401
 from tests.common.dualtor.dual_tor_utils import setup_standby_ports_on_rand_unselected_tor # noqa F401
 from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh_type
-
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test           # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0'),
@@ -847,7 +848,8 @@ def dynamic_acl_create_dhcp_forward_rule(duthost, setup):
     expect_acl_rule_match(duthost, "DHCPV6_RULE", expected_v6_rule_content, setup)
 
 
-def dynamic_acl_verify_packets(setup, ptfadapter, packets, packets_dropped, src_port=None):
+def dynamic_acl_verify_packets(setup, ptfadapter, packets, packets_dropped, src_port=None,
+                               skip_traffic_test=False):        # noqa F811
     """Verify that the given packets are either dropped/forwarded correctly
 
     Args:
@@ -862,6 +864,9 @@ def dynamic_acl_verify_packets(setup, ptfadapter, packets, packets_dropped, src_
     if src_port is None:
         src_port = setup["blocked_src_port_indice"]
 
+    if skip_traffic_test is True:
+        logger.info("Skipping traffic test")
+        return
     for rule, pkt in list(packets.items()):
         logger.info("Testing that {} packets are correctly {}".format(rule, action_type))
         exp_pkt = build_exp_pkt(pkt)
@@ -1066,7 +1071,8 @@ def test_gcu_acl_arp_rule_creation(rand_selected_dut,
                                    setup,
                                    dynamic_acl_create_table,
                                    prepare_ptf_intf_and_ip,
-                                   toggle_all_simulator_ports_to_rand_selected_tor):  # noqa F811
+                                   toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
+                                   skip_traffic_test):  # noqa F811
     """Test that we can create a blanket ARP/NDP packet forwarding rule with GCU, and that ARP/NDP packets
     are correctly forwarded while all others are dropped."""
 
@@ -1101,7 +1107,8 @@ def test_gcu_acl_arp_rule_creation(rand_selected_dut,
                                ptfadapter,
                                packets=generate_packets(setup, DST_IP_BLOCKED, DST_IPV6_BLOCKED),
                                packets_dropped=True,
-                               src_port=ptf_intf_index)
+                               src_port=ptf_intf_index,
+                               skip_traffic_test=skip_traffic_test)
 
 
 def test_gcu_acl_dhcp_rule_creation(rand_selected_dut,
@@ -1109,8 +1116,9 @@ def test_gcu_acl_dhcp_rule_creation(rand_selected_dut,
                                     ptfadapter,
                                     setup,
                                     dynamic_acl_create_table,
-                                    toggle_all_simulator_ports_to_rand_selected_tor, # noqa F811
-                                    setup_standby_ports_on_rand_unselected_tor):  # noqa F811
+                                    toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
+                                    setup_standby_ports_on_rand_unselected_tor,         # noqa F811
+                                    skip_traffic_test):  # noqa F811
     """Verify that DHCP and DHCPv6 forwarding rules can be created, and that dhcp packets are properly forwarded
     whereas others are dropped"""
 
@@ -1125,7 +1133,8 @@ def test_gcu_acl_dhcp_rule_creation(rand_selected_dut,
     dynamic_acl_verify_packets(setup,
                                ptfadapter,
                                packets=generate_packets(setup, DST_IP_BLOCKED, DST_IPV6_BLOCKED),
-                               packets_dropped=True)
+                               packets_dropped=True,
+                               skip_traffic_test=skip_traffic_test)
 
 
 def test_gcu_acl_drop_rule_creation(rand_selected_dut,
@@ -1133,7 +1142,8 @@ def test_gcu_acl_drop_rule_creation(rand_selected_dut,
                                     ptfadapter,
                                     setup,
                                     dynamic_acl_create_table,
-                                    toggle_all_simulator_ports_to_rand_selected_tor):  # noqa F811
+                                    toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
+                                    skip_traffic_test):  # noqa F811
     """Test that we can create a drop rule via GCU, and that once this drop rule is in place packets
     that match the drop rule are dropped and packets that do not match the drop rule are forwarded"""
 
@@ -1142,12 +1152,14 @@ def test_gcu_acl_drop_rule_creation(rand_selected_dut,
     dynamic_acl_verify_packets(setup,
                                ptfadapter,
                                packets=generate_packets(setup, DST_IP_BLOCKED, DST_IPV6_BLOCKED),
-                               packets_dropped=True)
+                               packets_dropped=True,
+                               skip_traffic_test=skip_traffic_test)
     dynamic_acl_verify_packets(setup,
                                ptfadapter,
                                packets=generate_packets(setup, DST_IP_BLOCKED, DST_IPV6_BLOCKED),
                                packets_dropped=False,
-                               src_port=setup["unblocked_src_port_indice"])
+                               src_port=setup["unblocked_src_port_indice"],
+                               skip_traffic_test=skip_traffic_test)
 
 
 def test_gcu_acl_drop_rule_removal(rand_selected_dut,
@@ -1155,7 +1167,8 @@ def test_gcu_acl_drop_rule_removal(rand_selected_dut,
                                    ptfadapter,
                                    setup,
                                    dynamic_acl_create_table,
-                                   toggle_all_simulator_ports_to_rand_selected_tor):  # noqa F811
+                                   toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
+                                   skip_traffic_test):  # noqa F811
     """Test that once a drop rule is removed, packets that were previously being dropped are now forwarded"""
 
     dynamic_acl_create_three_drop_rules(rand_selected_dut, setup)
@@ -1165,7 +1178,8 @@ def test_gcu_acl_drop_rule_removal(rand_selected_dut,
                                ptfadapter,
                                packets=generate_packets(setup, DST_IP_BLOCKED, DST_IPV6_BLOCKED),
                                packets_dropped=False,
-                               src_port=setup["scale_port_indices"][2])
+                               src_port=setup["scale_port_indices"][2],
+                               skip_traffic_test=skip_traffic_test)
 
 
 def test_gcu_acl_forward_rule_priority_respected(rand_selected_dut,
@@ -1173,7 +1187,8 @@ def test_gcu_acl_forward_rule_priority_respected(rand_selected_dut,
                                                  ptfadapter,
                                                  setup,
                                                  dynamic_acl_create_table,
-                                                 toggle_all_simulator_ports_to_rand_selected_tor):  # noqa F811
+                                                 toggle_all_simulator_ports_to_rand_selected_tor,   # noqa F811
+                                                 skip_traffic_test):  # noqa F811
     """Test that forward rules and drop rules can be created at the same time, with the forward rules having
     higher priority than drop.  Then, perform a traffic test to confirm that packets that match both the forward
     and drop rules are correctly forwarded, as the forwarding rules have higher priority"""
@@ -1181,10 +1196,11 @@ def test_gcu_acl_forward_rule_priority_respected(rand_selected_dut,
     dynamic_acl_create_forward_rules(rand_selected_dut, setup)
     dynamic_acl_create_secondary_drop_rule(rand_selected_dut, setup)
 
-    dynamic_acl_verify_packets(setup, ptfadapter, packets=generate_packets(setup), packets_dropped=False)
+    dynamic_acl_verify_packets(setup, ptfadapter, packets=generate_packets(setup),
+                               packets_dropped=False, skip_traffic_test=skip_traffic_test)
     dynamic_acl_verify_packets(setup, ptfadapter,
                                packets=generate_packets(setup, DST_IP_BLOCKED, DST_IPV6_BLOCKED),
-                               packets_dropped=True)
+                               packets_dropped=True, skip_traffic_test=skip_traffic_test)
 
 
 def test_gcu_acl_forward_rule_replacement(rand_selected_dut,
@@ -1192,7 +1208,8 @@ def test_gcu_acl_forward_rule_replacement(rand_selected_dut,
                                           ptfadapter,
                                           setup,
                                           dynamic_acl_create_table,
-                                          toggle_all_simulator_ports_to_rand_selected_tor):  # noqa F811
+                                          toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
+                                          skip_traffic_test):  # noqa F811
     """Test that forward rules can be created, and then afterwards can have their match pattern updated to a new value.
     Confirm that packets sent that match this new value are correctly forwarded, and that packets that are sent that
     match the old, replaced value are correctly dropped."""
@@ -1206,8 +1223,10 @@ def test_gcu_acl_forward_rule_replacement(rand_selected_dut,
                                packets=generate_packets(setup,
                                                         DST_IP_FORWARDED_REPLACEMENT,
                                                         DST_IPV6_FORWARDED_REPLACEMENT),
-                               packets_dropped=False)
-    dynamic_acl_verify_packets(setup, ptfadapter, packets=generate_packets(setup), packets_dropped=True)
+                               packets_dropped=False,
+                               skip_traffic_test=skip_traffic_test)
+    dynamic_acl_verify_packets(setup, ptfadapter, packets=generate_packets(setup), packets_dropped=True,
+                               skip_traffic_test=skip_traffic_test)
 
 
 @pytest.mark.parametrize("ip_type", ["IPV4", "IPV6"])
@@ -1217,7 +1236,8 @@ def test_gcu_acl_forward_rule_removal(rand_selected_dut,
                                       setup,
                                       ip_type,
                                       dynamic_acl_create_table,
-                                      toggle_all_simulator_ports_to_rand_selected_tor):  # noqa F811
+                                      toggle_all_simulator_ports_to_rand_selected_tor,          # noqa F811
+                                      skip_traffic_test):  # noqa F811
     """Test that if a forward rule is created, and then removed, that packets associated with that rule are properly
     no longer forwarded, and packets associated with the remaining rule are forwarded"""
 
@@ -1234,12 +1254,15 @@ def test_gcu_acl_forward_rule_removal(rand_selected_dut,
     # generate_packets returns ipv4 and ipv6 packets. remove vals from two dicts so that only correct packets remain
     drop_packets.pop(other_type)
     forward_packets.pop(ip_type)
-    dynamic_acl_verify_packets(setup, ptfadapter, drop_packets, packets_dropped=True)
-    dynamic_acl_verify_packets(setup, ptfadapter, forward_packets, packets_dropped=False)
+    dynamic_acl_verify_packets(setup, ptfadapter, drop_packets, packets_dropped=True,
+                               skip_traffic_test=skip_traffic_test)
+    dynamic_acl_verify_packets(setup, ptfadapter, forward_packets, packets_dropped=False,
+                               skip_traffic_test=skip_traffic_test)
 
 
 def test_gcu_acl_scale_rules(rand_selected_dut, rand_unselected_dut, ptfadapter, setup, dynamic_acl_create_table,
-                             toggle_all_simulator_ports_to_rand_selected_tor):  # noqa F811
+                             toggle_all_simulator_ports_to_rand_selected_tor,       # noqa F811
+                             skip_traffic_test):  # noqa F811
     """Perform a scale test, creating 150 forward rules with top priority,
     and then creating a drop rule for every single VLAN port on our device.
     Select any one of our blocked ports, as well as the ips for two of our forward rules,
@@ -1259,23 +1282,27 @@ def test_gcu_acl_scale_rules(rand_selected_dut, rand_unselected_dut, ptfadapter,
                                ptfadapter,
                                generate_packets(setup, v4_dest, v6_dest),
                                packets_dropped=False,
-                               src_port=blocked_scale_port)
+                               src_port=blocked_scale_port,
+                               skip_traffic_test=skip_traffic_test)
     dynamic_acl_verify_packets(setup,
                                ptfadapter,
                                generate_packets(setup, DST_IP_BLOCKED, DST_IPV6_BLOCKED),
                                packets_dropped=True,
-                               src_port=blocked_scale_port)
+                               src_port=blocked_scale_port,
+                               skip_traffic_test=skip_traffic_test)
 
 
 def test_gcu_acl_nonexistent_rule_replacement(rand_selected_dut,
                                               toggle_all_simulator_ports_to_rand_selected_tor, # noqa F811
-                                              setup):
+                                              setup,
+                                              skip_traffic_test):   # noqa F811
     """Confirm that replacing a nonexistent rule results in operation failure"""
     dynamic_acl_replace_nonexistent_rule(rand_selected_dut, setup)
 
 
 def test_gcu_acl_nonexistent_table_removal(rand_selected_dut,
                                            toggle_all_simulator_ports_to_rand_selected_tor, # noqa F811
-                                           setup):
+                                           setup,
+                                           skip_traffic_test):      # noqa F811
     """Confirm that removing a nonexistent table results in operation failure"""
     dynamic_acl_remove_nonexistent_table(rand_selected_dut, setup)

--- a/tests/hash/test_generic_hash.py
+++ b/tests/hash/test_generic_hash.py
@@ -1,6 +1,7 @@
 import pytest
 import random
 import time
+import logging
 
 from tests.common.helpers.assertions import pytest_assert
 from generic_hash_helper import get_hash_fields_from_option, get_ip_version_from_option, get_encap_type_from_option, \
@@ -13,7 +14,9 @@ from generic_hash_helper import mg_facts, restore_init_hash_config, restore_vxla
     get_supported_hash_algorithms, toggle_all_simulator_ports_to_upper_tor   # noqa:F401
 from tests.common.utilities import wait_until
 from tests.ptf_runner import ptf_runner
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory  # noqa F401
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test           # noqa F401
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.reboot import reboot
 from tests.common.config_reload import config_reload
@@ -25,6 +28,7 @@ PTF_LOG_PATH = "/tmp/generic_hash_test.GenericHashTest.log"
 pytestmark = [
     pytest.mark.topology('t0', 't1'),
 ]
+logger = logging.getLogger(__name__)
 
 
 def pytest_generate_tests(metafunc):
@@ -128,7 +132,7 @@ def test_hash_capability(duthost, global_hash_capabilities):  # noqa:F811
 
 
 def test_ecmp_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, global_hash_capabilities,  # noqa:F811
-                   restore_vxlan_port, toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+                   restore_vxlan_port, toggle_all_simulator_ports_to_upper_tor, skip_traffic_test):  # noqa:F811
     """
     Test case to validate the ecmp hash. The hash field to test is randomly chosen from the supported hash fields.
     Args:
@@ -167,6 +171,9 @@ def test_ecmp_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, global_hash_
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
             config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
 
+    if skip_traffic_test is True:
+        logger.info("Skipping traffic test")
+        return
     with allure.step('Start the ptf test, send traffic and check the balancing'):
         # Check the default route before the ptf test
         pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
@@ -184,8 +191,9 @@ def test_ecmp_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, global_hash_
         )
 
 
-def test_lag_hash(duthost, ptfhost, tbinfo, fine_params, mg_facts, restore_configuration,  # noqa:F811
-                  restore_vxlan_port, global_hash_capabilities, toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+def test_lag_hash(duthost, ptfhost, tbinfo, fine_params, mg_facts, restore_configuration,   # noqa:F811
+                  restore_vxlan_port, global_hash_capabilities,                             # noqa F811
+                  toggle_all_simulator_ports_to_upper_tor, skip_traffic_test):              # noqa:F811
     """
     Test case to validate the lag hash. The hash field to test is randomly chosen from the supported hash fields.
     When hash field is in [DST_MAC, ETHERTYPE, VLAN_ID], need to re-configure the dut for L2 traffic.
@@ -237,6 +245,10 @@ def test_lag_hash(duthost, ptfhost, tbinfo, fine_params, mg_facts, restore_confi
             downlink_interfaces, ecmp_hash=False, lag_hash=True, is_l2_test=is_l2_test)
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
             config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
+
+    if skip_traffic_test is True:
+        logger.info("Skipping traffic test")
+        return
     with allure.step('Start the ptf test, send traffic and check the balancing'):
         # Check the default route before the ptf test
         if not is_l2_test:
@@ -267,7 +279,7 @@ def config_all_hash_algorithm(duthost, ecmp_algorithm, lag_algorithm):  # noqa:F
 
 def test_ecmp_and_lag_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, global_hash_capabilities,  # noqa:F811
                            restore_vxlan_port, get_supported_hash_algorithms,  # noqa:F811
-                           toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+                           toggle_all_simulator_ports_to_upper_tor, skip_traffic_test):  # noqa:F811
     """
     Test case to validate the hash behavior when both ecmp and lag hash are configured with a same field.
     The hash field to test is randomly chosen from the supported hash fields.
@@ -302,6 +314,10 @@ def test_ecmp_and_lag_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, glob
             downlink_interfaces, ecmp_hash=True, lag_hash=True)
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
             config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
+
+    if skip_traffic_test is True:
+        logger.info("Skipping traffic test")
+        return
     with allure.step('Start the ptf test, send traffic and check the balancing'):
         # Check the default route before the ptf test
         pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
@@ -321,7 +337,7 @@ def test_ecmp_and_lag_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, glob
 
 def test_nexthop_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_interfaces,  # noqa:F811
                       restore_vxlan_port, global_hash_capabilities, get_supported_hash_algorithms,  # noqa:F811
-                      toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+                      toggle_all_simulator_ports_to_upper_tor, skip_traffic_test):  # noqa:F811
     """
     Test case to validate the ecmp hash when there is nexthop flapping.
     The hash field to test is randomly chosen from the supported hash fields.
@@ -357,21 +373,23 @@ def test_nexthop_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_i
             downlink_interfaces, ecmp_hash=True, lag_hash=True)
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
             config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
-    with allure.step('Start the ptf test, send traffic and check the balancing'):
-        # Check the default route before the ptf test
-        pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
-                      'The default route is not available or some nexthops are missing.')
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+
+    if not skip_traffic_test:
+        with allure.step('Start the ptf test, send traffic and check the balancing'):
+            # Check the default route before the ptf test
+            pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
+                          'The default route is not available or some nexthops are missing.')
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
     with allure.step('Randomly shutdown 1 nexthop interface'):
         interface = random.choice(list(uplink_interfaces.keys()))
         remaining_uplink_interfaces = uplink_interfaces.copy()
@@ -380,41 +398,44 @@ def test_nexthop_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_i
         _, ptf_params['expected_port_groups'] = get_ptf_port_indices(
             mg_facts, downlink_interfaces=[], uplink_interfaces=remaining_uplink_interfaces)
         shutdown_interface(duthost, interface)
-    with allure.step('Start the ptf test, send traffic and check the balancing'):
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+    if not skip_traffic_test:
+        with allure.step('Start the ptf test, send traffic and check the balancing'):
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
     with allure.step('Startup the interface, and then flap it 3 more times'):
         startup_interface(duthost, interface)
         flap_interfaces(duthost, [interface], times=3)
         pytest_assert(wait_until(10, 2, 0, check_default_route, duthost, uplink_interfaces.keys()),
                       'The default route is not restored after the flapping.')
         ptf_params['expected_port_groups'] = origin_ptf_expected_port_groups
-    with allure.step('Start the ptf test, send traffic and check the balancing'):
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+    if not skip_traffic_test:
+        with allure.step('Start the ptf test, send traffic and check the balancing'):
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
 
-def test_lag_member_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_configuration,  # noqa:F811
-                         restore_interfaces, global_hash_capabilities, restore_vxlan_port,  # noqa:F811
-                         get_supported_hash_algorithms, toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+def test_lag_member_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_configuration,    # noqa F811
+                         restore_interfaces, global_hash_capabilities, restore_vxlan_port,          # noqa F811
+                         get_supported_hash_algorithms, toggle_all_simulator_ports_to_upper_tor,    # noqa F811
+                         skip_traffic_test):                                                        # noqa F811
     """
     Test case to validate the lag hash when there is lag member flapping.
     The hash field to test is randomly chosen from the supported hash fields.
@@ -466,22 +487,24 @@ def test_lag_member_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restor
             downlink_interfaces, ecmp_hash=True, lag_hash=True, is_l2_test=is_l2_test)
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
             config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
-    with allure.step('Start the ptf test, send traffic and check the balancing'):
-        # Check the default route before the ptf test
-        if not is_l2_test:
-            pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
-                          'The default route is not available or some nexthops are missing.')
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+
+    if not skip_traffic_test:
+        with allure.step('Start the ptf test, send traffic and check the balancing'):
+            # Check the default route before the ptf test
+            if not is_l2_test:
+                pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
+                              'The default route is not available or some nexthops are missing.')
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
     with allure.step('Randomly select one member in each portchannel and flap them 3 times'):
         # Randomly choose the members to flap
@@ -496,24 +519,25 @@ def test_lag_member_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restor
         with allure.step('Wait for the default route to recover'):
             pytest_assert(wait_until(30, 5, 0, check_default_route, duthost, uplink_interfaces.keys()),
                           'The default route is not available or some nexthops are missing.')
+    if not skip_traffic_test:
+        with allure.step('Start the ptf test, send traffic and check the balancing'):
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
-    with allure.step('Start the ptf test, send traffic and check the balancing'):
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
 
-
-def test_lag_member_remove_add(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_configuration,  # noqa:F811
-                               restore_interfaces, global_hash_capabilities, restore_vxlan_port,  # noqa:F811
-                               get_supported_hash_algorithms, toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+def test_lag_member_remove_add(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_configuration,      # noqa F811
+                               restore_interfaces, global_hash_capabilities, restore_vxlan_port,            # noqa F811
+                               get_supported_hash_algorithms, toggle_all_simulator_ports_to_upper_tor,      # noqa F811
+                               skip_traffic_test):                                                          # noqa F811
     """
     Test case to validate the lag hash when a lag member is removed from the lag and added back for
     a few times.
@@ -566,22 +590,23 @@ def test_lag_member_remove_add(duthost, tbinfo, ptfhost, fine_params, mg_facts, 
             downlink_interfaces, ecmp_hash=True, lag_hash=True, is_l2_test=is_l2_test)
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
             config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
-    with allure.step('Start the ptf test, send traffic and check the balancing'):
-        # Check the default route before the ptf test
-        if not is_l2_test:
-            pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
-                          'The default route is not available or some nexthops are missing.')
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+    if not skip_traffic_test:
+        with allure.step('Start the ptf test, send traffic and check the balancing'):
+            # Check the default route before the ptf test
+            if not is_l2_test:
+                pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
+                              'The default route is not available or some nexthops are missing.')
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
     with allure.step('Randomly select one member in each portchannel and remove it from the lag and add it back'):
         # Randomly choose the members to remove/add
@@ -594,23 +619,24 @@ def test_lag_member_remove_add(duthost, tbinfo, ptfhost, fine_params, mg_facts, 
             pytest_assert(wait_until(30, 5, 0, check_default_route, duthost, uplink_interfaces.keys()),
                           'The default route is not available or some nexthops are missing.')
 
-    with allure.step('Start the ptf test, send traffic and check the balancing'):
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+    if not skip_traffic_test:
+        with allure.step('Start the ptf test, send traffic and check the balancing'):
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
 
-def test_reboot(duthost, tbinfo, ptfhost, localhost, fine_params, mg_facts, restore_vxlan_port,  # noqa:F811
-                global_hash_capabilities, reboot_type, get_supported_hash_algorithms,  # noqa:F811
-                toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+def test_reboot(duthost, tbinfo, ptfhost, localhost, fine_params, mg_facts, restore_vxlan_port,     # noqa F811
+                global_hash_capabilities, reboot_type, get_supported_hash_algorithms,               # noqa F811
+                toggle_all_simulator_ports_to_upper_tor, skip_traffic_test):                        # noqa F811
     """
     Test case to validate the hash behavior after fast/warm/cold reboot.
     The hash field to test is randomly chosen from the supported hash fields.
@@ -646,21 +672,22 @@ def test_reboot(duthost, tbinfo, ptfhost, localhost, fine_params, mg_facts, rest
             downlink_interfaces, ecmp_hash=True, lag_hash=True)
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
             config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
-    with allure.step('Start the ptf test, send traffic and check the balancing'):
-        # Check the default route before the ptf test
-        pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
-                      'The default route is not available or some nexthops are missing.')
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+    if not skip_traffic_test:
+        with allure.step('Start the ptf test, send traffic and check the balancing'):
+            # Check the default route before the ptf test
+            pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
+                          'The default route is not available or some nexthops are missing.')
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
     with allure.step(f'Randomly choose a reboot type: {reboot_type}, and reboot'):
         # Save config if reboot type is config reload or cold reboot
@@ -679,18 +706,19 @@ def test_reboot(duthost, tbinfo, ptfhost, localhost, fine_params, mg_facts, rest
     with allure.step('Check the route is established'):
         pytest_assert(wait_until(60, 10, 0, check_default_route, duthost, uplink_interfaces.keys()),
                       "The default route is not established after the cold reboot.")
-    with allure.step('Start the ptf test, send traffic and check the balancing'):
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+    if not skip_traffic_test:
+        with allure.step('Start the ptf test, send traffic and check the balancing'):
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/span/span_helpers.py
+++ b/tests/span/span_helpers.py
@@ -5,7 +5,7 @@ Helper functions for span tests
 import ptf.testutils as testutils
 
 
-def send_and_verify_mirrored_packet(ptfadapter, src_port, monitor):
+def send_and_verify_mirrored_packet(ptfadapter, src_port, monitor, skip_traffic_test=False):
     '''
     Send packet from ptf and verify it on monitor port
 
@@ -18,6 +18,8 @@ def send_and_verify_mirrored_packet(ptfadapter, src_port, monitor):
 
     pkt = testutils.simple_icmp_packet(eth_src=src_mac, eth_dst='ff:ff:ff:ff:ff:ff')
 
+    if skip_traffic_test is True:
+        return
     ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, src_port, pkt)
     testutils.verify_packet(ptfadapter, pkt, monitor)

--- a/tests/span/test_port_mirroring.py
+++ b/tests/span/test_port_mirroring.py
@@ -6,13 +6,15 @@ import pytest
 
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
 from span_helpers import send_and_verify_mirrored_packet
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test       # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t0')
 ]
 
 
-def test_mirroring_rx(ptfadapter, setup_session):
+def test_mirroring_rx(ptfadapter, setup_session, skip_traffic_test):    # noqa F811
     '''
     Test case #1
     Verify ingress direction session
@@ -26,10 +28,11 @@ def test_mirroring_rx(ptfadapter, setup_session):
     '''
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source1_index'],
-                                    setup_session['destination_index'])
+                                    setup_session['destination_index'],
+                                    skip_traffic_test=skip_traffic_test)
 
 
-def test_mirroring_tx(ptfadapter, setup_session):
+def test_mirroring_tx(ptfadapter, setup_session, skip_traffic_test):    # noqa F811
     '''
     Test case #2
     Verify egress direction session
@@ -43,10 +46,11 @@ def test_mirroring_tx(ptfadapter, setup_session):
     '''
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source2_index'],
-                                    setup_session['destination_index'])
+                                    setup_session['destination_index'],
+                                    skip_traffic_test=skip_traffic_test)
 
 
-def test_mirroring_both(ptfadapter, setup_session):
+def test_mirroring_both(ptfadapter, setup_session, skip_traffic_test):    # noqa F811
     '''
     Test case #3
     Verify bidirectional session
@@ -63,14 +67,16 @@ def test_mirroring_both(ptfadapter, setup_session):
     '''
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source1_index'],
-                                    setup_session['destination_index'])
+                                    setup_session['destination_index'],
+                                    skip_traffic_test=skip_traffic_test)
 
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source2_index'],
-                                    setup_session['destination_index'])
+                                    setup_session['destination_index'],
+                                    skip_traffic_test=skip_traffic_test)
 
 
-def test_mirroring_multiple_source(ptfadapter, setup_session):
+def test_mirroring_multiple_source(ptfadapter, setup_session, skip_traffic_test):    # noqa F811
     '''
     Test case #4
     Verify ingress direction session with multiple source ports
@@ -87,8 +93,10 @@ def test_mirroring_multiple_source(ptfadapter, setup_session):
     '''
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source1_index'],
-                                    setup_session['destination_index'])
+                                    setup_session['destination_index'],
+                                    skip_traffic_test=skip_traffic_test)
 
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source2_index'],
-                                    setup_session['destination_index'])
+                                    setup_session['destination_index'],
+                                    skip_traffic_test=skip_traffic_test)

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -2,6 +2,7 @@ import os
 import time
 import random
 import ipaddress
+import logging
 
 from collections import OrderedDict
 
@@ -20,6 +21,7 @@ from tests.common.utilities import wait_until
 from tests.common.pkt_filter.filter_pkt_in_buffer import FilterPktBuffer
 from tests.common import constants
 
+logger = logging.getLogger(__name__)
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 DUT_TMP_DIR = os.path.join('tmp', os.path.basename(BASE_DIR))
@@ -84,7 +86,7 @@ def create_packet(eth_dst, eth_src, ip_dst, ip_src, vlan_vid, tr_type, ttl, dl_v
 
 def generate_and_verify_traffic(duthost, ptfadapter, src_port, dst_port, ptfhost=None, ip_src='', ip_dst='',
                                 pkt_action=None, type_of_traffic='ICMP', ttl=64, pktlen=100, ip_tunnel=None,
-                                **kwargs):
+                                skip_traffic_test=False, **kwargs):
     """
     Send packet from PTF to DUT and
     verify that DUT sends/doesn't packet to PTF.
@@ -103,6 +105,9 @@ def generate_and_verify_traffic(duthost, ptfadapter, src_port, dst_port, ptfhost
         pktlen: packet length
         ip_tunnel: Tunnel IP address of DUT
     """
+    if skip_traffic_test is True:
+        logger.info("Skipping traffic test")
+        return
     type_of_traffic = [type_of_traffic] if not isinstance(type_of_traffic, list) else type_of_traffic
 
     for tr_type in type_of_traffic:

--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -15,7 +15,8 @@ from sub_ports_helpers import remove_vlan
 from sub_ports_helpers import check_sub_port
 from sub_ports_helpers import remove_sub_port
 from sub_ports_helpers import create_sub_port_on_dut
-
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test       # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t0', 't1')
@@ -346,7 +347,8 @@ class TestSubPorts(object):
                                             ttl=63,
                                             pktlen=pktlen)
 
-    def test_tunneling_between_sub_ports(self, duthost, ptfadapter, apply_tunnel_table_to_dut, apply_route_config):
+    def test_tunneling_between_sub_ports(self, duthost, ptfadapter, apply_tunnel_table_to_dut,
+                                         apply_route_config, skip_traffic_test):    # noqa F811
         """
         Validates that packets are routed between sub-ports.
 
@@ -379,9 +381,11 @@ class TestSubPorts(object):
                                             ip_tunnel=sub_ports[src_port]['ip'],
                                             pkt_action='fwd',
                                             type_of_traffic='decap',
-                                            ttl=63)
+                                            ttl=63,
+                                            skip_traffic_test=skip_traffic_test)
 
-    def test_balancing_sub_ports(self, duthost, ptfhost, ptfadapter, apply_balancing_config):
+    def test_balancing_sub_ports(self, duthost, ptfhost, ptfadapter,
+                                 apply_balancing_config, skip_traffic_test):        # noqa F811
         """
         Validates load-balancing when sub-port is part of ECMP
         Test steps:
@@ -414,12 +418,13 @@ class TestSubPorts(object):
                                         dst_port=dst_ports,
                                         ip_dst=ip_dst,
                                         type_of_traffic='balancing',
-                                        ttl=63)
+                                        ttl=63,
+                                        skip_traffic_test=skip_traffic_test)
 
 
 class TestSubPortsNegative(object):
     def test_packet_routed_with_invalid_vlan(self, duthost, ptfadapter, apply_config_on_the_dut,
-                                             apply_config_on_the_ptf):
+                                             apply_config_on_the_ptf, skip_traffic_test):       # noqa F811
         """
         Validates that packet aren't routed if sub-ports have invalid VLAN ID.
 
@@ -443,11 +448,13 @@ class TestSubPortsNegative(object):
                                         ip_src=value['neighbor_ip'],
                                         dst_port=sub_port,
                                         ip_dst=value['ip'],
-                                        pkt_action='drop')
+                                        pkt_action='drop',
+                                        skip_traffic_test=skip_traffic_test)
 
 
 class TestSubPortStress(object):
-    def test_max_numbers_of_sub_ports(self, duthost, ptfadapter, apply_config_on_the_dut, apply_config_on_the_ptf):
+    def test_max_numbers_of_sub_ports(self, duthost, ptfadapter, apply_config_on_the_dut,
+                                      apply_config_on_the_ptf, skip_traffic_test):      # noqa F811
         """
         Validates that 256 sub-ports can be created per port or LAG
 
@@ -480,4 +487,5 @@ class TestSubPortStress(object):
                                         ip_src=value['neighbor_ip'],
                                         dst_port=sub_port,
                                         ip_dst=value['ip'],
-                                        pkt_action='fwd')
+                                        pkt_action='fwd',
+                                        skip_traffic_test=skip_traffic_test)

--- a/tests/vrf/vrf_neigh.j2
+++ b/tests/vrf/vrf_neigh.j2
@@ -7,9 +7,9 @@
 {% endif -%}
 {%- endmacro %}
 
-{% for intf, ip_facts in intf_ips.iteritems() -%}
+{% for intf, ip_facts in intf_ips.items() -%}
 {% if 'Loopback' not in intf -%}
-{% for ver, ips in ip_facts.iteritems() -%}
+{% for ver, ips in ip_facts.items() -%}
 {% for ip in ips -%}
 {{ ip.ip + 1 }} {{ gen_dst_ports(intf) }}
 {% endfor -%}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed
#### How did you do it?
Add drop_packets/vrf/hash/sub_port/gcu/span data plane test to onboarding PR test and skip traffic test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
