### PR TITLE
Move stable onboarding t0/t1/dualtor test to PR checker

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -10,6 +10,7 @@ t0:
   - arp/test_stress_arp.py
   - arp/test_tagged_arp.py
   - arp/test_wr_arp.py
+  - arp/test_unknown_mac.py
   - autorestart/test_container_autorestart.py
   - bgp/test_bgp_dual_asn.py
   - bgp/test_bgp_fact.py
@@ -183,6 +184,8 @@ t0:
   - vlan/test_vlan.py
   - vlan/test_vlan_ping.py
   - vxlan/test_vnet_route_leak.py
+  - vxlan/test_vnet_vxlan.py
+  - vxlan/test_vxlan_decap.py
   - test_pktgen.py
   - bgp/test_bgp_peer_shutdown.py
   - clock/test_clock.py
@@ -217,6 +220,15 @@ t0-sonic:
 
 dualtor:
   - arp/test_arp_extended.py
+  - dualtor/test_ipinip.py
+  - dualtor/test_switchover_failure.py
+  - dualtor/test_tor_ecn.py
+  - dualtor/test_tunnel_memory_leak.py
+  - dualtor_io/test_heartbeat_failure.py
+  - dualtor_io/test_link_drop.py
+  - dualtor_io/test_normal_op.py
+  - dualtor_io/test_tor_bgp_failure.py
+  - dualtor_io/test_tor_failure.py
   - dualtor_mgmt/test_grpc_periodical_sync.py
   - dualtor_mgmt/test_server_failure.py
   - dualtor_mgmt/test_toggle_mux.py
@@ -278,6 +290,8 @@ t1-lag:
   - sub_port_interfaces/test_show_subinterface.py
   - test_interfaces.py
   - test_pktgen.py
+  - vxlan/test_vxlan_crm.py
+  - vxlan/test_vxlan_ecmp.py
 
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py
@@ -340,10 +354,7 @@ onboarding_t0:
   - snmp/test_snmp_link_local.py
   - snmp/test_snmp_queue_counters.py
   - sub_port_interfaces/test_sub_port_interfaces.py
-  - arp/test_unknown_mac.py
   - hash/test_generic_hash.py
-  - vxlan/test_vnet_vxlan.py
-  - vxlan/test_vxlan_decap.py
 
 onboarding_t1:
   - generic_config_updater/test_cacl.py
@@ -351,22 +362,11 @@ onboarding_t1:
   - gnmi/test_gnmi_countersdb.py
   - platform_tests/test_link_down.py
   - vxlan/test_vxlan_bfd_tsa.py
-  - vxlan/test_vxlan_crm.py
-  - vxlan/test_vxlan_ecmp.py
   - vxlan/test_vxlan_ecmp_switchover.py
 
 onboarding_dualtor:
-  - dualtor/test_ipinip.py
   - dualtor/test_orchagent_slb.py
-  - dualtor/test_switchover_failure.py
-  - dualtor/test_tor_ecn.py
-  - dualtor/test_tunnel_memory_leak.py
-  - dualtor_io/test_heartbeat_failure.py
-  - dualtor_io/test_link_drop.py
   - dualtor_io/test_link_failure.py
-  - dualtor_io/test_normal_op.py
-  - dualtor_io/test_tor_bgp_failure.py
-  - dualtor_io/test_tor_failure.py
   - dualtor_mgmt/test_ingress_drop.py
   - dualtor_mgmt/test_dualtor_bgp_update_delay.py
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Some dataplane test scripts have been added to PR test and put into optional onboarding job to test case performance, I calculated the success rate of test scripts in recent 5 days, I think I can move high success rate test scripts to t0/t1/dualtor job now
TestbedName | FilePath | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | --
vms-kvm-t0 | arp/test_unknown_mac.py | 303 | 11 | 314 | 0.965
vms-kvm-t0 | vxlan/test_vnet_vxlan.py | 104 | 0 | 104 | 1
vms-kvm-t0 | vxlan/test_vxlan_decap.py | 78 | 0 | 78 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_crm.py | 208 | 11 | 219 | 0.9498
vms-kvm-t1-lag | vxlan/test_vxlan_ecmp.py | 1781 | 7 | 1788 | 0.9961
vms-kvm-dual-t0 | dualtor/test_ipinip.py | 267 | 4 | 271 | 0.9852
vms-kvm-dual-t0 | dualtor/test_switchover_failure.py | 318 | 22 | 340 | 0.9353
vms-kvm-dual-t0 | dualtor/test_tor_ecn.py | 1461 | 5 | 1466 | 0.9966
vms-kvm-dual-t0 | dualtor/test_tunnel_memory_leak.py | 176 | 7 | 183 | 0.9617
vms-kvm-dual-t0 | dualtor_io/test_heartbeat_failure.py | 876 | 20 | 896 | 0.9777
vms-kvm-dual-t0 | dualtor_io/test_link_drop.py | 1016 | 6 | 1022 | 0.9941
vms-kvm-dual-t0 | dualtor_io/test_normal_op.py | 2008 | 40 | 2048 | 0.9805
vms-kvm-dual-t0 | dualtor_io/test_tor_bgp_failure.py | 920 | 14 | 934 | 0.985
vms-kvm-dual-t0 | dualtor_io/test_tor_failure.py | 728 | 20 | 748 | 0.9733
#### How did you do it?
Move test from onboarding job to t0/t1/dualtor job
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
