### PR TITLE
Test_ntp_ipv6_only flaky issue

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
@@ -1,0 +1,758 @@
+import ast
+import struct
+import ipaddress
+import binascii
+import os
+import logging
+import time
+import datetime
+
+# Packet Test Framework imports
+import ptf
+import ptf.packet as scapy
+import ptf.testutils as testutils
+from ptf import config
+from ptf.base_tests import BaseTest
+from ptf.mask import Mask
+import scapy.all as scapy2
+from threading import Thread
+
+
+# Helper function to increment an IP address
+# ip_addr should be passed as a dot-decimal string
+# Return value is also a dot-decimal string
+def incrementIpAddress(ip_addr, by=1):
+    new_addr = ipaddress.ip_address(str(ip_addr))
+    new_addr = new_addr + by
+    return str(new_addr)
+
+
+class DataplaneBaseTest(BaseTest):
+    def __init__(self):
+        BaseTest.__init__(self)
+        self.log_fp = open('/tmp/stress_test.log', 'a')
+
+    def log(self, message, debug=False):
+        current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        if (debug and self.verbose) or (not debug):
+            print(("%s : %s" % (current_time, message)))
+        self.log_fp.write("%s : %s\n" % (current_time, message))
+
+    def setUp(self):
+        self.dataplane = ptf.dataplane_instance
+        self.dataplane.flush()
+        if config["log_dir"] is not None:
+            filename = os.path.join(config["log_dir"], str(self)) + ".pcap"
+            self.dataplane.start_pcap(filename)
+
+    def tearDown(self):
+        if config["log_dir"] is not None:
+            self.dataplane.stop_pcap()
+
+        self.log_fp.close()
+
+
+"""
+ This test simulates a new host booting up on the VLAN network of a ToR and
+ requesting an IP address via DHCP. Setup is as follows:
+  - DHCP client is simulated by listening/sending on an interface connected to VLAN of ToR.
+  - DHCP server is simulated by listening/sending on injected PTF interfaces which link
+    ToR to leaves. This way we can listen for traffic sent from DHCP relay out to would-be DHCP servers
+
+ This test performs the following functionality under the CoPP policy:
+   1.) Simulated client broadcasts a DHCPDISCOVER message over a duration of 120 seconds.
+       It will send at a rate of 10,000 packets per second, but the CoPP policy will limit the packet rate.
+   2.) Verify DHCP relay running on ToR receives the DHCPDISCOVER message
+       and relays it to all of its known DHCP servers, appending the proper Option 82 information.
+       The number of packets received will be recorded into a log file.
+   3.) Simulate DHCPOFFER message broadcast from a DHCP server to the ToR over a duration of 120 seconds.
+   4.) Verify DHCP relay receives the DHCPOFFER message and forwards it to our simulated client.
+       The number of packets received will be recorded into a log file.
+   5.) Simulated client broadcasts a DHCPREQUEST message over a duration of 120 seconds over a duration of 120 seconds.
+   6.) Verify DHCP relay running on ToR receives the DHCPREQUEST message
+       and relays it to all of its known DHCP servers, appending the proper Option 82 information
+       The number of packets received will be recorded into a log file.
+   7.) Simulate DHCPACK message sent from a DHCP server to the ToR over a duration of 120 seconds.
+   8.) Verify DHCP relay receives the DHCPACK message and forwards it to our
+       simulated client. The number of packets received will be recorded into a log file.
+
+ To run: place the following in a shell script (this will test against str-s6000-acs-12 (ec:f4:bb:fe:88:0a)):
+   (ptf --test-dir ptftests dhcp_relay_stress_test.DHCPTest --platform remote -t "hostname=\"str-s6000-acs-12\";
+    client_ports_indices=\"[1, 2, 3, 4, ...]\"; client_iface_alias=\"fortyGigE0/4\"; leaf_port_indices=\"[29, 31, 28, 30]\";
+    num_dhcp_servers=\"48\"; server_ip=\"192.0.0.1\"; relay_iface_ip=\"192.168.0.1\";
+    relay_iface_mac=\"ec:f4:bb:fe:88:0a\"; relay_iface_netmask=\"255.255.255.224\""
+    --disable-vxlan --disable-geneve --disable-erspan --disable-mpls --disable-nvgre)
+
+ The above command is configured to test with the following configuration:
+  - VLAN IP of DuT is 192.168.0.1, MAC address is ec:f4:bb:fe:88:0a
+    (this is configured to test against str-s6000-acs-12)
+  - Simulated client will live on PTF interface eth4 (interface number 4)
+  - Assumes leaf switches are connected to injected PTF interfaces 28, 29, 30, 31
+  - Test will simulate replies from server with IP '192.0.0.1'
+  - Simulated server will offer simulated client IP '192.168.0.2' with a subnet of '255.255.255.0'
+    (this should be in the VLAN of DuT)
+
+
+ DHCP Relay currently installed with SONiC is isc-dhcp-relay
+
+ TODO???: Simulate client sending DISCOVER/REQUEST message from different source MAC.
+
+"""
+
+
+class DHCPTest(DataplaneBaseTest):
+
+    BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
+    BROADCAST_IP = '255.255.255.255'
+    DEFAULT_ROUTE_IP = '0.0.0.0'
+    DHCP_CLIENT_PORT = 68
+    DHCP_SERVER_PORT = 67
+    DHCP_LEASE_TIME_OFFSET = 292
+    DHCP_LEASE_TIME_LEN = 6
+    LEASE_TIME = 86400
+    DHCP_PKT_BOOTP_MIN_LEN = 300
+    DHCP_ETHER_TYPE_IP = 0x0800
+    DHCP_BOOTP_OP_REPLY = 2
+    DHCP_BOOTP_HTYPE_ETHERNET = 1
+    DHCP_BOOTP_HLEN_ETHERNET = 6
+    DHCP_BOOTP_FLAGS_BROADCAST_REPLY = 0x8000
+    PRE_SEND_DURATION = 1
+    PACKETS_SEND_DURATION = 120
+    CLIENT_PACKETS_PER_SEC = 10000
+
+    def __init__(self):
+        DataplaneBaseTest.__init__(self)
+
+    def setUp(self):
+        DataplaneBaseTest.setUp(self)
+
+        self.test_params = testutils.test_params_get()
+
+        self.hostname = self.test_params['hostname']
+        self.verified_option82 = False
+
+        # These are the interfaces we are injected into that link to out leaf switches
+        self.server_port_indices = ast.literal_eval(
+            self.test_params['leaf_port_indices'])
+        self.num_dhcp_servers = int(self.test_params['num_dhcp_servers'])
+
+        self.assertTrue(self.num_dhcp_servers > 0,
+                        "Error: This test requires at least one DHCP server to be specified!")
+
+        # We will simulate a responding DHCP server on the first interface in the provided set
+        self.server_ip = self.test_params['server_ip']
+        self.server_iface_mac = self.dataplane.get_mac(
+            0, self.server_port_indices[0])
+
+        self.relay_iface_ip = self.test_params['relay_iface_ip']
+        self.relay_iface_mac = self.test_params['relay_iface_mac']
+
+        self.client_iface_alias = self.test_params['client_iface_alias']
+        self.client_port_index = int(self.test_params['client_port_index'])
+        self.client_mac = self.dataplane.get_mac(0, self.client_port_index)
+
+        self.switch_loopback_ip = self.test_params['switch_loopback_ip']
+
+        self.uplink_mac = self.test_params['uplink_mac']
+
+        # 'dual' for dual tor testing
+        # 'single' for regular single tor testing
+        self.dual_tor = (self.test_params['testing_mode'] == 'dual')
+
+        self.testbed_mode = self.test_params['testbed_mode']
+
+        # option82 is a byte string created by the relay agent. It contains the circuit_id and remote_id fields.
+        # circuit_id is stored as suboption 1 of option 82.
+        # It consists of the following:
+        #  Byte 0: Suboption number, always set to 1
+        #  Byte 1: Length of suboption data in bytes
+        #  Bytes 2+: Suboption data
+        # Our circuit_id string is of the form "hostname:portname"
+        circuit_id_string = self.hostname + ":" + self.client_iface_alias
+        self.option82 = struct.pack('BB', 1, len(circuit_id_string))
+        self.option82 += circuit_id_string.encode('utf-8')
+
+        # remote_id is stored as suboption 2 of option 82.
+        # It consists of the following:
+        #  Byte 0: Suboption number, always set to 2
+        #  Byte 1: Length of suboption data in bytes
+        #  Bytes 2+: Suboption data
+        # Our remote_id string simply consists of the MAC address of the port that received the request
+        remote_id_string = self.relay_iface_mac
+        self.option82 += struct.pack('BB', 2, len(remote_id_string))
+        self.option82 += remote_id_string.encode('utf-8')
+
+        # In 'dual' testing mode, vlan ip is stored as suboption 5 of option 82.
+        # It consists of the following:
+        #  Byte 0: Suboption number, always set to 5
+        #  Byte 1: Length of suboption data in bytes, always set to 4 (ipv4 addr has 4 bytes)
+        #  Bytes 2+: vlan ip addr
+        if self.dual_tor:
+            link_selection = bytes(
+                list(map(int, self.relay_iface_ip.split('.'))))
+            self.option82 += struct.pack('BB', 5, 4)
+            self.option82 += link_selection
+
+        # We'll assign our client the IP address 1 greater than our relay interface (i.e., gateway) IP
+        self.client_ip = incrementIpAddress(self.relay_iface_ip, 1)
+        self.client_subnet = self.test_params['relay_iface_netmask']
+
+        self.dest_mac_address = self.test_params['dest_mac_address']
+        self.client_udp_src_port = self.test_params['client_udp_src_port']
+
+    def tearDown(self):
+        DataplaneBaseTest.tearDown(self)
+
+    """
+     Packet generation functions/wrappers
+
+    """
+
+    def create_dhcp_discover_packet(self, dst_mac=BROADCAST_MAC, src_port=DHCP_CLIENT_PORT):
+        discover_packet = testutils.dhcp_discover_packet(
+            eth_client=self.client_mac, set_broadcast_bit=True)
+
+        discover_packet[scapy.Ether].dst = dst_mac
+        discover_packet[scapy.IP].sport = src_port
+
+        if dst_mac != self.BROADCAST_MAC:
+            discover_packet[scapy.IP].dst = self.switch_loopback_ip
+            discover_packet[scapy.IP].src = self.client_ip
+
+        return discover_packet
+
+    def create_dhcp_discover_relayed_packet(self):
+        my_chaddr = binascii.unhexlify(self.client_mac.replace(':', ''))
+        my_chaddr += b'\x00\x00\x00\x00\x00\x00'
+
+        # Relay modifies the DHCPDISCOVER message in the following ways:
+        #  1.) Increments the hops count in the DHCP header
+        #  2.) Updates the gateway IP address in hte BOOTP header (if it is 0.0.0.0)
+        #  3.) Replaces the source IP with the IP of the interface which the relay
+        #      received the broadcast DHCPDISCOVER message on
+        #  4.) Replaces the destination IP with the IP address of the DHCP server
+        #      each message is being forwarded to
+        # Here, the actual destination MAC should be the MAC of the leaf the relay
+        # forwards through and the destination IP should be the IP of the DHCP server
+        # the relay is forwarding to. We don't need to confirm these, so we'll
+        # just mask them off later
+        #
+        # TODO: In IP layer, DHCP relay also replaces source IP with IP of interface on
+        #       which it received the broadcast DHCPDISCOVER from client. This appears to
+        #       be loopback. We could pull from minigraph and check here.
+        ether = scapy.Ether(dst=self.BROADCAST_MAC, 
+                            src=self.uplink_mac, type=0x0800)
+        ip = scapy.IP(src=self.DEFAULT_ROUTE_IP,
+                      dst=self.BROADCAST_IP, len=328, ttl=64)
+        udp = scapy.UDP(sport=self.DHCP_SERVER_PORT,
+                        dport=self.DHCP_SERVER_PORT, len=308)
+        bootp = scapy.BOOTP(op=1,
+                            htype=1,
+                            hlen=6,
+                            hops=1,
+                            xid=0,
+                            secs=0,
+                            flags=0x8000,
+                            ciaddr=self.DEFAULT_ROUTE_IP,
+                            yiaddr=self.DEFAULT_ROUTE_IP,
+                            siaddr=self.DEFAULT_ROUTE_IP,
+                            giaddr=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
+                            chaddr=my_chaddr)
+        bootp /= scapy.DHCP(options=[('message-type', 'discover'),
+                                     (82, self.option82),
+                                     ('end')])
+
+        # If our bootp layer is too small, pad it
+        pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - len(bootp)
+        if pad_bytes > 0:
+            bootp /= scapy.PADDING('\x00' * pad_bytes)
+
+        pkt = ether / ip / udp / bootp
+        return pkt
+
+    def dhcp_offer_packet(self,
+                          eth_server="00:01:02:03:04:05",
+                          eth_dst="06:07:08:09:10:11",
+                          eth_client="12:13:14:15:16:17",
+                          ip_server="0.1.2.3",
+                          ip_dst="255.255.255.255",
+                          ip_offered="8.9.10.11",
+                          port_dst=DHCP_CLIENT_PORT,
+                          netmask_client="255.255.255.0",
+                          ip_gateway=DEFAULT_ROUTE_IP,
+                          dhcp_lease=256,
+                          padding_bytes=0,
+                          set_broadcast_bit=False,
+                          ):
+        """
+        Return a DHCPOFFER packet
+        Supports a few parameters:
+        @param eth_server MAC address of DHCP server
+        @param eth_dst MAC address of destination (DHCP Client, Relay agent) or broadcast (ff:ff:ff:ff:ff:ff)
+        @param eth_client MAC address of DHCP client
+        @param ip_server IP address of DHCP server
+        @param ip_dst IP address of destination (DHCP Client, Relay agent) or broadcast (255.255.255.255)
+        @param ip_offered IP address that server is assigning to client
+        @param ip_gateway Gateway IP Address, address of relay agent if encountered
+        @param port_dst Destination port of packet (default: DHCP_PORT_CLIENT)
+        @param netmask_client Subnet mask of client
+        @param dhcp_lease Time in seconds of DHCP lease
+        @param padding_bytes Number of '\x00' bytes to append to end of packet
+        Destination IP can be unicast or broadcast (255.255.255.255)
+        Source port is always 67 (DHCP server port)
+        Destination port by default is 68 (DHCP client port),
+        but can be also be 67 (DHCP server port) if being sent to a DHCP relay agent
+        """
+        my_chaddr = binascii.unhexlify(eth_client.replace(':', ''))
+        my_chaddr += b'\x00\x00\x00\x00\x00\x00'
+
+        pkt = scapy.Ether(dst=eth_dst, src=eth_server,
+                          type=self.DHCP_ETHER_TYPE_IP)
+        pkt /= scapy.IP(src=ip_server, dst=ip_dst, ttl=128, id=0)
+        pkt /= scapy.UDP(sport=self.DHCP_SERVER_PORT, dport=port_dst)
+        pkt /= scapy.BOOTP(
+            op=self.DHCP_BOOTP_OP_REPLY,
+            htype=self.DHCP_BOOTP_HTYPE_ETHERNET,
+            hlen=self.DHCP_BOOTP_HLEN_ETHERNET,
+            hops=0,
+            xid=0,
+            secs=0,
+            flags=self.DHCP_BOOTP_FLAGS_BROADCAST_REPLY if set_broadcast_bit else 0,
+            ciaddr=self.DEFAULT_ROUTE_IP,
+            yiaddr=ip_offered,
+            siaddr=ip_server,
+            giaddr=ip_gateway,
+            chaddr=my_chaddr,
+        )
+        # The length of option82 is 41 bytes, and dhcp relay will strip option82,
+        # when the length of next option is bigger than 42 bytes,
+        # it could introduce the overwritten issue.
+        pkt /= scapy.DHCP(
+            options=[
+                ("message-type", "offer"),
+                ("server_id", ip_server),
+                ("lease_time", int(dhcp_lease)),
+                ("subnet_mask", netmask_client),
+                (82, self.option82),
+                ("vendor_class_id",
+                 "http://0.0.0.0/this_is_a_very_very_long_path/test.bin".encode('utf-8')),
+                ("end"),
+            ]
+        )
+        if padding_bytes:
+            pkt /= scapy.PADDING("\x00" * padding_bytes)
+        return pkt
+
+    def create_dhcp_offer_packet(self):
+        return self.dhcp_offer_packet(
+            eth_server=self.server_iface_mac,
+            eth_dst=self.uplink_mac,
+            eth_client=self.client_mac,
+            ip_server=self.server_ip[0],
+            ip_dst=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
+            ip_offered=self.client_ip,
+            port_dst=self.DHCP_SERVER_PORT,
+            ip_gateway=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
+            netmask_client=self.client_subnet,
+            dhcp_lease=self.LEASE_TIME,
+            padding_bytes=0,
+            set_broadcast_bit=True)
+
+    def create_dhcp_offer_relayed_packet(self):
+        my_chaddr = binascii.unhexlify(self.client_mac.replace(':', ''))
+        my_chaddr += b'\x00\x00\x00\x00\x00\x00'
+
+        # Relay modifies the DHCPOFFER message in the following ways:
+        #  1.) Replaces the source MAC with the MAC of the interface it received it on
+        #  2.) Replaces the destination MAC with boradcast (ff:ff:ff:ff:ff:ff)
+        #  3.) Replaces the source IP with the IP of the interface which the relay
+        #      received it on
+        #  4.) Replaces the destination IP with broadcast (255.255.255.255)
+        #  5.) Replaces the destination port with the DHCP client port (68)
+        ether = scapy.Ether(dst=self.BROADCAST_MAC,
+                            src=self.relay_iface_mac, type=0x0800)
+        ip = scapy.IP(src=self.relay_iface_ip, dst=self.BROADCAST_IP, ttl=64)
+        udp = scapy.UDP(sport=self.DHCP_SERVER_PORT,
+                        dport=self.DHCP_CLIENT_PORT)
+        bootp = scapy.BOOTP(op=2,
+                            htype=1,
+                            hlen=6,
+                            hops=0,
+                            xid=0,
+                            secs=0,
+                            flags=0x8000,
+                            ciaddr=self.DEFAULT_ROUTE_IP,
+                            yiaddr=self.client_ip,
+                            siaddr=self.server_ip[0],
+                            giaddr=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
+                            chaddr=my_chaddr)
+        bootp /= scapy.DHCP(options=[('message-type', 'offer'),
+                                     ('server_id', self.server_ip[0]),
+                                     ('lease_time', self.LEASE_TIME),
+                                     ('subnet_mask', self.client_subnet),
+                                     ("vendor_class_id",
+                                      "http://0.0.0.0/this_is_a_very_very_long_path/test.bin".encode('utf-8')),
+                                     ('end')])
+
+        # If our bootp layer is too small, pad it
+        pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - len(bootp)
+        if pad_bytes > 0:
+            bootp /= scapy.PADDING('\x00' * pad_bytes)
+
+        pkt = ether / ip / udp / bootp
+        return pkt
+
+    def create_dhcp_request_packet(self, dst_mac=BROADCAST_MAC, src_port=DHCP_CLIENT_PORT):
+        request_packet = testutils.dhcp_request_packet(
+            eth_client=self.client_mac,
+            ip_server=self.server_ip[0],
+            ip_requested=self.client_ip,
+            set_broadcast_bit=True
+        )
+
+        request_packet[scapy.Ether].dst = dst_mac
+        request_packet[scapy.IP].sport = src_port
+
+        if dst_mac != self.BROADCAST_MAC:
+            request_packet[scapy.IP].dst = self.switch_loopback_ip
+            request_packet[scapy.IP].src = self.client_ip
+
+        return request_packet
+
+    def create_dhcp_request_relayed_packet(self):
+        my_chaddr = binascii.unhexlify(self.client_mac.replace(':', ''))
+        my_chaddr += b'\x00\x00\x00\x00\x00\x00'
+
+        # Here, the actual destination MAC should be the MAC of the leaf the relay
+        # forwards through and the destination IP should be the IP of the DHCP server
+        # the relay is forwarding to. We don't need to confirm these, so we'll
+        # just mask them off later
+        #
+        # TODO: In IP layer, DHCP relay also replaces source IP with IP of interface on
+        #       which it received the broadcast DHCPREQUEST from client. This appears to
+        #       be loopback. We could pull from minigraph and check here.
+        ether = scapy.Ether(dst=self.BROADCAST_MAC,
+                            src=self.uplink_mac, type=0x0800)
+        ip = scapy.IP(src=self.DEFAULT_ROUTE_IP,
+                      dst=self.BROADCAST_IP, len=328, ttl=64)
+        udp = scapy.UDP(sport=self.DHCP_SERVER_PORT,
+                        dport=self.DHCP_SERVER_PORT, len=308)
+        bootp = scapy.BOOTP(op=1,
+                            htype=1,
+                            hlen=6,
+                            hops=1,
+                            xid=0,
+                            secs=0,
+                            flags=0x8000,
+                            ciaddr=self.DEFAULT_ROUTE_IP,
+                            yiaddr=self.DEFAULT_ROUTE_IP,
+                            siaddr=self.DEFAULT_ROUTE_IP,
+                            giaddr=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
+                            chaddr=my_chaddr)
+        bootp /= scapy.DHCP(options=[('message-type', 'request'),
+                                     ('requested_addr', self.client_ip),
+                                     ('server_id', self.server_ip[0]),
+                                     (82, self.option82),
+                                     ('end')])
+
+        # If our bootp layer is too small, pad it
+        pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - len(bootp)
+        if pad_bytes > 0:
+            bootp /= scapy.PADDING('\x00' * pad_bytes)
+
+        pkt = ether / ip / udp / bootp
+        return pkt
+
+    def create_dhcp_ack_packet(self):
+        return testutils.dhcp_ack_packet(
+            eth_server=self.server_iface_mac,
+            eth_dst=self.uplink_mac,
+            eth_client=self.client_mac,
+            ip_server=self.server_ip[0],
+            ip_dst=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
+            ip_offered=self.client_ip,
+            port_dst=self.DHCP_SERVER_PORT,
+            ip_gateway=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
+            netmask_client=self.client_subnet,
+            dhcp_lease=self.LEASE_TIME,
+            padding_bytes=0,
+            set_broadcast_bit=True)
+
+    def create_dhcp_ack_relayed_packet(self):
+        my_chaddr = binascii.unhexlify(self.client_mac.replace(':', ''))
+        my_chaddr += b'\x00\x00\x00\x00\x00\x00'
+
+        # Relay modifies the DHCPACK message in the following ways:
+        #  1.) Replaces the source MAC with the MAC of the interface it received it on
+        #  2.) Replaces the destination MAC with broadcast (ff:ff:ff:ff:ff:ff)
+        #  3.) Replaces the source IP with the IP of the interface which the relay
+        #      received it on
+        #  4.) Replaces the destination IP with broadcast (255.255.255.255)
+        #  5.) Replaces the destination port with the DHCP client port (68)
+        ether = scapy.Ether(dst=self.BROADCAST_MAC,
+                            src=self.relay_iface_mac, type=0x0800)
+        ip = scapy.IP(src=self.relay_iface_ip,
+                      dst=self.BROADCAST_IP, len=290, ttl=64)
+        udp = scapy.UDP(sport=self.DHCP_SERVER_PORT,
+                        dport=self.DHCP_CLIENT_PORT, len=262)
+        bootp = scapy.BOOTP(op=2,
+                            htype=1,
+                            hlen=6,
+                            hops=0,
+                            xid=0,
+                            secs=0,
+                            flags=0x8000,
+                            ciaddr=self.DEFAULT_ROUTE_IP,
+                            yiaddr=self.client_ip,
+                            siaddr=self.server_ip[0],
+                            giaddr=self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip,
+                            chaddr=my_chaddr)
+        bootp /= scapy.DHCP(options=[('message-type', 'ack'),
+                                     ('server_id', self.server_ip[0]),
+                                     ('lease_time', self.LEASE_TIME),
+                                     ('subnet_mask', self.client_subnet),
+                                     ('end')])
+
+        # TODO: Need to add this to the packet creation functions in PTF code first!
+        # If our bootp layer is too small, pad it
+        # pad_bytes = self.DHCP_PKT_BOOTP_MIN_LEN - len(bootp)
+        # if pad_bytes > 0:
+        #    bootp /= scapy.PADDING('\x00' * pad_bytes)
+
+        pkt = ether / ip / udp / bootp
+        return pkt
+
+    """
+     Send/receive functions
+
+    """
+    # Simulate client coming on VLAN and broadcasting a DHCPDISCOVER message
+    def client_send_discover(self, dst_mac=BROADCAST_MAC, src_port=DHCP_CLIENT_PORT,
+                             pkts_count = CLIENT_PACKETS_PER_SEC):
+
+        # Form and send DHCPDISCOVER packet
+        dhcp_discover = self.create_dhcp_discover_packet(dst_mac, src_port)
+        end_time = time.time() + self.PACKETS_SEND_DURATION
+        send_cnt = 0
+        while time.time() < end_time:
+            testutils.send_packet(self, self.client_port_index, dhcp_discover, count = pkts_count)
+            send_cnt += pkts_count
+            time.sleep(1)
+        self.log(f"DHCP Discover send {send_cnt} packets in {self.PACKETS_SEND_DURATION} sec via broadcast")
+
+    # Verify the relayed packet has option82 info or not. Sniffing for the relayed packet on leaves and
+    # once the packet is recieved checking for the destination and looking into options and verifying
+    # the option82 info
+
+    def pkt_callback(self, pkt):
+        if pkt.haslayer(scapy2.IP) and pkt.haslayer(scapy2.DHCP):
+            if pkt.getlayer(scapy2.IP).dst in self.server_ip and pkt.getlayer(scapy2.DHCP) is not None:
+                self.verified_option82 = False
+                pkt_options = ''
+                for option in pkt.getlayer(scapy2.DHCP).options:
+                    if option[0] == 'relay_agent_information':
+                        pkt_options = option[1]
+                        break
+                # if self.option82 in pkt_options:
+                #     self.verified_option82 = True
+
+    def Sniffer(self, iface):
+        scapy2.sniff(iface=iface, filter="udp and (port 67 or 68)",
+                     prn=self.pkt_callback, store=0, timeout=5)
+
+    # Verify that the DHCP relay actually received and relayed the DHCPDISCOVER message to all of
+    # its known DHCP servers. We also verify that the relay inserted Option 82 information in the
+    # packet.
+
+    def verify_relayed_discover(self):
+        # Create a packet resembling a relayed DCHPDISCOVER packet
+        dhcp_discover_relayed = self.create_dhcp_discover_relayed_packet()
+
+        # Mask off fields we don't care about matching
+        masked_discover = Mask(dhcp_discover_relayed)
+        masked_discover.set_do_not_care_scapy(scapy.Ether, "dst")
+
+        masked_discover.set_do_not_care_scapy(scapy.IP, "version")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "ihl")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "tos")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "len")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "id")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "flags")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "frag")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "ttl")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "proto")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "chksum")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "src")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "dst")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "options")
+
+        masked_discover.set_do_not_care_scapy(scapy.UDP, "chksum")
+        masked_discover.set_do_not_care_scapy(scapy.UDP, "len")
+
+        masked_discover.set_do_not_care_scapy(scapy.BOOTP, "sname")
+        masked_discover.set_do_not_care_scapy(scapy.BOOTP, "file")
+
+        discover_count = testutils.count_matched_packets_all_ports(
+            self, masked_discover, self.server_port_indices)
+        self.log(f"DHCP Discover received {discover_count} pkts, rate {discover_count/self.PACKETS_SEND_DURATION} pkts/sec")
+        return discover_count
+
+
+    # Simulate a DHCP server sending a DHCPOFFER message to client.
+    # We do this by injecting a DHCPOFFER message on the link connected to one
+    # of our leaf switches.
+    def server_send_offer(self, dhcp_pps):
+        dhcp_offer = self.create_dhcp_offer_packet()
+        end_time = time.time() + self.PACKETS_SEND_DURATION
+        send_cnt = 0
+        while time.time() < end_time:
+            testutils.send_packet(self, self.server_port_indices[0], dhcp_offer, count = dhcp_pps)
+            send_cnt += dhcp_pps
+            time.sleep(1)
+        self.log(f"DHCP Offer send {send_cnt} packets in {self.PACKETS_SEND_DURATION} sec via broadcast")
+        
+
+    # Verify that the DHCPOFFER would be received by our simulated client
+    def verify_offer_received(self):
+        dhcp_offer = self.create_dhcp_offer_relayed_packet()
+
+        masked_offer = Mask(dhcp_offer)
+        masked_offer.set_do_not_care_scapy(scapy.Ether, "dst")
+
+        masked_offer.set_do_not_care_scapy(scapy.IP, "version")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "ihl")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "tos")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "len")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "id")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "flags")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "frag")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "ttl")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "proto")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "chksum")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "options")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "src")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "dst")
+
+        masked_offer.set_do_not_care_scapy(scapy.UDP, "len")
+        masked_offer.set_do_not_care_scapy(scapy.UDP, "chksum")
+
+        masked_offer.set_do_not_care_scapy(scapy.BOOTP, "sname")
+        masked_offer.set_do_not_care_scapy(scapy.BOOTP, "file")
+
+        offer_count = testutils.count_matched_packets(
+            self, masked_offer, self.client_port_index)
+        self.log(f"DHCP Offer received {offer_count} pkts, rate {offer_count/self.PACKETS_SEND_DURATION} pkts/sec")
+        return offer_count
+
+    # Simulate our client sending a DHCPREQUEST message
+    def client_send_request(self, dhcp_pps, dst_mac=BROADCAST_MAC, src_port=DHCP_CLIENT_PORT):
+        dhcp_request = self.create_dhcp_request_packet(dst_mac, src_port)
+        end_time = time.time() + self.PACKETS_SEND_DURATION
+        send_cnt = 0
+        while time.time() < end_time:
+            testutils.send_packet(self, self.client_port_index, dhcp_request, count = dhcp_pps)
+            send_cnt += dhcp_pps
+            time.sleep(1)
+        self.log(f"DHCP Request send {send_cnt} packets in {self.PACKETS_SEND_DURATION} sec via broadcast")
+
+    # Verify that the DHCP relay actually received and relayed the DHCPREQUEST message to all of
+    # its known DHCP servers. We also verify that the relay inserted Option 82 information in the
+    # packet.
+    def verify_relayed_request(self):
+        # Create a packet resembling a relayed DCHPREQUEST packet
+        dhcp_request_relayed = self.create_dhcp_request_relayed_packet()
+
+        # Mask off fields we don't care about matching
+        masked_request = Mask(dhcp_request_relayed)
+        masked_request.set_do_not_care_scapy(scapy.Ether, "dst")
+
+        masked_request.set_do_not_care_scapy(scapy.IP, "version")
+        masked_request.set_do_not_care_scapy(scapy.IP, "ihl")
+        masked_request.set_do_not_care_scapy(scapy.IP, "tos")
+        masked_request.set_do_not_care_scapy(scapy.IP, "len")
+        masked_request.set_do_not_care_scapy(scapy.IP, "id")
+        masked_request.set_do_not_care_scapy(scapy.IP, "flags")
+        masked_request.set_do_not_care_scapy(scapy.IP, "frag")
+        masked_request.set_do_not_care_scapy(scapy.IP, "ttl")
+        masked_request.set_do_not_care_scapy(scapy.IP, "proto")
+        masked_request.set_do_not_care_scapy(scapy.IP, "chksum")
+        masked_request.set_do_not_care_scapy(scapy.IP, "src")
+        masked_request.set_do_not_care_scapy(scapy.IP, "dst")
+        masked_request.set_do_not_care_scapy(scapy.IP, "options")
+
+        masked_request.set_do_not_care_scapy(scapy.UDP, "chksum")
+        masked_request.set_do_not_care_scapy(scapy.UDP, "len")
+
+        masked_request.set_do_not_care_scapy(scapy.BOOTP, "sname")
+        masked_request.set_do_not_care_scapy(scapy.BOOTP, "file")
+
+        # Count the number of these packets received on the ports connected to our leaves
+        request_count = testutils.count_matched_packets_all_ports(
+            self, masked_request, self.server_port_indices)
+        self.log(f"DHCP Request received {request_count} pkts, rate {request_count/self.PACKETS_SEND_DURATION} pkts/sec")
+        return request_count
+
+    # Simulate a DHCP server sending a DHCPOFFER message to client from one of our leaves
+    def server_send_ack(self, dhcp_pps):
+        dhcp_ack = self.create_dhcp_ack_packet()
+        end_time = time.time() + self.PACKETS_SEND_DURATION
+        send_cnt = 0
+        while time.time() < end_time:
+            testutils.send_packet(self, self.server_port_indices[0], dhcp_ack, count = dhcp_pps)
+            send_cnt += dhcp_pps
+            time.sleep(1)
+        self.log(f"DHCP Ack send {send_cnt} packets in {self.PACKETS_SEND_DURATION} sec via broadcast")
+
+    # Verify that the DHCPACK would be received by our simulated client
+    def verify_ack_received(self):
+        dhcp_ack = self.create_dhcp_ack_relayed_packet()
+
+        masked_ack = Mask(dhcp_ack)
+        masked_ack.set_do_not_care_scapy(scapy.Ether, "dst")
+
+        masked_ack.set_do_not_care_scapy(scapy.IP, "version")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "ihl")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "tos")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "len")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "id")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "flags")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "frag")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "ttl")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "proto")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "chksum")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "options")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "src")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "dst")
+
+        masked_ack.set_do_not_care_scapy(scapy.UDP, "len")
+        masked_ack.set_do_not_care_scapy(scapy.UDP, "chksum")
+
+        masked_ack.set_do_not_care_scapy(scapy.BOOTP, "sname")
+        masked_ack.set_do_not_care_scapy(scapy.BOOTP, "file")
+
+        ack_count = testutils.count_matched_packets(
+            self, masked_ack, self.client_port_index)
+        self.log(f"DHCP Ack received {ack_count} pkts, rate {ack_count/self.PACKETS_SEND_DURATION} pkts/sec")
+
+    def runTest(self):
+        # Start sniffer process for each server port to capture DHCP packet
+        for interface_index in self.server_port_indices:
+            t1 = Thread(target=self.Sniffer, args=(
+                "eth"+str(interface_index),))
+            t1.start()
+
+        self.client_send_discover(self.dest_mac_address, self.client_udp_src_port)
+        discover_cnt = self.verify_relayed_discover()
+
+        dhcp_pps = discover_cnt // self.PACKETS_SEND_DURATION
+        self.server_send_offer(dhcp_pps)
+        offer_cnt = self.verify_offer_received()
+
+        dhcp_pps = offer_cnt // self.PACKETS_SEND_DURATION
+        self.client_send_request(dhcp_pps, self.dest_mac_address, self.client_udp_src_port)
+        request_cnt = self.verify_relayed_request()
+        
+        dhcp_pps = request_cnt // self.PACKETS_SEND_DURATION
+        self.server_send_ack(dhcp_pps)
+        self.verify_ack_received()
+

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
@@ -239,7 +239,7 @@ class DHCPTest(DataplaneBaseTest):
         # TODO: In IP layer, DHCP relay also replaces source IP with IP of interface on
         #       which it received the broadcast DHCPDISCOVER from client. This appears to
         #       be loopback. We could pull from minigraph and check here.
-        ether = scapy.Ether(dst=self.BROADCAST_MAC, 
+        ether = scapy.Ether(dst=self.BROADCAST_MAC,
                             src=self.uplink_mac, type=0x0800)
         ip = scapy.IP(src=self.DEFAULT_ROUTE_IP,
                       dst=self.BROADCAST_IP, len=328, ttl=64)
@@ -748,8 +748,7 @@ class DHCPTest(DataplaneBaseTest):
         dhcp_pps = offer_cnt // self.PACKETS_SEND_DURATION
         self.client_send_request(dhcp_pps, self.dest_mac_address, self.client_udp_src_port)
         request_cnt = self.verify_relayed_request()
-        
+
         dhcp_pps = request_cnt // self.PACKETS_SEND_DURATION
         self.server_send_ack(dhcp_pps)
         self.verify_ack_received()
-

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -11,6 +11,8 @@ from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs
 
 logger = logging.getLogger(__name__)
 
+CONFIG_RELOAD_INTERVAL_IN_SEC = 30
+
 config_sources = ['config_db', 'minigraph', 'running_golden_config']
 
 
@@ -124,6 +126,7 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
                 reloading = wait_until(wait_before_force_reload, 10, 0, _config_reload_cmd_wrapper, cmd, "/bin/bash")
             cmd = 'config reload -y -f &>/dev/null'
         if not reloading:
+            time.sleep(CONFIG_RELOAD_INTERVAL_IN_SEC)
             sonic_host.shell(cmd, executable="/bin/bash")
 
     elif config_source == 'running_golden_config':

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -306,13 +306,13 @@ dhcp_relay/test_dhcp_relay.py:
     conditions:
       - "platform in ['x86_64-8111_32eh_o-r0']"
 
-dhcp_relay/test_dhcpv6_relay.py:
+dhcp_relay/test_dhcp_reply_stress_with_copp.py:
   skip:
     reason: "Need to skip for platform x86_64-8111_32eh_o-r0"
     conditions:
       - "platform in ['x86_64-8111_32eh_o-r0']"
 
-dhcp_relay/test_dhcp_reply_stress_with_copp.py:
+dhcp_relay/test_dhcpv6_relay.py:
   skip:
     reason: "Need to skip for platform x86_64-8111_32eh_o-r0"
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -312,6 +312,12 @@ dhcp_relay/test_dhcpv6_relay.py:
     conditions:
       - "platform in ['x86_64-8111_32eh_o-r0']"
 
+dhcp_relay/test_dhcp_reply_stress_with_copp.py:
+  skip:
+    reason: "Need to skip for platform x86_64-8111_32eh_o-r0"
+    conditions:
+      - "platform in ['x86_64-8111_32eh_o-r0']"
+
 #######################################
 #####         drop_packets        #####
 #######################################

--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -1,32 +1,5 @@
 import pytest
 
-"""
-    Pytest configuration used by the COPP tests.
-"""
-def pytest_addoption(parser):
-    """
-        Adds options to pytest that are used by the COPP tests.
-    """
-
-    parser.addoption(
-        "--copp_swap_syncd",
-        action="store_true",
-        default=False,
-        help="Swap syncd container with syncd-rpc container",
-    )
-    parser.addoption(
-        "--send_rate_limit",
-        action="store",
-        default=2000,
-        help="Set custom server send rate limit",
-    )
-    parser.addoption(
-        "--copp_reboot_type",
-        action="store",
-        type=str,
-        default="cold",
-        help="reboot type such as cold, fast, warm, soft"
-    )
 
 @pytest.fixture(scope="module", autouse=True)
 def skip_dhcp_relay_tests(tbinfo):

--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -1,5 +1,32 @@
 import pytest
 
+"""
+    Pytest configuration used by the COPP tests.
+"""
+def pytest_addoption(parser):
+    """
+        Adds options to pytest that are used by the COPP tests.
+    """
+
+    parser.addoption(
+        "--copp_swap_syncd",
+        action="store_true",
+        default=False,
+        help="Swap syncd container with syncd-rpc container",
+    )
+    parser.addoption(
+        "--send_rate_limit",
+        action="store",
+        default=2000,
+        help="Set custom server send rate limit",
+    )
+    parser.addoption(
+        "--copp_reboot_type",
+        action="store",
+        type=str,
+        default="cold",
+        help="reboot type such as cold, fast, warm, soft"
+    )
 
 @pytest.fixture(scope="module", autouse=True)
 def skip_dhcp_relay_tests(tbinfo):

--- a/tests/dhcp_relay/test_dhcp_reply_stress_with_copp.py
+++ b/tests/dhcp_relay/test_dhcp_reply_stress_with_copp.py
@@ -12,18 +12,13 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_until
-from tests.common.helpers.dut_utils import check_link_status
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release
 from tests.common import config_reload
-from tests.common.platform.processes_utils import wait_critical_processes
-from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 
 from tests.copp import copp_utils
-from tests.common import config_reload, constants
+from tests.common import config_reload
 from tests.common.system_utils import docker
-from tests.common.utilities import find_duthost_on_role
-from tests.common.utilities import get_upstream_neigh_type
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0'),
@@ -50,6 +45,7 @@ _COPPTestParameters = namedtuple("_COPPTestParameters",
 
 _TEST_RATE_LIMIT_DEFAULT = 600
 _TEST_RATE_LIMIT_MARVELL = 625
+
 
 @pytest.fixture(scope="module", autouse=True)
 def check_dhcp_server_enabled(duthost):
@@ -168,7 +164,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
         dhcp_relay_data['uplink_port_indices'] = uplink_port_indices
         dhcp_relay_data['switch_loopback_ip'] = str(switch_loopback_ip)
         dhcp_relay_data['client_ports_indices'] = client_ports_indices
-        dhcp_relay_data['client_ports_alias']= client_ports_alias
+        dhcp_relay_data['client_ports_alias'] = client_ports_alias
 
         # Obtain MAC address of an uplink interface because vlan mac may be different than that of physical interfaces
         res = duthost.shell('cat /sys/class/net/{}/address'.format(uplink_interfaces[0]))
@@ -289,6 +285,7 @@ def check_interface_status(duthost):
 
     return False
 
+
 def start_dhcp_monitor_debug_counter(duthost):
     program_name = "dhcpmon"
     program_pid_list = []
@@ -391,7 +388,7 @@ def _gather_test_params(tbinfo, duthost, request, duts_minigraph_facts):
                 nn_target_namespace = mg_facts["minigraph_neighbors"][nn_target_interface]['namespace']
 
     logger.info("nn_target_port {} nn_target_interface {} nn_target_namespace {} nn_target_vlanid {}"
-                 .format(nn_target_port, nn_target_interface, nn_target_namespace, nn_target_vlanid))
+                .format(nn_target_port, nn_target_interface, nn_target_namespace, nn_target_vlanid))
 
     return _COPPTestParameters(nn_target_port=nn_target_port,
                                swap_syncd=swap_syncd,
@@ -402,6 +399,7 @@ def _gather_test_params(tbinfo, duthost, request, duts_minigraph_facts):
                                nn_target_namespace=nn_target_namespace,
                                send_rate_limit=send_rate_limit,
                                nn_target_vlanid=nn_target_vlanid)
+
 
 def _setup_testbed(dut, creds, ptf, test_params, tbinfo, upStreamDuthost):
     """
@@ -463,6 +461,7 @@ def _teardown_testbed(dut, creds, ptf, test_params, tbinfo, upStreamDuthost):
 
     # Testbed is not a T1 backend device, so bring up bgp session to upstream device
     # upStreamDuthost.command("sudo config bgp startup all")
+
 
 def _setup_multi_asic_proxy(dut, creds, test_params, tbinfo):
     """
@@ -546,6 +545,7 @@ def test_dhcp_relay_stress(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exi
                    log_file="/tmp/dhcp_relay_stress_test_yw.DHCPTest.log",
                    qlen=100000,
                    is_python3=True)
+
 
 def get_dhcp_relay_counter(duthost, ifname, type, dir):
     # counter table

--- a/tests/dhcp_relay/test_dhcp_reply_stress_with_copp.py
+++ b/tests/dhcp_relay/test_dhcp_reply_stress_with_copp.py
@@ -1,0 +1,579 @@
+import ipaddr
+import ipaddress
+import pytest
+import random
+import time
+import logging
+import re
+from collections import namedtuple
+
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
+from tests.ptf_runner import ptf_runner
+from tests.common.utilities import wait_until
+from tests.common.helpers.dut_utils import check_link_status
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import skip_release
+from tests.common import config_reload
+from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
+
+from tests.copp import copp_utils
+from tests.common import config_reload, constants
+from tests.common.system_utils import docker
+from tests.common.utilities import find_duthost_on_role
+from tests.common.utilities import get_upstream_neigh_type
+
+pytestmark = [
+    pytest.mark.topology('t0', 'm0'),
+    pytest.mark.device_type('vs')
+]
+
+BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
+DEFAULT_DHCP_CLIENT_PORT = 68
+SINGLE_TOR_MODE = 'single'
+DUAL_TOR_MODE = 'dual'
+
+logger = logging.getLogger(__name__)
+
+_COPPTestParameters = namedtuple("_COPPTestParameters",
+                                 ["nn_target_port",
+                                  "swap_syncd",
+                                  "topo",
+                                  "myip",
+                                  "peerip",
+                                  "nn_target_interface",
+                                  "nn_target_namespace",
+                                  "send_rate_limit",
+                                  "nn_target_vlanid"])
+
+_TEST_RATE_LIMIT_DEFAULT = 600
+_TEST_RATE_LIMIT_MARVELL = 625
+
+@pytest.fixture(scope="module", autouse=True)
+def check_dhcp_server_enabled(duthost):
+    print("fixture: check dhcp server enable start")
+    feature_status_output = duthost.show_and_parse("show feature status")
+    for feature in feature_status_output:
+        if feature["feature"] == "dhcp_server" and feature["state"] == "enabled":
+            pytest.skip("DHCPv4 relay is not supported when dhcp_server is enabled")
+
+
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
+    """Ignore expected failures logs during test execution."""
+    if loganalyzer:
+        ignoreRegex = [
+            r".*ERR snmp#snmp-subagent.*",
+            r".*ERR rsyslogd: omfwd: socket (\d+): error (\d+) sending via udp: Network is (unreachable|down).*",
+            r".*ERR rsyslogd: omfwd/udp: socket (\d+): sendto\(\) error: Network is (unreachable|down).*"
+        ]
+        loganalyzer[rand_one_dut_hostname].ignore_regex.extend(ignoreRegex)
+
+    yield
+
+
+@pytest.fixture(scope="module")
+def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
+    """ Fixture which returns a list of dictionaries where each dictionary contains
+        data necessary to test one instance of a DHCP relay agent running on the DuT.
+        This fixture is scoped to the module, as the data it gathers can be used by
+        all tests in this module. It does not need to be run before each test.
+    """
+    print("fixture: cdut_dhcp_relay_data")
+    duthost = duthosts[rand_one_dut_hostname]
+    dhcp_relay_data_list = []
+
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+    switch_loopback_ip = mg_facts['minigraph_lo_interfaces'][0]['addr']
+
+    # SONiC spawns one DHCP relay agent per VLAN interface configured on the DUT
+    vlan_dict = mg_facts['minigraph_vlans']
+    for vlan_iface_name, vlan_info_dict in list(vlan_dict.items()):
+        # Filter(remove) PortChannel interfaces from VLAN members list
+        vlan_members = [port for port in vlan_info_dict['members'] if 'PortChannel' not in port]
+
+        # Gather information about the downlink VLAN interface this relay agent is listening on
+        downlink_vlan_iface = {}
+        downlink_vlan_iface['name'] = vlan_iface_name
+
+        for vlan_interface_info_dict in mg_facts['minigraph_vlan_interfaces']:
+            if vlan_interface_info_dict['attachto'] == vlan_iface_name:
+                downlink_vlan_iface['addr'] = vlan_interface_info_dict['addr']
+                downlink_vlan_iface['mask'] = vlan_interface_info_dict['mask']
+                break
+
+        # Obtain MAC address of the VLAN interface
+        res = duthost.shell('cat /sys/class/net/{}/address'.format(vlan_iface_name))
+        downlink_vlan_iface['mac'] = res['stdout']
+
+        downlink_vlan_iface['dhcp_server_addrs'] = mg_facts['dhcp_servers']
+
+        # Obtain all the DHCP client ports and alias
+        first_port = None
+        client_ports_indices = []
+        client_ports_alias = []
+        for port in vlan_members:
+            if port in mg_facts['minigraph_port_name_to_alias_map']:
+                if first_port is None:
+                    first_port = port
+                client_ports_indices.append(mg_facts['minigraph_ptf_indices'][port])
+                client_ports_alias.append(mg_facts['minigraph_port_name_to_alias_map'][port])
+
+        # We choose the physical interface where our DHCP client resides to be index of first interface
+        # with alias (ignore PortChannel) in the VLAN
+        client_iface = {}
+        client_iface['name'] = first_port
+        client_iface['alias'] = mg_facts['minigraph_port_name_to_alias_map'][client_iface['name']]
+        client_iface['port_idx'] = mg_facts['minigraph_ptf_indices'][client_iface['name']]
+
+        # Obtain uplink port indicies for this DHCP relay agent
+        uplink_interfaces = []
+        uplink_port_indices = []
+        for iface_name, neighbor_info_dict in list(mg_facts['minigraph_neighbors'].items()):
+            if neighbor_info_dict['name'] in mg_facts['minigraph_devices']:
+                neighbor_device_info_dict = mg_facts['minigraph_devices'][neighbor_info_dict['name']]
+                if 'type' in neighbor_device_info_dict and neighbor_device_info_dict['type'] in \
+                        ['LeafRouter', 'MgmtLeafRouter']:
+                    # If this uplink's physical interface is a member of a portchannel interface,
+                    # we record the name of the portchannel interface here, as this is the actual
+                    # interface the DHCP relay will listen on.
+                    iface_is_portchannel_member = False
+                    for portchannel_name, portchannel_info_dict in list(mg_facts['minigraph_portchannels'].items()):
+                        if 'members' in portchannel_info_dict and iface_name in portchannel_info_dict['members']:
+                            iface_is_portchannel_member = True
+                            if portchannel_name not in uplink_interfaces:
+                                uplink_interfaces.append(portchannel_name)
+                            break
+                    # If the uplink's physical interface is not a member of a portchannel,
+                    # add it to our uplink interfaces list
+                    if not iface_is_portchannel_member:
+                        uplink_interfaces.append(iface_name)
+                    uplink_port_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
+
+        other_client_ports_indices = []
+        for iface_name in vlan_members:
+            if mg_facts['minigraph_ptf_indices'][iface_name] == client_iface['port_idx']:
+                pass
+            else:
+                other_client_ports_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
+
+        dhcp_relay_data = {}
+        dhcp_relay_data['downlink_vlan_iface'] = downlink_vlan_iface
+        dhcp_relay_data['client_iface'] = client_iface
+        dhcp_relay_data['other_client_ports'] = other_client_ports_indices
+        dhcp_relay_data['uplink_interfaces'] = uplink_interfaces
+        dhcp_relay_data['uplink_port_indices'] = uplink_port_indices
+        dhcp_relay_data['switch_loopback_ip'] = str(switch_loopback_ip)
+        dhcp_relay_data['client_ports_indices'] = client_ports_indices
+        dhcp_relay_data['client_ports_alias']= client_ports_alias
+
+        # Obtain MAC address of an uplink interface because vlan mac may be different than that of physical interfaces
+        res = duthost.shell('cat /sys/class/net/{}/address'.format(uplink_interfaces[0]))
+        dhcp_relay_data['uplink_mac'] = res['stdout']
+        dhcp_relay_data['default_gw_ip'] = mg_facts['minigraph_mgmt_interface']['gwaddr']
+
+        dhcp_relay_data_list.append(dhcp_relay_data)
+
+    return dhcp_relay_data_list
+
+
+def check_routes_to_dhcp_server(duthost, dut_dhcp_relay_data):
+    """Validate there is route on DUT to each DHCP server
+    """
+    default_gw_ip = dut_dhcp_relay_data[0]['default_gw_ip']
+    dhcp_servers = set()
+    for dhcp_relay in dut_dhcp_relay_data:
+        dhcp_servers |= set(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
+
+    for dhcp_server in dhcp_servers:
+        rtInfo = duthost.get_ip_route_info(ipaddress.ip_address(dhcp_server))
+        nexthops = rtInfo["nexthops"]
+        if len(nexthops) == 0:
+            logger.info("Failed to find route to DHCP server '{0}'".format(dhcp_server))
+            return False
+        if len(nexthops) == 1:
+            # if only 1 route to dst available - check that it's not default route via MGMT iface
+            route_index_in_list = 0
+            ip_dst_index = 0
+            route_dst_ip = nexthops[route_index_in_list][ip_dst_index]
+            if route_dst_ip == ipaddress.ip_address(default_gw_ip):
+                logger.info("Found route to DHCP server via default GW(MGMT interface)")
+                return False
+    return True
+
+
+@pytest.fixture(scope="module")
+def validate_dut_routes_exist(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data):
+    """Fixture to valid a route to each DHCP server exist
+    """
+    pytest_assert(wait_until(120, 5, 0, check_routes_to_dhcp_server, duthosts[rand_one_dut_hostname],
+                             dut_dhcp_relay_data), "Failed to find route for DHCP server")
+
+
+def restart_dhcp_service(duthost):
+    duthost.shell('systemctl reset-failed dhcp_relay')
+    duthost.shell('systemctl restart dhcp_relay')
+    duthost.shell('systemctl reset-failed dhcp_relay')
+
+    for retry in range(5):
+        time.sleep(30)
+        dhcp_status = duthost.shell('docker container top dhcp_relay | grep dhcrelay | cat')["stdout"]
+        if dhcp_status != "":
+            break
+    else:
+        assert False, "Failed to restart dhcp docker"
+
+    time.sleep(30)
+
+
+def get_subtype_from_configdb(duthost):
+    # HEXISTS returns 1 if the key exists, otherwise 0
+    subtype_exist = int(duthost.shell('redis-cli -n 4 HEXISTS "DEVICE_METADATA|localhost" "subtype"')["stdout"])
+    subtype_value = ""
+    if subtype_exist:
+        subtype_value = duthost.shell('redis-cli -n 4 HGET "DEVICE_METADATA|localhost" "subtype"')["stdout"]
+    return subtype_exist, subtype_value
+
+
+@pytest.fixture(scope="module", params=[SINGLE_TOR_MODE, DUAL_TOR_MODE])
+def testing_config(request, duthosts, rand_one_dut_hostname, tbinfo):
+    testing_mode = request.param
+    duthost = duthosts[rand_one_dut_hostname]
+    subtype_exist, subtype_value = get_subtype_from_configdb(duthost)
+    if 'dualtor' in tbinfo['topo']['name']:
+        if testing_mode == SINGLE_TOR_MODE:
+            pytest.skip("skip SINGLE_TOR_MODE tests on Dual ToR testbeds")
+
+        if testing_mode == DUAL_TOR_MODE:
+            if not subtype_exist or subtype_value != 'DualToR':
+                assert False, "Wrong DHCP setup on Dual ToR testbeds"
+
+            yield testing_mode, duthost, 'dual_testbed'
+    elif tbinfo['topo']['name'] in ('t0-54-po2vlan', 't0-56-po2vlan'):
+        if testing_mode == SINGLE_TOR_MODE:
+            if subtype_exist and subtype_value == 'DualToR':
+                assert False, "Wrong DHCP setup on po2vlan testbeds"
+
+            yield testing_mode, duthost, 'single_testbed'
+
+        if testing_mode == DUAL_TOR_MODE:
+            pytest.skip("skip DUAL_TOR_MODE tests on po2vlan testbeds")
+    else:
+        if testing_mode == DUAL_TOR_MODE:
+            pytest.skip("skip DUAL_TOR_MODE tests on Single ToR testbeds")
+
+        if testing_mode == SINGLE_TOR_MODE:
+            if subtype_exist:
+                duthost.shell('redis-cli -n 4 HDEL "DEVICE_METADATA|localhost" "subtype"')
+                restart_dhcp_service(duthost)
+
+        if testing_mode == DUAL_TOR_MODE:
+            if not subtype_exist or subtype_value != 'DualToR':
+                duthost.shell('redis-cli -n 4 HSET "DEVICE_METADATA|localhost" "subtype" "DualToR"')
+                restart_dhcp_service(duthost)
+
+        yield testing_mode, duthost, 'single_testbed'
+
+        if testing_mode == DUAL_TOR_MODE:
+            duthost.shell('redis-cli -n 4 HDEL "DEVICE_METADATA|localhost" "subtype"')
+            restart_dhcp_service(duthost)
+
+
+def check_interface_status(duthost):
+    if ":67" in duthost.shell("docker exec -t dhcp_relay ss -nlp | grep dhcrelay",
+                              module_ignore_errors=True)["stdout"]:
+        return True
+
+    return False
+
+def start_dhcp_monitor_debug_counter(duthost):
+    program_name = "dhcpmon"
+    program_pid_list = []
+    program_list = duthost.shell("ps aux | grep {}".format(program_name))
+    matches = re.findall(r'/usr/sbin/dhcpmon.*', program_list["stdout"])
+
+    for program_info in program_list["stdout_lines"]:
+        if program_name in program_info:
+            program_pid = int(program_info.split()[1])
+            program_pid_list.append(program_pid)
+
+    for program_pid in program_pid_list:
+        kill_cmd_result = duthost.shell("sudo kill {} || true".format(program_pid), module_ignore_errors=True)
+        # Get the exit code of 'kill' command
+        exit_code = kill_cmd_result["rc"]
+        if exit_code != 0:
+            stderr = kill_cmd_result.get("stderr", "")
+            if "No such process" not in stderr:
+                pytest.fail("Failed to stop program '{}' before test. Error: {}".format(program_name, stderr))
+
+    if matches:
+        for dhcpmon_cmd in matches:
+            if "-D" not in dhcpmon_cmd:
+                dhcpmon_cmd += " -D"
+            duthost.shell("docker exec -d dhcp_relay %s" % dhcpmon_cmd)
+    else:
+        assert False, "Failed to start dhcpmon in debug counter mode\n"
+
+
+# copp policy
+@pytest.fixture(scope="module")
+def copp_testbed(
+    duthosts,
+    enum_rand_one_per_hwsku_frontend_hostname,
+    creds,
+    ptfhost,
+    tbinfo,
+    duts_minigraph_facts,
+    request
+):
+    """
+        Pytest fixture to handle setup and cleanup for the COPP tests.
+    """
+    upStreamDuthost = None
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    test_params = _gather_test_params(tbinfo, duthost, request, duts_minigraph_facts)
+
+    # There is no upstream neighbor in T1 backend topology. Test is skipped on T0 backend.
+    # upStreamDuthost = find_duthost_on_role(duthosts, get_upstream_neigh_type(tbinfo['topo']['type']), tbinfo)
+
+    try:
+        _setup_multi_asic_proxy(duthost, creds, test_params, tbinfo)
+        _setup_testbed(duthost, creds, ptfhost, test_params, tbinfo, upStreamDuthost)
+        yield test_params
+    finally:
+        _teardown_multi_asic_proxy(duthost, creds, test_params, tbinfo)
+        _teardown_testbed(duthost, creds, ptfhost, test_params, tbinfo, upStreamDuthost)
+
+
+def _gather_test_params(tbinfo, duthost, request, duts_minigraph_facts):
+    """
+        Fetches the test parameters from pytest.
+    """
+
+    swap_syncd = request.config.getoption("--copp_swap_syncd")
+    send_rate_limit = request.config.getoption("--send_rate_limit")
+    topo = tbinfo["topo"]["name"]
+    mg_fact = duts_minigraph_facts[duthost.hostname]
+
+    port_index_map = {}
+    for mg_facts_tuple in mg_fact:
+        index, mg_facts = mg_facts_tuple
+        # filter out server peer port and only bgp peer ports remain, to support T0 topologies
+        bgp_peer_name_set = set([bgp_peer["name"] for bgp_peer in mg_facts["minigraph_bgp"]])
+        # get the port_index_map using the ptf_indicies to support multi DUT topologies
+        port_index_map.update({
+           k: v
+           for k, v in list(mg_facts["minigraph_ptf_indices"].items())
+           if k in mg_facts["minigraph_ports"] and
+           not duthost.is_backend_port(k, mg_facts) and
+           mg_facts["minigraph_neighbors"][k]["name"] in bgp_peer_name_set
+        })
+    # use randam sonic interface for testing
+    nn_target_interface = random.choice(list(port_index_map.keys()))
+    # get the  ptf port for choosen port
+    nn_target_port = port_index_map[nn_target_interface]
+    myip = None
+    peerip = None
+    nn_target_vlanid = None
+
+    for mg_facts_tuple in mg_fact:
+        index, mg_facts = mg_facts_tuple
+        if nn_target_interface not in mg_facts["minigraph_neighbors"]:
+            continue
+        for bgp_peer in mg_facts["minigraph_bgp"]:
+            if bgp_peer["name"] == mg_facts["minigraph_neighbors"][nn_target_interface]["name"] \
+                                   and ipaddr.IPAddress(bgp_peer["addr"]).version == 4:
+                myip = bgp_peer["addr"]
+                peerip = bgp_peer["peer_addr"]
+                nn_target_namespace = mg_facts["minigraph_neighbors"][nn_target_interface]['namespace']
+
+    logger.info("nn_target_port {} nn_target_interface {} nn_target_namespace {} nn_target_vlanid {}"
+                 .format(nn_target_port, nn_target_interface, nn_target_namespace, nn_target_vlanid))
+
+    return _COPPTestParameters(nn_target_port=nn_target_port,
+                               swap_syncd=swap_syncd,
+                               topo=topo,
+                               myip=myip,
+                               peerip=peerip,
+                               nn_target_interface=nn_target_interface,
+                               nn_target_namespace=nn_target_namespace,
+                               send_rate_limit=send_rate_limit,
+                               nn_target_vlanid=nn_target_vlanid)
+
+def _setup_testbed(dut, creds, ptf, test_params, tbinfo, upStreamDuthost):
+    """
+        Sets up the testbed to run the COPP tests.
+    """
+    logger.info("Set up the PTF for COPP tests")
+    copp_utils.configure_ptf(ptf, test_params, False)
+
+    rate_limit = _TEST_RATE_LIMIT_DEFAULT
+    if dut.facts["asic_type"] == "marvell":
+        rate_limit = _TEST_RATE_LIMIT_MARVELL
+
+    logger.info("Update the rate limit for the COPP policer")
+    copp_utils.limit_policer(dut, rate_limit, test_params.nn_target_namespace)
+
+    # Multi-asic will not support this mode as of now.
+    if test_params.swap_syncd:
+        logger.info("Swap out syncd to use RPC image...")
+        docker.swap_syncd(dut, creds, test_params.nn_target_namespace)
+    else:
+        # Set sysctl RCVBUF parameter for tests
+        dut.command("sysctl -w net.core.rmem_max=609430500")
+
+        # Set sysctl SENDBUF parameter for tests
+        dut.command("sysctl -w net.core.wmem_max=609430500")
+
+        # NOTE: Even if the rpc syncd image is already installed, we need to restart
+        # SWSS for the COPP changes to take effect.
+        logger.info("Reloading config and restarting swss...")
+        config_reload(dut, safe_reload=True, check_intf_up_ports=True)
+
+    # make sure traffic goes over management port by shutdown bgp toward upstream neigh that gives default route
+    # upStreamDuthost.command("sudo config bgp shutdown all")
+    # time.sleep(30)
+
+    logger.info("Configure syncd RPC for testing")
+    copp_utils.configure_syncd(dut, test_params.nn_target_port, test_params.nn_target_interface,
+                               test_params.nn_target_namespace, test_params.nn_target_vlanid,
+                               test_params.swap_syncd, creds)
+
+
+def _teardown_testbed(dut, creds, ptf, test_params, tbinfo, upStreamDuthost):
+    """
+        Tears down the testbed, returning it to its initial state.
+    """
+    logger.info("Restore PTF post COPP test")
+    copp_utils.restore_ptf(ptf)
+
+    logger.info("Restore COPP policer to default settings")
+    copp_utils.restore_policer(dut, test_params.nn_target_namespace)
+
+    if test_params.swap_syncd:
+        logger.info("Restore default syncd docker...")
+        docker.restore_default_syncd(dut, creds, test_params.nn_target_namespace)
+    else:
+        copp_utils.restore_syncd(dut, test_params.nn_target_namespace)
+        logger.info("Reloading config and restarting swss...")
+        config_reload(dut, safe_reload=True, check_intf_up_ports=True)
+
+    # Testbed is not a T1 backend device, so bring up bgp session to upstream device
+    # upStreamDuthost.command("sudo config bgp startup all")
+
+def _setup_multi_asic_proxy(dut, creds, test_params, tbinfo):
+    """
+        Sets up the testbed to run the COPP tests on multi-asic platfroms via setting proxy.
+    """
+    if not dut.is_multi_asic:
+        return
+
+    logger.info("Adding iptables rules and enabling eth0 port forwarding")
+    # Add IP Table rule for http and ptf nn_agent traffic.
+    dut.command("sudo sysctl net.ipv4.conf.eth0.forwarding=1")
+
+    if not test_params.swap_syncd:
+        mgmt_ip = dut.host.options["inventory_manager"].get_host(dut.hostname).vars["ansible_host"]
+        # Add Rule to communicate to http/s proxy from namespace
+        dut.command("sudo iptables -t nat -A POSTROUTING -p tcp --dport 8080 -j SNAT --to-source {}".format(mgmt_ip))
+    # Add Rule to communicate to ptf nn agent client from namespace
+    ns_ip = dut.shell("sudo ip -n {} -4 -o addr show eth0".format(test_params.nn_target_namespace)
+                      + " | awk '{print $4}' | cut -d'/' -f1")["stdout"]
+    dut.command("sudo iptables -t nat -A PREROUTING -p tcp --dport 10900 -j DNAT --to-destination {}".format(ns_ip))
+
+
+def _teardown_multi_asic_proxy(dut, creds, test_params, tbinfo):
+    """
+        Tears down multi asic proxy settings, returning it to its initial state.
+    """
+    if not dut.is_multi_asic:
+        return
+
+    logger.info("Removing iptables rules and disabling eth0 port forwarding")
+    dut.command("sudo sysctl net.ipv4.conf.eth0.forwarding=0")
+    if not test_params.swap_syncd:
+        # Delete IP Table rule for http and ptf nn_agent traffic.
+        mgmt_ip = dut.host.options["inventory_manager"].get_host(dut.hostname).vars["ansible_host"]
+        # Delete Rule to communicate to http/s proxy from namespace
+        dut.command("sudo iptables -t nat -D POSTROUTING -p tcp --dport 8080 -j SNAT --to-source {}".format(mgmt_ip))
+    # Delete Rule to communicate to ptf nn agent client from namespace
+    ns_ip = dut.shell("sudo ip -n {} -4 -o addr show eth0".format(test_params.nn_target_namespace)
+                      + " | awk '{print $4}' | cut -d'/' -f1")["stdout"]
+    dut.command("sudo iptables -t nat -D PREROUTING -p tcp --dport 10900 -j DNAT --to-destination {}".format(ns_ip))
+# end copp policy
+
+
+def test_dhcp_relay_stress(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config, copp_testbed,
+                                setup_standby_ports_on_rand_unselected_tor,				 # noqa F811
+                                toggle_all_simulator_ports_to_rand_selected_tor_m):     # noqa F811
+    """Test DHCP relay functionality on T0 topology with unicast mac
+       Instead of using broadcast MAC, use unicast MAC of DUT and verify that DHCP relay functionality is entact.
+    """
+    testing_mode, duthost, testbed_mode = testing_config
+
+    if testing_mode == DUAL_TOR_MODE:
+        skip_release(duthost, ["201811", "201911"])
+
+    if len(dut_dhcp_relay_data) > 1:
+        pytest.skip("skip the unicast mac testcase in the multi-Vlan setting")
+
+    for dhcp_relay in dut_dhcp_relay_data:
+        # Run the DHCP relay test on the PTF host
+        breakpoint()
+        ptf_runner(ptfhost,
+                   "ptftests",
+                   "dhcp_relay_stress_test.DHCPTest",
+                   platform_dir="ptftests",
+                   params={"hostname": duthost.hostname,
+                           "client_port_index": dhcp_relay['client_iface']['port_idx'],
+                           "client_iface_alias": str(dhcp_relay['client_iface']['alias']),
+                           "other_client_ports": repr(dhcp_relay['other_client_ports']),
+                           "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
+                           "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs']),
+                           "server_ip": dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'],
+                           "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                           "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
+                           "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask']),
+                           "dest_mac_address": BROADCAST_MAC,
+                           "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
+                           "switch_loopback_ip": dhcp_relay['switch_loopback_ip'],
+                           "uplink_mac": str(dhcp_relay['uplink_mac']),
+                           "testbed_mode": testbed_mode,
+                           "testing_mode": testing_mode},
+                   log_file="/tmp/dhcp_relay_stress_test_yw.DHCPTest.log",
+                   qlen=100000,
+                   is_python3=True)
+
+def get_dhcp_relay_counter(duthost, ifname, type, dir):
+    # counter table
+    # sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Vlan1000'
+    # {'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0',
+    #  'Nak':'0','Release':'0','Inform':'0'}",'TX': "{'Unknown':'0','Discover':'0','Offer':'0',
+    #  'Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}"}
+    cmd = 'sonic-db-cli STATE_DB hget "DHCP_COUNTER_TABLE|{}" {}'.format(ifname, dir)
+    output = duthost.shell(cmd)['stdout']
+    if len(output) != 0:
+        counters = eval(output)
+        if type in counters:
+            return int(counters[type])
+        return 0
+    else:
+        return 0
+
+
+def init_counter(duthost, ifname):
+    cmd = 'sonic-db-cli STATE_DB hget "DHCP_COUNTER_TABLE|{}" RX'.format(ifname)
+    output = duthost.shell(cmd)['stdout']
+    if len(output) != 0:
+        counters_str = ("{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0',"
+                        "'Ack':'0','Nack':'0','Release':'0','Inform':'0'}")
+        cmd = 'sonic-db-cli STATE_DB hmset "DHCP_COUNTER_TABLE|{}" "RX" "{}"'.format(ifname, str(counters_str))
+        duthost.shell(cmd)
+        cmd = 'sonic-db-cli STATE_DB hmset "DHCP_COUNTER_TABLE|{}" "TX" "{}"'.format(ifname, str(counters_str))
+        duthost.shell(cmd)
+    else:
+        # image does not support STATE_DB counter, ignore
+        pytest.skip("skip the dhcpv4 counter testing")

--- a/tests/dhcp_relay/test_dhcp_reply_stress_with_copp.py
+++ b/tests/dhcp_relay/test_dhcp_reply_stress_with_copp.py
@@ -14,7 +14,6 @@ from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release
-from tests.common import config_reload
 
 from tests.copp import copp_utils
 from tests.common import config_reload

--- a/tests/sai_qualify/sai_infra.py
+++ b/tests/sai_qualify/sai_infra.py
@@ -39,6 +39,7 @@ from .conftest import get_sai_running_vendor_id
 from .conftest import get_sai_test_container_name
 from .conftest import saiserver_warmboot_config
 from .conftest import *  # noqa: F403 F401
+from tests.common.config_reload import CONFIG_RELOAD_INTERVAL_IN_SEC
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,6 @@ pytestmark = [
 SAI_TEST_ENV_RESET_TIMES = 3
 LIVENESS_CHECK_RETRY_TIMES = 12
 LIVENESS_CHECK_INTERVAL_IN_SEC = 5
-CONFIG_RELOAD_INTERVAL_IN_SEC = 30
 TEST_INTERVAL_IN_SEC = 1
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The motivation for this change is to address flaky issues encountered during the test_ntp_ipv6_only test case. Specifically, the test case sometimes fails during teardown with the error “host unreachable” when running the config_reload function.

#### How did you do it?
By adding the sleep function, we aim to ensure that the config_reload function can run successfully.

#### How did you verify/test it?
No more flaky issues for the testcase.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
