### PR TITLE
fix for intermittent failures in vxlan ecmp test suite

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/vxlan_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan_traffic.py
@@ -71,7 +71,7 @@ VARS['udp_sport'] = 1234
 Logger = logging.getLogger(__name__)
 
 # Some constants used in this code
-MIN_PACKET_COUNT = 4
+MIN_PACKET_COUNT = 10
 MINIMUM_PACKETS_FOR_ECMP_VALIDATION = 300
 TEST_ECN = True
 


### PR DESCRIPTION
### Description of PR
improvement for flakiness of following tests:
1. vxlan.test_vxlan_ecmp.Test_VxLAN_ecmp_create.test_vxlan_configure_route1_ecmp_group_a
2. vxlan.test_vxlan_ecmp.Test_VxLAN_NHG_Modify.test_vxlan_remove_route2

Summary:
With this PR we have increased the no of test pkts sent before validating that each valid endpoint address has been used.
Fixes flakiness of the aforesaid tests in the description line.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
some tests in vxlan ecmp tests were flaky.

#### How did you do it?
increased the no of test pkts sent

#### How did you verify/test it?
Verified that the tests are passing consistently(5/5)

```
04:59:33.728  vxlan_traffic: INFO    : Sending 10 packets from port 0 to fddd:a150:a0::a31:1
04:59:33.770  vxlan_traffic: INFO    : Loop time:out 1000 milliseconds
04:59:33.786  vxlan_traffic: INFO    : Vxlan packets received:10, loop time:0.01598 seconds
04:59:33.786  vxlan_traffic: INFO    : received = {'fddd:a100:a0::a30:1': 10}
04:59:33.786  vxlan_traffic: INFO    : Sending 10 packets from port 0 to fddd:a150:a0::a31:1
04:59:33.829  vxlan_traffic: INFO    : Loop time:out 1000 milliseconds
04:59:33.844  vxlan_traffic: INFO    : Vxlan packets received:10, loop time:0.015429 seconds
04:59:33.844  vxlan_traffic: INFO    : received = {'fddd:a100:a0::a30:1': 17, 'fddd:a100:a0::a29:1': 3
}
04:59:33.844  vxlan_traffic: INFO    :     Each valid endpoint address has been used
04:59:33.844  vxlan_traffic: INFO    : Packets sent:10 distribution:
04:59:33.845  vxlan_traffic: INFO    :       fddd:a100:a0::a30:1 : 17
04:59:33.845  vxlan_traffic: INFO    :       fddd:a100:a0::a29:1 : 3


04:59:47.057  vxlan_traffic: INFO    : Sending 10 packets from port 0 to fddd:a150:a0::a31:1
04:59:47.104  vxlan_traffic: INFO    : Loop time:out 1000 milliseconds
04:59:47.125  vxlan_traffic: INFO    : Vxlan packets received:10, loop time:0.020929 seconds
04:59:47.125  vxlan_traffic: INFO    : received = {'fddd:a100:a0::a30:1': 3, 'fddd:a100:a0::a29:1': 7}
04:59:47.126  vxlan_traffic: INFO    : Sending 10 packets from port 0 to fddd:a150:a0::a31:1
04:59:47.173  vxlan_traffic: INFO    : Loop time:out 1000 milliseconds
04:59:47.195  vxlan_traffic: INFO    : Vxlan packets received:10, loop time:0.022607 seconds
04:59:47.195  vxlan_traffic: INFO    : received = {'fddd:a100:a0::a30:1': 6, 'fddd:a100:a0::a29:1': 14
}
04:59:47.195  vxlan_traffic: INFO    :     Each valid endpoint address has been used
04:59:47.195  vxlan_traffic: INFO    : Packets sent:10 distribution:
04:59:47.195  vxlan_traffic: INFO    :       fddd:a100:a0::a30:1 : 6
04:59:47.196  vxlan_traffic: INFO    :       fddd:a100:a0::a29:1 : 14
```

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
NA