### PR TITLE
Make drop_packet test compatible with VS platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -62,6 +62,15 @@ decap/test_decap.py:
       - "asic_type in ['vs']"
 
 #######################################
+#####         drop_packets        #####
+#######################################
+drop_packets/test_drop_counters.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
 #####           dualtor           #####
 #######################################
 dualtor/test_ipinip.py:

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -15,6 +15,8 @@ from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common import config_reload
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test       # noqa F401
 
 RX_DRP = "RX_DRP"
 RX_ERR = "RX_ERR"
@@ -549,7 +551,7 @@ def send_packets(pkt, ptfadapter, ptf_tx_port_id, num_packets=1):
 
 
 def test_equal_smac_dmac_drop(do_test, ptfadapter, setup, fanouthost,
-                              pkt_fields, ports_info, enum_fanout_graph_facts):      # noqa F811
+                              pkt_fields, ports_info, enum_fanout_graph_facts, skip_traffic_test):      # noqa F811
     """
     @summary: Create a packet with equal SMAC and DMAC.
     """
@@ -587,7 +589,8 @@ def test_equal_smac_dmac_drop(do_test, ptfadapter, setup, fanouthost,
     )
 
     group = "L2"
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], comparable_pkt=comparable_pkt)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            comparable_pkt=comparable_pkt, skip_traffic_test=skip_traffic_test)
 
 
 def test_multicast_smac_drop(do_test, ptfadapter, setup, fanouthost,
@@ -631,11 +634,11 @@ def test_multicast_smac_drop(do_test, ptfadapter, setup, fanouthost,
 
     group = "L2"
     do_test(group, pkt, ptfadapter, ports_info,
-            setup["neighbor_sniff_ports"], comparable_pkt=comparable_pkt)
+            setup["neighbor_sniff_ports"], comparable_pkt=comparable_pkt, skip_traffic_test=skip_traffic_test)
 
 
 def test_not_expected_vlan_tag_drop(do_test, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                    ptfadapter, setup, pkt_fields, ports_info):
+                                    ptfadapter, setup, pkt_fields, ports_info, skip_traffic_test):
     """
     @summary: Create a VLAN tagged packet which VLAN ID does not match ingress port VLAN ID.
     """
@@ -668,10 +671,11 @@ def test_not_expected_vlan_tag_drop(do_test, duthosts, enum_rand_one_per_hwsku_f
         )
 
     group = "L2"
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"])
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            skip_traffic_test=skip_traffic_test)
 
 
-def test_dst_ip_is_loopback_addr(do_test, ptfadapter, setup, pkt_fields, tx_dut_ports, ports_info):
+def test_dst_ip_is_loopback_addr(do_test, ptfadapter, setup, pkt_fields, tx_dut_ports, ports_info, skip_traffic_test):
     """
     @summary: Create a packet with loopback destination IP adress.
     """
@@ -689,10 +693,11 @@ def test_dst_ip_is_loopback_addr(do_test, ptfadapter, setup, pkt_fields, tx_dut_
         tcp_dport=pkt_fields["tcp_dport"])
 
     group = "L3"
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
-def test_src_ip_is_loopback_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info):
+def test_src_ip_is_loopback_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, skip_traffic_test):
     """
     @summary: Create a packet with loopback source IP adress.
     """
@@ -710,10 +715,11 @@ def test_src_ip_is_loopback_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_f
         tcp_dport=pkt_fields["tcp_dport"])
 
     group = "L3"
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
-def test_dst_ip_absent(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info):
+def test_dst_ip_absent(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, skip_traffic_test):
     """
     @summary: Create a packet with absent destination IP address.
     """
@@ -741,11 +747,13 @@ def test_dst_ip_absent(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, por
 
     group = "L3"
     print(("msm group {}, setup {}".format(group, setup)))
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
 @pytest.mark.parametrize("ip_addr", ["ipv4", "ipv6"])
-def test_src_ip_is_multicast_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ip_addr, ports_info):
+def test_src_ip_is_multicast_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ip_addr,
+                                  ports_info, skip_traffic_test):
     """
     @summary: Create a packet with multicast source IP adress.
     """
@@ -778,11 +786,12 @@ def test_src_ip_is_multicast_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_
                    ports_info["src_mac"], pkt_fields["ipv4_dst"], ip_src)
 
     group = "L3"
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports, ip_ver=ip_addr)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, ip_ver=ip_addr, skip_traffic_test=skip_traffic_test)
 
 
 def test_src_ip_is_class_e(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                           setup, tx_dut_ports, pkt_fields, ports_info):
+                           setup, tx_dut_ports, pkt_fields, ports_info, skip_traffic_test):
     """
     @summary: Create a packet with source IP address in class E.
     """
@@ -805,12 +814,14 @@ def test_src_ip_is_class_e(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsk
             tcp_dport=pkt_fields["tcp_dport"])
 
         group = "L3"
-        do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+        do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+                tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
 @pytest.mark.parametrize("addr_type, addr_direction", [("ipv4", "src"), ("ipv6", "src"),
                                                        ("ipv4", "dst"), ("ipv6", "dst")])
-def test_ip_is_zero_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, addr_type, addr_direction, ports_info):
+def test_ip_is_zero_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, addr_type, addr_direction,
+                         ports_info, skip_traffic_test):
     """
     @summary: Create a packet with "0.0.0.0" source or destination IP address.
     """
@@ -857,11 +868,11 @@ def test_ip_is_zero_addr(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, a
         pytest.skip("Src IP zero packets are not dropped on Broadcom DNX platform currently")
 
     do_test(group, pkt, ptfadapter, ports_info, list(setup["dut_to_ptf_port_map"].values()), tx_dut_ports,
-            ip_ver=addr_type)
+            ip_ver=addr_type, skip_traffic_test=skip_traffic_test)
 
 
 def test_dst_ip_link_local(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                           setup, tx_dut_ports, pkt_fields, ports_info):
+                           setup, tx_dut_ports, pkt_fields, ports_info, skip_traffic_test):
     """
     @summary: Create a packet with link-local address "169.254.0.0/16".
     """
@@ -884,10 +895,11 @@ def test_dst_ip_link_local(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsk
     group = "L3"
 
     logger.info(pkt_params)
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
-def test_loopback_filter(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info):
+def test_loopback_filter(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, skip_traffic_test):
     """
     @summary: Create a packet drops by loopback-filter. Loop-back filter means that route to the host
               with DST IP of received packet exists on received interface
@@ -915,11 +927,13 @@ def test_loopback_filter(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, p
 
     group = "L3"
 
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
 def test_ip_pkt_with_expired_ttl(duthost, do_test, ptfadapter, setup, tx_dut_ports, pkt_fields,
-                                 ports_info, sai_acl_drop_adj_enabled, configure_copp_drop_for_ttl_error):
+                                 ports_info, sai_acl_drop_adj_enabled, configure_copp_drop_for_ttl_error,
+                                 skip_traffic_test):
     """
     @summary: Create an IP packet with TTL=0.
     """
@@ -940,12 +954,12 @@ def test_ip_pkt_with_expired_ttl(duthost, do_test, ptfadapter, setup, tx_dut_por
 
     group = "L3"
     do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
-            tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
+            tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled, skip_traffic_test=skip_traffic_test)
 
 
 @pytest.mark.parametrize("pkt_field, value", [("version", 1), ("chksum", 10), ("ihl", 1)])
 def test_broken_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, pkt_field,
-                          value, ports_info, sai_acl_drop_adj_enabled):
+                          value, ports_info, sai_acl_drop_adj_enabled, skip_traffic_test):
     """
     @summary: Create a packet with broken IP header.
     """
@@ -964,10 +978,11 @@ def test_broken_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, 
 
     group = "L3"
     do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
-            tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
+            tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled, skip_traffic_test=skip_traffic_test)
 
 
-def test_absent_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info, sai_acl_drop_adj_enabled):
+def test_absent_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, ports_info,
+                          sai_acl_drop_adj_enabled, skip_traffic_test):
     """
     @summary: Create packets with absent IP header.
     """
@@ -990,12 +1005,12 @@ def test_absent_ip_header(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, 
     group = "L3"
 
     do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
-            tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled)
+            tx_dut_ports, skip_counter_check=sai_acl_drop_adj_enabled, skip_traffic_test=skip_traffic_test)
 
 
 @pytest.mark.parametrize("eth_dst", ["01:00:5e:00:01:02", "ff:ff:ff:ff:ff:ff"])
 def test_unicast_ip_incorrect_eth_dst(do_test, ptfadapter, setup, tx_dut_ports,
-                                      pkt_fields, eth_dst, ports_info):
+                                      pkt_fields, eth_dst, ports_info, skip_traffic_test):
     """
     @summary: Create packets with multicast/broadcast ethernet dst.
     """
@@ -1015,14 +1030,15 @@ def test_unicast_ip_incorrect_eth_dst(do_test, ptfadapter, setup, tx_dut_ports,
         )
 
     group = "L3"
-    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
 @pytest.mark.parametrize("igmp_version,msg_type", [("v1", "general_query"), ("v3", "general_query"),
                                                    ("v1", "membership_report"), ("v2", "membership_report"),
                                                    ("v3", "membership_report"), ("v2", "leave_group")])
 def test_non_routable_igmp_pkts(do_test, ptfadapter, setup, fanouthost, tx_dut_ports,
-                                pkt_fields, igmp_version, msg_type, ports_info):
+                                pkt_fields, igmp_version, msg_type, ports_info, skip_traffic_test):
     """
     @summary: Create an IGMP non-routable packets.
     """
@@ -1107,11 +1123,12 @@ def test_non_routable_igmp_pkts(do_test, ptfadapter, setup, fanouthost, tx_dut_p
                    pkt.getlayer("IP").dst, pkt_fields["ipv4_src"])
 
     group = "L3"
-    do_test(group, pkt, ptfadapter, ports_info, list(setup["dut_to_ptf_port_map"].values()), tx_dut_ports)
+    do_test(group, pkt, ptfadapter, ports_info, list(setup["dut_to_ptf_port_map"].values()),
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
 def test_acl_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                  setup, tx_dut_ports, pkt_fields, acl_ingress, ports_info):
+                  setup, tx_dut_ports, pkt_fields, acl_ingress, ports_info, skip_traffic_test):
     """
         @summary: Verify that DUT drops packet with SRC IP 20.0.0.0/24 matched by ingress ACL
     """
@@ -1135,11 +1152,12 @@ def test_acl_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_fronten
         tcp_dport=pkt_fields["tcp_dport"]
     )
 
-    do_test("ACL", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test("ACL", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
 def test_acl_egress_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                         setup, tx_dut_ports, pkt_fields, acl_egress, ports_info):
+                         setup, tx_dut_ports, pkt_fields, acl_egress, ports_info, skip_traffic_test):
     """
         @summary: Verify that DUT drops packet with DST IP 192.168.144.1/24
         matched by egress ACL and ACL drop counter incremented
@@ -1165,4 +1183,5 @@ def test_acl_egress_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_
         ip_ttl=64
     )
     do_test(discard_group="ACL", pkt=pkt, ptfadapter=ptfadapter, ports_info=ports_info,
-            sniff_ports=setup["neighbor_sniff_ports"], tx_dut_ports=tx_dut_ports, drop_information="OUTDATAACL")
+            sniff_ports=setup["neighbor_sniff_ports"], tx_dut_ports=tx_dut_ports, drop_information="OUTDATAACL",
+            skip_traffic_test=skip_traffic_test)

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -22,6 +22,8 @@ from .drop_packets import L2_COL_KEY, L3_COL_KEY, RX_ERR, RX_DRP, ACL_COUNTERS_U
     test_acl_egress_drop  # noqa F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts  # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test       # noqa F401
 
 pytestmark = [
     pytest.mark.topology("any")
@@ -116,8 +118,9 @@ def handle_backend_acl(duthost, tbinfo):
         duthost.shell('systemctl restart backend-acl')
 
 
-def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info,   # noqa F811
-                      tx_dut_ports=None, skip_counter_check=False, drop_information=None):  # noqa F811
+def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info,     # noqa F811
+                      tx_dut_ports=None, skip_counter_check=False, drop_information=None,   # noqa F811
+                      skip_traffic_test=False):  # noqa F811
     """
     Base test function for verification of L2 or L3 packet drops. Verification type depends on 'discard_group' value.
     Supported 'discard_group' values: 'L2', 'L3', 'ACL', 'NO_DROPS'
@@ -136,6 +139,9 @@ def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, port
     # Some test cases will not increase the drop counter consistently on certain platforms
     if skip_counter_check:
         logger.info("Skipping counter check")
+        return None
+    if skip_traffic_test is True:
+        logger.info("Skipping traffic test")
         return None
 
     if discard_group == "L2":
@@ -269,7 +275,8 @@ def check_if_skip():
 @pytest.fixture(scope='module')
 def do_test(duthosts):
     def do_counters_test(discard_group, pkt, ptfadapter, ports_info, sniff_ports, tx_dut_ports=None,    # noqa F811
-                         comparable_pkt=None, skip_counter_check=False, drop_information=None, ip_ver='ipv4'):
+                         comparable_pkt=None, skip_counter_check=False, drop_information=None, ip_ver='ipv4',
+                         skip_traffic_test=False):      # noqa F811
         """
         Execute test - send packet, check that expected discard counters were incremented and packet was dropped
         @param discard_group: Supported 'discard_group' values: 'L2', 'L3', 'ACL', 'NO_DROPS'
@@ -283,18 +290,22 @@ def do_test(duthosts):
         check_if_skip()
         asic_index = ports_info["asic_index"]
         base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info, tx_dut_ports,
-                          skip_counter_check=skip_counter_check, drop_information=drop_information)
+                          skip_counter_check=skip_counter_check, drop_information=drop_information,
+                          skip_traffic_test=skip_traffic_test)
 
         # Verify packets were not egresed the DUT
         if discard_group != "NO_DROPS":
             exp_pkt = expected_packet_mask(pkt, ip_ver=ip_ver)
+            if skip_traffic_test is True:
+                logger.info("Skipping traffic test")
+                return
             testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=sniff_ports)
 
     return do_counters_test
 
 
 def test_reserved_dmac_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                            setup, fanouthost, pkt_fields, ports_info):  # noqa F811
+                            setup, fanouthost, pkt_fields, ports_info, skip_traffic_test):  # noqa F811
     """
     @summary: Verify that packet with reserved DMAC is dropped and L2 drop counter incremented
     @used_mac_address:
@@ -328,10 +339,12 @@ def test_reserved_dmac_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hws
         )
 
         group = "L2"
-        do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"])
+        do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+                skip_traffic_test=skip_traffic_test)
 
 
-def test_no_egress_drop_on_down_link(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, rif_port_down, ports_info):  # noqa F811
+def test_no_egress_drop_on_down_link(do_test, ptfadapter, setup, tx_dut_ports,                      # noqa F811
+                                     pkt_fields, rif_port_down, ports_info, skip_traffic_test):     # noqa F811
     """
     @summary: Verify that packets on ingress port are not dropped
               when egress RIF link is down and check that drop counters not incremented
@@ -349,11 +362,12 @@ def test_no_egress_drop_on_down_link(do_test, ptfadapter, setup, tx_dut_ports, p
         tcp_dport=pkt_fields["tcp_dport"]
         )
 
-    do_test("NO_DROPS", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test("NO_DROPS", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
 def test_src_ip_link_local(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                           setup, tx_dut_ports, pkt_fields, ports_info):  # noqa F811
+                           setup, tx_dut_ports, pkt_fields, ports_info, skip_traffic_test):  # noqa F811
     """
     @summary: Verify that packet with link-local address "169.254.0.0/16" is dropped and L3 drop counter incremented
     """
@@ -376,10 +390,12 @@ def test_src_ip_link_local(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsk
     pkt = testutils.simple_tcp_packet(**pkt_params)
 
     logger.info(pkt_params)
-    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
+    do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+            tx_dut_ports, skip_traffic_test=skip_traffic_test)
 
 
-def test_ip_pkt_with_exceeded_mtu(do_test, ptfadapter, setup, tx_dut_ports, pkt_fields, mtu_config, ports_info):  # noqa F811
+def test_ip_pkt_with_exceeded_mtu(do_test, ptfadapter, setup, tx_dut_ports,                 # noqa F811
+                                  pkt_fields, mtu_config, ports_info, skip_traffic_test):   # noqa F811
     """
     @summary: Verify that IP packet with exceeded MTU is dropped and L3 drop counter incremented
     """
@@ -409,6 +425,7 @@ def test_ip_pkt_with_exceeded_mtu(do_test, ptfadapter, setup, tx_dut_ports, pkt_
     )
     L2_COL_KEY = RX_ERR
     try:
-        do_test("L2", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"])
+        do_test("L2", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"],
+                skip_traffic_test=skip_traffic_test)
     finally:
         L2_COL_KEY = RX_DRP


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed.
#### How did you do it?
Skip traffic test to make drop_packet test compatible with VS platform
#### How did you verify/test it?
Test on KVM
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
