### PR TITLE
[dualtor] Ignore syncd's SAI_API_TUNNEL:_brcm_sai_mptnl* logs

### DIFF
--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -65,7 +65,11 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
 
     ignore_errors = [
         r".* ERR bgp#bgpmon: \*ERROR\* Failed with rc:1 when execute: vtysh -c 'show bgp summary json'",
-        r".* ERR bgp#bgpmon: \*ERROR\* Failed with rc:1 when execute: \['vtysh', '-c', 'show bgp summary json'\]"
+        r".* ERR bgp#bgpmon: \*ERROR\* Failed with rc:1 when execute: \['vtysh', '-c', 'show bgp summary json'\]",
+        r".* ERR syncd#syncd: .*SAI_API_TUNNEL:_brcm_sai_mptnl_tnl_route_event_add:\d+ ecmp table entry lookup "
+        "failed with error.*",
+        r".* ERR syncd#syncd: .*SAI_API_TUNNEL:_brcm_sai_mptnl_process_route_add_mode_default_and_host:\d+ "
+        "_brcm_sai_mptnl_tnl_route_event_add failed with error.*"
     ]
 
     if loganalyzer:

--- a/tests/log_fidelity/test_bgp_shutdown.py
+++ b/tests/log_fidelity/test_bgp_shutdown.py
@@ -10,6 +10,23 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
+
+    ignore_errors = [
+        r".* ERR syncd#syncd: .*SAI_API_TUNNEL:_brcm_sai_mptnl_tnl_route_event_add:\d+ ecmp table entry lookup "
+        "failed with error.*",
+        r".* ERR syncd#syncd: .*SAI_API_TUNNEL:_brcm_sai_mptnl_process_route_add_mode_default_and_host:\d+ "
+        "_brcm_sai_mptnl_tnl_route_event_add failed with error.*"
+    ]
+
+    if loganalyzer:
+        for duthost in duthosts:
+            loganalyzer[duthost.hostname].ignore_regex.extend(ignore_errors)
+
+    return None
+
+
 def check_syslog(duthost, prefix, trigger_action, expected_log, restore_action):
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=prefix)
     loganalyzer.expect_regex = [expected_log]

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -19,6 +19,23 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
+
+    ignore_errors = [
+        r".* ERR syncd#syncd: .*SAI_API_TUNNEL:_brcm_sai_mptnl_tnl_route_event_add:\d+ ecmp table entry lookup "
+        "failed with error.*",
+        r".* ERR syncd#syncd: .*SAI_API_TUNNEL:_brcm_sai_mptnl_process_route_add_mode_default_and_host:\d+ "
+        "_brcm_sai_mptnl_tnl_route_event_add failed with error.*"
+    ]
+
+    if loganalyzer:
+        for duthost in duthosts:
+            loganalyzer[duthost.hostname].ignore_regex.extend(ignore_errors)
+
+    return None
+
+
 def get_upstream_neigh(tb, device_neigh_metadata):
     """
     Get the information for upstream neighbors present in the testbed


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Ignore unexpected logs seen in tests performing bgp shutdown.
Fixes # [aristanetworks/sonic-qual.msft#180](https://github.com/aristanetworks/sonic-qual.msft/issues/180)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Currently, tests `dualtor_io/test_tor_bgp_failure.py`, `log_fidelity/test_bgp_shutdown.py` and `route/test_default_route.py` which have testlets performing bgp shutdown are failing during teardown because of unexpected logs `SAI_API_TUNNEL:_brcm_sai_mptnl_*`.  Otherwise, these tests would be passing.

#### How did you do it?
For each of the failing tests added/updated autouse fixture `ignore_expected_loganalyzer_exception` to make `log_analyzer` to ignore `SAI_API_TUNNEL:_brcm_sai_mptnl_*` logs.

#### How did you verify/test it?
Stressed the failing tests on `Arista-7260CX3-D108C8` and `Arista-7050CX3-32S-C32` skus and tests are passing with the changes.
 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
