### PR TITLE
Remove dualtor_io/test_tor_failure.py from PR test set

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -231,7 +231,6 @@ dualtor:
   - dualtor_io/test_link_drop.py
   - dualtor_io/test_normal_op.py
   - dualtor_io/test_tor_bgp_failure.py
-  - dualtor_io/test_tor_failure.py
   - dualtor_mgmt/test_grpc_periodical_sync.py
   - dualtor_mgmt/test_server_failure.py
   - dualtor_mgmt/test_toggle_mux.py

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -1,6 +1,8 @@
 t0:
   # KVM do not support drop reason in testcase, and testcase would set drop reason in setup stage, can't do more test
   - drop_packets/test_configurable_drop_counters.py
+  # This script would toggle PDU, which is not supported on KVM
+  - dualtor_io/test_tor_failure.py
   # This script only supported on Mellanox
   - generic_config_updater/test_pfcwd_interval.py
   # There is no k8s in inventory file

--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -10,8 +10,6 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.dualtor.tor_failure_utils import reboot_tor, tor_blackhole_traffic, wait_for_device_reachable     # noqa F401
 from tests.common.dualtor.tor_failure_utils import wait_for_mux_container, wait_for_pmon_container                  # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, change_mac_addresses          # noqa F401
-# Temporary work around to add skip_traffic_test fixture from duthost_utils
-from tests.common.fixtures.duthost_utils import skip_traffic_test                                                   # noqa F401
 from tests.common.dualtor.nic_simulator_control import mux_status_from_nic_simulator                                # noqa F401
 from tests.common.dualtor.nic_simulator_control import ForwardingState
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor                                        # noqa F401
@@ -63,7 +61,7 @@ def test_active_tor_reboot_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_upper_tor_pdu,      # noqa F811
     wait_for_device_reachable, wait_for_mux_container, cable_type,      # noqa F811
-    wait_for_pmon_container, skip_traffic_test                          # noqa F811
+    wait_for_pmon_container                                             # noqa F811
 ):
     """
     Send upstream traffic and reboot the active ToR. Confirm switchover
@@ -73,8 +71,7 @@ def test_active_tor_reboot_upstream(
                      marker_prefix="test_active_tor_reboot_upstream"):
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            action=toggle_upper_tor_pdu, stop_after=60,
-            skip_traffic_test=skip_traffic_test
+            action=toggle_upper_tor_pdu, stop_after=60
         )
         wait_for_device_reachable(upper_tor_host)
         wait_for_mux_container(upper_tor_host)
@@ -99,7 +96,7 @@ def test_active_tor_reboot_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_upper_tor_pdu,      # noqa F811
     wait_for_device_reachable, wait_for_mux_container,                  # noqa F811
-    wait_for_pmon_container, skip_traffic_test                          # noqa F811
+    wait_for_pmon_container                                             # noqa F811
 ):
     """
     Send downstream traffic to the standby ToR and reboot the active ToR.
@@ -109,8 +106,7 @@ def test_active_tor_reboot_downstream_standby(
                      marker_prefix="test_active_tor_reboot_downstream_standby"):
         send_t1_to_server_with_action(
             lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            action=toggle_upper_tor_pdu, stop_after=60,
-            skip_traffic_test=skip_traffic_test
+            action=toggle_upper_tor_pdu, stop_after=60
         )
         wait_for_device_reachable(upper_tor_host)
         wait_for_mux_container(upper_tor_host)
@@ -126,7 +122,7 @@ def test_standby_tor_reboot_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_lower_tor_pdu,      # noqa F811
     wait_for_device_reachable, wait_for_mux_container,                  # noqa F811
-    wait_for_pmon_container, skip_traffic_test                          # noqa F811
+    wait_for_pmon_container                                             # noqa F811
 ):
     """
     Send upstream traffic and reboot the standby ToR. Confirm no switchover
@@ -136,8 +132,7 @@ def test_standby_tor_reboot_upstream(
                      marker_prefix="test_standby_tor_reboot_upstream"):
         send_server_to_t1_with_action(
             upper_tor_host, verify=True,
-            action=toggle_lower_tor_pdu, stop_after=60,
-            skip_traffic_test=skip_traffic_test
+            action=toggle_lower_tor_pdu, stop_after=60
         )
         wait_for_device_reachable(lower_tor_host)
         wait_for_mux_container(lower_tor_host)
@@ -153,7 +148,7 @@ def test_standby_tor_reboot_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_lower_tor_pdu,      # noqa F811
     wait_for_device_reachable, wait_for_mux_container,                  # noqa F811
-    wait_for_pmon_container, skip_traffic_test                          # noqa F811
+    wait_for_pmon_container                                             # noqa F811
 ):
     """
     Send downstream traffic to the active ToR and reboot the standby ToR.
@@ -163,8 +158,7 @@ def test_standby_tor_reboot_downstream_active(
                      marker_prefix="test_standby_tor_reboot_downstream_active"):
         send_t1_to_server_with_action(
             upper_tor_host, verify=True,
-            action=toggle_lower_tor_pdu, stop_after=60,
-            skip_traffic_test=skip_traffic_test
+            action=toggle_lower_tor_pdu, stop_after=60
         )
         wait_for_device_reachable(lower_tor_host)
         wait_for_mux_container(lower_tor_host)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
dualtor_io/test_tor_failure.py would toggle dualtor's pdu, but pdu action should not be included in KVM test
#### How did you do it?
Remove dualtor_io/test_tor_failure.py from PR test set
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
