### PR TITLE
[202405][Nokia-7215] Set timeout = 180s for config reload cmd

### DIFF
--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -5,7 +5,7 @@ This script is to cover the test case 'Reload configuration' in the SONiC platfo
 https://github.com/sonic-net/SONiC/blob/master/doc/pmon/sonic_platform_test_plan.md
 """
 import logging
-
+import time
 import pytest
 
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F401
@@ -110,6 +110,31 @@ def check_database_status(duthost):
     return True
 
 
+def execute_config_reload_cmd(duthost, timeout=120, check_interval=5):
+    start_time = time.time()
+    _, res = duthost.shell("sudo config reload -y",
+                           executable="/bin/bash",
+                           module_ignore_errors=True,
+                           module_async=True)
+
+    while not res.ready():
+        elapsed_time = time.time() - start_time
+        if elapsed_time > timeout:
+            logging.info("Config reload command did not complete within {} seconds".format(timeout))
+            return False, None
+
+        logging.debug("Waiting for config reload command to complete. Elapsed time: {} seconds.".format(elapsed_time))
+        time.sleep(check_interval)
+
+    if res.successful():
+        result = res.get()
+        logging.debug("Config reload command result: {}".format(result))
+        return True, result
+    else:
+        logging.info("Config reload command execution failed: {}".format(res))
+        return False, None
+
+
 def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname, delayed_services,
                                      localhost, conn_graph_facts, xcvr_skip_list):      # noqa F811
     """
@@ -129,25 +154,22 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     wait_until(360, 1, 0, check_database_status, duthost)
 
     logging.info("Reload configuration check")
-    out = duthost.shell("sudo config reload -y",
-                        executable="/bin/bash", module_ignore_errors=True)
+    result, out = execute_config_reload_cmd(duthost)
     # config reload command shouldn't work immediately after system reboot
-    assert "Retry later" in out['stdout']
+    assert result and "Retry later" in out['stdout']
 
     assert wait_until(300, 20, 0, config_system_checks_passed, duthost, delayed_services)
 
     # After the system checks succeed the config reload command should not throw error
-    out = duthost.shell("sudo config reload -y",
-                        executable="/bin/bash", module_ignore_errors=True)
-    assert "Retry later" not in out['stdout']
+    result, out = execute_config_reload_cmd(duthost)
+    assert result and "Retry later" not in out['stdout']
 
     # Immediately after one config reload command, another shouldn't execute and wait for system checks
     logging.info("Checking config reload after system is up")
     # Check if all database containers have started
     wait_until(60, 1, 0, check_database_status, duthost)
-    out = duthost.shell("sudo config reload -y",
-                        executable="/bin/bash", module_ignore_errors=True)
-    assert "Retry later" in out['stdout']
+    result, out = execute_config_reload_cmd(duthost)
+    assert result and "Retry later" in out['stdout']
     assert wait_until(300, 20, 0, config_system_checks_passed, duthost, delayed_services)
 
     logging.info("Stopping swss docker and checking config reload")
@@ -158,9 +180,8 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
         duthost.shell("sudo service swss stop")
 
     # Without swss running config reload option should not proceed
-    out = duthost.shell("sudo config reload -y",
-                        executable="/bin/bash", module_ignore_errors=True)
-    assert "Retry later" in out['stdout']
+    result, out = execute_config_reload_cmd(duthost)
+    assert result and "Retry later" in out['stdout']
 
     # However with force option config reload should proceed
     logging.info("Performing force config reload")


### PR DESCRIPTION
Backport PR #13922 and #13361

#### What is the motivation for this PR?
For Nokia-7215, 120 seconds is not enough for `config reload` command. Extend the time to 180s to make testcase stable.

#### How did you do it?
Set `config reload` timeout to 180s for Nokia-7215.

#### How did you verify/test it?
Verified on Nokia-7215 Mx testbed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
