### PR TITLE
Loose PFCWD timer accuracy test on Mellanox testbed with Non-Onyx or Non-Mellanox leaf fanout

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -16,6 +16,8 @@ pytestmark = [
     pytest.mark.topology('any')
 ]
 
+ITERATION_NUM = 20
+
 logger = logging.getLogger(__name__)
 
 
@@ -223,32 +225,46 @@ class TestPfcwdAllTimer(object):
         logger.info("Verify that real detection time is not greater than configured")
         logger.info("all detect time {}".format(self.all_detect_time))
         logger.info("all restore time {}".format(self.all_restore_time))
+
+        check_point = ITERATION_NUM // 2 - 1
+        # Loose the check if two conditions are met
+        # 1. Device is Mellanox plaform
+        # 2. Leaf-fanout is Non-Onyx or non-Mellanox SONiC devices
+        # It's because the pfc_gen.py running on leaf-fanout can't guarantee the PFCWD is triggered consistently
+        if self.dut.facts['asic_type'] == "mellanox":
+            for fanouthost in list(self.fanout.values()):
+                if fanouthost.get_fanout_os() != "onyx" or \
+                        fanouthost.get_fanout_os() == "sonic" and fanouthost.facts['asic_type'] != "mellanox":
+                    logger.info("Loose the check for non-Onyx or non-Mellanox leaf-fanout testbed")
+                    check_point = ITERATION_NUM // 3 - 1
+                    break
+
         config_detect_time = self.timers['pfc_wd_detect_time'] + self.timers['pfc_wd_poll_time']
         err_msg = ("Real detection time is greater than configured: Real detect time: {} "
-                   "Expected: {} (wd_detect_time + wd_poll_time)".format(self.all_detect_time[9],
+                   "Expected: {} (wd_detect_time + wd_poll_time)".format(self.all_detect_time[check_point],
                                                                          config_detect_time))
-        pytest_assert(self.all_detect_time[9] < config_detect_time, err_msg)
+        pytest_assert(self.all_detect_time[check_point] < config_detect_time, err_msg)
 
         if self.timers['pfc_wd_poll_time'] < self.timers['pfc_wd_detect_time']:
             logger.info("Verify that real detection time is not less than configured")
             err_msg = ("Real detection time is less than configured: Real detect time: {} "
-                       "Expected: {} (wd_detect_time)".format(self.all_detect_time[9],
+                       "Expected: {} (wd_detect_time)".format(self.all_detect_time[check_point],
                                                               self.timers['pfc_wd_detect_time']))
-            pytest_assert(self.all_detect_time[9] > self.timers['pfc_wd_detect_time'], err_msg)
+            pytest_assert(self.all_detect_time[check_point] > self.timers['pfc_wd_detect_time'], err_msg)
 
         if self.timers['pfc_wd_poll_time'] < self.timers['pfc_wd_restore_time']:
             logger.info("Verify that real restoration time is not less than configured")
             err_msg = ("Real restoration time is less than configured: Real restore time: {} "
-                       "Expected: {} (wd_restore_time)".format(self.all_restore_time[9],
+                       "Expected: {} (wd_restore_time)".format(self.all_restore_time[check_point],
                                                                self.timers['pfc_wd_restore_time']))
-            pytest_assert(self.all_restore_time[9] > self.timers['pfc_wd_restore_time'], err_msg)
+            pytest_assert(self.all_restore_time[check_point] > self.timers['pfc_wd_restore_time'], err_msg)
 
         logger.info("Verify that real restoration time is less than configured")
         config_restore_time = self.timers['pfc_wd_restore_time'] + self.timers['pfc_wd_poll_time']
         err_msg = ("Real restoration time is greater than configured: Real restore time: {} "
-                   "Expected: {} (wd_restore_time + wd_poll_time)".format(self.all_restore_time[9],
+                   "Expected: {} (wd_restore_time + wd_poll_time)".format(self.all_restore_time[check_point],
                                                                           config_restore_time))
-        pytest_assert(self.all_restore_time[9] < config_restore_time, err_msg)
+        pytest_assert(self.all_restore_time[check_point] < config_restore_time, err_msg)
 
     def verify_pfcwd_timers_t2(self):
         """
@@ -291,7 +307,7 @@ class TestPfcwdAllTimer(object):
         return int(timestamp_ms)
 
     def test_pfcwd_timer_accuracy(self, duthosts, ptfhost, enum_rand_one_per_hwsku_frontend_hostname,
-                                  pfcwd_timer_setup_restore):
+                                  pfcwd_timer_setup_restore, fanouthosts):
         """
         Tests PFCwd timer accuracy
 
@@ -305,6 +321,7 @@ class TestPfcwdAllTimer(object):
         self.timers = setup_info['timers']
         self.dut = duthost
         self.ptf = ptfhost
+        self.fanout = fanouthosts
         self.all_detect_time = list()
         self.all_restore_time = list()
         self.all_dut_detect_restore_time = list()
@@ -315,7 +332,7 @@ class TestPfcwdAllTimer(object):
                     self.run_test(setup_info)
                 self.verify_pfcwd_timers_t2()
             else:
-                for i in range(1, 20):
+                for i in range(1, ITERATION_NUM):
                     logger.info("--- Pfcwd Timer Test iteration #{}".format(i))
 
                     cmd = "show pfc counters"


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to stabilize pfcwd timer accuracy test on Mellanox testbed with Non-Onyx or Non-Mellanox leaf fanout.
The test is flaky if pfc_gen script running on leaf fanout cannot guarantee continuous PFC pause frame being sent to DUT if the leaf-fanout is not Mellanox. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to stabilize pfcwd timer accuracy test on Mellanox testbed with Non-Onyx or Non-Mellanox leaf fanout.

#### How did you do it?
Before this change, the test ran 20 iterations and checked the 10th timer after sorting.
This PR added a check of DUT ASIC and leaf-fanout. If the leaf-fanout is not Mellanox, and the DUT is Mellanox, then use the 6th   timer as checkpoint.

#### How did you verify/test it?
The change is verified on a Mellanox-SN2700 testbed.

#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
