### PR TITLE
remove xfail as iburst option has been enabled for NTP servers

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1024,15 +1024,6 @@ nat:
       - "'nat' not in feature_status"
 
 #######################################
-#####           ntp               #####
-#######################################
-ntp/test_ntp.py::test_ntp:
-  xfail:
-    reason: "iburst not enabled by default on 202311 and newer images"
-    conditions:
-      - https://github.com/sonic-net/sonic-buildimage/issues/19425
-
-#######################################
 #####           pc               #####
 #######################################
 pc/test_lag_2.py::test_lag_db_status_with_po_update:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Test cases xpassed in ntp/test_ntp.py, I found that the xfail marker was added to the NTP test cases due to iburst not being enabled by default in #13501 

#### How did you do it?
Remove xfail for NTP test case as iburst option has been enabled for NTP servers in [#19424](https://github.com/sonic-net/sonic-buildimage/pull/19424)

#### How did you verify/test it?
Validate it in internal setup
In ntp/test_ntp.py

```
----------------------------------------------------------------------------------------- live log sessionfinish ------------------------------------------------------------------------------------------

07:34:37 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs

================================================================================ 6 passed, 1 warning in 2788.12s (0:46:28) ================================================================================
 
```

#### Any platform specific information?
str3-7060x6-64pe-1

#### Supported testbed topology if it's a new test case?
t0-standalone-32

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
