### PR TITLE
Fix flaky test_reload_configuration_checks when all processes are not…

### DIFF
--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -189,7 +189,8 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     result, out = execute_config_reload_cmd(duthost, config_reload_timeout)
     assert result and "Retry later" in out['stdout']
     assert wait_until(300, 20, 0, config_system_checks_passed, duthost, delayed_services)
-
+    # Wait untill all critical processes come up so that it doesnt interfere with swss stop job
+    wait_critical_processes(duthost)
     logging.info("Stopping swss docker and checking config reload")
     if duthost.is_multi_asic:
         for asic in duthost.asics:


### PR DESCRIPTION
… up during swss stop job

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The testcase test_reload_configuration_checks fails sometimes when swss is stopped after a config reload and some of the critical processes are still coming up. The stop job of swss in the queue is cancelled due to other critical processes still coming up and trying to bring up swss. Hence, we get the error - "Job for swss.service cancelled"
#### How did you do it?
This PR enhanced the testcase to wait until all the critical processes are up after a config reload and then execute a stop job for swss. 
#### How did you verify/test it?
Ran the testcase 15-20 times to see if it fails. 
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA

