### PR TITLE
Policer test lldp udld cisco skip 202311

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -33,6 +33,7 @@ from tests.common import config_reload, constants
 from tests.common.system_utils import docker
 from tests.common.reboot import reboot
 from tests.common.utilities import skip_release
+from tests.common.utilities import skip_release_for_platform
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import find_duthost_on_role
@@ -90,6 +91,9 @@ class TestCOPP(object):
             that have a set rate limit.
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        # Skip LLDP/UDLD on Cisco platform(till queue4_group3 issue is fixed)
+        if protocol in ["LLDP", "UDLD"]:
+            skip_release_for_platform(duthost, ["202311"], ["8101", "8102", "8111"])
         _copp_runner(duthost,
                      ptfhost,
                      protocol,

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -93,7 +93,7 @@ class TestCOPP(object):
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         # Skip LLDP/UDLD on Cisco platform(till queue4_group3 issue is fixed)
         if protocol in ["LLDP", "UDLD"]:
-            skip_release_for_platform(duthost, ["202311"], ["8101", "8102", "8111"])
+            skip_release_for_platform(duthost, ["202311"], ["8101", "8111"])
         _copp_runner(duthost,
                      ptfhost,
                      protocol,


### PR DESCRIPTION
### Description of PR
We see that after configuring 100 pps for queue4_group3, policer test for LLDP/UDLD have started failing on Cisco platforms. This PR skips policer test for LLDP/UDLD tests on Cisco platform for 202311. Once the issue is fixed we will remove this skip.

Summary:
Skip policer test for UDLD/LLDP on Cisco platforms for 202311

### Type of change
- [ ] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 202311

### Approach
#### What is the motivation for this PR?
Skip policer test for UDLD/LLDP on Cisco platforms for 202311

#### How did you do it?
Skip policer test for UDLD/LLDP on Cisco platforms for 202311

#### How did you verify/test it?
Verified that the tests are skippd
UT:
```
- generated xml file: /run_logs/ananshar/copp/test_copp.py::TestCOPP::test_policer[croc-aaa12-dut-UDLD]_2024-08-16-13-51-30.xml -
INFO:root:Can not get Allure report URL. Please check logs
--------------------------------------- live log sessionfinish ---------------------------------------
13:58:50 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
====================================== short test summary info =======================================
SKIPPED [1] common/utilities.py:84: DUT has version azure_cisco_202311.14115-dirty-20240730.104536 and platform x86_64-8111_32eh_o-r0 and test does not support 202311 for 8101, 8102, 8111
============================= 1 skipped, 1 warning in 439.73s (0:07:19) ==============================
sonic@sonic-ucs-m5-8:/data/tests$ 
```
```
- generated xml file: /run_logs/ananshar/copp/test_copp.py::TestCOPP::test_policer[croc-aaa12-dut-LLDP]_2024-08-16-14-03-39.xml -
INFO:root:Can not get Allure report URL. Please check logs
--------------------------------------- live log sessionfinish ---------------------------------------
14:10:54 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
====================================== short test summary info =======================================
SKIPPED [1] common/utilities.py:84: DUT has version azure_cisco_202311.14115-dirty-20240730.104536 and platform x86_64-8111_32eh_o-r0 and test does not support 202311 for 8101, 8102, 8111
============================= 1 skipped, 1 warning in 433.81s (0:07:13) ==============================
sonic@sonic-ucs-m5-8:/data/tests$ 
```

#### Any platform specific information?
Applicable for Cisco platforms only

#### Supported testbed topology if it's a new test case?
NA
### Documentation
NA