### PR TITLE
Added sonic-mgmt tests for process-reboot-cause script

### DIFF
--- a/tests/platform_tests/test_process_reboot_cause.py
+++ b/tests/platform_tests/test_process_reboot_cause.py
@@ -21,7 +21,6 @@ REBOOT_CAUSE_FILE_FORMAT = "reboot-cause-{}.json"
 REBOOT_TYPES = ['warm-reboot', 'fast-reboot', 'soft-reboot', 'reboot', 'Power loss', 'Watchdog',  'Unknown', 'Hardware - Other', 'Non-Hardware']  # noqa: E501
 BAD_JSON = "{'gen_time:'"
 GOOD_JSON = {"gen_time": "9999_99_99_99_99_99", "cause": "", "user": "admin", "time": "N/A", "comment": "N/A"}  # noqa: E501
-JSON_DECODE_ERROR = "json.decoder.JSONDecodeError"
 EXCEPTION_HANDLED_SYSLOG = "Unable to process reload cause file"
 REBOOT_CAUSE_TEST_IDENTIFIER = "process-reboot-cause-test"
 
@@ -30,11 +29,12 @@ class TestProcessRebootCause():
 
     duthost = None
     image_ver = None
-    image_major_ver = None
-    image_minor_ver = None
+    reboot_cause_file = None
+    skip = None
+    reason = None
 
-    @pytest.fixture(scope="function", autouse=True)
-    def setup(self, duthosts, enum_rand_one_per_hwsku_hostname):
+    @pytest.fixture(autouse=True)
+    def setup_create_and_delete_json_files(self, duthosts, enum_rand_one_per_hwsku_hostname):  # noqa: E501
         if self.duthost is None:
             self.duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
@@ -42,12 +42,22 @@ class TestProcessRebootCause():
         if skip is True:
             pytest.skip("Skip test 'process-reboot-cause' for {} running image {} due to reason: {}".format(self.dthost.facts['platform'], self.duthost.os_version, reason))  # noqa: E501
 
-        # Get image version on DUT
-        self.image_ver = self.duthost.sonichost.os_version
+        if self.image_ver is None:
+            # Get image version on DUT
+            self.image_ver = self.duthost.sonichost.os_version
 
-        # Get major and minor version of image
-        self.image_major_ver = int(self.image_ver.split('.')[0])
-        self.image_minor_ver = int(self.image_ver.split('.')[-1])
+        # Create a dummy JSON file to test
+        self.create_json_file()
+
+        yield
+
+        # Remove the JSON file
+        self.remove_json_file()
+
+        # Restart process-reboot-cause.service
+        self.restart_service()
+
+        self.reboot_cause_file = None
 
     ##########################
     #                        #
@@ -80,55 +90,65 @@ class TestProcessRebootCause():
         logging.info("Restarting process-reboot-cause.service")
         _ = self.duthost.command(SYSTEMCTL_RESTART_CMD)
 
-    def create_json_file(self, filetype=""):
+    def create_json_file(self):
 
         gen_time = self.duthost.command(REBOOT_CAUSE_GEN_TIME_CMD)["stdout_lines"][0]  # noqa: E501
-        reboot_cause_file = os.path.join(REBOOT_CAUSE_HISTORY_DIR, REBOOT_CAUSE_FILE_FORMAT.format(gen_time))  # noqa: E501
+        self.reboot_cause_file = os.path.join(REBOOT_CAUSE_HISTORY_DIR, REBOOT_CAUSE_FILE_FORMAT.format(gen_time))  # noqa: E501
 
-        logging.info("Writing '{}' to {} on DUT".format(filetype, reboot_cause_file))  # noqa: E501
-        _ = self.duthost.command("bash -c 'echo {}>{}'".format(filetype, reboot_cause_file))  # noqa: E501
+        _ = self.duthost.command("bash -c 'touch {}'".format(self.reboot_cause_file))  # noqa: E501
 
-        return reboot_cause_file
+    def populate_json_file(self, filetype=""):
 
-    def remove_json_file(self, reboot_cause_file):
-        logging.info("Clean up the newly created JSON file: {}".format(reboot_cause_file))  # noqa: E501
-        _ = self.duthost.command('rm -f {}'.format(reboot_cause_file))
+        logging.info("Writing '{}' to {} on DUT".format(filetype, self.reboot_cause_file))  # noqa: E501
+        _ = self.duthost.command("bash -c 'echo {}>{}'".format(filetype, self.reboot_cause_file))  # noqa: E501
+
+    def remove_json_file(self):
+        logging.info("Clean up the newly created JSON file: {}".format(self.reboot_cause_file))  # noqa: E501
+        _ = self.duthost.command('rm -f {}'.format(self.reboot_cause_file))
 
     def bad_json_file_assertions(self, status, result, journalctl_output):
 
-        # Check for exeception if image version < 2023110.20 , 20230531.33 or 20220531.53  # noqa: E501
-        if self.image_major_ver < 20220531 or \
-          (self.image_major_ver == 20231110 and self.image_minor_ver < 20) or \
-          (self.image_major_ver == 20230531 and self.image_minor_ver < 33) or \
-          (self.image_major_ver == 20220531 and self.image_minor_ver < 53):
-
-            logging.info("OS Version {} does not have the patched process-reboot-cause file with try-except block".format(self.image_ver))  # noqa: E501
-            is_json_decode_error = any(JSON_DECODE_ERROR in line for line in journalctl_output)  # noqa: E501
-
-            pytest_assert(result == "exit-code")
-            pytest_assert(status == 1)
-            pytest_assert(is_json_decode_error)
-
-        else:
-            logging.info("OS Version {} has the patched process-reboot-cause file with try-except block".format(self.image_ver))  # noqa: E501
-            exception_handled_log = any(EXCEPTION_HANDLED_SYSLOG in line for line in journalctl_output)  # noqa: E501
-            logging.info("exception_handled_log: {}".format(journalctl_output))
-            pytest_assert(result == "success")
-            pytest_assert(status == 0)
-            pytest_assert(exception_handled_log)
+        logging.info("OS Version {} has the patched process-reboot-cause file with try-except block".format(self.image_ver))  # noqa: E501
+        exception_handled_log = any(EXCEPTION_HANDLED_SYSLOG in line for line in journalctl_output)  # noqa: E501
+        logging.info("exception_handled_log: {}".format(journalctl_output))
+        pytest_assert(result == "success")
+        pytest_assert(status == 0)
+        pytest_assert(exception_handled_log)
 
     def good_json_file_assertions(self, status, result, cause, journalctl_output, statedb_output):  # noqa: E501
 
-        excpected_reboot_cause = any(cause in line for line in statedb_output)  # noqa: E501
+        '''
+        With a good JSON file, the following assertions must be true:
+
+            1. process-reboot-cause service should have successfully run to completion  # noqa: E501
+            2. The status of the service should be 0 (no errors)
+            3. The reboot cause on the STATE_DB (expected_reboot_cause) should be the same as the one in the JSON file  # noqa: E501
+
+        For example, this is the reboot cause KVPs as parsed from a good JSON file:  # noqa: E501
+
+        admin@sonic-device:~$ redis-cli -n 6 HGETALL "REBOOT_CAUSE|2024_10_21_15_16_57"  # noqa: E501
+            1) "cause"
+            2) "reboot"
+            3) "time"
+            4) "Mon Oct 21 03:15:13 PM UTC 2024"
+            5) "user"
+            6) "admin"
+            7) "comment"
+            8) "N/A"
+
+        As we create a dummy JSON file with timestamp: 9999_99_99_99_99_99, we can get the reboot cause for just that entry,  # noqa: E501
+        and assert that it is the expected reboot cause rom the JSON file.
+        '''
+        logging.info("expected reboot cause: {} - statedb output: {}".format(cause, statedb_output))  # noqa: E501
 
         pytest_assert(result == "success")
         pytest_assert(status == 0)
-        pytest_assert(excpected_reboot_cause)
+        pytest_assert(cause == statedb_output)
 
     def process_reboot_cause_file_runner(self, filetype=""):
 
-        # Create a JSON file
-        reboot_cause_file = self.create_json_file(filetype)
+        # Populate the newly created reboot-cause file
+        self.populate_json_file(filetype)
 
         # Restart process-reboot-cause.service
         self.restart_service()
@@ -142,14 +162,17 @@ class TestProcessRebootCause():
         journalctl_output = self.duthost.command(JOURNALCTL_CMD.format(main_pid))["stdout_lines"]  # noqa: E501
 
         # Get STATE_DB kvps created from latest JSON file
-        statedb_output = self.duthost.command('redis-cli -n 6 HGETALL "REBOOT_CAUSE|9999_99_99_99_99_99"')["stdout_lines"]  # noqa: E501
-        _ = self.duthost.command('redis-cli -n 6 DEL "REBOOT_CAUSE|9999_99_99_99_99_99"')  # noqa: E501
+        statedb_output = None
 
-        # Remove the JSON file
-        self.remove_json_file(reboot_cause_file)
+        try:
+            statedb_output = self.duthost.command('sonic-db-cli STATE_DB HGET "REBOOT_CAUSE|9999_99_99_99_99_99" cause')["stdout_lines"][0].strip()  # noqa: E501
+        except IndexError:
+            pass
 
-        # Restart process-reboot-cause.service
-        self.restart_service()
+        logging.info("statedb output: {}".format(statedb_output))
+
+        # Remove the dummy reboot cause entry from the STATE_DB
+        _ = self.duthost.command('sonic-db-cli STATE_DB DEL "REBOOT_CAUSE|9999_99_99_99_99_99"')  # noqa: E501
 
         # Return relevant fields
         return main_pid, status, result, journalctl_output, statedb_output

--- a/tests/platform_tests/test_process_reboot_cause.py
+++ b/tests/platform_tests/test_process_reboot_cause.py
@@ -1,14 +1,9 @@
 import os
-import json
 import logging
 import time
 import pytest
 
-from retry.api import retry_call
-from tests.common.utilities import wait_until, check_skip_release
-from tests.common.helpers.assertions import pytest_assert, pytest_require
-from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
-from tests.common.utilities import wait_until, check_skip_release
+from tests.common.utilities import check_skip_release
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
@@ -16,23 +11,23 @@ pytestmark = [
     pytest.mark.device_type('physical'),
 ]
 
-SYSTEMCTL_SHOW_CMD = "systemctl show process-reboot-cause.service --property='ExecMainPID' --property='ExecMainStatus' --property='Result'"
+SYSTEMCTL_SHOW_CMD = "systemctl show process-reboot-cause.service --property='ExecMainPID' --property='ExecMainStatus' --property='Result'"  # noqa: E501
 SYSTEMCTL_RESTART_CMD = "systemctl restart process-reboot-cause.service"
 JOURNALCTL_CMD = "journalctl -u process-reboot-cause.service _PID={}"
 
 REBOOT_CAUSE_GEN_TIME_CMD = 'date +"%Y_%m_%d_%H_%M_%S"'
 REBOOT_CAUSE_HISTORY_DIR = "/host/reboot-cause/history/"
 REBOOT_CAUSE_FILE_FORMAT = "reboot-cause-{}.json"
-REBOOT_TYPES = ['warm-reboot', 'fast-reboot', 'soft-reboot', 'reboot', 'Power loss', 'Watchdog',  'Unknown', 'Hardware - Other', 'Non-Hardware']
+REBOOT_TYPES = ['warm-reboot', 'fast-reboot', 'soft-reboot', 'reboot', 'Power loss', 'Watchdog',  'Unknown', 'Hardware - Other', 'Non-Hardware']  # noqa: E501
 BAD_JSON = "{'gen_time:'"
-GOOD_JSON = {"gen_time": "9999_99_99_99_99_99", "cause": "", "user": "admin", "time": "N/A", "comment": "N/A"}
+GOOD_JSON = {"gen_time": "9999_99_99_99_99_99", "cause": "", "user": "admin", "time": "N/A", "comment": "N/A"}  # noqa: E501
 JSON_DECODE_ERROR = "json.decoder.JSONDecodeError"
-EXCEPTION_HANDLED_SYSLOG = "Unable to process reload cause file {}"
+EXCEPTION_HANDLED_SYSLOG = "Unable to process reload cause file"
 REBOOT_CAUSE_TEST_IDENTIFIER = "process-reboot-cause-test"
 
 
 class TestProcessRebootCause():
-    
+
     duthost = None
     image_ver = None
     image_major_ver = None
@@ -40,13 +35,13 @@ class TestProcessRebootCause():
 
     @pytest.fixture(scope="function", autouse=True)
     def setup(self, duthosts, enum_rand_one_per_hwsku_hostname):
-        if self.duthost == None:
+        if self.duthost is None:
             self.duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
         skip, reason = check_skip_release(self.duthost, ["201811", "201911"])
         if skip is True:
-            pytest.skip("Skip test 'process-reboot-cause' for {} running image {} due to reason: {}".format(self.duthost.facts['platform'], self.duthost.os_version, reason))
-        
+            pytest.skip("Skip test 'process-reboot-cause' for {} running image {} due to reason: {}".format(self.dthost.facts['platform'], self.duthost.os_version, reason))  # noqa: E501
+
         # Get image version on DUT
         self.image_ver = self.duthost.sonichost.os_version
 
@@ -54,17 +49,15 @@ class TestProcessRebootCause():
         self.image_major_ver = int(self.image_ver.split('.')[0])
         self.image_minor_ver = int(self.image_ver.split('.')[-1])
 
-
     ##########################
     #                        #
     #      HELPER FNS        #
     #                        #
     ##########################
 
-
     def get_service_status(self):
         """
-        @summary: Check status of process-reboot-cause.service and return parameters to calling function
+        @summary: Check status of process-reboot-cause.service and return parameters to calling function  # noqa: E501
         """
 
         status = -1
@@ -83,61 +76,54 @@ class TestProcessRebootCause():
 
         return main_pid, status, result
 
-
     def restart_service(self):
         logging.info("Restarting process-reboot-cause.service")
         _ = self.duthost.command(SYSTEMCTL_RESTART_CMD)
 
-
     def create_json_file(self, filetype=""):
 
-        gen_time = self.duthost.command(REBOOT_CAUSE_GEN_TIME_CMD)["stdout_lines"][0]
-        reboot_cause_file = os.path.join(REBOOT_CAUSE_HISTORY_DIR, REBOOT_CAUSE_FILE_FORMAT.format(gen_time))
+        gen_time = self.duthost.command(REBOOT_CAUSE_GEN_TIME_CMD)["stdout_lines"][0]  # noqa: E501
+        reboot_cause_file = os.path.join(REBOOT_CAUSE_HISTORY_DIR, REBOOT_CAUSE_FILE_FORMAT.format(gen_time))  # noqa: E501
 
-        logging.info("Writing '{}' to {} on DUT".format(filetype, reboot_cause_file))
-        _ = self.duthost.command("bash -c 'echo {}>{}'".format(filetype, reboot_cause_file))
+        logging.info("Writing '{}' to {} on DUT".format(filetype, reboot_cause_file))  # noqa: E501
+        _ = self.duthost.command("bash -c 'echo {}>{}'".format(filetype, reboot_cause_file))  # noqa: E501
 
         return reboot_cause_file
 
-
     def remove_json_file(self, reboot_cause_file):
-        logging.info("Clean up the newly created JSON file: {}".format(reboot_cause_file))
+        logging.info("Clean up the newly created JSON file: {}".format(reboot_cause_file))  # noqa: E501
         _ = self.duthost.command('rm -f {}'.format(reboot_cause_file))
 
-
     def bad_json_file_assertions(self, status, result, journalctl_output):
-        
-        # Check for exeception if image version < 2023110.20 , 20230531.33 or 20220531.53
-        if self.image_major_ver < 20220531 or \
-        (self.image_major_ver == 20231110 and self.image_minor_ver < 20) or \
-        (self.image_major_ver == 20230531 and self.image_minor_ver < 33) or \
-        (self.image_major_ver == 20220531 and self.image_minor_ver < 53):
 
-            logging.info("OS Version {} does not have the patched process-reboot-cause file with try-except block".format(self.image_ver))
-            is_json_decode_error = any(JSON_DECODE_ERROR in line for line in journalctl_output)
+        # Check for exeception if image version < 2023110.20 , 20230531.33 or 20220531.53  # noqa: E501
+        if self.image_major_ver < 20220531 or \
+          (self.image_major_ver == 20231110 and self.image_minor_ver < 20) or \
+          (self.image_major_ver == 20230531 and self.image_minor_ver < 33) or \
+          (self.image_major_ver == 20220531 and self.image_minor_ver < 53):
+
+            logging.info("OS Version {} does not have the patched process-reboot-cause file with try-except block".format(self.image_ver))  # noqa: E501
+            is_json_decode_error = any(JSON_DECODE_ERROR in line for line in journalctl_output)  # noqa: E501
 
             pytest_assert(result == "exit-code")
             pytest_assert(status == 1)
             pytest_assert(is_json_decode_error)
-        
+
         else:
-            logging.info("OS Version {} has the patched process-reboot-cause file with try-except block".format(self.image_ver))
-            message = EXCEPTION_HANDLED_SYSLOG.format(reboot_cause_file)
-            exception_handled_log = any(message in line for line in journalctl_output)
+            logging.info("OS Version {} has the patched process-reboot-cause file with try-except block".format(self.image_ver))  # noqa: E501
+            exception_handled_log = any(EXCEPTION_HANDLED_SYSLOG in line for line in journalctl_output)  # noqa: E501
             logging.info("exception_handled_log: {}".format(journalctl_output))
             pytest_assert(result == "success")
             pytest_assert(status == 0)
             pytest_assert(exception_handled_log)
 
+    def good_json_file_assertions(self, status, result, cause, journalctl_output, statedb_output):  # noqa: E501
 
-    def good_json_file_assertions(self, status, result, cause, journalctl_output, statedb_output):
+        excpected_reboot_cause = any(cause in line for line in statedb_output)  # noqa: E501
 
-            excpected_reboot_cause = any(cause in line for line in statedb_output)
-            
-            pytest_assert(result == "success")
-            pytest_assert(status == 0)
-            pytest_assert(excpected_reboot_cause)
-
+        pytest_assert(result == "success")
+        pytest_assert(status == 0)
+        pytest_assert(excpected_reboot_cause)
 
     def process_reboot_cause_file_runner(self, filetype=""):
 
@@ -153,12 +139,11 @@ class TestProcessRebootCause():
         # Get latest status of the service
         logging.info("Get latest status of the process-reboot-cause.service")
         main_pid, status, result = self.get_service_status()
-        journalctl_output = self.duthost.command(JOURNALCTL_CMD.format(main_pid))["stdout_lines"]
+        journalctl_output = self.duthost.command(JOURNALCTL_CMD.format(main_pid))["stdout_lines"]  # noqa: E501
 
         # Get STATE_DB kvps created from latest JSON file
-        statedb_output = self.duthost.command('redis-cli -n 6 HGETALL "REBOOT_CAUSE|9999_99_99_99_99_99"')["stdout_lines"]
-        _ = self.duthost.command('redis-cli -n 6 DEL "REBOOT_CAUSE|9999_99_99_99_99_99"')
-
+        statedb_output = self.duthost.command('redis-cli -n 6 HGETALL "REBOOT_CAUSE|9999_99_99_99_99_99"')["stdout_lines"]  # noqa: E501
+        _ = self.duthost.command('redis-cli -n 6 DEL "REBOOT_CAUSE|9999_99_99_99_99_99"')  # noqa: E501
 
         # Remove the JSON file
         self.remove_json_file(reboot_cause_file)
@@ -169,13 +154,11 @@ class TestProcessRebootCause():
         # Return relevant fields
         return main_pid, status, result, journalctl_output, statedb_output
 
-
     ##########################
     #                        #
     #      TESTS BEGIN       #
     #                        #
     ##########################
-
 
     def test_status_on_boot(self):
         main_pid, status, result = self.get_service_status()
@@ -183,28 +166,25 @@ class TestProcessRebootCause():
         pytest_assert(main_pid != -1)
         pytest_assert(status == 0)
         pytest_assert(result == "success")
-    
 
     def test_valid_reboot_causes(self):
 
         for cause in REBOOT_TYPES:
             logging.info("Testing valid reboot type: {}".format(cause))
-            
+
             GOOD_JSON["cause"] = cause
             valid_json_str = (str(GOOD_JSON)).replace("'", "\\\"")
 
-            main_pid, status, result, _, statedb_output = self.process_reboot_cause_file_runner(valid_json_str)
-            logging.info("PID: {} Status: {} Result: {} Cause: {} ".format(main_pid, status, result, cause))
-            self.good_json_file_assertions(status, result, cause, _ , statedb_output)
-
+            main_pid, status, result, _, statedb_output = self.process_reboot_cause_file_runner(valid_json_str)  # noqa: E501
+            logging.info("PID: {} Status: {} Result: {} Cause: {} ".format(main_pid, status, result, cause))  # noqa: E501
+            self.good_json_file_assertions(status, result, cause, _, statedb_output)  # noqa: E501
 
     def test_empty_json_file(self):
 
-       main_pid, status, result, journalctl_output, _ = self.process_reboot_cause_file_runner()
-       self.bad_json_file_assertions(status, result, journalctl_output)
-
+        main_pid, status, result, journalctl_output, _ = self.process_reboot_cause_file_runner()  # noqa: E501
+        self.bad_json_file_assertions(status, result, journalctl_output)
 
     def test_malformed_json_file(self):
 
-        main_pid, status, result, journalctl_output, _ = self.process_reboot_cause_file_runner(BAD_JSON)
+        main_pid, status, result, journalctl_output, _ = self.process_reboot_cause_file_runner(BAD_JSON)  # noqa: E501
         self.bad_json_file_assertions(status, result, journalctl_output)

--- a/tests/platform_tests/test_process_reboot_cause.py
+++ b/tests/platform_tests/test_process_reboot_cause.py
@@ -1,0 +1,210 @@
+import os
+import json
+import logging
+import time
+import pytest
+
+from retry.api import retry_call
+from tests.common.utilities import wait_until, check_skip_release
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
+from tests.common.utilities import wait_until, check_skip_release
+from tests.common.helpers.assertions import pytest_assert
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical'),
+]
+
+SYSTEMCTL_SHOW_CMD = "systemctl show process-reboot-cause.service --property='ExecMainPID' --property='ExecMainStatus' --property='Result'"
+SYSTEMCTL_RESTART_CMD = "systemctl restart process-reboot-cause.service"
+JOURNALCTL_CMD = "journalctl -u process-reboot-cause.service _PID={}"
+
+REBOOT_CAUSE_GEN_TIME_CMD = 'date +"%Y_%m_%d_%H_%M_%S"'
+REBOOT_CAUSE_HISTORY_DIR = "/host/reboot-cause/history/"
+REBOOT_CAUSE_FILE_FORMAT = "reboot-cause-{}.json"
+REBOOT_TYPES = ['warm-reboot', 'fast-reboot', 'soft-reboot', 'reboot', 'Power loss', 'Watchdog',  'Unknown', 'Hardware - Other', 'Non-Hardware']
+BAD_JSON = "{'gen_time:'"
+GOOD_JSON = {"gen_time": "9999_99_99_99_99_99", "cause": "", "user": "admin", "time": "N/A", "comment": "N/A"}
+JSON_DECODE_ERROR = "json.decoder.JSONDecodeError"
+EXCEPTION_HANDLED_SYSLOG = "Unable to process reload cause file {}"
+REBOOT_CAUSE_TEST_IDENTIFIER = "process-reboot-cause-test"
+
+
+class TestProcessRebootCause():
+    
+    duthost = None
+    image_ver = None
+    image_major_ver = None
+    image_minor_ver = None
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, duthosts, enum_rand_one_per_hwsku_hostname):
+        if self.duthost == None:
+            self.duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+        skip, reason = check_skip_release(self.duthost, ["201811", "201911"])
+        if skip is True:
+            pytest.skip("Skip test 'process-reboot-cause' for {} running image {} due to reason: {}".format(self.duthost.facts['platform'], self.duthost.os_version, reason))
+        
+        # Get image version on DUT
+        self.image_ver = self.duthost.sonichost.os_version
+
+        # Get major and minor version of image
+        self.image_major_ver = int(self.image_ver.split('.')[0])
+        self.image_minor_ver = int(self.image_ver.split('.')[-1])
+
+
+    ##########################
+    #                        #
+    #      HELPER FNS        #
+    #                        #
+    ##########################
+
+
+    def get_service_status(self):
+        """
+        @summary: Check status of process-reboot-cause.service and return parameters to calling function
+        """
+
+        status = -1
+        main_pid = -1
+        result = ""
+
+        systemctl_output = self.duthost.command(SYSTEMCTL_SHOW_CMD)
+
+        for line in systemctl_output["stdout_lines"]:
+            if "ExecMainPID" in line:
+                main_pid = int(line.split("=")[-1])
+            elif "ExecMainStatus" in line:
+                status = int(line.split("=")[-1])
+            elif "Result" in line:
+                result = line.split("=")[-1]
+
+        return main_pid, status, result
+
+
+    def restart_service(self):
+        logging.info("Restarting process-reboot-cause.service")
+        _ = self.duthost.command(SYSTEMCTL_RESTART_CMD)
+
+
+    def create_json_file(self, filetype=""):
+
+        gen_time = self.duthost.command(REBOOT_CAUSE_GEN_TIME_CMD)["stdout_lines"][0]
+        reboot_cause_file = os.path.join(REBOOT_CAUSE_HISTORY_DIR, REBOOT_CAUSE_FILE_FORMAT.format(gen_time))
+
+        logging.info("Writing '{}' to {} on DUT".format(filetype, reboot_cause_file))
+        _ = self.duthost.command("bash -c 'echo {}>{}'".format(filetype, reboot_cause_file))
+
+        return reboot_cause_file
+
+
+    def remove_json_file(self, reboot_cause_file):
+        logging.info("Clean up the newly created JSON file: {}".format(reboot_cause_file))
+        _ = self.duthost.command('rm -f {}'.format(reboot_cause_file))
+
+
+    def bad_json_file_assertions(self, status, result, journalctl_output):
+        
+        # Check for exeception if image version < 2023110.20 , 20230531.33 or 20220531.53
+        if self.image_major_ver < 20220531 or \
+        (self.image_major_ver == 20231110 and self.image_minor_ver < 20) or \
+        (self.image_major_ver == 20230531 and self.image_minor_ver < 33) or \
+        (self.image_major_ver == 20220531 and self.image_minor_ver < 53):
+
+            logging.info("OS Version {} does not have the patched process-reboot-cause file with try-except block".format(self.image_ver))
+            is_json_decode_error = any(JSON_DECODE_ERROR in line for line in journalctl_output)
+
+            pytest_assert(result == "exit-code")
+            pytest_assert(status == 1)
+            pytest_assert(is_json_decode_error)
+        
+        else:
+            logging.info("OS Version {} has the patched process-reboot-cause file with try-except block".format(self.image_ver))
+            message = EXCEPTION_HANDLED_SYSLOG.format(reboot_cause_file)
+            exception_handled_log = any(message in line for line in journalctl_output)
+            logging.info("exception_handled_log: {}".format(journalctl_output))
+            pytest_assert(result == "success")
+            pytest_assert(status == 0)
+            pytest_assert(exception_handled_log)
+
+
+    def good_json_file_assertions(self, status, result, cause, journalctl_output, statedb_output):
+
+            excpected_reboot_cause = any(cause in line for line in statedb_output)
+            
+            pytest_assert(result == "success")
+            pytest_assert(status == 0)
+            pytest_assert(excpected_reboot_cause)
+
+
+    def process_reboot_cause_file_runner(self, filetype=""):
+
+        # Create a JSON file
+        reboot_cause_file = self.create_json_file(filetype)
+
+        # Restart process-reboot-cause.service
+        self.restart_service()
+
+        # Wait 5 seconds
+        time.sleep(5)
+
+        # Get latest status of the service
+        logging.info("Get latest status of the process-reboot-cause.service")
+        main_pid, status, result = self.get_service_status()
+        journalctl_output = self.duthost.command(JOURNALCTL_CMD.format(main_pid))["stdout_lines"]
+
+        # Get STATE_DB kvps created from latest JSON file
+        statedb_output = self.duthost.command('redis-cli -n 6 HGETALL "REBOOT_CAUSE|9999_99_99_99_99_99"')["stdout_lines"]
+        _ = self.duthost.command('redis-cli -n 6 DEL "REBOOT_CAUSE|9999_99_99_99_99_99"')
+
+
+        # Remove the JSON file
+        self.remove_json_file(reboot_cause_file)
+
+        # Restart process-reboot-cause.service
+        self.restart_service()
+
+        # Return relevant fields
+        return main_pid, status, result, journalctl_output, statedb_output
+
+
+    ##########################
+    #                        #
+    #      TESTS BEGIN       #
+    #                        #
+    ##########################
+
+
+    def test_status_on_boot(self):
+        main_pid, status, result = self.get_service_status()
+
+        pytest_assert(main_pid != -1)
+        pytest_assert(status == 0)
+        pytest_assert(result == "success")
+    
+
+    def test_valid_reboot_causes(self):
+
+        for cause in REBOOT_TYPES:
+            logging.info("Testing valid reboot type: {}".format(cause))
+            
+            GOOD_JSON["cause"] = cause
+            valid_json_str = (str(GOOD_JSON)).replace("'", "\\\"")
+
+            main_pid, status, result, _, statedb_output = self.process_reboot_cause_file_runner(valid_json_str)
+            logging.info("PID: {} Status: {} Result: {} Cause: {} ".format(main_pid, status, result, cause))
+            self.good_json_file_assertions(status, result, cause, _ , statedb_output)
+
+
+    def test_empty_json_file(self):
+
+       main_pid, status, result, journalctl_output, _ = self.process_reboot_cause_file_runner()
+       self.bad_json_file_assertions(status, result, journalctl_output)
+
+
+    def test_malformed_json_file(self):
+
+        main_pid, status, result, journalctl_output, _ = self.process_reboot_cause_file_runner(BAD_JSON)
+        self.bad_json_file_assertions(status, result, journalctl_output)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The [process-reboot-cause](https://github.com/sonic-net/sonic-host-services/blob/master/scripts/process-reboot-cause) populates the STATE_DB with the most recent and 10 previous reboot causes. The script does this by reading `reboot-cause_*.json` files present in `/host/reboot-cause/history` populated by a different script.

This PR addresses the sonic-mgmt test gap for the following scenarios this script might encounter:

**1. test_status_on_boot**

This test asserts that the process-reboot-cause service ran sucessfully on boot, the result of the ExecStart process was successful and it's exit status is 0.

**2. test_empty_json_file**

This test creates an empty JSON file in the history directory and re-runs the process-reboot-cause service. It then asserts, based on the image version, that there was either a JSONDecodeError exception, or if it's a newer image, the exception managed log.

**3. test_malformed_json_file**

Same as the test above, except this time a malformed JSON file is created.

**4. test_valid_reboot_causes**

This test creates a valid JSON file, listing the reboot cause as one of several valid reboot causes. It then asserts that the process-reboot-cause script runs successfully to completion and updated the reboot cause to STATE_DB.

It tests all the valid reboot causes.

**Microsoft ADO:** 29471583

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Addresses sonic-mgmt test gap for process-reboot-cause.py

#### How did you do it?
Added test cases for various scenarios that script might encounter

#### How did you verify/test it?
Ran testcases on the following images:
- [x] 202205
- [x] 202305
- [x] 202311

[test-process-reboot-cause_logs.txt](https://github.com/user-attachments/files/17502877/test-process-reboot-cause_logs.txt)

