### PR TITLE
Fixed copp/test_policer testcase for DHCP, DHCP6, LLDP and UDLD scenarios for marvell based platforms

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -347,8 +347,11 @@ class DHCPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for DHCP
-        if self.hw_sku in {"Nokia-M0-7215", "Celestica-E1031-T48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4"}:
             self.PPS_LIMIT = 300
+        # Marvell based platforms have cir/cbs in steps of 125
+        elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
+            self.PPS_LIMIT = 250
         else:
             self.PPS_LIMIT = 100
         self.PPS_LIMIT_MIN = self.PPS_LIMIT * 0.9
@@ -388,8 +391,11 @@ class DHCP6Test(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for DHCPv6
-        if self.hw_sku in {"Nokia-M0-7215", "Celestica-E1031-T48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4"}:
             self.PPS_LIMIT = 300
+        # Marvell based platforms have cir/cbs in steps of 125
+        elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
+            self.PPS_LIMIT = 250
         else:
             self.PPS_LIMIT = 100
         self.PPS_LIMIT_MIN = self.PPS_LIMIT * 0.9
@@ -448,8 +454,11 @@ class LLDPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for LLDP
-        if self.hw_sku in {"Nokia-M0-7215", "Celestica-E1031-T48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4"}:
             self.PPS_LIMIT = 300
+        # Marvell based platforms have cir/cbs in steps of 125
+        elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
+            self.PPS_LIMIT = 250
         else:
             self.PPS_LIMIT = 100
         self.PPS_LIMIT_MIN = self.PPS_LIMIT * 0.9
@@ -476,8 +485,12 @@ class UDLDTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for UDLD
-        if self.hw_sku in {"Nokia-M0-7215", "Celestica-E1031-T48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4"}:
             self.PPS_LIMIT = 300
+        # Marvell based platforms have cir/cbs in steps of 125
+        elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
+            self.PPS_LIMIT = 250
+
         else:
             self.PPS_LIMIT = 100
         self.PPS_LIMIT_MIN = self.PPS_LIMIT * 0.9


### PR DESCRIPTION
### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Recently, a change was made in the test_policer testcase in copp_tests.py to retain the default value of cir/cbs for queue4_group3 (default value for mgmt is 300) instead of changing it to 600 on the DUT during the testcase run. The PR for this change is here - https://github.com/sonic-net/sonic-mgmt/pull/12836.  For marvell based platforms like Nokia-7215-T1 and Nokia-7215-A1, the cir/cbs values are supported in steps of 125. Therefore, a value of 300 in the copp_cfg.json will set it to 250 internally since 300 is not in steps of 125.  This was confirmed by Marvell - "Per talk, the policer/ traffic metering can work in packet per-second mode. The granularity is in step of 125 pps. So it’s 125, 250 …etc  Minimum is 125."
The PPS_LIMIT_MIN and PPS_LIMIT_MAX is therefore set in the testcase to 270,390 respectively which is completely out of range and causes this testcase to fail. Therefore, this PR sets cir/cbs to 250 for Marvell based platforms. 

#### How did you do it?
Added a platform specific check in copp_tests.py to change the PPS_LIMIT to 250 for Nokia platforms.
#### How did you verify/test it?
Ran test_policer testcase for DHCP, DHCP6, LLDP and UDLD. Verified that the testcase passes.
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA

