### PR TITLE
[Fanout] Support Nokia-7215A1 in 202311 SONiC fanout template

### DIFF
--- a/ansible/roles/fanout/templates/sonic_deploy_202311.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202311.j2
@@ -182,7 +182,7 @@
     {% endfor %}
     },
 {% endif %}
-{% if fanout_hwsku not in ("Nokia-7215", "Arista-720DT-G48S4") %}
+{% if fanout_hwsku not in ("Nokia-7215", "Nokia-7215-A1", "Arista-720DT-G48S4") %}
     "BUFFER_QUEUE": {
     {% for port_name in fanout_port_config %}
          "{{ port_name }}|0-7": {
@@ -198,7 +198,7 @@
     {% endfor %}
     },
 {% endif %}
-{% if fanout_hwsku in ("Nokia-7215", "Arista-720DT-G48S4") %}
+{% if fanout_hwsku in ("Nokia-7215", "Nokia-7215-A1", "Arista-720DT-G48S4") %}
 
     "FLEX_COUNTER_TABLE": {
         "ACL": {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Support Nokia-7215A1 in 202311 SONiC fanout template

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Support Nokia-7215A1 in 202311 SONiC fanout template

#### How did you do it?
Update config template: `sonic_deploy_202311.j2`

#### How did you verify/test it?
Verified by deploy Nokia-7215A1 fanout.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
