### PR TITLE
Add stable t1 scripts into T1 PR checker

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -293,6 +293,96 @@ t1-lag:
   - test_pktgen.py
   - vxlan/test_vxlan_crm.py
   - vxlan/test_vxlan_ecmp.py
+  - autorestart/test_container_autorestart.py
+  - bgp/test_bgp_gr_helper.py
+  - bgp/test_bgp_peer_shutdown.py
+  - bgp/test_bgp_queue.py
+  - bgp/test_bgp_session_flap.py
+  - cacl/test_cacl_application.py
+  - clock/test_clock.py
+  - console/test_console_availability.py
+  - console/test_console_driver.py
+  - console/test_console_loopback.py
+  - console/test_console_reversessh.py
+  - console/test_console_udevrule.py
+  - container_hardening/test_container_hardening.py
+  - database/test_db_config.py
+  - database/test_db_scripts.py
+  - disk/test_disk_exhaustion.py
+  - dns/static_dns/test_static_dns.py
+  - dns/test_dns_resolv_conf.py
+  - dut_console/test_console_baud_rate.py
+  - dut_console/test_escape_character.py
+  - dut_console/test_idle_timeout.py
+  - generic_config_updater/test_aaa.py
+  - generic_config_updater/test_bgp_prefix.py
+  - generic_config_updater/test_bgp_sentinel.py
+  - generic_config_updater/test_cacl.py
+  - generic_config_updater/test_ecn_config_update.py
+  - generic_config_updater/test_eth_interface.py
+  - generic_config_updater/test_ipv6.py
+  - generic_config_updater/test_kubernetes_config.py
+  - generic_config_updater/test_monitor_config.py
+  - generic_config_updater/test_ntp.py
+  - generic_config_updater/test_pfcwd_status.py
+  - generic_config_updater/test_pg_headroom_update.py
+  - generic_config_updater/test_syslog.py
+  - gnmi/test_gnmi.py
+  - gnmi/test_gnmi_appldb.py
+  - gnmi/test_gnmi_configdb.py
+  - gnmi/test_gnmi_countersdb.py
+  - iface_loopback_action/test_iface_loopback_action.py
+  - log_fidelity/test_bgp_shutdown.py
+  - memory_checker/test_memory_checker.py
+  - minigraph/test_masked_services.py
+  - ntp/test_ntp.py
+  - override_config_table/test_override_config_table_masic.py
+  - passw_hardening/test_passw_hardening.py
+  - pc/test_po_cleanup.py
+  - pc/test_retry_count.py
+  - platform_tests/broadcom/test_ser.py
+  - platform_tests/cli/test_show_platform.py
+  - platform_tests/counterpoll/test_counterpoll_watermark.py
+  - platform_tests/fwutil/test_fwutil.py
+  - platform_tests/link_flap/test_cont_link_flap.py
+  - platform_tests/link_flap/test_link_flap.py
+  - platform_tests/sfp/test_sfpshow.py
+  - platform_tests/sfp/test_sfputil.py
+  - platform_tests/sfp/test_show_intf_xcvr.py
+  - platform_tests/test_auto_negotiation.py
+  - platform_tests/test_first_time_boot_password_change/test_first_time_boot_password_change.py
+  - platform_tests/test_kdump.py
+  - platform_tests/test_link_down.py
+  - platform_tests/test_memory_exhaustion.py
+  - platform_tests/test_platform_info.py
+  - platform_tests/test_port_toggle.py
+  - platform_tests/test_power_off_reboot.py
+  - platform_tests/test_reboot.py
+  - platform_tests/test_secure_upgrade.py
+  - platform_tests/test_sensors.py
+  - platform_tests/test_sequential_restart.py
+  - platform_tests/test_xcvr_info_in_db.py
+  - portstat/test_portstat.py
+  - reset_factory/test_reset_factory.py
+  - show_techsupport/test_techsupport.py
+  - show_techsupport/test_techsupport_no_secret.py
+  - snmp/test_snmp_psu.py
+  - snmp/test_snmp_queue_counters.py
+  - ssh/test_ssh_ciphers.py
+  - ssh/test_ssh_default_password.py
+  - ssh/test_ssh_limit.py
+  - ssh/test_ssh_stress.py
+  - syslog/test_logrotate.py
+  - syslog/test_syslog.py
+  - syslog/test_syslog_rate_limit.py
+  - syslog/test_syslog_source_ip.py
+  - system_health/test_system_status.py
+  - system_health/test_watchdog.py
+  - tacacs/test_ro_disk.py
+  - telemetry/test_telemetry.py
+  - telemetry/test_telemetry_cert_rotation.py
+  - test_features.py
+  - test_procdockerstatsd.py
 
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py
@@ -370,104 +460,15 @@ onboarding_t1:
   - stress/test_stress_routes.py
   - drop_packets/test_drop_counters.py
   - sub_port_interfaces/test_sub_port_interfaces.py
-  - autorestart/test_container_autorestart.py
-  - bgp/test_bgp_gr_helper.py
-  - bgp/test_bgp_peer_shutdown.py
-  - bgp/test_bgp_queue.py
   - bgp/test_bgp_sentinel.py
-  - bgp/test_bgp_session_flap.py
   - bgp/test_bgp_suppress_fib.py
-  - cacl/test_cacl_application.py
-  - clock/test_clock.py
-  - console/test_console_availability.py
-  - console/test_console_driver.py
-  - console/test_console_loopback.py
-  - console/test_console_reversessh.py
-  - console/test_console_udevrule.py
-  - container_hardening/test_container_hardening.py
-  - database/test_db_config.py
-  - database/test_db_scripts.py
-  - disk/test_disk_exhaustion.py
-  - dns/static_dns/test_static_dns.py
-  - dns/test_dns_resolv_conf.py
-  - dut_console/test_console_baud_rate.py
-  - dut_console/test_escape_character.py
-  - dut_console/test_idle_timeout.py
-  - generic_config_updater/test_aaa.py
-  - generic_config_updater/test_bgp_prefix.py
-  - generic_config_updater/test_bgp_sentinel.py
-  - generic_config_updater/test_cacl.py
-  - generic_config_updater/test_ecn_config_update.py
-  - generic_config_updater/test_eth_interface.py
-  - generic_config_updater/test_ipv6.py
-  - generic_config_updater/test_kubernetes_config.py
-  - generic_config_updater/test_monitor_config.py
-  - generic_config_updater/test_ntp.py
-  - generic_config_updater/test_pfcwd_status.py
-  - generic_config_updater/test_pg_headroom_update.py
-  - generic_config_updater/test_syslog.py
-  - gnmi/test_gnmi.py
-  - gnmi/test_gnmi_appldb.py
-  - gnmi/test_gnmi_configdb.py
-  - gnmi/test_gnmi_countersdb.py
   - hash/test_generic_hash.py
-  - iface_loopback_action/test_iface_loopback_action.py
-  - log_fidelity/test_bgp_shutdown.py
-  - memory_checker/test_memory_checker.py
-  - minigraph/test_masked_services.py
-  - ntp/test_ntp.py
-  - override_config_table/test_override_config_table_masic.py
-  - passw_hardening/test_passw_hardening.py
-  - pc/test_po_cleanup.py
-  - pc/test_retry_count.py
-  - platform_tests/broadcom/test_ser.py
-  - platform_tests/cli/test_show_platform.py
-  - platform_tests/counterpoll/test_counterpoll_watermark.py
-  - platform_tests/fwutil/test_fwutil.py
-  - platform_tests/link_flap/test_cont_link_flap.py
-  - platform_tests/link_flap/test_link_flap.py
-  - platform_tests/sfp/test_sfpshow.py
-  - platform_tests/sfp/test_sfputil.py
-  - platform_tests/sfp/test_show_intf_xcvr.py
-  - platform_tests/test_auto_negotiation.py
-  - platform_tests/test_first_time_boot_password_change/test_first_time_boot_password_change.py
-  - platform_tests/test_kdump.py
-  - platform_tests/test_link_down.py
-  - platform_tests/test_memory_exhaustion.py
-  - platform_tests/test_platform_info.py
-  - platform_tests/test_port_toggle.py
-  - platform_tests/test_power_off_reboot.py
-  - platform_tests/test_reboot.py
   - platform_tests/test_reload_config.py
-  - platform_tests/test_secure_upgrade.py
-  - platform_tests/test_sensors.py
-  - platform_tests/test_sequential_restart.py
-  - platform_tests/test_xcvr_info_in_db.py
-  - portstat/test_portstat.py
-  - reset_factory/test_reset_factory.py
   - show_techsupport/test_auto_techsupport.py
-  - show_techsupport/test_techsupport.py
-  - show_techsupport/test_techsupport_no_secret.py
   - snmp/test_snmp_link_local.py
-  - snmp/test_snmp_psu.py
-  - snmp/test_snmp_queue_counters.py
-  - ssh/test_ssh_ciphers.py
-  - ssh/test_ssh_default_password.py
-  - ssh/test_ssh_limit.py
-  - ssh/test_ssh_stress.py
   - sub_port_interfaces/test_sub_port_interfaces.py
-  - syslog/test_logrotate.py
-  - syslog/test_syslog.py
-  - syslog/test_syslog_rate_limit.py
-  - syslog/test_syslog_source_ip.py
-  - system_health/test_system_status.py
-  - system_health/test_watchdog.py
-  - tacacs/test_ro_disk.py
   - telemetry/test_events.py
-  - telemetry/test_telemetry.py
-  - telemetry/test_telemetry_cert_rotation.py
-  - test_features.py
-  - test_procdockerstatsd.py
+
 
 onboarding_dualtor:
   - arp/test_arp_dualtor.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #13992, we add a batch of scripts into T1 PR checker. Now in this PR, we move some stable scripts into standard T1 PR checker. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In PR #13992, we add a batch of scripts into T1 PR checker. Now in this PR, we move some stable scripts into standard T1 PR checker. 

#### How did you do it?
Move some stable scripts into standard T1 PR checker. 

#### How did you verify/test it?

TestbedName | FilePath | RunDate | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-t1-lag | autorestart/test_container_autorestart.py | 2024-08-09 00:00:00.0000000 | 36 | 0 | 36 | 1
vms-kvm-t1-lag | bgp/test_bgp_gr_helper.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | bgp/test_bgp_peer_shutdown.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | bgp/test_bgp_queue.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | bgp/test_bgp_session_flap.py | 2024-08-09 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-t1-lag | cacl/test_cacl_application.py | 2024-08-09 00:00:00.0000000 | 12 | 0 | 12 | 1
vms-kvm-t1-lag | clock/test_clock.py | 2024-08-09 00:00:00.0000000 | 6 | 0 | 6 | 1
vms-kvm-t1-lag | console/test_console_availability.py | 2024-08-09 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | console/test_console_driver.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | console/test_console_loopback.py | 2024-08-09 00:00:00.0000000 | 52 | 0 | 52 | 1
vms-kvm-t1-lag | console/test_console_reversessh.py | 2024-08-09 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | console/test_console_udevrule.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | container_hardening/test_container_hardening.py | 2024-08-09 00:00:00.0000000 | 36 | 0 | 36 | 1
vms-kvm-t1-lag | database/test_db_config.py | 2024-08-09 00:00:00.0000000 | 6 | 0 | 6 | 1
vms-kvm-t1-lag | database/test_db_scripts.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | disk/test_disk_exhaustion.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | dns/static_dns/test_static_dns.py | 2024-08-09 00:00:00.0000000 | 10 | 0 | 10 | 1
vms-kvm-t1-lag | dns/test_dns_resolv_conf.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | dut_console/test_console_baud_rate.py | 2024-08-09 00:00:00.0000000 | 6 | 0 | 6 | 1
vms-kvm-t1-lag | dut_console/test_escape_character.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | dut_console/test_idle_timeout.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | generic_config_updater/test_aaa.py | 2024-08-09 00:00:00.0000000 | 6 | 0 | 6 | 1
vms-kvm-t1-lag | generic_config_updater/test_bgp_prefix.py | 2024-08-09 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-t1-lag | generic_config_updater/test_bgp_sentinel.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | generic_config_updater/test_cacl.py | 2024-08-09 00:00:00.0000000 | 16 | 0 | 16 | 1
vms-kvm-t1-lag | generic_config_updater/test_ecn_config_update.py | 2024-08-09 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | generic_config_updater/test_eth_interface.py | 2024-08-09 00:00:00.0000000 | 26 | 0 | 26 | 1
vms-kvm-t1-lag | generic_config_updater/test_ipv6.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | generic_config_updater/test_kubernetes_config.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | generic_config_updater/test_monitor_config.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | generic_config_updater/test_ntp.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | generic_config_updater/test_pfcwd_status.py | 2024-08-09 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | generic_config_updater/test_pg_headroom_update.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | generic_config_updater/test_syslog.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | gnmi/test_gnmi.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_appldb.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_configdb.py | 2024-08-09 00:00:00.0000000 | 26 | 0 | 26 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_countersdb.py | 2024-08-09 00:00:00.0000000 | 16 | 0 | 16 | 1
vms-kvm-t1-lag | iface_loopback_action/test_iface_loopback_action.py | 2024-08-09 00:00:00.0000000 | 6 | 0 | 6 | 1
vms-kvm-t1-lag | log_fidelity/test_bgp_shutdown.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | memory_checker/test_memory_checker.py | 2024-08-09 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | minigraph/test_masked_services.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | ntp/test_ntp.py | 2024-08-09 00:00:00.0000000 | 12 | 0 | 12 | 1
vms-kvm-t1-lag | override_config_table/test_override_config_table_masic.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | passw_hardening/test_passw_hardening.py | 2024-08-09 00:00:00.0000000 | 20 | 0 | 20 | 1
vms-kvm-t1-lag | pc/test_po_cleanup.py | 2024-08-09 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-t1-lag | pc/test_retry_count.py | 2024-08-09 00:00:00.0000000 | 16 | 0 | 16 | 1
vms-kvm-t1-lag | platform_tests/broadcom/test_ser.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | platform_tests/cli/test_show_platform.py | 2024-08-09 00:00:00.0000000 | 20 | 0 | 20 | 1
vms-kvm-t1-lag | platform_tests/counterpoll/test_counterpoll_watermark.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | platform_tests/fwutil/test_fwutil.py | 2024-08-09 00:00:00.0000000 | 20 | 0 | 20 | 1
vms-kvm-t1-lag | platform_tests/link_flap/test_cont_link_flap.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | platform_tests/link_flap/test_link_flap.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | platform_tests/sfp/test_sfpshow.py | 2024-08-09 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-t1-lag | platform_tests/sfp/test_sfputil.py | 2024-08-09 00:00:00.0000000 | 12 | 0 | 12 | 1
vms-kvm-t1-lag | platform_tests/sfp/test_show_intf_xcvr.py | 2024-08-09 00:00:00.0000000 | 6 | 0 | 6 | 1
vms-kvm-t1-lag | platform_tests/test_auto_negotiation.py | 2024-08-09 00:00:00.0000000 | 14 | 0 | 14 | 1
vms-kvm-t1-lag | platform_tests/test_first_time_boot_password_change/test_first_time_boot_password_change.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | platform_tests/test_kdump.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | platform_tests/test_link_down.py | 2024-08-09 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-t1-lag | platform_tests/test_memory_exhaustion.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | platform_tests/test_platform_info.py | 2024-08-09 00:00:00.0000000 | 12 | 0 | 12 | 1
vms-kvm-t1-lag | platform_tests/test_port_toggle.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | platform_tests/test_power_off_reboot.py | 2024-08-09 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-t1-lag | platform_tests/test_reboot.py | 2024-08-09 00:00:00.0000000 | 12 | 0 | 12 | 1
vms-kvm-t1-lag | platform_tests/test_secure_upgrade.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | platform_tests/test_sensors.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | platform_tests/test_sequential_restart.py | 2024-08-09 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-t1-lag | platform_tests/test_xcvr_info_in_db.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | portstat/test_portstat.py | 2024-08-09 00:00:00.0000000 | 42 | 0 | 42 | 1
vms-kvm-t1-lag | reset_factory/test_reset_factory.py | 2024-08-09 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | show_techsupport/test_techsupport.py | 2024-08-09 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | show_techsupport/test_techsupport_no_secret.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | snmp/test_snmp_psu.py | 2024-08-09 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-t1-lag | snmp/test_snmp_queue_counters.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | ssh/test_ssh_ciphers.py | 2024-08-09 00:00:00.0000000 | 80 | 0 | 80 | 1
vms-kvm-t1-lag | ssh/test_ssh_default_password.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | ssh/test_ssh_limit.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | ssh/test_ssh_stress.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | syslog/test_logrotate.py | 2024-08-09 00:00:00.0000000 | 14 | 0 | 14 | 1
vms-kvm-t1-lag | syslog/test_syslog.py | 2024-08-09 00:00:00.0000000 | 10 | 0 | 10 | 1
vms-kvm-t1-lag | syslog/test_syslog_rate_limit.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | syslog/test_syslog_source_ip.py | 2024-08-09 00:00:00.0000000 | 30 | 0 | 30 | 1
vms-kvm-t1-lag | system_health/test_system_status.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | system_health/test_watchdog.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | tacacs/test_ro_disk.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | telemetry/test_telemetry.py | 2024-08-09 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | telemetry/test_telemetry_cert_rotation.py | 2024-08-09 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | test_features.py | 2024-08-09 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | test_procdockerstatsd.py | 2024-08-09 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-t1-lag | autorestart/test_container_autorestart.py | 2024-08-08 00:00:00.0000000 | 324 | 0 | 324 | 1
vms-kvm-t1-lag | bgp/test_bgp_gr_helper.py | 2024-08-08 00:00:00.0000000 | 17 | 1 | 18 | 0.9444
vms-kvm-t1-lag | bgp/test_bgp_peer_shutdown.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | bgp/test_bgp_queue.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | bgp/test_bgp_session_flap.py | 2024-08-08 00:00:00.0000000 | 36 | 0 | 36 | 1
vms-kvm-t1-lag | cacl/test_cacl_application.py | 2024-08-08 00:00:00.0000000 | 108 | 0 | 108 | 1
vms-kvm-t1-lag | clock/test_clock.py | 2024-08-08 00:00:00.0000000 | 52 | 0 | 52 | 1
vms-kvm-t1-lag | console/test_console_availability.py | 2024-08-08 00:00:00.0000000 | 69 | 0 | 69 | 1
vms-kvm-t1-lag | console/test_console_driver.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | console/test_console_loopback.py | 2024-08-08 00:00:00.0000000 | 443 | 0 | 443 | 1
vms-kvm-t1-lag | console/test_console_reversessh.py | 2024-08-08 00:00:00.0000000 | 69 | 0 | 69 | 1
vms-kvm-t1-lag | console/test_console_udevrule.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | container_hardening/test_container_hardening.py | 2024-08-08 00:00:00.0000000 | 324 | 0 | 324 | 1
vms-kvm-t1-lag | database/test_db_config.py | 2024-08-08 00:00:00.0000000 | 54 | 0 | 54 | 1
vms-kvm-t1-lag | database/test_db_scripts.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | disk/test_disk_exhaustion.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | dns/static_dns/test_static_dns.py | 2024-08-08 00:00:00.0000000 | 90 | 0 | 90 | 1
vms-kvm-t1-lag | dns/test_dns_resolv_conf.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | dut_console/test_console_baud_rate.py | 2024-08-08 00:00:00.0000000 | 52 | 0 | 52 | 1
vms-kvm-t1-lag | dut_console/test_escape_character.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | dut_console/test_idle_timeout.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | generic_config_updater/test_aaa.py | 2024-08-08 00:00:00.0000000 | 54 | 0 | 54 | 1
vms-kvm-t1-lag | generic_config_updater/test_bgp_prefix.py | 2024-08-08 00:00:00.0000000 | 35 | 1 | 36 | 0.9722
vms-kvm-t1-lag | generic_config_updater/test_bgp_sentinel.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | generic_config_updater/test_cacl.py | 2024-08-08 00:00:00.0000000 | 144 | 0 | 144 | 1
vms-kvm-t1-lag | generic_config_updater/test_ecn_config_update.py | 2024-08-08 00:00:00.0000000 | 72 | 0 | 72 | 1
vms-kvm-t1-lag | generic_config_updater/test_eth_interface.py | 2024-08-08 00:00:00.0000000 | 231 | 1 | 232 | 0.9957
vms-kvm-t1-lag | generic_config_updater/test_ipv6.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | generic_config_updater/test_kubernetes_config.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | generic_config_updater/test_monitor_config.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | generic_config_updater/test_ntp.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | generic_config_updater/test_pfcwd_status.py | 2024-08-08 00:00:00.0000000 | 72 | 0 | 72 | 1
vms-kvm-t1-lag | generic_config_updater/test_pg_headroom_update.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | generic_config_updater/test_syslog.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | gnmi/test_gnmi.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_appldb.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_configdb.py | 2024-08-08 00:00:00.0000000 | 234 | 0 | 234 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_countersdb.py | 2024-08-08 00:00:00.0000000 | 144 | 0 | 144 | 1
vms-kvm-t1-lag | iface_loopback_action/test_iface_loopback_action.py | 2024-08-08 00:00:00.0000000 | 52 | 0 | 52 | 1
vms-kvm-t1-lag | log_fidelity/test_bgp_shutdown.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | memory_checker/test_memory_checker.py | 2024-08-08 00:00:00.0000000 | 72 | 0 | 72 | 1
vms-kvm-t1-lag | minigraph/test_masked_services.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | ntp/test_ntp.py | 2024-08-08 00:00:00.0000000 | 108 | 0 | 108 | 1
vms-kvm-t1-lag | override_config_table/test_override_config_table_masic.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | passw_hardening/test_passw_hardening.py | 2024-08-08 00:00:00.0000000 | 180 | 0 | 180 | 1
vms-kvm-t1-lag | pc/test_po_cleanup.py | 2024-08-08 00:00:00.0000000 | 36 | 0 | 36 | 1
vms-kvm-t1-lag | pc/test_retry_count.py | 2024-08-08 00:00:00.0000000 | 137 | 0 | 137 | 1
vms-kvm-t1-lag | platform_tests/broadcom/test_ser.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | platform_tests/cli/test_show_platform.py | 2024-08-08 00:00:00.0000000 | 180 | 0 | 180 | 1
vms-kvm-t1-lag | platform_tests/counterpoll/test_counterpoll_watermark.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | platform_tests/fwutil/test_fwutil.py | 2024-08-08 00:00:00.0000000 | 171 | 0 | 171 | 1
vms-kvm-t1-lag | platform_tests/link_flap/test_cont_link_flap.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | platform_tests/link_flap/test_link_flap.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | platform_tests/sfp/test_sfpshow.py | 2024-08-08 00:00:00.0000000 | 36 | 0 | 36 | 1
vms-kvm-t1-lag | platform_tests/sfp/test_sfputil.py | 2024-08-08 00:00:00.0000000 | 108 | 0 | 108 | 1
vms-kvm-t1-lag | platform_tests/sfp/test_show_intf_xcvr.py | 2024-08-08 00:00:00.0000000 | 54 | 0 | 54 | 1
vms-kvm-t1-lag | platform_tests/test_auto_negotiation.py | 2024-08-08 00:00:00.0000000 | 126 | 0 | 126 | 1
vms-kvm-t1-lag | platform_tests/test_first_time_boot_password_change/test_first_time_boot_password_change.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | platform_tests/test_kdump.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | platform_tests/test_link_down.py | 2024-08-08 00:00:00.0000000 | 36 | 0 | 36 | 1
vms-kvm-t1-lag | platform_tests/test_memory_exhaustion.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | platform_tests/test_platform_info.py | 2024-08-08 00:00:00.0000000 | 108 | 0 | 108 | 1
vms-kvm-t1-lag | platform_tests/test_port_toggle.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | platform_tests/test_power_off_reboot.py | 2024-08-08 00:00:00.0000000 | 36 | 0 | 36 | 1
vms-kvm-t1-lag | platform_tests/test_reboot.py | 2024-08-08 00:00:00.0000000 | 108 | 0 | 108 | 1
vms-kvm-t1-lag | platform_tests/test_secure_upgrade.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | platform_tests/test_sensors.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | platform_tests/test_sequential_restart.py | 2024-08-08 00:00:00.0000000 | 36 | 0 | 36 | 1
vms-kvm-t1-lag | platform_tests/test_xcvr_info_in_db.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | portstat/test_portstat.py | 2024-08-08 00:00:00.0000000 | 378 | 0 | 378 | 1
vms-kvm-t1-lag | reset_factory/test_reset_factory.py | 2024-08-08 00:00:00.0000000 | 69 | 0 | 69 | 1
vms-kvm-t1-lag | show_techsupport/test_techsupport.py | 2024-08-08 00:00:00.0000000 | 72 | 0 | 72 | 1
vms-kvm-t1-lag | show_techsupport/test_techsupport_no_secret.py | 2024-08-08 00:00:00.0000000 | 17 | 1 | 18 | 0.9444
vms-kvm-t1-lag | snmp/test_snmp_psu.py | 2024-08-08 00:00:00.0000000 | 36 | 0 | 36 | 1
vms-kvm-t1-lag | snmp/test_snmp_queue_counters.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | ssh/test_ssh_ciphers.py | 2024-08-08 00:00:00.0000000 | 720 | 0 | 720 | 1
vms-kvm-t1-lag | ssh/test_ssh_default_password.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | ssh/test_ssh_limit.py | 2024-08-08 00:00:00.0000000 | 17 | 1 | 18 | 0.9444
vms-kvm-t1-lag | ssh/test_ssh_stress.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | syslog/test_logrotate.py | 2024-08-08 00:00:00.0000000 | 121 | 1 | 122 | 0.9918
vms-kvm-t1-lag | syslog/test_syslog.py | 2024-08-08 00:00:00.0000000 | 86 | 0 | 86 | 1
vms-kvm-t1-lag | syslog/test_syslog_rate_limit.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | syslog/test_syslog_source_ip.py | 2024-08-08 00:00:00.0000000 | 256 | 0 | 256 | 1
vms-kvm-t1-lag | system_health/test_system_status.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | system_health/test_watchdog.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | tacacs/test_ro_disk.py | 2024-08-08 00:00:00.0000000 | 16 | 2 | 18 | 0.8889
vms-kvm-t1-lag | telemetry/test_telemetry.py | 2024-08-08 00:00:00.0000000 | 162 | 0 | 162 | 1
vms-kvm-t1-lag | telemetry/test_telemetry_cert_rotation.py | 2024-08-08 00:00:00.0000000 | 72 | 0 | 72 | 1
vms-kvm-t1-lag | test_features.py | 2024-08-08 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | test_procdockerstatsd.py | 2024-08-08 00:00:00.0000000 | 36 | 0 | 36 | 1
vms-kvm-t1-lag | autorestart/test_container_autorestart.py | 2024-08-07 00:00:00.0000000 | 687 | 0 | 687 | 1
vms-kvm-t1-lag | bgp/test_bgp_gr_helper.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | bgp/test_bgp_peer_shutdown.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | bgp/test_bgp_queue.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | bgp/test_bgp_session_flap.py | 2024-08-07 00:00:00.0000000 | 78 | 0 | 78 | 1
vms-kvm-t1-lag | cacl/test_cacl_application.py | 2024-08-07 00:00:00.0000000 | 234 | 0 | 234 | 1
vms-kvm-t1-lag | clock/test_clock.py | 2024-08-07 00:00:00.0000000 | 117 | 0 | 117 | 1
vms-kvm-t1-lag | console/test_console_availability.py | 2024-08-07 00:00:00.0000000 | 156 | 0 | 156 | 1
vms-kvm-t1-lag | console/test_console_driver.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | console/test_console_loopback.py | 2024-08-07 00:00:00.0000000 | 1014 | 0 | 1014 | 1
vms-kvm-t1-lag | console/test_console_reversessh.py | 2024-08-07 00:00:00.0000000 | 156 | 0 | 156 | 1
vms-kvm-t1-lag | console/test_console_udevrule.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | container_hardening/test_container_hardening.py | 2024-08-07 00:00:00.0000000 | 702 | 0 | 702 | 1
vms-kvm-t1-lag | database/test_db_config.py | 2024-08-07 00:00:00.0000000 | 117 | 0 | 117 | 1
vms-kvm-t1-lag | database/test_db_scripts.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | disk/test_disk_exhaustion.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | dns/static_dns/test_static_dns.py | 2024-08-07 00:00:00.0000000 | 195 | 0 | 195 | 1
vms-kvm-t1-lag | dns/test_dns_resolv_conf.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | dut_console/test_console_baud_rate.py | 2024-08-07 00:00:00.0000000 | 117 | 0 | 117 | 1
vms-kvm-t1-lag | dut_console/test_escape_character.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | dut_console/test_idle_timeout.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | generic_config_updater/test_aaa.py | 2024-08-07 00:00:00.0000000 | 117 | 0 | 117 | 1
vms-kvm-t1-lag | generic_config_updater/test_bgp_prefix.py | 2024-08-07 00:00:00.0000000 | 76 | 1 | 77 | 0.987
vms-kvm-t1-lag | generic_config_updater/test_bgp_sentinel.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | generic_config_updater/test_cacl.py | 2024-08-07 00:00:00.0000000 | 304 | 0 | 304 | 1
vms-kvm-t1-lag | generic_config_updater/test_ecn_config_update.py | 2024-08-07 00:00:00.0000000 | 156 | 0 | 156 | 1
vms-kvm-t1-lag | generic_config_updater/test_eth_interface.py | 2024-08-07 00:00:00.0000000 | 507 | 0 | 507 | 1
vms-kvm-t1-lag | generic_config_updater/test_ipv6.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | generic_config_updater/test_kubernetes_config.py | 2024-08-07 00:00:00.0000000 | 38 | 1 | 39 | 0.9744
vms-kvm-t1-lag | generic_config_updater/test_monitor_config.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | generic_config_updater/test_ntp.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | generic_config_updater/test_pfcwd_status.py | 2024-08-07 00:00:00.0000000 | 156 | 0 | 156 | 1
vms-kvm-t1-lag | generic_config_updater/test_pg_headroom_update.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | generic_config_updater/test_syslog.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | gnmi/test_gnmi.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_appldb.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_configdb.py | 2024-08-07 00:00:00.0000000 | 507 | 0 | 507 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_countersdb.py | 2024-08-07 00:00:00.0000000 | 312 | 0 | 312 | 1
vms-kvm-t1-lag | iface_loopback_action/test_iface_loopback_action.py | 2024-08-07 00:00:00.0000000 | 117 | 0 | 117 | 1
vms-kvm-t1-lag | log_fidelity/test_bgp_shutdown.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | memory_checker/test_memory_checker.py | 2024-08-07 00:00:00.0000000 | 154 | 0 | 154 | 1
vms-kvm-t1-lag | minigraph/test_masked_services.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | ntp/test_ntp.py | 2024-08-07 00:00:00.0000000 | 227 | 1 | 228 | 0.9956
vms-kvm-t1-lag | override_config_table/test_override_config_table_masic.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | passw_hardening/test_passw_hardening.py | 2024-08-07 00:00:00.0000000 | 390 | 0 | 390 | 1
vms-kvm-t1-lag | pc/test_po_cleanup.py | 2024-08-07 00:00:00.0000000 | 78 | 0 | 78 | 1
vms-kvm-t1-lag | pc/test_retry_count.py | 2024-08-07 00:00:00.0000000 | 312 | 0 | 312 | 1
vms-kvm-t1-lag | platform_tests/broadcom/test_ser.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | platform_tests/cli/test_show_platform.py | 2024-08-07 00:00:00.0000000 | 390 | 0 | 390 | 1
vms-kvm-t1-lag | platform_tests/counterpoll/test_counterpoll_watermark.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | platform_tests/fwutil/test_fwutil.py | 2024-08-07 00:00:00.0000000 | 390 | 0 | 390 | 1
vms-kvm-t1-lag | platform_tests/link_flap/test_cont_link_flap.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | platform_tests/link_flap/test_link_flap.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | platform_tests/sfp/test_sfpshow.py | 2024-08-07 00:00:00.0000000 | 78 | 0 | 78 | 1
vms-kvm-t1-lag | platform_tests/sfp/test_sfputil.py | 2024-08-07 00:00:00.0000000 | 234 | 0 | 234 | 1
vms-kvm-t1-lag | platform_tests/sfp/test_show_intf_xcvr.py | 2024-08-07 00:00:00.0000000 | 117 | 0 | 117 | 1
vms-kvm-t1-lag | platform_tests/test_auto_negotiation.py | 2024-08-07 00:00:00.0000000 | 273 | 0 | 273 | 1
vms-kvm-t1-lag | platform_tests/test_first_time_boot_password_change/test_first_time_boot_password_change.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | platform_tests/test_kdump.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | platform_tests/test_link_down.py | 2024-08-07 00:00:00.0000000 | 78 | 0 | 78 | 1
vms-kvm-t1-lag | platform_tests/test_memory_exhaustion.py | 2024-08-07 00:00:00.0000000 | 38 | 1 | 39 | 0.9744
vms-kvm-t1-lag | platform_tests/test_platform_info.py | 2024-08-07 00:00:00.0000000 | 234 | 0 | 234 | 1
vms-kvm-t1-lag | platform_tests/test_port_toggle.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | platform_tests/test_power_off_reboot.py | 2024-08-07 00:00:00.0000000 | 78 | 0 | 78 | 1
vms-kvm-t1-lag | platform_tests/test_reboot.py | 2024-08-07 00:00:00.0000000 | 228 | 0 | 228 | 1
vms-kvm-t1-lag | platform_tests/test_secure_upgrade.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | platform_tests/test_sensors.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | platform_tests/test_sequential_restart.py | 2024-08-07 00:00:00.0000000 | 78 | 0 | 78 | 1
vms-kvm-t1-lag | platform_tests/test_xcvr_info_in_db.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | portstat/test_portstat.py | 2024-08-07 00:00:00.0000000 | 819 | 0 | 819 | 1
vms-kvm-t1-lag | reset_factory/test_reset_factory.py | 2024-08-07 00:00:00.0000000 | 156 | 0 | 156 | 1
vms-kvm-t1-lag | show_techsupport/test_techsupport.py | 2024-08-07 00:00:00.0000000 | 156 | 0 | 156 | 1
vms-kvm-t1-lag | show_techsupport/test_techsupport_no_secret.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | snmp/test_snmp_psu.py | 2024-08-07 00:00:00.0000000 | 78 | 0 | 78 | 1
vms-kvm-t1-lag | snmp/test_snmp_queue_counters.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | ssh/test_ssh_ciphers.py | 2024-08-07 00:00:00.0000000 | 1560 | 0 | 1560 | 1
vms-kvm-t1-lag | ssh/test_ssh_default_password.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | ssh/test_ssh_limit.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | ssh/test_ssh_stress.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | syslog/test_logrotate.py | 2024-08-07 00:00:00.0000000 | 273 | 0 | 273 | 1
vms-kvm-t1-lag | syslog/test_syslog.py | 2024-08-07 00:00:00.0000000 | 195 | 0 | 195 | 1
vms-kvm-t1-lag | syslog/test_syslog_rate_limit.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | syslog/test_syslog_source_ip.py | 2024-08-07 00:00:00.0000000 | 585 | 0 | 585 | 1
vms-kvm-t1-lag | system_health/test_system_status.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | system_health/test_watchdog.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | tacacs/test_ro_disk.py | 2024-08-07 00:00:00.0000000 | 38 | 1 | 39 | 0.9744
vms-kvm-t1-lag | telemetry/test_telemetry.py | 2024-08-07 00:00:00.0000000 | 342 | 0 | 342 | 1
vms-kvm-t1-lag | telemetry/test_telemetry_cert_rotation.py | 2024-08-07 00:00:00.0000000 | 156 | 0 | 156 | 1
vms-kvm-t1-lag | test_features.py | 2024-08-07 00:00:00.0000000 | 39 | 0 | 39 | 1
vms-kvm-t1-lag | test_procdockerstatsd.py | 2024-08-07 00:00:00.0000000 | 78 | 0 | 78 | 1
vms-kvm-t1-lag | autorestart/test_container_autorestart.py | 2024-08-06 00:00:00.0000000 | 141 | 0 | 141 | 1
vms-kvm-t1-lag | bgp/test_bgp_gr_helper.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | bgp/test_bgp_peer_shutdown.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | bgp/test_bgp_queue.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | bgp/test_bgp_session_flap.py | 2024-08-06 00:00:00.0000000 | 14 | 0 | 14 | 1
vms-kvm-t1-lag | cacl/test_cacl_application.py | 2024-08-06 00:00:00.0000000 | 48 | 0 | 48 | 1
vms-kvm-t1-lag | clock/test_clock.py | 2024-08-06 00:00:00.0000000 | 24 | 0 | 24 | 1
vms-kvm-t1-lag | console/test_console_availability.py | 2024-08-06 00:00:00.0000000 | 32 | 0 | 32 | 1
vms-kvm-t1-lag | console/test_console_driver.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | console/test_console_loopback.py | 2024-08-06 00:00:00.0000000 | 182 | 1 | 183 | 0.9945
vms-kvm-t1-lag | console/test_console_reversessh.py | 2024-08-06 00:00:00.0000000 | 28 | 0 | 28 | 1
vms-kvm-t1-lag | console/test_console_udevrule.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | container_hardening/test_container_hardening.py | 2024-08-06 00:00:00.0000000 | 144 | 0 | 144 | 1
vms-kvm-t1-lag | database/test_db_config.py | 2024-08-06 00:00:00.0000000 | 21 | 0 | 21 | 1
vms-kvm-t1-lag | database/test_db_scripts.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | disk/test_disk_exhaustion.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | dns/static_dns/test_static_dns.py | 2024-08-06 00:00:00.0000000 | 35 | 0 | 35 | 1
vms-kvm-t1-lag | dns/test_dns_resolv_conf.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | dut_console/test_console_baud_rate.py | 2024-08-06 00:00:00.0000000 | 24 | 0 | 24 | 1
vms-kvm-t1-lag | dut_console/test_escape_character.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | dut_console/test_idle_timeout.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | generic_config_updater/test_aaa.py | 2024-08-06 00:00:00.0000000 | 21 | 0 | 21 | 1
vms-kvm-t1-lag | generic_config_updater/test_bgp_prefix.py | 2024-08-06 00:00:00.0000000 | 16 | 0 | 16 | 1
vms-kvm-t1-lag | generic_config_updater/test_bgp_sentinel.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | generic_config_updater/test_cacl.py | 2024-08-06 00:00:00.0000000 | 168 | 0 | 168 | 1
vms-kvm-t1-lag | generic_config_updater/test_ecn_config_update.py | 2024-08-06 00:00:00.0000000 | 32 | 0 | 32 | 1
vms-kvm-t1-lag | generic_config_updater/test_eth_interface.py | 2024-08-06 00:00:00.0000000 | 91 | 0 | 91 | 1
vms-kvm-t1-lag | generic_config_updater/test_ipv6.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | generic_config_updater/test_kubernetes_config.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | generic_config_updater/test_monitor_config.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | generic_config_updater/test_ntp.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | generic_config_updater/test_pfcwd_status.py | 2024-08-06 00:00:00.0000000 | 32 | 0 | 32 | 1
vms-kvm-t1-lag | generic_config_updater/test_pg_headroom_update.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | generic_config_updater/test_syslog.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | gnmi/test_gnmi.py | 2024-08-06 00:00:00.0000000 | 7 | 1 | 8 | 0.875
vms-kvm-t1-lag | gnmi/test_gnmi_appldb.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_configdb.py | 2024-08-06 00:00:00.0000000 | 91 | 0 | 91 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_countersdb.py | 2024-08-06 00:00:00.0000000 | 160 | 0 | 160 | 1
vms-kvm-t1-lag | iface_loopback_action/test_iface_loopback_action.py | 2024-08-06 00:00:00.0000000 | 24 | 0 | 24 | 1
vms-kvm-t1-lag | log_fidelity/test_bgp_shutdown.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | memory_checker/test_memory_checker.py | 2024-08-06 00:00:00.0000000 | 30 | 0 | 30 | 1
vms-kvm-t1-lag | minigraph/test_masked_services.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | ntp/test_ntp.py | 2024-08-06 00:00:00.0000000 | 43 | 0 | 43 | 1
vms-kvm-t1-lag | override_config_table/test_override_config_table_masic.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | passw_hardening/test_passw_hardening.py | 2024-08-06 00:00:00.0000000 | 70 | 0 | 70 | 1
vms-kvm-t1-lag | pc/test_po_cleanup.py | 2024-08-06 00:00:00.0000000 | 16 | 0 | 16 | 1
vms-kvm-t1-lag | pc/test_retry_count.py | 2024-08-06 00:00:00.0000000 | 64 | 0 | 64 | 1
vms-kvm-t1-lag | platform_tests/broadcom/test_ser.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | platform_tests/cli/test_show_platform.py | 2024-08-06 00:00:00.0000000 | 70 | 0 | 70 | 1
vms-kvm-t1-lag | platform_tests/counterpoll/test_counterpoll_watermark.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | platform_tests/fwutil/test_fwutil.py | 2024-08-06 00:00:00.0000000 | 80 | 0 | 80 | 1
vms-kvm-t1-lag | platform_tests/link_flap/test_cont_link_flap.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | platform_tests/link_flap/test_link_flap.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | platform_tests/sfp/test_sfpshow.py | 2024-08-06 00:00:00.0000000 | 16 | 0 | 16 | 1
vms-kvm-t1-lag | platform_tests/sfp/test_sfputil.py | 2024-08-06 00:00:00.0000000 | 42 | 0 | 42 | 1
vms-kvm-t1-lag | platform_tests/sfp/test_show_intf_xcvr.py | 2024-08-06 00:00:00.0000000 | 24 | 0 | 24 | 1
vms-kvm-t1-lag | platform_tests/test_auto_negotiation.py | 2024-08-06 00:00:00.0000000 | 56 | 0 | 56 | 1
vms-kvm-t1-lag | platform_tests/test_first_time_boot_password_change/test_first_time_boot_password_change.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | platform_tests/test_kdump.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | platform_tests/test_link_down.py | 2024-08-06 00:00:00.0000000 | 40 | 0 | 40 | 1
vms-kvm-t1-lag | platform_tests/test_memory_exhaustion.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | platform_tests/test_platform_info.py | 2024-08-06 00:00:00.0000000 | 42 | 0 | 42 | 1
vms-kvm-t1-lag | platform_tests/test_port_toggle.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | platform_tests/test_power_off_reboot.py | 2024-08-06 00:00:00.0000000 | 16 | 0 | 16 | 1
vms-kvm-t1-lag | platform_tests/test_reboot.py | 2024-08-06 00:00:00.0000000 | 42 | 1 | 43 | 0.9767
vms-kvm-t1-lag | platform_tests/test_secure_upgrade.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | platform_tests/test_sensors.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | platform_tests/test_sequential_restart.py | 2024-08-06 00:00:00.0000000 | 16 | 0 | 16 | 1
vms-kvm-t1-lag | platform_tests/test_xcvr_info_in_db.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | portstat/test_portstat.py | 2024-08-06 00:00:00.0000000 | 168 | 0 | 168 | 1
vms-kvm-t1-lag | reset_factory/test_reset_factory.py | 2024-08-06 00:00:00.0000000 | 32 | 0 | 32 | 1
vms-kvm-t1-lag | show_techsupport/test_techsupport.py | 2024-08-06 00:00:00.0000000 | 28 | 0 | 28 | 1
vms-kvm-t1-lag | show_techsupport/test_techsupport_no_secret.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | snmp/test_snmp_psu.py | 2024-08-06 00:00:00.0000000 | 16 | 0 | 16 | 1
vms-kvm-t1-lag | snmp/test_snmp_queue_counters.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | ssh/test_ssh_ciphers.py | 2024-08-06 00:00:00.0000000 | 320 | 0 | 320 | 1
vms-kvm-t1-lag | ssh/test_ssh_default_password.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | ssh/test_ssh_limit.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | ssh/test_ssh_stress.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | syslog/test_logrotate.py | 2024-08-06 00:00:00.0000000 | 49 | 0 | 49 | 1
vms-kvm-t1-lag | syslog/test_syslog.py | 2024-08-06 00:00:00.0000000 | 40 | 0 | 40 | 1
vms-kvm-t1-lag | syslog/test_syslog_rate_limit.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | syslog/test_syslog_source_ip.py | 2024-08-06 00:00:00.0000000 | 105 | 0 | 105 | 1
vms-kvm-t1-lag | system_health/test_system_status.py | 2024-08-06 00:00:00.0000000 | 7 | 0 | 7 | 1
vms-kvm-t1-lag | system_health/test_watchdog.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | tacacs/test_ro_disk.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | telemetry/test_telemetry.py | 2024-08-06 00:00:00.0000000 | 72 | 0 | 72 | 1
vms-kvm-t1-lag | telemetry/test_telemetry_cert_rotation.py | 2024-08-06 00:00:00.0000000 | 28 | 0 | 28 | 1
vms-kvm-t1-lag | test_features.py | 2024-08-06 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t1-lag | test_procdockerstatsd.py | 2024-08-06 00:00:00.0000000 | 16 | 0 | 16 | 1


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
