### PR TITLE
Wait for acl delete rule/table message in syslog

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -540,8 +540,6 @@ def create_or_remove_acl_table(duthost, acl_table_config, setup, op, topo):
             logger.info("Removing ACL table \"{}\" in namespace {} on device {}"
                         .format(acl_table_config["table_name"], namespace, duthost))
             sonic_host_or_asic_inst.command("config acl remove table {}".format(acl_table_config["table_name"]))
-    # Give the dut some time for the ACL to be applied and LOG message generated
-    time.sleep(30)
 
 
 @pytest.fixture(scope="module")
@@ -590,6 +588,8 @@ def tear_down_acl_table_single_dut(acl_table_config, duthost, loganalyzer, setup
     loganalyzer.expect_regex = [LOG_EXPECT_ACL_TABLE_REMOVE_RE]
     with loganalyzer:
         create_or_remove_acl_table(duthost, acl_table_config, setup, "remove", topo)
+        wait_until(60, 10, 0, check_msg_in_syslog,
+                   duthost, LOG_EXPECT_ACL_TABLE_REMOVE_RE)
 
 
 def set_up_acl_table_single_dut(acl_table_config, dut_to_analyzer_map, duthost, setup, topo):
@@ -701,6 +701,8 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         with loganalyzer:
             logger.info("Removing ACL rules")
             self.teardown_rules(duthost)
+            wait_until(60, 10, 0, check_msg_in_syslog,
+                       duthost, LOG_EXPECT_ACL_RULE_REMOVE_RE)
 
     def set_up_acl_rules_single_dut(self, request, acl_table,
                                     conn_graph_facts, dut_to_analyzer_map, duthost, # noqa F811


### PR DESCRIPTION
### Description of PR
On T2, the syslog messages from acl deletes can also take longer to appear, causing a few fails in acl tests.

Extend the changes from https://github.com/sonic-net/sonic-mgmt/pull/14255 to also wait for the syslog messages when the acl rules and table are deleted.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Reduce flakiness in acl tests

#### How did you do it?

#### How did you verify/test it?
Ran acl tests on single-asic T2 DUT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
