### PR TITLE
[7215A1] Update Nokia-7215-A1 port alias to name mapping in port_utils

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -292,12 +292,8 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             for i in range(0, 52):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
         elif hwsku in ["rd98DX35xx_cn9131", "rd98DX35xx", "Nokia-7215-A1"]:
-            for i in range(0, 32):
-                port_alias_to_name_map["oneGigE%d" % i] = "Ethernet%d" % i
-            for i in range(32, 48):
-                port_alias_to_name_map["twod5GigE%d" % i] = "Ethernet%d" % i
-            for i in range(48, 54):
-                port_alias_to_name_map["twenty5GigE%d" % i] = "Ethernet%d" % i
+            for i in range(1, 53):
+                port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % ((i - 1))
         elif hwsku == "Nokia-IXR7250E-36x400G" or hwsku == "Nokia-IXR7250E-36x100G":
             for i in range(1, 37):
                 sonic_name = "Ethernet%d" % ((i - 1) * 8)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update Nokia-7215-A1 port alias to name mapping.
Current code is not consistent with [sonic-buildimage/device/nokia/arm64-nokia_ixs7215_52xb-r0/Nokia-7215-A1/port_config.ini](https://github.com/sonic-net/sonic-buildimage/blob/master/device/nokia/arm64-nokia_ixs7215_52xb-r0/Nokia-7215-A1/port_config.ini).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Update Nokia-7215-A1 port alias to name mapping.

#### How did you do it?
Update Nokia-7215-A1 port alias to name mapping.

#### How did you verify/test it?
Verified by deploy Nokia-7215-A1 fanout switch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
