### PR TITLE
Fix an error of checking reboot type. 

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -344,7 +344,9 @@ def get_reboot_cause(dut):
     # is such like "User issued 'xxx' command [User: admin, Time: Sun Aug  4 06:43:19 PM UTC 2024]"
     # So, use the above pattern to get real reboot cause
     if dut.facts["asic_type"] == "vs":
-        cause = re.search("User issued '(.*)' command", cause).groups()[0]
+        match = re.search("User issued '(.*)' command", cause)
+        if match:
+            cause = match.groups()[0]
 
     for type, ctrl in list(reboot_ctrl_dict.items()):
         if re.search(ctrl['cause'], cause):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
There is another reboot cause `Unknown (First boot of SONiC version xxx)` on kvm besides `User issued xxx' command`, which will cause error `'NoneType' object has no attribute 'groups'` based on the current code. To address this, this PR suggests a conditional check to ensure that the match object is not None before attempting to access its 'groups' attribute, thereby preventing such issue.

Summary:
Fixes # (13979
)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
There is another reboot cause `Unknown (First boot of SONiC version xxx)` on kvm besides `User issued xxx' command`, which will cause error `'NoneType' object has no attribute 'groups'` based on the current code. To address this, this PR suggests a conditional check to ensure that the match object is not None before attempting to access its 'groups' attribute, thereby preventing such issue.

#### How did you do it?
This PR suggests a conditional check to ensure that the match object is not None before attempting to access its 'groups' attribute, thereby preventing such issue.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
