### PR TITLE
Add data plane test to PR test set and skip set

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -5,7 +5,6 @@ t0:
   - acl/test_acl_outer_vlan.py
   - acl/test_stress_acl.py
   - arp/test_arp_extended.py
-  - arp/test_neighbor_mac.py
   - arp/test_neighbor_mac_noptf.py
   - arp/test_stress_arp.py
   - arp/test_tagged_arp.py
@@ -249,6 +248,7 @@ t1-lag:
   - acl/test_acl.py
   - acl/test_stress_acl.py
   - arp/test_arpall.py
+  - arp/test_neighbor_mac.py
   - arp/test_neighbor_mac_noptf.py
   - bgp/test_bgp_allow_list.py
   - bgp/test_bgp_bbr.py

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -50,6 +50,8 @@ t0:
   - platform_tests/mellanox/test_hw_management_service.py
   - platform_tests/mellanox/test_psu_power_threshold.py
   - platform_tests/mellanox/test_reboot_cause.py
+  # read_mac test needs specific variables and image urls, currently do not support on KVM and regular nightly test
+  - read_mac/test_read_mac_metadata.py
   # This script only supported on Mellanox
   - restapi/test_restapi.py
   # Route flow counter is not supported on vs platform
@@ -109,6 +111,8 @@ t1-lag:
   - platform_tests/mellanox/test_hw_management_service.py
   - platform_tests/mellanox/test_psu_power_threshold.py
   - platform_tests/mellanox/test_reboot_cause.py
+  # read_mac test needs specific variables and image urls, currently do not support on KVM and regular nightly test
+  - read_mac/test_read_mac_metadata.py
   # Route flow counter is not supported on vs platform
   - route/test_route_flow_counter.py
   - snmp/test_snmp_phy_entity.py
@@ -159,6 +163,8 @@ t2:
   - platform_tests/mellanox/test_hw_management_service.py
   - platform_tests/mellanox/test_psu_power_threshold.py
   - platform_tests/mellanox/test_reboot_cause.py
+  # read_mac test needs specific variables and image urls, currently do not support on KVM and regular nightly test
+  - read_mac/test_read_mac_metadata.py
   - snmp/test_snmp_phy_entity.py
   # Remove from PR test in https://github.com/sonic-net/sonic-mgmt/pull/6073
   - cacl/test_ebtables_application.py
@@ -167,6 +173,16 @@ t2:
   - system_health/test_system_health.py
   # This script is also skipped in nightly test
   - mvrf/test_mgmtvrf.py
+  # Voq test only support on T2, currently not available in PR test
+  - voq/test_fabric_cli_and_db.py
+  - voq/test_fabric_reach.py
+  - voq/test_voq_chassis_app_db_consistency.py
+  - voq/test_voq_disrupts.py
+  - voq/test_voq_fabric_isolation.py
+  - voq/test_voq_fabric_status_all.py
+  - voq/test_voq_intfs.py
+  - voq/test_voq_ipfwd.py
+  - voq/test_voq_nbr.py
 
 dualtor:
   # This test only support on dualtor-aa testbed
@@ -199,6 +215,13 @@ tgen:
   - snappi_tests/bgp/test_bgp_scalability.py
   - snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
   - snappi_tests/ecn/test_red_accuracy_with_snappi.py
+  - snappi_tests/multidut/bgp/test_bgp_outbound_downlink_port_flap.py
+  - snappi_tests/multidut/bgp/test_bgp_outbound_downlink_process_crash.py
+  - snappi_tests/multidut/bgp/test_bgp_outbound_tsa.py
+  - snappi_tests/multidut/bgp/test_bgp_outbound_uplink_multi_po_flap.py
+  - snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_flap.py
+  - snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_member_flap.py
+  - snappi_tests/multidut/bgp/test_bgp_outbound_uplink_process_crash.py
   - snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
   - snappi_tests/multidut/ecn/test_multidut_red_accuracy_with_snappi.py
   - snappi_tests/multidut/pfc/test_lossless_response_to_external_pause_storms.py
@@ -233,6 +256,7 @@ tgen:
 
 snappi:
   # Snappi test only support on physical snappi testbed
+  - snappi_tests/multidut/pfcwd/test_multidut_pfcwd_runtime_traffic_with_snappi.py
   - snappi_tests/reboot/test_cold_reboot.py
   - snappi_tests/reboot/test_fast_reboot.py
   - snappi_tests/reboot/test_soft_reboot.py
@@ -242,6 +266,7 @@ snappi:
 
 wan-pub:
   # Currently PR test will not test wan topo
+  - macsec/test_interop_wan_isis.py
   - wan/isis/test_isis_authentication.py
   - wan/isis/test_isis_csnp_interval.py
   - wan/isis/test_isis_database.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
While adding test scripts to PR test, found there are some existing or newly added test scripts needs to skip in PR test, and `arp/test_neighbor_mac.py` was in incorrect topo
#### How did you do it?
Add voq test to skip yml for T2 is not supported in PR test
Add newly added snappi_tests/multidut/bgp test to skip yml for snappi and tgen topo are not supported in PR test
Add macsec/test_interop_wan_isis.py to skip yml for wan topo no longer supported in PR test
Add read_mac test to skip yml for test variable not supported in PR test and it's also skipped in nightly
Move `arp/test_neighbor_mac.py` to t1 PR test for it do not supported on T0
#### How did you verify/test it?
Run `arp/test_neighbor_mac.py` in T1 for multiple times in KVM platform
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
