### PR TITLE
Skip test_neighbor_mac_noptf on standalone topologies

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -45,6 +45,12 @@ arp/test_arp_dualtor.py::test_proxy_arp_for_standby_neighbor:
     conditions:
       - "release not in ['202012']"
 
+arp/test_neighbor_mac_noptf.py:
+  skip:
+    reason: "Not supported in standalone topologies."
+    conditions:
+      - "'standalone' in topo_name"
+
 arp/test_unknown_mac.py:
   skip:
     reason: "Behavior on cisco-8000 & Innovium(Marvell) platform for unknown MAC is flooding rather than DROP, hence skipping."


### PR DESCRIPTION
### Description of PR
Summary:
Standalone topologies have no upstream switch or any peer switches, meaning any test that requires a peer switch shouldn't be run on this topology.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The test fails due to lack of neighbor switches, which are not present in a standalone topology, hence this test should be skipped.

#### How did you do it?
Applied skip conditions to the applicable tests in the tests mark conditions yaml file in sonic-mgmt.

#### How did you verify/test it?
Ran the test and confirmed thatit is now skipped.

#### Any platform specific information?
Verified on Arista-7060X6-64PE-256x200G.