### PR TITLE
fix potentially ambiguous name

### DIFF
--- a/tests/syslog/test_logrotate.py
+++ b/tests/syslog/test_logrotate.py
@@ -272,7 +272,8 @@ def orch_logrotate_setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, en
     duthost.shell('sudo ip neigh flush {}'.format(FAKE_IP))
     if duthost.sonichost.is_multi_asic:
         target_asic = duthost.asics[enum_rand_one_frontend_asic_index]
-        target_port = next(iter(target_asic.get_active_ip_interfaces(tbinfo)))
+        testbed_info = tbinfo
+        target_port = next(iter(target_asic.get_active_ip_interfaces(testbed_info)))
     else:
         target_port = duthost.get_up_ip_ports()[0]
 


### PR DESCRIPTION
tbinfo was causing TypeError: 'function' object is not subscriptable. As intention was to pass over the object, not the function from conftest, rename the tbinfo to testbed_info to prevent the error.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
tbinfo was causing TypeError: 'function' object is not subscriptable. As intention was to pass over the object, not the function from conftest, rename the tbinfo to testbed_info to prevent the error.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
fix issue with test_logrotate.py
#### How did you do it?
add line of code to avoid ambiguity
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
