### PR TITLE
Move some stable test scripts into PR test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -209,6 +209,13 @@ t0:
   - drop_packets/test_drop_counters.py
   - copp/test_copp.py
   - crm/test_crm.py
+  - test_nbr_health.py
+  - dhcp_server/test_dhcp_server.py
+  - dhcp_server/test_dhcp_server_multi_vlans.py
+  - dhcp_server/test_dhcp_server_stress.py
+  - platform_tests/test_idle_driver.py
+  - wol/test_wol.py
+  - dhcp_relay/test_dhcp_pkt_fwd.py
 
 t0-2vlans:
   - dhcp_relay/test_dhcp_relay.py
@@ -404,6 +411,10 @@ t1-lag:
   - crm/test_crm.py
   - bgp/test_bgp_sentinel.py
   - bgp/test_bgp_suppress_fib.py
+  - test_nbr_health.py
+  - platform_tests/test_link_down.py
+  - gnmi/test_gnmi_countersdb.py
+  - generic_config_updater/test_cacl.py
 
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py
@@ -442,21 +453,11 @@ onboarding_t0:
   # - platform_tests/test_advanced_reboot.py
   - platform_tests/test_cont_warm_reboot.py
   - snmp/test_snmp_link_local.py
-  - test_nbr_health.py
-  - dhcp_server/test_dhcp_server.py
-  - dhcp_server/test_dhcp_server_multi_vlans.py
-  - dhcp_server/test_dhcp_server_stress.py
-  - platform_tests/test_idle_driver.py
-  - wol/test_wol.py
-  - dhcp_relay/test_dhcp_pkt_fwd.py
+
 
 onboarding_t1:
   - bgp/test_bgp_stress_link_flap.py
-  - generic_config_updater/test_cacl.py
-  - gnmi/test_gnmi_countersdb.py
-  - platform_tests/test_link_down.py
   - snmp/test_snmp_link_local.py
-  - test_nbr_health.py
 
 onboarding_dualtor:
   - dualtor_mgmt/test_dualtor_bgp_update_delay.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Move some stable test scripts into PR test

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Test case(new/improvement)

- [ ] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Move some stable test scripts into PR test

#### How did you do it?

#### How did you verify/test it?

TestbedName | FilePath | RunDate | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-t0 | dhcp_relay/test_dhcp_pkt_fwd.py | 2024-09-12 00:00:00.0000000 | 8 | 0 | 8 | 1
vms-kvm-t0 | dhcp_server/test_dhcp_server.py | 2024-09-12 00:00:00.0000000 | 40 | 0 | 40 | 1
vms-kvm-t0 | dhcp_server/test_dhcp_server_multi_vlans.py | 2024-09-12 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-t0 | dhcp_server/test_dhcp_server_stress.py | 2024-09-12 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t0 | platform_tests/test_idle_driver.py | 2024-09-12 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t0 | test_nbr_health.py | 2024-09-12 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t0 | wol/test_wol.py | 2024-09-12 00:00:00.0000000 | 48 | 0 | 48 | 1
vms-kvm-t0 | dhcp_relay/test_dhcp_pkt_fwd.py | 2024-09-11 00:00:00.0000000 | 196 | 0 | 196 | 1
vms-kvm-t0 | dhcp_server/test_dhcp_server.py | 2024-09-11 00:00:00.0000000 | 980 | 0 | 980 | 1
vms-kvm-t0 | dhcp_server/test_dhcp_server_multi_vlans.py | 2024-09-11 00:00:00.0000000 | 98 | 0 | 98 | 1
vms-kvm-t0 | dhcp_server/test_dhcp_server_stress.py | 2024-09-11 00:00:00.0000000 | 49 | 0 | 49 | 1
vms-kvm-t0 | platform_tests/test_idle_driver.py | 2024-09-11 00:00:00.0000000 | 49 | 0 | 49 | 1
vms-kvm-t0 | test_nbr_health.py | 2024-09-11 00:00:00.0000000 | 47 | 0 | 47 | 1
vms-kvm-t0 | wol/test_wol.py | 2024-09-11 00:00:00.0000000 | 1176 | 0 | 1176 | 1
vms-kvm-t0 | dhcp_relay/test_dhcp_pkt_fwd.py | 2024-09-10 00:00:00.0000000 | 136 | 0 | 136 | 1
vms-kvm-t0 | dhcp_server/test_dhcp_server.py | 2024-09-10 00:00:00.0000000 | 680 | 0 | 680 | 1
vms-kvm-t0 | dhcp_server/test_dhcp_server_multi_vlans.py | 2024-09-10 00:00:00.0000000 | 68 | 0 | 68 | 1
vms-kvm-t0 | dhcp_server/test_dhcp_server_stress.py | 2024-09-10 00:00:00.0000000 | 34 | 0 | 34 | 1
vms-kvm-t0 | platform_tests/test_idle_driver.py | 2024-09-10 00:00:00.0000000 | 34 | 0 | 34 | 1
vms-kvm-t0 | test_nbr_health.py | 2024-09-10 00:00:00.0000000 | 14 | 0 | 14 | 1
vms-kvm-t0 | wol/test_wol.py | 2024-09-10 00:00:00.0000000 | 816 | 0 | 816 | 1
vms-kvm-t0 | dhcp_relay/test_dhcp_pkt_fwd.py | 2024-09-09 00:00:00.0000000 | 88 | 0 | 88 | 1
vms-kvm-t0 | dhcp_server/test_dhcp_server.py | 2024-09-09 00:00:00.0000000 | 440 | 0 | 440 | 1
vms-kvm-t0 | dhcp_server/test_dhcp_server_multi_vlans.py | 2024-09-09 00:00:00.0000000 | 44 | 0 | 44 | 1
vms-kvm-t0 | dhcp_server/test_dhcp_server_stress.py | 2024-09-09 00:00:00.0000000 | 22 | 0 | 22 | 1
vms-kvm-t0 | platform_tests/test_idle_driver.py | 2024-09-09 00:00:00.0000000 | 22 | 0 | 22 | 1
vms-kvm-t0 | test_nbr_health.py | 2024-09-09 00:00:00.0000000 | 1 | 0 | 1 | 1
vms-kvm-t0 | wol/test_wol.py | 2024-09-09 00:00:00.0000000 | 528 | 0 | 528 | 1


TestbedName | FilePath | RunDate | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-t1-lag | generic_config_updater/test_cacl.py | 2024-09-12 00:00:00.0000000 | 16 | 0 | 16 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_countersdb.py | 2024-09-12 00:00:00.0000000 | 16 | 0 | 16 | 1
vms-kvm-t1-lag | platform_tests/test_link_down.py | 2024-09-12 00:00:00.0000000 | 4 | 0 | 4 | 1
vms-kvm-t1-lag | test_nbr_health.py | 2024-09-12 00:00:00.0000000 | 2 | 0 | 2 | 1
vms-kvm-t1-lag | generic_config_updater/test_cacl.py | 2024-09-11 00:00:00.0000000 | 360 | 0 | 360 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_countersdb.py | 2024-09-11 00:00:00.0000000 | 360 | 0 | 360 | 1
vms-kvm-t1-lag | platform_tests/test_link_down.py | 2024-09-11 00:00:00.0000000 | 90 | 0 | 90 | 1
vms-kvm-t1-lag | test_nbr_health.py | 2024-09-11 00:00:00.0000000 | 43 | 0 | 43 | 1
vms-kvm-t1-lag | generic_config_updater/test_cacl.py | 2024-09-10 00:00:00.0000000 | 288 | 0 | 288 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_countersdb.py | 2024-09-10 00:00:00.0000000 | 288 | 0 | 288 | 1
vms-kvm-t1-lag | platform_tests/test_link_down.py | 2024-09-10 00:00:00.0000000 | 72 | 0 | 72 | 1
vms-kvm-t1-lag | test_nbr_health.py | 2024-09-10 00:00:00.0000000 | 14 | 0 | 14 | 1
vms-kvm-t1-lag | generic_config_updater/test_cacl.py | 2024-09-09 00:00:00.0000000 | 40 | 0 | 40 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_countersdb.py | 2024-09-09 00:00:00.0000000 | 80 | 0 | 80 | 1
vms-kvm-t1-lag | platform_tests/test_link_down.py | 2024-09-09 00:00:00.0000000 | 22 | 0 | 22 | 1
vms-kvm-t1-lag | test_nbr_health.py | 2024-09-09 00:00:00.0000000 | 1 | 0 | 1 | 1

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
