### PR TITLE
Skip test_syslog_protocol_filter_severity and test_syslog_config_work by bugs

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1552,6 +1552,12 @@ syslog/test_syslog.py:
       - "branch in ['internal-202012']"
       - "build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 33"
 
+syslog/test_syslog_source_ip.py:
+  skip:
+    reason: "Vs setup doesn't work when creating mgmt vrf"
+    conditions:
+      - "asic_type in ['vs']"
+
 syslog/test_syslog_source_ip.py::TestSSIP::test_syslog_config_work_after_reboot:
   skip:
     reason: "Testcase consistent failed, raised issue to track"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1552,11 +1552,17 @@ syslog/test_syslog.py:
       - "branch in ['internal-202012']"
       - "build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 33"
 
-syslog/test_syslog_source_ip.py:
+syslog/test_syslog_source_ip.py::TestSSIP::test_syslog_config_work_after_reboot:
   skip:
     reason: "Testcase consistent failed, raised issue to track"
     conditions:
-      - https://github.com/sonic-net/sonic-mgmt/issues/6479
+      - https://github.com/sonic-net/sonic-buildimage/issues/19638
+
+syslog/test_syslog_source_ip.py::TestSSIP::test_syslog_protocol_filter_severity:
+  skip:
+    reason: "Testcase consistent failed, raised issue to track"
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/14493
 
 #######################################
 #####         system_health       #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

1. Skip test_syslog_protocol_filter_severity by https://github.com/sonic-net/sonic-mgmt/issues/14493
2. Skip test_syslog_config_work by bugs by https://github.com/sonic-net/sonic-buildimage/issues/19638

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
Skip test_syslog_protocol_filter_severity and test_syslog_config_work by bugs 

#### How did you do it?
Add skip conidtion

#### How did you verify/test it?
Run the two tests to check if they are skipped

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
