### PR TITLE
[snappi] Support single ASIC SKUs that have more 36 ports

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -631,7 +631,7 @@ def get_multidut_snappi_ports(duthosts, conn_graph_facts, fanout_graph_facts):  
         asic_port_map = {
             "asic0": ['Ethernet%d' % i for i in range(0, 72, 4)],
             "asic1": ['Ethernet%d' % i for i in range(72, 144, 4)],
-            None: ['Ethernet%d' % i for i in range(0, 144, 4)],
+            None: ['Ethernet%d' % i for i in range(0, 288, 4)],
         }
         ports = []
         for index, host in enumerate(duthosts):


### PR DESCRIPTION
…rts.

Update asic_port_map to accomodate these SKUs.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

DNX single ASIC SKU like Arista-7800R3-48CQM2-C48 has more than 36 ports.
Update `asic_port_map` to accomodate these SKUs.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
