### PR TITLE
Update last_down_time to keys_skip_val_comp in configlet test

### DIFF
--- a/tests/configlet/util/common.py
+++ b/tests/configlet/util/common.py
@@ -118,6 +118,7 @@ scan_dbs = {
                 },
             "keys_skip_val_comp": {
                 "last_up_time",
+                "last_down_time",
                 "flap_count"
             }
         },


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add 'last_down_time' into 'keys_skip_val_comp' to avoid "DB compare failed after adding T0 via generic patch updater"

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
DB compare failed after adding T0 via generic patch updater
#### How did you do it?
Add 'last_down_time' into 'keys_skip_val_comp'
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
