### PR TITLE
[Feat]Support to trim inventory files (#14246)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ ansible.log
 tests/logs
 tests/_cache
 tests/metadata
+ansible/plugins/*/*.pyc
+# Temporary trimmed inventory file
+ansible/*_tmp
 
 # Dev tools
 .vscode/

--- a/tests/common/helpers/inventory_utils.py
+++ b/tests/common/helpers/inventory_utils.py
@@ -1,0 +1,90 @@
+import logging
+import re
+
+import yaml
+
+from tests.common.helpers.yaml_utils import BlankNone
+
+logger = logging.getLogger(__name__)
+
+
+def trim_inventory(inv_files, tbinfo):
+    """
+    Trim the useless topology neighbor the inv_files according to testbed to speed up ansible inventory initialization.
+
+    For every test server, we pre-define ~100 ansible_hosts for the neighbors.
+    We put all of the ansible_hosts of test servers into one inventory file.
+    The inventory file contains thousands of ansible_hosts, but most of them are useless to the selected testbed,
+    Because the testbed only need the definition of the neighbor for its neighbor server.
+
+    During the establishment of the ansible_host, it iterate and compute the ansible_host one by one,
+    The useless ansible_host extremely slow down the initialization.
+
+    Hence, will trim and generate a temporary inventory file, for example:
+    ['../ansible/veos', '../ansible/inv1'] -> ['../ansible/veos_kvm-t0_trim_tmp', '../ansible/inv1']
+    Then pytest will use the light inventory file '../ansible/veos_kvm-t0_trim_tmp' to initialize the ansible_hosts.
+
+    Args:
+        inv_files: inventory file list, sample: ['../ansible/veos', '../ansible/inv1']
+        tbinfo: tbinfo
+
+    Returns:
+        Direct update inv_files and return nothing
+    """
+
+    vm_base = tbinfo.get("vm_base", None)
+    tb_name = tbinfo.get("conf-name", None)
+    pattern = r'VM\d{3,7}'
+    logger.info(f"Start to trim inventory, tb[{tb_name}] vm_base [{vm_base}], inv file {inv_files}")
+
+    # Find a key in all the levels of a dict,
+    # Return the val of the key and the vm_base_path of the key
+    def find_key(d: dict, target_key: str = None, regex: str = None):
+        # Stack to keep track of dictionaries and their paths
+        stack = [(d, [])]
+        while stack:
+            current_dict, path = stack.pop()
+            for key, value in current_dict.items():
+                # If regex is passed, use regex to match
+                if regex and re.match(regex, key):
+                    return value, path + [key]
+                # If regex is None, exact match
+                if key == target_key:
+                    return value, path + [key]
+                if isinstance(value, dict):
+                    stack.append((value, path + [key]))
+        return None, []
+
+    # Remove all the matched
+    for idx in range(len(inv_files)):
+        inv_file = inv_files[idx]
+        with open(inv_file, 'r') as file:
+            inv = yaml.safe_load(file)
+            # If the vm_base is found in the inv_file,
+            # then other useless topology neighbor definition are in it,
+            # that's the inventory to be trimmed
+            _, vm_base_path = find_key(d=inv, target_key=vm_base)
+            if vm_base_path:
+                keys_to_del = set()
+                logger.info(f"Find vm_base {vm_base} in inv file {inv_file}, path: {vm_base_path}")
+
+                for root_key in inv.keys():
+                    neighbor_val, neighbor_path = find_key(d=inv[root_key], regex=pattern)
+                    if neighbor_path:
+                        # Keep the neighbor server for the testbed
+                        if root_key == vm_base_path[0]:
+                            logger.info(f"vm_base[{vm_base}] located in {root_key}, inv file {inv_file}, keep it")
+                        # Remove all the useless neighbor server ansible_hosts
+                        else:
+                            logger.info(f"Attempt to remove {root_key} in inv file {inv_file}")
+                            keys_to_del.add(root_key)
+
+                for key_to_del in keys_to_del:
+                    del inv[key_to_del]
+
+                # dump and replace trimmed inventory file
+                trimmed_inventory_file_name = f"{inv_file}_{tb_name}_trim_tmp"
+                with BlankNone(), open(trimmed_inventory_file_name, 'w') as f:
+                    yaml.dump(inv, f)
+
+                inv_files[idx] = trimmed_inventory_file_name

--- a/tests/common/helpers/yaml_utils.py
+++ b/tests/common/helpers/yaml_utils.py
@@ -1,0 +1,26 @@
+import yaml
+from yaml import Dumper
+from yaml.representer import Representer
+
+# PyYaml default dump the key with empty values to null, like:
+# dict = {"key1": None, "key2": "val2"}  ->
+# key1: null
+# key2: val2
+# If we want to keep it as the blank values rather than null, like:
+# key1:
+# key2: val2
+# Need to use this Representer
+# refs to: https://stackoverflow.com/a/67524482/25406083
+
+
+class BlankNone(Representer):
+    """Print None as blank when used as context manager"""
+    def represent_none(self, *_):
+        return self.represent_scalar(u'tag:yaml.org,2002:null', u'')
+
+    def __enter__(self):
+        self.prior = Dumper.yaml_representers[type(None)]
+        yaml.add_representer(type(None), self.represent_none)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        Dumper.yaml_representers[type(None)] = self.prior

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ from tests.common.cache import FactsCache
 from tests.common.config_reload import config_reload
 from tests.common.connections.console_host import ConsoleHost
 from tests.common.helpers.assertions import pytest_assert as pt_assert
+from tests.common.helpers.inventory_utils import trim_inventory
 
 try:
     from tests.macsec import MacsecPluginT2, MacsecPluginT0
@@ -199,6 +200,11 @@ def pytest_addoption(parser):
     parser.addoption("--public_docker_registry", action="store_true", default=False,
                      help="To use public docker registry for syncd swap, by default is disabled (False)")
 
+    ##############################
+    #   ansible inventory option #
+    ##############################
+    parser.addoption("--trim_inv", action="store_true", default=False, help="Trim inventory files")
+
 
 def pytest_configure(config):
     if config.getoption("enable_macsec"):
@@ -210,7 +216,7 @@ def pytest_configure(config):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def enhance_inventory(request):
+def enhance_inventory(request, tbinfo):
     """
     This fixture is to enhance the capability of parsing the value of pytest cli argument '--inventory'.
     The pytest-ansible plugin always assumes that the value of cli argument '--inventory' is a single
@@ -227,7 +233,12 @@ def enhance_inventory(request):
     if isinstance(inv_opt, list):
         return
     inv_files = [inv_file.strip() for inv_file in inv_opt.split(",")]
+
+    if request.config.getoption("trim_inv"):
+        trim_inventory(inv_files, tbinfo)
+
     try:
+        logger.info(f"Inventory file: {inv_files}")
         setattr(request.config.option, "ansible_inventory", inv_files)
     except AttributeError:
         logger.error("Failed to set enhanced 'ansible_inventory' to request.config.option")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Support to trim the useless topology neighbor the inv_files according to testbed to speed up ansible inventory initialization.
Summary:
Fix conflict and cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/14246

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Trim the useless topology neighbor the inv_files according to testbed to speed up ansible inventory initialization.

  For every test server, we pre-define ~100 ansible_hosts for the neighbors.
  We put all of the ansible_hosts of test servers into one inventory file.
  The inventory file contains thousands of ansible_hosts, but most of them are useless to the selected testbed,
  Because the testbed only need the definition of the neighbor for its neighbor server.

  During the establishment of the ansible_host, it iterate and compute the ansible_host one by one,
  The useless ansible_host extremely slow down the initialization.
#### How did you do it?
trim and generate a temporary inventory file, for example:
    ['../ansible/veos', '../ansible/inv1'] -> ['../ansible/veos_kvm-t0_trim_tmp', '../ansible/inv1']
    Then pytest will use the light inventory file '../ansible/veos_kvm-t0_trim_tmp' to initialize the ansible_hosts.
#### How did you verify/test it?
Run test_nbr_health.py on physical devices, both T2 and t1-lag passed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
