### PR TITLE
[ptf-py3]: Add pipeline flag to use py3only PTF image

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -142,6 +142,12 @@ parameters:
     type: string
     default: ""
 
+  # Flag to indicate pipeline will use PTF PY3 image pilot testing
+  - name: PTF_PY3
+    type: string
+    default: "False"
+    displayName: "Use PTF py3only image"
+
 steps:
   - ${{ if not(contains(variables['BUILD.REPOSITORY.NAME'], 'sonic-mgmt')) }}:
       - script: |
@@ -192,6 +198,14 @@ steps:
 
         rm -f new_test_plan_id.txt
 
+        ptf_py3=${{ parameters.PTF_PY3 }}
+        # with no value mixed image is used
+        PTF_IMAGETAG=""
+        if [ $ptf_py3 == "True" ]
+        then
+          PTF_IMAGETAG="--ptf_imagetag=py3only"
+        fi
+
         python ./.azure-pipelines/test_plan.py create \
         -t ${{ parameters.TOPOLOGY }} \
         -o new_test_plan_id.txt \
@@ -202,7 +216,7 @@ steps:
         --kvm-build-id $(KVM_BUILD_ID) \
         --kvm-image-branch "${{ parameters.KVM_IMAGE_BRANCH }}" \
         --deploy-mg-extra-params="${{ parameters.DEPLOY_MG_EXTRA_PARAMS }}" \
-        --common-extra-params="${{ parameters.COMMON_EXTRA_PARAMS }}" \
+        --common-extra-params="${{ parameters.COMMON_EXTRA_PARAMS }} ${PTF_IMAGETAG}" \
         --vm-type ${{ parameters.VM_TYPE }} --num-asic ${{ parameters.NUM_ASIC }} \
         --image_url ${{ parameters.IMAGE_URL }} \
         --upgrade-image-param="${{ parameters.UPGRADE_IMAGE_PARAM }}" \

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -201,7 +201,7 @@ steps:
         ptf_py3=${{ parameters.PTF_PY3 }}
         # with no value mixed image is used
         PTF_IMAGETAG=""
-        if [ $ptf_py3 == "True" ]
+        if [ "$ptf_py3" == "True" ]
         then
           PTF_IMAGETAG="--ptf_imagetag=py3only"
         fi


### PR DESCRIPTION
### Description of PR

This PR adds a flag to enable tests to choose `py3only` PTF image to run tests. By default all PR pipelines continue to use the current PTF image (which contains both PY2 and PY3).

Summary:
Fixes # Not applicable

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

This would enable running pilot test for PTF Py3only image on selective testbeds.

#### How did you do it?

Add a flag to use `py3only` image which by default is False.

#### How did you verify/test it?

Will be verified on selective testbeds before using on public PR checkers.

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA