### PR TITLE
Add ECN profile before test case running.

### DIFF
--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -32,6 +32,10 @@ def ensure_dut_readiness(duthost):
         duthost: DUT host object
     """
     verify_orchagent_running_or_assert(duthost)
+
+    duthost.shell('sonic-db-cli CONFIG_DB hset "WRED_PROFILE|AZURE_LOSSLESS" green_min_threshold 100 \
+                   green_max_threshold 100000 green_drop_probability 10 wred_green_enable true')
+
     create_checkpoint(duthost)
 
     yield

--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -60,10 +60,10 @@ def ensure_application_of_updated_config(duthost, configdb_field, values):
     def _confirm_value_in_asic_db():
         wred_objects = duthost.shell('sonic-db-cli ASIC_DB keys *WRED*')["stdout"]
         wred_objects = wred_objects.split("\n")
-        if(len(wred_objects) > 1):
+        if (len(wred_objects) > 1):
             for wred_object in wred_objects:
                 wred_data = duthost.shell('sonic-db-cli ASIC_DB hgetall {}'.format(wred_object))["stdout"]
-                if('NULL' in wred_data):
+                if ('NULL' in wred_data):
                     continue
                 wred_data = ast.literal_eval(wred_data)
                 for field, value in zip(configdb_field.split(','), values.split(',')):

--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -47,6 +47,8 @@ def ensure_dut_readiness(duthost):
     finally:
         delete_checkpoint(duthost)
 
+    duthost.shell('sonic-db-cli CONFIG_DB del "WRED_PROFILE|AZURE_LOSSLESS"')
+
 
 def ensure_application_of_updated_config(duthost, configdb_field, values):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add ECN profile before test case running.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The device consistently fails the "test_ecn_config_update" test case because it lacks an ECN profile, and this test case is designed solely to verify configuration update behavior.

#### How did you do it?
Add ECN profile before test case running.

#### How did you verify/test it?
Run the "test_ecn_config_update", the test result do not show any error message.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
No

### Documentation
No
