### PR TITLE
Fix vlan/test_vlan_ping.py and vxlan/test_vxlan_crm.py failure

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1895,30 +1895,50 @@ vxlan/test_vxlan_crm.py::Test_VxLAN_Crm::test_crm_128_group_members[v6_in_v6]:
     reason: "On Mellanox spc1 platform, due to HW limitation, vxlan ipv6 tunnel is not supported"
     conditions:
       - "asic_gen == 'spc1'"
+  xfail:
+    reason: "Vnet route missed in ASIC DB for KVM platform, xfail for unblocking PR test"
+    conditions:
+      - "(asic_type in ['vs']) and https://github.com/sonic-net/sonic-mgmt/issues/14311"
 
 vxlan/test_vxlan_crm.py::Test_VxLAN_Crm::test_crm_16k_routes[v4_in_v6]:
   skip:
     reason: "On Mellanox spc1 platform, due to HW limitation, vxlan ipv6 tunnel is not supported"
     conditions:
       - "asic_gen == 'spc1'"
+  xfail:
+    reason: "Vnet route missed in ASIC DB for KVM platform, xfail for unblocking PR test"
+    conditions:
+      - "(asic_type in ['vs']) and https://github.com/sonic-net/sonic-mgmt/issues/14311"
 
 vxlan/test_vxlan_crm.py::Test_VxLAN_Crm::test_crm_16k_routes[v6_in_v6]:
   skip:
     reason: "On Mellanox spc1 platform, due to HW limitation, vxlan ipv6 tunnel is not supported"
     conditions:
       - "asic_gen == 'spc1'"
+  xfail:
+    reason: "Vnet route missed in ASIC DB for KVM platform, xfail for unblocking PR test"
+    conditions:
+      - "(asic_type in ['vs']) and https://github.com/sonic-net/sonic-mgmt/issues/14311"
 
 vxlan/test_vxlan_crm.py::Test_VxLAN_Crm::test_crm_512_nexthop_groups[v4_in_v6]:
   skip:
     reason: "On Mellanox spc1 platform, due to HW limitation, vxlan ipv6 tunnel is not supported"
     conditions:
       - "asic_gen == 'spc1'"
+  xfail:
+    reason: "Vnet route missed in ASIC DB for KVM platform, xfail for unblocking PR test"
+    conditions:
+      - "(asic_type in ['vs']) and https://github.com/sonic-net/sonic-mgmt/issues/14311"
 
 vxlan/test_vxlan_crm.py::Test_VxLAN_Crm::test_crm_512_nexthop_groups[v6_in_v6]:
   skip:
     reason: "On Mellanox spc1 platform, due to HW limitation, vxlan ipv6 tunnel is not supported"
     conditions:
       - "asic_gen == 'spc1'"
+  xfail:
+    reason: "Vnet route missed in ASIC DB for KVM platform, xfail for unblocking PR test"
+    conditions:
+      - "(asic_type in ['vs']) and https://github.com/sonic-net/sonic-mgmt/issues/14311"
 
 vxlan/test_vxlan_ecmp.py:
   skip:

--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -10,6 +10,8 @@ from ipaddress import ip_address, IPv4Address
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m   # noqa F401
 from tests.common.dualtor.dual_tor_utils import lower_tor_host   # noqa F401
+# Temporary work around to add skip_traffic_test fixture from duthost_utils
+from tests.common.fixtures.duthost_utils import skip_traffic_test       # noqa F401
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +180,11 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo, 
     duthost.shell("sudo ip neigh flush nud permanent")
 
 
-def verify_icmp_packet(dut_mac, src_port, dst_port, ptfadapter, tbinfo, vlan_mac=None, dtor_ul=False, dtor_dl=False):
+def verify_icmp_packet(dut_mac, src_port, dst_port, ptfadapter, tbinfo,
+                       vlan_mac=None, dtor_ul=False, dtor_dl=False, skip_traffic_test=False):   # noqa F811
+    if skip_traffic_test is True:
+        logger.info("Skipping traffic test")
+        return
     if dtor_ul is True:
         # use vlan int mac in case of dualtor UL test pkt
         pkt = testutils.simple_icmp_packet(eth_src=str(src_port['mac']),
@@ -218,8 +224,8 @@ def verify_icmp_packet(dut_mac, src_port, dst_port, ptfadapter, tbinfo, vlan_mac
                 raise e  # If it fails on the last attempt, raise the exception
 
 
-def test_vlan_ping(vlan_ping_setup, duthosts, rand_one_dut_hostname,
-                   ptfadapter, tbinfo, toggle_all_simulator_ports_to_rand_selected_tor_m):   # noqa F811
+def test_vlan_ping(vlan_ping_setup, duthosts, rand_one_dut_hostname, ptfadapter, tbinfo,
+                   toggle_all_simulator_ports_to_rand_selected_tor_m, skip_traffic_test):   # noqa F811
     """
     test for checking connectivity of statically added ipv4 and ipv6 arp entries
     """
@@ -247,12 +253,16 @@ def test_vlan_ping(vlan_ping_setup, duthosts, rand_one_dut_hostname,
     for member in ptfhost_info:
         if 'dualtor' in tbinfo["topo"]["name"]:
             verify_icmp_packet(duthost.facts['router_mac'], ptfhost_info[member],
-                               vmhost_info, ptfadapter, tbinfo, vlan_mac, dtor_ul=True)
+                               vmhost_info, ptfadapter, tbinfo, vlan_mac, dtor_ul=True,
+                               skip_traffic_test=skip_traffic_test)
             verify_icmp_packet(duthost.facts['router_mac'], vmhost_info, ptfhost_info[member],
-                               ptfadapter, tbinfo, vlan_mac, dtor_dl=True)
+                               ptfadapter, tbinfo, vlan_mac, dtor_dl=True,
+                               skip_traffic_test=skip_traffic_test)
         else:
-            verify_icmp_packet(duthost.facts['router_mac'], ptfhost_info[member], vmhost_info, ptfadapter, tbinfo)
-            verify_icmp_packet(duthost.facts['router_mac'], vmhost_info, ptfhost_info[member], ptfadapter, tbinfo)
+            verify_icmp_packet(duthost.facts['router_mac'], ptfhost_info[member], vmhost_info, ptfadapter, tbinfo,
+                               skip_traffic_test=skip_traffic_test)
+            verify_icmp_packet(duthost.facts['router_mac'], vmhost_info, ptfhost_info[member], ptfadapter, tbinfo,
+                               skip_traffic_test=skip_traffic_test)
 
     # flushing and re-adding ipv6 static arp entry
     static_neighbor_entry(duthost, ptfhost_info, "del", "6")
@@ -271,9 +281,13 @@ def test_vlan_ping(vlan_ping_setup, duthosts, rand_one_dut_hostname,
     for member in ptfhost_info:
         if 'dualtor' in tbinfo["topo"]["name"]:
             verify_icmp_packet(duthost.facts['router_mac'], ptfhost_info[member],
-                               vmhost_info, ptfadapter, tbinfo, vlan_mac, dtor_ul=True)
+                               vmhost_info, ptfadapter, tbinfo, vlan_mac, dtor_ul=True,
+                               skip_traffic_test=skip_traffic_test)
             verify_icmp_packet(duthost.facts['router_mac'], vmhost_info, ptfhost_info[member],
-                               ptfadapter, tbinfo, vlan_mac, dtor_dl=True)
+                               ptfadapter, tbinfo, vlan_mac, dtor_dl=True,
+                               skip_traffic_test=skip_traffic_test)
         else:
-            verify_icmp_packet(duthost.facts['router_mac'], ptfhost_info[member], vmhost_info, ptfadapter, tbinfo)
-            verify_icmp_packet(duthost.facts['router_mac'], vmhost_info, ptfhost_info[member], ptfadapter, tbinfo)
+            verify_icmp_packet(duthost.facts['router_mac'], ptfhost_info[member], vmhost_info, ptfadapter, tbinfo,
+                               skip_traffic_test=skip_traffic_test)
+            verify_icmp_packet(duthost.facts['router_mac'], vmhost_info, ptfhost_info[member], ptfadapter, tbinfo,
+                               skip_traffic_test=skip_traffic_test)

--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -25,7 +25,7 @@ ecmp_utils = Ecmp_Utils()
 def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loganalyzer):
     # Ignore in KVM test
     KVMIgnoreRegex = [
-        ".*'vnetRouteCheck' status failed.*",
+        ".*'vnetRouteCheck' status failed.*missed_in_asic_db_routes.*",
     ]
     duthost = duthosts[rand_one_dut_hostname]
     if loganalyzer:  # Skip if loganalyzer is disabled

--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -21,6 +21,18 @@ Logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loganalyzer):
+    # Ignore in KVM test
+    KVMIgnoreRegex = [
+        ".*'vnetRouteCheck' status failed.*",
+    ]
+    duthost = duthosts[rand_one_dut_hostname]
+    if loganalyzer:  # Skip if loganalyzer is disabled
+        if duthost.facts["asic_type"] == "vs":
+            loganalyzer[duthost.hostname].ignore_regex.extend(KVMIgnoreRegex)
+
+
 def uniq(lst):
     last = object()
     for item in sorted(lst):

--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -21,18 +21,6 @@ Logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()
 
 
-@pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loganalyzer):
-    # Ignore in KVM test
-    KVMIgnoreRegex = [
-        ".*'vnetRouteCheck' status failed.*missed_in_asic_db_routes.*",
-    ]
-    duthost = duthosts[rand_one_dut_hostname]
-    if loganalyzer:  # Skip if loganalyzer is disabled
-        if duthost.facts["asic_type"] == "vs":
-            loganalyzer[duthost.hostname].ignore_regex.extend(KVMIgnoreRegex)
-
-
 def uniq(lst):
     last = object()
     for item in sorted(lst):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
`vlan/test_vlan_ping.py` failed in PR test in verify traffic, which is not supported in KVM
`vxlan/test_vxlan_crm.py` has log analyzer failure for mismatch vnet routes '150.0.9.1/32' and '150.0.8.1/32' in asic db
#### How did you do it?
Skip traffic test in `vlan/test_vlan_ping.py` 
Created issue https://github.com/sonic-net/sonic-mgmt/issues/14311 for vnet routes mismatch, xfail test with issue
#### How did you verify/test it?
Test in KVM
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
