### PR TITLE
Add debug message in script `advanced-reboot.py`

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -161,7 +161,7 @@ class ReloadTest(BaseTest):
         self.check_param('lo_v6_prefix', 'fc00:1::/64', required=False)
         self.check_param('arista_vms', [], required=True)
         self.check_param('min_bgp_gr_timeout', 15, required=False)
-        self.check_param('warm_up_timeout_secs', 360, required=False)
+        self.check_param('warm_up_timeout_secs', 300, required=False)
         self.check_param('dut_stabilize_secs', 30, required=False)
         self.check_param('preboot_files', None, required=False)
         # preboot sad path to inject before warm-reboot
@@ -2180,6 +2180,7 @@ class ReloadTest(BaseTest):
                 up_time = None
 
             if elapsed > warm_up_timeout_secs:
+                self.log('Actual warm up time {}'.format(elapsed))
                 raise Exception("IO didn't come up within warm up timeout. Control plane: {}, Data plane: {}".format(
                     ctrlplane, dataplane))
             time.sleep(1)

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -2180,9 +2180,8 @@ class ReloadTest(BaseTest):
                 up_time = None
 
             if elapsed > warm_up_timeout_secs:
-                self.log('Actual warm up time {}'.format(elapsed))
-                raise Exception("IO didn't come up within warm up timeout. Control plane: {}, Data plane: {}".format(
-                    ctrlplane, dataplane))
+                raise Exception("IO didn't come up within warm up timeout. Control plane: {}, Data plane: {}."
+                                "Actual warm up time {}".format(ctrlplane, dataplane, elapsed))
             time.sleep(1)
 
         # check until flooding is over. Flooding happens when FDB entry of

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -161,7 +161,7 @@ class ReloadTest(BaseTest):
         self.check_param('lo_v6_prefix', 'fc00:1::/64', required=False)
         self.check_param('arista_vms', [], required=True)
         self.check_param('min_bgp_gr_timeout', 15, required=False)
-        self.check_param('warm_up_timeout_secs', 300, required=False)
+        self.check_param('warm_up_timeout_secs', 360, required=False)
         self.check_param('dut_stabilize_secs', 30, required=False)
         self.check_param('preboot_files', None, required=False)
         # preboot sad path to inject before warm-reboot


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
There is a certain probability that the script `test_cont_warm_reboot.py` fails because of the error `IO didn't come up within warm up timeout. Control plane: up, Data plane: partial`. It means data plane is not up within our specify time(300s). In this PR, we add the debug message to see how long it will take to bring up data plane. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
There is a certain probability that the script `test_cont_warm_reboot.py` fails because of the error `IO didn't come up within warm up timeout. Control plane: up, Data plane: partial`. It means data plane is not up within our specify time(300s). In this PR, we add the debug message to see how long it will take to bring up data plane. 

#### How did you do it?
Add the debug message to see how long it will take to bring up data plane. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
