### PR TITLE
[acstests] Migrate acltb_test to Python 3

### DIFF
--- a/ansible/roles/test/files/acstests/acltb_test.py
+++ b/ansible/roles/test/files/acstests/acltb_test.py
@@ -14,7 +14,7 @@ Usage:
         dst_ip_tor='172.16.1.0';dst_ip_tor_forwarded='172.16.2.0';dst_ip_tor_blocked='172.16.3.0';
         dst_ip_spine='192.168.0.0';dst_ip_spine_forwarded='192.168.0.16';dst_ip_spine_blocked='192.168.0.17'"
 '''
-from __future__ import print_function
+
 
 import logging
 
@@ -409,7 +409,7 @@ class AclTest(BaseTest):
                          self.tor_ports,
                          "spine->tor")
 
-        failed_cases = filter(lambda r: not r['result'], self.test_results)
+        failed_cases = [r for r in self.test_results if not r['result']]
         if len(failed_cases) == 0:
             print('!!!! All test cases passed! !!!!')
         assert (len(failed_cases) == 0), "TEST FAILED. Failed test cases: " + str(failed_cases)


### PR DESCRIPTION
### Description of PR

This PR migrates the test script `ansible/roles/test/files/acstests/acltb_test.py` to Python 3. 

_Note: The script is most likely deprecated and not being invoked._

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

Migrate ACS tests to Python 3

#### How did you do it?

Using `2to3`

#### How did you verify/test it?

Not verified as it is not being tested through any other tests or pipelines.

#### Any platform specific information?

Not applicable

#### Supported testbed topology if it's a new test case?

Not applicable.

### Documentation

Not applicable.