### PR TITLE
[Bugfix] Bugfix for getting maximum matching length of conditional mark. 

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -441,6 +441,7 @@ def find_all_matches(nodeid, conditions):
                         case_starting_substring: {
                             mark: match[case_starting_substring][mark]}
                     }})
+                max_length = length
 
     # We may have the same matches of different marks
     # Need to remove duplicate here

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -428,7 +428,7 @@ def find_all_matches(nodeid, conditions):
         marks = match[case_starting_substring].keys()
         for mark in marks:
             if mark in conditional_marks:
-                if length > max_length:
+                if length >= max_length:
                     conditional_marks.update({
                         mark: {
                             case_starting_substring: {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We changed the matching rule of conditional mark in PR #14395. There is a bug when getting the maximum matching length. In this PR, we fix this bug. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
We changed the matching rule of conditional mark in PR #14395. There is a bug when getting the maximum matching length. In this PR, we fix this bug. 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
