### PR TITLE
Fix lag flap check for sonic peer

### DIFF
--- a/ansible/roles/test/files/ptftests/sonic.py
+++ b/ansible/roles/test/files/ptftests/sonic.py
@@ -219,6 +219,9 @@ class Sonic(host_device.HostDevice):
         if cli_data['po'][1] > 0 and self.reboot_type == 'warm-reboot':
             self.fails.add('Port channel flap occurred!')
 
+        if cli_data['po'][1] > 1 and self.reboot_type == 'fast-reboot':
+            self.fails.add('More than one port channel flap occurred!')
+
         self.log('Finishing run()')
         return self.fails, self.info, cli_data, log_data, {
             "lacp_all": list(set(self.lacp_pdu_timings))

--- a/ansible/roles/test/files/ptftests/sonic.py
+++ b/ansible/roles/test/files/ptftests/sonic.py
@@ -216,7 +216,7 @@ class Sonic(host_device.HostDevice):
                 msg = 'BGP route GR timeout: neighbor %s (ASN %s' % (nei, asn)
                 self.fails.add(msg)
 
-        if cli_data['po'][1] > 0:
+        if cli_data['po'][1] > 0 and self.reboot_type == 'warm-reboot':
             self.fails.add('Port channel flap occurred!')
 
         self.log('Finishing run()')


### PR DESCRIPTION
If using sonic peer, currently any lag flap will result in fail. Lag flaps are expected for fast reboot, so fix check so that it only applies for warm reboot.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
qualifying fast upgrades using sonic peers - this currently will always fail due to inevitable flaps during fast reboot.

#### How did you do it?
only treat flaps during warm reboot as failures

#### How did you verify/test it?
tested on an Arista testbed with sonic peers

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
