### PR TITLE
Improve test_ro_disk logrotate failed because auth.log missing issue.

### DIFF
--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -155,6 +155,12 @@ def log_rotate(duthost):
         if "logrotate does not support parallel execution on the same set of logfiles" in e.message:
             # command will failed when log already in rotating
             logger.warning("logrotate command failed: {}".format(e))
+        elif "error: stat of /var/log/auth.log failed: Bad message" in e.message:
+            # command will failed because auth.log missing
+            logger.warning("logrotate command failed: {}".format(e))
+        elif "du: cannot access '/var/log/auth.log': Bad message" in e.message:
+            # command will failed because auth.log missing
+            logger.warning("logrotate command failed: {}".format(e))
         else:
             raise e
 


### PR DESCRIPTION
Improve test_ro_disk logrotate failed because auth.log missing issue.

#### Why I did it
test case  test_ro_disk failed because following error:
error: stat of /var/log/syslog failed: Bad message
du: cannot access '/var/log/auth.log': Bad message

##### Work item tracking
- Microsoft ADO: 29020193

#### How I did it
Improve test_ro_disk logrotate failed because auth.log missing issue.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Improve test_ro_disk logrotate failed because auth.log missing issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

