### PR TITLE
[dualtor] Fix `test_console_baud_rate`

### DIFF
--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -21,7 +21,7 @@ pass_config_test = True
 
 
 def is_sonic_console(conn_graph_facts, dut_hostname):
-    return conn_graph_facts['device_console_info'][dut_hostname]["Os"] == "sonic"
+    return conn_graph_facts['device_console_info'][dut_hostname].get("Os", "") == "sonic"
 
 
 def test_console_baud_rate_config(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix the following issue:
```
    def is_sonic_console(conn_graph_facts, dut_hostname):
>       return conn_graph_facts['device_console_info'][dut_hostname]["Os"] == "sonic"
E       KeyError: 'Os'
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Some lab device console information doesn't have the `"Os"` attribute.
Let's retrieve it with an empty string as a default.

#### How did you verify/test it?
Run on dualtor.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
