### PR TITLE
Update portchannel ip configuration command in generic hash script

### DIFF
--- a/tests/hash/generic_hash_helper.py
+++ b/tests/hash/generic_hash_helper.py
@@ -129,8 +129,8 @@ def restore_configuration(duthost):
             duthost.shell(f'config vlan del {vlan}')
         # Re-config ip interface
         for ip_interface in ip_interface_to_restore:
-            duthost.shell(f"config interface ip add {ip_interface['attachto']} "
-                          f"{ip_interface['addr']}/{ip_interface['mask']}")
+            formatted_ip_addr = format_ip_mask(f"{ip_interface['addr']}/{ip_interface['mask']}")
+            duthost.shell(f"config interface ip add {ip_interface['attachto']} {formatted_ip_addr}")
         # Re-config vlan interface
         if vlan_member_to_restore:
             duthost.shell(f"config vlan member add {vlan_member_to_restore['vlan_id']} "


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Currently, CLI/SWSS doesn't have a way to normalize the IP mask notation regardless of what was provided by user.
The code change here is to replace dotted decimal notation when adding ip address for portchannel.
Replace dot split mask during portchannel ip configuration would make the portchannel related test more stable.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Make the portchannel related script stable.
#### How did you do it?
Replace dot split mask during portchannel ip configuration
#### How did you verify/test it?
Run it in internal regression.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
