### PR TITLE
feat: improved wording for skipped test case

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -5,9 +5,17 @@
 #Hence, it is not dropped by default in Cisco-8000. For dropping link local address, it should be done through security/DATA ACL
 drop_packets/test_configurable_drop_counters.py::test_dip_link_local:
   skip:
-    reason: "Some mlx platforms does not drop DIP link local packets"
+    reason: "Cisco 8000 platform and some mlx platforms does not drop DIP link local packets"
+    conditions_logical_operator: or
     conditions:
       - "'Mellanox' in hwsku"
+      - asic_type=='cisco-8000'
+
+drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down:
+  skip:
+    reason: "This test case requires a T0 topology because it is mocking a server within VLAN."
+    conditions:
+      - "topo_type not in ['t0']"
 
 drop_packets/test_configurable_drop_counters.py::test_sip_link_local:
   skip:
@@ -16,8 +24,6 @@ drop_packets/test_configurable_drop_counters.py::test_sip_link_local:
     conditions:
       - asic_type=="cisco-8000"
       - "'Mellanox' in hwsku"
-
-
 #######################################
 #####     test_drop_counters.py   #####
 #######################################
@@ -83,31 +89,38 @@ drop_packets/test_drop_counters.py::test_ip_is_zero_addr:
 
 drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv4-dst]:
   skip:
-    reason: "Image issue on Boradcom dualtor testbeds. Cisco 8000 platform does not drop packets with 0.0.0.0 source or destination IP address"
+    reason:
+    - "Image issue on Broadcom dualtor testbeds. Cisco 8000 platform does not drop packets with 0.0.0.0 source or destination IP address"
+    - "Test case requires topology type t0 for vlan testing"
     strict: True
+    conditions_logical_operator: or
     conditions:
-      - "asic_type in ['broadcom', 'cisco-8000']"
-      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
+      - "asic_type in ['broadcom', 'cisco-8000'] and topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
+      - topo_type not in ['t0']
 
 drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv4-src]:
   skip:
-    reason: "Image issue on Boradcom dualtor testbeds. Cisco 8000 platform does not drop packets with 0.0.0.0 source or destination IP address"
+    reason:
+    - "Image issue on Broadcom dualtor testbeds. Cisco 8000 platform does not drop packets with 0.0.0.0 source or destination IP address"
+    - "Test case requires topology type t0 for vlan testing"
     strict: True
     conditions:
-      - "asic_type in ['broadcom', 'cisco-8000']"
-      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
+      - "asic_type in ['broadcom', 'cisco-8000'] and topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
+      - topo_type not in ['t0']
 
 drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv6-dst]:
   skip:
-    reason: "Image issue on Boradcom dualtor testbeds. Cisco 8000 platform does not drop packets with 0.0.0.0 source or destination IP address"
+    reason:
+    - "Image issue on Broadcom dualtor testbeds. Cisco 8000 platform does not drop packets with 0.0.0.0 source or destination IP address"
+    - "Test case requires topology type t0 for vlan testing"
     strict: True
     conditions:
-      - "asic_type in ['broadcom', 'cisco-8000']"
-      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
+      - "asic_type in ['broadcom', 'cisco-8000'] and topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
+      - topo_type not in ['t0']
 
 drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv6-src]:
   skip:
-    reason: "Image issue on Boradcom dualtor testbeds. Cisco 8000 platform does not drop packets with 0.0.0.0 source or destination IP address"
+    reason: "Image issue on Broadcom dualtor testbeds. Cisco 8000 platform does not drop packets with 0.0.0.0 source or destination IP address"
     strict: True
     conditions:
       - "asic_type in ['broadcom', 'cisco-8000']"

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -354,9 +354,15 @@ def rif_port_down(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup, fa
 
 
 @pytest.fixture(params=["port_channel_members", "vlan_members", "rif_members"])
-def tx_dut_ports(request, setup):
+def tx_dut_ports(request, setup, tbinfo):
     """ Fixture for getting port members of specific port group """
-    return setup[request.param] if setup[request.param] else pytest.skip("No {} available".format(request.param))
+    if not setup[request.param]:
+        reason = "No {} available".format(request.param)
+        if tbinfo["topo"]["type"] != "t0" and request.param == "vlan_members":
+            reason = "Test case is only suitable for t0 type topology since it requires vlan interfaces"
+        pytest.skip(reason)
+    else:
+        return setup[request.param]
 
 
 @pytest.fixture


### PR DESCRIPTION
Signed-off-by: Austin Pham austinpham@microsoft.com

This pull request enhances the clarity of skip reasons for test cases and adds new conditions for skipping tests based on topology types.

`/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml`: Improved skip reasons and added conditions for various test cases.
`/tests/drop_packets/drop_packets.py`: Updated tx_dut_ports fixture to skip tests based on topology type.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Some of the test cases were not able to leverage conditional marks since the introduction of dynamic parameters. Some of the conditional marks are not valid anymore in the files because the format is not rich enough to support dynamic parameters. As a result, I have to integrate skipping in our code

-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
