### PR TITLE
Remove bgp sanity check for t0 standalone

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -100,6 +100,9 @@ def filter_check_items(tbinfo, check_items):
     if tbinfo['topo']['type'] == 'ptf' and 'check_bgp' in filtered_check_items:
         filtered_check_items.remove('check_bgp')
 
+    if 'standalone' in tbinfo['topo']['name'] and 'check_bgp' in filtered_check_items:
+        filtered_check_items.remove('check_bgp')
+
     if 'dualtor' not in tbinfo['topo']['name'] and 'check_mux_simulator' in filtered_check_items:
         filtered_check_items.remove('check_mux_simulator')
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix ```Error loading BGP routerID - 'ipv4Unicast'``` when running sanity check for t0 standalone.

#### How did you do it?
Ignore BGP check in sanity check for standalone topology as no BGP neighbors detected.

#### How did you verify/test it?
Validate it in the internal nightly test setup

#### Any platform specific information?
str3-7060x6-64pe-1

#### Supported testbed topology if it's a new test case?
t0-standalone-32

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
