### PR TITLE
[ansible][minigraph] add support for adding autonegotiation in minigraph templates and fanout EOS

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -311,7 +311,7 @@ error handling: checks if attribute values are None type or string "None"
 
 
 def makeSonicLabLinks(data, outfile):
-    csv_columns = "StartDevice,StartPort,EndDevice,EndPort,BandWidth,VlanID,VlanMode,Autoneg,SlotId"
+    csv_columns = "StartDevice,StartPort,EndDevice,EndPort,BandWidth,VlanID,VlanMode,AutoNeg,SlotId"
     topology = data
     csv_file = outfile
 
@@ -347,10 +347,13 @@ def makeSonicLabLinks(data, outfile):
                         vlanMode = ""
                     if not slotId:
                         slotId = ""
+                    if not AutoNeg:
+                        AutoNeg = ""
 
                     row = startDevice + "," + startPort + "," + endDevice + "," + \
                         endPort + "," + str(bandWidth) + \
                         "," + str(vlanID) + "," + vlanMode + \
+                        "," + str(AutoNeg) + \
                         "," + str(slotId)
                     f.write(row + "\n")
     except IOError:

--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -311,7 +311,7 @@ error handling: checks if attribute values are None type or string "None"
 
 
 def makeSonicLabLinks(data, outfile):
-    csv_columns = "StartDevice,StartPort,EndDevice,EndPort,BandWidth,VlanID,VlanMode,SlotId"
+    csv_columns = "StartDevice,StartPort,EndDevice,EndPort,BandWidth,VlanID,VlanMode,Autoneg,SlotId"
     topology = data
     csv_file = outfile
 
@@ -331,6 +331,7 @@ def makeSonicLabLinks(data, outfile):
                     bandWidth = element.get("Bandwidth")
                     vlanID = element.get("VlanID")
                     vlanMode = element.get("VlanMode")
+                    AutoNeg = element.get("AutoNeg")
                     slotId = element.get("SlotId")
 
                     # catch empty values

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -299,6 +299,7 @@ class LabGraph(object):
             band_width = link["BandWidth"]
             vlan_ID = link["VlanID"]
             vlan_mode = link["VlanMode"]
+            autoneg_mode = link["AutoNeg"]
 
             if start_device not in links:
                 links[start_device] = {}
@@ -313,11 +314,13 @@ class LabGraph(object):
                 "peerdevice": end_device,
                 "peerport": end_port,
                 "speed": band_width,
+                "autoneg": autoneg_mode,
             }
             links[end_device][end_port] = {
                 "peerdevice": start_device,
                 "peerport": start_port,
                 "speed": band_width,
+                "autoneg": autoneg_mode,
             }
 
             port_vlans[start_device][start_port] = {

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -299,7 +299,7 @@ class LabGraph(object):
             band_width = link["BandWidth"]
             vlan_ID = link["VlanID"]
             vlan_mode = link["VlanMode"]
-            autoneg_mode = link["AutoNeg"]
+            autoneg_mode = link.get("AutoNeg", "off")
 
             if start_device not in links:
                 links[start_device] = {}

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -334,7 +334,6 @@ class ParseTestbedTopoinfo():
 
         if 'DUT' in topo_definition['topology']:
             vm_topo_config['DUT'] = topo_definition['topology']['DUT']
-            # Add AutoNeg interfaces
             if 'autoneg_interfaces' in vm_topo_config['DUT']:
                 vm_topo_config['autoneg_interfaces'] = topo_definition['topology']['DUT']['autoneg_interfaces']
         else:

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -334,6 +334,7 @@ class ParseTestbedTopoinfo():
 
         if 'DUT' in topo_definition['topology']:
             vm_topo_config['DUT'] = topo_definition['topology']['DUT']
+            # Add AutoNeg interfaces
             if 'autoneg_interfaces' in vm_topo_config['DUT']:
                 vm_topo_config['autoneg_interfaces'] = topo_definition['topology']['DUT']['autoneg_interfaces']
         else:

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -334,6 +334,8 @@ class ParseTestbedTopoinfo():
 
         if 'DUT' in topo_definition['topology']:
             vm_topo_config['DUT'] = topo_definition['topology']['DUT']
+            if 'autoneg_interfaces' in vm_topo_config['DUT']:
+                vm_topo_config['autoneg_interfaces'] = topo_definition['topology']['DUT']['autoneg_interfaces']
         else:
             vm_topo_config['DUT'] = {}
 

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -49,9 +49,9 @@ interface {{ intf }}
    switchport mode dot1q-tunnel
    switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
 # TODO: Add an additional var/check in fanout devices if autoneg is enabled with the below check
-{%   if device_conn[inventory_hostname][intf]['speed'] == "100000" and device_conn[inventory_hostname][intf]['autoneg']|lower == "off" %}
+{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" and device_conn[inventory_hostname][intf]['autoneg']|lower == "off" %}
    error-correction encoding reed-solomon
-{%   else %}
+{%     else %}
    no error-correction encoding
 {%     endif %}
 {%   endif %}

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -36,7 +36,7 @@ interface defaults
 {% for intf in device_port_vlans[inventory_hostname] %}
 interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-{%     if device_conn[inventory_hostname][intf]['autoneg'] == "on" %}
+{%     if device_conn[inventory_hostname][intf]['autoneg']|lower == "on" %}
    speed auto {{ device_conn[inventory_hostname][intf]['speed'] }}full
 {%   else %}
    speed force {{ device_conn[inventory_hostname][intf]['speed'] }}full
@@ -47,7 +47,7 @@ interface {{ intf }}
 {%   else %}
    switchport mode dot1q-tunnel
    switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" and device_conn[inventory_hostname][intf]['autoneg'] == "off" %}
+{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" and device_conn[inventory_hostname][intf]['autoneg']|lower == "off" %}
    error-correction encoding reed-solomon
 {%     else %}
    no error-correction encoding

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -47,9 +47,10 @@ interface {{ intf }}
 {%   else %}
    switchport mode dot1q-tunnel
    switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" and device_conn[inventory_hostname][intf]['autoneg']|lower == "off" %}
+# TODO: Add a var/check in fanout devices if autoneg is enabled with the below check
+{%   if device_conn[inventory_hostname][intf]['speed'] == "100000" and device_conn[inventory_hostname][intf]['autoneg']|lower == "off" %}
    error-correction encoding reed-solomon
-{%     else %}
+{%   else %}
    no error-correction encoding
 {%     endif %}
 {%   endif %}

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -36,14 +36,18 @@ interface defaults
 {% for intf in device_port_vlans[inventory_hostname] %}
 interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
+{%     if device_conn[inventory_hostname][intf]['autoneg'] == "on" %}
+   speed auto {{ device_conn[inventory_hostname][intf]['speed'] }}full
+{%   else %}
    speed force {{ device_conn[inventory_hostname][intf]['speed'] }}full
+{%     endif %}
 {%   if device_port_vlans[inventory_hostname][intf]['mode'] == 'Trunk' %}
    switchport mode trunk
    switchport trunk allowed vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
 {%   else %}
    switchport mode dot1q-tunnel
    switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" %}
+{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" and device_conn[inventory_hostname][intf]['autoneg'] == "off" %}
    error-correction encoding reed-solomon
 {%     else %}
    no error-correction encoding

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -36,6 +36,7 @@ interface defaults
 {% for intf in device_port_vlans[inventory_hostname] %}
 interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
+# TODO: Add an additional var/check in fanout devices if autoneg is enabled with the below check
 {%     if device_conn[inventory_hostname][intf]['autoneg']|lower == "on" %}
    speed auto {{ device_conn[inventory_hostname][intf]['speed'] }}full
 {%   else %}
@@ -47,7 +48,7 @@ interface {{ intf }}
 {%   else %}
    switchport mode dot1q-tunnel
    switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-# TODO: Add a var/check in fanout devices if autoneg is enabled with the below check
+# TODO: Add an additional var/check in fanout devices if autoneg is enabled with the below check
 {%   if device_conn[inventory_hostname][intf]['speed'] == "100000" and device_conn[inventory_hostname][intf]['autoneg']|lower == "off" %}
    error-correction encoding reed-solomon
 {%   else %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -58,6 +58,7 @@
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% for if_index in vm_topo_config['autoneg_interfaces']['intfs'] %}
 {% set autoneg_intf = "Ethernet" ~ if_index ~ "/1" %}
+{% if device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['autoneg']|lower == "on" %}
         <a:LinkMetadata>
             <a:Name i:nil="true"/>
             <a:Properties>
@@ -73,6 +74,7 @@
             </a:Properties>
             <a:Key>{{ device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['peerdevice'] }}:{{ device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['peerport'] }};{{ inventory_hostname }}:{{ autoneg_intf }}</a:Key>
         </a:LinkMetadata>
+{% endif %}
 {% endfor %}
     </Link>
   </LinkMetadataDeclaration>

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -53,7 +53,7 @@
   </LinkMetadataDeclaration>
 {% endif %}
 
-{% if autoneg_enabled is defined %}
+{% if msft_an_enabled is defined %}
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% for if_index in vm_topo_config['autoneg_interfaces']['intfs'] %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -53,7 +53,7 @@
   </LinkMetadataDeclaration>
 {% endif %}
 
-{% if autoneg is defined %}
+{% if autoneg_enabled is defined %}
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% for if_index in vm_topo_config['autoneg_interfaces']['intfs'] %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -52,3 +52,31 @@
     </Link>
   </LinkMetadataDeclaration>
 {% endif %}
+
+{% if autoneg is defined %}
+  <LinkMetadataDeclaration>
+    <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+{% for index in range(vms_number) %}
+{% set vm_intfs=vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|sort %}
+{% set dut_intfs=vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int]|sort %}
+{% for if_index in range(vm_intfs | length) %}
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+            <a:DeviceProperty>
+                <a:Name>AutoNegotiation</a:Name>
+                <a:Value>True</a:Value>
+            </a:DeviceProperty>
+          <a:DeviceProperty>
+                <a:Name>FECDisabled</a:Name>
+                <a:Reference i:nil="true"/>
+                <a:Value>True</a:Value>
+          </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>{{ vms[index] }}:{{ vm_intfs[if_index] }};{{ inventory_hostname }}:{{ port_alias[dut_intfs[if_index]] }}</a:Key>
+        </a:LinkMetadata>
+{% endfor %}
+{% endfor %}
+    </Link>
+  </LinkMetadataDeclaration>
+{% endif %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -56,26 +56,23 @@
 {% if autoneg is defined %}
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-{% for index in range(vms_number) %}
-{% set vm_intfs=vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|sort %}
-{% set dut_intfs=vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int]|sort %}
-{% for if_index in range(vm_intfs | length) %}
+{% for if_index in vm_topo_config['autoneg_interfaces']['intfs'] %}
+{% set autoneg_intf = "Ethernet" ~ if_index ~ "/1" %}
         <a:LinkMetadata>
             <a:Name i:nil="true"/>
             <a:Properties>
             <a:DeviceProperty>
-                <a:Name>AutoNegotiation</a:Name>
-                <a:Value>True</a:Value>
+                 <a:Name>AutoNegotiation</a:Name>
+                 <a:Value>True</a:Value>
             </a:DeviceProperty>
-          <a:DeviceProperty>
-                <a:Name>FECDisabled</a:Name>
-                <a:Reference i:nil="true"/>
-                <a:Value>True</a:Value>
-          </a:DeviceProperty>
+            <a:DeviceProperty>
+                 <a:Name>FECDisabled</a:Name>
+                 <a:Reference i:nil="true"/>
+                 <a:Value>True</a:Value>
+            </a:DeviceProperty>
             </a:Properties>
-            <a:Key>{{ vms[index] }}:{{ vm_intfs[if_index] }};{{ inventory_hostname }}:{{ port_alias[dut_intfs[if_index]] }}</a:Key>
+            <a:Key>{{ device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['peerdevice'] }}:{{ device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['peerport'] }};{{ inventory_hostname }}:{{ autoneg_intf }}</a:Key>
         </a:LinkMetadata>
-{% endfor %}
 {% endfor %}
     </Link>
   </LinkMetadataDeclaration>

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -136,7 +136,7 @@
             <a:Value>{{ switch_type }}</a:Value>
           </a:DeviceProperty>
 {% endif %}
-{% if autoneg_enabled is defined %}
+{% if msft_an_enabled is defined %}
           <a:DeviceProperty>
             <a:Name>AutoNegotiation</a:Name>
             <a:Reference i:nil="true"/>

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -136,7 +136,7 @@
             <a:Value>{{ switch_type }}</a:Value>
           </a:DeviceProperty>
 {% endif %}
-{% if autoneg is defined %}
+{% if autoneg_enabled is defined %}
           <a:DeviceProperty>
             <a:Name>AutoNegotiation</a:Name>
             <a:Reference i:nil="true"/>

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -140,7 +140,7 @@
           <a:DeviceProperty>
             <a:Name>AutoNegotiation</a:Name>
             <a:Reference i:nil="true"/>
-            <a:Value>{{ autoneg }}</a:Value>
+            <a:Value>{{ msft_an_enabled }}</a:Value>
           </a:DeviceProperty>
 {% endif %}
 {% if num_asics == 1 and switch_type is defined and switch_type == 'voq' %}

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -136,6 +136,13 @@
             <a:Value>{{ switch_type }}</a:Value>
           </a:DeviceProperty>
 {% endif %}
+{% if autoneg is defined %}
+          <a:DeviceProperty>
+            <a:Name>AutoNegotiation</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ autoneg }}</a:Value>
+          </a:DeviceProperty>
+{% endif %}
 {% if num_asics == 1 and switch_type is defined and switch_type == 'voq' %}
           <a:DeviceProperty>
             <a:Name>SwitchId</a:Name>

--- a/ansible/vars/topo_t0-116.yml
+++ b/ansible/vars/topo_t0-116.yml
@@ -135,7 +135,7 @@ topology:
       vm_offset: 3
   DUT:
     autoneg_interfaces:
-      intfs: [13, 14, 15, 16, 17, 18, 19, 20]
+      intfs: [13, 14, 15, 16]
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:

--- a/ansible/vars/topo_t0-116.yml
+++ b/ansible/vars/topo_t0-116.yml
@@ -134,6 +134,8 @@ topology:
         - 31
       vm_offset: 3
   DUT:
+    autoneg_interfaces:
+      intfs: [13, 14, 15, 16, 17, 18, 19, 20]
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:

--- a/ansible/vars/topo_t0.yml
+++ b/ansible/vars/topo_t0.yml
@@ -51,6 +51,8 @@ topology:
         - 31
       vm_offset: 3
   DUT:
+    autoneg_interfaces:
+      intfs: [7, 8, 9, 10]
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:



-->
### Description of PR

These changes add a support for adding auto negotiation to specific testbed based on variables defined in ansible

Two things are required for autoneg support 

1. autoneg_enabled : True 
must be enabled in inventory files 
2. to topo file must have a port list for autoneg 
Example:
intfs : [1, 2, 3, 4, 5, 6, 7, 8]

With these changes the PR includes changes to pick the port numbering from topo file and apply minigraph parsing changes such that during deploy-mg or gen-mg the required ports have autoneg and deployment is clean with link up 

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
