### PR TITLE
[pfcwd] Add half of polling time as compensation for test_pfcwd_timer_accuracy

### DIFF
--- a/tests/common/helpers/pfc_gen.py
+++ b/tests/common/helpers/pfc_gen.py
@@ -172,7 +172,7 @@ def main():
                 packet = packet + b"\x00\x00"
 
     pre_str = 'GLOBAL_PF' if options.global_pf else 'PFC'
-    logger.debug(pre_str + '_STORM_START')
+    logger.debug(pre_str + '_STORM_DEBUG')
 
     # Start sending PFC pause frames
     senders = []
@@ -186,6 +186,7 @@ def main():
             s.start()
             senders.append(s)
 
+    logger.debug(pre_str + '_STORM_START')
     # Wait PFC packets to be sent
     for sender in senders:
         sender.stop()

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -231,8 +231,9 @@ class TestPfcwdAllTimer(object):
         # Loose the check if two conditions are met
         # 1. Leaf-fanout is Non-Onyx or non-Mellanox SONiC devices
         # 2. Device is Mellanox plaform, Loose the check
-        # 3. Device is not Mellanox plaform, add 50% of poll time to detect time
+        # 3. Device is broadcom plaform, add 50% of poll time to detect time
         # It's because the pfc_gen.py running on leaf-fanout can't guarantee the PFCWD is triggered consistently
+        logger.debug("dut asic_type {}".format(self.dut.facts['asic_type']))
         for fanouthost in list(self.fanout.values()):
             if fanouthost.get_fanout_os() != "onyx" or \
                     fanouthost.get_fanout_os() == "sonic" and fanouthost.facts['asic_type'] != "mellanox":
@@ -240,8 +241,8 @@ class TestPfcwdAllTimer(object):
                     logger.info("Loose the check for non-Onyx or non-Mellanox leaf-fanout testbed")
                     check_point = ITERATION_NUM // 3 - 1
                     break
-                else:
-                    logger.info("Configuring detect time for non-Mellanox DUT")
+                elif self.dut.facts['asic_type'] == "broadcom":
+                    logger.info("Configuring detect time for broadcom DUT")
                     config_detect_time = (
                         self.timers['pfc_wd_detect_time'] +
                         self.timers['pfc_wd_poll_time'] +

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -231,7 +231,7 @@ class TestPfcwdAllTimer(object):
         # Loose the check if two conditions are met
         # 1. Leaf-fanout is Non-Onyx or non-Mellanox SONiC devices
         # 2. Device is Mellanox plaform, Loose the check
-        # 3. Device is broadcom plaform, add 50% of poll time to detect time
+        # 3. Device is broadcom plaform, add half of polling time as compensation for the detect config time
         # It's because the pfc_gen.py running on leaf-fanout can't guarantee the PFCWD is triggered consistently
         logger.debug("dut asic_type {}".format(self.dut.facts['asic_type']))
         for fanouthost in list(self.fanout.values()):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
test_pfcwd_timer_accuracy case is flaky on Arisa platform. Sometimes the detect time is larger than the config detect time.
Both the config detect time and polling time are 400ms, and most of the real detect times range between 800 ~ 1000 ms. 
Based on lua script log, in the failure loop (the detect time is larger than the config detect time), it took 3 polling durations to trigger the pfc storm, and in most of these cases, there was a little traffic in the first loop pooling duration. Suppose the timestamp for the script to send PFC frames was at the end of the first polling duration. then cause there were no enough PFC received and trigger the pfc storm in the third polling loop.

#### How did you do it?
Add half of polling time as compensation for the detect config time.

#### How did you verify/test it?
Run the case

#### Any platform specific information?
Broadcom

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
