### PR TITLE
Move dualtor/test_orchagent_slb.py to PR skip yaml

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -475,7 +475,6 @@ onboarding_t1:
   - telemetry/test_events.py
 
 onboarding_dualtor:
-  - dualtor/test_orchagent_slb.py
   - dualtor_io/test_link_failure.py
   - dualtor_mgmt/test_dualtor_bgp_update_delay.py
 

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -1,6 +1,8 @@
 t0:
   # KVM do not support drop reason in testcase, and testcase would set drop reason in setup stage, can't do more test
   - drop_packets/test_configurable_drop_counters.py
+  # KVM do not support dualtor tunnel functionality, lower tor bgp verify would fail
+  - dualtor/test_orchagent_slb.py
   # KVM do not support dualtor tunnel functionality, verify DB status would fail
   - dualtor_io/test_normal_op.py
   # This script would toggle PDU, which is not supported on KVM


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In `test_orchagent_slb.py`, lower tor bgp session verify always fails, because TCP packets from lower tor to server would use dualtor tunnel with encap and decap, which do not support in KVM testbed.
#### How did you do it?
Skip `test_orchagent_slb.py` in PR test.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
