### PR TITLE
[Snappi] fix TypeError in multidut snappi test cases and topo maker

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -105,7 +105,8 @@ def get_lossless_buffer_size(host_ans):
     Returns:
         total switch buffer size in byte (int)
     """
-    config_facts = host_ans.config_facts(host=host_ans.hostname,
+    dut_asic = host_ans.asic_instance()
+    config_facts = dut_asic.config_facts(host=host_ans.hostname,
                                          source="running")['ansible_facts']
 
     is_cisco8000_platform = True if 'cisco-8000' in host_ans.facts['platform_asic'] else False

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_runtime_traffic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_runtime_traffic_with_snappi.py
@@ -10,7 +10,7 @@ from tests.snappi_tests.variables import config_set, line_card_choice
 from tests.snappi_tests.multidut.pfcwd.files.pfcwd_multidut_runtime_traffic_helper import run_pfcwd_runtime_traffic_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 
-pytestmark = [pytest.mark.topology('snappi')]
+pytestmark = [pytest.mark.topology('multidut-tgen')]
 
 
 @pytest.mark.parametrize('line_card_choice', [line_card_choice])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Fix two issues:

1. errors in `test_multidut_pfc_pause_lossless_with_snappi.py`

```
snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[svcstr2-8800-sup-1|4-linecard_configuration_set0-chassis_multi_line_card_multi_asic] 
-------------------------------- live log call ---------------------------------
15:22:32 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 1788, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 501, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 119, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 138, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 102, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/data/sonic-mgmt-int/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py", line 89, in test_pfc_pause_single_lossless_prio
    run_pfc_test(api=snappi_api,
  File "/data/sonic-mgmt-int/tests/snappi_tests/multidut/pfc/files/multidut_helper.py", line 290, in run_pfc_test
    verify_in_flight_buffer_pkts(duthost=duthost,
  File "/data/sonic-mgmt-int/tests/common/snappi_tests/traffic_generation.py", line 569, in verify_in_flight_buffer_pkts
    pytest_assert(tx_bytes_total < dut_buffer_size,
TypeError: '<' not supported between instances of 'int' and 'NoneType'
```
2. wrong topology marker is used in `test_multidut_pfcwd_runtime_traffic_with_snappi.py`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix test case failure. 

#### How did you do it?
1. The TypeError was because `BUFFER_POOL` is not in the default `config_db.json` for multi-asic platform. need to use `config_db[x].json` to get it.  Use duthost.asic_instance() to suit both pizzabox and multi-asic DUT.
2. multi-dut test case should use multidut-tgen in the topology marker.

#### How did you verify/test it?
Verified locally.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
