### PR TITLE
update datetime restoration in clock tests

### DIFF
--- a/tests/clock/conftest.py
+++ b/tests/clock/conftest.py
@@ -42,6 +42,12 @@ def restore_time(duthosts, ntp_server):
     """
     @summary: fixture to restore time after test (using ntp)
     """
+    logging.info('Check NTP server reachability')
+    try:
+        ClockUtils.run_cmd(duthosts, f'{ClockConsts.CMD_NTPDATE} -q {ntp_server}', raise_err=True)
+    except Exception as e:
+        pytest.skip(f'Unreachable NTP server {ntp_server}: {str(e)}')
+
     logging.info('Check if there is ntp configured before test')
     show_ntp_output = ClockUtils.run_cmd(duthosts, ClockConsts.CMD_SHOW_NTP)
     if 'unsynchronised' in show_ntp_output:
@@ -69,36 +75,14 @@ def restore_time(duthosts, ntp_server):
 
     logging.info(f'Reset time after test. Sync with NTP server: {ntp_server}')
 
-    logging.info(f'Sync with NTP server: {ntp_server}')
-    output = ClockUtils.run_cmd(duthosts, ClockConsts.CMD_CONFIG_NTP_ADD, ntp_server)
-    assert ClockConsts.OUTPUT_CMD_NTP_ADD_SUCCESS.format(ntp_server) in output, \
-        f'Error: The given string does not contain the expected substring.\n' \
-        f'Expected substring: "{ClockConsts.OUTPUT_CMD_NTP_ADD_SUCCESS.format(ntp_server)}"\n' \
-        f'Given (whole) string: "{output}"'
+    logging.info('Stopping NTP service')
+    ClockUtils.run_cmd(duthosts, ClockConsts.CMD_NTP_STOP)
 
-    logging.info('Check polling time')
-    show_ntp_output = ClockUtils.run_cmd(duthosts, ClockConsts.CMD_SHOW_NTP)
-    match = re.search(ClockConsts.REGEX_NTP_POLLING_TIME, show_ntp_output)
-    if match:
-        polling_time_seconds = int(match.group(1))
-    else:
-        logging.info('Could not match the regex.\nPattern: "{}"\nShow ntp output string: "{}"'
-                     .format(ClockConsts.REGEX_NTP_POLLING_TIME, show_ntp_output))
-        polling_time_seconds = ClockConsts.RANDOM_NUM
-    logging.info(f'Polling time (in seconds): {polling_time_seconds + 1}')
+    logging.info(f'Syncing datetime with NTP server {ntp_server}')
+    ClockUtils.run_cmd(duthosts, ClockConsts.CMD_NTPDATE, f'-s {ntp_server}')
 
-    logging.info('Wait for the sync')
-    time.sleep(polling_time_seconds)
-
-    logging.info(f'Delete NTP server: {ntp_server}')
-    output = ClockUtils.run_cmd(duthosts, ClockConsts.CMD_CONFIG_NTP_DEL, ntp_server)
-    assert ClockConsts.OUTPUT_CMD_NTP_DEL_SUCCESS.format(ntp_server) in output, \
-        f'Error: The given string does not contain the expected substring.\n' \
-        f'Expected substring: "{ClockConsts.OUTPUT_CMD_NTP_DEL_SUCCESS.format(ntp_server)}"\n' \
-        f'Given (whole) string: "{output}"'
-
-    logging.info('Wait for the sync')
-    time.sleep(polling_time_seconds)
+    logging.info('Starting NTP service')
+    ClockUtils.run_cmd(duthosts, ClockConsts.CMD_NTP_START)
 
     if orig_ntp_server:
         logging.info('Restore original NTP server after test')

--- a/tests/clock/test_clock.py
+++ b/tests/clock/test_clock.py
@@ -31,6 +31,9 @@ class ClockConsts:
     CMD_SHOW_CLOCK_TIMEZONES = "show clock timezones"
     CMD_CONFIG_CLOCK_TIMEZONE = "config clock timezone"
     CMD_CONFIG_CLOCK_DATE = "config clock date"
+    CMD_NTP_STOP = 'service ntp stop'
+    CMD_NTP_START = 'service ntp start'
+    CMD_NTPDATE = 'ntpdate'
 
     # expected outputs
     OUTPUT_CMD_SUCCESS = ''
@@ -60,7 +63,7 @@ class ClockConsts:
 
 class ClockUtils:
     @staticmethod
-    def run_cmd(duthosts, cmd, param=''):
+    def run_cmd(duthosts, cmd, param='', raise_err=False):
         """
         @summary:
             Run a given command and return its output.
@@ -81,6 +84,8 @@ class ClockUtils:
                 err = cmd_err.results["stderr"]
                 cmd_output = output if output else err
                 logging.info(f'Command Error!\nError message: "{cmd_output}"')
+                if raise_err:
+                    raise Exception(cmd_output)
 
             cmd_output = str(cmd_output)
             logging.info(f'Output: {cmd_output}')


### PR DESCRIPTION
use ntpdate instead of a temporary adding of NTP server check NTP server reachability on the setup stage

Change-Id: I78ab7bab5609ae0ecad31887225abe152f7a39e8

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The motivation is to avoid waiting for the next poll and prevent the situation when the polling interval changes after adding the NTP server

#### How did you do it?
use ntpdate instead of a temporary adding of NTP server check NTP server reachability on the setup stage

#### How did you verify/test it?
Ran test_show_clock/test_config_clock_timezone/test_config_clock_date and verified datetime was restored after tests finished

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
