### PR TITLE
telemetry/test_events.py::test_events fix flakiness

### DIFF
--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -8,6 +8,8 @@ from tests.common.errors import RunAnsibleModuleFail
 from tests.common.utilities import wait_until, wait_tcp_connection, get_mgmt_ipv6
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from tests.telemetry.telemetry_utils import get_list_stdout, setup_telemetry_forpyclient, restore_telemetry_forpyclient
+from tests.telemetry.events.event_utils import reset_event_counters
+from tests.telemetry.events.event_utils import restart_eventd
 from contextlib import contextmanager
 
 EVENTS_TESTS_PATH = "./telemetry/events"
@@ -174,6 +176,9 @@ def test_eventd_healthy(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, ptf
 
     if duthost.is_multi_asic:
         pytest.skip("Skip eventd testing on multi-asic")
+
+    reset_event_counters(duthost)
+    restart_eventd(duthost)
 
     features_dict, succeeded = duthost.get_feature_status()
     if succeeded and ('eventd' not in features_dict or features_dict['eventd'] == 'disabled'):

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -101,6 +101,7 @@ def listen_for_events(duthost, gnxi_path, ptfhost, filter_event_regex, op_file, 
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               submode=SUBMODE_ONCHANGE, update_count=update_count, xpath="all[heartbeat=2]",
                               target="EVENTS", filter_event_regex=filter_event_regex, timeout=timeout)
+    cmd = f"timeout {timeout} " + cmd
     result = ptfhost.shell(cmd)
     assert result["rc"] == 0, "PTF command failed with non zero return code"
     output = result["stdout"]


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

Reset eventd and clear event counters to reduce flakiness for test_events.py. Events cache may be overfilled due to previous test run, causing the subsequent test runs to be flakey and events to not be delivered in time (ex: causing `AssertionError: No output from PTF docker, thread timed out after 30 seconds`).

Additionally, added timeout to gnmi client command call. Running two clients at the same time will error out, which also contributed to previous flakiness.

#### How did you do it?

Made changes to test case

#### How did you verify/test it?

Tested with testbed setup

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
