### PR TITLE
Add option to start existing / stopped container

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -116,6 +116,7 @@ function show_help_and_exit() {
     echo "  ./${SCRIPT_NAME} -n sonic-mgmt-${USER}_master -d /var/src"
     echo "  ./${SCRIPT_NAME} -n sonic-mgmt-${USER}_master -m /my/working/dir"
     echo "  ./${SCRIPT_NAME} -n sonic-mgmt-${USER}_master -p 192.0.2.1:8080:80/tcp"
+    echo "  ./${SCRIPT_NAME} -i docker-sonic-mgmt-username:master -s"
     echo "  ./${SCRIPT_NAME} -h"
     echo
     exit ${1}

--- a/setup-container.sh
+++ b/setup-container.sh
@@ -389,7 +389,7 @@ if [[ $# -eq 0 ]]; then
     show_help_and_exit "${EXIT_SUCCESS}"
 fi
 
-while getopts "n:i:d:m:p:fvxhs" opt; do
+while getopts "n:i:d:m:p:fvxh" opt; do
     case "${opt}" in
         n )
             CONTAINER_NAME="${OPTARG}"


### PR DESCRIPTION
### Description of PR

The idea is to improve the error message and start the stopped container instead of erroring out. The changes include -

- If caller runs `./setup-container.sh -d /var/src -n existing_container_name` the script simply starts the existing container instead of trying to create a new one and failing
- If the caller runs `./setup-container.sh -d /var/src` without the container name the script detects if a container with the local image tag exists and prints the command to start it.

Summary:
Fixes # Not applicable

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

Enhance script to start stopped container. This prevents the user from cleaning old containers on dev machines and start new ones every time.

#### How did you do it?

Run the script

#### How did you verify/test it?

Logged in

#### Any platform specific information?

Not applicable

#### Supported testbed topology if it's a new test case?

Not applicable

### Documentation

Not applicable