### PR TITLE
Relocate `vxlan_ecmp_utils.py` to `tests/common` for dependency reduction

### DIFF
--- a/tests/common/vxlan_ecmp_utils.py
+++ b/tests/common/vxlan_ecmp_utils.py
@@ -1,9 +1,6 @@
 '''
-    The functions used by test_vxlan_ecmp.py. Since there are plans to
-    seperate the test script to multiple files, we need a common location
-    for these functions.
     Usage:
-    from tests.vxlan.ecmp_utils import Ecmp_Utils
+    from tests.common.vxlan_ecmp_utils import Ecmp_Utils
     my_own_ecmp_utils = Ecmp_Utils()
     my_own_ecmp_utils.create_vxlan_tunnel(...)
 '''

--- a/tests/hash/generic_hash_helper.py
+++ b/tests/hash/generic_hash_helper.py
@@ -9,7 +9,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common import config_reload
 from tests.conftest import get_testbed_metadata
-from tests.vxlan.vxlan_ecmp_utils import Ecmp_Utils as VxLAN_Ecmp_Utils
+from tests.common.vxlan_ecmp_utils import Ecmp_Utils as VxLAN_Ecmp_Utils
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports  # noqa:F401
 from tests.common.dualtor.constants import UPPER_TOR
 

--- a/tests/vxlan/test_vxlan_bfd_tsa.py
+++ b/tests/vxlan/test_vxlan_bfd_tsa.py
@@ -16,7 +16,7 @@ from tests.common.utilities import wait_until
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
 from tests.common.fixtures.ptfhost_utils import skip_traffic_test           # noqa F401
 from tests.ptf_runner import ptf_runner
-from tests.vxlan.vxlan_ecmp_utils import Ecmp_Utils
+from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 from tests.common.config_reload import config_system_checks_passed
 Logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()

--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -4,6 +4,7 @@ import ipaddress
 from functools import reduce
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 from tests.vxlan.test_vxlan_ecmp import (   # noqa: F401
     Test_VxLAN,

--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -4,9 +4,7 @@ import ipaddress
 from functools import reduce
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.ptfhost_utils \
-    import copy_ptftests_directory     # noqa: F401
-from tests.vxlan.vxlan_ecmp_utils import Ecmp_Utils
+from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 from tests.vxlan.test_vxlan_ecmp import (   # noqa: F401
     Test_VxLAN,
     fixture_setUp,

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -63,7 +63,7 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # no
 from tests.common.fixtures.ptfhost_utils import skip_traffic_test           # noqa F401
 from tests.common.utilities import wait_until
 from tests.ptf_runner import ptf_runner
-from tests.vxlan.vxlan_ecmp_utils import Ecmp_Utils
+from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 
 Logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()

--- a/tests/vxlan/test_vxlan_ecmp_switchover.py
+++ b/tests/vxlan/test_vxlan_ecmp_switchover.py
@@ -13,7 +13,7 @@ import pytest
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
 from tests.common.fixtures.ptfhost_utils import skip_traffic_test           # noqa F401
 from tests.ptf_runner import ptf_runner
-from tests.vxlan.vxlan_ecmp_utils import Ecmp_Utils
+from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 
 Logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Several scripts import the class `Ecmp_Utils` in `vxlan_ecmp_utils.py` from the vxlan folder. To minimize cross-module dependencies, we move this script to the `tests/common` folder.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Several scripts import the class `Ecmp_Utils` in `vxlan_ecmp_utils.py` from the vxlan folder. To minimize cross-module dependencies, we move this script to the `tests/common` folder.

#### How did you do it?
Move script `vxlan_ecmp_utils.py` to the `tests/common` folder.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
