### PR TITLE
skip test when no portchannel interfaces are detected

### DIFF
--- a/tests/common/helpers/portchannel_to_vlan.py
+++ b/tests/common/helpers/portchannel_to_vlan.py
@@ -422,3 +422,23 @@ def setup_po2vlan(duthosts, ptfhost, rand_one_dut_hostname, rand_selected_dut, p
     finally:
         config_reload(duthost, safe_reload=True)
         ptf_teardown(ptfhost, ptf_lag_map)
+
+
+def has_portchannels(duthosts, rand_one_dut_hostname):
+    """
+    Check if the ansible_facts contain non-empty portchannel interfaces and portchannels.
+
+    Args:
+        duthosts: A dictionary that maps DUT hostnames to DUT instances.
+        rand_one_dut_hostname: A random hostname belonging to one of the DUT instances.
+    Returns:
+        bool: True if the ansible_facts contain non-empty portchannel interfaces and portchannels, False otherwise.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    # Retrieve the configuration facts from the DUT
+    cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    # Check if the portchannel interfaces list or portchannels dictionary is empty
+    if not cfg_facts.get("minigraph_portchannel_interfaces", []) or not cfg_facts.get("minigraph_portchannels", {}):
+        return False
+
+    return True

--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -14,6 +14,7 @@ from tests.common.helpers.portchannel_to_vlan import acl_rule_cleanup # noqa F40
 from tests.common.helpers.portchannel_to_vlan import vlan_intfs_dict  # noqa F401
 from tests.common.helpers.portchannel_to_vlan import setup_po2vlan    # noqa F401
 from tests.common.helpers.portchannel_to_vlan import running_vlan_ports_list
+from tests.common.helpers.portchannel_to_vlan import has_portchannels
 
 logger = logging.getLogger(__name__)
 
@@ -112,8 +113,6 @@ def verify_icmp_packets(ptfadapter, send_pkt, vlan_ports_list, vlan_port, vlan_i
     masked_tagged_pkt = Mask(tagged_pkt)
     masked_tagged_pkt.set_do_not_care_scapy(scapy.Dot1Q, "prio")
 
-    logger.info("Verify untagged packets from ports " +
-                str(vlan_port["port_index"][0]))
     for port in vlan_ports_list:
         if vlan_port["port_index"] == port["port_index"]:
             # Skip src port
@@ -132,10 +131,12 @@ def verify_icmp_packets(ptfadapter, send_pkt, vlan_ports_list, vlan_port, vlan_i
     ptfadapter.dataplane.flush()
     for src_port in vlan_port["port_index"]:
         testutils.send(ptfadapter, src_port, send_pkt)
+    logger.info("Verify untagged packets from ports " + str(vlan_port["port_index"][0]))
     verify_packets_with_portchannel(test=ptfadapter,
                                     pkt=untagged_pkt,
                                     ports=untagged_dst_ports,
                                     portchannel_ports=untagged_dst_pc_ports)
+    logger.info("Verify tagged packets from ports " + str(vlan_port["port_index"][0]))
     verify_packets_with_portchannel(test=ptfadapter,
                                     pkt=masked_tagged_pkt,
                                     ports=tagged_dst_ports,
@@ -168,6 +169,12 @@ def test_vlan_tc1_send_untagged(ptfadapter, duthosts, rand_one_dut_hostname, ran
     if "dualtor" in tbinfo["topo"]["name"]:
         pytest.skip("Dual TOR device does not support broadcast packet")
 
+    # Skip the test if no portchannel interfaces are detected
+    # e.g., when sending packets to an egress port with PVID 0 on a portchannel interface
+    # the absence of portchannel interfaces means the expected destination doesn't exist
+    if not has_portchannels(duthosts, rand_one_dut_hostname):
+        pytest.skip("Test skipped: No portchannels detected when sending untagged packets")
+
     untagged_pkt = build_icmp_packet(0)
     # Need a tagged packet for set_do_not_care_scapy
     tagged_pkt = build_icmp_packet(4095)
@@ -175,7 +182,7 @@ def test_vlan_tc1_send_untagged(ptfadapter, duthosts, rand_one_dut_hostname, ran
     exp_pkt.set_do_not_care_scapy(scapy.Dot1Q, "vlan")
     vlan_ports_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)
     for vlan_port in vlan_ports_list:
-        logger.info("Send untagged packet from {} ...".format(
+        logger.info("Send untagged packet from the port {} ...".format(
             vlan_port["port_index"][0]))
         logger.info(untagged_pkt.sprintf(
             "%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
@@ -207,11 +214,17 @@ def test_vlan_tc2_send_tagged(ptfadapter, duthosts, rand_one_dut_hostname, rand_
     if "dualtor" in tbinfo["topo"]["name"]:
         pytest.skip("Dual TOR device does not support broadcast packet")
 
+    # Skip the test if no portchannel interfaces are detected
+    # e.g., when sending packets to an egress port with PVID 0 on a portchannel interface
+    # the absence of portchannel interfaces means the expected destination doesn't exist
+    if not has_portchannels(duthosts, rand_one_dut_hostname):
+        pytest.skip("Test skipped: No portchannels detected when sending tagged packets")
+
     vlan_ports_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)
     for vlan_port in vlan_ports_list:
         for permit_vlanid in map(int, vlan_port["permit_vlanid"]):
             pkt = build_icmp_packet(permit_vlanid)
-            logger.info("Send tagged({}) packet from {} ...".format(
+            logger.info("Send tagged({}) packet from the port {} ...".format(
                 permit_vlanid, vlan_port["port_index"][0]))
             logger.info(pkt.sprintf(
                 "%Ether.src% %IP.src% -> %Ether.dst% %IP.dst%"))
@@ -374,6 +387,12 @@ def test_vlan_tc6_tagged_untagged_unicast(ptfadapter, duthosts, rand_one_dut_hos
     Send packets w/ src and dst specified over tagged port and untagged port in vlan
     Verify that bidirectional communication between tagged port and untagged port work
     """
+    # Skip the test if no portchannel interfaces are detected
+    # e.g., when sending packets to an egress port with PVID 0 on a portchannel interface
+    # the absence of portchannel interfaces means the expected destination doesn't exist
+    if not has_portchannels(duthosts, rand_one_dut_hostname):
+        pytest.skip("Test skipped: No portchannels detected when sending untagged packets")
+
     vlan_ports_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)
     for test_vlan in vlan_intfs_dict:
         untagged_ports_for_test = []


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix failed test cases when sending packets to portchannel interfaces in a T0 standalone topology.

#### How did you do it?
Added a common helper function to check if ansible_facts contain non-empty portchannel interfaces and portchannels. The test is skipped if no portchannel interfaces are detected. For example, when sending packets to an egress port with PVID 0 on a portchannel interface, the absence of portchannel interfaces means the expected destination does not exist.

#### How did you verify/test it?
Validate it in internal setup
In tests/vlan/test_vlan.py:
```
========================================================================================= short test summary info =========================================================================================
SKIPPED [1] vlan/test_vlan.py:168: Test skipped: No portchannels detected when sending untagged packets
SKIPPED [1] vlan/test_vlan.py:213: Test skipped: No portchannels detected when sending tagged packets
SKIPPED [1] vlan/test_vlan.py:385: Test skipped: No portchannels detected when sending untagged packets
SKIPPED [1] vlan/test_vlan.py:444: Unsupported platform.
========================================================================== 3 passed, 4 skipped, 2 warnings in 300.77s (0:05:00) ===========================================================================
```

#### Any platform specific information?
str3-7060x6-64pe-1
#### Supported testbed topology if it's a new test case?
t0-standalone-32
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
