### PR TITLE
Xfail `drop_packets/test_drop_counters.py` for KVM t1-lag platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -27,6 +27,12 @@ drop_packets/test_configurable_drop_counters.py::test_sip_link_local:
 #######################################
 #####     test_drop_counters.py   #####
 #######################################
+drop_packets/test_drop_counters.py:
+  xfail:
+    reason: "Xfail for KVM t1-lag platform"
+    conditions:
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/14512"
+
 drop_packets/test_drop_counters.py::test_absent_ip_header:
   skip:
     reason: "Test case not supported on Broadcom DNX platform"
@@ -155,11 +161,12 @@ drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[vlan_members
       - "asic_type in ['broadcom']"
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120']"
   xfail:
-    reason: "Image issue on broadcom platforms - CS00012209080"
+    reason: "Xfail for image issue on broadcom platforms - CS00012209080 or KVM t1-lag platform"
     strict: True
+    conditions_logical_operator: or
     conditions:
-      - "asic_type in ['broadcom']"
-      - "topo_name in ['t0-backend']"
+      - "asic_type in ['broadcom'] and topo_name in ['t0-backend']"
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/14512"
 
 drop_packets/test_drop_counters.py::test_src_ip_is_class_e:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In KVM t1-lag PR test, `drop_packets/test_drop_counters.py` failed for log analyzer issue:
E tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 0
E expected_match: 0
E expected_missing_match: 1
E
E Expected Messages that are missing:
E .Port Ethernet100 oper state set from up to down.
#### How did you do it?
Create an issue https://github.com/sonic-net/sonic-mgmt/issues/14512 and xfail `drop_packets/test_drop_counters.py` to unblock PR test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
