### PR TITLE
update rsyslog fixture to workaround /var/log size limitation

### DIFF
--- a/tests/fdb/test_fdb_mac_move.py
+++ b/tests/fdb/test_fdb_mac_move.py
@@ -27,50 +27,6 @@ pytestmark = [
 ]
 
 
-def modify_rsyslog_severity_level(dut):
-    logger.info('Modify rsyslog severity level to error on dut: {}'.format(dut.hostname))
-    dut.shell("sudo mv /etc/rsyslog.d /etc/rsyslog.d.bak")
-    dut.shell("sudo mkdir /etc/rsyslog.d")
-    dut.shell("sudo echo '*.err    /var/log/syslog' > /etc/rsyslog.d/50_debug.conf")
-    dut.shell("sudo systemctl restart rsyslog")
-    time.sleep(5)
-
-
-def revert_rsyslog_severity_level(dut):
-    logger.info('Revert rsyslog severity level to error on dut: {}'.format(dut.hostname))
-    dut.shell("sudo rm -rf /etc/rsyslog.d")
-    dut.shell("sudo mv /etc/rsyslog.d.bak /etc/rsyslog.d")
-    dut.shell("sudo systemctl restart rsyslog")
-    time.sleep(5)
-
-
-@pytest.fixture(scope="function")
-def fixture_rsyslog_conf_setup_teardown(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-
-    # workaround for small disk devices which also has limitation on /var/log size
-    cmd = "df -m"
-    cmd_response_lines = duthost.shell(cmd, module_ignore_errors=True).get('stdout_lines', [])
-    logger.debug("cmd {} rsp {}".format(cmd, cmd_response_lines))
-
-    available_size = 0
-    for line in cmd_response_lines:
-        if "/var/log" in line:
-            available_size = int(line.split()[3])
-            break
-
-    if available_size < 400:
-        modify_rsyslog_severity_level(duthost)
-        rsyslog_severity_level_modified = True
-    else:
-        rsyslog_severity_level_modified = False
-
-    yield
-
-    if rsyslog_severity_level_modified:
-        revert_rsyslog_severity_level(duthost)
-
-
 def get_fdb_dict(ptfadapter, vlan_table, dummay_mac_count):
     """
     :param ptfadapter: PTF adapter object

--- a/tests/fdb/test_fdb_mac_move.py
+++ b/tests/fdb/test_fdb_mac_move.py
@@ -57,7 +57,7 @@ def get_fdb_dict(ptfadapter, vlan_table, dummay_mac_count):
 
 
 def test_fdb_mac_move(ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, get_function_conpleteness_level,
-                      fixture_rsyslog_conf_setup_teardown):
+                      rotate_syslog):
     # Perform FDB clean up before each test
     fdb_cleanup(duthosts, rand_one_dut_hostname)
 

--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -6,11 +6,6 @@ import pytest
 from tests.common import config_reload
 from tests.common.utilities import wait_until
 from utils import get_crm_resource_status, check_queue_status, sleep_to_wait
-import subprocess
-import threading
-from tests.common.utilities import wait_until
-from utils import get_crm_resources, check_queue_status, sleep_to_wait
-from tests.common import config_reload
 
 CRM_POLLING_INTERVAL = 1
 CRM_DEFAULT_POLL_INTERVAL = 300

--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -6,6 +6,12 @@ import pytest
 from tests.common import config_reload
 from tests.common.utilities import wait_until
 from utils import get_crm_resource_status, check_queue_status, sleep_to_wait
+import subprocess
+import threading
+from tests.common.utilities import wait_until
+from utils import get_crm_resources, check_queue_status, sleep_to_wait
+from tests.common import config_reload
+from tests.common.utilities import InterruptableThread
 
 CRM_POLLING_INTERVAL = 1
 CRM_DEFAULT_POLL_INTERVAL = 300
@@ -92,3 +98,41 @@ def check_system_memmory(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     logger.debug("CMD {}: after test {}".format(cmd, cmd_response.get('stdout', None)))
 
     config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+
+
+def run_logrotate(duthost, stop_event):
+    logger.info("Start rotate_syslog on {}".format(duthost))
+    while not stop_event.is_set():
+        try:
+            # rm swss logs
+            duthost.shell("rm -rf /var/log/swss/sairedis.rec*.gz /var/log/swss/swss.rec*.gz", module_ignore_errors=True)
+            # Run logrotate for rsyslog
+            duthost.shell("logrotate -f /etc/logrotate.conf", module_ignore_errors=True)
+        except subprocess.CalledProcessError as e:
+            logger.error("Error: {}".format(str(e)))
+        # Wait for 30 seconds before the next rotation
+        time.sleep(30)
+
+
+@pytest.fixture(scope="function")
+def rotate_syslog(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+
+    stop_event = threading.Event()
+    thread = InterruptableThread(
+        target=run_logrotate,
+        args=(duthost, stop_event,)
+    )
+    thread.daemon = True
+    thread.start()
+
+    yield
+    stop_event.set()
+    try:
+        if thread.is_alive():
+            thread.join(timeout=30)
+            logger.info("thread {} joined".format(thread))
+    except Exception as e:
+        logger.debug("Exception occurred in thread {}".format(str(e)))
+
+    logger.info("rotate_syslog exit {}".format(thread))

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -43,7 +43,7 @@ def announce_withdraw_routes(duthost, namespace, localhost, ptf_ip, topo_name):
 def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_conpleteness_level,
                                  withdraw_and_announce_existing_routes, loganalyzer,
                                  enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index,
-                                 fixture_rsyslog_conf_setup_teardown, rotate_syslog):
+                                 rotate_syslog):
     ptf_ip = tbinfo["ptf_ip"]
     topo_name = tbinfo["topo"]["name"]
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -42,7 +42,8 @@ def announce_withdraw_routes(duthost, namespace, localhost, ptf_ip, topo_name):
 
 def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_conpleteness_level,
                                  withdraw_and_announce_existing_routes, loganalyzer,
-                                 enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index):
+                                 enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index,
+                                 fixture_rsyslog_conf_setup_teardown):
     ptf_ip = tbinfo["ptf_ip"]
     topo_name = tbinfo["topo"]["name"]
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -43,7 +43,7 @@ def announce_withdraw_routes(duthost, namespace, localhost, ptf_ip, topo_name):
 def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_conpleteness_level,
                                  withdraw_and_announce_existing_routes, loganalyzer,
                                  enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index,
-                                 fixture_rsyslog_conf_setup_teardown):
+                                 fixture_rsyslog_conf_setup_teardown, rotate_syslog):
     ptf_ip = tbinfo["ptf_ip"]
     topo_name = tbinfo["topo"]["name"]
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
The case failed sometimes due to cannot found the log.
It should be related to the small storage, since the var/log size limitation, logrotate would remove the previous syslogs during the test, then cause loganalyzer cannot find the previous log and teardown failure.

#### How did you do it?
It is caused by storage resource limitation, could not fix the issue, this PR is a workaround.
Since set the syslog to error lever and update the logroate to compress log immediately during the test still failed sometimes. Create a thread to do the logrotate every 60s during the test.

#### How did you verify/test it?
https://elastictest.org/scheduler/testplan/66d1ebb7f90c6cd947f4dd3e

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
