### PR TITLE
[Fix]: Enhancement of port selection criteria for multidut RDMA cases based on testbed informaition

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -16,7 +16,7 @@ from tests.common.snappi_tests.port import SnappiPortConfig, SnappiPortType
 from tests.common.helpers.assertions import pytest_assert
 from tests.snappi_tests.variables import dut_ip_start, snappi_ip_start, prefix_length, \
     dut_ipv6_start, snappi_ipv6_start, v6_prefix_length, pfcQueueGroupSize, \
-    pfcQueueValueDict, MULTIDUT_PORT_INFO
+    pfcQueueValueDict          # noqa: F401
 logger = logging.getLogger(__name__)
 
 
@@ -1119,7 +1119,7 @@ def get_snappi_ports_for_rdma(snappi_port_list, rdma_ports, tx_port_count, rx_po
     Returns the required tx and rx ports for the rdma test
     Args:
         snappi_port_list (list): List of snappi ports and connected DUT ports info of T1 and T2 testbed
-        rdma_ports (dict): RDMA port info for testbed subtype
+        rdma_ports (dict): RDMA port info for testbed subtype defined in variables.py
         tx_port_count (int): Number of Tx ports required for the test
         rx_port_count (int): Number of Rx ports required for the test
     Return: (list)

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -16,7 +16,7 @@ from tests.common.snappi_tests.port import SnappiPortConfig, SnappiPortType
 from tests.common.helpers.assertions import pytest_assert
 from tests.snappi_tests.variables import dut_ip_start, snappi_ip_start, prefix_length, \
     dut_ipv6_start, snappi_ipv6_start, v6_prefix_length, pfcQueueGroupSize, \
-    pfcQueueValueDict
+    pfcQueueValueDict, MULTIDUT_PORT_INFO
 logger = logging.getLogger(__name__)
 
 
@@ -1026,4 +1026,119 @@ def multidut_snappi_ports_for_bgp(duthosts,                                # noq
             port['speed'] = speed_type[port['speed']]
             port['api_server_ip'] = tbinfo['ptf_ip']
         multidut_snappi_ports = multidut_snappi_ports + snappi_ports
+    return multidut_snappi_ports
+
+
+@pytest.fixture(scope="module")
+def get_snappi_ports(duthosts,                                # noqa: F811
+                    tbinfo,                                  # noqa: F811
+                    conn_graph_facts,                        # noqa: F811
+                    fanout_graph_facts_multidut,
+                    ):                                      # noqa: F811
+    """
+    Populate snappi ports and connected DUT ports info of T1 and T2 testbed and returns as a list
+    Args:
+        duthost (pytest fixture): duthost fixture
+        tbinfo (pytest fixture): fixture provides information about testbed
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts_multidut (pytest fixture): fanout graph
+    Return: (list)
+        [{  'api_server_ip': '10.36.78.59',
+            'asic_type': 'broadcom',
+            'asic_value': None,
+            'card_id': '4',
+            'duthost': <MultiAsicSonicHost sonic-s6100-dut2>,
+            'ip': '10.36.78.53',
+            'location': '10.36.78.53;4;7',
+            'peer_device': 'sonic-s6100-dut1',
+            'peer_port': 'Ethernet72',
+            'port_id': '7',
+            'snappi_speed_type': 'speed_100_gbps',
+            'speed': '100000'
+        },
+        {   'api_server_ip': '10.36.78.59',
+            'asic_type': 'broadcom',
+            'asic_value': 'asic0',
+            'card_id': '4',
+            'duthost': <MultiAsicSonicHost sonic-s6100-dut2>,
+            'ip': '10.36.78.53',
+            'location': '10.36.78.53;4;8',
+            'peer_device': 'sonic-s6100-dut2',
+            'peer_port': 'Ethernet76',
+            'port_id': '8',
+            'snappi_speed_type': 'speed_100_gbps',
+            'speed': '100000'
+        }]
+    """
+    speed_type = {
+                  '10000': 'speed_10_gbps',
+                  '25000': 'speed_25_gbps',
+                  '40000': 'speed_40_gbps',
+                  '50000': 'speed_50_gbps',
+                  '100000': 'speed_100_gbps',
+                  '200000': 'speed_200_gbps',
+                  '400000': 'speed_400_gbps',
+                  '800000': 'speed_800_gbps'}
+    multidut_snappi_ports = []
+
+    for duthost in duthosts:
+        snappi_fanout = get_peer_snappi_chassis(conn_data=conn_graph_facts,
+                                                dut_hostname=duthost.hostname)
+        if snappi_fanout is None:
+            continue
+        snappi_fanout_id = list(fanout_graph_facts_multidut.keys()).index(snappi_fanout)
+        snappi_fanout_list = SnappiFanoutManager(fanout_graph_facts_multidut)
+        snappi_fanout_list.get_fanout_device_details(device_number=snappi_fanout_id)
+        snappi_ports = snappi_fanout_list.get_ports(peer_device=duthost.hostname)
+        port_speed = None
+        for i in range(len(snappi_ports)):
+            if port_speed is None:
+                port_speed = int(snappi_ports[i]['speed'])
+
+            elif port_speed != int(snappi_ports[i]['speed']):
+                """ All the ports should have the same bandwidth """
+                return None
+
+        for port in snappi_ports:
+            port['location'] = get_snappi_port_location(port)
+            port['speed'] = port['speed']
+            port['api_server_ip'] = tbinfo['ptf_ip']
+            port['asic_type'] = duthost.facts["asic_type"]
+            port['duthost'] = duthost
+            port['snappi_speed_type'] = speed_type[port['speed']]
+            if duthost.facts["num_asic"] > 1:
+                port['asic_value'] = duthost.get_port_asic_instance(port['peer_port']).namespace
+            else:
+                port['asic_value'] = None
+        multidut_snappi_ports = multidut_snappi_ports + snappi_ports
+    return multidut_snappi_ports
+
+
+def get_snappi_ports_for_rdma(snappi_port_list, tx_port_count, rx_port_count, testbed):
+    """
+    Returns the required tx and rx ports for the rdma test
+    Args:
+        snappi_port_list (list): List of snappi ports and connected DUT ports info of T1 and T2 testbed
+        tx_port_count (int): Number of Tx ports required for the test
+        rx_port_count (int): Number of Rx ports required for the test
+    Return: (list)
+    """
+    tx_snappi_ports = []
+    rx_snappi_ports = []
+    var_tx_ports = random.sample(MULTIDUT_PORT_INFO[testbed]['Tx Ports'], tx_port_count)
+    var_rx_ports = random.sample(MULTIDUT_PORT_INFO[testbed]['Rx Ports'], rx_port_count)
+    for port in snappi_port_list:
+        for var_rx_port in var_rx_ports:
+            if port['peer_port'] == var_rx_port['port_name'] and port['peer_device'] == var_rx_port['hostname']:
+                rx_snappi_ports.append(port)
+        for var_tx_port in var_tx_ports:
+            if port['peer_port'] == var_tx_port['port_name'] and port['peer_device'] == var_tx_port['hostname']:
+                tx_snappi_ports.append(port)
+
+    pytest_assert(len(rx_snappi_ports) == rx_port_count,
+                  'Rx Ports for {} in MULTIDUT_PORT_INFO doesn\'t match with ansible/files/*links.csv'.format(testbed))
+    pytest_assert(len(tx_snappi_ports) == tx_port_count,
+                  'Tx Ports for {} in MULTIDUT_PORT_INFO doesn\'t match with ansible/files/*links.csv'.format(testbed))
+
+    multidut_snappi_ports = rx_snappi_ports + tx_snappi_ports
     return multidut_snappi_ports

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1031,10 +1031,10 @@ def multidut_snappi_ports_for_bgp(duthosts,                                # noq
 
 @pytest.fixture(scope="module")
 def get_snappi_ports(duthosts,                                # noqa: F811
-                    tbinfo,                                  # noqa: F811
-                    conn_graph_facts,                        # noqa: F811
-                    fanout_graph_facts_multidut,
-                    ):                                      # noqa: F811
+                     tbinfo,                                  # noqa: F811
+                     conn_graph_facts,                        # noqa: F811
+                     fanout_graph_facts_multidut,
+                     ):                                      # noqa: F811
     """
     Populate snappi ports and connected DUT ports info of T1 and T2 testbed and returns as a list
     Args:
@@ -1114,19 +1114,20 @@ def get_snappi_ports(duthosts,                                # noqa: F811
     return multidut_snappi_ports
 
 
-def get_snappi_ports_for_rdma(snappi_port_list, tx_port_count, rx_port_count, testbed):
+def get_snappi_ports_for_rdma(snappi_port_list, rdma_ports, tx_port_count, rx_port_count, testbed):
     """
     Returns the required tx and rx ports for the rdma test
     Args:
         snappi_port_list (list): List of snappi ports and connected DUT ports info of T1 and T2 testbed
+        rdma_ports (dict): RDMA port info for testbed subtype
         tx_port_count (int): Number of Tx ports required for the test
         rx_port_count (int): Number of Rx ports required for the test
     Return: (list)
     """
     tx_snappi_ports = []
     rx_snappi_ports = []
-    var_tx_ports = random.sample(MULTIDUT_PORT_INFO[testbed]['Tx Ports'], tx_port_count)
-    var_rx_ports = random.sample(MULTIDUT_PORT_INFO[testbed]['Rx Ports'], rx_port_count)
+    var_tx_ports = random.sample(rdma_ports['tx_ports'], tx_port_count)
+    var_rx_ports = random.sample(rdma_ports['rx_ports'], rx_port_count)
     for port in snappi_port_list:
         for var_rx_port in var_rx_ports:
             if port['peer_port'] == var_rx_port['port_name'] and port['peer_device'] == var_rx_port['hostname']:

--- a/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
@@ -1,33 +1,27 @@
 import pytest
-import random
 import logging
 from tests.common.helpers.assertions import pytest_require, pytest_assert                            # noqa: F401
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
-     fanout_graph_facts                                                                              # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-     snappi_api, snappi_dut_base_config, get_tgen_peer_ports, get_multidut_snappi_ports, \
-     get_multidut_tgen_peer_port_set, cleanup_config                                                 # noqa: F401
+     snappi_api, snappi_dut_base_config, cleanup_config, get_snappi_ports, get_snappi_ports_for_rdma   # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import lossless_prio_list, prio_dscp_map                # noqa: F401
-from tests.snappi_tests.variables import config_set, line_card_choice
 from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_pfc_test                      # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.variables import MULTIDUT_PORT_INFO
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.topology('multidut-tgen')]
 
 
-@pytest.mark.parametrize('line_card_choice', [line_card_choice])
-@pytest.mark.parametrize('linecard_configuration_set', [config_set])
 def test_global_pause(snappi_api,                                   # noqa: F811
                       conn_graph_facts,                             # noqa: F811
-                      fanout_graph_facts,                           # noqa: F811
+                      fanout_graph_facts_multidut,         # noqa: F811
+                      get_snappi_ports,    # noqa: F811
                       duthosts,
                       prio_dscp_map,                                # noqa: F811
                       lossless_prio_list,                           # noqa: F811
-                      line_card_choice,
-                      linecard_configuration_set,
-                      get_multidut_snappi_ports                     # noqa: F811
+                      tbinfo,       # noqa: F811
                       ):
     """
     Test if IEEE 802.3X pause (a.k.a., global pause) will impact any priority
@@ -35,50 +29,46 @@ def test_global_pause(snappi_api,                                   # noqa: F811
     Args:
         snappi_api (pytest fixture): SNAPPI session
         conn_graph_facts (pytest fixture): connection graph
-        fanout_graph_facts (pytest fixture): fanout graph
+        fanout_graph_facts_multidut (pytest fixture): fanout graph for multiple duts
+        get_snappi_ports (pytest fixture): list of snappi port and duthost information
         duthosts (pytest fixture): list of DUTs
         lossless_prio_list (pytest fixture): list of all the lossless priorities
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
-        line_card_choice: Line card choice to be mentioned in the variable.py file
-        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
+        tbinfo (pytest fixture): fixture provides information about testbed
+        get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
     Returns:
         N/A
     """
+    MULTIDUT_TESTBED = tbinfo['conf-name']
+    tx_port_count = 1
+    rx_port_count = 1
+    snappi_port_list = get_snappi_ports
+    pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                  "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
-    pytest_assert(line_card_choice in linecard_configuration_set.keys(), "Invalid line_card_choice in parameter")
-    pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
-                   "Hostname can't be an empty list")
-    if (len(linecard_configuration_set[line_card_choice]['hostname']) == 2):
-        dut_list = random.sample(duthosts.frontend_nodes, 2)
-        duthost1, duthost2 = dut_list
-    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts.frontend_nodes if
-                    linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]      # noqa: E501
-        duthost1, duthost2 = dut_list[0], dut_list[0]
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Tx Ports']) >= tx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Rx Ports']) >= rx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
 
-    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
-                                                 line_card_info=linecard_configuration_set[line_card_choice])
-    pytest_assert(len(snappi_port_list) >= 2, "Need Minimum of 2 ports for the test")
+    snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, tx_port_count, rx_port_count, MULTIDUT_TESTBED)
 
-    snappi_ports = get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, 2)
-    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                             snappi_ports,
                                                                             snappi_api)
-
     all_prio_list = prio_dscp_map.keys()
     test_prio_list = lossless_prio_list
     bg_prio_list = [x for x in all_prio_list if x not in test_prio_list]
 
     snappi_extra_params = SnappiTestParams()
-    snappi_extra_params.multi_dut_params.duthost1 = duthost1
-    snappi_extra_params.multi_dut_params.duthost2 = duthost2
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
-
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
                  port_config_list=port_config_list,
                  conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts,
+                 fanout_data=fanout_graph_facts_multidut,
                  global_pause=True,
                  pause_prio_list=None,
                  test_prio_list=test_prio_list,
@@ -87,4 +77,4 @@ def test_global_pause(snappi_api,                                   # noqa: F811
                  test_traffic_pause=False,
                  snappi_extra_params=snappi_extra_params)
 
-    cleanup_config(dut_list, snappi_ports)
+    cleanup_config(duthosts, snappi_ports)

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -1,5 +1,4 @@
 import pytest
-import random
 from tests.common.helpers.assertions import pytest_require, pytest_assert                   # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -1,13 +1,13 @@
 import pytest
 import random
 from tests.common.helpers.assertions import pytest_require, pytest_assert                   # noqa: F401
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-    snappi_api, snappi_dut_base_config, get_tgen_peer_ports, get_multidut_snappi_ports, \
-    get_multidut_tgen_peer_port_set, cleanup_config                                         # noqa: F401
-from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
+    snappi_api, snappi_dut_base_config, get_snappi_ports_for_rdma, cleanup_config, \
+    get_snappi_ports                                        # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list, \
     lossy_prio_list                         # noqa F401
-from tests.snappi_tests.variables import config_set, line_card_choice
+from tests.snappi_tests.variables import MULTIDUT_PORT_INFO
 from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_pfc_test
 from tests.common.reboot import reboot
 from tests.common.utilities import wait_until
@@ -19,19 +19,16 @@ logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen')]
 
 
-@pytest.mark.parametrize('line_card_choice', [line_card_choice])
-@pytest.mark.parametrize('linecard_configuration_set', [config_set])
 def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: F811
                                         conn_graph_facts,               # noqa: F811
-                                        fanout_graph_facts,             # noqa: F811
+                                        fanout_graph_facts_multidut,             # noqa: F811
                                         duthosts,
                                         enum_dut_lossless_prio,
                                         prio_dscp_map,                   # noqa: F811
                                         lossless_prio_list,              # noqa: F811
-                                        all_prio_list,                   # noqa: F811
-                                        line_card_choice,
-                                        linecard_configuration_set,
-                                        get_multidut_snappi_ports):       # noqa: F811
+                                        all_prio_list,   # noqa: F811
+                                        get_snappi_ports,           # noqa: F811
+                                        tbinfo):             # noqa: F811
 
     """
     Test if PFC can pause a single lossless priority in multidut setup
@@ -39,36 +36,34 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
     Args:
         snappi_api (pytest fixture): SNAPPI session
         conn_graph_facts (pytest fixture): connection graph
-        fanout_graph_facts (pytest fixture): fanout graph
+        fanout_graph_facts_multidut (pytest fixture): fanout graph
         duthosts (pytest fixture): list of DUTs
         enum_dut_lossless_prio (str): lossless priority to test, e.g., 's6100-1|3'
         all_prio_list (pytest fixture): list of all the priorities
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
         lossless_prio_list (pytest fixture): list of all the lossless priorities
-        line_card_choice: Line card choice to be mentioned in the variable.py file
-        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
-        get_multidut_snappi_ports: Populates tgen and connected DUT ports info of T0 testbed and returns as a list
+        tbinfo (pytest fixture): fixture provides information about testbed
+        get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
 
     Returns:
         N/A
     """
-    pytest_assert(line_card_choice in linecard_configuration_set.keys(), "Invalid line_card_choice in parameter")
-    pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
-                   "Hostname can't be an empty list")
-    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(duthosts.frontend_nodes, 2)
-        duthost1, duthost2 = dut_list
-    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts.frontend_nodes
-                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
-        duthost1 = duthost2 = dut_list[0]
+    MULTIDUT_TESTBED = tbinfo['conf-name']
+    tx_port_count = 1
+    rx_port_count = 1
+    snappi_port_list = get_snappi_ports
+    pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                  "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
-    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
-                                                 line_card_info=linecard_configuration_set[line_card_choice])
-    pytest_require(len(snappi_port_list) >= 2, "Need Minimum of 2 ports for the test")
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Tx Ports']) >= tx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Rx Ports']) >= rx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
 
-    snappi_ports = get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, 2)
-    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+    snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                             snappi_ports,
                                                                             snappi_api)
 
@@ -82,15 +77,13 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
     logger.info("Snappi Ports : {}".format(snappi_ports))
 
     snappi_extra_params = SnappiTestParams()
-    snappi_extra_params.multi_dut_params.duthost1 = duthost1
-    snappi_extra_params.multi_dut_params.duthost2 = duthost2
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
                  port_config_list=port_config_list,
                  conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts,
+                 fanout_data=fanout_graph_facts_multidut,
                  global_pause=False,
                  pause_prio_list=pause_prio_list,
                  test_prio_list=test_prio_list,
@@ -98,21 +91,18 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=True,
                  snappi_extra_params=snappi_extra_params)
-    cleanup_config(dut_list, snappi_ports)
+    cleanup_config(duthosts, snappi_ports)
 
 
-@pytest.mark.parametrize('line_card_choice', [line_card_choice])
-@pytest.mark.parametrize('linecard_configuration_set', [config_set])
 def test_pfc_pause_multi_lossless_prio(snappi_api,                  # noqa: F811
                                        conn_graph_facts,            # noqa: F811
-                                       fanout_graph_facts,          # noqa: F811
+                                       fanout_graph_facts_multidut,          # noqa: F811
                                        duthosts,
                                        prio_dscp_map,                # noqa: F811
                                        lossy_prio_list,              # noqa: F811
-                                       lossless_prio_list,            # noqa: F811
-                                       line_card_choice,
-                                       linecard_configuration_set,
-                                       get_multidut_snappi_ports):    # noqa: F811
+                                       lossless_prio_list,  # noqa: F811
+                                       get_snappi_ports,     # noqa: F811
+                                       tbinfo):    # noqa: F811
 
     """
     Test if PFC can pause multiple lossless priorities in multidut setup
@@ -120,35 +110,32 @@ def test_pfc_pause_multi_lossless_prio(snappi_api,                  # noqa: F811
     Args:
         snappi_api (pytest fixture): SNAPPI session
         conn_graph_facts (pytest fixture): connection graph
-        fanout_graph_facts (pytest fixture): fanout graph
+        fanout_graph_facts_multidut (pytest fixture): fanout graph
         duthosts (pytest fixture): list of DUTs
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
         lossless_prio_list (pytest fixture): list of all the lossless priorities
         lossy_prio_list (pytest fixture): list of all the lossy priorities
-        line_card_choice: Line card choice to be mentioned in the variable.py file
-        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
-        get_multidut_snappi_ports: Populates tgen and connected DUT ports info of T0 testbed and returns as a list
+        tbinfo (pytest fixture): fixture provides information about testbed
+        get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
     Returns:
         N/A
     """
-    pytest_assert(line_card_choice in linecard_configuration_set.keys(), "Invalid line_card_choice in parameter")
-    pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
-                   "Hostname can't be an empty list")
-    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(list(duthosts), 2)
-        duthost1, duthost2 = dut_list
-    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts
-                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
-        duthost1 = duthost2 = dut_list[0]
+    MULTIDUT_TESTBED = tbinfo['conf-name']
+    tx_port_count = 1
+    rx_port_count = 1
+    snappi_port_list = get_snappi_ports
+    pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                  "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
-    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
-                                                 line_card_info=linecard_configuration_set[line_card_choice])
-    pytest_require(len(snappi_port_list) >= 2, "Need Minimum of 2 ports for the test")
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Tx Ports']) >= tx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Rx Ports']) >= rx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
 
-    snappi_ports = get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, 2)
-
-    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+    snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                             snappi_ports,
                                                                             snappi_api)
 
@@ -158,15 +145,13 @@ def test_pfc_pause_multi_lossless_prio(snappi_api,                  # noqa: F811
     logger.info("Snappi Ports : {}".format(snappi_ports))
 
     snappi_extra_params = SnappiTestParams()
-    snappi_extra_params.multi_dut_params.duthost1 = duthost1
-    snappi_extra_params.multi_dut_params.duthost2 = duthost2
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
                  port_config_list=port_config_list,
                  conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts,
+                 fanout_data=fanout_graph_facts_multidut,
                  global_pause=False,
                  pause_prio_list=pause_prio_list,
                  test_prio_list=test_prio_list,
@@ -174,67 +159,62 @@ def test_pfc_pause_multi_lossless_prio(snappi_api,                  # noqa: F811
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=True,
                  snappi_extra_params=snappi_extra_params)
-    cleanup_config(dut_list, snappi_ports)
+    cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
-@pytest.mark.parametrize('line_card_choice', [line_card_choice])
-@pytest.mark.parametrize('linecard_configuration_set', [config_set])
 def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # noqa: F811
                                                conn_graph_facts,            # noqa: F811
-                                               fanout_graph_facts,          # noqa: F811
+                                               fanout_graph_facts_multidut,          # noqa: F811
                                                duthosts,
                                                localhost,
                                                enum_dut_lossless_prio,    # noqa: F811
                                                prio_dscp_map,            # noqa: F811
                                                lossless_prio_list,         # noqa: F811
                                                all_prio_list,        # noqa: F811
-                                               line_card_choice,
-                                               linecard_configuration_set,
-                                               get_multidut_snappi_ports,   # noqa: F811
-                                               reboot_type):
+                                               reboot_type,
+                                               get_snappi_ports,    # noqa: F811
+                                               tbinfo):        # noqa: F811
     """
     Test if PFC can pause a single lossless priority even after various types of reboot in multidut setup
 
     Args:
         snappi_api (pytest fixture): SNAPPI session
         conn_graph_facts (pytest fixture): connection graph
-        fanout_graph_facts (pytest fixture): fanout graph
+        fanout_graph_facts_multidut (pytest fixture): fanout graph
         duthosts (pytest fixture): list of DUTs
         localhost (pytest fixture): localhost handle
         all_prio_list (pytest fixture): list of all the priorities
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
         lossless_prio_list (pytest fixture): list of all the lossless priorities
         reboot_type (str): reboot type to be issued on the DUT
-        line_card_choice: Line card choice to be mentioned in the variable.py file
-        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
-        get_multidut_snappi_ports: Populates tgen and connected DUT ports info of T0 testbed and returns as a list
+        tbinfo (pytest fixture): fixture provides information about testbed
+        get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
     Returns:
         N/A
     """
-    pytest_assert(line_card_choice in linecard_configuration_set.keys(), "Invalid line_card_choice in parameter")
-    pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
-                   "Hostname can't be an empty list")
-    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(list(duthosts), 2)
-        duthost1, duthost2 = dut_list
-    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts
-                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
-        duthost1 = duthost2 = dut_list[0]
+    MULTIDUT_TESTBED = tbinfo['conf-name']
+    tx_port_count = 1
+    rx_port_count = 1
+    snappi_port_list = get_snappi_ports
+    pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                  "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
-    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
-                                                 line_card_info=linecard_configuration_set[line_card_choice])
-    pytest_require(len(snappi_port_list) >= 2, "Need Minimum of 2 ports for the test")
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Tx Ports']) >= tx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Rx Ports']) >= rx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
 
-    snappi_ports = get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, 2)
-    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+    snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                             snappi_ports,
                                                                             snappi_api)
 
-    skip_warm_reboot(duthost1, reboot_type)
-    skip_warm_reboot(duthost2, reboot_type)
+    skip_warm_reboot(snappi_ports[0]['duthost'], reboot_type)
+    skip_warm_reboot(snappi_ports[1]['duthost'], reboot_type)
 
     _, lossless_prio = enum_dut_lossless_prio.split('|')
     lossless_prio = int(lossless_prio)
@@ -245,11 +225,9 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
     logger.info("Snappi Ports : {}".format(snappi_ports))
 
     snappi_extra_params = SnappiTestParams()
-    snappi_extra_params.multi_dut_params.duthost1 = duthost1
-    snappi_extra_params.multi_dut_params.duthost2 = duthost2
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
-    for duthost in dut_list:
+    for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
         duthost.shell("sudo config save -y")
         logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
         reboot(duthost, localhost, reboot_type=reboot_type)
@@ -260,7 +238,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
                  testbed_config=testbed_config,
                  port_config_list=port_config_list,
                  conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts,
+                 fanout_data=fanout_graph_facts_multidut,
                  global_pause=False,
                  pause_prio_list=pause_prio_list,
                  test_prio_list=test_prio_list,
@@ -269,79 +247,69 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
                  test_traffic_pause=True,
                  snappi_extra_params=snappi_extra_params)
 
-    cleanup_config(dut_list, snappi_ports)
+    cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
-@pytest.mark.parametrize('line_card_choice', [line_card_choice])
-@pytest.mark.parametrize('linecard_configuration_set', [config_set])
 def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noqa: F811
                                               conn_graph_facts,            # noqa: F811
-                                              fanout_graph_facts,          # noqa: F811
+                                              fanout_graph_facts_multidut,          # noqa: F811
                                               duthosts,
                                               localhost,
                                               prio_dscp_map,                 # noqa: F811
                                               lossy_prio_list,               # noqa: F811
-                                              lossless_prio_list,            # noqa: F811
-                                              line_card_choice,
-                                              linecard_configuration_set,
-                                              get_multidut_snappi_ports,   # noqa: F811
-                                              reboot_type):
+                                              lossless_prio_list,             # noqa: F811
+                                              reboot_type,
+                                              get_snappi_ports,          # noqa: F811
+                                              tbinfo):                   # noqa: F811
     """
     Test if PFC can pause multiple lossless priorities even after various types of reboot in multidut setup
 
     Args:
         snappi_api (pytest fixture): SNAPPI session
         conn_graph_facts (pytest fixture): connection graph
-        fanout_graph_facts (pytest fixture): fanout graph
+        fanout_graph_facts_multidut (pytest fixture): fanout graph
         duthosts (pytest fixture): list of DUTs
         localhost (pytest fixture): localhost handle
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
         lossless_prio_list (pytest fixture): list of all the lossless priorities
         lossy_prio_list (pytest fixture): list of all the lossy priorities
         reboot_type (str): reboot type to be issued on the DUT
-        line_card_choice: Line card choice to be mentioned in the variable.py file
-        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
-        get_multidut_snappi_ports: Populates tgen and connected DUT ports info of T0 testbed and returns as a list
-
+        tbinfo (pytest fixture): fixture provides information about testbed
+        get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
     Returns:
         N/A
     """
+    MULTIDUT_TESTBED = tbinfo['conf-name']
+    tx_port_count = 1
+    rx_port_count = 1
+    snappi_port_list = get_snappi_ports
+    pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                  "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
-    pytest_assert(line_card_choice in linecard_configuration_set.keys(), "Invalid line_card_choice in parameter")
-    pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
-                   "Hostname can't be an empty list")
-    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(list(duthosts), 2)
-        duthost1, duthost2 = dut_list
-    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts
-                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
-        duthost1 = duthost2 = dut_list[0]
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Tx Ports']) >= tx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Rx Ports']) >= rx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
 
-    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
-                                                 line_card_info=linecard_configuration_set[line_card_choice])
-    pytest_require(len(snappi_port_list) >= 2, "Need Minimum of 2 ports for the test")
-
-    snappi_ports = get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, 2)
-
-    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+    snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                             snappi_ports,
                                                                             snappi_api)
-    skip_warm_reboot(duthost1, reboot_type)
-    skip_warm_reboot(duthost2, reboot_type)
+    skip_warm_reboot(snappi_ports[0]['duthost'], reboot_type)
+    skip_warm_reboot(snappi_ports[1]['duthost'], reboot_type)
     pause_prio_list = lossless_prio_list
     test_prio_list = lossless_prio_list
     bg_prio_list = lossy_prio_list
     logger.info("Snappi Ports : {}".format(snappi_ports))
 
     snappi_extra_params = SnappiTestParams()
-    snappi_extra_params.multi_dut_params.duthost1 = duthost1
-    snappi_extra_params.multi_dut_params.duthost2 = duthost2
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
-    for duthost in dut_list:
+    for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
         duthost.shell("sudo config save -y")
         logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
         reboot(duthost, localhost, reboot_type=reboot_type)
@@ -352,7 +320,7 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noq
                  testbed_config=testbed_config,
                  port_config_list=port_config_list,
                  conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts,
+                 fanout_data=fanout_graph_facts_multidut,
                  global_pause=False,
                  pause_prio_list=pause_prio_list,
                  test_prio_list=test_prio_list,
@@ -361,4 +329,4 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noq
                  test_traffic_pause=True,
                  snappi_extra_params=snappi_extra_params)
 
-    cleanup_config(dut_list, snappi_ports)
+    cleanup_config(duthosts, snappi_ports)

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -1,18 +1,17 @@
 import pytest
 from tests.common.helpers.assertions import pytest_require, pytest_assert                   # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
-    fanout_graph_facts                                                                      # noqa: F401
+    fanout_graph_facts_multidut                                                                      # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-    snappi_api, snappi_dut_base_config, get_tgen_peer_ports, get_multidut_snappi_ports, \
-    get_multidut_tgen_peer_port_set, cleanup_config                                         # noqa: F401
+    snappi_api, snappi_dut_base_config, get_snappi_ports_for_rdma, cleanup_config, \
+    get_snappi_ports                                         # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list                         # noqa F401
-from tests.snappi_tests.variables import config_set, line_card_choice
+from tests.snappi_tests.variables import MULTIDUT_PORT_INFO
 from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_pfc_test
 from tests.common.reboot import reboot
 from tests.common.utilities import wait_until
 import logging
-import random
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import skip_warm_reboot
 logger = logging.getLogger(__name__)
@@ -20,57 +19,50 @@ logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen')]
 
 
-@pytest.mark.parametrize('line_card_choice', [line_card_choice])
-@pytest.mark.parametrize('linecard_configuration_set', [config_set])
 def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
                                      conn_graph_facts,          # noqa: F811
-                                     fanout_graph_facts,        # noqa: F811
+                                     fanout_graph_facts_multidut,        # noqa: F811
                                      duthosts,
-                                     enum_dut_lossy_prio,
+                                     enum_dut_lossy_prio,           # noqa: F811
                                      prio_dscp_map,                   # noqa: F811
                                      lossy_prio_list,              # noqa: F811
                                      all_prio_list,                   # noqa: F811
-                                     line_card_choice,
-                                     linecard_configuration_set,
-                                     get_multidut_snappi_ports):  # noqa: F811
+                                     get_snappi_ports,             # noqa: F811
+                                     tbinfo):        # noqa: F811
     """
     Test if PFC will impact a single lossy priority in multidut setup
 
     Args:
         snappi_api (pytest fixture): SNAPPI session
         conn_graph_facts (pytest fixture): connection graph
-        fanout_graph_facts (pytest fixture): fanout graph
+        fanout_graph_facts_multidut (pytest fixture): fanout graph
         duthosts (pytest fixture): list of DUTs
         enum_dut_lossy_prio (str): name of lossy priority to test, e.g., 's6100-1|2'
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
         lossy_prio_list (pytest fixture): list of all the lossy priorities
         all_prio_list (pytest fixture): list of all the priorities
-        get_multidut_snappi_ports: Populates tgen and connected DUT ports info of T0 testbed and returns as a list
-        line_card_choice: Line card choice to be mentioned in the variable.py file
-        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
         lossy_prio_list (pytest fixture): list of all the lossy priorities
 
 
     Returns:
         N/A
     """
-    pytest_assert(line_card_choice in linecard_configuration_set.keys(), "Invalid line_card_choice in parameter")
-    pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
-                   "Hostname can't be an empty list")
-    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(duthosts.frontend_nodes, 2)
-        duthost1, duthost2 = dut_list
-    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts.frontend_nodes
-                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
-        duthost1, duthost2 = dut_list[0], dut_list[0]
+    MULTIDUT_TESTBED = tbinfo['conf-name']
+    tx_port_count = 1
+    rx_port_count = 1
+    snappi_port_list = get_snappi_ports
+    pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                  "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
-    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
-                                                 line_card_info=linecard_configuration_set[line_card_choice])
-    pytest_require(len(snappi_port_list) >= 2, "Need Minimum of 2 ports for the test")
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Tx Ports']) >= tx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Rx Ports']) >= rx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
 
-    snappi_ports = get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, 2)
-    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+    snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                             snappi_ports,
                                                                             snappi_api)
 
@@ -82,15 +74,13 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
     bg_prio_list.remove(lossy_prio)
 
     snappi_extra_params = SnappiTestParams()
-    snappi_extra_params.multi_dut_params.duthost1 = duthost1
-    snappi_extra_params.multi_dut_params.duthost2 = duthost2
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
                  port_config_list=port_config_list,
                  conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts,
+                 fanout_data=fanout_graph_facts_multidut,
                  global_pause=False,
                  pause_prio_list=pause_prio_list,
                  test_prio_list=test_prio_list,
@@ -98,22 +88,18 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
                  snappi_extra_params=snappi_extra_params)
-    cleanup_config(dut_list, snappi_ports)
+    cleanup_config(duthosts, snappi_ports)
 
 
-@pytest.mark.parametrize('line_card_choice', [line_card_choice])
-@pytest.mark.parametrize('linecard_configuration_set', [config_set])
 def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
                                     conn_graph_facts,       # noqa: F811
                                     fanout_graph_facts,     # noqa: F811
                                     duthosts,
                                     prio_dscp_map,                   # noqa: F811
                                     lossy_prio_list,              # noqa: F811
-                                    lossless_prio_list,             # noqa: F811
-                                    line_card_choice,
-                                    linecard_configuration_set,
-                                    get_multidut_snappi_ports   # noqa: F811
-                                    ):
+                                    lossless_prio_list,              # noqa: F811
+                                    get_snappi_ports,         # noqa: F811
+                                    tbinfo):                 # noqa: F811
     """
     Test if PFC will impact multiple lossy priorities in multidut setup
 
@@ -125,30 +111,27 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
         lossless_prio_list (pytest fixture): list of all the lossless priorities
         lossy_prio_list (pytest fixture): list of all the lossy priorities
-        get_multidut_snappi_ports: Populates tgen and connected DUT ports info of T0 testbed and returns as a list
-        line_card_choice: Line card choice to be mentioned in the variable.py file
-        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
-
+        tbinfo (pytest fixture): fixture provides information about testbed
+        get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
     Returns:
         N/A
     """
-    pytest_assert(line_card_choice in linecard_configuration_set.keys(), "Invalid line_card_choice in parameter")
-    pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
-                   "Hostname can't be an empty list")
-    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(duthosts.frontend_nodes, 2)
-        duthost1, duthost2 = dut_list
-    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts.frontend_nodes
-                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
-        duthost1, duthost2 = dut_list[0], dut_list[0]
+    MULTIDUT_TESTBED = tbinfo['conf-name']
+    tx_port_count = 1
+    rx_port_count = 1
+    snappi_port_list = get_snappi_ports
+    pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                  "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
-    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
-                                                 line_card_info=linecard_configuration_set[line_card_choice])
-    pytest_require(len(snappi_port_list) >= 2, "Need Minimum of 2 ports for the test")
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Tx Ports']) >= tx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Rx Ports']) >= rx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
 
-    snappi_ports = get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, 2)
-    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+    snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                             snappi_ports,
                                                                             snappi_api)
 
@@ -157,8 +140,6 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
     bg_prio_list = lossless_prio_list
 
     snappi_extra_params = SnappiTestParams()
-    snappi_extra_params.multi_dut_params.duthost1 = duthost1
-    snappi_extra_params.multi_dut_params.duthost2 = duthost2
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
     run_pfc_test(api=snappi_api,
@@ -173,25 +154,22 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
                  snappi_extra_params=snappi_extra_params)
-    cleanup_config(dut_list, snappi_ports)
+    cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
-@pytest.mark.parametrize('line_card_choice', [line_card_choice])
-@pytest.mark.parametrize('linecard_configuration_set', [config_set])
 def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
                                             conn_graph_facts,       # noqa: F811
-                                            fanout_graph_facts,     # noqa: F811
+                                            fanout_graph_facts_multidut,     # noqa: F811
                                             duthosts,
                                             localhost,
-                                            enum_dut_lossy_prio,
+                                            enum_dut_lossy_prio,          # noqa: F811
                                             prio_dscp_map,                   # noqa: F811
                                             lossy_prio_list,              # noqa: F811
                                             all_prio_list,                   # noqa: F811
-                                            line_card_choice,
-                                            linecard_configuration_set,
-                                            get_multidut_snappi_ports,  # noqa: F811
+                                            get_snappi_ports,         # noqa: F811
+                                            tbinfo,                 # noqa: F811
                                             reboot_type):
     """
     Test if PFC will impact a single lossy priority after various kinds of reboots in multidut setup
@@ -206,36 +184,33 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
         lossy_prio_list (pytest fixture): list of all the lossy priorities
         all_prio_list (pytest fixture): list of all the priorities
-        get_multidut_snappi_ports: Populates tgen and connected DUT ports info of T0 testbed and returns as a list
         reboot_type (str): reboot type to be issued on the DUT
-        line_card_choice: Line card choice to be mentioned in the variable.py file
-        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
-
+        tbinfo (pytest fixture): fixture provides information about testbed
+        get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
     Returns:
         N/A
     """
-    pytest_assert(line_card_choice in linecard_configuration_set.keys(), "Invalid line_card_choice in parameter")
-    pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
-                   "Hostname can't be an empty list")
-    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(duthosts.frontend_nodes, 2)
-        duthost1, duthost2 = dut_list
-    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts.frontend_nodes
-                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
-        duthost1, duthost2 = dut_list[0], dut_list[0]
+    MULTIDUT_TESTBED = tbinfo['conf-name']
+    tx_port_count = 1
+    rx_port_count = 1
+    snappi_port_list = get_snappi_ports
+    pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                  "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
-    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
-                                                 line_card_info=linecard_configuration_set[line_card_choice])
-    pytest_require(len(snappi_port_list) >= 2, "Need Minimum of 2 ports for the test")
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Tx Ports']) >= tx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Rx Ports']) >= rx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
 
-    snappi_ports = get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, 2)
-    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+    snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                             snappi_ports,
                                                                             snappi_api)
 
-    skip_warm_reboot(duthost1, reboot_type)
-    skip_warm_reboot(duthost2, reboot_type)
+    skip_warm_reboot(snappi_ports[0]['duthost'], reboot_type)
+    skip_warm_reboot(snappi_ports[1]['duthost'], reboot_type)
 
     _, lossy_prio = enum_dut_lossy_prio.split('|')
     lossy_prio = int(lossy_prio)
@@ -244,7 +219,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
     bg_prio_list = [p for p in all_prio_list]
     bg_prio_list.remove(lossy_prio)
 
-    for duthost in dut_list:
+    for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
         duthost.shell("sudo config save -y")
         logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
         reboot(duthost, localhost, reboot_type=reboot_type)
@@ -252,15 +227,13 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
         wait_until(180, 20, 0, duthost.critical_services_fully_started)
 
     snappi_extra_params = SnappiTestParams()
-    snappi_extra_params.multi_dut_params.duthost1 = duthost1
-    snappi_extra_params.multi_dut_params.duthost2 = duthost2
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
                  port_config_list=port_config_list,
                  conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts,
+                 fanout_data=fanout_graph_facts_multidut,
                  global_pause=False,
                  pause_prio_list=pause_prio_list,
                  test_prio_list=test_prio_list,
@@ -268,13 +241,11 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
                  snappi_extra_params=snappi_extra_params)
-    cleanup_config(dut_list, snappi_ports)
+    cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
-@pytest.mark.parametrize('line_card_choice', [line_card_choice])
-@pytest.mark.parametrize('linecard_configuration_set', [config_set])
 def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
                                            conn_graph_facts,    # noqa: F811
                                            fanout_graph_facts,  # noqa: F811
@@ -283,9 +254,8 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
                                            prio_dscp_map,       # noqa: F811
                                            lossy_prio_list,     # noqa: F811
                                            lossless_prio_list,  # noqa: F811
-                                           line_card_choice,
-                                           linecard_configuration_set,
-                                           get_multidut_snappi_ports,   # noqa: F811
+                                           get_snappi_ports,    # noqa: F811
+                                           tbinfo,              # noqa: F811
                                            reboot_type):
     """
     Test if PFC will impact multiple lossy priorities after various kinds of reboots
@@ -300,42 +270,38 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
         lossless_prio_list (pytest fixture): list of all the lossless priorities
         lossy_prio_list (pytest fixture): list of all the lossy priorities
-        get_multidut_snappi_ports: Populates tgen and connected DUT ports info of T0 testbed and returns as a list
         reboot_type (str): reboot type to be issued on the DUT
-        line_card_choice: Line card choice to be mentioned in the variable.py file
-        linecard_configuration_set : Line card classification, (min 1 or max 2  hostnames and asics to be given)
-
+        tbinfo (pytest fixture): fixture provides information about testbed
+        get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
     Returns:
         N/A
     """
+    MULTIDUT_TESTBED = tbinfo['conf-name']
+    tx_port_count = 1
+    rx_port_count = 1
+    snappi_port_list = get_snappi_ports
+    pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                  "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
-    pytest_assert(line_card_choice in linecard_configuration_set.keys(), "Invalid line_card_choice in parameter")
-    pytest_require(len(linecard_configuration_set[line_card_choice]['hostname']) != 0,
-                   "Hostname can't be an empty list")
-    if (len(linecard_configuration_set[line_card_choice]['hostname']) >= 2):
-        dut_list = random.sample(duthosts.frontend_nodes, 2)
-        duthost1, duthost2 = dut_list
-    elif (len(linecard_configuration_set[line_card_choice]['hostname']) == 1):
-        dut_list = [dut for dut in duthosts.frontend_nodes
-                    if linecard_configuration_set[line_card_choice]['hostname'] == [dut.hostname]]
-        duthost1, duthost2 = dut_list[0], dut_list[0]
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Tx Ports']) >= tx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
+    pytest_assert(len(MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]['Rx Ports']) >= rx_port_count,
+                  'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for testbed {}'.
+                  format(MULTIDUT_TESTBED))
 
-    snappi_port_list = get_multidut_snappi_ports(line_card_choice=line_card_choice,
-                                                 line_card_info=linecard_configuration_set[line_card_choice])
-    pytest_require(len(snappi_port_list) >= 2, "Need Minimum of 2 ports for the test")
-
-    snappi_ports = get_multidut_tgen_peer_port_set(line_card_choice, snappi_port_list, config_set, 2)
-    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(dut_list,
+    snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                             snappi_ports,
                                                                             snappi_api)
-    skip_warm_reboot(duthost1, reboot_type)
-    skip_warm_reboot(duthost2, reboot_type)
+    skip_warm_reboot(snappi_ports[0]['duthost'], reboot_type)
+    skip_warm_reboot(snappi_ports[1]['duthost'], reboot_type)
 
     pause_prio_list = lossy_prio_list
     test_prio_list = lossy_prio_list
     bg_prio_list = lossless_prio_list
 
-    for duthost in dut_list:
+    for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
         duthost.shell("sudo config save -y")
         logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
         reboot(duthost, localhost, reboot_type=reboot_type)
@@ -343,15 +309,13 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
         wait_until(180, 20, 0, duthost.critical_services_fully_started)
 
     snappi_extra_params = SnappiTestParams()
-    snappi_extra_params.multi_dut_params.duthost1 = duthost1
-    snappi_extra_params.multi_dut_params.duthost2 = duthost2
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
                  port_config_list=port_config_list,
                  conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts,
+                 fanout_data=fanout_graph_facts_multidut,
                  global_pause=False,
                  pause_prio_list=pause_prio_list,
                  test_prio_list=test_prio_list,
@@ -359,4 +323,4 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
                  snappi_extra_params=snappi_extra_params)
-    cleanup_config(dut_list, snappi_ports)
+    cleanup_config(duthosts, snappi_ports)

--- a/tests/snappi_tests/variables.py
+++ b/tests/snappi_tests/variables.py
@@ -7,7 +7,7 @@ from ipaddress import ip_address, IPv4Address, IPv6Address
 MULTIDUT_TESTBED = 'vms-snappi-sonic-multidut'
 MULTIDUT_PORT_INFO = {MULTIDUT_TESTBED: (
     ({
-        'cross_dut': {
+        'multi-dut-single-asic': {
             'rx_ports': [
                 {'port_name': 'Ethernet72', 'hostname': "sonic-s6100-dut1"},
                 {'port_name': 'Ethernet76', 'hostname': "sonic-s6100-dut1"}
@@ -19,7 +19,7 @@ MULTIDUT_PORT_INFO = {MULTIDUT_TESTBED: (
         }
     }),
     ({
-        'cross_asic': {
+        'single-dut-single-asic': {
             'rx_ports': [
                 {'port_name': 'Ethernet72', 'hostname': "sonic-s6100-dut1"},
                 {'port_name': 'Ethernet76', 'hostname': "sonic-s6100-dut1"}

--- a/tests/snappi_tests/variables.py
+++ b/tests/snappi_tests/variables.py
@@ -1,6 +1,52 @@
 import sys
 import ipaddress
 from ipaddress import ip_address, IPv4Address, IPv6Address
+
+# NOTE: Ensure the ports are mapped correctly to the respective duts in ansible/files/*links.csv
+# NOTE: The keys of MULTIDUT_PORT_INFO are the conf-name defined in testbed.yml/testbed.csv file
+MULTIDUT_PORT_INFO = {
+                        'vms-snappi-sonic-multidut': {
+                                'Rx Ports': [
+                                    {'port_name': 'Ethernet64', 'hostname': "sonic-s6100-dut2"},
+                                    {'port_name': 'Ethernet68', 'hostname': "sonic-s6100-dut2"},
+                                    {'port_name': 'Ethernet72', 'hostname': "sonic-s6100-dut2"},
+                                    {'port_name': 'Ethernet76', 'hostname': "sonic-s6100-dut2"}
+                                ],
+                                'Tx Ports': [
+                                    {'port_name': 'Ethernet64', 'hostname': "sonic-s6100-dut1"},
+                                    {'port_name': 'Ethernet68', 'hostname': "sonic-s6100-dut1"},
+                                    {'port_name': 'Ethernet72', 'hostname': "sonic-s6100-dut1"},
+                                    {'port_name': 'Ethernet76', 'hostname': "sonic-s6100-dut1"}
+                                ]
+                        },
+                        'vms-snappi-sonic': {
+                                'Rx Ports': [
+                                    {'port_name': 'Ethernet72', 'hostname': "sonic-s6100-dut1"},
+                                    {'port_name': 'Ethernet76', 'hostname': "sonic-s6100-dut1"}
+                                ],
+                                'Tx Ports': [
+                                    {'port_name': 'Ethernet64', 'hostname': "sonic-s6100-dut1"},
+                                    {'port_name': 'Ethernet68', 'hostname': "sonic-s6100-dut1"}
+                                ]
+                        },
+                        'vms-snappi-single-dut-multi-asic': {
+                                'Rx Ports': [
+                                    {'port_name': 'Ethernet72', 'hostname': "sonic-s6100-dut1"}
+                                ],
+                                'Tx Ports': [
+                                    {'port_name': 'Ethernet68', 'hostname': "sonic-s6100-dut1"}
+                                ]
+                        },
+                        'vms-snappi-multi-dut-multi-asic': {
+                                'Rx Ports': [
+                                    {'port_name': 'Ethernet72', 'hostname': "sonic-s6100-dut2"}
+                                ],
+                                'Tx Ports': [
+                                    {'port_name': 'Ethernet68', 'hostname': "sonic-s6100-dut1"}
+                                ]
+                        },
+
+                     }
 '''
 In this file user can modify the line_card_choice and it chooses the corresponding hostname
 and asic values from the config_set hostnames can be modified according to the dut hostname mentioned

--- a/tests/snappi_tests/variables.py
+++ b/tests/snappi_tests/variables.py
@@ -3,50 +3,34 @@ import ipaddress
 from ipaddress import ip_address, IPv4Address, IPv6Address
 
 # NOTE: Ensure the ports are mapped correctly to the respective duts in ansible/files/*links.csv
-# NOTE: The keys of MULTIDUT_PORT_INFO are the conf-name defined in testbed.yml/testbed.csv file
-MULTIDUT_PORT_INFO = {
-                        'vms-snappi-sonic-multidut': {
-                                'Rx Ports': [
-                                    {'port_name': 'Ethernet64', 'hostname': "sonic-s6100-dut2"},
-                                    {'port_name': 'Ethernet68', 'hostname': "sonic-s6100-dut2"},
-                                    {'port_name': 'Ethernet72', 'hostname': "sonic-s6100-dut2"},
-                                    {'port_name': 'Ethernet76', 'hostname': "sonic-s6100-dut2"}
-                                ],
-                                'Tx Ports': [
-                                    {'port_name': 'Ethernet64', 'hostname': "sonic-s6100-dut1"},
-                                    {'port_name': 'Ethernet68', 'hostname': "sonic-s6100-dut1"},
-                                    {'port_name': 'Ethernet72', 'hostname': "sonic-s6100-dut1"},
-                                    {'port_name': 'Ethernet76', 'hostname': "sonic-s6100-dut1"}
-                                ]
-                        },
-                        'vms-snappi-sonic': {
-                                'Rx Ports': [
-                                    {'port_name': 'Ethernet72', 'hostname': "sonic-s6100-dut1"},
-                                    {'port_name': 'Ethernet76', 'hostname': "sonic-s6100-dut1"}
-                                ],
-                                'Tx Ports': [
-                                    {'port_name': 'Ethernet64', 'hostname': "sonic-s6100-dut1"},
-                                    {'port_name': 'Ethernet68', 'hostname': "sonic-s6100-dut1"}
-                                ]
-                        },
-                        'vms-snappi-single-dut-multi-asic': {
-                                'Rx Ports': [
-                                    {'port_name': 'Ethernet72', 'hostname': "sonic-s6100-dut1"}
-                                ],
-                                'Tx Ports': [
-                                    {'port_name': 'Ethernet68', 'hostname': "sonic-s6100-dut1"}
-                                ]
-                        },
-                        'vms-snappi-multi-dut-multi-asic': {
-                                'Rx Ports': [
-                                    {'port_name': 'Ethernet72', 'hostname': "sonic-s6100-dut2"}
-                                ],
-                                'Tx Ports': [
-                                    {'port_name': 'Ethernet68', 'hostname': "sonic-s6100-dut1"}
-                                ]
-                        },
-
-                     }
+# NOTE: The MULTIDUT_TESTBED must match with the conf-name defined in testbed.yml/testbed.csv file
+MULTIDUT_TESTBED = 'vms-snappi-sonic-multidut'
+MULTIDUT_PORT_INFO = {MULTIDUT_TESTBED: (
+    ({
+        'cross_dut': {
+            'rx_ports': [
+                {'port_name': 'Ethernet72', 'hostname': "sonic-s6100-dut1"},
+                {'port_name': 'Ethernet76', 'hostname': "sonic-s6100-dut1"}
+            ],
+            'tx_ports': [
+                {'port_name': 'Ethernet64', 'hostname': "sonic-s6100-dut2"},
+                {'port_name': 'Ethernet68', 'hostname': "sonic-s6100-dut2"}
+            ]
+        }
+    }),
+    ({
+        'cross_asic': {
+            'rx_ports': [
+                {'port_name': 'Ethernet72', 'hostname': "sonic-s6100-dut1"},
+                {'port_name': 'Ethernet76', 'hostname': "sonic-s6100-dut1"}
+            ],
+            'tx_ports': [
+                {'port_name': 'Ethernet64', 'hostname': "sonic-s6100-dut1"},
+                {'port_name': 'Ethernet68', 'hostname': "sonic-s6100-dut1"}
+            ]
+        }
+    })
+)}
 '''
 In this file user can modify the line_card_choice and it chooses the corresponding hostname
 and asic values from the config_set hostnames can be modified according to the dut hostname mentioned


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This PR enhances the logic for port selection for multidut RDMA cases based on the conf-name defined in the testbed.csv / testbed.yaml file. And also a generic fixture for single and multidut topology to get the snappi ports, dut port, asic_type, asic_value information
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/13389
https://github.com/sonic-net/sonic-mgmt/issues/13769

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
For enhancing the port selection logic and a generic fixture for single and multidut topology
#### How did you do it?
Added a pytest fixture called get_snappi_ports and get_snappi_ports_for_rdma whcih selects the ports from the information provided in MULTIDUT_PORT_INFO in variables.py and the testbed info as shown below in testbed.csv

```
vms-snappi-sonic,vms6-1,ptf64,docker-ptf-snappi,snappi-sonic-ptf,10.36.78.59,,Server_6,,sonic-s6100-dut1,snappi-sonic,True,Batman
vms-snappi-sonic-multidut,vms6-1,ptf64,docker-ptf-snappi,snappi-sonic-ptf,10.36.78.59,,Server_6,,[sonic-s6100-dut1;sonic-s6100-dut2],snappi-sonic,True,Batman
vms-snappi-single-dut-multi-asic,vms6-1,ptf64,docker-ptf-snappi,snappi-sonic-ptf,10.36.78.59,,Server_6,,sonic-s6100-dut1,snappi-sonic,True,Batman
vms-snappi-multi-dut-multi-asic,vms6-1,ptf64,docker-ptf-snappi,snappi-sonic-ptf,10.36.78.59,,Server_6,,[sonic-s6100-dut1;sonic-s6100-dut2],snappi-sonic,True,Batman
```
#### How did you verify/test it?
Tested the logic on pfc cases
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
