### PR TITLE
[202311]Add definition of topology dualtor-64-breakout and dualtor-aa-64-breakout for hwsku Mellanox-SN4700-V64

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -21,7 +21,7 @@ broadcom_jr2_hwskus: ['Arista-7800R3-48CQ2-C48', 'Arista-7800R3-48CQM2-C48']
 
 mellanox_spc1_hwskus: [ 'ACS-MSN2700', 'ACS-MSN2740', 'ACS-MSN2100', 'ACS-MSN2410', 'ACS-MSN2010', 'Mellanox-SN2700', 'Mellanox-SN2700-A1', 'Mellanox-SN2700-D48C8','Mellanox-SN2700-D40C8S8', 'Mellanox-SN2700-A1-D48C8']
 mellanox_spc2_hwskus: [ 'ACS-MSN3700', 'ACS-MSN3700C', 'ACS-MSN3800', 'Mellanox-SN3800-D112C8' , 'ACS-MSN3420']
-mellanox_spc3_hwskus: [ 'ACS-MSN4700', 'Mellanox-SN4700-O28', 'ACS-MSN4600', 'ACS-MSN4600C', 'ACS-MSN4410', 'Mellanox-SN4600C-D112C8', 'Mellanox-SN4600C-C64', 'Mellanox-SN4700-O8C48', 'Mellanox-SN4700-O8V48']
+mellanox_spc3_hwskus: [ 'ACS-MSN4700', 'Mellanox-SN4700-O28', 'ACS-MSN4600', 'ACS-MSN4600C', 'ACS-MSN4410', 'Mellanox-SN4600C-D112C8', 'Mellanox-SN4600C-C64', 'Mellanox-SN4700-O8C48', 'Mellanox-SN4700-O8V48', 'Mellanox-SN4700-V64']
 mellanox_spc4_hwskus: [ 'ACS-SN5600' ]
 mellanox_hwskus: "{{ mellanox_spc1_hwskus + mellanox_spc2_hwskus + mellanox_spc3_hwskus + mellanox_spc4_hwskus }}"
 mellanox_dualtor_hwskus: [ 'Mellanox-SN4600C-C64' ]

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -186,7 +186,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
                 alias = "etp%d" % (i / 4 + 1) + ("a" if i % 4 == 0 else "b")
                 # print alias, "Ethernet%d" % i
                 port_alias_to_name_map[alias] = "Ethernet%d" % i
-        elif hwsku in ["ACS-MSN3800", "ACS-MSN4600C"]:
+        elif hwsku in ["ACS-MSN3800", "ACS-MSN4600C", 'Mellanox-SN4700-V64']:
             for i in range(1, 65):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % ((i - 1) * 4)
         elif hwsku == "Mellanox-SN2700" or hwsku == "ACS-MSN2700":

--- a/ansible/roles/eos/templates/dualtor-64-breakout-leaf.j2
+++ b/ansible/roles/eos/templates/dualtor-64-breakout-leaf.j2
@@ -1,0 +1,1 @@
+dualtor-leaf.j2

--- a/ansible/roles/eos/templates/dualtor-aa-64-breakout-leaf.j2
+++ b/ansible/roles/eos/templates/dualtor-aa-64-breakout-leaf.j2
@@ -1,0 +1,1 @@
+dualtor-leaf.j2

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -259,7 +259,7 @@ testcases:
 
     reboot:
       filename: reboot.yml
-      topologies: [dualtor, t0, t0-52, t0-56, t0-56-po2vlan, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-28-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [dualtor, dualtor-64-breakout, dualtor-aa-64-breakout, t0, t0-52, t0-56, t0-56-po2vlan, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-28-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     repeat_harness:
       filename: repeat_harness.yml

--- a/ansible/vars/topo_dualtor-64-breakout.yml
+++ b/ansible/vars/topo_dualtor-64-breakout.yml
@@ -1,0 +1,359 @@
+topology:
+  dut_num: 2
+  host_interfaces:
+    - 0.0@0,1.0@0
+    - 0.1@1,1.1@1
+    - 0.2@2,1.2@2
+    - 0.3@3,1.3@3
+    - 0.4@4,1.4@4
+    - 0.5@5,1.5@5
+    - 0.6@6,1.6@6
+    - 0.7@7,1.7@7
+    - 0.8@8,1.8@8
+    - 0.9@9,1.9@9
+    - 0.10@10,1.10@10
+    - 0.11@11,1.11@11
+    - 0.12@12,1.12@12
+    - 0.13@13,1.13@13
+    - 0.14@14,1.14@14
+    - 0.15@15,1.15@15
+    - 0.16@16,1.16@16
+    - 0.17@17,1.17@17
+    - 0.18@18,1.18@18
+    - 0.19@19,1.19@19
+    - 0.20@20,1.20@20
+    - 0.21@21,1.21@21
+    - 0.22@22,1.22@22
+    - 0.23@23,1.23@23
+    - 0.40@40,1.40@40
+    - 0.41@41,1.41@41
+    - 0.42@42,1.42@42
+    - 0.43@43,1.43@43
+    - 0.44@44,1.44@44
+    - 0.45@45,1.45@45
+    - 0.46@46,1.46@46
+    - 0.47@47,1.47@47
+    - 0.48@48,1.48@48
+    - 0.49@49,1.49@49
+    - 0.50@50,1.50@50
+    - 0.51@51,1.51@51
+    - 0.52@52,1.52@52
+    - 0.53@53,1.53@53
+    - 0.54@54,1.54@54
+    - 0.55@55,1.55@55
+    - 0.56@56,1.56@56
+    - 0.57@57,1.57@57
+    - 0.58@58,1.58@58
+    - 0.59@59,1.59@59
+    - 0.60@60,1.60@60
+    - 0.61@61,1.61@61
+    - 0.62@62,1.62@62
+    - 0.63@63,1.63@63
+  disabled_host_interfaces:
+    - 0.1@1,1.1@1
+    - 0.3@3,1.3@3
+    - 0.5@5,1.5@5
+    - 0.7@7,1.7@7
+    - 0.9@9,1.9@9
+    - 0.11@11,1.11@11
+    - 0.13@13,1.13@13
+    - 0.15@15,1.15@15
+    - 0.17@17,1.17@17
+    - 0.19@19,1.19@19
+    - 0.21@21,1.21@21
+    - 0.23@23,1.23@23
+    - 0.41@41,1.41@41
+    - 0.43@43,1.43@43
+    - 0.45@45,1.45@45
+    - 0.47@47,1.47@47
+    - 0.49@49,1.49@49
+    - 0.51@51,1.51@51
+    - 0.53@53,1.53@53
+    - 0.55@55,1.55@55
+    - 0.57@57,1.57@57
+    - 0.59@59,1.59@59
+    - 0.61@61,1.61@61
+    - 0.62@62,1.62@62
+    - 0.63@63,1.63@63
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - "0.24@64"
+        - "0.26@65"
+        - "1.24@66"
+        - "1.26@67"
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - "0.28@68"
+        - "0.30@69"
+        - "1.28@70"
+        - "1.30@71"
+      vm_offset: 1
+    ARISTA03T1:
+      vlans:
+        - "0.32@72"
+        - "0.34@73"
+        - "1.32@74"
+        - "1.34@75"
+      vm_offset: 2
+    ARISTA04T1:
+      vlans:
+        - "0.36@76"
+        - "0.38@77"
+        - "1.36@78"
+        - "1.38@79"
+      vm_offset: 3
+  DUT:
+    loopback:
+      ipv4:
+        - 10.1.0.32/32
+        - 10.1.0.33/32
+      ipv6:
+        - FC00:1:0:32::/128
+        - FC00:1:0:33::/128
+    loopback1:
+      ipv4:
+        - 10.1.0.34/32
+        - 10.1.0.35/32
+      ipv6:
+        - FC00:1:0:34::/128
+        - FC00:1:0:35::/128
+    loopback2:
+      ipv4:
+        - 10.1.0.36/32
+        - 10.1.0.36/32
+      ipv6:
+        - FC00:1:0:36::/128
+        - FC00:1:0:36::/128
+    loopback3:
+      ipv4:
+        - 10.1.0.38/32
+        - 10.1.0.39/32
+      ipv6:
+        - FC00:1:0:38::/128
+        - FC00:1:0:39::/128
+    vlan_configs:
+      default_vlan_config: one_vlan_a
+      one_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60]
+          prefix: 192.168.0.1/21
+          prefix_v6: fc02:1000::1/64
+          tag: 1000
+          mac: 00:aa:bb:cc:dd:ee
+      two_vlan_a:
+        Vlan100:
+          id: 100
+          intfs: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22]
+          prefix: 192.168.0.1/22
+          prefix_v6: fc02:100::1/64
+          tag: 100
+        Vlan200:
+          id: 200
+          intfs: [40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60]
+          prefix: 192.168.4.1/22
+          prefix_v6: fc02:200::1/64
+          tag: 200
+      four_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [0, 2, 4, 6, 8, 10]
+          prefix: 192.168.0.1/23
+          prefix_v6: fc02:400::1/64
+          tag: 1000
+        Vlan2000:
+          id: 2000
+          intfs: [12, 14, 16, 18, 20, 22]
+          prefix: 192.168.2.1/23
+          prefix_v6: fc02:401::1/64
+          tag: 2000
+        Vlan3000:
+          id: 3000
+          intfs: [40, 42, 44, 46, 48, 50]
+          prefix: 192.168.4.1/23
+          prefix_v6: fc02:402::1/64
+          tag: 3000
+        Vlan4000:
+          id: 4000
+          intfs: [52, 54, 56, 58, 60]
+          prefix: 192.168.6.1/23
+          prefix_v6: fc02:403::1/64
+          tag: 4000
+    tunnel_configs:
+      default_tunnel_config: tunnel_ipinip
+      tunnel_ipinip:
+        MuxTunnel0:
+          type: IPInIP
+          attach_to: Loopback0
+          dscp: uniform
+          ecn_encap: standard
+          ecn_decap: copy_from_outer
+          ttl_mode: pipe
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: ToRRouter
+    swrole: leaf
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65500
+    failure_rate: 0
+
+configuration:
+  ARISTA01T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.56
+        - FC00::71
+        - 10.0.1.56
+        - FC00::1:71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+      Port-Channel2:
+        ipv4: 10.0.1.57/31
+        ipv6: fc00::1:72/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::1d/64
+
+  ARISTA02T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.58
+        - FC00::75
+        - 10.0.1.58
+        - FC00::1:75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+      Port-Channel2:
+        ipv4: 10.0.1.59/31
+        ipv6: fc00::1:76/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::1e/64
+
+  ARISTA03T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.60
+        - FC00::79
+        - 10.0.1.60
+        - FC00::1:79
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+      Port-Channel2:
+        ipv4: 10.0.1.61/31
+        ipv6: fc00::1:7a/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::1f/64
+
+  ARISTA04T1:
+    properties:
+    - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.62
+        - FC00::7D
+        - 10.0.1.62
+        - FC00::1:7D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+      Port-Channel2:
+        ipv4: 10.0.1.63/31
+        ipv6: fc00::1:7e/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::20/64

--- a/ansible/vars/topo_dualtor-aa-64-breakout.yml
+++ b/ansible/vars/topo_dualtor-aa-64-breakout.yml
@@ -1,0 +1,384 @@
+topology:
+  dut_num: 2
+  host_interfaces:
+    - 0.0@0,1.0@0
+    - 0.1@1,1.1@1
+    - 0.2@2,1.2@2
+    - 0.3@3,1.3@3
+    - 0.4@4,1.4@4
+    - 0.5@5,1.5@5
+    - 0.6@6,1.6@6
+    - 0.7@7,1.7@7
+    - 0.8@8,1.8@8
+    - 0.9@9,1.9@9
+    - 0.10@10,1.10@10
+    - 0.11@11,1.11@11
+    - 0.12@12,1.12@12
+    - 0.13@13,1.13@13
+    - 0.14@14,1.14@14
+    - 0.15@15,1.15@15
+    - 0.16@16,1.16@16
+    - 0.17@17,1.17@17
+    - 0.18@18,1.18@18
+    - 0.19@19,1.19@19
+    - 0.20@20,1.20@20
+    - 0.21@21,1.21@21
+    - 0.22@22,1.22@22
+    - 0.23@23,1.23@23
+    - 0.40@40,1.40@40
+    - 0.41@41,1.41@41
+    - 0.42@42,1.42@42
+    - 0.43@43,1.43@43
+    - 0.44@44,1.44@44
+    - 0.45@45,1.45@45
+    - 0.46@46,1.46@46
+    - 0.47@47,1.47@47
+    - 0.48@48,1.48@48
+    - 0.49@49,1.49@49
+    - 0.50@50,1.50@50
+    - 0.51@51,1.51@51
+    - 0.52@52,1.52@52
+    - 0.53@53,1.53@53
+    - 0.54@54,1.54@54
+    - 0.55@55,1.55@55
+    - 0.56@56,1.56@56
+    - 0.57@57,1.57@57
+    - 0.58@58,1.58@58
+    - 0.59@59,1.59@59
+    - 0.60@60,1.60@60
+    - 0.61@61,1.61@61
+    - 0.62@62,1.62@62
+    - 0.63@63,1.63@63
+  disabled_host_interfaces:
+    - 0.1@1,1.1@1
+    - 0.3@3,1.3@3
+    - 0.5@5,1.5@5
+    - 0.7@7,1.7@7
+    - 0.9@9,1.9@9
+    - 0.11@11,1.11@11
+    - 0.13@13,1.13@13
+    - 0.15@15,1.15@15
+    - 0.17@17,1.17@17
+    - 0.19@19,1.19@19
+    - 0.21@21,1.21@21
+    - 0.23@23,1.23@23
+    - 0.41@41,1.41@41
+    - 0.43@43,1.43@43
+    - 0.45@45,1.45@45
+    - 0.47@47,1.47@47
+    - 0.49@49,1.49@49
+    - 0.51@51,1.51@51
+    - 0.53@53,1.53@53
+    - 0.55@55,1.55@55
+    - 0.57@57,1.57@57
+    - 0.59@59,1.59@59
+    - 0.61@61,1.61@61
+    - 0.62@62,1.62@62
+    - 0.63@63,1.63@63
+  host_interfaces_active_active:
+    - 0.0@0,1.0@0
+    - 0.2@2,1.2@2
+    - 0.4@4,1.4@4
+    - 0.6@6,1.6@6
+    - 0.8@8,1.8@8
+    - 0.10@10,1.10@10
+    - 0.12@12,1.12@12
+    - 0.14@14,1.14@14
+    - 0.16@16,1.16@16
+    - 0.18@18,1.18@18
+    - 0.20@20,1.20@20
+    - 0.22@22,1.22@22
+    - 0.40@40,1.40@40
+    - 0.42@42,1.42@42
+    - 0.44@44,1.44@44
+    - 0.46@46,1.46@46
+    - 0.48@48,1.48@48
+    - 0.50@50,1.50@50
+    - 0.52@52,1.52@52
+    - 0.54@54,1.54@54
+    - 0.56@56,1.56@56
+    - 0.58@58,1.58@58
+    - 0.60@60,1.60@60
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - "0.24@64"
+        - "0.26@65"
+        - "1.24@66"
+        - "1.26@67"
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - "0.28@68"
+        - "0.30@69"
+        - "1.28@70"
+        - "1.30@71"
+      vm_offset: 1
+    ARISTA03T1:
+      vlans:
+        - "0.32@72"
+        - "0.34@73"
+        - "1.32@74"
+        - "1.34@75"
+      vm_offset: 2
+    ARISTA04T1:
+      vlans:
+        - "0.36@76"
+        - "0.38@77"
+        - "1.36@78"
+        - "1.38@79"
+      vm_offset: 3
+  DUT:
+    loopback:
+      ipv4:
+        - 10.1.0.32/32
+        - 10.1.0.33/32
+      ipv6:
+        - FC00:1:0:32::/128
+        - FC00:1:0:33::/128
+    loopback1:
+      ipv4:
+        - 10.1.0.34/32
+        - 10.1.0.35/32
+      ipv6:
+        - FC00:1:0:34::/128
+        - FC00:1:0:35::/128
+    loopback2:
+      ipv4:
+        - 10.1.0.36/32
+        - 10.1.0.36/32
+      ipv6:
+        - FC00:1:0:36::/128
+        - FC00:1:0:36::/128
+    loopback3:
+      ipv4:
+        - 10.1.0.38/32
+        - 10.1.0.39/32
+      ipv6:
+        - FC00:1:0:38::/128
+        - FC00:1:0:39::/128
+    vlan_configs:
+      default_vlan_config: one_vlan_a
+      one_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [ 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60 ]
+          prefix: 192.168.0.1/21
+          prefix_v6: fc02:1000::1/64
+          tag: 1000
+          mac: 00:aa:bb:cc:dd:ee
+      two_vlan_a:
+        Vlan100:
+          id: 100
+          intfs: [ 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22 ]
+          prefix: 192.168.0.1/22
+          prefix_v6: fc02:100::1/64
+          tag: 100
+        Vlan200:
+          id: 200
+          intfs: [ 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60 ]
+          prefix: 192.168.4.1/22
+          prefix_v6: fc02:200::1/64
+          tag: 200
+      four_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [ 0, 2, 4, 6, 8, 10 ]
+          prefix: 192.168.0.1/23
+          prefix_v6: fc02:400::1/64
+          tag: 1000
+        Vlan2000:
+          id: 2000
+          intfs: [ 12, 14, 16, 18, 20, 22 ]
+          prefix: 192.168.2.1/23
+          prefix_v6: fc02:401::1/64
+          tag: 2000
+        Vlan3000:
+          id: 3000
+          intfs: [ 40, 42, 44, 46, 48, 50 ]
+          prefix: 192.168.4.1/23
+          prefix_v6: fc02:402::1/64
+          tag: 3000
+        Vlan4000:
+          id: 4000
+          intfs: [ 52, 54, 56, 58, 60 ]
+          prefix: 192.168.6.1/23
+          prefix_v6: fc02:403::1/64
+          tag: 4000
+    tunnel_configs:
+      default_tunnel_config: tunnel_ipinip
+      tunnel_ipinip:
+        MuxTunnel0:
+          type: IPInIP
+          attach_to: Loopback0
+          dscp: uniform
+          ecn_encap: standard
+          ecn_decap: copy_from_outer
+          ttl_mode: pipe
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: ToRRouter
+    swrole: leaf
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65500
+    failure_rate: 0
+
+
+configuration:
+  ARISTA01T1:
+    properties:
+      - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.56
+          - FC00::71
+          - 10.0.1.56
+          - FC00::1:71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+      Port-Channel2:
+        ipv4: 10.0.1.57/31
+        ipv6: fc00::1:72/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::1d/64
+
+  ARISTA02T1:
+    properties:
+      - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.58
+          - FC00::75
+          - 10.0.1.58
+          - FC00::1:75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+      Port-Channel2:
+        ipv4: 10.0.1.59/31
+        ipv6: fc00::1:76/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::1e/64
+
+  ARISTA03T1:
+    properties:
+      - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.60
+          - FC00::79
+          - 10.0.1.60
+          - FC00::1:79
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+      Port-Channel2:
+        ipv4: 10.0.1.61/31
+        ipv6: fc00::1:7a/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::1f/64
+
+  ARISTA04T1:
+    properties:
+      - common
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+          - 10.0.0.62
+          - FC00::7D
+          - 10.0.1.62
+          - FC00::1:7D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Ethernet3:
+        lacp: 2
+        dut_index: 1
+      Ethernet4:
+        lacp: 2
+        dut_index: 1
+      Port-Channel1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+      Port-Channel2:
+        ipv4: 10.0.1.63/31
+        ipv6: fc00::1:7e/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::20/64

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -36,7 +36,7 @@ class QosBase:
     Common APIs
     """
     SUPPORTED_T0_TOPOS = ["t0", "t0-56-po2vlan", "t0-64", "t0-116", "t0-35", "dualtor-56", "dualtor-64", "dualtor-120",
-                          "dualtor", "t0-120", "t0-80", "t0-backend", "t0-56-o8v48", "t0-8-lag"]
+                          "dualtor", "dualtor-64-breakout", "t0-120", "t0-80", "t0-backend", "t0-56-o8v48", "t0-8-lag"]
     SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-56-lag", "t1-backend", "t1-28-lag", "t1-32-lag"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
     SUPPORTED_ASIC_LIST = ["pac", "gr", "gr2", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "td3", "th3",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add definition of the two new dualtor breakout topology dualtor-64-breakout and dualtor-64-aa-breakout for hwsku Mellanox-SN4700-V64 test usage
Add support into related cases in regression test
It's the conflict handle of original PR #13980.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Add new topology definition for dualtor setup
#### How did you do it?
Add definition of topology dualtor-64-breakout and dualtor-aa-64-breakout
#### How did you verify/test it?
Validate it in internal setup
#### Any platform specific information?
Mellanox sn4700
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
