### PR TITLE
[dualtor] Improve `test_orchagent_slb`

### DIFF
--- a/tests/dualtor/test_orchagent_slb.py
+++ b/tests/dualtor/test_orchagent_slb.py
@@ -267,6 +267,7 @@ def test_orchagent_slb(
         )
         with tunnel_monitor, server_traffic_monitor:
             testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)
+            time.sleep(5)
 
     connections = setup_interfaces
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Stablize `test_orchagent_slb`

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
1. show the output of `tcpdump` for debug purpose.
2. sleep for 5 seconds to allow `tcpdump` to have sufficient time to capture the packets.

#### How did you verify/test it?

```
dualtor/test_orchagent_slb.py::test_orchagent_slb[ipv4-active-standby] PASSED                                                                                                                                                                        [ 50%]
dualtor/test_orchagent_slb.py::test_orchagent_slb[ipv4-active-active] SKIPPED (Skip cable type 'active-active')                                                                                                                                      [100%]

===================================================================================================================== warnings summary =====================================================================================================================
../../../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

dualtor/test_orchagent_slb.py: 96 warnings
  /usr/local/lib/python3.8/dist-packages/ptf/mask.py:69: DeprecationWarning: "set_do_not_care_scapy" is going to be deprecated, please switch to the new one: "set_do_not_care_packet"
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================== 1 passed, 1 skipped, 2 deselected, 97 warnings in 442.44s (0:07:22) ============================================================================================
INFO:root:Can not get Allure report URL. Please check logs
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
