### PR TITLE
[Snappi] Infra changes to make snappi multidut work for T0/T1 testbed

### DIFF
--- a/tests/common/fixtures/conn_graph_facts.py
+++ b/tests/common/fixtures/conn_graph_facts.py
@@ -32,11 +32,17 @@ def fanout_graph_facts_multidut(localhost, duthosts, conn_graph_facts):
     if not dev_conn:
         return facts
 
+    fanout_set = set()
     for duthost in duthosts:
         for _, val in list(dev_conn[duthost.hostname].items()):
-            fanout = val["peerdevice"]
-            if fanout not in facts:
-                facts[fanout] = {k: v[fanout] for k, v in list(get_graph_facts(duthost, localhost, fanout).items())}
+            fanout_set.add(val["peerdevice"])
+
+    # Only take IXIA/SNAPPI testers into fanout_facts
+    for fanout in fanout_set:
+        fanout_data = {k: v[fanout] for k, v in list(get_graph_facts(duthost, localhost, fanout).items())}
+        if fanout_data['device_info']['HwSku'] in ('SNAPPI-tester', 'IXIA-tester'):
+            facts[fanout] = fanout_data
+
     return facts
 
 

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -229,7 +229,13 @@ def get_peer_snappi_chassis(conn_data, dut_hostname):
     if len(peer_devices) == 1:
         return peer_devices[0]
     else:
-        return None
+        # in case there are other fanout devices (Arista, SONiC, etc) defined in the inventory file,
+        # try to filter out the other device based on the name for now.
+        peer_snappi_devices = list(filter(lambda dut_name: ('ixia' in dut_name), peer_devices))
+        if len(peer_snappi_devices) == 1:
+            return peer_snappi_devices[0]
+        else:
+            return None
 
 
 def get_peer_port(conn_data, dut_hostname, dut_intf):

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1036,15 +1036,16 @@ def multidut_snappi_ports_for_bgp(duthosts,                                # noq
         multidut_snappi_ports = multidut_snappi_ports + snappi_ports
     return multidut_snappi_ports
 
+
 @pytest.fixture(scope="module")
-def get_snappi_ports_single_dut(duthosts,                                # noqa: F811
-                     conn_graph_facts,                        # noqa: F811
-                     fanout_graph_facts,
-                     tbinfo,
-                     snappi_api_serv_ip,
-                     rand_one_dut_hostname,
-                     rand_one_dut_portname_oper_up
-                     ):                                      # noqa: F811
+def get_snappi_ports_single_dut(duthosts,  # noqa: F811
+                                conn_graph_facts,  # noqa: F811
+                                fanout_graph_facts,  # noqa: F811
+                                tbinfo,
+                                snappi_api_serv_ip,
+                                rand_one_dut_hostname,
+                                rand_one_dut_portname_oper_up
+                                ):  # noqa: F811
     speed_type = {
                   '10000': 'speed_10_gbps',
                   '25000': 'speed_25_gbps',
@@ -1097,12 +1098,13 @@ def get_snappi_ports_single_dut(duthosts,                                # noqa:
             tx_ports.append(port)
     return rx_ports + tx_ports
 
+
 @pytest.fixture(scope="module")
-def get_snappi_ports_multi_dut(duthosts,                                # noqa: F811
-                     tbinfo,                                  # noqa: F811
-                     conn_graph_facts,                        # noqa: F811
-                     fanout_graph_facts_multidut,
-                     ):                                      # noqa: F811
+def get_snappi_ports_multi_dut(duthosts,  # noqa: F811
+                               tbinfo,  # noqa: F811
+                               conn_graph_facts,  # noqa: F811
+                               fanout_graph_facts_multidut,
+                               ):  # noqa: F811
     """
     Populate snappi ports and connected DUT ports info of T1 and T2 testbed and returns as a list
     Args:
@@ -1185,11 +1187,13 @@ def get_snappi_ports_multi_dut(duthosts,                                # noqa: 
         multidut_snappi_ports = multidut_snappi_ports + snappi_ports
     return multidut_snappi_ports
 
+
 def is_snappi_multidut(duthosts):
     if duthosts is None or len(duthosts) == 0:
         return False
 
     return duthosts[0].get_facts().get("modular_chassis")
+
 
 @pytest.fixture(scope="module")
 def get_snappi_ports(duthosts, request):
@@ -1207,6 +1211,7 @@ def get_snappi_ports(duthosts, request):
     else:
         snappi_ports = request.getfixturevalue("get_snappi_ports_single_dut")
     return snappi_ports
+
 
 def get_snappi_ports_for_rdma(snappi_port_list, rdma_ports, tx_port_count, rx_port_count, testbed):
     """

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -7,6 +7,7 @@ import snappi
 import sys
 import random
 import snappi_convergence
+from tests.common.helpers.assertions import pytest_require
 from ipaddress import ip_address, IPv4Address, IPv6Address
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
 from tests.common.snappi_tests.common_helpers import get_addrs_in_subnet, get_peer_snappi_chassis, \
@@ -365,6 +366,11 @@ def snappi_testbed_config(conn_graph_facts, fanout_graph_facts,     # noqa F811
         - config (obj): Snappi API config of the testbed
         - port_config_list (list): list of port configuration information
     """
+    # As of now both single dut and multidut fixtures are being called from the same test,
+    # When this function is called for T2 testbed, just return empty.
+    if is_snappi_multidut(duthosts):
+        return None, []
+
     duthost = duthosts[rand_one_dut_hostname]
 
     """ Generate L1 config """
@@ -776,6 +782,7 @@ def __intf_config_multidut(config, port_config_list, duthost, snappi_ports):
                                                                                     port['peer_port'],
                                                                                     dutIp,
                                                                                     prefix_length))
+        port['intf_config_changed'] = True
         device = config.devices.device(name='Device Port {}'.format(port_id))[-1]
         ethernet = device.ethernets.add()
         ethernet.name = 'Ethernet Port {}'.format(port_id)
@@ -912,7 +919,7 @@ def cleanup_config(duthost_list, snappi_ports):
         port_count = len(snappi_ports)
         dutIps = create_ip_list(dut_ip_start, port_count, mask=prefix_length)
         for port in snappi_ports:
-            if port['peer_device'] == duthost.hostname:
+            if port['peer_device'] == duthost.hostname and port['intf_config_changed']:
                 port_id = port['port_id']
                 dutIp = dutIps[port_id]
                 logger.info('Removing Configuration on Dut: {} with port {} with ip :{}/{}'.format(
@@ -931,6 +938,7 @@ def cleanup_config(duthost_list, snappi_ports):
                                                                                                 port['peer_port'],
                                                                                                 dutIp,
                                                                                                 prefix_length))
+                port['intf_config_changed'] = False
 
 
 def pre_configure_dut_interface(duthost, snappi_ports):
@@ -1028,9 +1036,69 @@ def multidut_snappi_ports_for_bgp(duthosts,                                # noq
         multidut_snappi_ports = multidut_snappi_ports + snappi_ports
     return multidut_snappi_ports
 
+@pytest.fixture(scope="module")
+def get_snappi_ports_single_dut(duthosts,                                # noqa: F811
+                     conn_graph_facts,                        # noqa: F811
+                     fanout_graph_facts,
+                     tbinfo,
+                     snappi_api_serv_ip,
+                     rand_one_dut_hostname,
+                     rand_one_dut_portname_oper_up
+                     ):                                      # noqa: F811
+    speed_type = {
+                  '10000': 'speed_10_gbps',
+                  '25000': 'speed_25_gbps',
+                  '40000': 'speed_40_gbps',
+                  '50000': 'speed_50_gbps',
+                  '100000': 'speed_100_gbps',
+                  '200000': 'speed_200_gbps',
+                  '400000': 'speed_400_gbps',
+                  '800000': 'speed_800_gbps'}
+
+    if is_snappi_multidut(duthosts):
+        return []
+
+    duthost = duthosts[rand_one_dut_hostname]
+
+    dut_hostname, dut_port = rand_one_dut_portname_oper_up.split('|')
+    pytest_require(rand_one_dut_hostname == dut_hostname,
+                   "Port is not mapped to the expected DUT")
+
+    """ Generate L1 config """
+    snappi_fanout = get_peer_snappi_chassis(conn_data=conn_graph_facts,
+                                            dut_hostname=duthost.hostname)
+
+    pytest_assert(snappi_fanout is not None, 'Fail to get snappi_fanout')
+
+    snappi_fanout_id = list(fanout_graph_facts.keys()).index(snappi_fanout)
+    snappi_fanout_list = SnappiFanoutManager(fanout_graph_facts)
+    snappi_fanout_list.get_fanout_device_details(device_number=snappi_fanout_id)
+
+    snappi_ports = snappi_fanout_list.get_ports(peer_device=duthost.hostname)
+
+    rx_ports = []
+    tx_ports = []
+    for port in snappi_ports:
+        port['intf_config_changed'] = False
+        port['location'] = get_snappi_port_location(port)
+        port['speed'] = port['speed']
+        port['api_server_ip'] = tbinfo['ptf_ip']
+        port['asic_type'] = duthost.facts["asic_type"]
+        port['duthost'] = duthost
+        port['snappi_speed_type'] = speed_type[port['speed']]
+        if duthost.facts["num_asic"] > 1:
+            port['asic_value'] = duthost.get_port_asic_instance(port['peer_port']).namespace
+        else:
+            port['asic_value'] = None
+        # convert to RX ports first, tx ports later to be consistent with multi-dut
+        if port['peer_port'] == dut_port:
+            rx_ports.append(port)
+        else:
+            tx_ports.append(port)
+    return rx_ports + tx_ports
 
 @pytest.fixture(scope="module")
-def get_snappi_ports(duthosts,                                # noqa: F811
+def get_snappi_ports_multi_dut(duthosts,                                # noqa: F811
                      tbinfo,                                  # noqa: F811
                      conn_graph_facts,                        # noqa: F811
                      fanout_graph_facts_multidut,
@@ -1081,6 +1149,9 @@ def get_snappi_ports(duthosts,                                # noqa: F811
                   '800000': 'speed_800_gbps'}
     multidut_snappi_ports = []
 
+    if not is_snappi_multidut(duthosts):
+        return []
+
     for duthost in duthosts:
         snappi_fanout = get_peer_snappi_chassis(conn_data=conn_graph_facts,
                                                 dut_hostname=duthost.hostname)
@@ -1100,6 +1171,7 @@ def get_snappi_ports(duthosts,                                # noqa: F811
                 return None
 
         for port in snappi_ports:
+            port['intf_config_changed'] = False
             port['location'] = get_snappi_port_location(port)
             port['speed'] = port['speed']
             port['api_server_ip'] = tbinfo['ptf_ip']
@@ -1113,6 +1185,28 @@ def get_snappi_ports(duthosts,                                # noqa: F811
         multidut_snappi_ports = multidut_snappi_ports + snappi_ports
     return multidut_snappi_ports
 
+def is_snappi_multidut(duthosts):
+    if duthosts is None or len(duthosts) == 0:
+        return False
+
+    return duthosts[0].get_facts().get("modular_chassis")
+
+@pytest.fixture(scope="module")
+def get_snappi_ports(duthosts, request):
+    """
+    Returns the snappi port info based on the testbed type
+    Args:
+        duthosts (pytest fixture): list of DUTs
+        request (pytest fixture): request fixture
+    Return: (list)
+    """
+    # call the fixture based on the testbed type for minimize the impact
+    # use the same fixture for different testbeds in the future if possible?
+    if is_snappi_multidut(duthosts):
+        snappi_ports = request.getfixturevalue("get_snappi_ports_multi_dut")
+    else:
+        snappi_ports = request.getfixturevalue("get_snappi_ports_single_dut")
+    return snappi_ports
 
 def get_snappi_ports_for_rdma(snappi_port_list, rdma_ports, tx_port_count, rx_port_count, testbed):
     """

--- a/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
@@ -19,7 +19,6 @@ pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_global_pause(snappi_api,                                   # noqa: F811
-                      snappi_testbed_config,                        # noqa: F811
                       conn_graph_facts,                             # noqa: F811
                       fanout_graph_facts_multidut,                # noqa: F811
                       get_snappi_ports,                           # noqa: F811
@@ -46,34 +45,33 @@ def test_global_pause(snappi_api,                                   # noqa: F811
     """
     snappi_port_list = get_snappi_ports
 
-    if is_snappi_multidut(duthosts):
-        tbname = tbinfo.get('conf-name', None)
+    tbname = tbinfo.get('conf-name', None)
 
-        tx_port_count = 1
-        rx_port_count = 1
+    tx_port_count = 1
+    rx_port_count = 1
 
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+    pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                  "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
-        for testbed_subtype, rdma_ports in multidut_port_info.items():
-            pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                          'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                          testbed {}, subtype {} in variables.py'.
-                          format(MULTIDUT_TESTBED, testbed_subtype))
+    for testbed_subtype, rdma_ports in multidut_port_info.items():
+        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
+                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
+                      testbed {}, subtype {} in variables.py'.
+                      format(MULTIDUT_TESTBED, testbed_subtype))
 
-            pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                          'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                          testbed {}, subtype {} in variables.py'.
-                          format(tbname, testbed_subtype))
-            logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
+                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
+                      testbed {}, subtype {} in variables.py'.
+                      format(tbname, testbed_subtype))
+        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+        if is_snappi_multidut(duthosts):
             snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
                                                      tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-            testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                    snappi_ports,
-                                                                                    snappi_api)
-    else:
-        snappi_ports = get_snappi_ports
-        testbed_config, port_config_list = snappi_testbed_config
+        else:
+            snappi_ports = snappi_port_list
+        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
+                                                                                snappi_ports,
+                                                                                snappi_api)
 
     all_prio_list = prio_dscp_map.keys()
     test_prio_list = lossless_prio_list

--- a/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
@@ -4,8 +4,9 @@ from tests.common.helpers.assertions import pytest_require, pytest_assert       
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
     fanout_graph_facts_multidut     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-     get_snappi_ports_single_dut, get_snappi_ports, snappi_testbed_config, is_snappi_multidut, get_snappi_ports_multi_dut, \
-     snappi_api, snappi_dut_base_config, cleanup_config,  get_snappi_ports_for_rdma   # noqa: F401
+    snappi_api, get_snappi_ports, is_snappi_multidut, \
+    get_snappi_ports_single_dut, snappi_testbed_config, \
+    get_snappi_ports_multi_dut, snappi_dut_base_config, cleanup_config, get_snappi_ports_for_rdma  # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import lossless_prio_list, prio_dscp_map                # noqa: F401
 from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_pfc_test                      # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
@@ -18,7 +19,7 @@ pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_global_pause(snappi_api,                                   # noqa: F811
-                      snappi_testbed_config,
+                      snappi_testbed_config,                        # noqa: F811
                       conn_graph_facts,                             # noqa: F811
                       fanout_graph_facts_multidut,                # noqa: F811
                       get_snappi_ports,                           # noqa: F811

--- a/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
@@ -21,7 +21,7 @@ def test_global_pause(snappi_api,                                   # noqa: F811
                       snappi_testbed_config,
                       conn_graph_facts,                             # noqa: F811
                       fanout_graph_facts_multidut,                # noqa: F811
-                      get_snappi_ports,
+                      get_snappi_ports,                           # noqa: F811
                       duthosts,
                       prio_dscp_map,                                # noqa: F811
                       lossless_prio_list,                           # noqa: F811

--- a/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
@@ -1,9 +1,11 @@
 import pytest
 import logging
 from tests.common.helpers.assertions import pytest_require, pytest_assert                            # noqa: F401
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut     # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
+    fanout_graph_facts_multidut     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-     snappi_api, snappi_dut_base_config, cleanup_config, get_snappi_ports, get_snappi_ports_for_rdma   # noqa: F401
+     get_snappi_ports_single_dut, get_snappi_ports, snappi_testbed_config, is_snappi_multidut, get_snappi_ports_multi_dut, \
+     snappi_api, snappi_dut_base_config, cleanup_config,  get_snappi_ports_for_rdma   # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import lossless_prio_list, prio_dscp_map                # noqa: F401
 from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_pfc_test                      # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
@@ -11,14 +13,15 @@ from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('multidut-tgen')]
+pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_global_pause(snappi_api,                                   # noqa: F811
+                      snappi_testbed_config,
                       conn_graph_facts,                             # noqa: F811
                       fanout_graph_facts_multidut,                # noqa: F811
-                      get_snappi_ports,                           # noqa: F811
+                      get_snappi_ports,
                       duthosts,
                       prio_dscp_map,                                # noqa: F811
                       lossless_prio_list,                           # noqa: F811
@@ -40,30 +43,37 @@ def test_global_pause(snappi_api,                                   # noqa: F811
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
+    snappi_port_list = get_snappi_ports
+
+    if is_snappi_multidut(duthosts):
+        tbname = tbinfo.get('conf-name', None)
+
         tx_port_count = 1
         rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(MULTIDUT_TESTBED == tbinfo['conf-name'],
-                      "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
+
         pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
+        for testbed_subtype, rdma_ports in multidut_port_info.items():
+            pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
+                          'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
+                          testbed {}, subtype {} in variables.py'.
+                          format(MULTIDUT_TESTBED, testbed_subtype))
 
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
+            pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
+                          'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
+                          testbed {}, subtype {} in variables.py'.
+                          format(tbname, testbed_subtype))
+            logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+            testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
+                                                                                    snappi_ports,
+                                                                                    snappi_api)
+    else:
+        snappi_ports = get_snappi_ports
+        testbed_config, port_config_list = snappi_testbed_config
+
     all_prio_list = prio_dscp_map.keys()
     test_prio_list = lossless_prio_list
     bg_prio_list = [x for x in all_prio_list if x not in test_prio_list]

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -22,7 +22,6 @@ pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: F811
-                                        snappi_testbed_config,          # noqa: F811
                                         conn_graph_facts,               # noqa: F811
                                         fanout_graph_facts_multidut,             # noqa: F811
                                         duthosts,
@@ -53,34 +52,32 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
         N/A
     """
     snappi_port_list = get_snappi_ports
-    if is_snappi_multidut(duthosts):
-        for testbed_subtype, rdma_ports in multidut_port_info.items():
-            tx_port_count = 1
-            rx_port_count = 1
-            snappi_port_list = get_snappi_ports
-            pytest_assert(MULTIDUT_TESTBED == tbinfo['conf-name'],
-                          "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
-            pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                          "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+    for testbed_subtype, rdma_ports in multidut_port_info.items():
+        tx_port_count = 1
+        rx_port_count = 1
+        snappi_port_list = get_snappi_ports
 
-            pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                          'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                          testbed {}, subtype {} in variables.py'.
-                          format(MULTIDUT_TESTBED, testbed_subtype))
+        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
-            pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                          'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                          testbed {}, subtype {} in variables.py'.
-                          format(MULTIDUT_TESTBED, testbed_subtype))
-            logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
+                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
+                      testbed {}, subtype {} in variables.py'.
+                      format(MULTIDUT_TESTBED, testbed_subtype))
+
+        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
+                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
+                      testbed {}, subtype {} in variables.py'.
+                      format(MULTIDUT_TESTBED, testbed_subtype))
+        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+        if is_snappi_multidut(duthosts):
             snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
                                                      tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-            testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                    snappi_ports,
-                                                                                    snappi_api)
-    else:
-        snappi_ports = get_snappi_ports
-        testbed_config, port_config_list = snappi_testbed_config
+        else:
+            snappi_ports = snappi_port_list
+        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
+                                                                                snappi_ports,
+                                                                                snappi_api)
 
     _, lossless_prio = enum_dut_lossless_prio.split('|')
     lossless_prio = int(lossless_prio)

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -22,7 +22,7 @@ pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: F811
-                                        snappi_testbed_config,
+                                        snappi_testbed_config,          # noqa: F811
                                         conn_graph_facts,               # noqa: F811
                                         fanout_graph_facts_multidut,             # noqa: F811
                                         duthosts,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Infra change for #14144 #14220
This change is to add initial infra changes for current tests/snappi_tests/multidut test cases to be able to run on T0/T1 testbed.

Main changes are the following:
1. `get_snappi_ports_single_dut`:  generate port lists for T0/T1 testbed without the need to add port definition in variables.py.
2. `get_snappi_ports`: unified function to return snappi port lists for both T0/T1 and T2 testbed.
3. Add vlan and port-channel support into `snappi_dut_base_config`: make it consistent for T0/T1 testbed.
4. sample change in two test case `test_multidut_global_pause_with_snappi.py` and `test_multidut_pfc_pause_lossless_with_snappi.py`

After this change, following function can work for both T0/T1 and T2, and test case can adopt the same method to support T0/T1.
1. `get_snappi_ports`
2. `cleanup_config`
3. `snappi_dut_base_config`
4. existing helper files are unchanged.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
support T0/T1 testbed for T2.

#### How did you do it?
use `get_snappi_ports` for both T0/T1 testbed and T2 testbed. For T0/T1 testbed, return all the available ports, for T2 testbed, return the ports defined in MULTIDUT_PORT_INFO.

#### How did you verify/test it?
Tested in local T0/T1 testbed.

```
snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py::test_global_pause[multidut_port_info0] PASSED                                                                   [100%]
```
```
snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[xxx|3-multidut_port_info0]  PASSED                                                                   [ 50%]
snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[xxx|4-multidut_port_info0] PASSED [100%]

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
