### PR TITLE
[iface_namingmode] Skip the test for lldp on ptf topology

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -225,7 +225,8 @@ def select_interface_for_mellnaox_device(setup, duthost):
 #############################################################
 #                        START OF TESTS                     #
 #############################################################
-# Tests to be run in all topologies
+# Tests to be run in the topologies except 'ptf'
+@pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx')
 class TestShowLLDP():
 
     @pytest.fixture(scope="class")
@@ -298,6 +299,7 @@ class TestShowLLDP():
             assert re.search(r'SysName:\s+{}'.format(minigraph_neighbors[test_intf]['name']), lldp_neighbor) is not None
 
 
+# Tests to be run in all topologies
 class TestShowInterfaces():
 
     def test_show_interfaces_counter(self, setup, setup_config_mode):

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -319,7 +319,7 @@ class TestShowInterfaces():
             if regex_int.match(line):
                 interfaces.append(regex_int.match(line).group(0))
 
-        assert(len(interfaces) > 0)
+        assert (len(interfaces) > 0)
 
         for item in interfaces:
             if mode == 'alias':
@@ -553,7 +553,7 @@ class TestShowQueue():
                 intfsChecked += 1
 
         # At least one interface should have been checked to have a valid result
-        assert(intfsChecked > 0)
+        assert (intfsChecked > 0)
 
     def test_show_queue_counters_interface(self, setup_config_mode, sample_intf):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #9912 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fix the test case fail of test_iface_namingmode.py::TestShowLLDP when running in PTF topology

#### How did you do it?
Skip the test_iface_namingmode.py::TestShowLLDP when the topology is PTF.

#### How did you verify/test it?
Run the test case and make sure the result is skipped.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
