### PR TITLE
Update test scripts in PFCwd 

### DIFF
--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -539,3 +539,22 @@ def _stop_background_traffic(ptfhost, background_traffic_log):
     pids = ptfhost.shell(f"pgrep -f {background_traffic_log}")["stdout_lines"]
     for pid in pids:
         ptfhost.shell(f"kill -9 {pid}", module_ignore_errors=True)
+
+
+def has_neighbor_device(setup_pfc_test):
+    """
+    Check if there are neighbor devices present
+
+    Args:
+        setup_pfc_test (fixture): Module scoped autouse fixture for PFCwd
+
+    Returns:
+        bool: True if there are neighbor devices present, False otherwise
+    """
+    for _, details in setup_pfc_test['selected_test_ports'].items():
+        # 'rx_port' and 'rx_port_id' are expected to be conjugate attributes
+        # if one is unset or contains None, the other should be as well
+        if (not details.get('rx_port') or None in details['rx_port']) or \
+                (not details.get('rx_port_id') or None in details['rx_port_id']):
+            return False  # neighbor devices are not present
+    return True

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -12,6 +12,7 @@ from tests.common.helpers.pfc_storm import PFCStorm
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from .files.pfcwd_helper import start_wd_on_ports
 from .files.pfcwd_helper import EXPECT_PFC_WD_DETECT_RE, EXPECT_PFC_WD_RESTORE_RE, fetch_vendor_specific_diagnosis_re
+from .files.pfcwd_helper import has_neighbor_device
 from tests.ptf_runner import ptf_runner
 from tests.common import port_toggle
 from tests.common import constants
@@ -872,6 +873,12 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.tx_action = None
         self.is_dualtor = setup_dut_info['basicParams']['is_dualtor']
 
+        # skip the pytest when the device does not have neighbors
+        # 'rx_port' being None indicates there are no ports available to receive frames for pfc storm
+        if not has_neighbor_device(setup_pfc_test):
+            pytest.skip("Test skipped: No neighbors detected as 'rx_port' is None for selected test ports,"
+                        " which is necessary for PFCwd test setup.")
+
         for idx, port in enumerate(self.ports):
             logger.info("")
             logger.info("--- Testing various Pfcwd actions on {} ---".format(port))
@@ -961,6 +968,12 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.set_traffic_action(duthost, "drop")
         self.stats = PfcPktCntrs(self.dut, self.rx_action, self.tx_action)
 
+        # skip the pytest when the device does not have neighbors
+        # 'rx_port' being None indicates there are no ports available to receive frames for pfc storm
+        if not has_neighbor_device(setup_pfc_test):
+            pytest.skip("Test skipped: No neighbors detected as 'rx_port' is None for selected test ports,"
+                        " which is necessary for PFCwd test setup.")
+
         for count in range(2):
             try:
                 for idx, port in enumerate(selected_ports):
@@ -1042,6 +1055,12 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.tx_action = None
         self.set_traffic_action(duthost, "drop")
         self.stats = PfcPktCntrs(self.dut, self.rx_action, self.tx_action)
+
+        # skip the pytest when the device does not have neighbors
+        # 'rx_port' being None indicates there are no ports available to receive frames for pfc storm
+        if not has_neighbor_device(setup_pfc_test):
+            pytest.skip("Test skipped: No neighbors detected as 'rx_port' is None for selected test ports,"
+                        " which is necessary for PFCwd test setup.")
 
         try:
             for idx, mmu_action in enumerate(MMU_ACTIONS):
@@ -1126,6 +1145,12 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.tx_action = None
         self.is_dualtor = setup_dut_info['basicParams']['is_dualtor']
         action = "dontcare"
+
+        # skip the pytest when the device does not have neighbors
+        # 'rx_port' being None indicates there are no ports available to receive frames for pfc storm
+        if not has_neighbor_device(setup_pfc_test):
+            pytest.skip("Test skipped: No neighbors detected as 'rx_port' is None for selected test ports,"
+                        " which is necessary for PFCwd test setup.")
 
         for idx, port in enumerate(self.ports):
             logger.info("")
@@ -1214,6 +1239,12 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         self.tx_action = None
         self.is_dualtor = setup_dut_info['basicParams']['is_dualtor']
         self.fake_storm = False  # Not needed for this test.
+
+        # skip the pytest when the device does not have neighbors
+        # 'rx_port' being None indicates there are no ports available to receive frames for pfc storm
+        if not has_neighbor_device(setup_pfc_test):
+            pytest.skip("Test skipped: No neighbors detected as 'rx_port' is None for selected test ports,"
+                        " which is necessary for PFCwd test setup.")
 
         for idx, port in enumerate(self.ports):
             logger.info("")

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -449,10 +449,12 @@ class TestPfcwdWb(SetupPfcwdFunc):
             bool: True if there are neighbor devices present, False otherwise
         """
         for _, details in setup_pfc_test['selected_test_ports'].items():
-            # If any 'rx_port_id' is not [None], neighbor devices are present
-            if details['rx_port_id'] != [None]:
-                return True
-        return False
+            # Check if 'rx_port_id' is missing or contains None
+            # If any 'rx_port_id' is missing or contains None, it indicates no neighbors
+            # Return False to prevent executing tests
+            if not details['rx_port_id'] or None in details['rx_port_id']:
+                return False
+        return True
     
     @pytest.fixture(autouse=True)
     def pfcwd_wb_test_cleanup(self, setup_pfc_test):

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -603,8 +603,6 @@ class TestPfcwdWb(SetupPfcwdFunc):
         """
         yield request.param
 
-
-
     def test_pfcwd_wb(self, fake_storm, testcase_action, setup_pfc_test, enum_fanout_graph_facts,   # noqa F811
                       ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                       localhost, fanouthosts, two_queues):

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -440,7 +440,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
 
     def has_neighbor_device(self, setup_pfc_test):
         """
-        Check if there are neighbor devices present 
+        Check if there are neighbor devices present
 
         Args:
             setup_pfc_test (fixture): Module scoped autouse fixture for PFCwd
@@ -455,7 +455,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
             if not details['rx_port_id'] or None in details['rx_port_id']:
                 return False
         return True
-    
+
     @pytest.fixture(autouse=True)
     def pfcwd_wb_test_cleanup(self, setup_pfc_test):
         """
@@ -602,6 +602,8 @@ class TestPfcwdWb(SetupPfcwdFunc):
             testcase_action(string) : testcase to execute
         """
         yield request.param
+
+
 
     def test_pfcwd_wb(self, fake_storm, testcase_action, setup_pfc_test, enum_fanout_graph_facts,   # noqa F811
                       ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add a common helper function to check if there are neighbor devices present before executing PFCwd warm reboot tests and PFCwd function tests. 
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Skip pytest execution for a selected subset of ports if 'rx_port' or 'rx_port_id' does not exist or contains None (e.g., 'rx_port_id' being None indicates there are no ports available to receive frames for fake storm in a t0 standalone topo) during PFCwd test setup. 

#### How did you do it?
Added a common helper function to check if there are neighbor devices present. If there are no neighbor devices detected, skip pytest and exit the cleanup function early. 'rx_port' and 'rx_port_id' are expected to be conjugate attributes, if one is unset or contains None, the other should be as well.

#### How did you verify/test it?
Validate it in internal setup
In pfcwd/test_pfcwd_warm_reboot.py:
```
===================================================================================== short test summary info ======================================================================================
SKIPPED [3] pfcwd/test_pfcwd_warm_reboot.py:631: Skipping test as 'rx_port_id' is None for selected test ports, which is required for PFCwd test setup.
============================================================================ 3 skipped, 1 warning in 143.46s (0:02:23) =============================================================================
```
In pfcwd/test_pfcwd_function.py:
```
========================================================================================== short test summary info ===========================================================================================
SKIPPED [1] pfcwd/test_pfcwd_function.py:885: Test skipped: No neighbors detected as 'rx_port' is None for selected test ports, which is necessary for PFCwd test setup.
SKIPPED [1] pfcwd/test_pfcwd_function.py:980: Test skipped: No neighbors detected as 'rx_port' is None for selected test ports, which is necessary for PFCwd test setup.
SKIPPED [1] pfcwd/test_pfcwd_function.py:1068: Test skipped: No neighbors detected as 'rx_port' is None for selected test ports, which is necessary for PFCwd test setup.
SKIPPED [1] pfcwd/test_pfcwd_function.py:1155: Test skipped: No neighbors detected as 'rx_port' is None for selected test ports, which is necessary for PFCwd test setup.
SKIPPED [1] pfcwd/test_pfcwd_function.py: This test is applicable only for cisco-8000
================================================================================= 5 skipped, 1 warning in 297.44s (0:04:57) ==================================================================================
```
#### Any platform specific information?
<html>
<body>
<!--StartFragment-->
str3-7060x6-64pe-1

<!--EndFragment-->
</body>
</html>

#### Supported testbed topology if it's a new test case?
t0-standalone-32
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
