### PR TITLE
[test_orchagent_slb] Fix test_orchagent_slb

### DIFF
--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -279,9 +279,7 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
                 ][0]
 
             self.existing = existing
-            self.inner_packet = None
-            if self.existing:
-                self.inner_packet = inner_packet
+            self.inner_packet = inner_packet
             self.exp_pkt = self._build_tunnel_packet(self.standby_tor_lo_addr, self.active_tor_lo_addr,
                                                      inner_packet=self.inner_packet)
             self.rec_pkt = None


### PR DESCRIPTION
… traffic

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix `test_orchagent_slb`

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
During the tunnel traffic not-exist check, we need to explicitly match the inner packet, because there are other IPinIP tunnel packets with different inner packet from the standby to active.

#### How did you verify/test it?
```
dualtor/test_orchagent_slb.py::test_orchagent_slb[ipv4-active-standby] PASSED                                                                                                                                                                        [ 25%]
dualtor/test_orchagent_slb.py::test_orchagent_slb[ipv4-active-active] SKIPPED (Skip cable type 'active-active')                                                                                                                                      [ 50%]
dualtor/test_orchagent_slb.py::test_orchagent_slb[ipv6-active-standby] PASSED                                                                                                                                                                        [ 75%]
dualtor/test_orchagent_slb.py::test_orchagent_slb[ipv6-active-active] SKIPPED (Skip cable type 'active-active')                                                                                                                                      [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
