### PR TITLE
Add an additional check to verify FEC stat counters

### DIFF
--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -130,15 +130,20 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
         fec_symbol_err = intf.get('fec_symbol_err', '').lower()
         # Check if fec_corr, fec_uncorr, and fec_symbol_err are valid integers
         try:
-            int(fec_corr)
+            fec_corr_int = int(fec_corr)
             fec_uncorr_int = int(fec_uncorr)
-            int(fec_symbol_err)
+            fec_symbol_err_int = int(fec_symbol_err)
         except ValueError:
             pytest.fail("FEC stat counters are not valid integers for interface {}, \
                         fec_corr: {} fec_uncorr: {} fec_symbol_err: {}"
                         .format(intf_name, fec_corr, fec_uncorr, fec_symbol_err))
 
-        # Check for uncorrectable FEC errors
+        # Check for FEC uncorrectable errors
         if fec_uncorr_int > 0:
             pytest.fail("FEC uncorrectable errors are non-zero for interface {}: {}"
                         .format(intf_name, fec_uncorr_int))
+
+        # Check for FEC correctable errors > FEC symbol errors
+        if fec_symbol_err_int > fec_corr_int :
+            pytest.fail("FEC symbol errors:{} are higher than FEC correctable errors:{} for interface {}"
+                        .format(intf_name, fec_symbol_err_int, fec_corr_int))

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -138,12 +138,12 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
                         fec_corr: {} fec_uncorr: {} fec_symbol_err: {}"
                         .format(intf_name, fec_corr, fec_uncorr, fec_symbol_err))
 
-        # Check for FEC uncorrectable errors
+        # Check for non-zero FEC uncorrectable errors
         if fec_uncorr_int > 0:
             pytest.fail("FEC uncorrectable errors are non-zero for interface {}: {}"
                         .format(intf_name, fec_uncorr_int))
 
-        # Check for FEC correctable errors > FEC symbol errors
-        if fec_symbol_err_int > fec_corr_int :
+        # Check for valid FEC correctable errors > FEC symbol errors
+        if fec_symbol_err_int > fec_corr_int:
             pytest.fail("FEC symbol errors:{} are higher than FEC correctable errors:{} for interface {}"
                         .format(intf_name, fec_symbol_err_int, fec_corr_int))

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -143,7 +143,7 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
             pytest.fail("FEC uncorrectable errors are non-zero for interface {}: {}"
                         .format(intf_name, fec_uncorr_int))
 
-        # Check for valid FEC correctable errors > FEC symbol errors
+        # Check for valid FEC correctable codeword errors > FEC symbol errors
         if fec_symbol_err_int > fec_corr_int:
             pytest.fail("FEC symbol errors:{} are higher than FEC correctable errors:{} for interface {}"
                         .format(intf_name, fec_symbol_err_int, fec_corr_int))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Add a validation check for FEC stat counters, FEC correctable errors should be always higher than FEC symbol errors

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
 FEC symbol errors refer to the number of erroneous symbols detected, while FEC correctable errors count the individual bit errors within those symbols that can be corrected. Since a single symbol can contain multiple bit errors, the number of FEC correctable errors is often higher than the number of symbol errors, as FEC can correct multiple bit errors per symbol.

#### How did you do it?
Fail the test if FEC symbol errors > FEC correctable errors

#### How did you verify/test it?
Verified on Mellanox-SN4600C-C64 lab testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
