### PR TITLE
Fix IndexError: Bad index 'None' type in fixture check_dut_asic_type

### DIFF
--- a/tests/common/plugins/custom_fixtures/check_dut_asic_type.py
+++ b/tests/common/plugins/custom_fixtures/check_dut_asic_type.py
@@ -3,8 +3,8 @@ from tests.common.helpers.assertions import pytest_require
 
 
 @pytest.fixture(scope="function")
-def check_dut_asic_type(request, duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def check_dut_asic_type(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic_marks = [mark for mark in request.node.iter_markers(name="asic")]
     if not asic_marks:
         return

--- a/tests/common/plugins/custom_fixtures/check_dut_asic_type.py
+++ b/tests/common/plugins/custom_fixtures/check_dut_asic_type.py
@@ -3,8 +3,8 @@ from tests.common.helpers.assertions import pytest_require
 
 
 @pytest.fixture(scope="function")
-def check_dut_asic_type(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+def check_dut_asic_type(request, duthosts, rand_one_dut_front_end_hostname):
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     asic_marks = [mark for mark in request.node.iter_markers(name="asic")]
     if not asic_marks:
         return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Due to https://github.com/sonic-net/sonic-mgmt/pull/12824, `rand_one_dut_hostname` is None in fixture `check_dut_asic_type`
It throws failed on `setup with "IndexError: Bad index 'None' type `" in test case `test_ecmp_hash_seed_value`
#### How did you do it?
Use `rand_one_dut_front_end_hostname` in stead of `rand_one_dut_hostname`
#### How did you verify/test it?
Run PR test case and `test_ecmp_hash_seed_value`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
