### PR TITLE
Update test scripts in PFCwd warm reboot

### DIFF
--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -439,14 +439,21 @@ class TestPfcwdWb(SetupPfcwdFunc):
         self.traffic_inst.verify_wd_func(self.dut, detect=detect)
 
     @pytest.fixture(autouse=True)
-    def pfcwd_wb_test_cleanup(self):
+    def pfcwd_wb_test_cleanup(self, setup_pfc_test):
         """
         Cleanup method
+
+        Args:
+            setup_pfc_test(fixture): module scoped autouse fixture
         """
         yield
 
         # stop all threads that might stuck in wait
         DUT_ACTIVE.set()
+        # if there are no neighbor devices detected, exit the cleanup function early
+        if not self.has_neighbor_device(setup_pfc_test):
+            return
+
         for thread in self.storm_threads:
             thread_exception = thread.join(timeout=0.1,
                                            suppress_exception=True)
@@ -577,6 +584,23 @@ class TestPfcwdWb(SetupPfcwdFunc):
             testcase_action(string) : testcase to execute
         """
         yield request.param
+    
+    def has_neighbor_device(self, setup_pfc_test):
+        """
+        Check if there are neighbor devices present 
+
+        Args:
+            setup_pfc_test (fixture): Module scoped autouse fixture for PFCwd
+
+        Returns:
+            bool: True if there are neighbor devices present, False otherwise
+        """
+        for _, details in setup_pfc_test['selected_test_ports'].items():
+            # If any 'rx_port_id' is not [None], neighbor devices are present
+            if details['rx_port_id'] != [None]:
+                return True
+            
+        return False
 
     def test_pfcwd_wb(self, fake_storm, testcase_action, setup_pfc_test, enum_fanout_graph_facts,   # noqa F811
                       ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
@@ -604,6 +628,12 @@ class TestPfcwdWb(SetupPfcwdFunc):
             localhost(AnsibleHost) : localhost instance
             fanouthosts(AnsibleHost): fanout instance
         """
+        # skip the pytest when the device does not have neighbors
+        # 'rx_port_id' being None indicates there are no ports available to send frames for the fake storm
+        if not self.has_neighbor_device(setup_pfc_test):
+            pytest.skip("Test skipped: No neighbors detected as 'rx_port_id' is None for selected test ports,"
+                        " which is necessary for PFCwd test setup.")
+
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         logger.info("--- {} ---".format(TESTCASE_INFO[testcase_action]['desc']))
         self.pfcwd_wb_helper(fake_storm, TESTCASE_INFO[testcase_action]['test_sequence'], setup_pfc_test,

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -452,7 +452,6 @@ class TestPfcwdWb(SetupPfcwdFunc):
             # If any 'rx_port_id' is not [None], neighbor devices are present
             if details['rx_port_id'] != [None]:
                 return True
-            
         return False
     
     @pytest.fixture(autouse=True)

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -438,6 +438,23 @@ class TestPfcwdWb(SetupPfcwdFunc):
         # test pfcwd functionality on a storm/restore
         self.traffic_inst.verify_wd_func(self.dut, detect=detect)
 
+    def has_neighbor_device(self, setup_pfc_test):
+        """
+        Check if there are neighbor devices present 
+
+        Args:
+            setup_pfc_test (fixture): Module scoped autouse fixture for PFCwd
+
+        Returns:
+            bool: True if there are neighbor devices present, False otherwise
+        """
+        for _, details in setup_pfc_test['selected_test_ports'].items():
+            # If any 'rx_port_id' is not [None], neighbor devices are present
+            if details['rx_port_id'] != [None]:
+                return True
+            
+        return False
+    
     @pytest.fixture(autouse=True)
     def pfcwd_wb_test_cleanup(self, setup_pfc_test):
         """
@@ -584,23 +601,6 @@ class TestPfcwdWb(SetupPfcwdFunc):
             testcase_action(string) : testcase to execute
         """
         yield request.param
-    
-    def has_neighbor_device(self, setup_pfc_test):
-        """
-        Check if there are neighbor devices present 
-
-        Args:
-            setup_pfc_test (fixture): Module scoped autouse fixture for PFCwd
-
-        Returns:
-            bool: True if there are neighbor devices present, False otherwise
-        """
-        for _, details in setup_pfc_test['selected_test_ports'].items():
-            # If any 'rx_port_id' is not [None], neighbor devices are present
-            if details['rx_port_id'] != [None]:
-                return True
-            
-        return False
 
     def test_pfcwd_wb(self, fake_storm, testcase_action, setup_pfc_test, enum_fanout_graph_facts,   # noqa F811
                       ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add a function to check if there are neighbor devices present before executing PFCwd warm reboot tests
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Skip pytest execution for a selected subset of ports if 'rx_port_id' is None (e.g., in a t0 standalone topo) during PFCwd test setup

#### How did you do it?
Added a function to check if there are neighbor devices present. If there are no neighbor devices detected, skip pytest and exit the cleanup function early.

#### How did you verify/test it?
Validate it in internal setup

#### Any platform specific information?
<html>
<body>
<!--StartFragment-->
str3-7060x6-64pe-1

<!--EndFragment-->
</body>
</html>

#### Supported testbed topology if it's a new test case?
t0-standalone-32
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
