### PR TITLE
fix: add extra wait time for ACL test

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1435,7 +1435,7 @@ class TestAclWithReboot(TestBasicAcl):
 
         """
         dut.command("config save -y")
-        reboot(dut, localhost, wait=240)
+        reboot(dut, localhost, safe_reboot=True, check_intf_up_ports=True)
         # We need some additional delay on e1031
         if dut.facts["platform"] == "x86_64-cel_e1031-r0":
             time.sleep(240)

--- a/tests/common/port_toggle.py
+++ b/tests/common/port_toggle.py
@@ -40,7 +40,7 @@ def port_toggle(duthost, tbinfo, ports=None, wait_time_getter=None, wait_after_p
     if not wait_time_getter:
         wait_time_getter = default_port_toggle_wait_time
 
-    port_down_wait_time, port_up_wait_time = wait_time_getter(duthost, len(ports), tbinfo['topo']['type'])
+    port_down_wait_time, port_up_wait_time = wait_time_getter(duthost, len(ports))
     logger.info("Toggling ports:\n%s", pprint.pformat(ports))
 
     cmds_down = []
@@ -105,7 +105,7 @@ def log_system_resources(duthost, logger):
     logger.info("Redis Memory: %s", redis_memory)
 
 
-def default_port_toggle_wait_time(duthost, port_count, topo_type):
+def default_port_toggle_wait_time(duthost, port_count):
     """Get the default timeout for shutting down/starting up a set of ports.
 
     Port toggle wait time can depend on many factors: port count, cpu type, etc. The callback allows
@@ -114,7 +114,6 @@ def default_port_toggle_wait_time(duthost, port_count, topo_type):
     Args:
         duthost: DUT host object
         port_count: total number of ports to toggle
-        topo_type: topology type
 
     Returns
         (int, int): timeout for shutting down ports, and timeout for bringing up ports
@@ -129,7 +128,7 @@ def default_port_toggle_wait_time(duthost, port_count, topo_type):
         port_count_factor = port_count / BASE_PORT_COUNT
         port_down_wait_time = int(port_down_wait_time * port_count_factor)
         port_up_wait_time = int(port_up_wait_time * port_count_factor)
-    elif asic_type == "cisco-8000" and topo_type == "t2":
+    elif duthost.get_facts().get("modular_chassis").lower() == "true":
         port_down_wait_time = 300
         port_up_wait_time = 300
 

--- a/tests/common/port_toggle.py
+++ b/tests/common/port_toggle.py
@@ -40,7 +40,7 @@ def port_toggle(duthost, tbinfo, ports=None, wait_time_getter=None, wait_after_p
     if not wait_time_getter:
         wait_time_getter = default_port_toggle_wait_time
 
-    port_down_wait_time, port_up_wait_time = wait_time_getter(duthost, len(ports))
+    port_down_wait_time, port_up_wait_time = wait_time_getter(duthost, len(ports), tbinfo['topo']['type'])
     logger.info("Toggling ports:\n%s", pprint.pformat(ports))
 
     cmds_down = []
@@ -105,7 +105,7 @@ def log_system_resources(duthost, logger):
     logger.info("Redis Memory: %s", redis_memory)
 
 
-def default_port_toggle_wait_time(duthost, port_count):
+def default_port_toggle_wait_time(duthost, port_count, topo_type):
     """Get the default timeout for shutting down/starting up a set of ports.
 
     Port toggle wait time can depend on many factors: port count, cpu type, etc. The callback allows
@@ -114,6 +114,7 @@ def default_port_toggle_wait_time(duthost, port_count):
     Args:
         duthost: DUT host object
         port_count: total number of ports to toggle
+        topo_type: topology type
 
     Returns
         (int, int): timeout for shutting down ports, and timeout for bringing up ports
@@ -128,5 +129,8 @@ def default_port_toggle_wait_time(duthost, port_count):
         port_count_factor = port_count / BASE_PORT_COUNT
         port_down_wait_time = int(port_down_wait_time * port_count_factor)
         port_up_wait_time = int(port_up_wait_time * port_count_factor)
+    elif asic_type == "cisco-8000" and topo_type == "t2":
+        port_down_wait_time = 300
+        port_up_wait_time = 300
 
     return port_down_wait_time, port_up_wait_time


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In the last chassis sync meeting, we agreed on the following changes to `acl/test_acl.py` to make it more stable on T2 chassis:
1. Increase the reboot wait time
2. Increase the wait time for port toggle to 5 min for both up and down
3. Increase the `aclshow -a` wait time

In this PR, we have increased the reboot wait time by enabling `safe_reboot` and increased the wait time for port toggle to 5 min if it is a chassis. The `aclshow -a` wait time increase has been included in #13858.

Summary:
Fixes # (issue) Microsoft ADO 29182672

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Make `acl/test_acl.py` more stable on Cisco T2 chassis

#### How did you do it?

#### How did you verify/test it?
I ran the updated test on Cisco T2 chassis and made sure the changes are in-place.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
