### PR TITLE
[snappi]:Change ipv4 to random-src-port udp traffic.

### DIFF
--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
@@ -5,6 +5,7 @@
 # Compiled at: 2023-02-10 09:15:26
 from math import ceil                                                                                # noqa: F401
 import logging                                                                                       # noqa: F401
+import random
 from tests.common.helpers.assertions import pytest_assert, pytest_require                            # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts              # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                                 # noqa: F401
@@ -316,7 +317,12 @@ def __gen_data_flow(testbed_config,
         flow = testbed_config.flows.flow(name='{} {} -> {}'.format(flow_name_prefix, src_port_id, dst_port_id))[-1]
         flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
         flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
-        eth, ipv4 = flow.packet.ethernet().ipv4()
+        eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
+        src_port = random.randomint(5000, 6000)
+        udp.src_port.increment.start = src_port
+        udp.src_port.increment.step = 1
+        udp.src_port.increment.coun = 1
+
         eth.src.value = tx_mac
         eth.dst.value = rx_mac
 

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
@@ -318,7 +318,7 @@ def __gen_data_flow(testbed_config,
         flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
         flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
         eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-        src_port = random.randomint(5000, 6000)
+        src_port = random.randint(5000, 6000)
         udp.src_port.increment.start = src_port
         udp.src_port.increment.step = 1
         udp.src_port.increment.coun = 1

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
@@ -321,7 +321,7 @@ def __gen_data_flow(testbed_config,
         src_port = random.randint(5000, 6000)
         udp.src_port.increment.start = src_port
         udp.src_port.increment.step = 1
-        udp.src_port.increment.coun = 1
+        udp.src_port.increment.count = 1
 
         eth.src.value = tx_mac
         eth.dst.value = rx_mac

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
@@ -324,7 +324,7 @@ def __gen_data_flow(testbed_config,
         flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
         flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
         eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-        src_port = random.randomint(5000, 6000)
+        src_port = random.randint(5000, 6000)
         udp.src_port.increment.start = src_port
         udp.src_port.increment.step = 1
         udp.src_port.increment.count = 1

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
@@ -5,6 +5,7 @@
 # Compiled at: 2023-02-10 09:15:26
 from math import ceil                                                                                      # noqa: F401
 import logging                                                                                             # noqa: F401
+import random
 from tests.common.helpers.assertions import pytest_assert, pytest_require                                  # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts                    # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                                       # noqa: F401
@@ -322,7 +323,12 @@ def __gen_data_flow(testbed_config,
         flow = testbed_config.flows.flow(name='{} {} -> {}'.format(flow_name_prefix, src_port_id, dst_port_id))[-1]
         flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
         flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
-        eth, ipv4 = flow.packet.ethernet().ipv4()
+        eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
+        src_port = random.randomint(5000, 6000)
+        udp.src_port.increment.start = src_port
+        udp.src_port.increment.step = 1
+        udp.src_port.increment.count = 1
+
         eth.src.value = tx_mac
         eth.dst.value = rx_mac
 

--- a/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -1,4 +1,5 @@
 import logging                                                                          # noqa: F401
+import random
 from tests.common.helpers.assertions import pytest_assert, pytest_require               # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                     # noqa: F401
@@ -302,7 +303,12 @@ def __gen_data_flow(testbed_config,
                                                   src_port_id, dst_port_id, flow_rate_percent))[-1]
     flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
-    eth, ipv4 = flow.packet.ethernet().ipv4()
+    eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
+    src_port = random.randomint(5000, 6000)
+    udp.src_port.increment.start = src_port
+    udp.src_port.increment.step = 1
+    udp.src_port.increment.count = 1
+
     eth.src.value = tx_mac
     eth.dst.value = rx_mac
 

--- a/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -304,7 +304,7 @@ def __gen_data_flow(testbed_config,
     flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
     eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-    src_port = random.randomint(5000, 6000)
+    src_port = random.randint(5000, 6000)
     udp.src_port.increment.start = src_port
     udp.src_port.increment.step = 1
     udp.src_port.increment.count = 1

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_helper.py
@@ -5,6 +5,7 @@
 # Compiled at: 2023-02-10 09:15:26
 from math import ceil                                                                   # noqa: F401
 import logging                                                                          # noqa: F401
+import random
 from tests.common.helpers.assertions import pytest_assert, pytest_require               # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                          # noqa: F401
@@ -280,7 +281,12 @@ def __gen_data_flow(testbed_config,
     flow = testbed_config.flows.flow(name='{} {} -> {}'.format(flow_name_prefix, src_port_id, dst_port_id))[-1]
     flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
-    eth, ipv4 = flow.packet.ethernet().ipv4()
+    eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
+    src_port = random.randomint(5000, 6000)
+    udp.src_port.increment.start = src_port
+    udp.src_port.increment.step = 1
+    udp.src_port.increment.count = 1
+
     eth.src.value = tx_mac
     eth.dst.value = rx_mac
     flow.duration.fixed_seconds.delay.nanoseconds = int(sec_to_nanosec(DATA_FLOW_DELAY_SEC))

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_helper.py
@@ -282,7 +282,7 @@ def __gen_data_flow(testbed_config,
     flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
     eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-    src_port = random.randomint(5000, 6000)
+    src_port = random.randint(5000, 6000)
     udp.src_port.increment.start = src_port
     udp.src_port.increment.step = 1
     udp.src_port.increment.count = 1

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -5,6 +5,7 @@
 # Compiled at: 2023-02-10 09:15:26
 from math import ceil                                                                   # noqa: F401
 import logging                                                                          # noqa: F401
+import random
 from tests.common.helpers.assertions import pytest_assert, pytest_require               # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                     # noqa: F401
@@ -290,7 +291,12 @@ def __gen_data_flow(testbed_config,
                                                                        dst_port_id, flow_rate_percent))[-1]
     flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
-    eth, ipv4 = flow.packet.ethernet().ipv4()
+    eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
+    src_port = random.randomint(5000, 6000)
+    udp.src_port.increment.start = src_port
+    udp.src_port.increment.step = 1
+    udp.src_port.increment.count = 1
+
     eth.src.value = tx_mac
     eth.dst.value = rx_mac
     flow.duration.fixed_seconds.delay.nanoseconds = 0

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -292,7 +292,7 @@ def __gen_data_flow(testbed_config,
     flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
     eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-    src_port = random.randomint(5000, 6000)
+    src_port = random.randint(5000, 6000)
     udp.src_port.increment.start = src_port
     udp.src_port.increment.step = 1
     udp.src_port.increment.count = 1

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossy_helper.py
@@ -5,6 +5,7 @@
 # Compiled at: 2023-02-10 09:15:26
 from math import ceil                                                                               # noqa: F401
 import logging                                                                                      # noqa: F401
+import random
 from tests.common.helpers.assertions import pytest_assert, pytest_require                           # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts             # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                                # noqa: F401
@@ -301,7 +302,12 @@ def __gen_data_flow(testbed_config,
     flow = testbed_config.flows.flow(name='{} {} -> {}'.format(flow_name_prefix, src_port_id, dst_port_id))[-1]
     flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
-    eth, ipv4 = flow.packet.ethernet().ipv4()
+    eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
+    src_port = random.randomint(5000, 6000)
+    udp.src_port.increment.start = src_port
+    udp.src_port.increment.step = 1
+    udp.src_port.increment.count = 1
+
     eth.src.value = tx_mac
     eth.dst.value = rx_mac
 

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossy_helper.py
@@ -303,7 +303,7 @@ def __gen_data_flow(testbed_config,
     flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
     eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-    src_port = random.randomint(5000, 6000)
+    src_port = random.randint(5000, 6000)
     udp.src_port.increment.start = src_port
     udp.src_port.increment.step = 1
     udp.src_port.increment.count = 1

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
@@ -126,6 +126,7 @@ def run_pfcwd_basic_test(api,
         flow1_min_loss_rate = 0
 
     exp_dur_sec = flow2_delay_sec + flow2_dur_sec + 1
+    cisco_platform = "Cisco" in egress_duthost.facts['hwsku']
 
     """ Generate traffic config """
     __gen_traffic(testbed_config=testbed_config,
@@ -141,7 +142,9 @@ def run_pfcwd_basic_test(api,
                       warm_up_traffic_dur_sec, flow1_dur_sec, flow2_dur_sec],
                   data_pkt_size=DATA_PKT_SIZE,
                   prio_list=prio_list,
-                  prio_dscp_map=prio_dscp_map)
+                  prio_dscp_map=prio_dscp_map,
+                  traffic_rate = 99.98 if cisco_platform else 100.0,
+                  number_of_streams = 2 if cisco_platform else 1)
 
     flows = testbed_config.flows
 
@@ -205,7 +208,9 @@ def __gen_traffic(testbed_config,
                   data_flow_dur_sec_list,
                   data_pkt_size,
                   prio_list,
-                  prio_dscp_map):
+                  prio_dscp_map,
+                  traffic_rate,
+                  number_of_streams):
     """
     Generate configurations of flows, including data flows and pause storm.
 
@@ -221,6 +226,8 @@ def __gen_traffic(testbed_config,
         data_pkt_size (int): size of data packets in byte
         prio_list (list): priorities of data flows and pause storm
         prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
+        traffic_rate: Total rate of traffic for all streams together.
+        number_of_streams: The number of UDP streams needed.
 
     Returns:
         N/A
@@ -293,7 +300,7 @@ def __gen_traffic(testbed_config,
 
     tx_port_name = testbed_config.ports[tx_port_id].name
     rx_port_name = testbed_config.ports[rx_port_id].name
-    data_flow_rate_percent = int(99.98 / len(prio_list))
+    data_flow_rate_percent = int(traffic_rate / len(prio_list))
 
     """ For each data flow """
     for i in range(len(data_flow_name_list)):
@@ -309,7 +316,7 @@ def __gen_traffic(testbed_config,
             src_port = random.randint(5000, 6000)
             udp.src_port.increment.start = src_port
             udp.src_port.increment.step = 1
-            udp.src_port.increment.count = 2
+            udp.src_port.increment.count = number_of_streams
 
             eth.src.value = tx_mac
             eth.dst.value = rx_mac

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
@@ -143,8 +143,8 @@ def run_pfcwd_basic_test(api,
                   data_pkt_size=DATA_PKT_SIZE,
                   prio_list=prio_list,
                   prio_dscp_map=prio_dscp_map,
-                  traffic_rate = 99.98 if cisco_platform else 100.0,
-                  number_of_streams = 2 if cisco_platform else 1)
+                  traffic_rate=99.98 if cisco_platform else 100.0,
+                  number_of_streams=2 if cisco_platform else 1)
 
     flows = testbed_config.flows
 

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
@@ -293,7 +293,7 @@ def __gen_traffic(testbed_config,
 
     tx_port_name = testbed_config.ports[tx_port_id].name
     rx_port_name = testbed_config.ports[rx_port_id].name
-    data_flow_rate_percent = int(100 / len(prio_list))
+    data_flow_rate_percent = int(99.98 / len(prio_list))
 
     """ For each data flow """
     for i in range(len(data_flow_name_list)):
@@ -309,7 +309,7 @@ def __gen_traffic(testbed_config,
             src_port = random.randint(5000, 6000)
             udp.src_port.increment.start = src_port
             udp.src_port.increment.step = 1
-            udp.src_port.increment.count = 1
+            udp.src_port.increment.count = 2
 
             eth.src.value = tx_mac
             eth.dst.value = rx_mac

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
@@ -1,6 +1,7 @@
 import time
 from math import ceil
 import logging
+import random
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
@@ -304,7 +305,12 @@ def __gen_traffic(testbed_config,
             data_flow.tx_rx.port.tx_name = tx_port_name
             data_flow.tx_rx.port.rx_name = rx_port_name
 
-            eth, ipv4 = data_flow.packet.ethernet().ipv4()
+            eth, ipv4, udp = data_flow.packet.ethernet().ipv4().udp()
+            src_port = random.randomint(5000, 6000)
+            udp.src_port.increment.start = src_port
+            udp.src_port.increment.step = 1
+            udp.src_port.increment.count = 1
+
             eth.src.value = tx_mac
             eth.dst.value = rx_mac
             if pfcQueueGroupSize == 8:

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
@@ -306,7 +306,7 @@ def __gen_traffic(testbed_config,
             data_flow.tx_rx.port.rx_name = rx_port_name
 
             eth, ipv4, udp = data_flow.packet.ethernet().ipv4().udp()
-            src_port = random.randomint(5000, 6000)
+            src_port = random.randint(5000, 6000)
             udp.src_port.increment.start = src_port
             udp.src_port.increment.step = 1
             udp.src_port.increment.count = 1

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_burst_storm_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_burst_storm_helper.py
@@ -1,6 +1,7 @@
 import time
 from math import ceil
 import logging
+import random
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id              # noqa: F401
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, \
@@ -180,7 +181,12 @@ def __gen_traffic(testbed_config,
             data_flow.tx_rx.port.tx_name = tx_port_name
             data_flow.tx_rx.port.rx_name = rx_port_name
 
-            eth, ipv4 = data_flow.packet.ethernet().ipv4()
+            eth, ipv4, udp = data_flow.packet.ethernet().ipv4().udp()
+            src_port = random.randomint(5000, 6000)
+            udp.src_port.increment.start = src_port
+            udp.src_port.increment.step = 1
+            udp.src_port.increment.count = 1
+
             eth.src.value = tx_mac
             eth.dst.value = rx_mac
             if pfcQueueGroupSize == 8:

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_burst_storm_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_burst_storm_helper.py
@@ -182,7 +182,7 @@ def __gen_traffic(testbed_config,
             data_flow.tx_rx.port.rx_name = rx_port_name
 
             eth, ipv4, udp = data_flow.packet.ethernet().ipv4().udp()
-            src_port = random.randomint(5000, 6000)
+            src_port = random.randint(5000, 6000)
             udp.src_port.increment.start = src_port
             udp.src_port.increment.step = 1
             udp.src_port.increment.count = 1

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_multi_node_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_multi_node_helper.py
@@ -108,6 +108,16 @@ def run_pfcwd_multi_node_test(api,
         pfc_storm_dur_sec = 0.5 * detect_time_sec
 
     exp_dur_sec = ceil(pfc_storm_dur_sec + 1)
+    cisco_platform = "Cisco" in egress_duthost.facts['hwsku']
+
+    speed_str = testbed_config.layer1[0].speed
+    speed_gbps = int(speed_str.split('_')[1])
+    # Backplane is 200G in Cisco platforms.
+    if speed_gbps > 200 and cisco_platform:
+        global TEST_FLOW_AGGR_RATE_PERCENT
+        global BG_FLOW_AGGR_RATE_PERCENT
+        TEST_FLOW_AGGR_RATE_PERCENT = TEST_FLOW_AGGR_RATE_PERCENT * 200 / speed_gbps
+        BG_FLOW_AGGR_RATE_PERCENT = BG_FLOW_AGGR_RATE_PERCENT * 200 / speed_gbps
 
     """ Generate traffic config """
     test_flow_rate_percent = int(TEST_FLOW_AGGR_RATE_PERCENT /
@@ -144,9 +154,6 @@ def run_pfcwd_multi_node_test(api,
                                config=testbed_config,
                                all_flow_names=all_flow_names,
                                exp_dur_sec=exp_dur_sec)
-
-    speed_str = testbed_config.layer1[0].speed
-    speed_gbps = int(speed_str.split('_')[1])
 
     __verify_results(rows=flow_stats,
                      speed_gbps=speed_gbps,

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_multi_node_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_multi_node_helper.py
@@ -1,6 +1,7 @@
 import time
 from math import ceil
 import logging
+import random
 
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
@@ -409,7 +410,12 @@ def __gen_data_flow(testbed_config,
     flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
 
-    eth, ipv4 = flow.packet.ethernet().ipv4()
+    eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
+    src_port = random.randomint(5000, 6000)
+    udp.src_port.increment.start = src_port
+    udp.src_port.increment.step = 1
+    udp.src_port.increment.count = 1
+
     eth.src.value = tx_mac
     eth.dst.value = rx_mac
     if pfcQueueGroupSize == 8:

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_multi_node_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_multi_node_helper.py
@@ -411,7 +411,7 @@ def __gen_data_flow(testbed_config,
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
 
     eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-    src_port = random.randomint(5000, 6000)
+    src_port = random.randint(5000, 6000)
     udp.src_port.increment.start = src_port
     udp.src_port.increment.step = 1
     udp.src_port.increment.count = 1

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_runtime_traffic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_runtime_traffic_helper.py
@@ -146,7 +146,7 @@ def __gen_traffic(testbed_config,
         data_flow.tx_rx.port.rx_name = rx_port_name
 
         eth, ipv4, udp = data_flow.packet.ethernet().ipv4().udp()
-        src_port = random.randomint(5000, 6000)
+        src_port = random.randint(5000, 6000)
         udp.src_port.increment.start = src_port
         udp.src_port.increment.step = 1
         udp.src_port.increment.count = 1

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_runtime_traffic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_runtime_traffic_helper.py
@@ -1,5 +1,6 @@
 import time
 import logging
+import random
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id          # noqa: F401
@@ -144,7 +145,12 @@ def __gen_traffic(testbed_config,
         data_flow.tx_rx.port.tx_name = tx_port_name
         data_flow.tx_rx.port.rx_name = rx_port_name
 
-        eth, ipv4 = data_flow.packet.ethernet().ipv4()
+        eth, ipv4, udp = data_flow.packet.ethernet().ipv4().udp()
+        src_port = random.randomint(5000, 6000)
+        udp.src_port.increment.start = src_port
+        udp.src_port.increment.step = 1
+        udp.src_port.increment.count = 1
+
         eth.src.value = tx_mac
         eth.dst.value = rx_mac
         if pfcQueueGroupSize == 8:

--- a/tests/snappi_tests/test_multidut_snappi.py
+++ b/tests/snappi_tests/test_multidut_snappi.py
@@ -57,7 +57,7 @@ def __gen_all_to_all_traffic(testbed_config,
             flow.tx_rx.port.rx_name = rx_port_name
 
             eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-            src_port = random.randomint(5000, 6000)
+            src_port = random.randint(5000, 6000)
             udp.src_port.increment.start = src_port
             udp.src_port.increment.step = 1
             udp.src_port.increment.count = 1

--- a/tests/snappi_tests/test_multidut_snappi.py
+++ b/tests/snappi_tests/test_multidut_snappi.py
@@ -56,7 +56,12 @@ def __gen_all_to_all_traffic(testbed_config,
             flow.tx_rx.port.tx_name = tx_port_name
             flow.tx_rx.port.rx_name = rx_port_name
 
-            eth, ipv4 = flow.packet.ethernet().ipv4()
+            eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
+            src_port = random.randomint(5000, 6000)
+            udp.src_port.increment.start = src_port
+            udp.src_port.increment.step = 1
+            udp.src_port.increment.count = 1
+
             eth.src.value = tx_mac
             eth.dst.value = rx_mac
             eth.pfc_queue.value = priority


### PR DESCRIPTION
This PR proposes to change the IPv4 traffic used in snappi_tests/multidut to UDP traffic with different src ports for every stream.

We need this change since this allows the traffic to be well load-balanced in the backplane ports of the Multi-ASIC architecture. This doesn't affect the other platforms, since they should continue to behave the same irrespective of IPv4 or UDP traffic.

@selldinesh , @kamalsahu0001 , @sdszhang : FYI.
This allows 9 extra tests passing in multi-dut.