### PR TITLE
Add cont warm reboot into onboarding T0 PR checker. 

### DIFF
--- a/ansible/library/extract_log.py
+++ b/ansible/library/extract_log.py
@@ -151,6 +151,14 @@ def convert_date(fct, s):
             if len(re_result) > 0:
                 str_date = re_result[0]
                 dt = datetime.datetime.strptime(str_date, '%Y-%m-%d.%X.%f')
+
+            else:
+                re_result = re.findall(
+                    r'^\d{4} \w{3} \d{2} \d{2}:\d{2}:\d{2}\.\d{6}', s)
+                if len(re_result) > 0:
+                    str_date = re_result[0]
+                    dt = datetime.datetime.strptime(str_date, '%Y %b %d %H:%M:%S.%f')
+
     locale.setlocale(locale.LC_ALL, loc)
 
     return dt


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Script `platform_tests/test_cont_warm_reboot.py` will fail due to the below error on kvm testbed. 
```
22:11:18 verify_dut_health._wrapper               L0026 ERROR  | Health check run_reboot_testcase failed with unknown error: run module extract_log failed, Ansible Results =>
{"changed": false, "failed": true, "msg": "Traceback (most recent call last):\n  File \"/tmp/ansible_extract_log_payload_00d_trvf/ansible_extract_log_payload.zip/ansible/modules/extract_log.py\", line 306, in main\n  File \"/tmp/ansible_extract_log_payload_00d_trvf/ansible_extract_log_payload.zip/ansible/modules/extract_log.py\", line 275, in extract_log\n  File \"/tmp/ansible_extract_log_payload_00d_trvf/ansible_extract_log_payload.zip/ansible/modules/extract_log.py\", line 222, in extract_latest_line_with_string\n  File \"/tmp/ansible_extract_log_payload_00d_trvf/ansible_extract_log_payload.zip/ansible/modules/extract_log.py\", line 167, in comparator\nTypeError: '<' not supported between instances of 'NoneType' and 'datetime.datetime'\n"}
```

This is because of the different format of date `2024 Aug 14 03:50:27.701716` in syslog, which is not match the current regular matching in ansible module `extract_log.py`. In this PR, we add a situation to match this pattern in module `extract_log.py`, so it can handle such format. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Script `platform_tests/test_cont_warm_reboot.py` will fail due to the below error on kvm testbed. 
```
22:11:18 verify_dut_health._wrapper               L0026 ERROR  | Health check run_reboot_testcase failed with unknown error: run module extract_log failed, Ansible Results =>
{"changed": false, "failed": true, "msg": "Traceback (most recent call last):\n  File \"/tmp/ansible_extract_log_payload_00d_trvf/ansible_extract_log_payload.zip/ansible/modules/extract_log.py\", line 306, in main\n  File \"/tmp/ansible_extract_log_payload_00d_trvf/ansible_extract_log_payload.zip/ansible/modules/extract_log.py\", line 275, in extract_log\n  File \"/tmp/ansible_extract_log_payload_00d_trvf/ansible_extract_log_payload.zip/ansible/modules/extract_log.py\", line 222, in extract_latest_line_with_string\n  File \"/tmp/ansible_extract_log_payload_00d_trvf/ansible_extract_log_payload.zip/ansible/modules/extract_log.py\", line 167, in comparator\nTypeError: '<' not supported between instances of 'NoneType' and 'datetime.datetime'\n"}
```

This is because of the different format of date `2024 Aug 14 03:50:27.701716` in syslog, which is not match the current regular matching in ansible module `extract_log.py`. In this PR, we add a situation to match this pattern in module `extract_log.py`, so it can handle such format. 

#### How did you do it?
Add a situation to match another format of date in syslog. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
