### PR TITLE
Download tagged images based on branch for sonic-metadata pipelines

### DIFF
--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -247,6 +247,7 @@ def main():
                                                url_prefix=args.url_prefix,
                                                access_token=args.access_token,
                                                token=args.token)
+
     download_artifacts(dl_url, args.content, args.platform,
                        buildid, args.num_asic, access_token=args.access_token, token=args.token)
 

--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -93,6 +93,18 @@ def get_download_url(buildid, artifact_name, url_prefix, access_token, token):
     return (download_url, artifact_size)
 
 
+def get_download_url_for_tagged_latest(branch):
+    # retrun download URL for tagged latest for sonic-metadata pipelines
+    if branch == 'internal-202305':
+        dl_url = 'https://sonic.packages.trafficmanager.net/pipelines/Networking-acs-buildimage-Official/vs/internal-202305/tagged/latest/target/'
+    elif branch == 'internal-202311':
+        dl_url = 'https://sonic.packages.trafficmanager.net/pipelines/Networking-acs-buildimage-Official/vs/internal-202311/tagged/latest/target/'
+    elif branch == 'internal-202405':
+        dl_url = 'https://sonic.packages.trafficmanager.net/pipelines/Networking-acs-buildimage-Official/vs/internal-202405/tagged/latest/target/'
+
+    return dl_url
+
+
 def download_artifacts(url, content_type, platform, buildid, num_asic, access_token, token):
     """find latest successful build id for a branch"""
 
@@ -195,6 +207,8 @@ def main():
                         help='Specifiy number of asics')
     parser.add_argument('--url_prefix', metavar='url_prefix',
                         type=str, default='mssonic/build', help='url prefix')
+    parser.add_argument('--source_repo', metavar='source_repo',
+                        type=str, default='', help='source repo')
     parser.add_argument('--access_token', metavar='access_token', type=str,
                         default='', nargs='?', const='', required=False, help='access token (PAT)')
     parser.add_argument('--token', metavar='token', type=str,
@@ -221,6 +235,9 @@ def main():
                                                url_prefix=args.url_prefix,
                                                access_token=args.access_token,
                                                token=args.token)
+
+    if args.source_repo == "sonic-metadata":
+        dl_url = get_download_url_for_tagged_latest(args.branch)
 
     download_artifacts(dl_url, args.content, args.platform,
                        buildid, args.num_asic, access_token=args.access_token, token=args.token)

--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -216,6 +216,12 @@ def main():
 
     args = parser.parse_args()
 
+    if args.source_repo == "sonic-metadata":
+        dl_url = get_download_url_for_tagged_latest(args.branch)
+        download_artifacts(dl_url, args.content, args.platform,
+                       -1, args.num_asic, access_token=args.access_token, token=args.token)
+        return
+
     if args.buildid is None:
         buildid_succ = find_latest_build_id(args.branch, "succeeded")
         buildid_partial = find_latest_build_id(
@@ -235,10 +241,6 @@ def main():
                                                url_prefix=args.url_prefix,
                                                access_token=args.access_token,
                                                token=args.token)
-
-    if args.source_repo == "sonic-metadata":
-        dl_url = get_download_url_for_tagged_latest(args.branch)
-
     download_artifacts(dl_url, args.content, args.platform,
                        buildid, args.num_asic, access_token=args.access_token, token=args.token)
 

--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -94,13 +94,19 @@ def get_download_url(buildid, artifact_name, url_prefix, access_token, token):
 
 
 def get_download_url_for_tagged_latest(branch):
-    # retrun download URL for tagged latest for sonic-metadata pipelines
+    # Return download URL for tagged latest for sonic-metadata pipelines
+    base_url = 'https://sonic.packages.trafficmanager.net/pipelines/' \
+               'Networking-acs-buildimage-Official/vs/'
+    tagged_path = 'tagged/latest/target/'
+
     if branch == 'internal-202305':
-        dl_url = 'https://sonic.packages.trafficmanager.net/pipelines/Networking-acs-buildimage-Official/vs/internal-202305/tagged/latest/target/'
+        dl_url = f'{base_url}internal-202305/{tagged_path}'
     elif branch == 'internal-202311':
-        dl_url = 'https://sonic.packages.trafficmanager.net/pipelines/Networking-acs-buildimage-Official/vs/internal-202311/tagged/latest/target/'
+        dl_url = f'{base_url}internal-202311/{tagged_path}'
     elif branch == 'internal-202405':
-        dl_url = 'https://sonic.packages.trafficmanager.net/pipelines/Networking-acs-buildimage-Official/vs/internal-202405/tagged/latest/target/'
+        dl_url = f'{base_url}internal-202405/{tagged_path}'
+    else:
+        raise ValueError(f"Unknown branch: {branch}")
 
     return dl_url
 
@@ -219,7 +225,7 @@ def main():
     if args.source_repo == "sonic-metadata":
         dl_url = get_download_url_for_tagged_latest(args.branch)
         download_artifacts(dl_url, args.content, args.platform,
-                       -1, args.num_asic, access_token=args.access_token, token=args.token)
+                           -1, args.num_asic, access_token=args.access_token, token=args.token)
         return
 
     if args.buildid is None:

--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -106,7 +106,7 @@ def get_download_url_for_tagged_latest(branch):
     elif branch == 'internal-202405':
         dl_url = f'{base_url}internal-202405/{tagged_path}'
     else:
-        raise ValueError(f"Unknown branch: {branch}")
+        raise Exception(f"Unknown branch: {branch}")
 
     return dl_url
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
Download tagged latest image url based on branches for sonic-metadata pipelines.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Sonic-metadata pipeline has no tagged image to be download on KVMs.
#### How did you do it?
Add latest tagged url for use.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
