### PR TITLE
Add `multi-asic` support to `test_snmp_phy_entity.py`

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -786,7 +786,8 @@ def redis_get_keys(duthost, db_id, pattern):
     :param pattern: Redis key pattern
     :return: A list of key name in string
     """
-    totalOutput=[]
+    totalOutput = []
+
     def run_cmd_store_output(cmd):
         logging.debug('Getting keys from redis by command: {}'.format(cmd))
         output = duthost.shell(cmd)['stdout'].strip()
@@ -802,6 +803,7 @@ def redis_get_keys(duthost, db_id, pattern):
     cmd = 'sonic-db-cli {} KEYS \"{}\"'.format(db_id, pattern)
     run_cmd_store_output(cmd)
     return totalOutput if totalOutput else None
+
 
 def redis_hgetall(duthost, db_id, key):
     """
@@ -833,6 +835,7 @@ def redis_hgetall(duthost, db_id, key):
     if output:
         return output
     return {}
+
 
 def is_null_str(value):
     """


### PR DESCRIPTION
`test_snmp_phy_entity.py` queries `STATE_DB` in only the default namespace.
Some of the test require access to entries that are only present in the asic namespaces on multi-asic systems.
E.G. `test_transceiver_info` queries for the `TRANSCEIVER_INFO` in the default namespace but they only exist in the asic namespace:
```
root@cmp214-6:~# sonic-db-cli STATE_DB keys \* | grep -i "TRANSCEIVER_INFO" | wc -l
0
root@cmp214-6:~# sonic-db-cli -n asic0 STATE_DB keys \* | grep -i "TRANSCEIVER_INFO" | wc -l
13
root@cmp214-6:~# sonic-db-cli -n asic1 STATE_DB keys \* | grep -i "TRANSCEIVER_INFO" | wc -l
14
```

It's for that reason that the test is being skipped on multi-asic LCs:
```
keys = redis_get_keys(duthost, STATE_DB, XCVR_KEY_TEMPLATE.format('*'))
# Ignore the test if the platform does not have interfaces (e.g Supervisor)
if not keys:
    pytest.skip('Transceiver information does not exist in DB, skipping this test')
```

Updated the functions to query asic DBs:
`redis_get_keys` - Concatenate results from asic namespaces and default namespaces
`redis_hgetall` - Search and return result from either asic namespace or default namespace

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
