### PR TITLE
Ignore `missed_in_asic_db_routes` error in `vxlan/test_vxlan_crm.py` test for KVM

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1894,50 +1894,30 @@ vxlan/test_vxlan_crm.py::Test_VxLAN_Crm::test_crm_128_group_members[v6_in_v6]:
     reason: "On Mellanox spc1 platform, due to HW limitation, vxlan ipv6 tunnel is not supported"
     conditions:
       - "asic_gen == 'spc1'"
-  xfail:
-    reason: "Vnet route missed in ASIC DB for KVM platform, xfail for unblocking PR test"
-    conditions:
-      - "(asic_type in ['vs']) and https://github.com/sonic-net/sonic-mgmt/issues/14311"
 
 vxlan/test_vxlan_crm.py::Test_VxLAN_Crm::test_crm_16k_routes[v4_in_v6]:
   skip:
     reason: "On Mellanox spc1 platform, due to HW limitation, vxlan ipv6 tunnel is not supported"
     conditions:
       - "asic_gen == 'spc1'"
-  xfail:
-    reason: "Vnet route missed in ASIC DB for KVM platform, xfail for unblocking PR test"
-    conditions:
-      - "(asic_type in ['vs']) and https://github.com/sonic-net/sonic-mgmt/issues/14311"
 
 vxlan/test_vxlan_crm.py::Test_VxLAN_Crm::test_crm_16k_routes[v6_in_v6]:
   skip:
     reason: "On Mellanox spc1 platform, due to HW limitation, vxlan ipv6 tunnel is not supported"
     conditions:
       - "asic_gen == 'spc1'"
-  xfail:
-    reason: "Vnet route missed in ASIC DB for KVM platform, xfail for unblocking PR test"
-    conditions:
-      - "(asic_type in ['vs']) and https://github.com/sonic-net/sonic-mgmt/issues/14311"
 
 vxlan/test_vxlan_crm.py::Test_VxLAN_Crm::test_crm_512_nexthop_groups[v4_in_v6]:
   skip:
     reason: "On Mellanox spc1 platform, due to HW limitation, vxlan ipv6 tunnel is not supported"
     conditions:
       - "asic_gen == 'spc1'"
-  xfail:
-    reason: "Vnet route missed in ASIC DB for KVM platform, xfail for unblocking PR test"
-    conditions:
-      - "(asic_type in ['vs']) and https://github.com/sonic-net/sonic-mgmt/issues/14311"
 
 vxlan/test_vxlan_crm.py::Test_VxLAN_Crm::test_crm_512_nexthop_groups[v6_in_v6]:
   skip:
     reason: "On Mellanox spc1 platform, due to HW limitation, vxlan ipv6 tunnel is not supported"
     conditions:
       - "asic_gen == 'spc1'"
-  xfail:
-    reason: "Vnet route missed in ASIC DB for KVM platform, xfail for unblocking PR test"
-    conditions:
-      - "(asic_type in ['vs']) and https://github.com/sonic-net/sonic-mgmt/issues/14311"
 
 vxlan/test_vxlan_ecmp.py:
   skip:

--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -21,6 +21,17 @@ Logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()
 
 
+@pytest.fixture(autouse=True)
+def _ignore_route_sync_errlogs(rand_one_dut_hostname, loganalyzer):
+    """Ignore expected failures logs during test execution."""
+    if loganalyzer:
+        IgnoreRegex = [
+            ".*missed_in_asic_db_routes.*",
+        ]
+        loganalyzer[rand_one_dut_hostname].ignore_regex.extend(IgnoreRegex)
+    return
+
+
 def uniq(lst):
     last = object()
     for item in sorted(lst):

--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -22,13 +22,16 @@ ecmp_utils = Ecmp_Utils()
 
 
 @pytest.fixture(autouse=True)
-def _ignore_route_sync_errlogs(rand_one_dut_hostname, loganalyzer):
+def _ignore_route_sync_errlogs(duthosts, rand_one_dut_hostname, loganalyzer):
     """Ignore expected failures logs during test execution."""
     if loganalyzer:
-        IgnoreRegex = [
+        # Ignore in KVM test
+        KVMIgnoreRegex = [
             ".*missed_in_asic_db_routes.*",
         ]
-        loganalyzer[rand_one_dut_hostname].ignore_regex.extend(IgnoreRegex)
+        duthost = duthosts[rand_one_dut_hostname]
+        if duthost.facts["asic_type"] == "vs":
+            loganalyzer[rand_one_dut_hostname].ignore_regex.extend(KVMIgnoreRegex)
     return
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
When running `vxlan/test_vxlan_crm.py`, there is a chance to get `missed_in_asic_db_routes` error in log analyzer for KVM
#### How did you do it?
Since `missed_in_asic_db_routes` has been ignored in other test scripts in vxlan module, ignore in `vxlan/test_vxlan_crm.py` test for KVM
Remove conditional mark xfail but keep mgmt issue https://github.com/sonic-net/sonic-mgmt/issues/14311 open
#### How did you verify/test it?
Test in KVM
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
