### PR TITLE
Fix routeCheck failures in tests for chassis : test_stress_routes, test_lag_2

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -23,20 +23,6 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exceptions(duthosts, loganalyzer):
-    """Ignore expected failures logs during test execution."""
-    if loganalyzer:
-        for duthost in duthosts:
-            loganalyzer[duthost.hostname].ignore_regex.extend(
-                [
-                    r".* ERR monit\[\d+\]: 'routeCheck' status failed \(255\) -- Failure results:.*",
-                ]
-            )
-
-    return
-
-
 @pytest.fixture(scope="module")
 def common_setup_teardown(copy_acstests_directory, copy_ptftests_directory, ptfhost, duthosts): # noqa F811
 
@@ -359,7 +345,7 @@ def test_lag(common_setup_teardown, duthosts, tbinfo, nbrhosts, fanouthosts,
 
 
 @pytest.fixture(scope='function')
-def ignore_expected_loganalyzer_exceptions_lag2(duthosts, rand_one_dut_hostname, loganalyzer):
+def ignore_expected_loganalyzer_exceptions_lag(duthosts, rand_one_dut_hostname, loganalyzer):
     """
         Ignore expected failures logs during test execution.
 
@@ -370,15 +356,14 @@ def ignore_expected_loganalyzer_exceptions_lag2(duthosts, rand_one_dut_hostname,
             rand_one_dut_hostname: Hostname of a random chosen dut
             loganalyzer: Loganalyzer utility fixture
     """
-    # When loganalyzer is disabled, the object could be None
-    duthost = duthosts[rand_one_dut_hostname]
-    if loganalyzer:
-        ignoreRegex = [
-            # Valid test_lag_db_status and test_lag_db_status_with_po_update
-            ".*ERR swss[0-9]*#orchagent: :- getPortOperSpeed.*",
-            r".* ERR monit\[\d+\]: 'routeCheck' status failed \(255\) -- Failure results:.*",
-        ]
-        loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
+    ignoreRegex = [
+        r".*ERR swss[0-9]*#orchagent: :- getPortOperSpeed.*",
+        r".* ERR monit\[\d+\]: 'routeCheck' status failed \(255\) -- Failure results:.*",
+    ]
+
+    for duthost in duthosts.frontend_nodes:
+        if duthost.loganalyzer:
+            duthost.loganalyzer.ignore_regex.extend(ignoreRegex)
 
 
 @pytest.fixture(scope='function')
@@ -465,7 +450,7 @@ def check_link_is_down(asichost, po_intf):
 
 
 def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level,
-                       ignore_expected_loganalyzer_exceptions_lag2):
+                       ignore_expected_loganalyzer_exceptions_lag):
     # Test state_db status for lag interfaces
     dut_name, dut_lag = decode_dut_port_name(enum_dut_portchannel_with_completeness_level)
     logger.info("Start test_lag_db_status test on dut {} for lag {}".format(dut_name, dut_lag))
@@ -539,7 +524,7 @@ def test_lag_db_status(duthosts, enum_dut_portchannel_with_completeness_level,
 
 
 def test_lag_db_status_with_po_update(duthosts, teardown, enum_dut_portchannel_with_completeness_level,
-                                      ignore_expected_loganalyzer_exceptions_lag2):
+                                      ignore_expected_loganalyzer_exceptions_lag):
     """
     test port channel add/deletion and check interface status in state_db
     """

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -50,22 +50,22 @@ def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_conpl
     asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
     namespace = asichost.namespace
 
-    if loganalyzer:
-        ignoreRegex = [
-            ".*ERR route_check.py:.*",
-            ".*ERR.* 'routeCheck' status failed.*",
-            ".*Process \'orchagent\' is stuck in namespace \'host\'.*",
-            ".*ERR rsyslogd: .*"
-        ]
+    ignoreRegex = [
+        ".*ERR route_check.py:.*",
+        ".*ERR.* 'routeCheck' status failed.*",
+        ".*Process \'orchagent\' is stuck in namespace \'host\'.*",
+        ".*ERR rsyslogd: .*"
+    ]
 
-        hwsku = duthost.facts['hwsku']
-        if hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7050-QX32', 'Arista-7050QX-32S-S4Q31']:
-            ignoreRegex.append(".*ERR memory_threshold_check:.*")
-            ignoreRegex.append(".*ERR monit.*memory_check.*")
-            ignoreRegex.append(".*ERR monit.*mem usage of.*matches resource limit.*")
+    hwsku = duthost.facts['hwsku']
+    if hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7050-QX32', 'Arista-7050QX-32S-S4Q31']:
+        ignoreRegex.append(".*ERR memory_threshold_check:.*")
+        ignoreRegex.append(".*ERR monit.*memory_check.*")
+        ignoreRegex.append(".*ERR monit.*mem usage of.*matches resource limit.*")
 
-        # Ignore errors in ignoreRegex for *all* DUTs
-        for dut in duthosts:
+    # Ignore errors in ignoreRegex for *all* DUTs
+    for dut in duthosts.frontend_nodes:
+        if dut.loganalyzer:
             loganalyzer[dut.hostname].ignore_regex.extend(ignoreRegex)
 
     normalized_level = get_function_conpleteness_level


### PR DESCRIPTION
Summary:
Fixes # 10147

There was failure in chassis with multiple linecards (multi-dut scenario) seen in test_stress_routes, test_lag_2. This was because when these tests are run on chassis and not on a specific dut, the route check ERR occurs on the other duts than the dut which is under test.

In case of a chassis system, interface/pc flap on a particular linecard (dut) will cause route churn in other linecards(duts) and hence this PR addresses this.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

As explained in Summary

#### How did you do it?
Add the log analyzer skip message to all duts other than supervisor.

This fix should work for single asic sonic devices as duthosts.frontend_nodes will cover those cases too.

#### How did you verify/test it?
```
stress/test_stress_routes.py::test_announce_withdraw_route[svcstr-xxxx-lc3-1-1]  PASSED                                                                                                             [100%]

--------------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml ----------------------------------------------------------------------
====================================================================================== 1 passed in 2741.01 seconds =======================================================================================

```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
