### PR TITLE
[dhcp_server_test] fix test failure due to lease was not updated to state db

### DIFF
--- a/tests/dhcp_server/dhcp_server_test_common.py
+++ b/tests/dhcp_server/dhcp_server_test_common.py
@@ -3,6 +3,7 @@ import contextlib
 from datetime import datetime
 import json
 import logging
+import time
 import pytest
 import ptf.packet as scapy
 import ptf.testutils as testutils
@@ -472,8 +473,7 @@ def send_release_packet(
     xid,
     client_mac,
     ip_assigned,
-    gateway,
-    count=3
+    gateway
 ):
     release_pkt = create_dhcp_client_packet(
         src_mac=client_mac,
@@ -482,5 +482,5 @@ def send_release_packet(
         xid=xid,
         ciaddr=ip_assigned
     )
-    for _ in range(count):
-        testutils.send_packet(ptfadapter, ptf_port_index, release_pkt)
+    testutils.send_packet(ptfadapter, ptf_port_index, release_pkt)
+    time.sleep(1)  # give server some time to update lease file

--- a/tests/dhcp_server/dhcp_server_test_common.py
+++ b/tests/dhcp_server/dhcp_server_test_common.py
@@ -472,7 +472,8 @@ def send_release_packet(
     xid,
     client_mac,
     ip_assigned,
-    gateway
+    gateway,
+    count=3
 ):
     release_pkt = create_dhcp_client_packet(
         src_mac=client_mac,
@@ -481,4 +482,5 @@ def send_release_packet(
         xid=xid,
         ciaddr=ip_assigned
     )
-    testutils.send_packet(ptfadapter, ptf_port_index, release_pkt)
+    for _ in range(count):
+        testutils.send_packet(ptfadapter, ptf_port_index, release_pkt)

--- a/tests/dhcp_server/dhcp_server_test_common.py
+++ b/tests/dhcp_server/dhcp_server_test_common.py
@@ -464,7 +464,7 @@ def verify_discover_and_request_then_release(
     )
     if expected_assigned_ip and release_needed:
         verify_lease(duthost, dhcp_interface, client_mac, expected_assigned_ip, exp_lease_time)
-        send_release_packet(ptfadapter, ptf_port_index, test_xid, client_mac, expected_assigned_ip, exp_gateway)
+        send_release_packet(ptfadapter, ptf_port_index, test_xid, client_mac, expected_assigned_ip, server_id)
 
 
 def send_release_packet(
@@ -473,14 +473,13 @@ def send_release_packet(
     xid,
     client_mac,
     ip_assigned,
-    gateway
+    server_id
 ):
     release_pkt = create_dhcp_client_packet(
         src_mac=client_mac,
         message_type=DHCP_MESSAGE_TYPE_RELEASE_NUM,
-        client_options=[("server_id", gateway)],
+        client_options=[("server_id", server_id)],
         xid=xid,
         ciaddr=ip_assigned
     )
     testutils.send_packet(ptfadapter, ptf_port_index, release_pkt)
-    time.sleep(1)  # give server some time to update lease file

--- a/tests/dhcp_server/dhcp_server_test_common.py
+++ b/tests/dhcp_server/dhcp_server_test_common.py
@@ -463,11 +463,22 @@ def verify_discover_and_request_then_release(
     )
     if expected_assigned_ip and release_needed:
         verify_lease(duthost, dhcp_interface, client_mac, expected_assigned_ip, exp_lease_time)
-        release_pkt = create_dhcp_client_packet(
-            src_mac=client_mac,
-            message_type=DHCP_MESSAGE_TYPE_RELEASE_NUM,
-            client_options=[("server_id", exp_gateway)],
-            xid=test_xid,
-            ciaddr=expected_assigned_ip
-        )
-        testutils.send_packet(ptfadapter, ptf_port_index, release_pkt)
+        send_release_packet(ptfadapter, ptf_port_index, test_xid, client_mac, expected_assigned_ip, exp_gateway)
+
+
+def send_release_packet(
+    ptfadapter,
+    ptf_port_index,
+    xid,
+    client_mac,
+    ip_assigned,
+    gateway
+):
+    release_pkt = create_dhcp_client_packet(
+        src_mac=client_mac,
+        message_type=DHCP_MESSAGE_TYPE_RELEASE_NUM,
+        client_options=[("server_id", gateway)],
+        xid=xid,
+        ciaddr=ip_assigned
+    )
+    testutils.send_packet(ptfadapter, ptf_port_index, release_pkt)

--- a/tests/dhcp_server/dhcp_server_test_common.py
+++ b/tests/dhcp_server/dhcp_server_test_common.py
@@ -3,7 +3,6 @@ import contextlib
 from datetime import datetime
 import json
 import logging
-import time
 import pytest
 import ptf.packet as scapy
 import ptf.testutils as testutils

--- a/tests/dhcp_server/test_dhcp_server.py
+++ b/tests/dhcp_server/test_dhcp_server.py
@@ -498,6 +498,7 @@ def test_dhcp_server_port_based_customize_options(
             pkts_validator_kwargs=pkts_validator_kwargs,
             refresh_fdb_ptf_port='eth'+str(ptf_port_index)
         )
+        verify_lease(duthost, vlan_name, client_mac, expected_assigned_ip)
         send_release_packet(ptfadapter, ptf_port_index, test_xid, client_mac, expected_assigned_ip, gateway)
 
 

--- a/tests/dhcp_server/test_dhcp_server.py
+++ b/tests/dhcp_server/test_dhcp_server.py
@@ -498,7 +498,7 @@ def test_dhcp_server_port_based_customize_options(
             pkts_validator_kwargs=pkts_validator_kwargs,
             refresh_fdb_ptf_port='eth'+str(ptf_port_index)
         )
-        send_release_packet(ptfadapter, ptf_port_index, client_mac, gateway, test_xid, expected_assigned_ip)
+        send_release_packet(ptfadapter, ptf_port_index, test_xid, client_mac, expected_assigned_ip, gateway)
 
 
 def test_dhcp_server_config_change_dhcp_interface(
@@ -741,7 +741,7 @@ def test_dhcp_server_lease_config_change(
     apply_dhcp_server_config_gcu(duthost, change_to_apply)
     client_mac = ptfadapter.dataplane.get_mac(0, ptf_port_index).decode('utf-8')
     verify_lease(duthost, vlan_name, client_mac, expected_assigned_ip, DHCP_DEFAULT_LEASE_TIME)
-    send_release_packet(ptfadapter, ptf_port_index, client_mac, gateway, test_xid, expected_assigned_ip)
+    send_release_packet(ptfadapter, ptf_port_index, test_xid, client_mac, expected_assigned_ip, gateway)
 
 
 def test_dhcp_server_config_vlan_intf_change(

--- a/tests/dhcp_server/test_dhcp_server.py
+++ b/tests/dhcp_server/test_dhcp_server.py
@@ -6,7 +6,7 @@ import time
 from tests.common.helpers.assertions import pytest_assert
 from dhcp_server_test_common import DHCP_SERVER_CONFIG_TOOL_GCU, DHCP_SERVER_CONFIG_TOOL_CLI, \
     create_common_config_patch, generate_common_config_cli_commands, dhcp_server_config, \
-    validate_dhcp_server_pkts_custom_option, verify_lease, \
+    validate_dhcp_server_pkts_custom_option, verify_lease, send_release_packet, \
     verify_discover_and_request_then_release, send_and_verify, DHCP_MESSAGE_TYPE_DISCOVER_NUM, \
     DHCP_SERVER_SUPPORTED_OPTION_ID, DHCP_MESSAGE_TYPE_REQUEST_NUM, DHCP_DEFAULT_LEASE_TIME, \
     apply_dhcp_server_config_gcu, create_dhcp_client_packet, vlan_n2i
@@ -498,6 +498,7 @@ def test_dhcp_server_port_based_customize_options(
             pkts_validator_kwargs=pkts_validator_kwargs,
             refresh_fdb_ptf_port='eth'+str(ptf_port_index)
         )
+        send_release_packet(ptfadapter, ptf_port_index, client_mac, gateway, test_xid, expected_assigned_ip)
 
 
 def test_dhcp_server_config_change_dhcp_interface(
@@ -740,6 +741,7 @@ def test_dhcp_server_lease_config_change(
     apply_dhcp_server_config_gcu(duthost, change_to_apply)
     client_mac = ptfadapter.dataplane.get_mac(0, ptf_port_index).decode('utf-8')
     verify_lease(duthost, vlan_name, client_mac, expected_assigned_ip, DHCP_DEFAULT_LEASE_TIME)
+    send_release_packet(ptfadapter, ptf_port_index, client_mac, gateway, test_xid, expected_assigned_ip)
 
 
 def test_dhcp_server_config_vlan_intf_change(

--- a/tests/dhcp_server/test_dhcp_server.py
+++ b/tests/dhcp_server/test_dhcp_server.py
@@ -498,7 +498,7 @@ def test_dhcp_server_port_based_customize_options(
             pkts_validator_kwargs=pkts_validator_kwargs,
             refresh_fdb_ptf_port='eth'+str(ptf_port_index)
         )
-        verify_lease(duthost, vlan_name, client_mac, expected_assigned_ip)
+        verify_lease(duthost, vlan_name, client_mac, expected_assigned_ip, DHCP_DEFAULT_LEASE_TIME)
         send_release_packet(ptfadapter, ptf_port_index, test_xid, client_mac, expected_assigned_ip, gateway)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
When running nightly test, sometimes, there are test cases failed on verify lease in state db.

After investigation, I found that it's because when ip assigned was expired it will be appended to the last line in lease file
and dhcpservd will choice that line. When two tests randomly select the same port, and the previous test didn't release the ip, the next test may fail, because dhcpservd will only pick the last record of that mac in lease file.

To fix that, we need to release ip assigned after test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
When running nightly test, sometimes, there are test cases failed on verify lease in state db.

#### How did you do it?
Release ip assigned after test.

#### How did you verify/test it?
Run tests on testbed and monitor lease file to make sure every lease was released after the test.
![image](https://github.com/user-attachments/assets/b31e0c0c-8771-44ed-879f-7cdf2e4d8f95)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
