### PR TITLE
[ansible/library/exabgp]: Output handling for PY3

### DIFF
--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -172,7 +172,12 @@ def exec_command(module, cmd, ignore_error=False, msg="executing command"):
 
 def get_exabgp_status(module, name):
     output = exec_command(module, cmd="supervisorctl status exabgp-%s" % name)
-    m = re.search(r'^([\w|-]*)\s+(\w*).*$', output.decode("utf-8"))
+    m = None
+    if six.PY2:
+        m = re.search(r'^([\w|-]*)\s+(\w*).*$', output.decode("utf-8"))
+    else:
+        # For PY3 module.run_command encoding is "utf-8" by default
+        m = re.search(r'^([\w|-]*)\s+(\w*).*$', output)
     return m.group(2)
 
 


### PR DESCRIPTION
### Description of PR

This PR fixes test failures in Py3 only environment (`str has no decode`). For Python 3 the output string returned by `ansible.module.run_command` is already in utf-8. The default "encoding" argument is "utf-8" to enable Py3 to return native strings. [doc](https://docs.ansible.com/ansible/latest/reference_appendices/module_utils.html)


Summary:
Fixes # Not applicable

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

This is a PY3 only fix and not applicable for backport.

### Approach
#### What is the motivation for this PR?

Tests running in PTF Py3 only image fail with error -

```
E           {"changed": false, "failed": true, "msg": "Error: (<class 'AttributeError'>, AttributeError(\"'str' object has no attribute 'decode'\"), <traceback object at 0x7f60a07fe2c0>)"}
```

#### How did you do it?

Fixed to code to treat output as UTF-8 native string in Py3.

#### How did you verify/test it?

By running failed tests manually on a testbed.

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

Not applicable

### Documentation

Not applicable.