### PR TITLE
Enhance test_disable_rsyslog_rate_limit

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -166,6 +166,7 @@ def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
 
     output = duthost.command('config syslog --help')['stdout']
     manually_enable_feature = False
+    feature_exception_dict = dict()
     if 'rate-limit-feature' in output:
         # in 202305, the feature is disabled by default for warmboot/fastboot
         # performance, need manually enable it via command
@@ -182,9 +183,14 @@ def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
             output = duthost.shell("docker images", module_ignore_errors=True)['stdout']
             if "sonic-telemetry" not in output:
                 continue
-        duthost.modify_syslog_rate_limit(feature_name, rl_option='disable')
+        try:
+            duthost.modify_syslog_rate_limit(feature_name, rl_option='disable')
+        except Exception as e:
+            feature_exception_dict[feature_name] = str(e)
     if manually_enable_feature:
         duthost.command('config syslog rate-limit-feature disable')
+    if feature_exception_dict:
+        pytest.fail(f"The test failed on some of the dockers. feature_exception_dict = {feature_exception_dict}")
 
 
 def collect_dut_lossless_prio(dut):


### PR DESCRIPTION
…all features

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Enhance test_disable_rsyslog_rate_limit to only fail after iterating all features

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Avoid rsyslog_rate_limit not being disabled on working dockers when other dockers are unresponsive.
#### How did you do it?
Adjust test_disable_rsyslog_rate_limit to collect the errors and only fail the test and display them after iterating through all features.
#### How did you verify/test it?
Run the test on a SONiC Platform
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
