### PR TITLE
[202311][dualtor] Fix `test_stress_route` (#14162)

### DIFF
--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -31,8 +31,18 @@ def set_polling_interval(duthost):
     time.sleep(wait_time)
 
 
+@pytest.fixture(scope="module")
+def cleanup_neighbors_dualtor(duthosts, ptfhost, tbinfo):
+    """Cleanup neighbors on dualtor testbed."""
+    if "dualtor" in tbinfo["topo"]["name"]:
+        ptfhost.shell("supervisorctl stop garp_service", module_ignore_errors=True)
+        ptfhost.shell("supervisorctl stop arp_responder", module_ignore_errors=True)
+        duthosts.shell("sonic-clear arp")
+        duthosts.shell("sonic-clear ndp")
+
+
 @pytest.fixture(scope='module')
-def withdraw_and_announce_existing_routes(duthost, localhost, tbinfo):
+def withdraw_and_announce_existing_routes(duthost, localhost, tbinfo, cleanup_neighbors_dualtor):   # noqa F811
     ptf_ip = tbinfo["ptf_ip"]
     topo_name = tbinfo["topo"]["name"]
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
This is to cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/14162 into 202311

If there are neighbors left on the target device of dualtor testbed, the presence of tunnel routes of those neighbors on standby mux ports will be counted in the ipv4/ipv6 route crm counters; and if those neighbors are expired during test_stress_route, those tunnel routes will be removed, the ipv4/ipv6 route crm counters after the test will be less than those before the test.

Let's cleanup the neighbors on dualtor testbed and stop any arp-related ptf services(arp_responder and garp_service) if any.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
