### PR TITLE
[dhcp_test] Extend test_dhcp_pkt_recv to support dualtor topo format

### DIFF
--- a/tests/dhcp_relay/test_dhcp_pkt_recv.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_recv.py
@@ -39,6 +39,8 @@ class Dhcpv6PktRecvBase:
     @pytest.fixture(scope="class")
     def setup_teardown(self, rand_selected_dut, tbinfo):
         ptf_indices = tbinfo['topo']['properties']['topology']['host_interfaces']
+        disabled_ptf_indices = tbinfo['topo']['properties']['topology'].get('disabled_host_interfaces', [])
+        ptf_indices = [index for index in ptf_indices if index not in disabled_ptf_indices]
         dut_intf_ptf_index = rand_selected_dut.get_extended_minigraph_facts(tbinfo)['minigraph_ptf_indices']
         if 'dualtor' in tbinfo['topo']['name']:
             pattern = r'0.(\d+)'

--- a/tests/dhcp_relay/test_dhcp_pkt_recv.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_recv.py
@@ -38,9 +38,9 @@ class Dhcpv6PktRecvBase:
 
     @pytest.fixture(scope="class")
     def setup_teardown(self, rand_selected_dut, tbinfo):
-        ptf_indices = tbinfo['topo']['properties']['topology']['host_interfaces']
-        disabled_ptf_indices = tbinfo['topo']['properties']['topology'].get('disabled_host_interfaces', [])
-        ptf_indices = [index for index in ptf_indices if index not in disabled_ptf_indices]
+        disabled_host_interfaces = tbinfo['topo']['properties']['topology'].get('disabled_host_interfaces', [])
+        ptf_indices = [interface for interface in tbinfo['topo']['properties']['topology'].get('host_interfaces', [])
+                       if interface not in disabled_host_interfaces]
         dut_intf_ptf_index = rand_selected_dut.get_extended_minigraph_facts(tbinfo)['minigraph_ptf_indices']
         if 'dualtor' in tbinfo['topo']['name']:
             pattern = r'0.(\d+)'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The format of host interfaces in dualtor topo file is quite different, we need to extend the code to support it.

For host interfaces in mo topo file is a number, however, in dualtor it's in format like 0.10@10,1.10@10 or 0.10,1.10

To support it, we use regex to match correct interface index

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The format of host interfaces in dualtor topo file is quite different, we need to extend the code to support it.

#### How did you do it?
Use regex to match correct interface index

#### How did you verify/test it?
test it on mx, m0 dualtor and dualtor-aa testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
