### PR TITLE
[chassis]: Update test_snmp_lldp.py: skip lldpLocManAddrTable for LC

### DIFF
--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -65,12 +65,14 @@ def test_snmp_lldp(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_
                 assert "No Such Object currently exists" not in v[oid]
 
     # Check if lldpLocManAddrTable is present
-    for k in ['lldpLocManAddrLen',
-              'lldpLocManAddrIfSubtype',
-              'lldpLocManAddrIfId',
-              'lldpLocManAddrOID']:
-        assert snmp_facts['snmp_lldp'][k]
-        assert "No Such Object currently exists" not in snmp_facts['snmp_lldp'][k]
+    if duthost.facts['modular_chassis'] == "False":
+        # Modular Chassis LCs do not run global lldp service
+        for k in ['lldpLocManAddrLen',
+                  'lldpLocManAddrIfSubtype',
+                  'lldpLocManAddrIfId',
+                  'lldpLocManAddrOID']:
+            assert snmp_facts['snmp_lldp'][k]
+            assert "No Such Object currently exists" not in snmp_facts['snmp_lldp'][k]
 
     minigraph_lldp_nei = []
     for k, v in list(mg_facts.items()):


### PR DESCRIPTION
Signed-off-by: anamehra anamehra@cisco.com

Chassis LC does not have global lldp docker. Removing check for lldpLocManAddrTable for LC lldp.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/13405


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fixes: https://github.com/sonic-net/sonic-mgmt/issues/13405

#### How did you do it?
Removed lldpLocManAddrTable check for modular chassis.

#### How did you verify/test it?
Run test_snmp_lldp.py on Modular chassis LC

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
