### PR TITLE
Restrict list of commands to run on chassis supervisor in test_authorization_tacacs_only

### DIFF
--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -195,8 +195,6 @@ def test_authorization_tacacs_only(
     # check commands used by scripts
     commands = [
         "show interfaces counters -a -p 3",
-        "show ip bgp neighbor",
-        "show ipv6 bgp neighbor",
         "touch testfile",
         "chmod +w testfile",
         "echo \"test\" > testfile",
@@ -207,10 +205,7 @@ def test_authorization_tacacs_only(
         "rm -f testfi*",
         "mkdir -p test",
         "portstat -c",
-        "show ip bgp summary",
-        "show ipv6 bgp summary",
         "show interfaces portchannel",
-        "show muxcable firmware",
         "show platform summary",
         "show version",
         "show lldp table",
@@ -219,7 +214,17 @@ def test_authorization_tacacs_only(
         "sonic-db-cli  CONFIG_DB HGET \"FEATURE|macsec\" state"
     ]
 
+    frontend_commands = [
+        "show ip bgp neighbor",
+        "show ipv6 bgp neighbor",
+        "show ip bgp summary",
+        "show ipv6 bgp summary",
+        "show muxcable firmware",
+    ]
+
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if duthost.sonichost.is_frontend_node():
+        commands.extend(frontend_commands)
     telemetry_is_running = is_container_running(duthost, 'telemetry')
     gnmi_is_running = is_container_running(duthost, 'gnmi')
     if not telemetry_is_running and gnmi_is_running:


### PR DESCRIPTION
### Description of PR
Restrict the list of commands in `test_authorization_tacacs_only` when run on chassis supervisor to avoid commands that currently fail or require authentication prompt.

Summary:
Fixes # [(issue)](https://github.com/sonic-net/sonic-mgmt/issues/14506)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This is a proposed fix to https://github.com/sonic-net/sonic-mgmt/issues/14506 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
