### PR TITLE
Stabilize test_pfcwd_timer_accuracy

### DIFF
--- a/tests/common/templates/pfc_storm_mlnx_sonic.j2
+++ b/tests/common/templates/pfc_storm_mlnx_sonic.j2
@@ -1,5 +1,5 @@
 {% if (pfc_asym  is defined) and (pfc_asym == True) %}
-docker exec syncd /bin/bash -c "{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} python /root/{{pfc_gen_file}} -p {{pfc_queue_index}} -n {{pfc_frames_number}} -i {{pfc_fanout_interface}} -l {{pfc_fanout_label_port}}" > /dev/null 2>&1 &
+docker exec syncd /bin/bash -c "{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} python /root/{{pfc_gen_file}} -p {{pfc_queue_index}} -n {{pfc_frames_number}} -i {{pfc_fanout_interface}} -l {{pfc_fanout_label_port}}" > /dev/null 2>&1
 {% else %}
-docker exec syncd /bin/bash -c "{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} python /root/{{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -n {{pfc_frames_number}} -s {{send_pfc_frame_interval}} -i {{pfc_fanout_interface}} -l {{pfc_fanout_label_port}} -r {{ansible_eth0_ipv4_addr}}" > /dev/null 2>&1 &
+docker exec syncd /bin/bash -c "{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} python /root/{{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -n {{pfc_frames_number}} -s {{send_pfc_frame_interval}} -i {{pfc_fanout_interface}} -l {{pfc_fanout_label_port}} -r {{ansible_eth0_ipv4_addr}}" > /dev/null 2>&1
 {% endif %}

--- a/tests/common/templates/pfc_storm_stop_mlnx_sonic.j2
+++ b/tests/common/templates/pfc_storm_stop_mlnx_sonic.j2
@@ -1,5 +1,5 @@
 {% if (pfc_asym  is defined) and (pfc_asym == True) %}
-docker exec syncd /bin/bash -c "{% if pfc_storm_stop_defer_time is defined %} sleep {{pfc_storm_stop_defer_time}} &&{% endif %} python /root/{{pfc_gen_file}} -d -p {{pfc_queue_index}} -n {{pfc_frames_number}} -i {{pfc_fanout_interface}} -l {{pfc_fanout_label_port}}" > /dev/null 2>&1 &
+docker exec syncd /bin/bash -c "{% if pfc_storm_stop_defer_time is defined %} sleep {{pfc_storm_stop_defer_time}} &&{% endif %} python /root/{{pfc_gen_file}} -d -p {{pfc_queue_index}} -n {{pfc_frames_number}} -i {{pfc_fanout_interface}} -l {{pfc_fanout_label_port}}" > /dev/null 2>&1
 {% else %}
-docker exec syncd /bin/bash -c "{% if pfc_storm_stop_defer_time is defined %} sleep {{pfc_storm_stop_defer_time}} &&{% endif %} python /root/{{pfc_gen_file}} -d -p {{(1).__lshift__(pfc_queue_index)}} -n {{pfc_frames_number}} -i {{pfc_fanout_interface}} -l {{pfc_fanout_label_port}} -r {{ansible_eth0_ipv4_addr}}" > /dev/null 2>&1 &
+docker exec syncd /bin/bash -c "{% if pfc_storm_stop_defer_time is defined %} sleep {{pfc_storm_stop_defer_time}} &&{% endif %} python /root/{{pfc_gen_file}} -d -p {{(1).__lshift__(pfc_queue_index)}} -n {{pfc_frames_number}} -i {{pfc_fanout_interface}} -l {{pfc_fanout_label_port}} -r {{ansible_eth0_ipv4_addr}}" > /dev/null 2>&1
 {% endif %}

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -182,6 +182,8 @@ class TestPfcwdAllTimer(object):
         queues = [self.storm_handle.pfc_queue_idx]
 
         with send_background_traffic(self.dut, self.ptf, queues, selected_test_ports, test_ports_info):
+            # Ensure the background traffic is running
+            time.sleep(1)
             self.storm_handle.start_storm()
             logger.info("Wait for queue to recover from PFC storm")
             time.sleep(32)
@@ -206,6 +208,9 @@ class TestPfcwdAllTimer(object):
             self.all_restore_time.append(real_restore_time)
 
         dut_detect_restore_time = storm_restore_ms - storm_detect_ms
+        logger.info(
+            "Iteration all_dut_detect_time list {} and length {}".format(
+                ",".join(str(i) for i in self.all_detect_time), len(self.all_detect_time)))
         self.all_dut_detect_restore_time.append(dut_detect_restore_time)
         logger.info(
             "Iteration all_dut_detect_restore_time list {} and length {}".format(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to stabilize `test_pfcwd_timer_accuracy`.
The test was flaky on some Mellanox platforms. There are two different issues
1. PFCWD didn't fire as expected
```
Failed: run module shell failed, Ansible Results =>
{"changed": true, "cmd": "grep \"[d]etected PFC storm\" /var/log/syslog", "delta": "0:00:00.007635", "end": "2024-07-24 10:38:26.948660", "failed": true, "msg": "non-zero return code", "rc": 1, "start": "2024-07-24 10:38:26.941025", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```
2. The timer accuracy (mainly detection time) is above the threshold.
```
Failed: Real detection time is greater than configured: Real detect time: 802 Expected: 800 (wd_detect_time + wd_poll_time)
```

This PR fixed the issue by
1. Force `pfc_gen.py` script to run in foreground to ensure the script start sending PFC pause before the test (remove &). It doesn't have to be running in background as the script returns immediately.
2. Add 1 second delay after start sending background traffic. This change is to ensure the background traffic is running when test started

This PR also added a new log message for debugging purpose.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to stabilize `test_pfcwd_timer_accuracy`.

#### How did you do it?
This PR fixed the issue by
1. Force `pfc_gen.py` script to run in foreground to ensure the script start sending PFC pause before the test (remove &). It doesn't have to be running in background as the script returns immediately.
2. Add 1 second delay after start sending background traffic. This change is to ensure the background traffic is running when test started.

#### How did you verify/test it?
The change is verified on a Mellanox testbed 
```
collected 1 item                                                                                                                                                                                      

pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy[str-msn4700-02]  ^H ^H ^H ^H ^H ^HPASSED                                                                                         [100%]
```

#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
