### PR TITLE
Fix dut selection for bgp-passive-peering tests 

### DIFF
--- a/tests/bgp/test_passive_peering.py
+++ b/tests/bgp/test_passive_peering.py
@@ -22,12 +22,12 @@ wrong_password = "wrong-password"
 
 
 @pytest.fixture(scope='module')
-def setup(tbinfo, nbrhosts, duthosts, rand_one_dut_hostname, request):
+def setup(tbinfo, nbrhosts, duthosts, rand_one_dut_front_end_hostname, request):
     # verify neighbors are type sonic
     if request.config.getoption("neighbor_type") != "sonic":
         pytest.skip("Neighbor type must be sonic")
 
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     dut_asn = tbinfo['topo']['properties']['configuration_properties']['common']['dut_asn']
 
     lldp_table = duthost.shell("show lldp table")['stdout'].split("\n")[3].split()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes the DUT selection for the _bgp-passive-peering_ tests to run.
- Tests were using '_rand_one_dut_hostname_', which sometimes picks supervisor as dut for running test cases in case of T2 topo.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

- Sometimes, for T2 topo, test-bgp-passive-peering selects dut as Supervisor which is not correct.
- This PR fixes the DUT selection for the _bgp-passive-peering_ tests to run.

**Tests fail with the following error:**

` bgp/test_passive_peering.py:38: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 self = <MultiAsicSonicHost ixre-cpm-chassis19>, port = 'eth0' def get_port_asic_instance(self, port): """ Returns the ASIC instance to which the port belongs Args: port: Port ID Returns: returns the ASIC instance if found, else None """ for asic in self.asics: if asic.port_exists(port): return asic > pytest_assert( False, "ASIC instance not found for port {}".format(port) ) E Failed: ASIC instance not found for port eth0 asic = <SonicAsic 9> port = 'eth0' self = <MultiAsicSonicHost ixre-cpm-chassis19> common/devices/multi_asic.py:428: Failed`

#### How did you do it?

- Instead of using '_rand_one_dut_hostname_', use '_rand_one_dut_front_end_hostname_' for dut selection during test run.

#### How did you verify/test it?

- Ran all the above-mentioned test case on a T2 chassis and made sure tests passed with expected behavior.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/user-attachments/assets/3c1ab52a-ec8e-4e3b-be27-290f4178c3e4)

