### PR TITLE
[202405] [PR:13821] Fix syslog test failure about fixture tbinfo

### DIFF
--- a/tests/syslog/test_logrotate.py
+++ b/tests/syslog/test_logrotate.py
@@ -6,7 +6,6 @@ from tests.common.plugins.loganalyzer.loganalyzer import DisableLogrotateCronCon
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from tests.conftest import tbinfo
 
 logger = logging.getLogger(__name__)
 
@@ -262,7 +261,8 @@ def no_pending_entries(duthost, ignore_list=None):
 
 
 @pytest.fixture
-def orch_logrotate_setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index):
+def orch_logrotate_setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo,
+                         enum_rand_one_frontend_asic_index):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     if duthost.sonichost.is_multi_asic:
         asic_id = enum_rand_one_frontend_asic_index


### PR DESCRIPTION
Description of PR
This PR is to cherry-pick #13821 to 202405 branch.

Syslog test failed for complaining about tbinfo usage as it's a fixture. Solution is to add tbinfo as fixture in the orch_logrotate_setup. Then referencing tbinfo will be the yield of tbinfo which is a dict

What is the motivation for this PR?
Fix the test failure for syslog test_logrotate.

How did you do it?
How did you verify/test it?
Tested on OC test bed and see test pass now.

co-authorized by: jianquanye@microsoft.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
