### PR TITLE
Xfail copp add/remove trap tests on 7050CX3 SKUs

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -208,6 +208,7 @@ copp/test_copp.py::TestCOPP::test_add_new_trap:
     conditions:
       - "hwsku in ['Arista-7050CX3-32C-C32', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
       - "release in ['202311']"
+      - https://github.com/sonic-net/sonic-buildimage/issues/20081
 
 copp/test_copp.py::TestCOPP::test_remove_trap:
   skip:
@@ -220,6 +221,7 @@ copp/test_copp.py::TestCOPP::test_remove_trap:
     conditions:
       - "hwsku in ['Arista-7050CX3-32C-C32', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
       - "release in ['202311']"
+      - https://github.com/sonic-net/sonic-buildimage/issues/20081
 
 copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -203,11 +203,23 @@ copp/test_copp.py::TestCOPP::test_add_new_trap:
     conditions:
       - "is_multi_asic==True"
 
+  xfail:
+    reason: "Can't unisntall trap on broadcom 7050CX3 SKUs successfully"
+    conditions:
+      - "hwsku in ['Arista-7050CX3-32C-C32', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
+      - "release in ['202311']"
+
 copp/test_copp.py::TestCOPP::test_remove_trap:
   skip:
     reason: "Copp test_remove_trap is not yet supported on multi-asic platform"
     conditions:
       - "is_multi_asic==True"
+
+  xfail:
+    reason: "Can't unisntall trap on broadcom 7050CX3 SKUs successfully"
+    conditions:
+      - "hwsku in ['Arista-7050CX3-32C-C32', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
+      - "release in ['202311']"
 
 copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
   skip:


### PR DESCRIPTION
### Description of PR
Adding and removing traps still unsupported for 7050CX3 SKUs in 202311 as well, so should continue to xfail tests.

Summary:
Fixes [# (issue)](https://github.com/aristanetworks/sonic-qual.msft/issues/200)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
