### PR TITLE
[Fix] Fixing ecnconfig command

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -507,7 +507,7 @@ def enable_ecn(host_ans, prio, asic_value=None):
             return True
     else:
         host_ans.shell('sudo ip netns exec {} ecnconfig -q {} on'.format(asic_value, prio))
-        results = host_ans.shell('sudo ip netns exec {} ecnconfig {}'.format(asic_value, prio))
+        results = host_ans.shell('sudo ip netns exec {} ecnconfig -q {}'.format(asic_value, prio))
         if re.search("queue {}: on".format(prio), results['stdout']):
             return True
     return False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fixing ecnconfig command where -q was missing
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/14126
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
###OUTPUT
============================= test session starts ==============================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.3.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.8.10', 'Platform': 'Linux-5.4.0-150-generic-x86_64-with-glibc2.29', 'Packages': {'pytest': '7.4.0', 'pluggy': '1.3.0'}, 'Plugins': {'allure-pytest': '2.8.22', 'ansible': '4.0.0', 'forked': '1.6.0', 'html': '4.1.0', 'metadata': '3.0.0', 'repeat': '0.9.3', 'xdist': '1.28.0'}}
ansible: 2.13.13
rootdir: /var/AzDevOps/sonic-mgmt/tests
configfile: pytest.ini
plugins: allure-pytest-2.8.22, ansible-4.0.0, forked-1.6.0, html-4.1.0, metadata-3.0.0, repeat-0.9.3, xdist-1.28.0
collecting ... 
----------------------------- live log collection ------------------------------
22:57:46 conftest.generate_params_dut_hostname    L1210 INFO   | Using DUTs ['sonic-s6100-dut1'] in testbed 'vms-snappi-sonic'
22:57:46 conftest.set_rand_one_dut_hostname       L0418 INFO   | Randomly select dut sonic-s6100-dut1 for testing
22:57:46 __init__.pytest_collection_modifyitems   L0581 INFO   | Available basic facts that can be used in conditional skip:
{
  "topo_type": "ptf",
  "topo_name": "ptf64",
  "testbed": "vms-snappi-sonic"
}
collected 1 item

snappi_tests/ecn/test_dequeue_ecn_with_snappi.py::test_dequeue_ecn 
-------------------------------- live log setup --------------------------------
22:57:46 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
22:57:46 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
22:57:46 conftest.enhance_inventory               L0245 INFO   | Inventory file: ['../ansible/snappi-sonic']
22:57:52 ptfhost_utils.run_icmp_responder_session L0239 INFO   | Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
22:57:52 conftest.core_dump_and_config_check      L2154 INFO   | Dumping Disk and Memory Space informataion before test on sonic-s6100-dut1
22:57:52 conftest.core_dump_and_config_check      L2158 INFO   | Collecting core dumps before test on sonic-s6100-dut1
22:57:53 conftest.core_dump_and_config_check      L2167 INFO   | Collecting running config before test on sonic-s6100-dut1
22:57:55 __init__.sanity_check                    L0306 INFO   | Skip sanity check according to command line argument
22:57:55 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture enable_packet_aging_after_test setup starts --------------------
22:57:55 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture enable_packet_aging_after_test setup ends --------------------
22:57:55 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossless_prio setup starts --------------------
22:57:55 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossless_prio setup ends --------------------
22:57:55 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossy_prio setup starts --------------------
22:57:55 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossy_prio setup ends --------------------
22:57:55 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture start_pfcwd_after_test setup starts --------------------
22:57:55 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture start_pfcwd_after_test setup ends --------------------
22:57:55 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_ip setup starts --------------------
22:57:55 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_ip setup ends --------------------
22:57:55 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_port setup starts --------------------
22:57:55 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_port setup ends --------------------
22:57:55 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture snappi_api setup starts --------------------
22:57:55 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture snappi_api setup ends --------------------
22:57:55 conftest.rand_one_dut_front_end_hostname L0450 INFO   | Randomly select dut sonic-s6100-dut1 for testing
22:57:56 conftest.generate_port_lists             L1279 INFO   | Generate dut_port_map: {'sonic-s6100-dut1': ['sonic-s6100-dut1|Ethernet0', 'sonic-s6100-dut1|Ethernet4']}
22:57:56 conftest.generate_port_lists             L1302 INFO   | Generate port_list: ['sonic-s6100-dut1|Ethernet0', 'sonic-s6100-dut1|Ethernet4']
22:57:56 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture prio_dscp_map setup starts --------------------
22:57:56 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture prio_dscp_map setup ends --------------------
22:57:56 __init__.loganalyzer                     L0051 INFO   | Log analyzer is disabled
22:57:56 __init__.memory_utilization              L0091 INFO   | Hostname: sonic-s6100-dut1, Hwsku: Accton-AS7726-32X, Platform: x86_64-accton_as7726_32x-r0
22:57:56 __init__.store_fixture_values            L0017 INFO   | store memory_utilization test_dequeue_ecn
22:57:56 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_testbed_config setup starts --------------------
22:57:57 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_testbed_config setup ends --------------------
22:57:57 __init__.pytest_runtest_setup            L0024 INFO   | collect memory before test test_dequeue_ecn
22:57:58 __init__.pytest_runtest_setup            L0044 INFO   | Before test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 15.3}}}, 'after_test': {'sonic-s6100-dut1': {}}}
-------------------------------- live log call ---------------------------------
22:57:58 test_dequeue_ecn_with_snappi.test_dequeu L0066 INFO   | Running ECN dequeue test with params: {'kmin': 50000, 'kmax': 51000, 'pmax': 100}
22:57:58 helper.run_ecn_test                      L0058 INFO   | Stopping PFC watchdog
22:57:58 helper.run_ecn_test                      L0060 INFO   | Disabling packet aging if necessary
22:57:58 helper.run_ecn_test                      L0064 INFO   | Configuring WRED and ECN thresholds
22:58:00 helper.run_ecn_test                      L0072 INFO   | Enabling ECN markings
22:58:03 helper.run_ecn_test                      L0081 INFO   | Waiting on ECN and dynamic buffer configuration to take effect. Sleeping for 10 seconds.
22:58:13 helper.run_ecn_test                      L0097 INFO   | Generating base flow config
22:58:13 helper.run_ecn_test                      L0102 INFO   | Setting test flow config params
22:58:13 helper.run_ecn_test                      L0110 INFO   | Setting pause flow config params
22:58:13 helper.run_ecn_test                      L0124 INFO   | Generating test flows
22:58:13 helper.run_ecn_test                      L0130 INFO   | Generating pause flows
22:58:13 helper.run_ecn_test                      L0141 INFO   | Setting packet capture port to Port 1
22:58:13 helper.run_ecn_test                      L0145 INFO   | Running 1 iteration(s)
22:58:13 helper.run_ecn_test                      L0147 INFO   | Running iteration 0
22:58:13 helper.run_ecn_test                      L0149 INFO   | Packet capture file: ECN_cap-0.pcapng
22:58:13 helper.run_ecn_test                      L0156 INFO   | Running traffic
22:58:13 connection._warn                         L0246 WARNING| Verification of certificates is disabled
22:58:13 connection._info                         L0243 INFO   | Determining the platform and rest_port using the 10.36.78.59 address...
22:58:13 connection._warn                         L0246 WARNING| Unable to connect to http://10.36.78.59:443.
22:58:13 connection._info                         L0243 INFO   | Connection established to `https://10.36.78.59:443 on linux`
22:58:36 connection._info                         L0243 INFO   | Using IxNetwork api server version 10.20.2403.2
22:58:36 connection._info                         L0243 INFO   | User info IxNetwork/ixnetworkweb/admin-62-23797
22:58:37 snappi_api.info                          L1132 INFO   | snappi-0.9.1
22:58:37 snappi_api.info                          L1132 INFO   | snappi_ixnetwork-0.8.2
22:58:37 snappi_api.info                          L1132 INFO   | ixnetwork_restpy-1.0.64
22:58:38 snappi_api.info                          L1132 INFO   | Config validation 0.013s
22:58:41 snappi_api.info                          L1132 INFO   | Ports configuration 2.098s
22:58:41 snappi_api.info                          L1132 INFO   | Captures configuration 0.631s
22:58:44 snappi_api.info                          L1132 INFO   | Add location hosts [10.36.78.96] 2.458s
22:58:49 snappi_api.info                          L1132 INFO   | Location hosts ready [10.36.78.96] 4.298s
22:58:49 snappi_api.info                          L1132 INFO   | Speed conversion is not require for (port.name, speed) : [('Port 0', 'novusHundredGigNonFanOut'), ('Port 1', 'novusHundredGigNonFanOut')]
22:58:49 snappi_api.info                          L1132 INFO   | Aggregation mode speed change 0.549s
22:58:54 snappi_api.info                          L1132 INFO   | Location preemption [10.36.78.96;1;5, 10.36.78.96;1;6] 0.241s
22:59:17 snappi_api.info                          L1132 INFO   | Location connect [Port 0, Port 1] 22.595s
22:59:17 snappi_api.warning                       L1138 WARNING| Port 0 connectedLinkDown
22:59:17 snappi_api.warning                       L1138 WARNING| Port 1 connectedLinkDown
22:59:17 snappi_api.info                          L1132 INFO   | Location state check [Port 0, Port 1] 0.455s
22:59:17 snappi_api.info                          L1132 INFO   | Location configuration 35.939s
22:59:27 snappi_api.info                          L1132 INFO   | Layer1 configuration 9.982s
22:59:28 snappi_api.info                          L1132 INFO   | Lag Configuration 0.160s
22:59:28 snappi_api.info                          L1132 INFO   | Convert device config : 0.412s
22:59:28 snappi_api.info                          L1132 INFO   | Create IxNetwork device config : 0.000s
22:59:29 snappi_api.info                          L1132 INFO   | Push IxNetwork device config : 0.849s
22:59:29 snappi_api.info                          L1132 INFO   | Devices configuration 1.397s
22:59:33 snappi_api.info                          L1132 INFO   | Flows configuration 4.227s
22:59:44 snappi_api.info                          L1132 INFO   | Start interfaces 10.798s
22:59:45 snappi_api.info                          L1132 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
22:59:45 traffic_generation.run_traffic           L0322 INFO   | Wait for Arp to Resolve ...
22:59:47 traffic_generation.run_traffic           L0333 INFO   | Starting packet capture ...
22:59:49 snappi_api.info                          L1132 INFO   | Captures start 1.911s
22:59:53 traffic_generation.run_traffic           L0343 INFO   | Starting transmit on all flows ...
22:59:58 snappi_api.info                          L1132 INFO   | Flows generate/apply 4.230s
23:00:10 snappi_api.info                          L1132 INFO   | Flows clear statistics 11.831s
23:00:11 snappi_api.info                          L1132 INFO   | Captures start 1.086s
23:00:15 snappi_api.info                          L1132 INFO   | Flows start 3.528s
23:00:16 traffic_generation.run_traffic           L0380 INFO   | Polling TGEN for in-flight traffic statistics...
23:00:20 traffic_generation.run_traffic           L0388 INFO   | Checking if all flows have stopped. Attempt #1
23:00:22 traffic_generation.run_traffic           L0395 INFO   | All test and background traffic flows stopped
23:00:24 traffic_generation.run_traffic           L0406 INFO   | Stopping packet capture ...
23:00:26 snappi_api.info                          L1132 INFO   | Captures stop 1.348s
23:00:26 traffic_generation.run_traffic           L0412 INFO   | Retrieving and saving packet capture to ECN_cap-0.pcapng
23:03:05 snappi_api.warning                       L1138 WARNING| Capture was not stopped for this port Port 1
23:03:05 snappi_api.info                          L1132 INFO   | Captures stop 158.173s
23:03:08 traffic_generation.run_traffic           L0418 INFO   | Dumping per-flow statistics
23:03:10 traffic_generation.run_traffic           L0420 INFO   | Stopping transmit on all remaining flows
23:03:11 read_pcap.get_ipv4_pkts                  L0080 INFO   | Reading packets from pcap file -> ECN_cap-0.pcapng
23:03:11 read_pcap.get_ipv4_pkts                  L0081 INFO   | Extracting ethernet frames from pcap file
23:03:11 test_dequeue_ecn_with_snappi.test_dequeu L0085 INFO   | Running verification for ECN dequeue test
23:03:11 read_pcap.is_ecn_marked                  L0103 INFO   | Checking if the packet is ECN congestion marked
23:03:11 read_pcap.is_ecn_marked                  L0103 INFO   | Checking if the packet is ECN congestion marked
23:03:11 test_dequeue_ecn_with_snappi.test_dequeu L0098 INFO   | Reloading config to teardown ECN config
23:03:11 config_reload.config_reload              L0138 INFO   | reloading config_db
23:04:52 processes_utils.wait_critical_processes  L0076 INFO   | Wait until all critical processes are healthy in 300 sec
23:04:52 processes_utils._all_critical_processes_ L0045 INFO   | Check critical processes status
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
23:04:56 __init__.pytest_runtest_teardown         L0049 INFO   | collect memory after test test_dequeue_ecn
23:04:57 __init__.pytest_runtest_teardown         L0072 INFO   | After test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 15.3}}}, 'after_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 5.6}}}}
23:04:57 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture snappi_api teardown starts --------------------
23:05:20 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture snappi_api teardown ends --------------------
23:05:20 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture start_pfcwd_after_test teardown starts --------------------
23:05:21 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture start_pfcwd_after_test teardown ends --------------------
23:05:21 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossy_prio teardown starts --------------------
23:05:21 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossy_prio teardown ends --------------------
23:05:21 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossless_prio teardown starts --------------------
23:05:21 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossless_prio teardown ends --------------------
23:05:21 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture enable_packet_aging_after_test teardown starts --------------------
23:05:21 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture enable_packet_aging_after_test teardown ends --------------------
23:05:21 conftest.core_dump_and_config_check      L2195 INFO   | Dumping Disk and Memory Space informataion after test on sonic-s6100-dut1
23:05:22 conftest.core_dump_and_config_check      L2199 INFO   | Collecting core dumps after test on sonic-s6100-dut1
23:05:22 conftest.core_dump_and_config_check      L2216 INFO   | Collecting running config after test on sonic-s6100-dut1
23:05:23 conftest.core_dump_and_config_check      L2344 WARNING| Core dump or config check failed for test_dequeue_ecn_with_snappi.py, results: {"core_dump_check": {"pass": true, "new_core_dumps": {"sonic-s6100-dut1": []}}, "config_db_check": {"pass": false, "pre_only_config": {"sonic-s6100-dut1": {"null": {}}}, "cur_only_config": {"sonic-s6100-dut1": {"null": {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "200"}}}}}, "inconsistent_config": {"sonic-s6100-dut1": {"null": {}}}}}
23:05:23 conftest.__dut_reload                    L2086 INFO   | dut reload called on sonic-s6100-dut1
23:05:23 config_reload.config_reload              L0138 INFO   | reloading config_db
23:08:45 parallel.on_terminate                    L0085 INFO   | process __dut_reload--<MultiAsicSonicHost sonic-s6100-dut1> terminated with exit code None
23:08:45 parallel.parallel_run                    L0221 INFO   | Completed running processes for target "__dut_reload" in 0:03:22.578938 seconds


=============================== warnings summary ===============================
../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.loganalyzer
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.sanity_check
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.test_completeness
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

../../../../usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:471
  /usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:471: CryptographyDeprecationWarning: Blowfish has been deprecated
    cipher=algorithms.Blowfish,

../../../../usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:485
  /usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:485: CryptographyDeprecationWarning: CAST5 has been deprecated
    cipher=algorithms.CAST5,

snappi_tests/ecn/test_dequeue_ecn_with_snappi.py::test_dequeue_ecn
snappi_tests/ecn/test_dequeue_ecn_with_snappi.py::test_dequeue_ecn
snappi_tests/ecn/test_dequeue_ecn_with_snappi.py::test_dequeue_ecn
snappi_tests/ecn/test_dequeue_ecn_with_snappi.py::test_dequeue_ecn
  /usr/local/lib/python3.8/dist-packages/pytest_ansible/module_dispatcher/v213.py:100: UserWarning: provided hosts list is empty, only localhost is available
    warnings.warn("provided hosts list is empty, only localhost is available")

snappi_tests/ecn/test_dequeue_ecn_with_snappi.py::test_dequeue_ecn
  /var/AzDevOps/.local/lib/python3.8/site-packages/snappi_ixnetwork/device/utils.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import namedtuple, Mapping

snappi_tests/ecn/test_dequeue_ecn_with_snappi.py::test_dequeue_ecn
snappi_tests/ecn/test_dequeue_ecn_with_snappi.py::test_dequeue_ecn
  /usr/local/lib/python3.8/dist-packages/ixnetwork_restpy/testplatform/sessions/sessions.py:59: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    elif LooseVersion(build_number) < LooseVersion('8.52'):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
---------------------------- live log sessionfinish ----------------------------
23:08:45 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================== 1 passed, 14 warnings in 659.38s (0:10:59) ==================
