### PR TITLE
Add Arista M0 devices to copp_tests M0 device list

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -347,7 +347,7 @@ class DHCPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for DHCP
-        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-48S","Arista-720DT-G48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-48S", "Arista-720DT-G48S4"}:
             self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
         elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
@@ -391,7 +391,7 @@ class DHCP6Test(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for DHCPv6
-        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-48S","Arista-720DT-G48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-48S", "Arista-720DT-G48S4"}:
             self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
         elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
@@ -454,7 +454,7 @@ class LLDPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for LLDP
-        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-48S","Arista-720DT-G48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-48S", "Arista-720DT-G48S4"}:
             self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
         elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
@@ -485,7 +485,7 @@ class UDLDTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for UDLD
-        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-48S","Arista-720DT-G48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-48S", "Arista-720DT-G48S4"}:
             self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
         elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:

--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -347,7 +347,7 @@ class DHCPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for DHCP
-        if self.hw_sku in {"Celestica-E1031-T48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-48S","Arista-720DT-G48S4"}:
             self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
         elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
@@ -391,7 +391,7 @@ class DHCP6Test(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for DHCPv6
-        if self.hw_sku in {"Celestica-E1031-T48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-48S","Arista-720DT-G48S4"}:
             self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
         elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
@@ -454,7 +454,7 @@ class LLDPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for LLDP
-        if self.hw_sku in {"Celestica-E1031-T48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-48S","Arista-720DT-G48S4"}:
             self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
         elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
@@ -485,7 +485,7 @@ class UDLDTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for UDLD
-        if self.hw_sku in {"Celestica-E1031-T48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-48S","Arista-720DT-G48S4"}:
             self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
         elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:


### PR DESCRIPTION
### Description of PR
PR https://github.com/sonic-net/sonic-mgmt/pull/12836 changed the copp policer limit for some traffic classes from 300 to 100 for all DUTs except M0.  Add Arista M0 devices to the test's M0 list.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Copp tests were failing on Arista M0 devices due to the policer limit change.

#### How did you do it?

#### How did you verify/test it?
Copp tests pass on Arista M0 devices with this fix.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
