### PR TITLE
[202405] Remove onboarding PR test job

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -271,13 +271,6 @@ wan-pub:
 dpu:
   - dash/test_dash_vnet.py
 
-onboarding_t0:
-  - console/test_console_availability.py
-  - platform_tests/test_power_off_reboot.py
-  - platform_tests/test_sequential_restart.py
-  - platform_tests/test_xcvr_info_in_db.py
-
-
 specific_param:
   t0-sonic:
   - name: bgp/test_bgp_fact.py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,22 +174,6 @@ stages:
           KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           MGMT_BRANCH: $(BUILD_BRANCH)
 
-  - job: onboarding_elastictest_t0
-    displayName: "onboarding testcases by Elastictest"
-    timeoutInMinutes: 240
-    continueOnError: true
-    pool: sonic-ubuntu-1c
-    steps:
-      - template: .azure-pipelines/run-test-elastictest-template.yml@sonic-mgmt
-        parameters:
-          TOPOLOGY: t0
-          MIN_WORKER: $(T0_ONBOARDING_SONIC_INSTANCE_NUM)
-          MAX_WORKER: $(T0_ONBOARDING_SONIC_INSTANCE_NUM)
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-          TEST_SET: onboarding_t0
-
-
 #  - job: wan_elastictest
 #    displayName: "kvmtest-wan by Elastictest"
 #    timeoutInMinutes: 240


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently we are adding more control plane and data plane test to PR test in master branch, and we added onboarding test job for piloting. When we are working on this goal, 202405 branch was created with onboarding test job, but it's not needed.
#### How did you do it?
Remove onboarding PR test job in 202405 branch
#### How did you verify/test it?
Verify in PR test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
