### PR TITLE
[Chassis] Recover chassis by config reload all RP/LCs

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -185,7 +185,7 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
         sonic_host.shell(cmd, executable="/bin/bash")
 
     modular_chassis = sonic_host.get_facts().get("modular_chassis")
-    wait = max(wait, 240) if modular_chassis else wait
+    wait = max(wait, 900) if modular_chassis else wait
 
     if safe_reload:
         # The wait time passed in might not be guaranteed to cover the actual
@@ -196,11 +196,11 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
                       "All critical services should be fully started!")
         wait_critical_processes(sonic_host)
         if config_source == 'minigraph':
-            pytest_assert(wait_until(300, 20, 0, chk_for_pfc_wd, sonic_host),
+            pytest_assert(wait_until(wait + 300, 20, 0, chk_for_pfc_wd, sonic_host),
                           "PFC_WD is missing in CONFIG-DB")
 
         if check_intf_up_ports:
-            pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, sonic_host),
+            pytest_assert(wait_until(wait + 300, 20, 0, check_interface_status_of_up_ports, sonic_host),
                           "Not all ports that are admin up on are operationally up")
     else:
         time.sleep(wait)
@@ -208,6 +208,6 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
     if wait_for_bgp:
         bgp_neighbors = sonic_host.get_bgp_neighbors_per_asic()
         pytest_assert(
-            wait_until(120, 10, 0, sonic_host.check_bgp_session_state_all_asics, bgp_neighbors),
+            wait_until(wait + 120, 10, 0, sonic_host.check_bgp_session_state_all_asics, bgp_neighbors),
             "Not all bgp sessions are established after config reload",
         )

--- a/tests/common/helpers/parallel_utils.py
+++ b/tests/common/helpers/parallel_utils.py
@@ -1,0 +1,5 @@
+from tests.common import config_reload
+
+
+def config_reload_parallel_compatible(node, results, *args, **kwargs):
+    return config_reload(node, *args, **kwargs)

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from tests.common.plugins.sanity_check import constants
 from tests.common.plugins.sanity_check import checks
 from tests.common.plugins.sanity_check.checks import *      # noqa: F401, F403
-from tests.common.plugins.sanity_check.recover import recover
+from tests.common.plugins.sanity_check.recover import recover, recover_chassis
 from tests.common.plugins.sanity_check.constants import STAGE_PRE_TEST, STAGE_POST_TEST
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 
@@ -287,10 +287,15 @@ def recover_on_sanity_check_failure(duthosts, failed_results, fanouthosts, local
                     infra_recovery_actions.append(failed_result['action'])
         for action in infra_recovery_actions:
             action()
-        for dut_name, dut_results in list(dut_failed_results.items()):
-            # Attempt to restore DUT state
-            recover(duthosts[dut_name], localhost, fanouthosts, nbrhosts, tbinfo, dut_results,
-                    recover_method)
+
+        is_modular_chassis = duthosts.nodes[0].get_facts().get("modular_chassis")
+        if is_modular_chassis:
+            recover_chassis(duthosts)
+        else:
+            for dut_name, dut_results in list(dut_failed_results.items()):
+                # Attempt to restore DUT state
+                recover(duthosts[dut_name], localhost, fanouthosts, nbrhosts, tbinfo, dut_results,
+                        recover_method)
 
     except BaseException as e:
         request.config.cache.set(cache_key, True)

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -288,7 +288,7 @@ def recover_on_sanity_check_failure(duthosts, failed_results, fanouthosts, local
         for action in infra_recovery_actions:
             action()
 
-        is_modular_chassis = duthosts.nodes[0].get_facts().get("modular_chassis")
+        is_modular_chassis = duthosts[0].get_facts().get("modular_chassis")
         if is_modular_chassis:
             recover_chassis(duthosts)
         else:

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -91,7 +91,7 @@ def check_interfaces(duthosts):
 
     def _check(*args, **kwargs):
         result = parallel_run(_check_interfaces_on_dut, args, kwargs, duthosts.frontend_nodes,
-                              timeout=600, init_result=init_result)
+                              timeout=1200, init_result=init_result)
         return list(result.values())
 
     @reset_ansible_local_tmp
@@ -102,6 +102,8 @@ def check_interfaces(duthosts):
 
         networking_uptime = dut.get_networking_uptime().seconds
         timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 0)
+        if dut.get_facts().get("modular_chassis"):
+            timeout = max(timeout, 900)
         interval = 20
         logger.info("networking_uptime=%d seconds, timeout=%d seconds, interval=%d seconds" %
                     (networking_uptime, timeout, interval))
@@ -155,7 +157,7 @@ def check_bgp(duthosts, tbinfo):
 
     def _check(*args, **kwargs):
         result = parallel_run(_check_bgp_on_dut, args, kwargs, duthosts.frontend_nodes,
-                              timeout=600, init_result=init_result)
+                              timeout=1200, init_result=init_result)
         return list(result.values())
 
     @reset_ansible_local_tmp
@@ -228,6 +230,8 @@ def check_bgp(duthosts, tbinfo):
             max_timeout = 500
         else:
             max_timeout = SYSTEM_STABILIZE_MAX_TIME - networking_uptime + 480
+        if dut.get_facts().get("modular_chassis"):
+            max_timeout = max(max_timeout, 900)
         timeout = max(max_timeout, 1)
         interval = 20
         wait_until(timeout, interval, 0, _check_bgp_status_helper)

--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -9,6 +9,7 @@ from tests.common.reboot import REBOOT_TYPE_WARM, REBOOT_TYPE_FAST, REBOOT_TYPE_
 from tests.common.reboot import reboot
 from tests.common.utilities import wait
 from . import constants
+from ...helpers.parallel_utils import config_reload_parallel_compatible
 
 logger = logging.getLogger(__name__)
 
@@ -195,3 +196,12 @@ def recover(dut, localhost, fanouthosts, nbrhosts, tbinfo, check_results, recove
         reboot_dut(dut, localhost, method["cmd"])
     else:
         _recover_with_command(dut, method['cmd'], wait_time)
+
+
+def recover_chassis(duthosts):
+    logger.warning(f"Try to recover chassis {[dut.hostname for dut in duthosts]} using config reload")
+    return parallel_run(config_reload_parallel_compatible, (),
+                        {
+                            'config_source': 'running_golden_config', 'safe_reload': True,
+                            'check_intf_up_ports': True, 'wait_for_bgp': True},
+                        duthosts, timeout=1200)

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -276,7 +276,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     wait_for_startup(duthost, localhost, delay, timeout)
 
     logger.info('waiting for switch {} to initialize'.format(hostname))
-
+    wait = max(wait, 900) if duthost.get_facts().get("modular_chassis") else wait
     if safe_reboot:
         # The wait time passed in might not be guaranteed to cover the actual
         # time it takes for containers to come back up. Therefore, add 5
@@ -287,7 +287,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         wait_critical_processes(duthost)
 
         if check_intf_up_ports:
-            pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
+            pytest_assert(wait_until(wait + 300, 20, 0, check_interface_status_of_up_ports, duthost),
                           "Not all ports that are admin up on are operationally up")
     else:
         time.sleep(wait)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2349,7 +2349,7 @@ def core_dump_and_config_check(duthosts, tbinfo,
             logger.warning("Core dump or config check failed for {}, results: {}"
                            .format(module_name, json.dumps(check_result)))
 
-            is_modular_chassis = duthosts.nodes[0].get_facts().get("modular_chassis")
+            is_modular_chassis = duthosts[0].get_facts().get("modular_chassis")
             if is_modular_chassis:
                 results = recover_chassis(duthosts)
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ from tests.common.helpers.constants import (
 )
 from tests.common.helpers.dut_ports import encode_dut_port_name
 from tests.common.helpers.dut_utils import encode_dut_and_container_name
+from tests.common.plugins.sanity_check import recover_chassis
 from tests.common.system_utils import docker
 from tests.common.testbed import TestbedInfo
 from tests.common.utilities import get_inventory_files
@@ -2347,7 +2348,13 @@ def core_dump_and_config_check(duthosts, tbinfo,
             }
             logger.warning("Core dump or config check failed for {}, results: {}"
                            .format(module_name, json.dumps(check_result)))
-            results = parallel_run(__dut_reload, (), {"duts_data": duts_data}, duthosts, timeout=360)
+
+            is_modular_chassis = duthosts.nodes[0].get_facts().get("modular_chassis")
+            if is_modular_chassis:
+                results = recover_chassis(duthosts)
+            else:
+                results = parallel_run(__dut_reload, (), {"duts_data": duts_data}, duthosts, timeout=360)
+
             logger.debug('Results of dut reload: {}'.format(json.dumps(dict(results))))
         else:
             logger.info("Core dump and config check passed for {}".format(module_name))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. Extend the wait time of the readiness check for chassis devices
2. Provide a modular-chassis specific recover way, for example, if the iBGP on the LC can't be up, do config reload on the faulty LC doesn't help, the required action is to config reload on the RP. Hence for the chassis device, directly config reload all the RP/LCs
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The current recover doesn't help chassis testbed well when it's in the bad state.
#### How did you do it?
1. Extend the wait time of the readiness check for chassis devices
2. Provide a modular-chassis specific recover way, config reload all the devices.
#### How did you verify/test it?
In the nightly test and PR tests
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
