### PR TITLE
Prevent delete temporary file in test_bgp_update_timer case

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -840,7 +840,7 @@ def fetch_and_delete_pcap_file(bgp_pcap, log_dir, duthost, request):
             log_dir, LOCAL_PCAP_FILE_TEMPLATE % request.node.name
         )
     else:
-        local_pcap_file = tempfile.NamedTemporaryFile()
+        local_pcap_file = tempfile.NamedTemporaryFile(delete=False)
         local_pcap_filename = local_pcap_file.name
     duthost.fetch(src=bgp_pcap, dest=local_pcap_filename, flat=True)
     duthost.file(path=bgp_pcap, state="absent")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
By default, `tempfile.NamedTemporaryFile()` creates a temporary file that will be deleted once it is closed. When the function `fetch_and_delete_pcap_file` is exited, the temporary file will be deleted. In the following code, the file cannot be found, so the test case fails.

Fixes # 
Set `delete=False`, it will prevent the file from being deleted



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
