### PR TITLE
[bugfix] fix pfc_counter does not select the correct dut_host_name

### DIFF
--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -182,40 +182,40 @@ def run_test(fanouthosts, duthost, conn_graph_facts, fanout_graph_facts, leaf_fa
                     assert pfc_rx[intf]['Rx'][i] == '0'
 
 
-def test_pfc_pause(fanouthosts, duthosts, rand_one_dut_hostname,
+def test_pfc_pause(fanouthosts, duthosts, rand_one_tgen_dut_hostname,
                    conn_graph_facts, fanout_graph_facts, leaf_fanouts):          # noqa F811
     """ @Summary: Run PFC pause frame (pause time quanta > 0) tests """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[rand_one_tgen_dut_hostname]
     run_test(fanouthosts, duthost, conn_graph_facts,
              fanout_graph_facts, leaf_fanouts)
 
 
-def test_pfc_unpause(fanouthosts, duthosts, rand_one_dut_hostname,
+def test_pfc_unpause(fanouthosts, duthosts, rand_one_tgen_dut_hostname,
                      conn_graph_facts, fanout_graph_facts, leaf_fanouts):        # noqa F811
     """ @Summary: Run PFC unpause frame (pause time quanta = 0) tests """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[rand_one_tgen_dut_hostname]
     run_test(fanouthosts, duthost, conn_graph_facts,
              fanout_graph_facts, leaf_fanouts, pause_time=0)
 
 
-def test_fc_pause(fanouthosts, duthosts, rand_one_dut_hostname,
+def test_fc_pause(fanouthosts, duthosts, rand_one_tgen_dut_hostname,
                   conn_graph_facts, fanout_graph_facts, leaf_fanouts):           # noqa F811
     """ @Summary: Run FC pause frame (pause time quanta > 0) tests """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[rand_one_tgen_dut_hostname]
     run_test(fanouthosts, duthost, conn_graph_facts,
              fanout_graph_facts, leaf_fanouts, is_pfc=False)
 
 
-def test_fc_unpause(fanouthosts, duthosts, rand_one_dut_hostname,
+def test_fc_unpause(fanouthosts, duthosts, rand_one_tgen_dut_hostname,
                     conn_graph_facts, fanout_graph_facts, leaf_fanouts):         # noqa F811
     """ @Summary: Run FC pause frame (pause time quanta = 0) tests """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[rand_one_tgen_dut_hostname]
     run_test(fanouthosts, duthost, conn_graph_facts,
              fanout_graph_facts, leaf_fanouts, is_pfc=False, pause_time=0)
 
 
-def test_continous_pfc(fanouthosts, duthosts, rand_one_dut_hostname,
+def test_continous_pfc(fanouthosts, duthosts, rand_one_tgen_dut_hostname,
                        conn_graph_facts, fanout_graph_facts, leaf_fanouts):     # noqa F811
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[rand_one_tgen_dut_hostname]
     run_test(fanouthosts, duthost, conn_graph_facts,
              fanout_graph_facts, leaf_fanouts, check_continous_pfc=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 29400374

From #13763, we changed the `fanout_graph_facts` to be using `rand_one_tgen_dut_hostname` instead of `rand_one_dut_hostname`.

This will cause test_pfc_counters to be flaky failing since in the test we're still using `rand_one_dut_hostname` as the testing device whereas fanout facts could completely fetching a different device with different fanout structure.

We should all use `rand_one_tgen_dut_hostname` for consistency

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
