### PR TITLE
[sanity check] Fix dualtor sanity check issue

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -610,7 +610,7 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs):
             # NOTE: Let's probe here to see if those inconsistent mux ports could be
             # restored before using the recovery method.
             port_index_map = duts_minigraph_facts[duthosts[0].hostname][0][1]['minigraph_port_indices']
-            dut_wrong_mux_status_ports = set(dut_wrong_mux_status_ports)
+            dut_wrong_mux_status_ports = list(set(dut_wrong_mux_status_ports))
             inconsistent_mux_ports = [port for port, port_index in port_index_map.items()
                                       if port_index in dut_wrong_mux_status_ports]
             _probe_mux_ports(duthosts, inconsistent_mux_ports)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This is to fix the following issue:
```
04:21:44 utilities.wait_until                     L0140 ERROR  | Exception caught while checking _check_mux_status_helper:Traceback (most recent call last):
  File "/azp/_work/8/s/tests/common/utilities.py", line 136, in wait_until
    check_result = condition(*args, **kwargs)
  File "/azp/_work/8/s/tests/common/plugins/sanity_check/checks.py", line 545, in _check_mux_status_helper
    dut_wrong_mux_status_ports[:] = []
TypeError: 'set' object does not support item assignment
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
`dut_wrong_mux_status_ports` should be list all the time.

#### How did you verify/test it?
Run dualtor tests with sanity check.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
