### PR TITLE
Fix duplicate entry of admin user in the tacacs config

### DIFF
--- a/tests/common/helpers/tacacs/tacacs_helper.py
+++ b/tests/common/helpers/tacacs/tacacs_helper.py
@@ -170,9 +170,12 @@ def setup_tacacs_server(ptfhost, tacacs_creds, duthost):
     if 'ansible_ssh_user' in dut_options and 'ansible_ssh_pass' in dut_options:
         duthost_ssh_user = dut_options['ansible_ssh_user']
         duthost_ssh_passwd = dut_options['ansible_ssh_pass']
-        logger.debug("setup_tacacs_server: update extra_vars with ansible_ssh_user and ansible_ssh_pass.")
-        extra_vars['duthost_ssh_user'] = duthost_ssh_user
-        extra_vars['duthost_ssh_passwd'] = crypt.crypt(duthost_ssh_passwd, 'abc')
+        if not duthost_ssh_user == extra_vars['duthost_admin_user']:
+            logger.debug("setup_tacacs_server: update extra_vars with ansible_ssh_user and ansible_ssh_pass.")
+            extra_vars['duthost_ssh_user'] = duthost_ssh_user
+            extra_vars['duthost_ssh_passwd'] = crypt.crypt(duthost_ssh_passwd, 'abc')
+        else:
+            logger.debug("setup_tacacs_server: ansible_ssh_user is the same as duthost_admin_user.")
     else:
         logger.debug("setup_tacacs_server: duthost options does not contains config for ansible_ssh_user.")
 


### PR DESCRIPTION
### Description of PR
PR11614 adds two new sets of credentials to the tacplus authentication config, "duthost_admin_user" and "ansible_ssh_user", however in our testbed set-up, these are both the DUT admin user, causing problems due to duplicate tacplus config.  The observed behavior is as described in https://github.com/sonic-net/sonic-mgmt/issues/13708

This PR adds a check for whether ansible_ssh_user is the same as duthost_admin_user, preventing duplicate config.

Summary:
Fixes #13708

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Investigating the cause of sonic-mgmt tacacs test fails on 202405, determined it was caused by duplicate user entry in tacplus config.

#### How did you do it?

#### How did you verify/test it?
After this change, all the tacacs sonic-mgmt tests pass for us in 202405.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
