### PR TITLE
Prevent duplication of topology subclasses in PR statistic

### DIFF
--- a/.azure-pipelines/testscripts_analyse/analyse_testscripts.py
+++ b/.azure-pipelines/testscripts_analyse/analyse_testscripts.py
@@ -98,7 +98,8 @@ def collect_all_scripts():
                                 "testscript": filename,
                                 "topology": topo_name_to_type(topology_mark)
                             }
-                            test_scripts.append(result)
+                            if result not in test_scripts:
+                                test_scripts.append(result)
         except Exception as e:
             logging.error('Failed to load file {}, error {}'.format(f, e))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #14437, we consider the topologies `m0`, `mx` and `mc0` as subclassses of `t0`. Since we have scripts marked for both t0 and its subclasses, we add a condition in this PR to avoid duplication in our statistics.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In PR #14437, we consider the topologies `m0`, `mx` and `mc0` as subclassses of `t0`. Since we have scripts marked for both t0 and its subclasses, we add a condition in this PR to avoid duplication in our statistics.

#### How did you do it?
Add a condition in this PR to avoid duplication in our statistics.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
