### PR TITLE
Fix generic_config_updater.test_mgmt_interface test failed

### DIFF
--- a/tests/generic_config_updater/test_mgmt_interface.py
+++ b/tests/generic_config_updater/test_mgmt_interface.py
@@ -81,10 +81,10 @@ def update_and_check_forced_mgmt_routes(duthost, forced_mgmt_routes, interface_a
     interfaces = duthost.command("cat /etc/network/interfaces")['stdout']
     logging.debug("interfaces: {}".format(interfaces))
 
-    pytest_assert("up ip {} rule add pref {} to {} table default"
-                  .format(ip_type, FORCED_MGMT_ROUTE_PRIORITY, test_route) in interfaces == expect_exist)
-    pytest_assert("pre-down ip {} rule delete pref {} to {} table default"
-                  .format(ip_type, FORCED_MGMT_ROUTE_PRIORITY, test_route) in interfaces == expect_exist)
+    pytest_assert(("up ip {} rule add pref {} to {} table default"
+                  .format(ip_type, FORCED_MGMT_ROUTE_PRIORITY, test_route) in interfaces) == expect_exist)
+    pytest_assert(("pre-down ip {} rule delete pref {} to {} table default"
+                  .format(ip_type, FORCED_MGMT_ROUTE_PRIORITY, test_route) in interfaces) == expect_exist)
 
 
 def test_forced_mgmt_routes_update(duthost, ensure_dut_readiness):


### PR DESCRIPTION
Fix generic_config_updater.test_mgmt_interface test failed

#### Why I did it
generic_config_updater.test_mgmt_interface test case failed.

##### Work item tracking
- Microsoft ADO: 29294578

#### How I did it
Add brackets to fix the assert failed issue

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Fix generic_config_updater.test_mgmt_interface test failed

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

