### PR TITLE
Modified ssdhealth test to account for currently supported disk types

### DIFF
--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -453,7 +453,7 @@ def test_show_platform_ssdhealth(duthosts, enum_supervisor_dut_hostname):
 
     ssdhealth_output_lines = duthost.command(cmd)["stdout_lines"]
     if not any(disk_type in ssdhealth_output_lines[0] for disk_type in supported_disks):
-        pytest.skip("Disk Type is not supported")
+        pytest.skip("Disk Type {} is not supported".format(ssdhealth_output_lines[0].split(':')[-1]))
     ssdhealth_dict = util.parse_colon_speparated_lines(ssdhealth_output_lines)
     expected_fields = {"Disk Type", "Device Model", "Health", "Temperature"}
     actual_fields = set(ssdhealth_dict.keys())

--- a/tests/platform_tests/cli/test_show_platform.py
+++ b/tests/platform_tests/cli/test_show_platform.py
@@ -447,11 +447,15 @@ def test_show_platform_ssdhealth(duthosts, enum_supervisor_dut_hostname):
     """
     duthost = duthosts[enum_supervisor_dut_hostname]
     cmd = " ".join([CMD_SHOW_PLATFORM, "ssdhealth"])
+    supported_disks = ["SATA", "NVME"]
 
     logging.info("Verifying output of '{}' on ''{}'...".format(cmd, duthost.hostname))
+
     ssdhealth_output_lines = duthost.command(cmd)["stdout_lines"]
+    if not any(disk_type in ssdhealth_output_lines[0] for disk_type in supported_disks):
+        pytest.skip("Disk Type is not supported")
     ssdhealth_dict = util.parse_colon_speparated_lines(ssdhealth_output_lines)
-    expected_fields = {"Device Model", "Health", "Temperature"}
+    expected_fields = {"Disk Type", "Device Model", "Health", "Temperature"}
     actual_fields = set(ssdhealth_dict.keys())
 
     missing_fields = expected_fields - actual_fields


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This is a sonic-mgmt test for [sonic-buildimage issue 9407](https://github.com/sonic-net/sonic-buildimage/issues/9407), which has a fix PR raised here: https://github.com/sonic-net/sonic-utilities/pull/3399 -- the change in this PR tests that fix.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 202012
- [x] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
`show platform ssdhealth` fails on certain platforms such as Arista 7050qx because the sonic utility that the command calls relies on `smartctl` output, which fails on storage device of type EUSB. This PR skips the test on unsupported disk types.

#### How did you do it?
Added a new field `Disk Type` to the `ssdutil` sonic-utility that the `show platform ssdhealth` calls. The test checks for a supported disk type and skips if not found.

#### How did you verify/test it?
Tested on 4 HWSKUs each with storage disk type EUSB (skip), EMMC (skip), SATA (pass) and NVME (pass). Logs are attached here: [test_show_platform_ssdhealth.txt](https://github.com/user-attachments/files/16571432/test_show_platform_ssdhealth.txt)

#### Any platform specific information?
Skipped on platforms with storage device type EUSB and EMMC.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
