### PR TITLE
Skip BGPAllowListMgr syslog in test_bgp_prefix_tc1_suite for Cisco 8111 CompuateAI deployment

### DIFF
--- a/tests/generic_config_updater/test_bgp_prefix.py
+++ b/tests/generic_config_updater/test_bgp_prefix.py
@@ -22,6 +22,20 @@ PREFIXES_V4_RE = r"ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_{}_V4 
 PREFIXES_V6_RE = r"ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_{}_V6 seq \d+ permit {}"
 
 
+@pytest.fixture(autouse=True)
+def _ignore_allow_list_errlogs(duthosts, rand_one_dut_hostname, loganalyzer):
+    """Ignore expected failures logs during test execution."""
+    if loganalyzer:
+        IgnoreRegex = [
+            ".*ERR bgp#bgpcfgd: BGPAllowListMgr::Default action community value is not found.*",
+        ]
+        duthost = duthosts[rand_one_dut_hostname]
+        """Cisco 8111-O64 has different allow list config"""
+        if duthost.facts['hwsku'] == 'Cisco-8111-O64':
+            loganalyzer[rand_one_dut_hostname].ignore_regex.extend(IgnoreRegex)
+    return
+
+
 def get_bgp_prefix_runningconfig(duthost):
     """ Get bgp prefix config
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip BGPAllowListMgr syslog in test_bgp_prefix_tc1_suite for Cisco 8111 CompuateAI deployment

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Skip BGPAllowListMgr syslog in test_bgp_prefix_tc1_suite for Cisco 8111 CompuateAI deployment
Cisco 8111 ComputeAI deployment does NOT use allow list like ALLOW_LIST_DEPLOYMENT_ID_0_V4, ALLOW_LIST_DEPLOYMENT_ID_0_V6

#### How did you do it?
Add syslog pattern to ignore list.

#### How did you verify/test it?
Test with physical testbed.

#### Any platform specific information?
Cisco 8111 ComputeAI deployment

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
