### PR TITLE
added arm64 platform check to skip /proc/dma command check

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -528,7 +528,7 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
             )
     # Remove /proc/dma for armh
     elif duthost.facts["asic_type"] == "marvell":
-        if 'armhf-' in duthost.facts["platform"]:
+        if 'armhf-' in duthost.facts["platform"] or 'arm64-' in duthost.facts["platform"]:
             cmds.copy_proc_files.remove("/proc/dma")
 
     return cmds_to_check


### PR DESCRIPTION

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The testcase test_techsupport_commands check if /proc/dma is expected in show techsupport output. For marvell based platforms, we need to remove this check for /proc/dma. This has been implemented for armhf based platforms. Adding the check for arm64 based platforms as well. 
#### How did you do it?
Added a check for arm64 based platforms to remove /proc/dma from commands to check list.
#### How did you verify/test it?
ran the testcase test_techsupport.py entirely to see if all the testcases pass. 
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
