### PR TITLE
[202405] Remove some vlan test from PR checker list

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -159,10 +159,6 @@ t0:
   - test_procdockerstatsd.py
   - testbed_setup/test_populate_fdb.py
   - upgrade_path/test_upgrade_path.py
-  - vlan/test_autostate_disabled.py
-  - vlan/test_host_vlan.py
-  - vlan/test_vlan.py
-  - vlan/test_vlan_ping.py
   - vxlan/test_vnet_route_leak.py
   - ip/test_mgmt_ipv6_only.py
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In master branch, we added some data plane test to PR checker with skipping traffic test, but fixtures to skipping traffic test didn't sync to 202405, and in 202405, some vlan test has added traffic validation
#### How did you do it?
202405 branch is not in our test set expand scope, , so remove vlan data plane test from PR checker in 202405, test in master branch is enough
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
