### PR TITLE
Added multi-hop SONiC upgrade path test case

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -421,12 +421,13 @@ class AdvancedReboot:
         logger.info('Clearing all fdb entries on DUT  {}'.format(self.duthost.hostname))
         self.duthost.shell('sonic-clear fdb all')
 
-    def __fetchTestLogs(self, rebootOper=None):
+    def __fetchTestLogs(self, log_dst_suffix=None):
         """
-        Fetch test logs from duthost and ptfhost after individual test run
+        Fetch test logs from duthost and ptfhost. If `log_dst_suffix` is provided,
+        the logs will be stored in a directory with that suffix.
         """
-        if rebootOper:
-            dir_name = "{}_{}".format(self.request.node.name, rebootOper)
+        if log_dst_suffix:
+            dir_name = "{}_{}".format(self.request.node.name, log_dst_suffix)
         else:
             dir_name = self.request.node.name
         report_file_dir = os.path.realpath((os.path.join(os.path.dirname(__file__), "../../logs/platform_tests/")))
@@ -445,7 +446,7 @@ class AdvancedReboot:
             reboot_file_prefix = "warm-reboot"
         else:
             reboot_file_prefix = self.rebootType
-        if rebootOper is None:
+        if log_dst_suffix is None:
             rebootLog = '/tmp/{0}.log'.format(reboot_file_prefix)
             rebootReport = '/tmp/{0}-report.json'.format(reboot_file_prefix)
             capturePcap = '/tmp/capture.pcap'
@@ -454,13 +455,13 @@ class AdvancedReboot:
             sairedisRec = '/tmp/sairedis.rec'
             swssRec = '/tmp/swss.rec'
         else:
-            rebootLog = '/tmp/{0}-{1}.log'.format(reboot_file_prefix, rebootOper)
-            rebootReport = '/tmp/{0}-{1}-report.json'.format(reboot_file_prefix, rebootOper)
-            capturePcap = '/tmp/capture_{0}.pcap'.format(rebootOper)
-            filterPcap = '/tmp/capture_filtered_{0}.pcap'.format(rebootOper)
-            syslogFile = '/tmp/syslog_{0}'.format(rebootOper)
-            sairedisRec = '/tmp/sairedis.rec.{0}'.format(rebootOper)
-            swssRec = '/tmp/swss.rec.{0}'.format(rebootOper)
+            rebootLog = '/tmp/{0}-{1}.log'.format(reboot_file_prefix, log_dst_suffix)
+            rebootReport = '/tmp/{0}-{1}-report.json'.format(reboot_file_prefix, log_dst_suffix)
+            capturePcap = '/tmp/capture_{0}.pcap'.format(log_dst_suffix)
+            filterPcap = '/tmp/capture_filtered_{0}.pcap'.format(log_dst_suffix)
+            syslogFile = '/tmp/syslog_{0}'.format(log_dst_suffix)
+            sairedisRec = '/tmp/sairedis.rec.{0}'.format(log_dst_suffix)
+            swssRec = '/tmp/swss.rec.{0}'.format(log_dst_suffix)
 
         logger.info('Extract log files on dut host')
         dutLogFiles = [
@@ -629,6 +630,88 @@ class AdvancedReboot:
         self.imageInstall(prebootList, inbootList, prebootFiles)
         return self.runRebootTest()
 
+    def runMultiHopRebootTestcase(self, upgrade_path_urls, prebootFiles='peer_dev_info,neigh_port_info',
+                                  base_image_setup=None, pre_hop_setup=None,
+                                  post_hop_teardown=None, multihop_advanceboot_loganalyzer_factory=None):
+        """
+        This method validates and prepares test bed for multi-hop reboot test case. It runs the reboot test case using
+        provided test arguments.
+        @param prebootList: list of operation to run before reboot process
+        @param prebootFiles: preboot files
+        """
+        # Install image A (base image)
+        self.imageInstall(None, None, prebootFiles)
+        if base_image_setup:
+            base_image_setup()
+
+        test_results = dict()
+        test_case_name = str(self.request.node.name)
+        test_results[test_case_name] = list()
+        for hop_index, _ in enumerate(upgrade_path_urls[1:], start=1):
+            try:
+                if pre_hop_setup:
+                    pre_hop_setup(hop_index)
+                if multihop_advanceboot_loganalyzer_factory:
+                    pre_reboot_analysis, post_reboot_analysis = multihop_advanceboot_loganalyzer_factory(hop_index)
+                    marker = pre_reboot_analysis()
+                event_counters = self.__setupRebootOper(None)
+
+                # Run the upgrade
+                thread = InterruptableThread(
+                    target=self.__runPtfRunner,
+                    kwargs={"ptf_collect_dir": "./logs/ptf_collect/hop{}/".format(hop_index)})
+                thread.daemon = True
+                thread.start()
+                # give the test REBOOT_CASE_TIMEOUT (1800s) to complete the reboot with IO,
+                # and then additional 300s to examine the pcap, logs and generate reports
+                ptf_timeout = REBOOT_CASE_TIMEOUT + 300
+                thread.join(timeout=ptf_timeout, suppress_exception=True)
+                self.ptfhost.shell("pkill -f 'ptftests advanced-reboot.ReloadTest'", module_ignore_errors=True)
+                # the thread might still be running, and to catch any exceptions after pkill allow 10s to join
+                thread.join(timeout=10)
+
+                self.__verifyRebootOper(None)
+                if self.duthost.num_asics() == 1 and not check_bgp_router_id(self.duthost, self.mgFacts):
+                    test_results[test_case_name].append("Failed to verify BGP router identifier is Loopback0 on %s" %
+                                                        self.duthost.hostname)
+                if post_hop_teardown:
+                    post_hop_teardown(hop_index)
+            except Exception:
+                traceback_msg = traceback.format_exc()
+                err_msg = "Exception caught while running advanced-reboot test on ptf: \n{}".format(traceback_msg)
+                logger.error(err_msg)
+                test_results[test_case_name].append(err_msg)
+            finally:
+                # capture the test logs, and print all of them in case of failure, or a summary in case of success
+                log_dir = self.__fetchTestLogs(log_dst_suffix="hop{}".format(hop_index))
+                self.print_test_logs_summary(log_dir)
+                if multihop_advanceboot_loganalyzer_factory and post_reboot_analysis:
+                    verification_errors = post_reboot_analysis(marker, event_counters=event_counters, log_dir=log_dir)
+                    if verification_errors:
+                        logger.error("Post reboot verification failed. List of failures: {}"
+                                     .format('\n'.join(verification_errors)))
+                        test_results[test_case_name].extend(verification_errors)
+                    # Set the post_reboot_analysis to None to avoid using it again after post_hop_teardown
+                    # on the subsequent iteration in the event that we land in the finally block before
+                    # the new one is initialised
+                    post_reboot_analysis = None
+                self.acl_manager_checker(test_results[test_case_name])
+                self.__clearArpAndFdbTables()
+                self.__revertRebootOper(None)
+
+            failed_list = [(testcase, failures) for testcase, failures in list(test_results.items())
+                           if len(failures) != 0]
+            pytest_assert(len(failed_list) == 0, "Advanced-reboot failure. Failed multi-hop test {testname} "
+                                                 "on update {hop_index} from {from_image} to {to_image}, "
+                                                 "failure summary:\n{fail_summary}".format(
+                                                    testname=self.request.node.name,
+                                                    hop_index=hop_index,
+                                                    from_image=upgrade_path_urls[hop_index-1],
+                                                    to_image=upgrade_path_urls[hop_index],
+                                                    fail_summary=failed_list
+                                                ))
+        return True  # Success
+
     def __setupRebootOper(self, rebootOper):
         if self.dual_tor_mode:
             for device in self.duthosts:
@@ -693,10 +776,11 @@ class AdvancedReboot:
             logger.info('Running revert handler for reboot operation {}'.format(rebootOper))
             rebootOper.revert()
 
-    def __runPtfRunner(self, rebootOper=None):
+    def __runPtfRunner(self, rebootOper=None, ptf_collect_dir="./logs/ptf_collect/"):
         """
         Run single PTF advanced-reboot.ReloadTest
         @param rebootOper:Reboot operation to conduct before/during reboot process
+        @param ptf_collect_dir: PTF log collection directory
         """
         logger.info("Running PTF runner on PTF host: {0}".format(self.ptfhost))
 
@@ -773,6 +857,7 @@ class AdvancedReboot:
             platform="remote",
             params=params,
             log_file='/tmp/advanced-reboot.ReloadTest.log',
+            ptf_collect_dir=ptf_collect_dir,
             module_ignore_errors=self.moduleIgnoreErrors,
             timeout=REBOOT_CASE_TIMEOUT,
             is_python3=True

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -421,10 +421,11 @@ class AdvancedReboot:
         logger.info('Clearing all fdb entries on DUT  {}'.format(self.duthost.hostname))
         self.duthost.shell('sonic-clear fdb all')
 
-    def __fetchTestLogs(self, log_dst_suffix=None):
+    def __fetchTestLogs(self, rebootOper=None, log_dst_suffix=None):
         """
-        Fetch test logs from duthost and ptfhost. If `log_dst_suffix` is provided,
-        the logs will be stored in a directory with that suffix.
+        Fetch test logs from duthost and ptfhost.
+        @param rebootOper: if provided it will be added to each individual file name
+        @param log_dst_suffix: if provided it will be appended to the directory name
         """
         if log_dst_suffix:
             dir_name = "{}_{}".format(self.request.node.name, log_dst_suffix)
@@ -446,7 +447,7 @@ class AdvancedReboot:
             reboot_file_prefix = "warm-reboot"
         else:
             reboot_file_prefix = self.rebootType
-        if log_dst_suffix is None:
+        if rebootOper is None:
             rebootLog = '/tmp/{0}.log'.format(reboot_file_prefix)
             rebootReport = '/tmp/{0}-report.json'.format(reboot_file_prefix)
             capturePcap = '/tmp/capture.pcap'
@@ -455,13 +456,13 @@ class AdvancedReboot:
             sairedisRec = '/tmp/sairedis.rec'
             swssRec = '/tmp/swss.rec'
         else:
-            rebootLog = '/tmp/{0}-{1}.log'.format(reboot_file_prefix, log_dst_suffix)
-            rebootReport = '/tmp/{0}-{1}-report.json'.format(reboot_file_prefix, log_dst_suffix)
-            capturePcap = '/tmp/capture_{0}.pcap'.format(log_dst_suffix)
-            filterPcap = '/tmp/capture_filtered_{0}.pcap'.format(log_dst_suffix)
-            syslogFile = '/tmp/syslog_{0}'.format(log_dst_suffix)
-            sairedisRec = '/tmp/sairedis.rec.{0}'.format(log_dst_suffix)
-            swssRec = '/tmp/swss.rec.{0}'.format(log_dst_suffix)
+            rebootLog = '/tmp/{0}-{1}.log'.format(reboot_file_prefix, rebootOper)
+            rebootReport = '/tmp/{0}-{1}-report.json'.format(reboot_file_prefix, rebootOper)
+            capturePcap = '/tmp/capture_{0}.pcap'.format(rebootOper)
+            filterPcap = '/tmp/capture_filtered_{0}.pcap'.format(rebootOper)
+            syslogFile = '/tmp/syslog_{0}'.format(rebootOper)
+            sairedisRec = '/tmp/sairedis.rec.{0}'.format(rebootOper)
+            swssRec = '/tmp/swss.rec.{0}'.format(rebootOper)
 
         logger.info('Extract log files on dut host')
         dutLogFiles = [
@@ -596,7 +597,7 @@ class AdvancedReboot:
                 if self.postboot_setup:
                     self.postboot_setup()
                 # capture the test logs, and print all of them in case of failure, or a summary in case of success
-                log_dir = self.__fetchTestLogs(rebootOper)
+                log_dir = self.__fetchTestLogs(rebootOper, log_dst_suffix=rebootOper)
                 self.print_test_logs_summary(log_dir)
                 if self.advanceboot_loganalyzer and post_reboot_analysis:
                     verification_errors = post_reboot_analysis(marker, event_counters=event_counters,

--- a/tests/common/platform/args/advanced_reboot_args.py
+++ b/tests/common/platform/args/advanced_reboot_args.py
@@ -136,6 +136,12 @@ def add_advanced_reboot_args(parser):
         )
 
     parser.addoption(
+        "--multi_hop_upgrade_path",
+        default="",
+        help="Specify the multi-hop upgrade path as a comma separated list of image URLs to download",
+    )
+
+    parser.addoption(
         "--restore_to_image",
         default="",
         help="Specify the target image to restore to, or stay in target image if empty",

--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -12,14 +12,18 @@ import six
 logger = logging.getLogger(__name__)
 
 
-def ptf_collect(host, log_file, skip_pcap=False):
+def ptf_collect(host, log_file, skip_pcap=False, dst_dir='./logs/ptf_collect/'):
+    """
+    Collect PTF log and pcap files from PTF container to sonic-mgmt container.
+    Optionally, save the files to a sub-directory in the destination.
+    """
     pos = log_file.rfind('.')
     filename_prefix = log_file[0:pos] if pos > -1 else log_file
 
     pos = filename_prefix.rfind('/') + 1
     rename_prefix = filename_prefix[pos:] if pos > 0 else filename_prefix
     suffix = str(datetime.utcnow()).replace(' ', '.')
-    filename_log = './logs/ptf_collect/' + rename_prefix + '.' + suffix + '.log'
+    filename_log = dst_dir + rename_prefix + '.' + suffix + '.log'
     host.fetch(src=log_file, dest=filename_log, flat=True, fail_on_missing=False)
     allure.attach.file(filename_log, 'ptf_log: ' + filename_log, allure.attachment_type.TEXT)
     if skip_pcap:
@@ -31,7 +35,7 @@ def ptf_collect(host, log_file, skip_pcap=False):
         compressed_pcap_file = pcap_file + '.tar.gz'
         host.archive(path=pcap_file, dest=compressed_pcap_file, format='gz')
         # Copy compressed file from ptf to sonic-mgmt
-        filename_pcap = './logs/ptf_collect/' + rename_prefix + '.' + suffix + '.pcap.tar.gz'
+        filename_pcap = dst_dir + rename_prefix + '.' + suffix + '.pcap.tar.gz'
         host.fetch(src=compressed_pcap_file, dest=filename_pcap, flat=True, fail_on_missing=False)
         allure.attach.file(filename_pcap, 'ptf_pcap: ' + filename_pcap, allure.attachment_type.PCAP)
 
@@ -101,9 +105,10 @@ def is_py3_compat(test_fpath):
 
 def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                platform="remote", qlen=0, relax=True, debug_level="info",
-               socket_recv_size=None, log_file=None, device_sockets=[], timeout=0, custom_options="",
+               socket_recv_size=None, log_file=None,
+               ptf_collect_dir="./logs/ptf_collect/",
+               device_sockets=[], timeout=0, custom_options="",
                module_ignore_errors=False, is_python3=None, async_mode=False, pdb=False):
-
     dut_type = get_dut_type(host)
     kvm_support = params.get("kvm_support", False)
     if dut_type == "kvm" and kvm_support is False:
@@ -201,7 +206,7 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
         result = host.shell(cmd, chdir="/root", module_ignore_errors=module_ignore_errors, module_async=async_mode)
         if not async_mode:
             if log_file:
-                ptf_collect(host, log_file)
+                ptf_collect(host, log_file, dst_dir=ptf_collect_dir)
             if result:
                 allure.attach(json.dumps(result, indent=4), 'ptf_console_result', allure.attachment_type.TEXT)
         if module_ignore_errors:
@@ -209,7 +214,7 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                 return result
     except Exception:
         if log_file:
-            ptf_collect(host, log_file)
+            ptf_collect(host, log_file, dst_dir=ptf_collect_dir)
         traceback_msg = traceback.format_exc()
         allure.attach(traceback_msg, 'ptf_runner_exception_traceback', allure.attachment_type.TEXT)
         logger.error("Exception caught while executing case: {}. Error message: {}".format(testname, traceback_msg))

--- a/tests/upgrade_path/conftest.py
+++ b/tests/upgrade_path/conftest.py
@@ -4,6 +4,9 @@ import pytest
 def pytest_runtest_setup(item):
     from_list = item.config.getoption('base_image_list')
     to_list = item.config.getoption('target_image_list')
+    multi_hop_upgrade_path = item.config.getoption('multi_hop_upgrade_path')
+    if multi_hop_upgrade_path:
+        return
     if not from_list or not to_list:
         pytest.skip("base_image_list or target_image_list is empty")
 

--- a/tests/upgrade_path/test_multi_hop_upgrade_path.py
+++ b/tests/upgrade_path/test_multi_hop_upgrade_path.py
@@ -1,0 +1,74 @@
+import pytest
+import logging
+from tests.common.fixtures.advanced_reboot import get_advanced_reboot                   # noqa F401
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.reboot import get_reboot_cause
+from tests.common.utilities import wait_until
+from tests.common.platform.device_utils import check_neighbors, \
+    multihop_advanceboot_loganalyzer_factory, verify_dut_health                                         # noqa F401
+from tests.common.helpers.upgrade_helpers import SYSTEM_STABILIZE_MAX_TIME, check_copp_config, check_reboot_cause, \
+    check_services, install_sonic, multi_hop_warm_upgrade_test_helper
+from tests.upgrade_path.utilities import cleanup_prev_images, set_base_image_a
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                 # noqa F401
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.sanity_check(skip_sanity=True),
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.skip_check_dut_health
+]
+logger = logging.getLogger(__name__)
+
+
+def test_multi_hop_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request,
+                                get_advanced_reboot, multihop_advanceboot_loganalyzer_factory,  # noqa F811
+                                verify_dut_health):                                             # noqa F811
+    duthost = duthosts[rand_one_dut_hostname]
+    multi_hop_upgrade_path = request.config.getoption('multi_hop_upgrade_path')
+    upgrade_type = request.config.getoption('upgrade_type')
+    assert upgrade_type == "warm", "test_multi_hop_upgrade_path only supports warm upgrade"
+    enable_cpa = request.config.getoption('enable_cpa')
+    upgrade_path_urls = multi_hop_upgrade_path.split(",")
+    if len(upgrade_path_urls) < 2:
+        pytest.skip("Need atleast 2 URLs to test multi-hop upgrade path")
+
+    def base_image_setup():
+        """Run only once, to boot the device into the base image"""
+        base_image = upgrade_path_urls[0]
+        logger.info("Setting up base image {}".format(base_image))
+        cleanup_prev_images(duthost)
+
+        # Install base image
+        set_base_image_a(duthost, localhost, base_image, tbinfo)
+        logger.info("Base image setup complete")
+
+    def pre_hop_setup(hop_index):
+        """Run before each hop in the multi-hop upgrade path"""
+        # Install target image
+        to_image = upgrade_path_urls[hop_index]
+        logger.info("Installing hop {} image {}".format(hop_index, to_image))
+        install_sonic(duthost, to_image, tbinfo)
+        logger.info("Finished setup for hop {} image {}".format(hop_index, to_image))
+
+    def post_hop_teardown(hop_index):
+        """Run after each hop in the multi-hop upgrade path"""
+        to_image = upgrade_path_urls[hop_index]
+        logger.info("Starting post hop teardown for hop {} image {}".format(hop_index, to_image))
+
+        logger.info("Check reboot cause of hop {}. Expected cause {}".format(hop_index, upgrade_type))
+        networking_uptime = duthost.get_networking_uptime().seconds
+        timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 1)
+        pytest_assert(wait_until(timeout, 5, 0, check_reboot_cause, duthost, upgrade_type),
+                      "Reboot cause {} did not match the trigger - {}".format(get_reboot_cause(duthost), upgrade_type))
+        check_services(duthost)
+        check_neighbors(duthost, tbinfo)
+        check_copp_config(duthost)
+        logger.info("Finished post hop teardown for hop {} image {}".format(hop_index, to_image))
+
+    multi_hop_warm_upgrade_test_helper(
+        duthost, localhost, ptfhost, tbinfo, get_advanced_reboot, upgrade_type,
+        upgrade_path_urls,
+        multihop_advanceboot_loganalyzer_factory=multihop_advanceboot_loganalyzer_factory,
+        base_image_setup=base_image_setup,
+        pre_hop_setup=pre_hop_setup, post_hop_teardown=post_hop_teardown,
+        enable_cpa=enable_cpa)

--- a/tests/upgrade_path/test_multi_hop_upgrade_path.py
+++ b/tests/upgrade_path/test_multi_hop_upgrade_path.py
@@ -1,15 +1,16 @@
 import pytest
 import logging
-from tests.common.fixtures.advanced_reboot import get_advanced_reboot                   # noqa F401
+from tests.common.fixtures.advanced_reboot import get_advanced_reboot                                   # noqa F401
+from tests.common.fixtures.consistency_checker.consistency_checker import consistency_checker_provider  # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.reboot import get_reboot_cause
 from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import check_neighbors, \
     multihop_advanceboot_loganalyzer_factory, verify_dut_health                                         # noqa F401
 from tests.common.helpers.upgrade_helpers import SYSTEM_STABILIZE_MAX_TIME, check_copp_config, check_reboot_cause, \
-    check_services, install_sonic, multi_hop_warm_upgrade_test_helper
+    check_services, install_sonic, multi_hop_warm_upgrade_test_helper, check_asic_and_db_consistency
 from tests.upgrade_path.utilities import cleanup_prev_images, set_base_image_a
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                 # noqa F401
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                 # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -22,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 def test_multi_hop_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request,
                                 get_advanced_reboot, multihop_advanceboot_loganalyzer_factory,  # noqa F811
-                                verify_dut_health):                                             # noqa F811
+                                verify_dut_health, consistency_checker_provider):               # noqa F811
     duthost = duthosts[rand_one_dut_hostname]
     multi_hop_upgrade_path = request.config.getoption('multi_hop_upgrade_path')
     upgrade_type = request.config.getoption('upgrade_type')
@@ -63,6 +64,7 @@ def test_multi_hop_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfh
         check_services(duthost)
         check_neighbors(duthost, tbinfo)
         check_copp_config(duthost)
+        check_asic_and_db_consistency(request.config, duthost, consistency_checker_provider)
         logger.info("Finished post hop teardown for hop {} image {}".format(hop_index, to_image))
 
     multi_hop_warm_upgrade_test_helper(

--- a/tests/upgrade_path/test_multi_hop_upgrade_path.py
+++ b/tests/upgrade_path/test_multi_hop_upgrade_path.py
@@ -9,7 +9,7 @@ from tests.common.platform.device_utils import check_neighbors, \
     multihop_advanceboot_loganalyzer_factory, verify_dut_health                                         # noqa F401
 from tests.common.helpers.upgrade_helpers import SYSTEM_STABILIZE_MAX_TIME, check_copp_config, check_reboot_cause, \
     check_services, install_sonic, multi_hop_warm_upgrade_test_helper, check_asic_and_db_consistency
-from tests.upgrade_path.utilities import cleanup_prev_images, set_base_image_a
+from tests.upgrade_path.utilities import cleanup_prev_images, boot_into_base_image
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                 # noqa F401
 
 pytestmark = [
@@ -40,7 +40,7 @@ def test_multi_hop_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfh
         cleanup_prev_images(duthost)
 
         # Install base image
-        set_base_image_a(duthost, localhost, base_image, tbinfo)
+        boot_into_base_image(duthost, localhost, base_image, tbinfo)
         logger.info("Base image setup complete")
 
     def pre_hop_setup(hop_index):

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -2,7 +2,7 @@ import pytest
 import logging
 from tests.common.helpers.upgrade_helpers import install_sonic, upgrade_test_helper, check_asic_and_db_consistency
 from tests.common.helpers.upgrade_helpers import restore_image            # noqa F401
-from tests.upgrade_path.utilities import cleanup_prev_images, set_base_image_a
+from tests.upgrade_path.utilities import cleanup_prev_images, boot_into_base_image
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot   # noqa F401
 from tests.common.fixtures.consistency_checker.consistency_checker import consistency_checker_provider  # noqa F401
 from tests.common.platform.device_utils import verify_dut_health    # noqa F401
@@ -46,7 +46,7 @@ def setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
     logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
     cleanup_prev_images(duthost)
     # Install base image
-    set_base_image_a(duthost, localhost, from_image, tbinfo)
+    boot_into_base_image(duthost, localhost, from_image, tbinfo)
 
     # Install target image
     logger.info("Upgrading to {}".format(to_image))

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -1,10 +1,8 @@
 import pytest
 import logging
-import re
-from tests.common import reboot
-from tests.common.helpers.upgrade_helpers import install_sonic, check_sonic_version,\
-    upgrade_test_helper, check_asic_and_db_consistency
+from tests.common.helpers.upgrade_helpers import install_sonic, upgrade_test_helper, check_asic_and_db_consistency
 from tests.common.helpers.upgrade_helpers import restore_image            # noqa F401
+from tests.upgrade_path.utilities import cleanup_prev_images, set_base_image_a
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot   # noqa F401
 from tests.common.fixtures.consistency_checker.consistency_checker import consistency_checker_provider  # noqa F401
 from tests.common.platform.device_utils import verify_dut_health    # noqa F401
@@ -14,7 +12,6 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses      # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # noqa F401
-from tests.common.errors import RunAnsibleModuleFail
 from tests.common.platform.warmboot_sad_cases import get_sad_case_list, SAD_CASE_LIST
 
 
@@ -44,47 +41,16 @@ def upgrade_path_lists(request):
     return upgrade_type, from_list, to_list, restore_to_image, enable_cpa
 
 
-def cleanup_prev_images(duthost):
-    logger.info("Cleaning up previously installed images on DUT")
-    current_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
-    duthost.shell("sonic_installer set_next_boot {}".format(current_os_version), module_ignore_errors=True)
-    duthost.shell("sonic_installer set-next-boot {}".format(current_os_version), module_ignore_errors=True)
-    duthost.shell("sonic_installer cleanup -y", module_ignore_errors=True)
-
-
 def setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
                        upgrade_type, modify_reboot_script=None, allow_fail=False):
     logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
     cleanup_prev_images(duthost)
     # Install base image
-    logger.info("Installing {}".format(from_image))
-    try:
-        target_version = install_sonic(duthost, from_image, tbinfo)
-    except RunAnsibleModuleFail as err:
-        migration_err_regexp = r"Traceback.*migrate_sonic_packages.*SonicRuntimeException"
-        msg = err.results['msg'].replace('\n', '')
-        if re.search(migration_err_regexp, msg):
-            logger.info(
-                "Ignore the package migration error when downgrading to from_image")
-            target_version = duthost.shell(
-                "cat /tmp/downloaded-sonic-image-version")['stdout']
-        else:
-            raise err
-    # Remove old config_db before rebooting the DUT in case it is not successfully
-    # removed in install_sonic due to migration error
-    logger.info("Remove old config_db file if exists, to load minigraph from scratch")
-    if duthost.shell("ls /host/old_config/minigraph.xml", module_ignore_errors=True)['rc'] == 0:
-        duthost.shell("rm -f /host/old_config/config_db.json")
-    # Perform a cold reboot
-    logger.info("Cold reboot the DUT to make the base image as current")
-    # for 6100 devices, sometimes cold downgrade will not work, use soft-reboot here
-    reboot_type = 'soft' if "s6100" in duthost.facts["platform"] else 'cold'
-    reboot(duthost, localhost, reboot_type=reboot_type)
-    check_sonic_version(duthost, target_version)
+    set_base_image_a(duthost, localhost, from_image, tbinfo)
 
     # Install target image
     logger.info("Upgrading to {}".format(to_image))
-    target_version = install_sonic(duthost, to_image, tbinfo)
+    install_sonic(duthost, to_image, tbinfo)
 
     if allow_fail and modify_reboot_script:
         # add fail step to reboot script

--- a/tests/upgrade_path/utilities.py
+++ b/tests/upgrade_path/utilities.py
@@ -6,7 +6,7 @@ from tests.common.helpers.upgrade_helpers import install_sonic, reboot, check_so
 logger = logging.getLogger(__name__)
 
 
-def set_base_image_a(duthost, localhost, base_image, tbinfo):
+def boot_into_base_image(duthost, localhost, base_image, tbinfo):
     logger.info("Installing {}".format(base_image))
     try:
         target_version = install_sonic(duthost, base_image, tbinfo)

--- a/tests/upgrade_path/utilities.py
+++ b/tests/upgrade_path/utilities.py
@@ -1,0 +1,41 @@
+import logging
+import re
+from tests.common.errors import RunAnsibleModuleFail
+from tests.common.helpers.upgrade_helpers import install_sonic, reboot, check_sonic_version
+
+logger = logging.getLogger(__name__)
+
+
+def set_base_image_a(duthost, localhost, base_image, tbinfo):
+    logger.info("Installing {}".format(base_image))
+    try:
+        target_version = install_sonic(duthost, base_image, tbinfo)
+    except RunAnsibleModuleFail as err:
+        migration_err_regexp = r"Traceback.*migrate_sonic_packages.*SonicRuntimeException"
+        msg = err.results['msg'].replace('\n', '')
+        if re.search(migration_err_regexp, msg):
+            logger.info(
+                "Ignore the package migration error when downgrading to base_image")
+            target_version = duthost.shell(
+                "cat /tmp/downloaded-sonic-image-version")['stdout']
+        else:
+            raise err
+    # Remove old config_db before rebooting the DUT in case it is not successfully
+    # removed in install_sonic due to migration error
+    logger.info("Remove old config_db file if exists, to load minigraph from scratch")
+    if duthost.shell("ls /host/old_config/minigraph.xml", module_ignore_errors=True)['rc'] == 0:
+        duthost.shell("rm -f /host/old_config/config_db.json")
+    # Perform a cold reboot
+    logger.info("Cold reboot the DUT to make the base image as current")
+    # for 6100 devices, sometimes cold downgrade will not work, use soft-reboot here
+    reboot_type = 'soft' if "s6100" in duthost.facts["platform"] else 'cold'
+    reboot(duthost, localhost, reboot_type=reboot_type)
+    check_sonic_version(duthost, target_version)
+
+
+def cleanup_prev_images(duthost):
+    logger.info("Cleaning up previously installed images on DUT")
+    current_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
+    duthost.shell("sonic_installer set_next_boot {}".format(current_os_version), module_ignore_errors=True)
+    duthost.shell("sonic_installer set-next-boot {}".format(current_os_version), module_ignore_errors=True)
+    duthost.shell("sonic_installer cleanup -y", module_ignore_errors=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Added a new advanced_reboot test case that verifies consecutive warm-upgrades. The upgrade path is specified through the `--multi_hop_upgrade_path` pytest option i.e. `--multi_hop_upgrade_path http://builds.test/sonic-aboot-broadcom-20181130.105.swi,http://builds.test/sonic-aboot-broadcom-20201231.97.swi,http://builds.test/sonic-aboot-broadcom-20230531.22.swi` which will cold reboot into the base image 20181130 then warm-reboot into 20201231 and finally, warm-reboot into 20230531.

To make the test easy to understand, the style, assertions, etc was kept consistent with the existing A->B test in `tests/upgrade_path/test_upgrade_path.py::test_upgrade_path`. Points to note are as follows:
 - There are 3 lifecycle hooks:
   - `base_image_setup` - run only once which is used to cold-boot the device into image A (20181130.105 from example prior)
   - `pre_hop_setup` - run before each hop which is used to prepare the device for warm-boot into image B, C, etc
   - `post_hop_teardown` - run after each hop which can be used for any cleanup or assertions before the next hop starts.
  - There is a separate `ReloadTest` for each warm-reboot - it doesn't span multiple warm-reboots
  - There is a separate log analyzer per warm-reboot with the logs being captured separately for each.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Our existing testing can only do a single hop therefore, to test an upgrade path like A-(warm-boot)->B-(warm-boot)->C, we'd do (cold-boot)->A->(warm-boot)->B, then (cold-boot)->B-(warm-boot)->C. This doesn't cover bugs spanning multiple upgrade hops which we've seen in production. This new test addresses the gap.

#### How did you do it?
Took the existing A->B upgrade_tests, duplicated and modified it to support multi-hop upgrades.

#### How did you verify/test it?
Tested in our lab on Arista-7260CX3-D108C8 going through hops 20181130, 20201231 and 20230531
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
t0*
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Not yet