### PR TITLE
Add debug message for script `test_bgp_sentinel.py`

### DIFF
--- a/tests/bgp/test_bgp_sentinel.py
+++ b/tests/bgp/test_bgp_sentinel.py
@@ -394,9 +394,15 @@ def prepare_bgp_sentinel_routes(rand_selected_dut, common_setup_teardown, bgp_co
             announce_route(ptfip, lo_ipv6_addr, route, ptf_bp_v6, BGP_SENTINEL_PORT_V6, community)
 
     time.sleep(10)
+
     # Check if the routes are not announced to ebgp peers with no-export community
     # or w/o no-export, routes announced to ebgp peers
     for route in ipv4_routes + ipv6_routes:
+        # Check if DUT receives the routes that announced from ptf
+        cmd = "vtysh -c \'show ip bgp neighbors {} received-routes json\'".format(route)
+        output = json.loads(duthost.shell(cmd)['stdout'])
+        logger.debug(output)
+
         if 'no-export' in community:
             pytest_assert(not is_route_advertised_to_ebgp_peers(duthost, route, ibgp_sessions),
                           "Route {} should not be advertised to bgp peers".format(route))

--- a/tests/bgp/test_bgp_sentinel.py
+++ b/tests/bgp/test_bgp_sentinel.py
@@ -395,13 +395,25 @@ def prepare_bgp_sentinel_routes(rand_selected_dut, common_setup_teardown, bgp_co
 
     time.sleep(10)
 
+    # Check if DUT receives the routes that announced from ptf
+    for ibgp_session in ibgp_sessions:
+        if request.param == "IPv4":
+            cmd = "vtysh -c \'show bgp ipv4 neighbors {} received-routes json\'".format(ptf_bp_v4)
+        else:
+            cmd = "vtysh -c \'show bgp ipv6 neighbors {} received-routes json\'".format(ptf_bp_v6)
+        output = json.loads(duthost.shell(cmd)['stdout'])
+        logger.debug("ibgp_session: {}, neighbors: {}".format(ibgp_session, output))
+
     # Check if the routes are not announced to ebgp peers with no-export community
     # or w/o no-export, routes announced to ebgp peers
     for route in ipv4_routes + ipv6_routes:
-        # Check if DUT receives the routes that announced from ptf
-        cmd = "vtysh -c \'show ip bgp neighbors {} received-routes json\'".format(route)
+        # Check the status of signal routes
+        if route in ipv4_routes:
+            cmd = "vtysh -c \'show bgp ipv4 {} json\'".format(route)
+        else:
+            cmd = "vtysh -c \'show bgp ipv6 {} json\'".format(route)
         output = json.loads(duthost.shell(cmd)['stdout'])
-        logger.debug(output)
+        logger.debug("route: {}, status: {}".format(route, output))
 
         if 'no-export' in community:
             pytest_assert(not is_route_advertised_to_ebgp_peers(duthost, route, ibgp_sessions),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Flaky failure will happen in test script `test_bgp_sentinel.py`. 
```
for route in ipv4_routes + ipv6_routes:
    if 'no-export' in community:
>     pytest_assert(not is_route_advertised_to_ebgp_peers(duthost, route, ibgp_sessions),
                              "Route {} should not be advertised to bgp peers".format(route))
E     Failed: Route 100.1.0.17/32 should not be advertised to bgp peers
```
We suspect that DUT may not receive the update routes from ptf, which causes this failure. So in this PR, we add some debug  message to check if DUT receives the specific routes announced from ptf. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Flaky failure will happen in test script `test_bgp_sentinel.py`. 
```
for route in ipv4_routes + ipv6_routes:
    if 'no-export' in community:
>     pytest_assert(not is_route_advertised_to_ebgp_peers(duthost, route, ibgp_sessions),
                              "Route {} should not be advertised to bgp peers".format(route))
E     Failed: Route 100.1.0.17/32 should not be advertised to bgp peers
```
We suspect that DUT may not receive the update routes from ptf, which causes this failure. So in this PR, we add some debug  message to check if DUT receives the specific routes announced from ptf. 

#### How did you do it?
Add some debug  message to check if DUT receives the specific routes announced from ptf. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
