### PR TITLE
Skip test_config_fec_oper_mode test for unsupported speeds

### DIFF
--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -72,8 +72,9 @@ def test_config_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
         if sfp_presence:
             presence = sfp_presence[0].get('presence', '').lower()
             oper = intf.get('oper', '').lower()
+            speed = intf.get('speed', '')
 
-            if presence == "not present" or oper != "up":
+            if presence == "not present" or oper != "up" or speed not in SUPPORTED_SPEEDS:
                 continue
 
         config_status = duthost.command("sudo config interface fec {} rs"

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -59,7 +59,7 @@ def test_config_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
                               enum_frontend_asic_index, conn_graph_facts):
     """
     @Summary: Configure the FEC operational mode for all the interfaces, then check
-    FEC operational mode is retored to default FEC mode
+    FEC operational mode is restored to 'rs' FEC mode
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
test_config_fec_oper_mode should be configuring the rs fec mode only on ports with speed >= 100G, otherwise the interface fails to come up.

#### How did you do it?

#### How did you verify/test it?
Verified the test on a x86_64-mlnx_msn2700-r0 platform testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
