### PR TITLE
Updating the PFC lossy counter check for Cisco 8000 - to expect 0.

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -1189,3 +1189,25 @@ def get_pfc_count(duthost, port):
         pfc_dict[duthost.hostname][port]['rx_pfc_'+str(m-1)] = int(pause_frame_count[m].replace(',', ''))
 
     return pfc_dict
+
+
+def get_pfc_priorities(duthost, port):
+    """
+    Get the pfc lossless priorities of the given port in the given DUT.
+
+    Args:
+        duthost : SonicHost Object
+        port    : Interface name in the same DUT.
+
+    Returns:
+        A list of lossless priorities, as listed by "show pfc priorities" command.
+    """
+
+    asic_index = duthost.get_port_asic_instance(port).asic_index
+    cmd = ""
+    if asic_index is not None:
+        cmd = f"ip netns exec asic{asic_index} "
+    cmd = cmd + f"show pfc priority {port} | grep {port} | awk '{{print $2}}'"
+
+    output = duthost.shell(cmd)['stdout']
+    return [int(f) for f in output.split(',')]

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -611,9 +611,15 @@ def verify_pause_frame_count_dut(rx_dut,
                 pytest_assert(pfc_pause_rx_frames == 0,
                               "PFC pause frames with no bit set in the class enable vector should be dropped")
             else:
-                pytest_assert(pfc_pause_rx_frames > 0,
-                              "PFC pause frames should be received and counted in RX PFC counters for priority {}"
-                              .format(prio))
+                if "Cisco" in tx_dut.facts['hwsku']:
+                    pytest_assert(
+                        pfc_pause_rx_frames == 0,
+                        "Cisco platforms should't increment PFC counter for lossy priorities.")
+                else:
+                    pytest_assert(
+                        pfc_pause_rx_frames > 0,
+                        "PFC pause frames should be received and counted in RX PFC counters for priority {}"
+                        .format(prio))
 
     for peer_port, prios in dut_port_config[0].items():  # PFC pause frames sent by DUT's ingress port to TGEN
         for prio in prios:


### PR DESCRIPTION
### Description of PR
Fixes [#13800](https://github.com/sonic-net/sonic-mgmt/issues/13800)
Summary:
Fixes [# 13800](https://github.com/sonic-net/sonic-mgmt/issues/13800)

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
In snappi tests, there is a check for lossy priorities' PFC counters. Cisco-8000 doesn't support the lossy-prioirity PFC counts. So we need to modify this check to look only for 0.

#### How did you do it?
Updated the check condition to match 0 for cisco-8000.

#### How did you verify/test it?
Ran it on my testbeds.

#### Any platform specific information?
Specific to cisco-8000.

FYI: @sdszhang , @kamalsahu0001 , @selldinesh .