### PR TITLE
[202311]Add test_acl_egress_drop to skip list on Cisco 8111 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -308,6 +308,12 @@ drop_packets/test_drop_counters.py::test_acl_drop:
     conditions:
       - "platform in ['x86_64-8111_32eh_o-r0']"
 
+drop_packets/test_drop_counters.py::test_acl_egress_drop:
+  skip:
+    reason: "Cisco 8111 platform has known issue with test_acl_egress_drop"
+    conditions:
+      - "platform in ['x86_64-8111_32eh_o-r0']"
+
 #######################################
 #####           dualtor           #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add test_acl_egress_drop to skip list on Cisco 8111 platform
This is 202311 branch only

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Cisco 8111 platform doesn't support egress ACL counter.

#### How did you do it?
Add test_acl_egress_drop to skip list on Cisco 8111 platform

#### How did you verify/test it?
Verify with Cisco 8111 physical testbed.

#### Any platform specific information?
Cisco 8111 platform

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
