### PR TITLE
Updating J2C+ qos yaml  for 400G and 100G profile _egress_pkt count for lossy profile

### DIFF
--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -267,7 +267,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 2396560
+                    pkts_num_trig_egr_drp: 2179900
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
@@ -283,7 +283,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2179900
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -309,7 +309,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2179900
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8
@@ -374,7 +374,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 2396560
+                    pkts_num_trig_egr_drp: 2179900
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
@@ -390,7 +390,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2179900
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -416,7 +416,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2179900
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8
@@ -481,7 +481,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 2396560
+                    pkts_num_trig_egr_drp: 2179900
                     pkts_num_margin: 100
                 wm_pg_shared_lossless:
                     dscp: 3
@@ -497,7 +497,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2179900
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -523,7 +523,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2179900
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8

--- a/tests/qos/files/qos_params.jr2.yaml
+++ b/tests/qos/files/qos_params.jr2.yaml
@@ -160,7 +160,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2179900
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
@@ -176,7 +176,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2179900
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -202,7 +202,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2179900
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8
@@ -266,7 +266,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2179900
                     pkts_num_margin: 200
                 wm_pg_shared_lossless:
                     dscp: 3
@@ -282,7 +282,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2179900
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -308,7 +308,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_trig_egr_drp: 2179900
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Since the dynamic_th-alpha changed from 0 to -4 (400g) & 100g port speed for egress lossy profile.
PR  #https://github.com/sonic-net/sonic-buildimage/pull/20132
Corresponding  changes made in J2C+ qos yaml for t2 -broadcom-dnx
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [x] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Verified the qos test case execution with the new changes. 
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
