### PR TITLE
Add sonic-vpp image download instructions and `t1` vtestbed topology

### DIFF
--- a/ansible/roles/vm_set/templates/sonic.xml.j2
+++ b/ansible/roles/vm_set/templates/sonic.xml.j2
@@ -3,13 +3,25 @@
 {% if hwsku  == 'msft_four_asic_vs' %}
   <memory unit='GB'>8</memory>
   <vcpu placement='static'>10</vcpu>
+  <cpu mode='host-model'>
+    <model fallback='forbid'/>
+    <topology sockets='1' dies='1' cores='5' threads='2'/>
+  </cpu>
 {% elif hwsku == 'msft_multi_asic_vs' %}
   <memory unit='GB'>8</memory>
   <vcpu placement='static'>16</vcpu>
+  <cpu mode='host-model'>
+    <model fallback='forbid'/>
+    <topology sockets='1' dies='1' cores='8' threads='2'/>
+  </cpu>
 {% else %}
   <memory unit='GiB'>4</memory>
   <currentMemory unit='GiB'>4</currentMemory>
   <vcpu placement='static'>4</vcpu>
+  <cpu mode='host-model'>
+    <model fallback='forbid'/>
+    <topology sockets='1' dies='1' cores='2' threads='2'/>
+  </cpu>
 {% endif %}
   <resource>
     <partition>/machine</partition>

--- a/ansible/vtestbed.yaml
+++ b/ansible/vtestbed.yaml
@@ -336,3 +336,18 @@
   inv_name: veos_vtb
   auto_recover: False
   comment: Tests virtual switch vm as DPU
+
+- conf-name: vms-kvm-t1
+  group-name: vms6-2
+  topo: t1
+  ptf_image_name: docker-ptf
+  ptf: ptf-02
+  ptf_ip: 10.250.0.106/24
+  ptf_ipv6: fec0::ffff:afa:6/64
+  server: server_1
+  vm_base: VM0104
+  dut:
+    - vlab-03
+  inv_name: veos_vtb
+  auto_recover: 'False'
+  comment: Tests virtual switch vm

--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -122,6 +122,7 @@ You need to create a valid SONiC image named `sonic-vs.img` in the `~/veos-vm/im
 ## Download the sonic-vs image
 To run the tests with a virtual SONiC device, we need a virtual SONiC image. The simplest way to do so is to download the latest succesful build.
 
+### Option 1: Download sonic-vs image
 1. Download the sonic-vs image from [here](https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/sonic-vs.img.gz)
 
 ```
@@ -138,6 +139,18 @@ mkdir -p ~/veos-vm/images
 mv sonic-vs.img ~/veos-vm/images
 ```
 
+### Option 2: Download sonic-vpp image
+1. Download the sonic-vs image from [here](https://github.com/cisco-mt-fuji/Sonic-Vpp).
+Note that the link is currently a private repo for internal use only, we will update the url with latest successful build soon.
+2. Unzip the image, rename the image and copy it into `~/sonic-vm/images/` and also `~/veos-vm/images`
+```
+gzip -d sonic-vpp.img.gz
+mv sonic-vpp.img sonic-vs.img
+mkdir -p ~/sonic-vm/images
+cp sonic-vs.img ~/sonic-vm/images
+mkdir -p ~/veos-vm/images
+mv sonic-vs.img ~/veos-vm/images
+```
 ## Setup sonic-mgmt docker
 All testbed configuration steps and tests are run from a `sonic-mgmt` docker container. This container has all the necessary packages and tools for SONiC testing so that test behavior is consistent between different developers and lab setups.
 

--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -139,9 +139,8 @@ mkdir -p ~/veos-vm/images
 mv sonic-vs.img ~/veos-vm/images
 ```
 
-### Option 2: Download sonic-vpp image
-1. Download the sonic-vs image from [here](https://github.com/cisco-mt-fuji/Sonic-Vpp).
-Note that the link is currently a private repo for internal use only, we will update the url with latest successful build soon.
+### Option 2: Use sonic-vpp image
+1. Follow the instructions from [sonic-platform-vpp](https://github.com/sonic-net/sonic-platform-vpp?tab=readme-ov-file#building-a-kvm-vm-image) and build a **kvm** vm image.
 2. Unzip the image, rename the image and copy it into `~/sonic-vm/images/` and also `~/veos-vm/images`
 ```
 gzip -d sonic-vpp.img.gz

--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -120,16 +120,28 @@ root_path: /data/veos-vm
 You need to create a valid SONiC image named `sonic-vs.img` in the `~/veos-vm/images/` directory. Currently, we don’t support downloading a pre-built SONiC image. However, for testing purposes, you can refer to the section Download the sonic-vs image to obtain an available image and place it in the `~/veos-vm/images/` directory.
 
 ## Download the sonic-vs image
-To run the tests with a virtual SONiC device, we need a virtual SONiC image. The simplest way to do so is to download the latest succesful build.
 
-### Option 1: Download sonic-vs image
-1. Download the sonic-vs image from [here](https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/sonic-vs.img.gz)
+### 1. To run the tests with a virtual SONiC device, we need a virtual SONiC image.
+
+#### Option 1: Download sonic-vs image
+
+The simplest way to do so is to download the latest succesful build. Download the sonic-vs image from [here](https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/sonic-vs.img.gz)
 
 ```
 wget "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/sonic-vs.img.gz" -O sonic-vs.img.gz
 ```
 
-2. Unzip the image and copy it into `~/sonic-vm/images/` and also `~/veos-vm/images`
+#### Option 2: Build sonic-vpp image
+
+Follow the instructions from [sonic-platform-vpp](https://github.com/sonic-net/sonic-platform-vpp?tab=readme-ov-file#building-a-kvm-vm-image) and build a **kvm** vm image.
+
+__Note: make sure you rename the vpp image to `sonic-vs.img`.__
+
+```
+mv sonic-vpp.img.gz sonic-vs.img.gz
+```
+
+### 2. Unzip the image and copy it into `~/sonic-vm/images/` and also `~/veos-vm/images`
 
 ```
 gzip -d sonic-vs.img.gz
@@ -139,17 +151,6 @@ mkdir -p ~/veos-vm/images
 mv sonic-vs.img ~/veos-vm/images
 ```
 
-### Option 2: Use sonic-vpp image
-1. Follow the instructions from [sonic-platform-vpp](https://github.com/sonic-net/sonic-platform-vpp?tab=readme-ov-file#building-a-kvm-vm-image) and build a **kvm** vm image.
-2. Unzip the image, rename the image and copy it into `~/sonic-vm/images/` and also `~/veos-vm/images`
-```
-gzip -d sonic-vpp.img.gz
-mv sonic-vpp.img sonic-vs.img
-mkdir -p ~/sonic-vm/images
-cp sonic-vs.img ~/sonic-vm/images
-mkdir -p ~/veos-vm/images
-mv sonic-vs.img ~/veos-vm/images
-```
 ## Setup sonic-mgmt docker
 All testbed configuration steps and tests are run from a `sonic-mgmt` docker container. This container has all the necessary packages and tools for SONiC testing so that test behavior is consistent between different developers and lab setups.
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Raising this PR as the phase one of smart switch sand box.

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
1. Add a no-lag t1 kvm testbed 
2. Update sonic vm template to allow nested virtualization 
3. Add link to sonic-vpp build instructions

#### How did you do it?

#### How did you verify/test it?
Tried to deploy a t1 kvm testbed on Azure VM with sonic-vpp image. Was able to get bgp sessions up. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
