### PR TITLE
Increase the check option of config reload in fixture simulate_small_var_log_partition

### DIFF
--- a/tests/syslog/test_logrotate.py
+++ b/tests/syslog/test_logrotate.py
@@ -74,7 +74,7 @@ def simulate_small_var_log_partition(rand_selected_dut, localhost):
         logger.info('Remove the small var log partition')
         duthost.shell('sudo rm -f log-new-partition')
 
-        config_reload(duthost, safe_reload=True)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
         logger.info('Restart logrotate-config service')
         duthost.shell('sudo service logrotate-config restart')


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Increase the check option of config reload in fixture simulate_small_var_log_partition
It would leave a clean environment for test case test_orchagent_logrotate

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix the issue that the first loop failure of case test_orchagent_logrotate
#### How did you do it?
Add check option in the config reload function of fixture simulate_small_var_log_partition.
It would leave a clean and fully recovered environment for case test_orchagent_logrotate.
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
