### PR TITLE
Test_ntp_ipv6_only flaky issue

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -171,6 +171,7 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
                 reloading = wait_until(wait_before_force_reload, 10, 0, _config_reload_cmd_wrapper, cmd, "/bin/bash")
             cmd = 'config reload -y -f &>/dev/null'
         if not reloading:
+            time.sleep(30)
             sonic_host.shell(cmd, executable="/bin/bash")
 
     elif config_source == 'running_golden_config':


### PR DESCRIPTION
…run successfully

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The motivation for this change is to address flaky issues encountered during the test_ntp_ipv6_only test case. Specifically, the test case sometimes fails during teardown with the error “host unreachable” when running the config_reload function.

#### How did you do it?
By adding the sleep function, we aim to ensure that the config_reload function can run successfully.

#### How did you verify/test it?
No more flaky issues for the testcase.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
