### PR TITLE
Enable Py3 and fix issue for lag test

### DIFF
--- a/ansible/roles/test/files/acstests/py3/lag_test.py
+++ b/ansible/roles/test/files/acstests/py3/lag_test.py
@@ -117,7 +117,7 @@ class LacpTimingTest(BaseTest, RouterUtility):
 
         # Get the median
         intervals.sort()
-        current_pkt_timing = intervals[self.interval_count / 2]
+        current_pkt_timing = intervals[int(self.interval_count / 2)]
         return current_pkt_timing
 
     def runTest(self):

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -116,7 +116,8 @@ class LagTest:
             'ether_type': 0x8809,
             'interval_count': 3
         }
-        ptf_runner(self.ptfhost, 'acstests', "lag_test.LacpTimingTest", '/root/ptftests', params=params)
+        ptf_runner(self.ptfhost, 'acstests', "lag_test.LacpTimingTest",
+                   '/root/ptftests', params=params, is_python3=True)
 
     def __verify_lag_minlink(self, host, lag_name, lag_facts,
                              neighbor_intf, deselect_time, wait_timeout=30):


### PR DESCRIPTION
### Description of PR

Bug fix for PR - #14001 

- Fix to enable python3 for `pc/test_lag_2.py -> acstest/lag_test.py`. 
- Fix error that fails in py3 environment

Summary:
Fixes # Not applicable

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

Fix bug in PR #14001 

#### How did you do it?

Enable the test to run in python 3 environment, and fix an issue in `lag_test.py`

#### How did you verify/test it?

Run test on `vs` testbed.

#### Any platform specific information?

Not applicable to the change.

#### Supported testbed topology if it's a new test case?

Not applicable

### Documentation

Not applicable