### PR TITLE
add retry for installing packages on server

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -67,6 +67,10 @@
     - name: Install necessary packages
       apt: pkg={{ item }} update_cache=yes cache_valid_time=86400
       become: yes
+      register: apt_res
+      retries: 2
+      delay: 30
+      until: apt_res is success
       with_items:
         - ifupdown
         - qemu
@@ -78,6 +82,10 @@
     - name: Install necessary packages
       apt: pkg={{ item }} update_cache=yes cache_valid_time=86400
       become: yes
+      register: apt_res
+      retries: 2
+      delay: 30
+      until: apt_res is success
       with_items:
         - iproute2
         - vlan
@@ -88,6 +96,10 @@
         - libvirt-clients
 
     - name: Install necessary packages
+      register: apt_res
+      retries: 2
+      delay: 30
+      until: apt_res is success
       apt:
         pkg:
         - python
@@ -98,6 +110,10 @@
       when: host_distribution_version.stdout == "18.04"
 
     - name: Install necessary packages
+      register: apt_res
+      retries: 2
+      delay: 30
+      until: apt_res is success
       apt:
         pkg:
         - python3-libvirt


### PR DESCRIPTION
Change-Id: Ic083fe88b02cc377d7aa4380c228946ccbce6689

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: introduce retry for installing needed packages during the topology deployment to avoid `Failed to lock apt for exclusive operation` error
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The motivation is to avoid concurrent apt lock by multiple setups

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
