### PR TITLE
Change topo requirements on dualtor tests to only run on dualtor

### DIFF
--- a/tests/dualtor/test_orch_stress.py
+++ b/tests/dualtor/test_orch_stress.py
@@ -29,7 +29,7 @@ from tests.common.dualtor.dual_tor_utils import tor_mux_intfs       # noqa F401
 from tests.common.dualtor.dual_tor_mock import *                    # noqa F401
 
 pytestmark = [
-    pytest.mark.topology("t0")
+    pytest.mark.topology("dualtor")
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -29,7 +29,7 @@ from tests.common.utilities import wait_until
 
 
 pytestmark = [
-    pytest.mark.topology('t0'),
+    pytest.mark.topology('dualtor'),
     pytest.mark.usefixtures('apply_mock_dual_tor_tables',
                             'apply_mock_dual_tor_kernel_configs',
                             'apply_active_state_to_orchagent',

--- a/tests/dualtor/test_orchagent_mac_move.py
+++ b/tests/dualtor/test_orchagent_mac_move.py
@@ -20,7 +20,7 @@ from tests.common.utilities import dump_scapy_packet_show_output
 
 
 pytestmark = [
-    pytest.mark.topology('t0'),
+    pytest.mark.topology('dualtor'),
     pytest.mark.usefixtures('apply_mock_dual_tor_tables',
                             'apply_mock_dual_tor_kernel_configs',
                             'run_garp_service',

--- a/tests/dualtor/test_orchagent_standby_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_standby_tor_downstream.py
@@ -31,7 +31,7 @@ from tests.common.utilities import wait_until
 
 
 pytestmark = [
-    pytest.mark.topology('t0'),
+    pytest.mark.topology('dualtor'),
     pytest.mark.usefixtures('apply_mock_dual_tor_tables',
                             'apply_mock_dual_tor_kernel_configs',
                             'apply_standby_state_to_orchagent',

--- a/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
+++ b/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
@@ -18,7 +18,7 @@ from tests.common.fixtures.duthost_utils import skip_traffic_test               
 logger = logging.getLogger(__file__)
 
 pytestmark = [
-    pytest.mark.topology('t0'),
+    pytest.mark.topology('dualtor'),
     pytest.mark.usefixtures('apply_mock_dual_tor_tables', 'apply_mock_dual_tor_kernel_configs',
                             'run_garp_service', 'run_icmp_responder')
 ]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Currently there are dualtor tests that match on the 't0' topo, which include non-dualtor 't0' topos. Changing the tests so it will only match 'dualtor' topos.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Replace the topo check with `dualtor`
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
