### PR TITLE
fix: skip pfc test for peer-device without fanout

### DIFF
--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -59,6 +59,9 @@ def setup_testbed(fanouthosts, duthost, leaf_fanouts):           # noqa F811
 
     """ Copy the PFC generator to all the leaf fanout switches """
     for peer_device in leaf_fanouts:
+        if peer_device not in fanouthosts:
+            continue
+
         peerdev_ans = fanouthosts[peer_device]
         file_src = os.path.join(os.path.dirname(
             __file__), PFC_GEN_FILE_RELATIVE_PATH)
@@ -92,6 +95,10 @@ def run_test(fanouthosts, duthost, conn_graph_facts, fanout_graph_facts, leaf_fa
         for intf in active_phy_intfs:
             peer_device = conn_facts[intf]['peerdevice']
             peer_port = conn_facts[intf]['peerport']
+
+            if peer_device not in fanouthosts:
+                continue
+
             peerdev_ans = fanouthosts[peer_device]
             fanout_os = peerdev_ans.get_fanout_os()
             fanout_hwsku = fanout_graph_facts[peerdev_ans.hostname]["device_info"]["HwSku"]
@@ -147,6 +154,10 @@ def run_test(fanouthosts, duthost, conn_graph_facts, fanout_graph_facts, leaf_fa
 
                 peer_device = conn_facts[intf]['peerdevice']
                 peer_port = conn_facts[intf]['peerport']
+
+                if peer_device not in fanouthosts:
+                    continue
+
                 peerdev_ans = fanouthosts[peer_device]
                 fanout_os = peerdev_ans.get_fanout_os()
                 fanout_hwsku = fanout_graph_facts[peerdev_ans.hostname]["device_info"]["HwSku"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: for peer device has no peer fanouts. We should skip the pfc test on these peers.

We have already skipped ixia in here: https://github.com/sonic-net/sonic-mgmt/blob/master/tests/conftest.py#L700


Fixes # (issue) 29428890

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
