### PR TITLE
[Snappi]: Support to clear and check fabric counters

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -2,6 +2,7 @@
 This module contains the snappi fixture in the snappi_tests directory.
 """
 import pytest
+import time
 import logging
 import snappi
 import sys
@@ -1267,3 +1268,39 @@ def get_snappi_ports_for_rdma(snappi_port_list, rdma_ports, tx_port_count, rx_po
 
     multidut_snappi_ports = rx_snappi_ports + tx_snappi_ports
     return multidut_snappi_ports
+
+
+def clear_fabric_counters(duthost):
+    """
+    Clears the fabric counters for the duthost.
+    Args:
+        duthost(obj): dut host object
+    Returns:
+        None
+    """
+    logger.info('Clearing fabric counters for DUT:{}'.format(duthost.hostname))
+    duthost.shell('sonic-clear fabriccountersport \n')
+    time.sleep(1)
+
+
+def check_fabric_counters(duthost):
+    """
+    Check for the fabric counters for the duthosts.
+    Test assert if the value of CRC, and FEC_UNCORRECTABLE.
+    Args:
+        duthost(obj): dut host object
+    Returns:
+        None
+    """
+    raw_out = duthost.shell("show fabric counters port | grep -Ev 'ASIC|---|down'")['stdout']
+    logger.info('Verifying fabric counters for DUT:{}'.format(duthost.hostname))
+    for line in raw_out.split('\n'):
+        # Checking if the port is UP.
+        if 'up' in line:
+            val_list = line.split()
+            crc_errors = int(val_list[7].replace(',', ''))
+            fec_uncor_err = int(val_list[9].replace(',', ''))
+            pytest_assert(crc_errors == 0, 'CRC errors:{} for DUT:{}, ASIC:{}, Port:{}'.
+                          format(crc_errors, duthost.hostname, val_list[0], val_list[1]))
+            pytest_assert(fec_uncor_err == 0, 'Forward Uncorrectable errors:{} for DUT:{}, ASIC:{}, Port:{}'.
+                          format(fec_uncor_err, duthost.hostname, val_list[0], val_list[1]))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Currently, there is no mechanism in the Snappi testcases to check for the fabric counters.

Purpose of this PR is to have support to clear the counters before test-case execution. The dut host can be supervisor card or line cards.

Second function will check for the CRC and uncorrectable FEC errors. The check should assert if the count is nonzero.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
#14095  
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Currently there is no mechanism to verify the fabric counters on the DUT. The function is added to check for the CRC and uncorrectable errors on line card/s and supervisor.

#### How did you do it?
Two simple functions are added. First to clear the counter and second to parse for errors. If the errors are non-zero, the test will ASSERT.

#### How did you verify/test it?
Tested on local clone.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
