### PR TITLE
Enable readiness check in the config_reload of the core_dump and config check

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -586,13 +586,12 @@ def acl_table(duthosts, rand_one_dut_hostname, setup, stage, ip_version, tbinfo)
             create_or_remove_acl_table(duthost, acl_table_config, setup, "remove", topo)
             raise err
 
-    try:
-        yield acl_table_config
-    finally:
-        for duthost, loganalyzer in list(dut_to_analyzer_map.items()):
-            loganalyzer.expect_regex = [LOG_EXPECT_ACL_TABLE_REMOVE_RE]
-            with loganalyzer:
-                create_or_remove_acl_table(duthost, acl_table_config, setup, "remove", topo)
+    yield acl_table_config
+
+    for duthost, loganalyzer in list(dut_to_analyzer_map.items()):
+        loganalyzer.expect_regex = [LOG_EXPECT_ACL_TABLE_REMOVE_RE]
+        with loganalyzer:
+            create_or_remove_acl_table(duthost, acl_table_config, setup, "remove", topo)
 
 
 class BaseAclTest(six.with_metaclass(ABCMeta, object)):

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -538,7 +538,10 @@ def create_or_remove_acl_table(duthost, acl_table_config, setup, op, topo):
 
 
 @pytest.fixture(scope="module")
-def acl_table(duthosts, rand_one_dut_hostname, setup, stage, ip_version, tbinfo):
+def acl_table(duthosts, rand_one_dut_hostname, setup, stage, ip_version, tbinfo,
+              # make sure the tear down of core_dump_and_config_check happened after acl_table
+              core_dump_and_config_check
+              ):
     """Apply ACL table configuration and remove after tests.
 
     Args:
@@ -586,12 +589,13 @@ def acl_table(duthosts, rand_one_dut_hostname, setup, stage, ip_version, tbinfo)
             create_or_remove_acl_table(duthost, acl_table_config, setup, "remove", topo)
             raise err
 
-    yield acl_table_config
-
-    for duthost, loganalyzer in list(dut_to_analyzer_map.items()):
-        loganalyzer.expect_regex = [LOG_EXPECT_ACL_TABLE_REMOVE_RE]
-        with loganalyzer:
-            create_or_remove_acl_table(duthost, acl_table_config, setup, "remove", topo)
+    try:
+        yield acl_table_config
+    finally:
+        for duthost, loganalyzer in list(dut_to_analyzer_map.items()):
+            loganalyzer.expect_regex = [LOG_EXPECT_ACL_TABLE_REMOVE_RE]
+            with loganalyzer:
+                create_or_remove_acl_table(duthost, acl_table_config, setup, "remove", topo)
 
 
 class BaseAclTest(six.with_metaclass(ABCMeta, object)):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2066,7 +2066,7 @@ def __dut_reload(duts_data, node=None, results=None):
             node.copy(src=asic_cfg_file, dest='/etc/sonic/config_db{}.json'.format(asic_index), verbose=False)
             os.remove(asic_cfg_file)
 
-    config_reload(node, wait_before_force_reload=300)
+    config_reload(node, wait_before_force_reload=300, safe_reload=True)
 
 
 def compare_running_config(pre_running_config, cur_running_config):
@@ -2093,7 +2093,11 @@ def compare_running_config(pre_running_config, cur_running_config):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def core_dump_and_config_check(duthosts, tbinfo, request):
+def core_dump_and_config_check(duthosts, tbinfo,
+                               request,
+                               # make sure the tear down of sanity_check happened after core_dump_and_config_check
+                               sanity_check
+                               ):
     '''
     Check if there are new core dump files and if the running config is modified after the test case running.
     If so, we will reload the running config after test case running.


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
core_dump_and_config_check will issue config_reload to the duthosts after test module finished and if there's coredump or config_db changes.
For now, it simply issues the config_reload command then returns and finishes.
For the testbeds that require more time to be ready, it possibly fails on the sanity check of the next test module.
Hence enable the readiness check of the config_reload.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Enable the readiness check.
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
