### PR TITLE
[Disk Exhaustion] Adding "ARP Responder" to test case for PTF topology

### DIFF
--- a/tests/common/ptf_arp_responder.py
+++ b/tests/common/ptf_arp_responder.py
@@ -1,0 +1,51 @@
+import ipaddress
+import logging
+import pytest
+import json
+
+
+@pytest.fixture
+def ptf_arp_responder(duthost, tbinfo, ptfhost, ptfadapter):
+    """
+    Set up the ARP responder utility in the PTF container.
+    """
+    if 'ptf' not in tbinfo["topo"]["name"]:
+        yield
+        return
+
+    logging.info("Generating ARP responder topology")
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    arp_responder_conf = {}
+    for bgp_info in mg_facts["minigraph_bgp"]:
+        if (ipaddress.ip_address(bgp_info['peer_addr']).version != 4):
+            continue
+        ptf_ip_addr = bgp_info['addr']
+        for port in mg_facts["minigraph_neighbors"]:
+            if (bgp_info['name'] == mg_facts["minigraph_neighbors"][port]['name']):
+                ptf_port_idx = mg_facts["minigraph_ptf_indices"][port]
+                ptf_mac_addr = ptfadapter.dataplane.get_mac(0, ptf_port_idx).decode("utf-8")
+                arp_responder_conf["eth{}".format(ptf_port_idx)] = {
+                    "{}".format(ptf_ip_addr): "{}".format(ptf_mac_addr)
+                }
+                break
+
+    logging.info("Copying ARP responder topology to PTF")
+    with open("/tmp/from_t1.json", "w") as ar_config:
+        json.dump(arp_responder_conf, ar_config)
+    ptfhost.copy(src="/tmp/from_t1.json", dest="/tmp/from_t1.json")
+
+    logging.info("Copying ARP responder to PTF container")
+
+    logging.info("Copying ARP responder config file")
+    ptfhost.host.options["variable_manager"].extra_vars.update({"arp_responder_args": ""})
+    ptfhost.template(src="templates/arp_responder.conf.j2",
+                     dest="/etc/supervisor/conf.d/arp_responder.conf")
+
+    logging.info("Refreshing supervisor and starting ARP responder")
+    ptfhost.shell("supervisorctl reread && supervisorctl update")
+    ptfhost.shell("supervisorctl restart arp_responder")
+
+    yield
+
+    logging.info("Stopping ARP responder")
+    ptfhost.shell("supervisorctl stop arp_responder", module_ignore_errors=True)

--- a/tests/disk/test_disk_exhaustion.py
+++ b/tests/disk/test_disk_exhaustion.py
@@ -10,6 +10,10 @@ from ptf import mask, packet
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import paramiko_ssh
 
+from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py
+from tests.common.ptf_arp_responder import ptf_arp_responder
+
+
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -133,7 +137,7 @@ def construct_packet_and_get_params(duthost, ptfadapter, tbinfo):
     return pkt, ptf_port_idx, exp_pkt, out_ptf_indices, rif_support
 
 
-def test_disk_exhaustion(duthost, ptfadapter, tbinfo, creds):
+def test_disk_exhaustion(duthost, ptfadapter, tbinfo, creds, ptf_arp_responder):
     """Test SONiC basic performance(like ssh-connect, packet forward...) when disk is exhausted
     Args:
         duthost: DUT host object


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
* The test case failed on PTF topology.
* The DUT sends ARP requests to search for the test packet's destination, but the PTF container does not handle those ARP packets.
* An ARP responder needs to be imported to this test case to update the ARP table records and allow DUT to forward the test packets back to the PTF container.

#### How did you do it?
* Import an ARP responder to this test case for the PTF container. 
* Enable arp responder if testing in the PTF topology. 
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
