### PR TITLE
Remove any null characters before parsing string in test_snmp_phy_entity

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -808,6 +808,8 @@ def redis_hgetall(duthost, db_id, key):
         return {}
     # fix to make literal_eval() work with nested dictionaries
     content = content.replace("'{", '"{').replace("}'", '}"')
+    # Remove any null characters
+    content = content.replace('\x00', '')
     return ast.literal_eval(content)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Solve ```ValueError``` when parsing a string that contains null bytes (\x00). ```ast.literal_eval``` is essentially trying to compile a string into an Abstract Syntax Tree node, but it can't handle null bytes in the string. e,g., ```node_or_string = '{\'ext_identifier\': \'Power Class 8 (16.0W Max)\', \'media_lane_count\': \'N/A\', \'ma: \'2024-05-23 \x00\x00\', \'active_apsel_hostlane7\': \'N/A\'}'```


#### How did you do it?
Remove any null characters before parsing string.


#### How did you verify/test it?
In snmp/test_snmp_phy_entity.py:
```
======================================================================================== short test summary info ========================================================================================

SKIPPED [1] snmp/test_snmp_phy_entity.py:367: Not supported on non supervisor node

SKIPPED [1] platform_tests/thermal_control_test_helper.py:123: No mocker defined for this platform x86_64-arista_7060x6_64pe

SKIPPED [1] snmp/test_snmp_phy_entity.py:636: psu_controller is None, skipping this test

========================================================================== 4 passed, 3 skipped, 1 warning in 853.68s (0:14:13) ==========================================================================
```

#### Any platform specific information?
str3-7060x6-64pe-1
#### Supported testbed topology if it's a new test case?
t0-standalone-32
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
