### PR TITLE
Check for determine-reboot-cause service status

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -500,12 +500,10 @@ def check_reboot_cause_history(dut, reboot_type_history_queue):
 def check_determine_reboot_cause_service(dut):
     """
     @summary: This function verifies the status of the 'determine-reboot-cause' service on the device under test (DUT).
-    It checks:
-    1. The service's ActiveState and SubState using systemctl.
-    2. The kernel logs (dmesg) for critical errors that may indicate service failures or system instability.
+    It checks the service's ActiveState and SubState using systemctl.
     @param dut: The AnsibleHost object of DUT.
     """
-    # Step 1: Check the 'determine-reboot-cause' service status
+    # Check the 'determine-reboot-cause' service status
     logger.info("Checking 'determine-reboot-cause' service status using systemctl")
     service_state = dut.get_service_props("determine-reboot-cause.service")
 
@@ -517,23 +515,3 @@ def check_determine_reboot_cause_service(dut):
     assert active_state == "active", f"Service 'determine-reboot-cause' is not active. Current state: {active_state}"
     assert sub_state == "exited", f"Service 'determine-reboot-cause' did not exit cleanly. \
             Current sub-state: {sub_state}"
-
-    # Step 2: Check kernel logs (dmesg) for any critical errors
-    logger.info("Checking dmesg for critical errors")
-    dmesg_output = dut.command("sudo dmesg")["stdout"]
-
-    # List of error keywords to look for in the dmesg logs
-    error_keywords = ["crash", "Out of memory", "Call Trace", "Exception", "panic", "segfault"]
-    found_errors = []
-
-    for err_kw in error_keywords:
-        if re.search(err_kw, dmesg_output, re.I):
-            found_errors.append(err_kw)
-
-    # Log any found errors and assert no critical issues
-    if found_errors:
-        logger.error(f"Found critical error keywords in dmesg: {found_errors}")
-        logger.error(f"dmesg output: {dmesg_output}")
-        assert not found_errors, f"Critical errors found in dmesg: {', '.join(found_errors)}"
-    else:
-        logger.info("No critical errors found in dmesg.")

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -13,8 +13,8 @@ import pytest
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F401
 from tests.common.utilities import wait_until, get_plt_reboot_ctrl
 from tests.common.reboot import sync_reboot_history_queue_with_dut, reboot, check_reboot_cause,\
-    check_reboot_cause_history, reboot_ctrl_dict, wait_for_startup,\
-    REBOOT_TYPE_HISTOYR_QUEUE, REBOOT_TYPE_COLD,\
+    check_reboot_cause_history, check_determine_reboot_cause_service, reboot_ctrl_dict,\
+    wait_for_startup, REBOOT_TYPE_HISTOYR_QUEUE, REBOOT_TYPE_COLD,\
     REBOOT_TYPE_SOFT, REBOOT_TYPE_FAST, REBOOT_TYPE_WARM, REBOOT_TYPE_WATCHDOG
 from tests.common.platform.transceiver_utils import check_transceiver_basic
 from tests.common.platform.interface_utils import check_all_interface_information, get_port_map
@@ -149,6 +149,14 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list,
         check_sysfs(dut)
 
     if reboot_type is not None:
+        logging.info("Check the determine-reboot-cause service")
+        os_version = dut.os_version.split(".")[0]
+        if os_version < "202106":
+            logging.info("DUT has OS version {}, skip the check determine-reboot-cause service \
+                    for release before 202106" .format(os_version))
+        else:
+            check_determine_reboot_cause_service(dut)
+
         logging.info("Check reboot cause")
         assert wait_until(MAX_WAIT_TIME_FOR_REBOOT_CAUSE, 20, 30, check_reboot_cause, dut, reboot_type), \
             "got reboot-cause failed after rebooted by %s" % reboot_type


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes  https://github.com/sonic-net/sonic-mgmt/issues/13459

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 202012
- [x] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To validate the functionality of the determine-reboot-cause service in SONiC. This service is responsible for detecting and logging the cause of system reboots (e.g., cold reboot, warm reboot, fast reboot, etc.). Accurate identification of reboot causes is critical for troubleshooting, monitoring, and maintaining system stability, so ensuring its correctness and reliability is essential.

#### How did you do it?
1. Verify the service running status:
 - After each type of reboot, verify the determine-reboot-cause service status.
2. Validated Logs:
 - After each reboot, validated the system logs to confirm that the correct reboot cause was captured by the determine-reboot-cause service.

#### How did you verify/test it?
- Ran unit tests to validate the logic inside the determine-reboot-cause service, ensuring correct detection and classification of reboot causes.
- Manually induced cold, warm, and fast reboots on test devices and confirmed that the service correctly identified each cause.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
