### PR TITLE
add healthy check after warm reboot for test_pfcwd_wb

### DIFF
--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -19,6 +19,7 @@ from tests.ptf_runner import ptf_runner
 from .files.pfcwd_helper import EXPECT_PFC_WD_DETECT_RE, EXPECT_PFC_WD_RESTORE_RE
 from .files.pfcwd_helper import send_background_traffic
 from .files.pfcwd_helper import has_neighbor_device
+from tests.common.utilities import wait_until
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
 TESTCASE_INFO = {'no_storm': {'test_sequence': ["detect", "restore", "warm-reboot", "detect", "restore"],
@@ -520,8 +521,13 @@ class TestPfcwdWb(SetupPfcwdFunc):
         self.storm_threads = []
 
         for t_idx, test_action in enumerate(testcase_actions):
+            logger.info("Index {} test_action {}".format(t_idx, test_action))
             if 'warm-reboot' in test_action:
                 reboot(self.dut, localhost, reboot_type="warm", wait_warmboot_finalizer=True)
+
+                assert wait_until(300, 20, 20, self.dut.critical_services_fully_started), \
+                    "All critical services should fully started!"
+
                 continue
 
             # Need to wait some time after warm-reboot for the counters to be created


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
29093771

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
The case is flaky, failed sometimes.

#### How did you do it?
Add healthy check after warm reboot to determine whether the failed caused by warm-reboot or pfcwd

#### How did you verify/test it?
Local run the case

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
