### PR TITLE
Delete ONIE Component skip on fwutil test

### DIFF
--- a/tests/platform_tests/fwutil/conftest.py
+++ b/tests/platform_tests/fwutil/conftest.py
@@ -85,8 +85,6 @@ def extract_fw_data(fw_pkg_path):
 def random_component(duthost, fw_pkg):
     chass = list(show_firmware(duthost)["chassis"].keys())[0]
     components = list(fw_pkg["chassis"].get(chass, {}).get("component", {}).keys())
-    if 'ONIE' in components:
-        components.remove('ONIE')
     if len(components) == 0:
         pytest.skip("No suitable components found in config file for platform {}.".format(duthost.facts['platform']))
     return components[randrange(len(components))]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Undo skip of ONIE component as result of 
### Type of change
Undo skip on ONIE component in fwutildue to old ONIE version not supporting downgrade test (https://github.com/sonic-net/sonic-mgmt/pull/5920)
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Undo skip on ONIE component due to old ONIE version not supporting downgrade test
#### How did you do it?

#### How did you verify/test it?
Run the test on SONiC Platforms
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
