### PR TITLE
Enable test_pktgen.py for Cisco-8000 ASIC Type

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1649,8 +1649,10 @@ test_nbr_health.py:
 #######################################
 test_pktgen.py:
   skip:
-    reason: "have known issue, skip for now"
-    conditions: https://github.com/sonic-net/sonic-mgmt/issues/13804
+    reason: "Have known issue, only running for 'cisco-8000', skipping for all other ASIC types"
+    conditions:
+      - "asic_type not in ['cisco-8000']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/13804"
 
 #######################################
 #####            vlan             #####

--- a/tests/test_pktgen.py
+++ b/tests/test_pktgen.py
@@ -56,7 +56,7 @@ def clear_pktgen(duthosts, enum_dut_hostname):
         duthost.shell(cmd)
 
 
-def test_pktgen(duthosts, enum_dut_hostname, enum_frontend_asic_index, tbinfo, loganalyzer, setup_thresholds):
+def test_pktgen(duthosts, enum_dut_hostname, enum_frontend_asic_index, tbinfo, loganalyzer):
     '''
     Testcase does the following steps:
     1. Check max CPU utilized , number of core and dump files before starting the run


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Enable the 'test_pktgen.py' test to run on Cisco-8000 devices.

#### How did you do it?
Modified the skip condition in test_pktgen.py.

#### How did you verify/test it?
1. Tested the 'test_pktgen.py' on a Cisco-8000 device to ensure the test runs successfully.
2. Verified that the test is still skipped on other ASIC types.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
