### PR TITLE
Cisco-8111: adjust reduced_pause_thr to hardware value

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -71,6 +71,8 @@ class QosParamCisco(object):
                 self.reduced_pause_thr = 3 * (1024 ** 2)
             else:
                 self.reduced_pause_thr = 2.25 * (1024 ** 2)
+            if dutAsic == "gr":
+                self.reduced_pause_thr = self.gr_get_hw_thr_buffs(self.reduced_pause_thr // self.buffer_size) * self.buffer_size
             self.log("Max pause thr bytes:       {}".format(max_pause))
             self.log("Attempted pause thr bytes: {}".format(attempted_pause))
             self.log("Pre-pad pause thr bytes:   {}".format(pre_pad_pause))

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -72,7 +72,8 @@ class QosParamCisco(object):
             else:
                 self.reduced_pause_thr = 2.25 * (1024 ** 2)
             if dutAsic == "gr":
-                self.reduced_pause_thr = self.gr_get_hw_thr_buffs(self.reduced_pause_thr // self.buffer_size) * self.buffer_size
+                self.reduced_pause_thr = self.gr_get_hw_thr_buffs(self.reduced_pause_thr
+                                                                  // self.buffer_size) * self.buffer_size
             self.log("Max pause thr bytes:       {}".format(max_pause))
             self.log("Attempted pause thr bytes: {}".format(attempted_pause))
             self.log("Pre-pad pause thr bytes:   {}".format(pre_pad_pause))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
MIGSMSFT-620 [sonic-mgmt] [202305] [8111] testQosSaiPfcXonLimit failure is image regression issue.

8111 hardware value of pause threshold is slightly smaller than software config, script used software value for reduced_pause_thr which is too large. At the Xon case failure point, the SQ buffer counter indicated that SQ usage below 10MB (but above 9.75MB), from hardware threshold, it need to drop below 9.75MB to trigger XON.

```
cisco@croc-aaa12-dut:~$ sudo show platform npu rx cgm_profile -t 3 -i Ethernet16
Units are in MBytes
SQG 0
Headroom buffers 2658

ft: fc trigger
fc: flow control
dy: drop yellow
dg: drop green
NOTE: Real HW RX CGM SQ thresholds are:
  Bytes: [2555904, 10223616, 21233664]
  MB: [2.44, 9.75, 20.25]
SQG usage > 0 ==============================================

sq\ctr-a      <78.0        <85.5        <88.0         else    
                     ft           ft                     fc,ft
     2.5  ----------------------------------------------------
                     ft                     fc,ft        fc,ft
    10.0  ----------------------------------------------------
                               fc,ft        fc,ft        fc,ft
   20.71  ----------------------------------------------------
                  fc,ft        fc,ft        fc,ft        fc,ft

cisco@croc-aaa12-dut:~$ sudo show platform npu rx interface_cgm -t 3 -i Ethernet16
Rx CGM is enabled for interface Ethernet16 on slice 4
PFC enabled True, pfc mask 24
Port speed 20
Flow control mode: PFC
PFC periodic timer in ns 83333
PFC time quanta 83883
Source queue counters for Ethernet16 tc 3:
   SQ buffer counter 27304
   SQ congestion state Xoff

>>> 27304*384
10484736
>>> 10484736/1024**2
9.9990234375
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fix the testQosSaiPfcXonLimit failure for 8111.

#### How did you do it?
Adjust reduced_pause_thr to hardware value.

#### How did you verify/test it?
Verified it on 8111 T1 testbed.
```
============================================================================================= PASSES ==============================================================================================
_______________________________________________________________________ TestQosSai.testQosSaiPfcXonLimit[single_asic-xon_1] _______________________________________________________________________
_______________________________________________________________________ TestQosSai.testQosSaiPfcXonLimit[single_asic-xon_2] _______________________________________________________________________
--------------------------------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit_2024-08-21-21-20-08.xml ---------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
21:28:10 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
===================================================================================== short test summary info =====================================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2]
SKIPPED [2] qos/test_qos_sai.py:611: Additional DSCPs are not supported on non-dual ToR ports
SKIPPED [4] qos/qos_sai_base.py:632: Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests
SKIPPED [4] qos/qos_sai_base.py:639: multi-dut is not supported on T1 topologies
====================================================================== 2 passed, 10 skipped, 1 warning in 480.34s (0:08:00) =======================================================================
sonic@sonic-ucs-m5-8:/data/tests$ 
```
sonic version:
```
cisco@croc-aaa12-dut:~$ show platform version

Cisco Platform Release Version: v1.1.ss-150-g45622c85
Cisco Platform Build commit Version: 45622c851e64cc039dff25578ee36b7a4942b814
Cisco Silicon One SDK Version: 1.66.11.129-sai-1.13.0-bullseye-67b8ff1e0c
Cisco SDK Validation Version: 1.66.11.129
Cisco NP Suite Version: 1.137.1
Cisco Whitebox BSP Version: 0.4-450-g347c22b7
Cisco Whitebox FPD Version: 0.9-34-g773b29d-bullseye

cisco@croc-aaa12-dut:~$ show version

SONiC Software Version: SONiC.azure_cisco_202311.14115-dirty-20240730.104536
SONiC OS Version: 11
Distribution: Debian 11.10
Kernel: 5.10.0-23-2-amd64
Build commit: 14df88942
Build date: Tue Jul 30 23:11:18 UTC 2024
Built by: sonicci@sonic-ci-17-lnx

Platform: x86_64-8111_32eh_o-r0
HwSKU: Cisco-8111-O32
ASIC: cisco-8000
ASIC Count: 1
Serial Number: FLM2641070L
Model Number: 8111-32EH-O
Hardware Revision: 1.0
Uptime: 21:34:17 up  3:35,  1 user,  load average: 1.88, 1.73, 1.66
Date: Wed 21 Aug 2024 21:34:17
```

#### Any platform specific information?
Issue happened on 8111.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
