### PR TITLE
Add test for telemetry container not running error

### DIFF
--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -255,22 +255,32 @@ def test_container_checker_telemetry(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     container_name = "telemetry"
 
-    # Skip test if telemetry is disabled by other test
+    # test_container_checker can disable the telemetry container
+    # Start service if telemetry is disabled
     dut_command = r"docker inspect -f \{\{.State.Running\}\} %s" % container_name
     result = duthost.command(dut_command, module_ignore_errors=True)
     if result['stdout'] == "false":
-        pytest.skip("Telemetry is disabled")
+        logger.info("Start service as '{}' is not up ...".format(container_name))
+        duthost.shell("sudo systemctl reset-failed {}.service".format(container_name), module_ignore_errors=True)
+        duthost.shell("sudo systemctl start {}.service".format(container_name), module_ignore_errors=True)
+        restarted = wait_until(CONTAINER_RESTART_THRESHOLD_SECS,
+                               CONTAINER_CHECK_INTERVAL_SECS,
+                               0,
+                               check_container_state, duthost, container_name, True)
+        pytest_assert(restarted, "Failed to restart container '{}' after reset-failed was cleared".format(container_name))
 
+    # Enable LogAnalyzer
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="container_checker_{}".format(container_name))
-    sleep_time = 70
+    loganalyzer.expect_regex = get_expected_alerting_message(container_name)
+    marker = loganalyzer.init()
 
     # Enable telemetry in FEATURE table
     dut_command = "sonic-db-cli CONFIG_DB hset \"FEATURE|{}\" state enabled".format(container_name)
     duthost.command(dut_command, module_ignore_errors=True)
 
-    loganalyzer.expect_regex = get_expected_alerting_message(container_name)
-    marker = loganalyzer.init()
-    # Wait for 70s such that Monit has a chance to write alerting message into syslog.
+    # Monit checks services at 1-minute intervals
+    # Add a 10-second delay to ensure Monit has time to write alert messages to syslog
+    sleep_time = 70
     logger.info("Sleep '{}'s to wait for the alerting message...".format(sleep_time))
     time.sleep(sleep_time)
     analysis = loganalyzer.analyze(marker, fail=False)

--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -267,7 +267,7 @@ def test_container_checker_telemetry(duthosts, rand_one_dut_hostname):
                                CONTAINER_CHECK_INTERVAL_SECS,
                                0,
                                check_container_state, duthost, container_name, True)
-        pytest_assert(restarted, "Failed to restart container '{}' after reset-failed was cleared".format(container_name))
+        pytest_assert(restarted, "Failed to restart container '{}'".format(container_name))
 
     # Enable LogAnalyzer
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="container_checker_{}".format(container_name))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Microsoft ADO: 28480805

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
We have used gnmi container to replace telemetry container, and telemetry is still enabled after warm upgrade.
Need new test for telemetry container not running error.

#### How did you do it?
Modify the FEATURE table to emulate a warm upgrade, and use loganalyzer to detect possible error.

#### How did you verify/test it?
Run end to end test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
