### PR TITLE
[CI]Fix inconsistency issue of status between pipeline and test plan

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -162,13 +162,13 @@ steps:
             curl -u :$(MSSONIC-TOKEN) "${{ parameters.MGMT_URL }}&commitOrBranch=${{ parameters.MGMT_BRANCH }}&api-version=5.0-preview.1&path=.azure-pipelines%2Fpr_test_scripts.yaml" -o ./.azure-pipelines/pr_test_scripts.yaml
           fi
         displayName: "Download pr script"
-  - ${{ else }}:
-      - ${{ if ne(parameters.MGMT_BRANCH, 'master') }}:
-          - script: |
-              # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
-              set -ex
-              curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
-            displayName: "Download test plan script"
+#  - ${{ else }}:
+#      - ${{ if ne(parameters.MGMT_BRANCH, 'master') }}:
+#          - script: |
+#              # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
+#              set -ex
+#              curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
+#            displayName: "Download test plan script"
 
   - script: |
       # Check if azure cli is installed. If not, try to install it

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -162,13 +162,13 @@ steps:
             curl -u :$(MSSONIC-TOKEN) "${{ parameters.MGMT_URL }}&commitOrBranch=${{ parameters.MGMT_BRANCH }}&api-version=5.0-preview.1&path=.azure-pipelines%2Fpr_test_scripts.yaml" -o ./.azure-pipelines/pr_test_scripts.yaml
           fi
         displayName: "Download pr script"
-#  - ${{ else }}:
-#      - ${{ if ne(parameters.MGMT_BRANCH, 'master') }}:
-#          - script: |
-#              # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
-#              set -ex
-#              curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
-#            displayName: "Download test plan script"
+  - ${{ else }}:
+      - ${{ if ne(parameters.MGMT_BRANCH, 'master') }}:
+          - script: |
+              # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
+              set -ex
+              curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
+            displayName: "Download test plan script"
 
   - script: |
       # Check if azure cli is installed. If not, try to install it

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -74,7 +74,7 @@ def test_plan_status_factory(status):
     raise Exception("The status is not correct.")
 
 
-class AbstractStatus():
+class AbstractStatus:
     def __init__(self, status):
         self.status = status
 
@@ -380,7 +380,7 @@ class TestPlanManager(object):
         }
         start_time = time.time()
         http_exception_times = 0
-        while (timeout < 0 or (time.time() - start_time) < timeout):
+        while timeout < 0 or (time.time() - start_time) < timeout:
             try:
                 if self.with_auth:
                     headers["Authorization"] = "Bearer {}".format(self.get_token())
@@ -402,12 +402,14 @@ class TestPlanManager(object):
             if not resp_data:
                 raise Exception("No valid data in response: {}".format(str(resp)))
 
-            status = resp_data.get("status", None)
-            result = resp_data.get("result", None)
+            current_tp_status = resp_data.get("status", None)
+            current_tp_result = resp_data.get("result", None)
 
             if expected_state:
-                current_status = test_plan_status_factory(status)
+                current_status = test_plan_status_factory(current_tp_status)
                 expected_status = test_plan_status_factory(expected_state)
+
+                print("current test plan status: {}, expected status: {}".format(current_tp_status, expected_state))
 
                 if expected_status.get_status() == current_status.get_status():
                     current_status.print_logs(test_plan_id, resp_data, start_time)
@@ -430,7 +432,14 @@ class TestPlanManager(object):
 
                     # We fail the step only if the step_status is "FAILED".
                     # Other status such as "SKIPPED", "CANCELED" are considered successful.
-                    if step_status == "FAILED":
+                    """
+                    If step_status is None, means that current step was not executed but current status is in a post
+                    status behind the step. For example: current is {Failed}, expect is {Executing}, and after prepare
+                    tb it went to fail(run test not executed), so executing not started. In this scenario, step_status
+                    is None but current status is Failed. So, should return to failure. Otherwise, it will return to
+                    pass and cause inconsistency issues between pipeline and test plan.
+                    """
+                    if step_status == "FAILED" or (step_status is None and current_tp_status == "FAILED"):
 
                         # Print error type and message
                         err_code = resp_data.get("runtime", {}).get("err_code", None)
@@ -443,23 +452,24 @@ class TestPlanManager(object):
 
                         raise Exception("Test plan id: {}, status: {}, result: {}, Elapsed {:.0f} seconds. "
                                         "Check {}/scheduler/testplan/{} for test plan status"
-                                        .format(test_plan_id, step_status, result, time.time() - start_time,
+                                        .format(test_plan_id, step_status, current_tp_result, time.time() - start_time,
                                                 self.frontend_url,
                                                 test_plan_id))
                     if expected_result:
-                        if result != expected_result:
+                        if current_tp_result != expected_result:
                             raise Exception("Test plan id: {}, status: {}, result: {} not match expected result: {}, "
                                             "Elapsed {:.0f} seconds. "
                                             "Check {}/scheduler/testplan/{} for test plan status"
-                                            .format(test_plan_id, step_status, result,
+                                            .format(test_plan_id, step_status, current_tp_result,
                                                     expected_result, time.time() - start_time,
                                                     self.frontend_url,
                                                     test_plan_id))
 
-                    print("Current status is {}".format(step_status))
+                    print("Current step status is {}".format(step_status))
                     return
                 else:
-                    print("Current state is {}, waiting for the state {}".format(status, expected_state))
+                    print("Current test plan state is {}, waiting for the expected state {}".format(current_tp_status,
+                                                                                                    expected_state))
 
                 time.sleep(interval)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

[CI]Fix inconsistency issue of pipeline and test plan
The issue is that pipeline said the test job passed but test plan failed. It's the inconsistency issue of polling test plan status.
One example is: 
https://dev.azure.com/mssonic/build/_build/results?buildId=631446&view=logs&jobId=f1a75c01-4f64-5de9-bd52-755062a8a04a&j=f1a75c01-4f64-5de9-bd52-755062a8a04a&t=9246549a-3ee7-52ff-a097-753e4679a4f2
![image](https://github.com/user-attachments/assets/852d4b1a-cfb7-4eac-a3fc-5ddada732ce2)
To fix the bug, need to check current step staus, if it's None and current test plan failed. Need to fail the pipeline step.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
See description.

#### How did you do it?
See description.

#### How did you verify/test it?
Raised Daft PR to vefify: https://github.com/sonic-net/sonic-mgmt/pull/14386
The expected behavior is: It failed on every test job.(Because hard-code pre-test fail). Not passed anyone any more.
https://dev.azure.com/mssonic/build/_build/results?buildId=634534&view=logs&j=f1a75c01-4f64-5de9-bd52-755062a8a04a&t=9246549a-3ee7-52ff-a097-753e4679a4f2
![image](https://github.com/user-attachments/assets/90c35f5c-656f-42fa-b036-7558aab05c4a)
![image](https://github.com/user-attachments/assets/ce90135f-6409-4b49-bacd-5907a1e8bfa8)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
