### PR TITLE
Make gcu/hash/span/sub_port test compatible with VS platform

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -357,8 +357,6 @@ onboarding_t0:
   - hash/test_generic_hash.py
   - span/test_port_mirroring.py
   - drop_packets/test_drop_counters.py
-  - vrf/test_vrf.py
-  - vrf/test_vrf_attr.py
 
 onboarding_t1:
   - generic_config_updater/test_cacl.py

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -56,8 +56,10 @@ t0:
   # There is no table SYSTEM_HEALTH_INFO in STATE_DB on kvm testbed
   # The tests in this script are all related to the above table
   - system_health/test_system_health.py
-  # This script is also skipped in nightly test
+  # Vrf tests are also skipped in nightly test
   - mvrf/test_mgmtvrf.py
+  - vrf/test_vrf.py
+  - vrf/test_vrf_attr.py
 
 t1-lag:
   # KVM do not support bfd test
@@ -109,7 +111,7 @@ t1-lag:
   # There is no table SYSTEM_HEALTH_INFO in STATE_DB on kvm testbed
   # The tests in this script are all related to the above table
   - system_health/test_system_health.py
-  # This script is also skipped in nightly test
+  # Vrf tests are also skipped in nightly test
   - mvrf/test_mgmtvrf.py
 
 t2:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -721,21 +721,27 @@ hash/test_generic_hash.py::test_ecmp_and_lag_hash:
 
 hash/test_generic_hash.py::test_lag_member_flap:
   skip:
-    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm'
+    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm, for other platforms, skipping due to missing object in SonicHost'
+    conditions_logical_operator: "OR"
     conditions:
       - "asic_gen == 'spc1'"
+      - https://github.com/sonic-net/sonic-mgmt/issues/13919
 
 hash/test_generic_hash.py::test_lag_member_remove_add:
   skip:
-    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm'
+    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm, for other platforms, skipping due to missing object in SonicHost'
+    conditions_logical_operator: "OR"
     conditions:
       - "asic_gen == 'spc1'"
+      - https://github.com/sonic-net/sonic-mgmt/issues/13919
 
 hash/test_generic_hash.py::test_nexthop_flap:
   skip:
-    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm'
+    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm, for other platforms, skipping due to missing object in SonicHost'
+    conditions_logical_operator: "OR"
     conditions:
       - "asic_gen == 'spc1'"
+      - https://github.com/sonic-net/sonic-mgmt/issues/13919
 
 hash/test_generic_hash.py::test_reboot:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -178,6 +178,24 @@ fib/test_fib.py:
       - "asic_type in ['vs']"
 
 #######################################
+#####   generic_config_updater    #####
+#######################################
+generic_config_updater/test_dynamic_acl.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
+#####           hash              #####
+#######################################
+hash/test_generic_hash.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
 #####            ip               #####
 #######################################
 ip/test_ip_packet.py:
@@ -190,6 +208,24 @@ ip/test_ip_packet.py:
 #####            ipfwd            #####
 #######################################
 ipfwd/test_dir_bcast.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
+#####            span             #####
+#######################################
+span/test_port_mirroring.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
+#####     sub_port_interfaces     #####
+#######################################
+sub_port_interfaces/test_sub_port_interfaces.py:
   skip_traffic_test:
     reason: "Skip traffic test for KVM testbed"
     conditions:

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -35,7 +35,8 @@ from tests.generic_config_updater.gu_utils import expect_acl_table_match_multipl
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa F401
 from tests.common.dualtor.dual_tor_utils import setup_standby_ports_on_rand_unselected_tor # noqa F401
 from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh_type
-
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test           # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0'),
@@ -847,7 +848,8 @@ def dynamic_acl_create_dhcp_forward_rule(duthost, setup):
     expect_acl_rule_match(duthost, "DHCPV6_RULE", expected_v6_rule_content, setup)
 
 
-def dynamic_acl_verify_packets(setup, ptfadapter, packets, packets_dropped, src_port=None):
+def dynamic_acl_verify_packets(setup, ptfadapter, packets, packets_dropped, src_port=None,
+                               skip_traffic_test=False):        # noqa F811
     """Verify that the given packets are either dropped/forwarded correctly
 
     Args:
@@ -862,6 +864,9 @@ def dynamic_acl_verify_packets(setup, ptfadapter, packets, packets_dropped, src_
     if src_port is None:
         src_port = setup["blocked_src_port_indice"]
 
+    if skip_traffic_test is True:
+        logger.info("Skipping traffic test")
+        return
     for rule, pkt in list(packets.items()):
         logger.info("Testing that {} packets are correctly {}".format(rule, action_type))
         exp_pkt = build_exp_pkt(pkt)
@@ -1066,7 +1071,8 @@ def test_gcu_acl_arp_rule_creation(rand_selected_dut,
                                    setup,
                                    dynamic_acl_create_table,
                                    prepare_ptf_intf_and_ip,
-                                   toggle_all_simulator_ports_to_rand_selected_tor):  # noqa F811
+                                   toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
+                                   skip_traffic_test):  # noqa F811
     """Test that we can create a blanket ARP/NDP packet forwarding rule with GCU, and that ARP/NDP packets
     are correctly forwarded while all others are dropped."""
 
@@ -1101,7 +1107,8 @@ def test_gcu_acl_arp_rule_creation(rand_selected_dut,
                                ptfadapter,
                                packets=generate_packets(setup, DST_IP_BLOCKED, DST_IPV6_BLOCKED),
                                packets_dropped=True,
-                               src_port=ptf_intf_index)
+                               src_port=ptf_intf_index,
+                               skip_traffic_test=skip_traffic_test)
 
 
 def test_gcu_acl_dhcp_rule_creation(rand_selected_dut,
@@ -1109,8 +1116,9 @@ def test_gcu_acl_dhcp_rule_creation(rand_selected_dut,
                                     ptfadapter,
                                     setup,
                                     dynamic_acl_create_table,
-                                    toggle_all_simulator_ports_to_rand_selected_tor, # noqa F811
-                                    setup_standby_ports_on_rand_unselected_tor):  # noqa F811
+                                    toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
+                                    setup_standby_ports_on_rand_unselected_tor,         # noqa F811
+                                    skip_traffic_test):  # noqa F811
     """Verify that DHCP and DHCPv6 forwarding rules can be created, and that dhcp packets are properly forwarded
     whereas others are dropped"""
 
@@ -1125,7 +1133,8 @@ def test_gcu_acl_dhcp_rule_creation(rand_selected_dut,
     dynamic_acl_verify_packets(setup,
                                ptfadapter,
                                packets=generate_packets(setup, DST_IP_BLOCKED, DST_IPV6_BLOCKED),
-                               packets_dropped=True)
+                               packets_dropped=True,
+                               skip_traffic_test=skip_traffic_test)
 
 
 def test_gcu_acl_drop_rule_creation(rand_selected_dut,
@@ -1133,7 +1142,8 @@ def test_gcu_acl_drop_rule_creation(rand_selected_dut,
                                     ptfadapter,
                                     setup,
                                     dynamic_acl_create_table,
-                                    toggle_all_simulator_ports_to_rand_selected_tor):  # noqa F811
+                                    toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
+                                    skip_traffic_test):  # noqa F811
     """Test that we can create a drop rule via GCU, and that once this drop rule is in place packets
     that match the drop rule are dropped and packets that do not match the drop rule are forwarded"""
 
@@ -1142,12 +1152,14 @@ def test_gcu_acl_drop_rule_creation(rand_selected_dut,
     dynamic_acl_verify_packets(setup,
                                ptfadapter,
                                packets=generate_packets(setup, DST_IP_BLOCKED, DST_IPV6_BLOCKED),
-                               packets_dropped=True)
+                               packets_dropped=True,
+                               skip_traffic_test=skip_traffic_test)
     dynamic_acl_verify_packets(setup,
                                ptfadapter,
                                packets=generate_packets(setup, DST_IP_BLOCKED, DST_IPV6_BLOCKED),
                                packets_dropped=False,
-                               src_port=setup["unblocked_src_port_indice"])
+                               src_port=setup["unblocked_src_port_indice"],
+                               skip_traffic_test=skip_traffic_test)
 
 
 def test_gcu_acl_drop_rule_removal(rand_selected_dut,
@@ -1155,7 +1167,8 @@ def test_gcu_acl_drop_rule_removal(rand_selected_dut,
                                    ptfadapter,
                                    setup,
                                    dynamic_acl_create_table,
-                                   toggle_all_simulator_ports_to_rand_selected_tor):  # noqa F811
+                                   toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
+                                   skip_traffic_test):  # noqa F811
     """Test that once a drop rule is removed, packets that were previously being dropped are now forwarded"""
 
     dynamic_acl_create_three_drop_rules(rand_selected_dut, setup)
@@ -1165,7 +1178,8 @@ def test_gcu_acl_drop_rule_removal(rand_selected_dut,
                                ptfadapter,
                                packets=generate_packets(setup, DST_IP_BLOCKED, DST_IPV6_BLOCKED),
                                packets_dropped=False,
-                               src_port=setup["scale_port_indices"][2])
+                               src_port=setup["scale_port_indices"][2],
+                               skip_traffic_test=skip_traffic_test)
 
 
 def test_gcu_acl_forward_rule_priority_respected(rand_selected_dut,
@@ -1173,7 +1187,8 @@ def test_gcu_acl_forward_rule_priority_respected(rand_selected_dut,
                                                  ptfadapter,
                                                  setup,
                                                  dynamic_acl_create_table,
-                                                 toggle_all_simulator_ports_to_rand_selected_tor):  # noqa F811
+                                                 toggle_all_simulator_ports_to_rand_selected_tor,   # noqa F811
+                                                 skip_traffic_test):  # noqa F811
     """Test that forward rules and drop rules can be created at the same time, with the forward rules having
     higher priority than drop.  Then, perform a traffic test to confirm that packets that match both the forward
     and drop rules are correctly forwarded, as the forwarding rules have higher priority"""
@@ -1181,10 +1196,11 @@ def test_gcu_acl_forward_rule_priority_respected(rand_selected_dut,
     dynamic_acl_create_forward_rules(rand_selected_dut, setup)
     dynamic_acl_create_secondary_drop_rule(rand_selected_dut, setup)
 
-    dynamic_acl_verify_packets(setup, ptfadapter, packets=generate_packets(setup), packets_dropped=False)
+    dynamic_acl_verify_packets(setup, ptfadapter, packets=generate_packets(setup),
+                               packets_dropped=False, skip_traffic_test=skip_traffic_test)
     dynamic_acl_verify_packets(setup, ptfadapter,
                                packets=generate_packets(setup, DST_IP_BLOCKED, DST_IPV6_BLOCKED),
-                               packets_dropped=True)
+                               packets_dropped=True, skip_traffic_test=skip_traffic_test)
 
 
 def test_gcu_acl_forward_rule_replacement(rand_selected_dut,
@@ -1192,7 +1208,8 @@ def test_gcu_acl_forward_rule_replacement(rand_selected_dut,
                                           ptfadapter,
                                           setup,
                                           dynamic_acl_create_table,
-                                          toggle_all_simulator_ports_to_rand_selected_tor):  # noqa F811
+                                          toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
+                                          skip_traffic_test):  # noqa F811
     """Test that forward rules can be created, and then afterwards can have their match pattern updated to a new value.
     Confirm that packets sent that match this new value are correctly forwarded, and that packets that are sent that
     match the old, replaced value are correctly dropped."""
@@ -1206,8 +1223,10 @@ def test_gcu_acl_forward_rule_replacement(rand_selected_dut,
                                packets=generate_packets(setup,
                                                         DST_IP_FORWARDED_REPLACEMENT,
                                                         DST_IPV6_FORWARDED_REPLACEMENT),
-                               packets_dropped=False)
-    dynamic_acl_verify_packets(setup, ptfadapter, packets=generate_packets(setup), packets_dropped=True)
+                               packets_dropped=False,
+                               skip_traffic_test=skip_traffic_test)
+    dynamic_acl_verify_packets(setup, ptfadapter, packets=generate_packets(setup), packets_dropped=True,
+                               skip_traffic_test=skip_traffic_test)
 
 
 @pytest.mark.parametrize("ip_type", ["IPV4", "IPV6"])
@@ -1217,7 +1236,8 @@ def test_gcu_acl_forward_rule_removal(rand_selected_dut,
                                       setup,
                                       ip_type,
                                       dynamic_acl_create_table,
-                                      toggle_all_simulator_ports_to_rand_selected_tor):  # noqa F811
+                                      toggle_all_simulator_ports_to_rand_selected_tor,          # noqa F811
+                                      skip_traffic_test):  # noqa F811
     """Test that if a forward rule is created, and then removed, that packets associated with that rule are properly
     no longer forwarded, and packets associated with the remaining rule are forwarded"""
 
@@ -1234,12 +1254,15 @@ def test_gcu_acl_forward_rule_removal(rand_selected_dut,
     # generate_packets returns ipv4 and ipv6 packets. remove vals from two dicts so that only correct packets remain
     drop_packets.pop(other_type)
     forward_packets.pop(ip_type)
-    dynamic_acl_verify_packets(setup, ptfadapter, drop_packets, packets_dropped=True)
-    dynamic_acl_verify_packets(setup, ptfadapter, forward_packets, packets_dropped=False)
+    dynamic_acl_verify_packets(setup, ptfadapter, drop_packets, packets_dropped=True,
+                               skip_traffic_test=skip_traffic_test)
+    dynamic_acl_verify_packets(setup, ptfadapter, forward_packets, packets_dropped=False,
+                               skip_traffic_test=skip_traffic_test)
 
 
 def test_gcu_acl_scale_rules(rand_selected_dut, rand_unselected_dut, ptfadapter, setup, dynamic_acl_create_table,
-                             toggle_all_simulator_ports_to_rand_selected_tor):  # noqa F811
+                             toggle_all_simulator_ports_to_rand_selected_tor,       # noqa F811
+                             skip_traffic_test):  # noqa F811
     """Perform a scale test, creating 150 forward rules with top priority,
     and then creating a drop rule for every single VLAN port on our device.
     Select any one of our blocked ports, as well as the ips for two of our forward rules,
@@ -1259,23 +1282,27 @@ def test_gcu_acl_scale_rules(rand_selected_dut, rand_unselected_dut, ptfadapter,
                                ptfadapter,
                                generate_packets(setup, v4_dest, v6_dest),
                                packets_dropped=False,
-                               src_port=blocked_scale_port)
+                               src_port=blocked_scale_port,
+                               skip_traffic_test=skip_traffic_test)
     dynamic_acl_verify_packets(setup,
                                ptfadapter,
                                generate_packets(setup, DST_IP_BLOCKED, DST_IPV6_BLOCKED),
                                packets_dropped=True,
-                               src_port=blocked_scale_port)
+                               src_port=blocked_scale_port,
+                               skip_traffic_test=skip_traffic_test)
 
 
 def test_gcu_acl_nonexistent_rule_replacement(rand_selected_dut,
                                               toggle_all_simulator_ports_to_rand_selected_tor, # noqa F811
-                                              setup):
+                                              setup,
+                                              skip_traffic_test):   # noqa F811
     """Confirm that replacing a nonexistent rule results in operation failure"""
     dynamic_acl_replace_nonexistent_rule(rand_selected_dut, setup)
 
 
 def test_gcu_acl_nonexistent_table_removal(rand_selected_dut,
                                            toggle_all_simulator_ports_to_rand_selected_tor, # noqa F811
-                                           setup):
+                                           setup,
+                                           skip_traffic_test):      # noqa F811
     """Confirm that removing a nonexistent table results in operation failure"""
     dynamic_acl_remove_nonexistent_table(rand_selected_dut, setup)

--- a/tests/hash/test_generic_hash.py
+++ b/tests/hash/test_generic_hash.py
@@ -1,6 +1,7 @@
 import pytest
 import random
 import time
+import logging
 
 from tests.common.helpers.assertions import pytest_assert
 from generic_hash_helper import get_hash_fields_from_option, get_ip_version_from_option, get_encap_type_from_option, \
@@ -13,7 +14,9 @@ from generic_hash_helper import mg_facts, restore_init_hash_config, restore_vxla
     get_supported_hash_algorithms, toggle_all_simulator_ports_to_upper_tor   # noqa:F401
 from tests.common.utilities import wait_until
 from tests.ptf_runner import ptf_runner
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory  # noqa F401
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test           # noqa F401
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.reboot import reboot
 from tests.common.config_reload import config_reload
@@ -25,6 +28,7 @@ PTF_LOG_PATH = "/tmp/generic_hash_test.GenericHashTest.log"
 pytestmark = [
     pytest.mark.topology('t0', 't1'),
 ]
+logger = logging.getLogger(__name__)
 
 
 def pytest_generate_tests(metafunc):
@@ -128,7 +132,7 @@ def test_hash_capability(duthost, global_hash_capabilities):  # noqa:F811
 
 
 def test_ecmp_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, global_hash_capabilities,  # noqa:F811
-                   restore_vxlan_port, toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+                   restore_vxlan_port, toggle_all_simulator_ports_to_upper_tor, skip_traffic_test):  # noqa:F811
     """
     Test case to validate the ecmp hash. The hash field to test is randomly chosen from the supported hash fields.
     Args:
@@ -171,21 +175,23 @@ def test_ecmp_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, global_hash_
         # Check the default route before the ptf test
         pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
                       'The default route is not available or some nexthops are missing.')
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+        if not skip_traffic_test:
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
 
-def test_lag_hash(duthost, ptfhost, tbinfo, fine_params, mg_facts, restore_configuration,  # noqa:F811
-                  restore_vxlan_port, global_hash_capabilities, toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+def test_lag_hash(duthost, ptfhost, tbinfo, fine_params, mg_facts, restore_configuration,   # noqa:F811
+                  restore_vxlan_port, global_hash_capabilities,                             # noqa F811
+                  toggle_all_simulator_ports_to_upper_tor, skip_traffic_test):              # noqa:F811
     """
     Test case to validate the lag hash. The hash field to test is randomly chosen from the supported hash fields.
     When hash field is in [DST_MAC, ETHERTYPE, VLAN_ID], need to re-configure the dut for L2 traffic.
@@ -242,17 +248,18 @@ def test_lag_hash(duthost, ptfhost, tbinfo, fine_params, mg_facts, restore_confi
         if not is_l2_test:
             pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
                           'The default route is not available or some nexthops are missing.')
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+        if not skip_traffic_test:
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
 
 def config_all_hash_fields(duthost, global_hash_capabilities):  # noqa:F811
@@ -267,7 +274,7 @@ def config_all_hash_algorithm(duthost, ecmp_algorithm, lag_algorithm):  # noqa:F
 
 def test_ecmp_and_lag_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, global_hash_capabilities,  # noqa:F811
                            restore_vxlan_port, get_supported_hash_algorithms,  # noqa:F811
-                           toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+                           toggle_all_simulator_ports_to_upper_tor, skip_traffic_test):  # noqa:F811
     """
     Test case to validate the hash behavior when both ecmp and lag hash are configured with a same field.
     The hash field to test is randomly chosen from the supported hash fields.
@@ -306,22 +313,23 @@ def test_ecmp_and_lag_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, glob
         # Check the default route before the ptf test
         pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
                       'The default route is not available or some nexthops are missing.')
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+        if not skip_traffic_test:
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
 
 def test_nexthop_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_interfaces,  # noqa:F811
                       restore_vxlan_port, global_hash_capabilities, get_supported_hash_algorithms,  # noqa:F811
-                      toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+                      toggle_all_simulator_ports_to_upper_tor, skip_traffic_test):  # noqa:F811
     """
     Test case to validate the ecmp hash when there is nexthop flapping.
     The hash field to test is randomly chosen from the supported hash fields.
@@ -361,17 +369,18 @@ def test_nexthop_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_i
         # Check the default route before the ptf test
         pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
                       'The default route is not available or some nexthops are missing.')
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+        if not skip_traffic_test:
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
     with allure.step('Randomly shutdown 1 nexthop interface'):
         interface = random.choice(list(uplink_interfaces.keys()))
         remaining_uplink_interfaces = uplink_interfaces.copy()
@@ -381,17 +390,18 @@ def test_nexthop_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_i
             mg_facts, downlink_interfaces=[], uplink_interfaces=remaining_uplink_interfaces)
         shutdown_interface(duthost, interface)
     with allure.step('Start the ptf test, send traffic and check the balancing'):
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+        if not skip_traffic_test:
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
     with allure.step('Startup the interface, and then flap it 3 more times'):
         startup_interface(duthost, interface)
         flap_interfaces(duthost, [interface], times=3)
@@ -399,22 +409,24 @@ def test_nexthop_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_i
                       'The default route is not restored after the flapping.')
         ptf_params['expected_port_groups'] = origin_ptf_expected_port_groups
     with allure.step('Start the ptf test, send traffic and check the balancing'):
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+        if not skip_traffic_test:
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
 
-def test_lag_member_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_configuration,  # noqa:F811
-                         restore_interfaces, global_hash_capabilities, restore_vxlan_port,  # noqa:F811
-                         get_supported_hash_algorithms, toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+def test_lag_member_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_configuration,    # noqa F811
+                         restore_interfaces, global_hash_capabilities, restore_vxlan_port,          # noqa F811
+                         get_supported_hash_algorithms, toggle_all_simulator_ports_to_upper_tor,    # noqa F811
+                         skip_traffic_test):                                                        # noqa F811
     """
     Test case to validate the lag hash when there is lag member flapping.
     The hash field to test is randomly chosen from the supported hash fields.
@@ -471,17 +483,18 @@ def test_lag_member_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restor
         if not is_l2_test:
             pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
                           'The default route is not available or some nexthops are missing.')
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+        if not skip_traffic_test:
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
     with allure.step('Randomly select one member in each portchannel and flap them 3 times'):
         # Randomly choose the members to flap
@@ -496,24 +509,25 @@ def test_lag_member_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restor
         with allure.step('Wait for the default route to recover'):
             pytest_assert(wait_until(30, 5, 0, check_default_route, duthost, uplink_interfaces.keys()),
                           'The default route is not available or some nexthops are missing.')
-
     with allure.step('Start the ptf test, send traffic and check the balancing'):
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+        if not skip_traffic_test:
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
 
-def test_lag_member_remove_add(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_configuration,  # noqa:F811
-                               restore_interfaces, global_hash_capabilities, restore_vxlan_port,  # noqa:F811
-                               get_supported_hash_algorithms, toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+def test_lag_member_remove_add(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_configuration,      # noqa F811
+                               restore_interfaces, global_hash_capabilities, restore_vxlan_port,            # noqa F811
+                               get_supported_hash_algorithms, toggle_all_simulator_ports_to_upper_tor,      # noqa F811
+                               skip_traffic_test):                                                          # noqa F811
     """
     Test case to validate the lag hash when a lag member is removed from the lag and added back for
     a few times.
@@ -571,17 +585,18 @@ def test_lag_member_remove_add(duthost, tbinfo, ptfhost, fine_params, mg_facts, 
         if not is_l2_test:
             pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
                           'The default route is not available or some nexthops are missing.')
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+        if not skip_traffic_test:
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
     with allure.step('Randomly select one member in each portchannel and remove it from the lag and add it back'):
         # Randomly choose the members to remove/add
@@ -595,22 +610,23 @@ def test_lag_member_remove_add(duthost, tbinfo, ptfhost, fine_params, mg_facts, 
                           'The default route is not available or some nexthops are missing.')
 
     with allure.step('Start the ptf test, send traffic and check the balancing'):
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+        if not skip_traffic_test:
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
 
-def test_reboot(duthost, tbinfo, ptfhost, localhost, fine_params, mg_facts, restore_vxlan_port,  # noqa:F811
-                global_hash_capabilities, reboot_type, get_supported_hash_algorithms,  # noqa:F811
-                toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+def test_reboot(duthost, tbinfo, ptfhost, localhost, fine_params, mg_facts, restore_vxlan_port,     # noqa F811
+                global_hash_capabilities, reboot_type, get_supported_hash_algorithms,               # noqa F811
+                toggle_all_simulator_ports_to_upper_tor, skip_traffic_test):                        # noqa F811
     """
     Test case to validate the hash behavior after fast/warm/cold reboot.
     The hash field to test is randomly chosen from the supported hash fields.
@@ -650,17 +666,18 @@ def test_reboot(duthost, tbinfo, ptfhost, localhost, fine_params, mg_facts, rest
         # Check the default route before the ptf test
         pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
                       'The default route is not available or some nexthops are missing.')
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+        if not skip_traffic_test:
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
     with allure.step(f'Randomly choose a reboot type: {reboot_type}, and reboot'):
         # Save config if reboot type is config reload or cold reboot
@@ -680,17 +697,18 @@ def test_reboot(duthost, tbinfo, ptfhost, localhost, fine_params, mg_facts, rest
         pytest_assert(wait_until(60, 10, 0, check_default_route, duthost, uplink_interfaces.keys()),
                       "The default route is not established after the cold reboot.")
     with allure.step('Start the ptf test, send traffic and check the balancing'):
-        ptf_runner(
-            ptfhost,
-            "ptftests",
-            "generic_hash_test.GenericHashTest",
-            platform_dir="ptftests",
-            params=ptf_params,
-            log_file=PTF_LOG_PATH,
-            qlen=PTF_QLEN,
-            socket_recv_size=16384,
-            is_python3=True
-        )
+        if not skip_traffic_test:
+            ptf_runner(
+                ptfhost,
+                "ptftests",
+                "generic_hash_test.GenericHashTest",
+                platform_dir="ptftests",
+                params=ptf_params,
+                log_file=PTF_LOG_PATH,
+                qlen=PTF_QLEN,
+                socket_recv_size=16384,
+                is_python3=True
+            )
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/span/span_helpers.py
+++ b/tests/span/span_helpers.py
@@ -5,7 +5,7 @@ Helper functions for span tests
 import ptf.testutils as testutils
 
 
-def send_and_verify_mirrored_packet(ptfadapter, src_port, monitor):
+def send_and_verify_mirrored_packet(ptfadapter, src_port, monitor, skip_traffic_test=False):
     '''
     Send packet from ptf and verify it on monitor port
 
@@ -18,6 +18,8 @@ def send_and_verify_mirrored_packet(ptfadapter, src_port, monitor):
 
     pkt = testutils.simple_icmp_packet(eth_src=src_mac, eth_dst='ff:ff:ff:ff:ff:ff')
 
+    if skip_traffic_test is True:
+        return
     ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, src_port, pkt)
     testutils.verify_packet(ptfadapter, pkt, monitor)

--- a/tests/span/test_port_mirroring.py
+++ b/tests/span/test_port_mirroring.py
@@ -6,13 +6,15 @@ import pytest
 
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
 from span_helpers import send_and_verify_mirrored_packet
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test       # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t0')
 ]
 
 
-def test_mirroring_rx(ptfadapter, setup_session):
+def test_mirroring_rx(ptfadapter, setup_session, skip_traffic_test):    # noqa F811
     '''
     Test case #1
     Verify ingress direction session
@@ -26,10 +28,11 @@ def test_mirroring_rx(ptfadapter, setup_session):
     '''
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source1_index'],
-                                    setup_session['destination_index'])
+                                    setup_session['destination_index'],
+                                    skip_traffic_test=skip_traffic_test)
 
 
-def test_mirroring_tx(ptfadapter, setup_session):
+def test_mirroring_tx(ptfadapter, setup_session, skip_traffic_test):    # noqa F811
     '''
     Test case #2
     Verify egress direction session
@@ -43,10 +46,11 @@ def test_mirroring_tx(ptfadapter, setup_session):
     '''
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source2_index'],
-                                    setup_session['destination_index'])
+                                    setup_session['destination_index'],
+                                    skip_traffic_test=skip_traffic_test)
 
 
-def test_mirroring_both(ptfadapter, setup_session):
+def test_mirroring_both(ptfadapter, setup_session, skip_traffic_test):    # noqa F811
     '''
     Test case #3
     Verify bidirectional session
@@ -63,14 +67,16 @@ def test_mirroring_both(ptfadapter, setup_session):
     '''
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source1_index'],
-                                    setup_session['destination_index'])
+                                    setup_session['destination_index'],
+                                    skip_traffic_test=skip_traffic_test)
 
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source2_index'],
-                                    setup_session['destination_index'])
+                                    setup_session['destination_index'],
+                                    skip_traffic_test=skip_traffic_test)
 
 
-def test_mirroring_multiple_source(ptfadapter, setup_session):
+def test_mirroring_multiple_source(ptfadapter, setup_session, skip_traffic_test):    # noqa F811
     '''
     Test case #4
     Verify ingress direction session with multiple source ports
@@ -87,8 +93,10 @@ def test_mirroring_multiple_source(ptfadapter, setup_session):
     '''
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source1_index'],
-                                    setup_session['destination_index'])
+                                    setup_session['destination_index'],
+                                    skip_traffic_test=skip_traffic_test)
 
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source2_index'],
-                                    setup_session['destination_index'])
+                                    setup_session['destination_index'],
+                                    skip_traffic_test=skip_traffic_test)

--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -2,6 +2,7 @@ import os
 import time
 import random
 import ipaddress
+import logging
 
 from collections import OrderedDict
 
@@ -20,6 +21,7 @@ from tests.common.utilities import wait_until
 from tests.common.pkt_filter.filter_pkt_in_buffer import FilterPktBuffer
 from tests.common import constants
 
+logger = logging.getLogger(__name__)
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 DUT_TMP_DIR = os.path.join('tmp', os.path.basename(BASE_DIR))
@@ -84,7 +86,7 @@ def create_packet(eth_dst, eth_src, ip_dst, ip_src, vlan_vid, tr_type, ttl, dl_v
 
 def generate_and_verify_traffic(duthost, ptfadapter, src_port, dst_port, ptfhost=None, ip_src='', ip_dst='',
                                 pkt_action=None, type_of_traffic='ICMP', ttl=64, pktlen=100, ip_tunnel=None,
-                                **kwargs):
+                                skip_traffic_test=False, **kwargs):
     """
     Send packet from PTF to DUT and
     verify that DUT sends/doesn't packet to PTF.
@@ -103,6 +105,9 @@ def generate_and_verify_traffic(duthost, ptfadapter, src_port, dst_port, ptfhost
         pktlen: packet length
         ip_tunnel: Tunnel IP address of DUT
     """
+    if skip_traffic_test is True:
+        logger.info("Skipping traffic test")
+        return
     type_of_traffic = [type_of_traffic] if not isinstance(type_of_traffic, list) else type_of_traffic
 
     for tr_type in type_of_traffic:

--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -15,7 +15,8 @@ from sub_ports_helpers import remove_vlan
 from sub_ports_helpers import check_sub_port
 from sub_ports_helpers import remove_sub_port
 from sub_ports_helpers import create_sub_port_on_dut
-
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test       # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t0', 't1')
@@ -346,7 +347,8 @@ class TestSubPorts(object):
                                             ttl=63,
                                             pktlen=pktlen)
 
-    def test_tunneling_between_sub_ports(self, duthost, ptfadapter, apply_tunnel_table_to_dut, apply_route_config):
+    def test_tunneling_between_sub_ports(self, duthost, ptfadapter, apply_tunnel_table_to_dut,
+                                         apply_route_config, skip_traffic_test):    # noqa F811
         """
         Validates that packets are routed between sub-ports.
 
@@ -379,9 +381,11 @@ class TestSubPorts(object):
                                             ip_tunnel=sub_ports[src_port]['ip'],
                                             pkt_action='fwd',
                                             type_of_traffic='decap',
-                                            ttl=63)
+                                            ttl=63,
+                                            skip_traffic_test=skip_traffic_test)
 
-    def test_balancing_sub_ports(self, duthost, ptfhost, ptfadapter, apply_balancing_config):
+    def test_balancing_sub_ports(self, duthost, ptfhost, ptfadapter,
+                                 apply_balancing_config, skip_traffic_test):        # noqa F811
         """
         Validates load-balancing when sub-port is part of ECMP
         Test steps:
@@ -414,12 +418,13 @@ class TestSubPorts(object):
                                         dst_port=dst_ports,
                                         ip_dst=ip_dst,
                                         type_of_traffic='balancing',
-                                        ttl=63)
+                                        ttl=63,
+                                        skip_traffic_test=skip_traffic_test)
 
 
 class TestSubPortsNegative(object):
     def test_packet_routed_with_invalid_vlan(self, duthost, ptfadapter, apply_config_on_the_dut,
-                                             apply_config_on_the_ptf):
+                                             apply_config_on_the_ptf, skip_traffic_test):       # noqa F811
         """
         Validates that packet aren't routed if sub-ports have invalid VLAN ID.
 
@@ -443,11 +448,13 @@ class TestSubPortsNegative(object):
                                         ip_src=value['neighbor_ip'],
                                         dst_port=sub_port,
                                         ip_dst=value['ip'],
-                                        pkt_action='drop')
+                                        pkt_action='drop',
+                                        skip_traffic_test=skip_traffic_test)
 
 
 class TestSubPortStress(object):
-    def test_max_numbers_of_sub_ports(self, duthost, ptfadapter, apply_config_on_the_dut, apply_config_on_the_ptf):
+    def test_max_numbers_of_sub_ports(self, duthost, ptfadapter, apply_config_on_the_dut,
+                                      apply_config_on_the_ptf, skip_traffic_test):      # noqa F811
         """
         Validates that 256 sub-ports can be created per port or LAG
 
@@ -480,4 +487,5 @@ class TestSubPortStress(object):
                                         ip_src=value['neighbor_ip'],
                                         dst_port=sub_port,
                                         ip_dst=value['ip'],
-                                        pkt_action='fwd')
+                                        pkt_action='fwd',
+                                        skip_traffic_test=skip_traffic_test)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed.
#### How did you do it?
Skip traffic test to make gcu/hash/span/sub_port test compatible with VS platform
Create https://github.com/sonic-net/sonic-mgmt/issues/13919 regarding missing object in SonicHost, skip related test until issue resolved
#### How did you verify/test it?
Test in KVM
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
