### PR TITLE
Changes to support asic name change from marvell to marvell-prestera

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -250,7 +250,7 @@ class EverflowPolicerTest(BaseTest):
 
         if self.asic_type in ["innovium"]:
             masked_exp_pkt.set_do_not_care_scapy(scapy.GRE, "seqnum_present")
-        if self.asic_type in ["marvell"]:
+        if self.asic_type in ["marvell-prestera"]:
             masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "id")
             masked_exp_pkt.set_do_not_care_scapy(scapy.GRE, "seqnum_present")
 

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -118,7 +118,7 @@ class FibTest(BaseTest):
         '''
         self.dataplane = ptf.dataplane_instance
         self.asic_type = self.test_params.get('asic_type')
-        if self.asic_type == "marvell":
+        if self.asic_type == "marvell-prestera":
             fib.EXCLUDE_IPV4_PREFIXES.append("240.0.0.0/4")
 
         self.fibs = []

--- a/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
@@ -114,7 +114,7 @@ class DecapPacketTest(BaseTest):
         self.max_internal_hops = self.test_params.get('max_internal_hops', 0)
         if self.max_internal_hops:
             self.TTL_RANGE = list(range(self.max_internal_hops + 1, 63))
-        if self.asic_type == "marvell":
+        if self.asic_type == "marvell-prestera":
             fib.EXCLUDE_IPV4_PREFIXES.append("240.0.0.0/4")
         self.fibs = []
         for fib_info_file in self.test_params.get('fib_info_files'):

--- a/tests/common/marvell_data.py
+++ b/tests/common/marvell_data.py
@@ -1,2 +1,0 @@
-def is_marvell_device(dut):
-    return dut.facts["asic_type"] == "marvell"

--- a/tests/common/marvell_prestera_data.py
+++ b/tests/common/marvell_prestera_data.py
@@ -1,0 +1,2 @@
+def is_marvell_prestera_device(dut):
+    return dut.facts["asic_type"] == "marvell-prestera"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -262,15 +262,15 @@ crm/test_crm.py::test_crm_route:
 #######################################
 decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=disable]:
   skip:
-    reason: "Not supported on broadcom after 201911 release, mellanox all releases and cisco-8000 all releases and marvell asics"
+    reason: "Not supported on broadcom after 201911 release, mellanox all releases and cisco-8000 all releases and marvell-prestera asics"
     conditions:
       - "(asic_type in ['broadcom'] and release not in ['201811', '201911']) or (asic_type in ['mellanox']) or (asic_type in ['cisco-8000'])"
 
 decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=set_unset]:
   skip:
-    reason: "Not supported on broadcom after 201911 release, mellanox all releases and cisco-8000 all releases and marvell asics"
+    reason: "Not supported on broadcom after 201911 release, mellanox all releases and cisco-8000 all releases and marvell-prestera asics"
     conditions:
-      - "(asic_type in ['broadcom'] and release not in ['201811', '201911']) or (asic_type in ['mellanox']) or (asic_type in ['cisco-8000']) or (asic_type in ['marvell'])"
+      - "(asic_type in ['broadcom'] and release not in ['201811', '201911']) or (asic_type in ['mellanox']) or (asic_type in ['cisco-8000']) or (asic_type in ['marvell-prestera'])"
 
 decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=disable]:
   skip:
@@ -642,19 +642,19 @@ everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-defaul
   skip:
     reason: "Skip everflow per interface IPv6 test on unsupported platforms"
     conditions:
-      - "asic_type in ['cisco-8000', 'marvell', 'mellanox'] or (asic_subtype in ['broadcom-dnx'] and https://github.com/sonic-net/sonic-swss/issues/2204)"
+      - "asic_type in ['cisco-8000', 'marvell-prestera', 'mellanox'] or (asic_subtype in ['broadcom-dnx'] and https://github.com/sonic-net/sonic-swss/issues/2204)"
 
 everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-m0_l3_scenario]:
   skip:
-    reason: "Skip m0 everflow per interface IPv6 test on marvell"
+    reason: "Skip m0 everflow per interface IPv6 test on marvell-prestera"
     conditions:
-      - "asic_type in ['marvell']"
+      - "asic_type in ['marvell-prestera']"
 
 everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-m0_vlan_scenario]:
   skip:
-    reason: "Skip m0 everflow per interface IPv6 test on marvell"
+    reason: "Skip m0 everflow per interface IPv6 test on marvell-prestera"
     conditions:
-      - "asic_type in ['marvell']"
+      - "asic_type in ['marvell-prestera']"
 
 everflow/test_everflow_testbed.py::EverflowIPv4Tests::test_everflow_dscp_with_policer:
   skip:
@@ -927,7 +927,7 @@ ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_dr
   skip:
     reason: "Broadcom, Cisco, Barefoot, Innovium and Marvell Asic will tolorate IP packets with 0xffff checksum"
     conditions:
-      - "asic_type in ['broadcom', 'cisco-8000', 'marvell', 'barefoot', 'innovium'] and asic_subtype not in ['broadcom-dnx']"
+      - "asic_type in ['broadcom', 'cisco-8000', 'marvell-prestera', 'barefoot', 'innovium'] and asic_subtype not in ['broadcom-dnx']"
 
 ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_tolerant:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -660,7 +660,7 @@ platform_tests/broadcom:
   skip:
     reason: "Marvell devices does not support platform_tests/broadcom"
     conditions:
-      - "'marvell' in asic_type"
+      - "'marvell-prestera' in asic_type"
 
 platform_tests/broadcom/test_ser.py:
   skip:

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -387,7 +387,7 @@ def _setup_testbed(dut, creds, ptf, test_params, tbinfo, upStreamDuthost, is_bac
     copp_utils.configure_ptf(ptf, test_params, is_backend_topology)
 
     rate_limit = _TEST_RATE_LIMIT_DEFAULT
-    if dut.facts["asic_type"] == "marvell":
+    if dut.facts["asic_type"] == "marvell-prestera":
         rate_limit = _TEST_RATE_LIMIT_MARVELL
 
     logging.info("Update the rate limit for the COPP policer")

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -296,7 +296,7 @@ def cleanup_ptf_interface(duthosts, ip_ver, enum_rand_one_per_hwsku_frontend_hos
 
     yield
 
-    if duthost.facts["asic_type"] == "marvell":
+    if duthost.facts["asic_type"] == "marvell-prestera":
         asichost.shell(ip_remove_cmd)
         # Check if member not removed
         output = asichost.shell(check_vlan_cmd, module_ignore_errors=True)

--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -650,7 +650,7 @@ def test_crm_nexthop(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     asic_type = duthost.facts['asic_type']
     skip_stats_check = True if asic_type == "vs" else False
     RESTORE_CMDS["crm_threshold_name"] = "ipv{ip_ver}_nexthop".format(ip_ver=ip_ver)
-    if duthost.facts["asic_type"] == "marvell":
+    if duthost.facts["asic_type"] == "marvell-prestera":
         if ip_ver == "4":
             ptfhost.add_ip_to_dev('eth1', nexthop+'/24')
             ptfhost.set_dev_up_or_down('eth1', 'is_up')
@@ -701,7 +701,7 @@ def test_crm_nexthop(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                   "\"crm_stats_ipv{}_nexthop_available\" counter was not decremented".format(ip_ver, ip_ver))
     # Remove nexthop
     asichost.shell(nexthop_del_cmd)
-    if duthost.facts["asic_type"] == "marvell":
+    if duthost.facts["asic_type"] == "marvell-prestera":
         asichost.shell(ip_remove_cmd)
         asichost.sonichost.add_member_to_vlan(1000, 'Ethernet1', is_tagged=False)
         ptfhost.remove_ip_addresses()
@@ -925,7 +925,7 @@ def test_acl_entry(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     asichost = duthost.asic_instance(enum_frontend_asic_index)
     asic_collector = collector[asichost.asic_index]
     try:
-        if duthost.facts["asic_type"] == "marvell":
+        if duthost.facts["asic_type"] == "marvell-prestera":
             # Remove DATA ACL Table and add it again with ports in same port group
             mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
             tmp_ports = sorted(mg_facts["minigraph_ports"], key=lambda x: int(x[8:]))
@@ -1027,7 +1027,7 @@ def verify_acl_crm_stats(duthost, asichost, enum_rand_one_per_hwsku_frontend_hos
                             .format(db_cli=asichost.sonic_db_cli, acl_tbl_key=acl_tbl_key)
 
     global crm_stats_checker
-    if duthost.facts["asic_type"] == "marvell":
+    if duthost.facts["asic_type"] == "marvell-prestera":
         crm_stats_checker = wait_until(
             30,
             5,

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -596,7 +596,7 @@ class BaseEverflowTest(object):
         duthost.command(command)
 
     def apply_policer_config(self, duthost, policer_name, config_method, rate_limit=100):
-        if duthost.facts["asic_type"] == "marvell":
+        if duthost.facts["asic_type"] == "marvell-prestera":
             rate_limit = rate_limit * 1.25
         for namespace in duthost.get_frontend_asic_namespace_list():
             if config_method == CONFIG_MODE_CLI:
@@ -889,7 +889,7 @@ class BaseEverflowTest(object):
         expected_packet.set_do_not_care_scapy(packet.IP, "len")
         expected_packet.set_do_not_care_scapy(packet.IP, "flags")
         expected_packet.set_do_not_care_scapy(packet.IP, "chksum")
-        if duthost.facts["asic_type"] == 'marvell':
+        if duthost.facts["asic_type"] == 'marvell-prestera':
             expected_packet.set_do_not_care_scapy(packet.IP, "id")
             expected_packet.set_do_not_care_scapy(packet.GRE, "seqnum_present")
         if duthost.facts["asic_type"] in ["cisco-8000", "innovium"] or \

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -553,7 +553,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_tolerance = 11
 
         rate_limit = 100
-        if vendor == "marvell":
+        if vendor == "marvell-prestera":
             rate_limit = rate_limit * 1.25
 
         send_time = "10"

--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -664,7 +664,7 @@ class TestIPPacket(object):
             return
         pytest_assert(rx_ok >= self.PKT_NUM_MIN,
                       "Received {} packets in rx, not in expected range".format(rx_ok))
-        pytest_assert(max(rx_drp, rx_err) >= self.PKT_NUM_MIN if asic_type not in ["marvell"] else True,
+        pytest_assert(max(rx_drp, rx_err) >= self.PKT_NUM_MIN if asic_type not in ["marvell-prestera"] else True,
                       "Dropped {} packets in rx, not in expected range".format(rx_err))
         pytest_assert(tx_ok <= self.PKT_NUM_ZERO,
                       "Forwarded {} packets in tx, not in expected range".format(tx_ok))

--- a/tests/sai_qualify/conftest.py
+++ b/tests/sai_qualify/conftest.py
@@ -812,7 +812,7 @@ def get_sai_running_vendor_id(duthost):
         vendor_id = "mlnx"
     elif is_barefoot_device(duthost):
         vendor_id = "bfn"
-    elif vendor_id.facts["asic_type"] == "marvell":
+    elif vendor_id.facts["asic_type"] == "marvell-prestera":
         vendor_id = "mrvl"
     else:
         error_message = '"{}" does not currently \

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -527,7 +527,7 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
                 }
             )
     # Remove /proc/dma for armh
-    elif duthost.facts["asic_type"] == "marvell":
+    elif duthost.facts["asic_type"] == "marvell-prestera":
         if 'armhf-' in duthost.facts["platform"] or 'arm64-' in duthost.facts["platform"]:
             cmds.copy_proc_files.remove("/proc/dma")
 


### PR DESCRIPTION
### Description of PR
Adding the changes to support chip name change from marvell to marvell-prestera

Summary:
The chip name for marvell is changed to marvell-prestera
Same need to be modified in sonic-mgmt where we do conditional checks for different scripts.

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
https://github.com/sonic-net/sonic-buildimage/pull/19829

#### Supported testbed topology if it's a new test case?
