### PR TITLE
Improve test_ssh_limit test case not receive EOF issue

### DIFF
--- a/tests/ssh/test_ssh_limit.py
+++ b/tests/ssh/test_ssh_limit.py
@@ -43,17 +43,19 @@ def get_device_type(duthost):
     return dut_type
 
 
-def modify_template(admin_session, template_path, additional_content, hwsku, type):
-    admin_session.exec_command(TEMPLATE_BACKUP_COMMAND.format(template_path))
-    admin_session.exec_command(TEMPLATE_CREATE_COMMAND.format(template_path))
-    admin_session.exec_command(
-        LIMITS_CONF_TEMPLATE_TO_HOME.format(hwsku, type, additional_content))
-    admin_session.exec_command(TEMPLATE_MOVE_COMMAND.format(template_path))
+def exec_command(admin_session, command):
+    stdin, stdout, stderr = admin_session.exec_command(command)
+    outstr = stdout.readlines()
+    errstr = stderr.readlines()
+    logging.info("Command: '{}' stdout: {} stderr: {}".format(command, outstr, errstr))
 
-    stdin, stdout, stderr = admin_session.exec_command(
-        'sudo cat {0}'.format(template_path))
-    config_file_content = stdout.readlines()
-    logging.info("Updated template file: {0}".format(config_file_content))
+
+def modify_template(admin_session, template_path, additional_content, hwsku, type):
+    exec_command(admin_session, TEMPLATE_BACKUP_COMMAND.format(template_path))
+    exec_command(admin_session, TEMPLATE_CREATE_COMMAND.format(template_path))
+    exec_command(admin_session, LIMITS_CONF_TEMPLATE_TO_HOME.format(hwsku, type, additional_content))
+    exec_command(admin_session, TEMPLATE_MOVE_COMMAND.format(template_path))
+    exec_command(admin_session, 'sudo cat {0}'.format(template_path))
 
 
 def modify_templates(duthost, tacacs_creds, creds):     # noqa F811


### PR DESCRIPTION
Improve test_ssh_limit test case not receive EOF issue

#### Why I did it
test_ssh_limit randomly failed, according to syslog, the paramiko connection does not receive EOF after exec command.

##### Work item tracking
- Microsoft ADO: 28874779

#### How I did it
Read stdout and stderr after exec command via paramiko, and print output for debug

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Improve test_ssh_limit test case not receive EOF issue

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

