### PR TITLE
[docker-ptf]: Choose PTF image based on branch

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -142,6 +142,20 @@ parameters:
     type: string
     default: ""
 
+  - name: MIXED_PTF_IMAGE_BRANCHES
+    type: object
+    default:
+      - 201803
+      - 201807
+      - 201811
+      - 201911
+      - 202211
+      - 202012
+      - 202205
+      - 202305
+      - 202311
+      - 202405
+
 steps:
   - ${{ if not(contains(variables['BUILD.REPOSITORY.NAME'], 'sonic-mgmt')) }}:
       - script: |
@@ -191,24 +205,20 @@ steps:
         pip install PyYAML
 
         rm -f new_test_plan_id.txt
-
-        # all feature branches branched out from master can use py3only image
-        parent_commit=$(git rev-parse HEAD^1)
-        master_commit=$(git rev-parse master)
-        branch_from_master=0
-        if [ "$parent_commit" == "$master_commit" ]
+        ptf_image_type="py3only"
+        for old_branch in ${{ parameters.MIXED_PTF_IMAGE_BRANCHES }}
+        do
+          if [ $old_branch == "${{ parameters.MGMT_BRANCH }}" ]
+          then
+            ptf_image_type="mixed"
+            break
+          fi
+        done
+        PTF_IMAGETAG="--ptf_imagetag=py3only"
+        if [ $ptf_image_type == "mixed" ]
         then
-          branch_from_master=1
-        fi
-
-        if [ "${{ parameters.MGMT_BRANCH }}" == "master" ] || [ $branch_from_master -eq 1 ]
-        then
-          PTF_IMAGETAG="--ptf_imagetag=py3only"
-        else
           PTF_IMAGETAG="--ptf_imagetag=internal"
         fi
-        common_extra_params="${{ parameters.COMMON_EXTRA_PARAMS }} $PTF_IMAGETAG"
-        echo "##vso[task.setvariable variable=COMMON_EXTRA_PARAMS;]$common_extra_params"
 
         python ./.azure-pipelines/test_plan.py create \
         -t ${{ parameters.TOPOLOGY }} \
@@ -220,7 +230,7 @@ steps:
         --kvm-build-id $(KVM_BUILD_ID) \
         --kvm-image-branch "${{ parameters.KVM_IMAGE_BRANCH }}" \
         --deploy-mg-extra-params="${{ parameters.DEPLOY_MG_EXTRA_PARAMS }}" \
-        --common-extra-params="${{ parameters.COMMON_EXTRA_PARAMS }}" \
+        --common-extra-params="${{ parameters.COMMON_EXTRA_PARAMS }} ${PTF_IMAGETAG}" \
         --vm-type ${{ parameters.VM_TYPE }} --num-asic ${{ parameters.NUM_ASIC }} \
         --image_url ${{ parameters.IMAGE_URL }} \
         --upgrade-image-param="${{ parameters.UPGRADE_IMAGE_PARAM }}" \

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -205,20 +205,15 @@ steps:
         pip install PyYAML
 
         rm -f new_test_plan_id.txt
-        ptf_image_type="py3only"
+        PTF_IMAGETAG="--ptf_imagetag=py3only"
         for old_branch in ${{ parameters.MIXED_PTF_IMAGE_BRANCHES }}
         do
           if [ $old_branch == "${{ parameters.MGMT_BRANCH }}" ]
           then
-            ptf_image_type="mixed"
+            PTF_IMAGETAG="--ptf_imagetag=internal"
             break
           fi
         done
-        PTF_IMAGETAG="--ptf_imagetag=py3only"
-        if [ $ptf_image_type == "mixed" ]
-        then
-          PTF_IMAGETAG="--ptf_imagetag=internal"
-        fi
 
         python ./.azure-pipelines/test_plan.py create \
         -t ${{ parameters.TOPOLOGY }} \

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -192,6 +192,15 @@ steps:
 
         rm -f new_test_plan_id.txt
 
+        if [ "${{ parameters.MGMT_BRANCH }}" == "master" ] || [ "${{ parameters.MGMT_BRANCH }}" == "feat/ptf-py3-tests-verification" ]
+        then
+          PTF_IMAGETAG="-e ptf_imagetag=py3only"
+        else
+          PTF_IMAGETAG="-e ptf_imagetag=internal"
+        fi
+        common_extra_params="${{ parameters.COMMON_EXTRA_PARAMS }} $PTF_IMAGETAG"
+        echo "##vso[task.setvariable variable=COMMON_EXTRA_PARAMS;]$common_extra_params"
+
         python ./.azure-pipelines/test_plan.py create \
         -t ${{ parameters.TOPOLOGY }} \
         -o new_test_plan_id.txt \

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -203,9 +203,9 @@ steps:
 
         if [ "${{ parameters.MGMT_BRANCH }}" == "master" ] || [ $branch_from_master -eq 1 ]
         then
-          PTF_IMAGETAG="-e ptf_imagetag=py3only"
+          PTF_IMAGETAG="--ptf_imagetag=py3only"
         else
-          PTF_IMAGETAG="-e ptf_imagetag=internal"
+          PTF_IMAGETAG="--ptf_imagetag=internal"
         fi
         common_extra_params="${{ parameters.COMMON_EXTRA_PARAMS }} $PTF_IMAGETAG"
         echo "##vso[task.setvariable variable=COMMON_EXTRA_PARAMS;]$common_extra_params"

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -192,7 +192,16 @@ steps:
 
         rm -f new_test_plan_id.txt
 
-        if [ "${{ parameters.MGMT_BRANCH }}" == "master" ] || [ "${{ parameters.MGMT_BRANCH }}" == "feat/ptf-py3-tests-verification" ]
+        # all feature branches branched out from master can use py3only image
+        parent_commit=$(git rev-parse HEAD^1)
+        master_commit=$(git rev-parse master)
+        branch_from_master=0
+        if [ "$parent_commit" == "$master_commit" ]
+        then
+          branch_from_master=1
+        fi
+
+        if [ "${{ parameters.MGMT_BRANCH }}" == "master" ] || [ $branch_from_master -eq 1 ]
         then
           PTF_IMAGETAG="-e ptf_imagetag=py3only"
         else


### PR DESCRIPTION
### Description of PR

This PR adds condition to pipeline to choose PTF image tag based on the branch. All `master` branch test scripts have been migrated to Python 3 and can run in `py3only` PTF image. For all feature branches branched out of `master` the PTF image tag can be `py3only`. For all other branches we continue to the internal tag with mixed Py2+Py3 image.

Summary:
Fixes # Not applicable

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

All PTF scripts have been migrated to Python 3. And the PTF image with Python 3 only has been built and published. This PR now modifies the PR testing pipeline to choose the PTF image based on the branch. For master branch `py3only` tag can be chosen. For all other release branches, we use the existing mixed image.

#### How did you do it?

Check the "MGMT_BRANCH" to detect current branch and pass the `ptf_imagetag` to the pytest framework via common extra parameters.

#### How did you verify/test it?

Can only be verified here.

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

None

### Documentation

Not applicable.