### PR TITLE
Add sonic peer support for SAD reboot testing

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -594,10 +594,10 @@ class Arista(host_device.HostDevice):
             self.do_cmd(item)
         self.do_cmd('exit')
 
-    def change_bgp_neigh_state(self, asn, is_up=True):
+    def change_bgp_neigh_state(self, bgp_info, is_up=True):
         state = ['shut', 'no shut']
         self.do_cmd('configure')
-        self.do_cmd('router bgp %s' % asn)
+        self.do_cmd('router bgp %s' % bgp_info['asn'])
         if self.veos_version < 4.20:
             self.do_cmd('%s' % state[is_up])
         else:
@@ -619,7 +619,7 @@ class Arista(host_device.HostDevice):
             data = '\n'.join(output.split('\r\n')[1:-1])
             obj = json.loads(data)
 
-            if state == 'down':
+            if 'down' in state:
                 if 'vrfs' in obj:
                     # return True when obj['vrfs'] is empty which is the case when the bgp state is 'down'
                     bgp_state[ver] = not obj['vrfs']

--- a/ansible/roles/test/files/ptftests/host_device.py
+++ b/ansible/roles/test/files/ptftests/host_device.py
@@ -23,7 +23,7 @@ class HostDevice(object):
     def verify_neigh_lag_no_flap(self):
         raise NotImplementedError
 
-    def change_bgp_neigh_state(self, asn, is_up=True):
+    def change_bgp_neigh_state(self, bgp_info, is_up=True):
         raise NotImplementedError
 
     def change_bgp_route(self, cfg_map):

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -180,7 +180,7 @@ class ReloadTest(BaseTest):
         self.check_param('asic_type', '', required=False)
         self.check_param('logfile_suffix', None, required=False)
         self.check_param('neighbor_type', 'eos', required=False)
-        self.check_param('port_channel_intf_idx', 0, required=False)
+        self.check_param('port_channel_intf_idx', [], required=False)
         if not self.test_params['preboot_oper'] or self.test_params['preboot_oper'] == 'None':
             self.test_params['preboot_oper'] = None
         if not self.test_params['inboot_oper'] or self.test_params['inboot_oper'] == 'None':

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -180,6 +180,7 @@ class ReloadTest(BaseTest):
         self.check_param('asic_type', '', required=False)
         self.check_param('logfile_suffix', None, required=False)
         self.check_param('neighbor_type', 'eos', required=False)
+        self.check_param('port_channel_intf_idx', 0, required=False)
         if not self.test_params['preboot_oper'] or self.test_params['preboot_oper'] == 'None':
             self.test_params['preboot_oper'] = None
         if not self.test_params['inboot_oper'] or self.test_params['inboot_oper'] == 'None':

--- a/ansible/roles/test/files/ptftests/sonic.py
+++ b/ansible/roles/test/files/ptftests/sonic.py
@@ -444,7 +444,8 @@ class Sonic(host_device.HostDevice):
     def verify_bgp_neigh_state(self, dut=None, state="Active"):
         bgp_state = {}
         bgp_state['v4'] = bgp_state['v6'] = False
-        for cmd, ver in [("vtysh -c 'show ip bgp summary json'", 'v4'), ("vtysh -c 'show bgp ipv6 summary json'", 'v6')]:
+        for cmd, ver in [("vtysh -c 'show ip bgp summary json'", 'v4'),
+                         ("vtysh -c 'show bgp ipv6 summary json'", 'v6')]:
             output = self.do_cmd(cmd)
             obj = json.loads(output)
 
@@ -479,7 +480,7 @@ class Sonic(host_device.HostDevice):
                 obj = json.loads(output)
                 if lag in obj:
                     obj = obj[lag]
-                    if not 'operationalStatus' in obj or obj['operationalStatus'] == 'down':
+                    if 'operationalStatus' not in obj or obj['operationalStatus'] == 'down':
                         lag_state = state == 'down'
                     else:
                         lag_state = (obj['operationalStatus'] in state)

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -2039,8 +2039,9 @@ Totals               6450                 6449
         return self.command("sudo config feature state bgp enabled")
 
     def no_shutdown_bgp(self, asn):
-        logging.warning("SONiC don't support `no shutdown bgp`")
-        return None
+        command = "vtysh -c 'config' -c 'router bgp {}'".format(asn)
+        logging.info('No shut BGP: {}'.format(asn))
+        return self.command(command)
 
     def no_shutdown_bgp_neighbors(self, asn, neighbors=[]):
         if not neighbors:

--- a/tests/common/helpers/sad_path.py
+++ b/tests/common/helpers/sad_path.py
@@ -237,6 +237,7 @@ class LagMemberDown(SadOperation):
                 state = output["interfaces"][nbr_lag_name]["interfaceStatus"]
                 assert state in ["notconnect"]
 
+
 class DutLagMemberDown(LagMemberDown):
     """ Sad path to test warm-reboot when LAG member on DUT is shutdown
     and verify that after warm-reboot LAG member state is still down on DUT and neighbor. """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add support for SONiC peers in SAD reboot testing (test_upgrade_path, test_advanced_reboot)
Fixes #13627 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This adds sonic peer/neighbor support for SAD reboot cases (i.e. when `--neighbor_type == sonic`)
Previously the SAD reboot cases were only supported for eos peers (i.e. `--neighbor_type == eos`)
Sonic peers via vsonic testbed are required for teamd retry extension.

#### How did you do it?
Update/implement the `Sonic` `HostDevice` API, much of which was previously copy pasted from the `Arista` API.

#### How did you verify/test it?
Ran `test_warm_upgrade_sad_path` on Arista 7050CX3 device using sonic peer on master, 202405, and 202311. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
