### PR TITLE
Set device type to BackEnd if enable_compute_ai_deployment is true

### DIFF
--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -113,7 +113,17 @@
 {% endif %}
     </DeviceInterfaceLinks>
     <Devices>
+{% if enable_compute_ai_deployment|default('false')|bool %}
+    {% if vm_topo_config['dut_type'] | lower == 'torrouter' %}
+      <Device i:type="BackEndToRRouter">
+    {% elif vm_topo_config['dut_type'] | lower == 'leafrouter' %}
+      <Device i:type="BackEndLeafRouter">
+    {% else %}
       <Device i:type="{{ vm_topo_config['dut_type'] }}">
+    {% endif %}
+{% else %}
+      <Device i:type="{{ vm_topo_config['dut_type'] }}">
+{% endif %}
         <Hostname>{{ inventory_hostname }}</Hostname>
         <HwSku>{{ hwsku }}</HwSku>
 {% if 'loopback' in dual_tor_facts %}

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -199,6 +199,8 @@
 {% if vm_topo_config['vm'][dev]['intfs'][dut_index|int]|length %}
 {% if 'properties' in vm_topo_config['vm'][dev] and 'device_type' in vm_topo_config['vm'][dev]['properties'] %}
 {% set dev_type = vm_topo_config['vm'][dev]['properties']['device_type'] %}
+{% elif ('T1' in dev) and (enable_compute_ai_deployment|default('false')|bool) %}
+{% set dev_type = 'BackEndLeafRouter' %}
 {% elif 'T1' in dev %}
 {% set dev_type = 'LeafRouter' %}
 {% elif 'T2' in dev %}
@@ -209,6 +211,8 @@
 {% else %}
 {% set dev_type = 'AZNGHub' %}
 {% endif %}
+{% elif ('T0' in dev) and (enable_compute_ai_deployment|default('false')|bool) %}
+{% set dev_type = 'BackEndToRRouter' %}
 {% elif 'T0' in dev %}
 {% set dev_type = 'ToRRouter' %}
 {% elif 'M1' in dev %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Set device type to BackEndToRRouter or BackEndLeafRouter if enable_compute_ai_deployment is true during minigraph .xml generation.
sonic-mgmt-internal branch PR#6352

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Set device type to BackEndToRRouter or BackEndLeafRouter if enable_compute_ai_deployment is true during minigraph .xml generation.

#### How did you do it?

#### How did you verify/test it?
Verify with physical testbed internally.
![image](https://github.com/user-attachments/assets/a5f789db-b110-4d1d-8791-d0284a8a1b02)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
