### PR TITLE
[202311]Skip TestCOPP[LLDP][UDLD] on Cisco 8111 platform

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -90,6 +90,10 @@ class TestCOPP(object):
             that have a set rate limit.
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        hwsku = duthost.facts['hwsku']
+        if ((hwsku == "Cisco-8111-O64") and
+            (protocol == "LLDP" or protocol == "UDLD")):
+            pytest.skip("LLDP and UDLD have known issue on Cisco-8111-O64")
         _copp_runner(duthost,
                      ptfhost,
                      protocol,

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -92,7 +92,7 @@ class TestCOPP(object):
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         hwsku = duthost.facts['hwsku']
         if ((hwsku == "Cisco-8111-O64") and
-            (protocol == "LLDP" or protocol == "UDLD")):
+                (protocol == "LLDP" or protocol == "UDLD")):
             pytest.skip("LLDP and UDLD have known issue on Cisco-8111-O64")
         _copp_runner(duthost,
                      ptfhost,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip TestCOPP[LLDP][UDLD] on Cisco 8111 platform
There is known issue on Cisco 8111 platform with this testcase.
This is 202311 branch only.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
There is known issue on Cisco 8111 platform with this testcase.

#### How did you do it?
Skip TestCOPP[LLDP][UDLD] on Cisco 8111 platform

#### How did you verify/test it?
Run with Cisco 8111 platform.
```
06:59:23 test_copp._setup_testbed                 L0411 INFO   | Configure syncd RPC for testing
07:00:07 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture copp_testbed setup ends --------------------
07:00:07 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture dut_type setup starts --------------------
07:00:08 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture dut_type setup ends --------------------
07:00:08 __init__.loganalyzer                     L0045 INFO   | Log analyzer is disabled
07:00:08 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture ignore_expected_loganalyzer_exceptions setup starts --------------------
07:00:08 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture ignore_expected_loganalyzer_exceptions setup ends --------------------
SKIPPED (LLDP and UDLD have known issue on Cisco-8111-O64)                                                                                          [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
