### PR TITLE
Add a loop check of loopback route after config reload for script test_traffic_shift.py

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -535,8 +535,8 @@ def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
                                                              bgpmon_setup_teardown['namespace']) == [],
                           "Not all routes are announced to bgpmon")
 
-        pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(duthosts, duthost, nbrhosts_to_dut,
-                                                                          traffic_shift_community),
+        pytest_assert(wait_until(90, 10, 0, verify_only_loopback_routes_are_announced_to_neighs, duthosts, duthost,
+                                 nbrhosts_to_dut, traffic_shift_community),
                       "Failed to verify routes on nbr in TSA")
     finally:
         """


### PR DESCRIPTION

### Description of PR
Add a loop check of loopback route after config reload for script test_traffic_shift.py.
It would loop check the loopback route after port all up in a config reload.
And it would make the test more stable.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Under some situation, the when the ports are UP in a config reload, the bgp routes are not all ready. The loopback route check would be failed at this moment.
#### How did you do it?
Add a loop check for it.
#### How did you verify/test it?
Run it in internal regression.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
