### PR TITLE
[COPP][720DT] Fix copp test failure for 720dt

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -81,6 +81,7 @@ class ControlPlaneBaseTest(BaseTest):
                 self.hw_sku == "Cisco-8111-O62C2"):
             self.PPS_LIMIT_MAX = self.PPS_LIMIT * 1.4
         self.asic_type = test_params.get('asic_type', None)
+        self.topo_type = test_params.get('topo_type', None)
 
     def log(self, message, debug=False):
         current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -346,12 +347,12 @@ class DHCPTopoT1Test(PolicyTest):
 class DHCPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
-        # M0 devices have CIR of 300 for DHCP
-        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-G48S4"}:
-            self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
-        elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
+        if self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
             self.PPS_LIMIT = 250
+        # M0 devices have CIR of 300 for DHCP
+        elif self.topo_type in {"m0", "mx"}:
+            self.PPS_LIMIT = 300
         else:
             self.PPS_LIMIT = 100
         self.PPS_LIMIT_MIN = self.PPS_LIMIT * 0.9
@@ -390,12 +391,12 @@ class DHCPTest(PolicyTest):
 class DHCP6Test(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
-        # M0 devices have CIR of 300 for DHCPv6
-        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-G48S4"}:
-            self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
-        elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
+        if self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
             self.PPS_LIMIT = 250
+        # M0 devices have CIR of 300 for DHCP
+        elif self.topo_type in {"m0", "mx"}:
+            self.PPS_LIMIT = 300
         else:
             self.PPS_LIMIT = 100
         self.PPS_LIMIT_MIN = self.PPS_LIMIT * 0.9
@@ -453,12 +454,12 @@ class DHCP6TopoT1Test(PolicyTest):
 class LLDPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
-        # M0 devices have CIR of 300 for LLDP
-        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-G48S4"}:
-            self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
-        elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
+        if self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
             self.PPS_LIMIT = 250
+        # M0 devices have CIR of 300 for DHCP
+        elif self.topo_type in {"m0", "mx"}:
+            self.PPS_LIMIT = 300
         else:
             self.PPS_LIMIT = 100
         self.PPS_LIMIT_MIN = self.PPS_LIMIT * 0.9
@@ -484,13 +485,12 @@ class LLDPTest(PolicyTest):
 class UDLDTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
-        # M0 devices have CIR of 300 for UDLD
-        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-G48S4"}:
-            self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
-        elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
+        if self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
             self.PPS_LIMIT = 250
-
+        # M0 devices have CIR of 300 for DHCP
+        elif self.topo_type in {"m0", "mx"}:
+            self.PPS_LIMIT = 300
         else:
             self.PPS_LIMIT = 100
         self.PPS_LIMIT_MIN = self.PPS_LIMIT * 0.9

--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -347,7 +347,7 @@ class DHCPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for DHCP
-        if self.hw_sku in {"Celestica-E1031-T48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-G48S4"}:
             self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
         elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
@@ -391,7 +391,7 @@ class DHCP6Test(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for DHCPv6
-        if self.hw_sku in {"Celestica-E1031-T48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-G48S4"}:
             self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
         elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
@@ -454,7 +454,7 @@ class LLDPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for LLDP
-        if self.hw_sku in {"Celestica-E1031-T48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-G48S4"}:
             self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
         elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:
@@ -485,7 +485,7 @@ class UDLDTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
         # M0 devices have CIR of 300 for UDLD
-        if self.hw_sku in {"Celestica-E1031-T48S4"}:
+        if self.hw_sku in {"Celestica-E1031-T48S4", "Arista-720DT-G48S4"}:
             self.PPS_LIMIT = 300
         # Marvell based platforms have cir/cbs in steps of 125
         elif self.hw_sku in {"Nokia-M0-7215", "Nokia-7215", "Nokia-7215-A1"}:

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -56,7 +56,8 @@ _COPPTestParameters = namedtuple("_COPPTestParameters",
                                   "nn_target_interface",
                                   "nn_target_namespace",
                                   "send_rate_limit",
-                                  "nn_target_vlanid"])
+                                  "nn_target_vlanid",
+                                  "topo_type"])
 
 _TOR_ONLY_PROTOCOL = ["DHCP", "DHCP6"]
 _TEST_RATE_LIMIT_DEFAULT = 600
@@ -290,7 +291,8 @@ def _copp_runner(dut, ptf, protocol, test_params, dut_type, has_trap=True, skip_
               "send_rate_limit": test_params.send_rate_limit,
               "has_trap": has_trap,
               "hw_sku": dut.facts["hwsku"],
-              "asic_type": dut.facts["asic_type"]}
+              "asic_type": dut.facts["asic_type"],
+              "topo_type": test_params.topo_type}
 
     dut_ip = dut.mgmt_ip
     device_sockets = ["0-{}@tcp://127.0.0.1:10900".format(test_params.nn_target_port),
@@ -326,6 +328,7 @@ def _gather_test_params(tbinfo, duthost, request, duts_minigraph_facts):
     swap_syncd = request.config.getoption("--copp_swap_syncd")
     send_rate_limit = request.config.getoption("--send_rate_limit")
     topo = tbinfo["topo"]["name"]
+    topo_type = tbinfo["topo"]["type"]
     mg_fact = duts_minigraph_facts[duthost.hostname]
 
     port_index_map = {}
@@ -375,7 +378,8 @@ def _gather_test_params(tbinfo, duthost, request, duts_minigraph_facts):
                                nn_target_interface=nn_target_interface,
                                nn_target_namespace=nn_target_namespace,
                                send_rate_limit=send_rate_limit,
-                               nn_target_vlanid=nn_target_vlanid)
+                               nn_target_vlanid=nn_target_vlanid,
+                               topo_type=topo_type)
 
 
 def _setup_testbed(dut, creds, ptf, test_params, tbinfo, upStreamDuthost, is_backend_topology):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
COPP rate of queue4_group3 for Mgmt devices is set to 300. But in copp_test it's expected to be 100 for Arista 720DT. This PR is to fix that.
https://github.com/sonic-net/sonic-buildimage/blob/2c47e35472b1f9fd5801a884ce7993d873c07afa/files/image_config/copp/copp_cfg.j2#L37

#### How did you do it?
Set expected copp rate for 720dt

#### How did you verify/test it?
Run test_copp.py in m0/t0/t1 topos, all passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
