### PR TITLE
Move some stable data plane test scripts to PR checker sets

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -204,6 +204,10 @@ t0:
   - snmp/test_snmp_psu.py
   - platform_tests/cli/test_show_platform.py
   - snmp/test_snmp_queue_counters.py
+  - generic_config_updater/test_dynamic_acl.py
+  - sub_port_interfaces/test_sub_port_interfaces.py
+  - hash/test_generic_hash.py
+  - span/test_port_mirroring.py
 
 t0-2vlans:
   - dhcp_relay/test_dhcp_relay.py
@@ -222,6 +226,7 @@ t0-sonic:
   - platform_tests/test_advanced_reboot.py::test_warm_reboot
 
 dualtor:
+  - arp/test_arp_dualtor.py
   - arp/test_arp_extended.py
   - dualtor/test_ipinip.py
   - dualtor/test_switchover_failure.py
@@ -232,6 +237,7 @@ dualtor:
   - dualtor_io/test_normal_op.py
   - dualtor_io/test_tor_bgp_failure.py
   - dualtor_mgmt/test_grpc_periodical_sync.py
+  - dualtor_mgmt/test_ingress_drop.py
   - dualtor_mgmt/test_server_failure.py
   - dualtor_mgmt/test_toggle_mux.py
 
@@ -385,6 +391,8 @@ t1-lag:
   - telemetry/test_telemetry_cert_rotation.py
   - test_features.py
   - test_procdockerstatsd.py
+  - hash/test_generic_hash.py
+  - sub_port_interfaces/test_sub_port_interfaces.py
 
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py
@@ -435,7 +443,6 @@ dpu:
 
 onboarding_t0:
   # We will add a batch of T0 control plane cases and fix the failed cases later
-  - generic_config_updater/test_dynamic_acl.py
   - pfcwd/test_pfcwd_all_port_storm.py
   - pfcwd/test_pfcwd_function.py
   - pfcwd/test_pfcwd_timer_accuracy.py
@@ -445,36 +452,26 @@ onboarding_t0:
   - platform_tests/test_reload_config.py
   - route/test_route_bgp_ecmp.py
   - snmp/test_snmp_link_local.py
-  - sub_port_interfaces/test_sub_port_interfaces.py
-  - hash/test_generic_hash.py
-  - span/test_port_mirroring.py
   - drop_packets/test_drop_counters.py
 
 onboarding_t1:
   - generic_config_updater/test_cacl.py
-  - hash/test_generic_hash.py
   - gnmi/test_gnmi_countersdb.py
   - platform_tests/test_link_down.py
   - vxlan/test_vxlan_bfd_tsa.py
   - vxlan/test_vxlan_ecmp_switchover.py
   - stress/test_stress_routes.py
   - drop_packets/test_drop_counters.py
-  - sub_port_interfaces/test_sub_port_interfaces.py
   - bgp/test_bgp_sentinel.py
   - bgp/test_bgp_suppress_fib.py
-  - hash/test_generic_hash.py
   - platform_tests/test_reload_config.py
   - show_techsupport/test_auto_techsupport.py
   - snmp/test_snmp_link_local.py
-  - sub_port_interfaces/test_sub_port_interfaces.py
   - telemetry/test_events.py
 
-
 onboarding_dualtor:
-  - arp/test_arp_dualtor.py
   - dualtor/test_orchagent_slb.py
   - dualtor_io/test_link_failure.py
-  - dualtor_mgmt/test_ingress_drop.py
   - dualtor_mgmt/test_dualtor_bgp_update_delay.py
 
 specific_param:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Some dataplane test scripts have been added to PR test and put into optional onboarding job to test case performance, I calculated the success rate of test scripts in recent 5 days, I think I can move high success rate test scripts to t0/t1/dualtor job now
TestbedName | FilePath | RunDate | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-dual-t0 | arp/test_arp_dualtor.py | 2024-08-15 00:00:00.0000000 | 24 | 0 | 24 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_ingress_drop.py | 2024-08-15 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-t0 | generic_config_updater/test_dynamic_acl.py | 2024-08-15 00:00:00.0000000 | 24 | 0 | 24 | 1
vms-kvm-t0 | hash/test_generic_hash.py | 2024-08-15 00:00:00.0000000 | 20 | 0 | 20 | 1
vms-kvm-t1-lag | hash/test_generic_hash.py | 2024-08-15 00:00:00.0000000 | 10 | 0 | 10 | 1
vms-kvm-t0 | span/test_port_mirroring.py | 2024-08-15 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t0 | sub_port_interfaces/test_sub_port_interfaces.py | 2024-08-15 00:00:00.0000000 | 64 | 0 | 64 | 1
vms-kvm-t1-lag | sub_port_interfaces/test_sub_port_interfaces.py | 2024-08-15 00:00:00.0000000 | 32 | 0 | 32 | 1
vms-kvm-dual-t0 | arp/test_arp_dualtor.py | 2024-08-14 00:00:00.0000000 | 564 | 0 | 564 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_ingress_drop.py | 2024-08-14 00:00:00.0000000 | 94 | 0 | 94 | 1
vms-kvm-t0 | generic_config_updater/test_dynamic_acl.py | 2024-08-14 00:00:00.0000000 | 568 | 2 | 570 | 0.9965
vms-kvm-t0 | hash/test_generic_hash.py | 2024-08-14 00:00:00.0000000 | 487 | 0 | 490 | 0.9939
vms-kvm-t1-lag | hash/test_generic_hash.py | 2024-08-14 00:00:00.0000000 | 491 | 2 | 496 | 0.9899
vms-kvm-t0 | span/test_port_mirroring.py | 2024-08-14 00:00:00.0000000 | 192 | 1 | 193 | 0.9948
vms-kvm-t0 | sub_port_interfaces/test_sub_port_interfaces.py | 2024-08-14 00:00:00.0000000 | 1462 | 5 | 1467 | 0.9966
vms-kvm-t1-lag | sub_port_interfaces/test_sub_port_interfaces.py | 2024-08-14 00:00:00.0000000 | 1505 | 4 | 1509 | 0.9973
vms-kvm-dual-t0 | arp/test_arp_dualtor.py | 2024-08-13 00:00:00.0000000 | 228 | 0 | 228 | 1
vms-kvm-dual-t0 | dualtor_mgmt/test_ingress_drop.py | 2024-08-13 00:00:00.0000000 | 38 | 0 | 38 | 1
vms-kvm-t0 | generic_config_updater/test_dynamic_acl.py | 2024-08-13 00:00:00.0000000 | 180 | 3 | 183 | 0.9836
vms-kvm-t1-lag | hash/test_generic_hash.py | 2024-08-13 00:00:00.0000000 | 152 | 5 | 157 | 0.9682
vms-kvm-t0 | hash/test_generic_hash.py | 2024-08-13 00:00:00.0000000 | 155 | 3 | 158 | 0.981
vms-kvm-t0 | span/test_port_mirroring.py | 2024-08-13 00:00:00.0000000 | 60 | 3 | 63 | 0.9524
vms-kvm-t1-lag | sub_port_interfaces/test_sub_port_interfaces.py | 2024-08-13 00:00:00.0000000 | 506 | 4 | 510 | 0.9922
vms-kvm-t0 | sub_port_interfaces/test_sub_port_interfaces.py | 2024-08-13 00:00:00.0000000 | 513 | 3 | 516 | 0.9942
#### How did you do it?
Move test from onboarding job to t0/t1/dualtor job
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
