### PR TITLE
Added skip for test_mgmt_ipv6_only TC if ipv6 mgmt not available

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -686,7 +686,7 @@ def convert_and_restore_config_db_to_ipv6_only(duthosts):
                     try:
                         # Add a temporary debug log to see if the DUT is reachable via IPv6 mgmt-ip. Will remove later
                         duthost_interface = duthost.shell("sudo ifconfig eth0")['stdout']
-                        logging.debug(f"Checking host[{duthost.hostname}] ifconfig eth0:[{duthost_interface}]")
+                        logging.debug(f"Checking host[{duthost.hostname}] ifconfig eth0: [{duthost_interface}]")
                         ssh_client.connect(ip_addr_without_mask,
                                            username="WRONG_USER", password="WRONG_PWD", timeout=15)
                     except AuthenticationException:
@@ -698,10 +698,12 @@ def convert_and_restore_config_db_to_ipv6_only(duthosts):
                     finally:
                         ssh_client.close()
 
-        pytest_assert(len(ipv6_address[duthost.hostname]) > 0,
-                      f"{duthost.hostname} doesn't have IPv6 Management IP address")
-        pytest_assert(has_available_ipv6_addr,
-                      f"{duthost.hostname} doesn't have available IPv6 Management IP address")
+        if (not ipv6_address[duthost.hostname] and not has_available_ipv6_addr or
+                ipaddress.IPv6Address(ipv6_address[duthost.hostname][0]).is_link_local):
+            pytest.skip(f"{duthost.hostname} doesn't have IPv6 Management IP address or doesn't have available IPv6 "
+                        f"Management IP address")
+        if ipv6_address[duthost.hostname] and not has_available_ipv6_addr:
+            pytest.fail(f"{duthost.hostname}  IPv6 address configuration presents but not applied to mgmt port")
 
     # Remove IPv4 mgmt-ip
     for duthost in duthosts.nodes:
@@ -843,9 +845,9 @@ def assert_addr_in_output(addr_set: Dict[str, List], hostname: str,
     for addr in addr_set[hostname]:
         if expect_exists:
             pytest_assert(addr in cmd_output,
-                          f"{addr} not appeared in {hostname} {cmd_desc}")
+                          f"{addr} not in {hostname} {cmd_desc}")
             logger.info(f"{addr} exists in the output of {cmd_desc}")
         else:
             pytest_assert(addr not in cmd_output,
                           f"{hostname} {cmd_desc} still with addr {addr}")
-            logger.info(f"{addr} not exists in the output of {cmd_desc} which is expected")
+            logger.info(f"{addr} not in the output of {cmd_desc} which is expected")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes failure if DUT does not have ipv6 management address set

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
If DUT does not have ipv6 mgmt address to be set - TC fails 
#### How did you do it?
Add pytest.skip if ipv6 mgmt address not set
#### How did you verify/test it?
Run TC. TC skip
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
