### PR TITLE
Fix leap year FEB29 causing ValueError exception in test_warm_reboot

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -290,8 +290,9 @@ class Arista(host_device.HostDevice):
             m = re_compiled.match(line)
             if not m:
                 continue
+            # add year to avoid ValueError exception for FEB29 during leap year
             raw_data.append((datetime.datetime.strptime(
-                m.group(1), "%b %d %X"), m.group(2), m.group(3)))
+                    str(datetime.datetime.now().year) + " " + m.group(1), "%Y %b %d %X"), m.group(2), m.group(3)))
 
         if len(raw_data) > 0:
             initial_time = raw_data[0][0]

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -44,7 +44,11 @@ def _parse_timestamp(timestamp):
             return time
         except ValueError:
             continue
-    raise ValueError("Unable to parse {} with any known format".format(timestamp))
+    # Handling leap year FEB29 case, where year not provided causing exception
+    # if strptime fails for all format, check if its leap year
+    # ValueError exception will be raised for invalid cases for strptime
+    time = datetime.strptime(str(datetime.now().year) + " " + timestamp, FMT_YEAR)
+    return time
 
 
 @pytest.fixture(autouse=True, scope="module")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix platform_tests/test_advanced_reboot.py::test_warm_reboot, [Issue #11816 ](https://github.com/sonic-net/sonic-mgmt/issues/11816) where FEB29 raises ValueError exception during date parsing function strptime.
Added code to check if current year is leap year to prevent this false exception, where default year used during date parsing was year 1900, not a leap year.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Pipeline failure back in 2024 FEB 29, where tests failed during test_warm_reboot, due to default year(1900) not a leap year, which makes 1900FEB29 an invalid date to parse.
#### How did you do it?

#### How did you verify/test it?
Change local time to FEB29 to check if new change can handle the day as expected.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
