### PR TITLE
Fix only test eBGP neighbors for test_bgp_queues

### DIFF
--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -59,6 +59,11 @@ def test_bgp_queues(duthosts, enum_frontend_dut_hostname, enum_asic_index, tbinf
     for k, v in list(bgp_facts['bgp_neighbors'].items()):
         # Only consider established bgp sessions
         if v['state'] == 'established':
+            # For "peer group" if it's internal it will be "INTERNAL_PEER_V4" or "INTERNAL_PEER_V6"
+            # If it's external it will be "RH_V4", "RH_V6", "AH_V4", "AH_V6", ...
+            if "INTERNAL" in v["peer group"] and duthost.get_facts().get('modular_chassis'):
+                # Skip iBGP neighbors since we only want to verify eBGP
+                continue
             assert (k in arp_dict.keys() or k in ndp_dict.keys())
             if k in arp_dict:
                 ifname = arp_dict[k].split('.', 1)[0]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: only test eBGP neighbors for test_bgp_queues
Fixes # (issue) 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Complete #11116 

#### How did you do it?

#### How did you verify/test it?
T2 profile

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
