### PR TITLE
[202405] Stabilize PFC watchdog test

### DIFF
--- a/tests/common/helpers/pfc_gen.py
+++ b/tests/common/helpers/pfc_gen.py
@@ -17,14 +17,8 @@ from socket import socket, AF_PACKET, SOCK_RAW
 logger = logging.getLogger('MyLogger')
 logger.setLevel(logging.DEBUG)
 
-# Minimum number of processes to be created
-MIN_PROCESS_NUM = 2
-
 # Maximum number of processes to be created
 MAX_PROCESS_NUM = 4
-
-# Minimum number of packets for enabling multiple processes
-MIN_PACKET_NUM_MP = 10000
 
 
 class PacketSender():
@@ -179,13 +173,6 @@ def main():
 
     pre_str = 'GLOBAL_PF' if options.global_pf else 'PFC'
     logger.debug(pre_str + '_STORM_START')
-
-    # Send PFC pause with multiple processes even if only one interface is provided
-    # if packet number is smaller than the threshold, then it's not necessary to use multiple processes
-    if options.num >= MIN_PACKET_NUM_MP:
-        while len(interfaces) < MIN_PROCESS_NUM:
-            interfaces.extend(interfaces)
-            options.num /= 2
 
     # Start sending PFC pause frames
     senders = []

--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -5,6 +5,7 @@ import random
 import pytest
 import contextlib
 import time
+import logging
 
 from tests.ptf_runner import ptf_runner
 from tests.common import constants
@@ -23,6 +24,8 @@ VENDOR_SPEC_ADDITIONAL_INFO_RE = {
     }
 
 EXPECT_PFC_WD_RESTORE_RE = ".*storm restored.*"
+
+logger = logging.getLogger(__name__)
 
 
 class TrafficPorts(object):
@@ -541,3 +544,18 @@ def _stop_background_traffic(ptfhost, background_traffic_log):
     pids = ptfhost.shell(f"pgrep -f {background_traffic_log}")["stdout_lines"]
     for pid in pids:
         ptfhost.shell(f"kill -9 {pid}", module_ignore_errors=True)
+
+
+def check_pfc_storm_state(dut, port, queue):
+    """
+    Helper function to check if PFC storm is detected/restored on a given queue
+    """
+    pfcwd_stats = dut.show_and_parse("show pfcwd stats")
+    queue_name = str(port) + ":" + str(queue)
+    for entry in pfcwd_stats:
+        if entry["queue"] == queue_name:
+            logger.info("PFCWD status on queue {} stats: {}".format(queue_name, entry))
+            return entry['storm detected/restored']
+    logger.info("PFCWD not triggered on queue {}".format(queue_name))
+    return None
+

--- a/tests/pfcwd/files/pfcwd_helper.py
+++ b/tests/pfcwd/files/pfcwd_helper.py
@@ -558,4 +558,3 @@ def check_pfc_storm_state(dut, port, queue):
             return entry['storm detected/restored']
     logger.info("PFCWD not triggered on queue {}".format(queue_name))
     return None
-

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -17,7 +17,8 @@ from tests.common import port_toggle
 from tests.common import constants
 from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled, dualtor_ports # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m # noqa F401, E501
-from .files.pfcwd_helper import send_background_traffic
+from .files.pfcwd_helper import send_background_traffic, check_pfc_storm_state
+from tests.common.utilities import wait_until
 
 
 PTF_PORT_MAPPING_MODE = 'use_orig_interface'
@@ -712,6 +713,9 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         test_ports_info = {self.pfc_wd['rx_port'][0]: self.pfc_wd}
         queues = [self.storm_hndle.pfc_queue_idx]
 
+        PFC_STORM_TIMEOUT = 30
+        pfcwd_stats_before_test = check_pfc_storm_state(dut, port, self.storm_hndle.pfc_queue_idx)
+
         with send_background_traffic(dut, self.ptf, queues, selected_test_ports, test_ports_info):
             if action != "dontcare":
                 start_wd_on_ports(dut, port, restore_time, detect_time, action)
@@ -728,7 +732,10 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             if self.pfc_wd['fake_storm']:
                 PfcCmd.set_storm_status(dut, self.queue_oid, "enabled")
 
-            time.sleep(5)
+            # Wait until PFC storm state changes
+            pytest_assert(wait_until(PFC_STORM_TIMEOUT, 2, 0,
+                                     lambda: check_pfc_storm_state(dut, port, self.storm_hndle.pfc_queue_idx) != pfcwd_stats_before_test),  # noqa: E501
+                                     "PFC storm state did not change as expected")  # noqa: E127
 
         # storm detect
         logger.info("Verify if PFC storm is detected on port {}".format(port))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/14425 to `202405` branch.
Changes include
1. Do not use multi-process to send PFC pause frames if there is only one interface to be paused
    This is because I didn't see improvement using multiple processes to send PFC pause frames when there is only 1 port to be paused. And the multi-processing caused test flakiness in `test_pfcwd_multi_port`
2. Check PFCWD stats after triggering PFC pause on leaf fanout
    Before this change, there was a hard-coded 5 seconds delay. But on some platform (e.g, Mellanox) more time is needed until PFC watchdog is triggered.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
This PR is to stabilize PFC watchdog test.

#### How did you do it?
1. Do not use multi-process to send PFC pause frames if there is only one interface to be paused
2. Check PFCWD stats after triggering PFC pause on leaf fanout

#### How did you verify/test it?
The change is verified on a Mellanox testbed. All test cases in `pfcwd/test_pfcwd_function.py` are consistently passing now.
```
collected 5 items                                                                                                                                                                                     

pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[str-msn2700a1-0 ^H ^HPASSED                                                                                                        [ 20%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[str-msn2700a1-03]  ^H ^HPASSED                                                                                                     [ 40%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[str-msn2700a1-03]  ^HPASSED                                                                                                     [ 60%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[str-msn2700a1-03]  ^H ^HPASSED                                                                                                    [ 80%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[str-msn2700a1-03] SKIPPED (This test is applicable only for cisco-8000)                                                      [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

