### PR TITLE
Update software control module disable steps in fanout deployment

### DIFF
--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202311.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202311.yml
@@ -13,11 +13,35 @@
   become: yes
   when: "'mellanox' in fanout_sonic_version.asic_type"
 
-- name: Disable software control module function in SAI
-  lineinfile:
-    path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/sai.profile
-    line: 'SAI_INDEPENDENT_MODULE_MODE=1'
-    state: absent
+- name: Disable software control module function
+  block:
+    - name: Disable software control module function in SAI
+      lineinfile:
+        path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/sai.profile
+        line: 'SAI_INDEPENDENT_MODULE_MODE=1'
+        state: absent
+
+    - name: Check whether pmon_daemon_control.json exist
+      stat:
+        path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/pmon_daemon_control.json
+      register: pmon_daemon_control_json
+
+    - name: Skip transceiver cmis manager
+      lineinfile:
+        path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/pmon_daemon_control.json
+        regexp: '"skip_xcvrd_cmis_mgr": false'
+        line: '    "skip_xcvrd_cmis_mgr": true'
+      when: pmon_daemon_control_json.stat.exists
+
+    - name: Remove media setting file
+      file:
+        path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/media_settings.json
+        state: absent
+
+    - name: Remove optical setting file
+      file:
+        path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/optics_si_settings.json
+        state: absent
   become: yes
   when: "'mellanox' in fanout_sonic_version.asic_type"
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
To compatible with the latest software implementation, update some steps in fanout switch deployment:
Add pmon_daemon_control.json handle step
Add media_settings.json handle step
Add optics_si_settings.json handle step

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To compatible with the latest software implementation
#### How did you do it?
Add pmon_daemon_control.json handle step
Add media_settings.json handle step
Add optics_si_settings.json handle step
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
