### PR TITLE
added log ignore to ignore BFD session creation failure logs. On mlnx…

### DIFF
--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -108,6 +108,15 @@ def _ignore_route_sync_errlogs(rand_one_dut_hostname, loganalyzer):
                 ".*'vnetRouteCheck' status failed.*",
                 ".*Vnet Route Mismatch reported.*",
                 ".*_M_construct null not valid.*",
+                ".*Failed to bind BFD socket to local_addr.*-98.*",
+                ".*Failed to create TX socket for session.*-5.*",
+                ".*Parsing BFD command.*-5.*",
+                ".*[BFD.ERR] ioctl failed.*",
+                ".*[CORE_API.ERR] Failed in bfd_offload_set.*",
+                ".*mlnx_set_offload_bfd_tx_session.*",
+                ".*api SAI_COMMON_API_CREATE failed in syncd mode.*",
+                ".*ERR syncd.*SAI_BFD_SESSION_ATTR_.*",
+                ".*ERR swss.*SAI_STATUS_FAILURE.*",
             ])
     return
 


### PR DESCRIPTION
On Mlnx paltforms, while running this test BFD session creation can fail sometime resulting in the following logs.
THe syncd retries in such a case  and is able to create the BFD session subsequently. So these errors can be ignored.
`E               Jun  9 14:12:41.474573 strtk5-msn2700-06 ERR kernel: [35758.641097] sxd_kernel: [error] Failed to bind BFD socket to local_addr (ip:10.1.0.32 ,port:49171) (err:-98).
E              
E               Jun  9 14:12:41.474603 strtk5-msn2700-06 ERR kernel: [35758.760511] sxd_kernel: [error] Failed to create TX socket for session 8165 (err:-5).
E              
E               Jun  9 14:12:41.552788 strtk5-msn2700-06 ERR kernel: [35758.854304] sxd_kernel: [error] Parsing BFD command 0 failed (err:-5).
E              
E               Jun  9 14:12:41.553068 strtk5-msn2700-06 ERR syncd#SDK: [BFD.ERR] ioctl failed, error description: Input/output error
E              
E               Jun  9 14:12:41.553203 strtk5-msn2700-06 ERR syncd#SDK: [CORE_API.ERR] Failed in bfd_offload_set() , error: Internal Error
E              
E               Jun  9 14:12:41.553454 strtk5-msn2700-06 ERR syncd#SDK: [SAI_BFD.ERR] ./src/mlnx_sai_bfd.c[393]- mlnx_set_offload_bfd_tx_session: Error create TX BFD session: Internal Error.
E              
E               Jun  9 14:12:41.554748 strtk5-msn2700-06 ERR syncd#SDK: :- sendApiResponse: api SAI_COMMON_API_CREATE failed in syncd mode: SAI_STATUS_FAILURE
E              
E               Jun  9 14:12:41.555685 strtk5-msn2700-06 ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_TYPE: SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE
E              
E               Jun  9 14:12:41.555751 strtk5-msn2700-06 ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_LOCAL_DISCRIMINATOR: 20
E              
E               Jun  9 14:12:41.555792 strtk5-msn2700-06 ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_UDP_SRC_PORT: 49171
E              
E               Jun  9 14:12:41.555891 strtk5-msn2700-06 ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_REMOTE_DISCRIMINATOR: 0
E              
E               Jun  9 14:12:41.556028 strtk5-msn2700-06 ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_BFD_ENCAPSULATION_TYPE: SAI_BFD_ENCAPSULATION_TYPE_NONE
E              
E               Jun  9 14:12:41.556076 strtk5-msn2700-06 ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_IPHDR_VERSION: 4
E              
E               Jun  9 14:12:41.556191 strtk5-msn2700-06 ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS: 10.1.0.32
E              
E               Jun  9 14:12:41.556239 strtk5-msn2700-06 ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS: 100.0.27.1
E              
E               Jun  9 14:12:41.556322 strtk5-msn2700-06 ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_MIN_TX: 1000000
E              
E               Jun  9 14:12:41.556451 strtk5-msn2700-06 ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_MIN_RX: 1000000
E              
E               Jun  9 14:12:41.556451 strtk5-msn2700-06 ERR swss#orchagent: :- create: create status: SAI_STATUS_FAILURE
E              
E               Jun  9 14:12:41.556510 strtk5-msn2700-06 ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_MULTIPLIER: 10
E              
E               Jun  9 14:12:41.556549 strtk5-msn2700-06 ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_TOS: 192
E              
E               Jun  9 14:12:41.556627 strtk5-msn2700-06 ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_MULTIHOP: true
E              
E               Jun  9 14:12:41.556669 strtk5-msn2700-06 ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_VIRTUAL_ROUTER: oid:0x3000000000002
`

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change
Testfix
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [X] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
This PR is added to ignore the BFD session creation failure messages as these messages lead to test failure due to unexpected logs. The Mlnx platform has the capability to retry the BFD session creation.The 2nd attempt passes and the test works fine, 
In the event the platform fails to create the BFD session, the test would eventually fail so by ignoring these these logs we are not impacting the test itself.
#### How did you do it?
Added log ignore for these messages.
#### How did you verify/test it?
Ran this multiple times to check for failure.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
