### PR TITLE
restapi_vxlan_ecmp_test on mlnx 4600 and 8000 T1

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1503,7 +1503,7 @@ restapi/test_restapi.py:
 
 restapi/test_restapi_vxlan_ecmp.py:
   skip:
-    reason: "Only supported on cisco 8102 T1"
+    reason: "Only supported on cisco 8102, 8101 and mlnx 4600C T1"
     conditions:
       - "not (platform in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-mlnx_msn4600c-r0']  and 't1' in topo_type)"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1498,7 +1498,7 @@ restapi/test_restapi_vxlan_ecmp.py:
   skip:
     reason: "Only supported on cisco 8102 T1"
     conditions:
-      - "not (asic_type in ['cisco-8000'] and 't1' in topo_type)"
+      - "not (platform in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-mlnx_msn4600c-r0']  and 't1' in topo_type)"
 
 #######################################
 #####           route             #####

--- a/tests/restapi/test_restapi_vxlan_ecmp.py
+++ b/tests/restapi/test_restapi_vxlan_ecmp.py
@@ -9,7 +9,7 @@ from restapi_operations import Restapi
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t1', 't1-lag', 't1-64-lag'),
+    pytest.mark.topology('t1'),
     pytest.mark.disable_loganalyzer
 ]
 

--- a/tests/restapi/test_restapi_vxlan_ecmp.py
+++ b/tests/restapi/test_restapi_vxlan_ecmp.py
@@ -9,7 +9,7 @@ from restapi_operations import Restapi
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0'),
+    pytest.mark.topology('t1', 't1-lag', 't1-64-lag'),
     pytest.mark.disable_loganalyzer
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Enabled the Test on 4600C T1.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [X] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Better test coverage.
#### How did you do it?
Enabled the test.
#### How did you verify/test it?
Ran the test naually on 4600
```
$ ./run_tests.sh -n  vms18-t1-msn4600c-acs-1  -i ../ansible/str2,../ansible/veos -r -u -c restapi/test_restapi_vxlan_ecmp.py
=== Running tests in groups ===
Running: python3 -m pytest restapi/test_restapi_vxlan_ecmp.py --inventory ../ansible/str2,../ansible/veos --host-pattern str2-msn4600c-acs-01 --testbed vms18-t1-msn4600c-acs-1 --testbed_file /var/src/sonic-mgmt-int/ansible/testbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/tr.xml --log-file=logs/test.log
==================================================================================================================================== test session starts =====================================================================================================================================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.5.0
ansible: 2.13.13
rootdir: /var/src/sonic-mgmt-int/tests
configfile: pytest.ini
plugins: metadata-3.1.1, allure-pytest-2.8.22, forked-1.6.0, repeat-0.9.3, html-4.1.1, ansible-4.0.0, xdist-1.28.0
collecting ...
------------------------------------------------------------------------------------------------------------------------------------ live log collection -------------------------------------------------------------------------------------------------------------------------------------
23:16:45 testbed.get_testbed_type                 L0261 WARNING| Unsupported testbed type - point-to-point-256
/usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
/usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
/usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
/usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
/usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
collecting 0 items                                                                                                                                                                                                                                                                           23:17:11 testbed.get_testbed_type                 L0261 WARNING| Unsupported testbed type - point-to-point-256
collected 1 item

restapi/test_restapi_vxlan_ecmp.py::test_vxlan_ecmp_multirequest PASSED                                                                                                                                                                                                                [100%]

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
