### PR TITLE
Adjust fixture core_dump_and_config_check and sanity check to session scope level

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -586,13 +586,12 @@ def acl_table(duthosts, rand_one_dut_hostname, setup, stage, ip_version, tbinfo)
             create_or_remove_acl_table(duthost, acl_table_config, setup, "remove", topo)
             raise err
 
-    try:
-        yield acl_table_config
-    finally:
-        for duthost, loganalyzer in list(dut_to_analyzer_map.items()):
-            loganalyzer.expect_regex = [LOG_EXPECT_ACL_TABLE_REMOVE_RE]
-            with loganalyzer:
-                create_or_remove_acl_table(duthost, acl_table_config, setup, "remove", topo)
+    yield acl_table_config
+
+    for duthost, loganalyzer in list(dut_to_analyzer_map.items()):
+        loganalyzer.expect_regex = [LOG_EXPECT_ACL_TABLE_REMOVE_RE]
+        with loganalyzer:
+            create_or_remove_acl_table(duthost, acl_table_config, setup, "remove", topo)
 
 
 class BaseAclTest(six.with_metaclass(ABCMeta, object)):

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -586,12 +586,13 @@ def acl_table(duthosts, rand_one_dut_hostname, setup, stage, ip_version, tbinfo)
             create_or_remove_acl_table(duthost, acl_table_config, setup, "remove", topo)
             raise err
 
-    yield acl_table_config
-
-    for duthost, loganalyzer in list(dut_to_analyzer_map.items()):
-        loganalyzer.expect_regex = [LOG_EXPECT_ACL_TABLE_REMOVE_RE]
-        with loganalyzer:
-            create_or_remove_acl_table(duthost, acl_table_config, setup, "remove", topo)
+    try:
+        yield acl_table_config
+    finally:
+        for duthost, loganalyzer in list(dut_to_analyzer_map.items()):
+            loganalyzer.expect_regex = [LOG_EXPECT_ACL_TABLE_REMOVE_RE]
+            with loganalyzer:
+                create_or_remove_acl_table(duthost, acl_table_config, setup, "remove", topo)
 
 
 class BaseAclTest(six.with_metaclass(ABCMeta, object)):

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -107,7 +107,7 @@ def mux_server_url(mux_server_info):
     return ""
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def url(mux_server_url, duthost, tbinfo):
     """
     A helper function is returned to make fixture accept arguments
@@ -851,7 +851,7 @@ def simulator_clear_flap_counters(url):
     pytest_assert(_post(server_url, data), "Failed to clear flap counter for all ports")
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def reset_simulator_port(url):
 
     def _reset_simulator_port(interface_name=None):
@@ -869,7 +869,7 @@ def reset_all_simulator_ports(url):
     pytest_assert(_post(server_url, {}))
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def get_mux_status(url):
 
     def _get_mux_status(interface_name=None):

--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -111,7 +111,7 @@ def restart_nic_simulator_session(nic_simulator_info, vmhost):
     _restart_nic_simulator(vmhost, vmset_name)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def restart_nic_simulator(nic_simulator_info, vmhost):
     """Fixture to restart nic_simulator service on the VM server host."""
     _, _, vmset_name = nic_simulator_info

--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -5,13 +5,13 @@ import yaml
 import copy
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def conn_graph_facts(duthosts, localhost):
     return get_graph_facts(duthosts[0], localhost,
                            [dh.hostname for dh in duthosts])
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def fanout_graph_facts(localhost, duthosts, rand_one_tgen_dut_hostname, conn_graph_facts):
     duthost = duthosts[rand_one_tgen_dut_hostname]
     facts = dict()

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -119,7 +119,7 @@ def do_checks(request, check_items, *args, **kwargs):
     return check_results
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def sanity_check_full(localhost, duthosts, request, fanouthosts, nbrhosts, tbinfo):
     logger.info("Prepare sanity check")
 
@@ -313,7 +313,7 @@ def recover_on_sanity_check_failure(duthosts, failed_results, fanouthosts, local
                   f"{json.dumps(new_failed_results, indent=4, default=fallback_serializer)}")
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def sanity_check(request):
     if request.config.option.skip_sanity:
         logger.info("Skip sanity check according to command line argument")

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -846,7 +846,7 @@ def check_secureboot(duthosts, request):
 
     default_allowlist = [r".*\.pyc"]
     cache_location = 'secureboot_sanity_check'
-    module = request.module.__name__
+    key = "check_secureboot_key"
 
     def _read_config_by_dut(duthost):
         results = {}
@@ -910,11 +910,11 @@ def check_secureboot(duthosts, request):
 
     def _pre_check():
         configs = _read_configs()
-        cache.write(cache_location, module, configs)
+        cache.write(cache_location, key, configs)
 
     def _post_check():
         check_results = []
-        old_configs = cache.read(cache_location, module)
+        old_configs = cache.read(cache_location, key)
         if not old_configs:
             old_configs = {}
         new_configs = _read_configs()

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -632,7 +632,7 @@ def _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs):
     return True, "", duts_parsed_mux_status
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def check_mux_simulator(tbinfo, duthosts, duts_minigraph_facts, get_mux_status,     # noqa F811
                         reset_simulator_port, restart_nic_simulator,                # noqa F811
                         active_standby_ports):                                      # noqa F811

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -85,7 +85,7 @@ def _find_down_ports(dut, phy_interfaces, ip_interfaces):
     return down_ports
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def check_interfaces(duthosts):
     init_result = {"failed": False, "check_item": "interfaces"}
 
@@ -149,7 +149,7 @@ def check_interfaces(duthosts):
     return _check
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def check_bgp(duthosts, tbinfo):
     init_result = {"failed": False, "check_item": "bgp"}
 
@@ -274,7 +274,7 @@ def _is_db_omem_over_threshold(command_output):
     return result, total_omem, non_zero_output
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def check_dbmemory(duthosts):
     def _check(*args, **kwargs):
         init_result = {"failed": False, "check_item": "dbmemory"}
@@ -698,7 +698,7 @@ def check_mux_simulator(tbinfo, duthosts, duts_minigraph_facts, get_mux_status, 
     return _check
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def check_monit(duthosts):
     """
     @summary: Check whether the Monit is running and whether the services which were monitored by Monit are
@@ -769,7 +769,7 @@ def check_monit(duthosts):
     return _check
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def check_processes(duthosts):
     def _check(*args, **kwargs):
         init_result = {"failed": False, "check_item": "processes"}
@@ -837,7 +837,7 @@ def check_processes(duthosts):
     return _check
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def check_secureboot(duthosts, request):
     """
     Check if the file change in rw folder is as expected when secureboot feature enabled
@@ -956,7 +956,7 @@ def check_secureboot(duthosts, request):
     return _check
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def check_neighbor_macsec_empty(ctrl_links):
     nodes = []
     nodes_name = set()
@@ -993,7 +993,7 @@ def check_neighbor_macsec_empty(ctrl_links):
 
 
 # check ipv6 neighbor reachability
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def check_ipv6_mgmt(duthosts, localhost):
     # check ipv6 mgmt interface reachability for debugging purpose only.
     # No failure will be trigger for this sanity check.
@@ -1025,7 +1025,7 @@ def check_ipv6_mgmt(duthosts, localhost):
     return _check
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def check_orchagent_usage(duthosts):
     def _check(*args, **kwargs):
         init_result = {"failed": False, "check_item": "orchagent_usage"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2096,7 +2096,7 @@ def __dut_reload(duts_data, node=None, results=None):
             node.copy(src=asic_cfg_file, dest='/etc/sonic/config_db{}.json'.format(asic_index), verbose=False)
             os.remove(asic_cfg_file)
 
-    config_reload(node, wait_before_force_reload=300)
+    config_reload(node, wait_before_force_reload=300, safe_reload=True)
 
 
 def compare_running_config(pre_running_config, cur_running_config):
@@ -2123,7 +2123,11 @@ def compare_running_config(pre_running_config, cur_running_config):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def core_dump_and_config_check(duthosts, tbinfo, request):
+def core_dump_and_config_check(duthosts, tbinfo,
+                               request,
+                               # make sure the tear down of sanity_check happened after core_dump_and_config_check
+                               sanity_check
+                               ):
     '''
     Check if there are new core dump files and if the running config is modified after the test case running.
     If so, we will reload the running config after test case running.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -418,7 +418,7 @@ def set_rand_one_dut_hostname(request):
         logger.info("Randomly select dut {} for testing".format(rand_one_dut_hostname_var))
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def rand_one_dut_hostname(request):
     """
     """
@@ -440,7 +440,7 @@ def selected_rand_dut(request):
     return rand_one_dut_hostname_var
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def rand_one_dut_front_end_hostname(request):
     """
     """
@@ -451,7 +451,7 @@ def rand_one_dut_front_end_hostname(request):
     return dut_hostnames[0]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def rand_one_tgen_dut_hostname(request, tbinfo, rand_one_dut_front_end_hostname, rand_one_dut_hostname):
     """
     Return the randomly selected duthost for TGEN test cases

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2122,7 +2122,7 @@ def compare_running_config(pre_running_config, cur_running_config):
             return False
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def core_dump_and_config_check(duthosts, tbinfo,
                                request,
                                # make sure the tear down of sanity_check happened after core_dump_and_config_check

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1971,7 +1971,7 @@ def dut_test_params(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo,
     yield rtn_dict
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def duts_minigraph_facts(duthosts, tbinfo):
     """Return minigraph facts for all DUT hosts
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -654,7 +654,7 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
     return devices
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def fanouthosts(enhance_inventory, ansible_adhoc, conn_graph_facts, creds, duthosts):      # noqa F811
     """
     Shortcut fixture for getting Fanout hosts

--- a/tests/macsec/__init__.py
+++ b/tests/macsec/__init__.py
@@ -120,7 +120,7 @@ class MacsecPlugin(object):
     def macsec_nbrhosts(self, ctrl_links):
         return {nbr["name"]: nbr for nbr in list(ctrl_links.values())}
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture(scope="session")
     def ctrl_links(self, macsec_duthost, tbinfo, nbrhosts):
 
         if not nbrhosts:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. Adjust fixture core_dump_and_config_check and sanity check to session scope level 
2. Enable readiness check in the core_dump_and_config_check 
3. Adjust the order between sanity_check and core_dump_and_config_check 




### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
1. Adjust fixture core_dump_and_config_check and sanity check to session scope level 
In our pytest usage, we don't use multi-module in one single session.
So for session scope and module scope fixtures, they run once during each test modules.

Supposedly, we expect the running order of fixtures to be:

fixture setting up -> test_module run -> fixtures tearing down:
sanity_check -> core_dump_and_config_check -> test_module fixtures ->test module running -> test_module fixtures ->  core_dump_and_config_check -> sanity_check 

But due to pytest fixture mechanism, there's chance that the tear down of core_dump_and_config_check happens before test_module fixtures.

This will cause unexpected error, for example, on the acl_table(module level fixture of test_acl.py) , it relies on the configuration updated during the test module, but it have already recovered by core_dump_and_config_check , which causes failure.

Hance upgrade core_dump_and_config_check and sanity check to session scope level, to confirm the order of setting up/ tearing down the fixtures.

2. Enable readiness check in the core_dump_and_config_check 
core_dump_and_config_check will issue config_reload to the duthosts after test module finished and if there's coredump or config_db changes.
For now, it simply issues the config_reload command then returns and finishes.
For the testbeds that require more time to be ready, it possibly fails on the sanity check of the next test module.
Hence enable the readiness check of the config_reload.


3. Adjust the order between sanity_check and core_dump_and_config_check 
sanity_check -> core_dump_and_config_check ->test module running -> core_dump_and_config_check -> sanity_check 
To make sure post_sanity check is the last fixture that modifies the testbeds.

#### How did you do it?

#### How did you verify/test it?
KVM test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
