### PR TITLE
tests-common: Handle SSHConsoleConn being closed prematurely

### DIFF
--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -4,6 +4,7 @@ from .base_console_conn import BaseConsoleConn, CONSOLE_SSH
 from netmiko.ssh_exception import NetMikoAuthenticationException
 from paramiko.ssh_exception import SSHException
 
+
 class SSHConsoleConn(BaseConsoleConn):
     def __init__(self, **kwargs):
         if "console_username" not in kwargs \
@@ -28,9 +29,10 @@ class SSHConsoleConn(BaseConsoleConn):
     def session_preparation(self):
         session_init_msg = self._test_channel_read()
         self.logger.debug(session_init_msg)
-        
+
         if re.search(r"Port is in use. Closing connection...", session_init_msg, flags=re.M):
-            raise PortInUseException(f"Host aborted connection, as console port '{self.username.split(':')[-1]}' is currently occupied.")
+            console_port = self.username.split(':')[-1]
+            raise PortInUseException(f"Host closed connection, as console port '{console_port}' is currently occupied.")
 
         if (self.menu_port):
             # For devices logining via menu port, 2 additional login are needed
@@ -161,4 +163,3 @@ class SSHConsoleConn(BaseConsoleConn):
 class PortInUseException(SSHException):
     '''Exception to denote a console port is in use.'''
     pass
-

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -2,7 +2,7 @@ import time
 import re
 from .base_console_conn import BaseConsoleConn, CONSOLE_SSH
 from netmiko.ssh_exception import NetMikoAuthenticationException
-
+from paramiko.ssh_exception import SSHException
 
 class SSHConsoleConn(BaseConsoleConn):
     def __init__(self, **kwargs):
@@ -26,7 +26,12 @@ class SSHConsoleConn(BaseConsoleConn):
         super(SSHConsoleConn, self).__init__(**kwargs)
 
     def session_preparation(self):
-        self._test_channel_read()
+        session_init_msg = self._test_channel_read()
+        self.logger.debug(session_init_msg)
+        
+        if re.search(r"Port is in use. Closing connection...", session_init_msg, flags=re.M):
+            raise PortInUseException(f"Host aborted connection, as console port '{self.username.split(':')[-1]}' is currently occupied.")
+
         if (self.menu_port):
             # For devices logining via menu port, 2 additional login are needed
             # Since we have attempted all passwords in __init__ of base class until successful login
@@ -151,3 +156,9 @@ class SSHConsoleConn(BaseConsoleConn):
         # and any other login is prevented
         self.remote_conn.close()
         del self.remote_conn
+
+
+class PortInUseException(SSHException):
+    '''Exception to denote a console port is in use.'''
+    pass
+


### PR DESCRIPTION
### Description of PR

There was an issue whereby certain dut_console tests would throw an `OSError: Socket is closed` prior to the test cases being run on certain devices. 

This was caused due to the way in which, upon a successful login to the in-use console port, the device would close the connection with a `Port is in use. Closing connection...` message. 

As such, this PR adds a check during session preparation, throwing a more descriptive error in the instance a console port is blocked, so that it is easy to diagnose and resolve the issue for an affected device.

Summary:
Adds more descriptive error for a blocked console port (for dut_console tests)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
dut_console/test_idle_timeout was failing due to the console port being blocked (on a specific device with a blocked port), but the error was a generic OSError.

#### How did you do it?
Added a more descriptive error for ease of diagnosing and resolving the issue.

#### How did you verify/test it?
Ran on the affected testbed, resulting in the new error being thrown when the device's console port is blocked.

#### Any platform specific information?
There may be platforms which do not use the same `Port is in use. Closing connection...` message - however if such a case is encountered, it would be trivial to enhance the check to account for platform differences.

### Documentation
This is a minor enhancement, so I have not updated any documentation.