### PR TITLE
Move stable data plane test to PR checker sets

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -211,6 +211,7 @@ t0:
   - route/test_route_bgp_ecmp.py
   - drop_packets/test_drop_counters.py
   - copp/test_copp.py
+  - crm/test_crm.py
 
 t0-2vlans:
   - dhcp_relay/test_dhcp_relay.py
@@ -404,6 +405,7 @@ t1-lag:
   - copp/test_copp.py
   - stress/test_stress_routes.py
   - drop_packets/test_drop_counters.py
+  - crm/test_crm.py
   - bgp/test_bgp_suppress_fib.py
 
 multi-asic-t1-lag:
@@ -455,7 +457,6 @@ dpu:
 
 onboarding_t0:
   - bgp/test_bgp_stress_link_flap.py
-  - crm/test_crm.py
   # We will add a batch of T0 control plane cases and fix the failed cases later
   - pfcwd/test_pfcwd_all_port_storm.py
   - pfcwd/test_pfcwd_function.py
@@ -467,7 +468,6 @@ onboarding_t0:
 
 onboarding_t1:
   - bgp/test_bgp_stress_link_flap.py
-  - crm/test_crm.py
   - generic_config_updater/test_cacl.py
   - gnmi/test_gnmi_countersdb.py
   - platform_tests/test_link_down.py

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -208,6 +208,9 @@ t0:
   - sub_port_interfaces/test_sub_port_interfaces.py
   - hash/test_generic_hash.py
   - span/test_port_mirroring.py
+  - route/test_route_bgp_ecmp.py
+  - drop_packets/test_drop_counters.py
+  - copp/test_copp.py
 
 t0-2vlans:
   - dhcp_relay/test_dhcp_relay.py
@@ -234,6 +237,7 @@ dualtor:
   - dualtor/test_tunnel_memory_leak.py
   - dualtor_io/test_heartbeat_failure.py
   - dualtor_io/test_link_drop.py
+  - dualtor_io/test_link_failure.py
   - dualtor_io/test_tor_bgp_failure.py
   - dualtor_mgmt/test_grpc_periodical_sync.py
   - dualtor_mgmt/test_ingress_drop.py
@@ -395,6 +399,11 @@ t1-lag:
   - sub_port_interfaces/test_sub_port_interfaces.py
   - telemetry/test_events.py
   - show_techsupport/test_auto_techsupport.py
+  - vxlan/test_vxlan_bfd_tsa.py
+  - vxlan/test_vxlan_ecmp_switchover.py
+  - copp/test_copp.py
+  - stress/test_stress_routes.py
+  - drop_packets/test_drop_counters.py
 
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py
@@ -445,7 +454,6 @@ dpu:
 
 onboarding_t0:
   - bgp/test_bgp_stress_link_flap.py
-  - copp/test_copp.py
   - crm/test_crm.py
   # We will add a batch of T0 control plane cases and fix the failed cases later
   - pfcwd/test_pfcwd_all_port_storm.py
@@ -454,27 +462,19 @@ onboarding_t0:
   - pfcwd/test_pfcwd_warm_reboot.py
   # - platform_tests/test_advanced_reboot.py
   - platform_tests/test_cont_warm_reboot.py
-  - route/test_route_bgp_ecmp.py
   - snmp/test_snmp_link_local.py
-  - drop_packets/test_drop_counters.py
 
 onboarding_t1:
   - bgp/test_bgp_stress_link_flap.py
-  - copp/test_copp.py
   - crm/test_crm.py
   - generic_config_updater/test_cacl.py
   - gnmi/test_gnmi_countersdb.py
   - platform_tests/test_link_down.py
-  - vxlan/test_vxlan_bfd_tsa.py
-  - vxlan/test_vxlan_ecmp_switchover.py
-  - stress/test_stress_routes.py
-  - drop_packets/test_drop_counters.py
   - bgp/test_bgp_sentinel.py
   - bgp/test_bgp_suppress_fib.py
   - snmp/test_snmp_link_local.py
 
 onboarding_dualtor:
-  - dualtor_io/test_link_failure.py
   - dualtor_mgmt/test_dualtor_bgp_update_delay.py
 
 specific_param:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Some dataplane test scripts have been added to PR test and put into optional onboarding job to test case performance, I calculated the success rate of test scripts in recent 5 days, I think I can move high success rate test scripts to t0/t1/dualtor job now
TestbedName | FilePath | TestCase | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_down_upstream[active-standby] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_down_upstream[active-active] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_down_downstream_active[active-standby] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_down_downstream_active[active-active] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_down_downstream_standby[active-standby] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_down_downstream_standby[active-active] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_standby_link_down_upstream[active-standby] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_standby_link_down_upstream[active-active] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_standby_link_down_downstream_active[active-standby] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_standby_link_down_downstream_active[active-active] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_standby_link_down_downstream_standby[active-standby] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_standby_link_down_downstream_standby[active-active] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_tor_downlink_down_upstream[active-standby] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_tor_downlink_down_upstream[active-active] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_tor_downlink_down_downstream_active[active-standby] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_tor_downlink_down_downstream_active[active-active] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_tor_downlink_down_downstream_standby[active-standby] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_tor_downlink_down_downstream_standby[active-active] | 40 | 0 | 40 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_standby_tor_downlink_down_upstream[active-standby] | 39 | 1 | 40 | 0.975
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_standby_tor_downlink_down_upstream[active-active] | 39 | 0 | 39 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_standby_tor_downlink_down_downstream_active[active-standby] | 39 | 0 | 39 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_standby_tor_downlink_down_downstream_active[active-active] | 39 | 0 | 39 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_standby_tor_downlink_down_downstream_standby[active-standby] | 37 | 2 | 39 | 0.9487
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_standby_tor_downlink_down_downstream_standby[active-active] | 37 | 0 | 37 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_down_upstream_soc[active-standby] | 37 | 0 | 37 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_down_upstream_soc[active-active] | 37 | 0 | 37 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_down_downstream_active_soc[active-standby] | 37 | 0 | 37 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_down_downstream_active_soc[active-active] | 37 | 0 | 37 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_admin_down_config_reload_upstream[active-standby] | 37 | 0 | 37 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_admin_down_config_reload_upstream[active-active] | 37 | 0 | 37 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_admin_down_config_reload_downstream[active-standby] | 37 | 0 | 37 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_admin_down_config_reload_downstream[active-active] | 37 | 0 | 37 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_admin_down_config_reload_link_up_upstream[active-standby] | 37 | 0 | 37 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_admin_down_config_reload_link_up_upstream[active-active] | 37 | 0 | 37 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_admin_down_config_reload_link_up_downstream_standby[active-standby] | 37 | 0 | 37 | 1
vms-kvm-dual-t0 | dualtor_io/test_link_failure.py | test_active_link_admin_down_config_reload_link_up_downstream_standby[active-active] | 37 | 0 | 37 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case1[v4_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case2[v4_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case3[v4_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case4[v4_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case5[v4_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case6[v4_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case1[v6_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case2[v6_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case3[v6_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case4[v6_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case5[v6_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case6[v6_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case1[v4_in_v6] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case2[v4_in_v6] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case3[v4_in_v6] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case4[v4_in_v6] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case5[v4_in_v6] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case6[v4_in_v6] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case1[v6_in_v6] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case2[v6_in_v6] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case3[v6_in_v6] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case4[v6_in_v6] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case5[v6_in_v6] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_bfd_tsa.py | test_tsa_case6[v6_in_v6] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_ecmp_switchover.py | test_vxlan_priority_single_pri_sec_switchover[v4_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_ecmp_switchover.py | test_vxlan_priority_multi_pri_sec_switchover[v4_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_ecmp_switchover.py | test_vxlan_priority_single_pri_sec_switchover[v6_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_ecmp_switchover.py | test_vxlan_priority_multi_pri_sec_switchover[v6_in_v4] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | drop_packets/test_drop_counters.py | test_reserved_dmac_drop[port_channel_members-vlab-03] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | drop_packets/test_drop_counters.py | test_reserved_dmac_drop[vlan_members-vlab-03] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | drop_packets/test_drop_counters.py | test_reserved_dmac_drop[rif_members-vlab-03] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | drop_packets/test_drop_counters.py | test_no_egress_drop_on_down_link[port_channel_members-vlab-03] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | drop_packets/test_drop_counters.py | test_no_egress_drop_on_down_link[vlan_members-vlab-03] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | drop_packets/test_drop_counters.py | test_no_egress_drop_on_down_link[rif_members-vlab-03] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | drop_packets/test_drop_counters.py | test_src_ip_link_local[port_channel_members-vlab-03] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | drop_packets/test_drop_counters.py | test_src_ip_link_local[vlan_members-vlab-03] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | drop_packets/test_drop_counters.py | test_src_ip_link_local[rif_members-vlab-03] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | drop_packets/test_drop_counters.py | test_ip_pkt_with_exceeded_mtu[port_channel_members-vlab-03] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | drop_packets/test_drop_counters.py | test_ip_pkt_with_exceeded_mtu[vlan_members-vlab-03] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | drop_packets/test_drop_counters.py | test_ip_pkt_with_exceeded_mtu[rif_members-vlab-03] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | stress/test_stress_routes.py | test_announce_withdraw_route[vlab-03-None] | 40 | 0 | 40 | 1
vms-kvm-t1-lag | copp/test_copp.py | test_policer[vlab-03-ARP] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | copp/test_copp.py | test_policer[vlab-03-IP2ME] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | copp/test_copp.py | test_policer[vlab-03-SNMP] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | copp/test_copp.py | test_policer[vlab-03-SSH] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | copp/test_copp.py | test_policer[vlab-03-DHCP] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | copp/test_copp.py | test_policer[vlab-03-DHCP6] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | copp/test_copp.py | test_policer[vlab-03-BGP] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | copp/test_copp.py | test_policer[vlab-03-LACP] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | copp/test_copp.py | test_policer[vlab-03-LLDP] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | copp/test_copp.py | test_policer[vlab-03-UDLD] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | copp/test_copp.py | test_add_new_trap[vlab-03] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | copp/test_copp.py | test_remove_trap[vlab-03-delete_feature_entry] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | copp/test_copp.py | test_remove_trap[vlab-03-disable_feature_status] | 41 | 0 | 41 | 1
vms-kvm-t1-lag | copp/test_copp.py | test_trap_config_save_after_reboot[vlab-03] | 41 | 0 | 41 | 1
vms-kvm-t0 | route/test_route_bgp_ecmp.py | test_route_bgp_ecmp[vlab-01] | 44 | 0 | 44 | 1
vms-kvm-t0 | drop_packets/test_drop_counters.py | test_reserved_dmac_drop[port_channel_members-vlab-01] | 44 | 0 | 44 | 1
vms-kvm-t0 | drop_packets/test_drop_counters.py | test_reserved_dmac_drop[vlan_members-vlab-01] | 44 | 0 | 44 | 1
vms-kvm-t0 | drop_packets/test_drop_counters.py | test_reserved_dmac_drop[rif_members-vlab-01] | 44 | 0 | 44 | 1
vms-kvm-t0 | drop_packets/test_drop_counters.py | test_no_egress_drop_on_down_link[port_channel_members-vlab-01] | 44 | 0 | 44 | 1
vms-kvm-t0 | drop_packets/test_drop_counters.py | test_no_egress_drop_on_down_link[vlan_members-vlab-01] | 44 | 0 | 44 | 1
vms-kvm-t0 | drop_packets/test_drop_counters.py | test_no_egress_drop_on_down_link[rif_members-vlab-01] | 44 | 0 | 44 | 1
vms-kvm-t0 | drop_packets/test_drop_counters.py | test_src_ip_link_local[port_channel_members-vlab-01] | 44 | 0 | 44 | 1
vms-kvm-t0 | drop_packets/test_drop_counters.py | test_src_ip_link_local[vlan_members-vlab-01] | 44 | 0 | 44 | 1
vms-kvm-t0 | drop_packets/test_drop_counters.py | test_src_ip_link_local[rif_members-vlab-01] | 44 | 0 | 44 | 1
vms-kvm-t0 | drop_packets/test_drop_counters.py | test_ip_pkt_with_exceeded_mtu[port_channel_members-vlab-01] | 44 | 0 | 44 | 1
vms-kvm-t0 | drop_packets/test_drop_counters.py | test_ip_pkt_with_exceeded_mtu[vlan_members-vlab-01] | 44 | 0 | 44 | 1
vms-kvm-t0 | drop_packets/test_drop_counters.py | test_ip_pkt_with_exceeded_mtu[rif_members-vlab-01] | 44 | 0 | 44 | 1
vms-kvm-t0 | copp/test_copp.py | test_policer[vlab-01-ARP] | 44 | 0 | 44 | 1
vms-kvm-t0 | copp/test_copp.py | test_policer[vlab-01-IP2ME] | 44 | 0 | 44 | 1
vms-kvm-t0 | copp/test_copp.py | test_policer[vlab-01-SNMP] | 44 | 0 | 44 | 1
vms-kvm-t0 | copp/test_copp.py | test_policer[vlab-01-SSH] | 44 | 0 | 44 | 1
vms-kvm-t0 | copp/test_copp.py | test_policer[vlab-01-DHCP] | 44 | 0 | 44 | 1
vms-kvm-t0 | copp/test_copp.py | test_policer[vlab-01-DHCP6] | 44 | 0 | 44 | 1
vms-kvm-t0 | copp/test_copp.py | test_policer[vlab-01-BGP] | 44 | 0 | 44 | 1
vms-kvm-t0 | copp/test_copp.py | test_policer[vlab-01-LACP] | 44 | 0 | 44 | 1
vms-kvm-t0 | copp/test_copp.py | test_policer[vlab-01-LLDP] | 44 | 0 | 44 | 1
vms-kvm-t0 | copp/test_copp.py | test_policer[vlab-01-UDLD] | 44 | 0 | 44 | 1
vms-kvm-t0 | copp/test_copp.py | test_add_new_trap[vlab-01] | 44 | 0 | 44 | 1
vms-kvm-t0 | copp/test_copp.py | test_remove_trap[vlab-01-delete_feature_entry] | 44 | 0 | 44 | 1
vms-kvm-t0 | copp/test_copp.py | test_remove_trap[vlab-01-disable_feature_status] | 44 | 0 | 44 | 1
vms-kvm-t0 | copp/test_copp.py | test_trap_config_save_after_reboot[vlab-01] | 44 | 0 | 44 | 1
#### How did you do it?
Move test from onboarding job to t0/t1/dualtor job
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
