### PR TITLE
mgmt|202311: Skip some route tests for standalone topos.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1360,11 +1360,10 @@ route/test_route_perf.py:
 
 route/test_static_route.py:
   skip:
-    reason: "Test not supported for 201911 images or older."
+    reason: "Test not supported for 201911 images or older. Does not apply to standalone topos."
+    conditions_logical_operator: OR
     conditions:
       - "release in ['201811', '201911']"
-    reason: "Does not apply to standalone topos."
-    conditions:
       - "'standalone' in topo_name"
 
 route/test_static_route.py::test_static_route_ecmp_ipv6:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1340,11 +1340,32 @@ restapi/test_restapi_vxlan_ecmp.py:
 #######################################
 #####           route             #####
 #######################################
+route/test_default_route.py:
+  skip:
+    reason: "Does not apply to standalone topos."
+    conditions:
+      - "'standalone' in topo_name"
+
+route/test_route_flap.py:
+  skip:
+    reason: "Does not apply to standalone topos."
+    conditions:
+      - "'standalone' in topo_name"
+
+route/test_route_perf.py:
+  skip:
+    reason: "Does not apply to standalone topos."
+    conditions:
+      - "'standalone' in topo_name"
+
 route/test_static_route.py:
   skip:
     reason: "Test not supported for 201911 images or older."
     conditions:
       - "release in ['201811', '201911']"
+    reason: "Does not apply to standalone topos."
+    conditions:
+      - "'standalone' in topo_name"
 
 route/test_static_route.py::test_static_route_ecmp_ipv6:
   # This test case may fail due to a known issue https://github.com/sonic-net/sonic-buildimage/issues/4930.


### PR DESCRIPTION
### Description of PR
Summary:

Some route tests do not apply to standalone
topologies and should be skipped. This patch skips such tests.

Corresponding PR was opened, approved, and merged for master and 202405: https://github.com/sonic-net/sonic-mgmt/pull/13889

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Some route tests are not applicable to t0 topos and should be skipped rather than failing unecessarily, negatively impacting pass rate.

#### How did you do it?
Applied skip conditions to the applicable tests in the tests mark conditions yaml file in sonic-mgmt.

#### How did you verify/test it?
Ran the route test suite and confirmed that the desired tests are now skipped.

#### Any platform specific information?
Verified on Arista-7060X6-64PE-256x200G.