### PR TITLE
Skip warm_reboot test on low CPU performance platform

### DIFF
--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -16,7 +16,7 @@ from tests.common.dualtor.mux_simulator_control import get_mux_status, check_mux
     toggle_all_simulator_ports, toggle_simulator_port_to_upper_tor              # noqa F401
 from tests.common.dualtor.constants import LOWER_TOR
 from tests.common.utilities import wait_until
-from tests.common.devices.sonic import SonicHost
+
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -79,17 +79,15 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture(scope="function")
-def skip_on_low_cpu_platform(duthosts, rand_one_dut_hostname, nbrhosts):
+def skip_on_low_cpu_platform(request, duthosts, rand_one_dut_hostname):
     '''
     skip the test on some low CPU platform if the neighbor is not vsonic
     '''
     LOW_CPU_PLATFORMS = ["x86_64-mlnx_msn2700-r0"]
     duthost = duthosts[rand_one_dut_hostname]
     platform = duthost.facts["platform"]
-    if platform in LOW_CPU_PLATFORMS:
-        for nbrhost in list(nbrhosts.values()):
-            if not isinstance(nbrhost, SonicHost):
-                pytest.skip("Skip the test on low performance CPU platform with Non-vSONiC neighbors")
+    if platform in LOW_CPU_PLATFORMS and request.config.getoption("neighbor_type") != "sonic":
+        pytest.skip("Skip the test on low performance CPU platform with Non-vSONiC neighbors")
 
 
 # Tetcases to verify normal reboot procedure ###

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -16,6 +16,7 @@ from tests.common.dualtor.mux_simulator_control import get_mux_status, check_mux
     toggle_all_simulator_ports, toggle_simulator_port_to_upper_tor              # noqa F401
 from tests.common.dualtor.constants import LOWER_TOR
 from tests.common.utilities import wait_until
+from tests.common.devices.sonic import SonicHost
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -77,6 +78,20 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("sad_case_type", sad_cases, scope="module")
 
 
+@pytest.fixture(scope="function")
+def skip_on_low_cpu_platform(duthosts, rand_one_dut_hostname, nbrhosts):
+    '''
+    skip the test on some low CPU platform if the neighbor is not vsonic
+    '''
+    LOW_CPU_PLATFORMS = ["x86_64-mlnx_msn2700-r0"]
+    duthost = duthosts[rand_one_dut_hostname]
+    platform = duthost.facts["platform"]
+    if platform in LOW_CPU_PLATFORMS:
+        for nbrhost in list(nbrhosts.values()):
+            if not isinstance(nbrhost, SonicHost):
+                pytest.skip("Skip the test on low performance CPU platform with Non-vSONiC neighbors")
+
+
 # Tetcases to verify normal reboot procedure ###
 def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,           # noqa F811
                      advanceboot_loganalyzer, capture_interface_counters):
@@ -112,7 +127,7 @@ def test_fast_reboot_from_other_vendor(duthosts,  rand_one_dut_hostname, request
 def test_warm_reboot(request, testing_config, get_advanced_reboot, verify_dut_health,           # noqa F811
                      duthosts, advanceboot_loganalyzer, capture_interface_counters,
                      toggle_all_simulator_ports, enum_rand_one_per_hwsku_frontend_hostname,     # noqa F811
-                     toggle_simulator_port_to_upper_tor):                                       # noqa F811
+                     toggle_simulator_port_to_upper_tor, skip_on_low_cpu_platform):            # noqa F811
     '''
     Warm reboot test case is run using advacned reboot test fixture
 
@@ -138,7 +153,8 @@ def test_warm_reboot(request, testing_config, get_advanced_reboot, verify_dut_he
 
 
 def test_warm_reboot_mac_jump(request, get_advanced_reboot, verify_dut_health,          # noqa F811
-                              advanceboot_loganalyzer, capture_interface_counters):
+                              advanceboot_loganalyzer, capture_interface_counters,
+                              skip_on_low_cpu_platform): # noqa F811
     '''
     Warm reboot testcase with one MAC address (00-06-07-08-09-0A) jumping from
     all VLAN ports.
@@ -162,7 +178,7 @@ def test_warm_reboot_mac_jump(request, get_advanced_reboot, verify_dut_health,  
 def test_warm_reboot_sad(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts, vmhost, tbinfo,
                          get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,           # noqa F811
                          backup_and_restore_config_db, advanceboot_neighbor_restore,                # noqa F811
-                         sad_case_type):
+                         sad_case_type, skip_on_low_cpu_platform): # noqa F811
     '''
     Warm reboot with sad path
     @param get_advanced_reboot: Fixture located in advanced_reboot.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip warm_reboot related test on low performance CPU platform if the neighbor is not running vSONiC.
Skipped test cases are
- test_warm_reboot
- test_warm_reboot_mac_jump
- test_warm_reboot_sad

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to skip warm_reboot related test on low performance CPU platform if the neighbor is not running vSONiC.

#### How did you do it?
Check platform and OS running on neighbors. Skip the test if neighbor is not running vSONiC and the platform is in the low CPU performance list.

#### How did you verify/test it?
Verified on a SN2700 platform.
```
collected 2 items                                                                                                                                                                                     

platform_tests/test_advanced_reboot.py::test_warm_reboot[single-str-msn2700-20] SKIPPED (Skip the test on low performance CPU platform with Non-vSONiC neighbors)                               [ 50%]
platform_tests/test_advanced_reboot.py::test_warm_reboot[dual-str-msn2700-20] SKIPPED (skip DUAL_TOR_MODE tests on Single ToR testbeds)                                                         [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
