### PR TITLE
Setup TACACS server on PTF device when renumber topo.

### DIFF
--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -207,4 +207,7 @@
       nic_simulator_action: start
     when: topology.host_interfaces_active_active is defined and topology.host_interfaces_active_active|length > 0
 
+  - name: Start tacacs+ daily daemon
+    include_tasks: start_tacacs_daily_daemon.yml
+
   when: container_type == "PTF"

--- a/ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
+++ b/ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
@@ -11,7 +11,7 @@
     delegate_to: localhost
 
   - debug: msg="testbed_facts {{ testbed_facts }}"
-  
+
   - name: Include tacacs_passkey by inv_name
     include_vars: "{{ playbook_dir }}/group_vars/{{testbed_facts['inv_name']}}/{{testbed_facts['inv_name']}}.yml"
     when: testbed_facts is defined

--- a/ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
+++ b/ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
@@ -1,5 +1,24 @@
 ---
-- name: Include tacacs_passkey
+- name: Include tacacs_passkey by testbed_facts['inv_name']
+  block:
+  - name: set default testbed file
+    set_fact:
+      testbed_file: testbed.yaml
+    when: testbed_file is not defined
+
+  - name: Gathering testbed information
+    test_facts: testbed_name="{{ testbed_name }}" testbed_file="{{ testbed_file }}"
+    delegate_to: localhost
+
+  - debug: msg="testbed_facts {{ testbed_facts }}"
+  
+  - name: Include tacacs_passkey by inv_name
+    include_vars: "{{ playbook_dir }}/group_vars/{{testbed_facts['inv_name']}}/{{testbed_facts['inv_name']}}.yml"
+    when: testbed_facts is defined
+
+  when: tacacs_passkey is not defined
+
+- name: Include tacacs_passkey by  inventory_file
   block:
   - name: Get inventory folder name
     set_fact: inv_file="{{ playbook_dir }}/group_vars/{{ inventory_file.split("/")[-1] }}/{{ inventory_file.split("/")[-1] }}.yml"
@@ -15,10 +34,10 @@
     include_vars: "{{ inv_file }}"
     when: inventory_file.stat.exists
 
-  - name: Include default tacacs_passkey
-    include_vars: "{{ playbook_dir }}/group_vars/lab/lab.yml"
-    when: tacacs_passkey is not defined
+  when: tacacs_passkey is not defined
 
+- name: Include default tacacs_passkey
+  include_vars: "{{ playbook_dir }}/group_vars/lab/lab.yml"
   when: tacacs_passkey is not defined
 
 - debug: msg="tacacs_passkey {{ tacacs_passkey }}"

--- a/ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
+++ b/ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
@@ -9,8 +9,7 @@
   - name: Gathering testbed information
     test_facts: testbed_name="{{ testbed_name }}" testbed_file="{{ testbed_file }}"
     delegate_to: localhost
-
-  - debug: msg="testbed_facts {{ testbed_facts }}"
+    ignore_errors: yes
 
   - name: Include tacacs_passkey by inv_name
     include_vars: "{{ playbook_dir }}/group_vars/{{testbed_facts['inv_name']}}/{{testbed_facts['inv_name']}}.yml"

--- a/ansible/testbed.yaml
+++ b/ansible/testbed.yaml
@@ -96,7 +96,7 @@
   topo: t0-116
   ptf_image_name: docker-ptf
   ptf: ptf_vms3-1
-  ptf_ip: 10.255.2.18010.255.2.180/24
+  ptf_ip: 10.255.2.180/24
   ptf_ipv6:
   server: server_1
   vm_base: VM0100


### PR DESCRIPTION
Setup TACACS server on PTF host when renumber topo.

#### Why I did it
Some test failed because loganalyzer found TACACS error log.
The error log is because TACACS enabled on DUT host but not setup TACACS server on PTF host.
Those test bed are setup PTF device with renumber_topo.yml, and the setup TACACS server step missing in this file.

##### Work item tracking
- Microsoft ADO: 29386436

#### How I did it
Setup TACACS server on PTF device when renumber topo.
Load TACACS passkey by inv_name for renumber topo scenario.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Setup TACACS server on PTF device when renumber topo.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

