### PR TITLE
enlarge timeout for test_bgp_session_interface_down

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -147,7 +147,7 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
 
     duthost.shell('show ip bgp summary', module_ignore_errors=True)
     pytest_assert(
-        wait_until(60, 5, 0, verify_bgp_session_down, duthost, neighbor),
+        wait_until(90, 5, 0, verify_bgp_session_down, duthost, neighbor),
         "neighbor {} state is still established".format(neighbor)
     )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The session turning down time is much longer on the kvm than on the physical device, on kvm need more than 60s to down while the timeout in case is 60s, then caused the failure.

kvm
https://elastictest.org/scheduler/testplan/66c75e63e97672c662eb2109?testcase=bgp%2Ftest_bgp_session.py&type=log
22/08/2024 16:21:48 utilities.wait_until                     L0125 DEBUG  | Wait until check_bgp_session_state is True, timeout is 30 seconds, checking interval is 5, delay is 0 seconds
22/08/2024 16:23:02 utilities.wait_until                     L0135 DEBUG  | Time elapsed: 62.065256 seconds
...
22/08/2024 16:23:04 utilities.wait_until                     L0150 DEBUG  | verify_bgp_session_down is True, exit early with True
 
Physical device
https://elastictest.org/scheduler/testplan/66c7110cf93ad6e0b17253fb?testcase=bgp%2Ftest_bgp_session.py%7C%7C%7C0&type=log
22/08/2024 11:30:53 utilities.wait_until                     L0125 DEBUG  | Wait until verify_bgp_session_down is True, timeout is 60 seconds, checking interval is 5, delay is 0 seconds
22/08/2024 11:30:53 utilities.wait_until                     L0135 DEBUG  | Time elapsed: 0.000000 seconds
...
22/08/2024 11:30:58 utilities.wait_until                     L0150 DEBUG  | verify_bgp_session_down is True, exit early with True

#### How did you do it?
Enlarge the timeout value at this moment, need to check why the different between physical and kvm device

#### How did you verify/test it?
https://elastictest.org/scheduler/testplan/66c75e63e97672c662eb2109?testcase=bgp%2Ftest_bgp_session.py&type=log

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
