### PR TITLE
[dhcp_relay] Add stress test for restarting dhcp_relay

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
@@ -1,0 +1,39 @@
+import time
+import ptf.testutils as testutils
+from dhcp_relay_test import DHCPTest
+
+
+class DHCPContinuousStressTest(DHCPTest):
+    """
+    Keep sending packets, but don't verify form ptf side.
+    """
+    def __init__(self):
+        DHCPTest.__init__(self)
+
+    def setUp(self):
+        DHCPTest.setUp(self)
+        self.send_interval = 1 / self.test_params["pps"]
+        self.duration = self.test_params["duration"]
+        self.client_ports = self.other_client_port
+        self.client_ports.append(self.client_port_index)
+
+    def send_packet_with_interval(self, pkt, index):
+        testutils.send_packet(self, index, pkt)
+        time.sleep(self.send_interval)
+
+    def runTest(self):
+        dhcp_discover = self.create_dhcp_discover_packet(self.dest_mac_address, self.client_udp_src_port)
+        dhcp_offer = self.create_dhcp_offer_packet()
+        dhcp_request = self.create_dhcp_request_packet(self.dest_mac_address, self.client_udp_src_port)
+        dhcp_ack = self.create_dhcp_ack_packet()
+
+        start_time = time.time()
+        while time.time() - start_time <= self.duration:
+            for client_port in self.client_ports:
+                self.send_packet_with_interval(dhcp_discover, client_port)
+            for server_port in self.server_port_indices:
+                self.send_packet_with_interval(dhcp_offer, server_port)
+            for client_port in self.client_ports:
+                self.send_packet_with_interval(dhcp_request, client_port)
+            for server_port in self.server_port_indices:
+                self.send_packet_with_interval(dhcp_ack, server_port)

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -799,6 +799,9 @@ class DHCPTest(DataplaneBaseTest):
 
 
 class DHCPContinuousStressTest(DHCPTest):
+    """
+    Keep sending packets, but don't verify form ptf side.
+    """
     def __init__(self):
         DHCPTest.__init__(self)
 

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -3,7 +3,6 @@ import struct
 import ipaddress
 import binascii
 import os
-import time
 
 # Packet Test Framework imports
 import ptf
@@ -796,39 +795,3 @@ class DHCPTest(DataplaneBaseTest):
         if not self.dual_tor and 'other_client_port' in self.test_params:
             self.verify_dhcp_relay_pkt_on_server_port_with_no_padding(
                 self.dest_mac_address, self.client_udp_src_port)
-
-
-class DHCPContinuousStressTest(DHCPTest):
-    """
-    Keep sending packets, but don't verify form ptf side.
-    """
-    def __init__(self):
-        DHCPTest.__init__(self)
-
-    def setUp(self):
-        DHCPTest.setUp(self)
-        self.send_interval = 1 / self.test_params["pps"]
-        self.duration = self.test_params["duration"]
-        self.client_ports = self.other_client_port
-        self.client_ports.append(self.client_port_index)
-
-    def send_packet_with_interval(self, pkt, index):
-        testutils.send_packet(self, index, pkt)
-        time.sleep(self.send_interval)
-
-    def runTest(self):
-        dhcp_discover = self.create_dhcp_discover_packet(self.dest_mac_address, self.client_udp_src_port)
-        dhcp_offer = self.create_dhcp_offer_packet()
-        dhcp_request = self.create_dhcp_request_packet(self.dest_mac_address, self.client_udp_src_port)
-        dhcp_ack = self.create_dhcp_ack_packet()
-
-        start_time = time.time()
-        while time.time() - start_time <= self.duration:
-            for client_port in self.client_ports:
-                self.send_packet_with_interval(dhcp_discover, client_port)
-            for server_port in self.server_port_indices:
-                self.send_packet_with_interval(dhcp_offer, server_port)
-            for client_port in self.client_ports:
-                self.send_packet_with_interval(dhcp_request, client_port)
-            for server_port in self.server_port_indices:
-                self.send_packet_with_interval(dhcp_ack, server_port)

--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -23,7 +23,7 @@ def pytest_addoption(parser):
         "--stress_restart_pps",
         action="store",
         type=int,
-        default=20,
+        default=100,
         help="Set custom restart rounds",
     )
 

--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -1,5 +1,12 @@
 import pytest
 
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert as py_assert
+from tests.dhcp_relay.dhcp_relay_utils import check_routes_to_dhcp_server
+
+SINGLE_TOR_MODE = 'single'
+DUAL_TOR_MODE = 'dual'
+
 
 def pytest_addoption(parser):
     """
@@ -41,3 +48,126 @@ def skip_dhcp_relay_tests(tbinfo):
     """
     if 'backend' in tbinfo['topo']['name']:
         pytest.skip("Skipping dhcp relay tests. Unsupported topology {}".format(tbinfo['topo']['name']))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def check_dhcp_server_enabled(duthost):
+    feature_status_output = duthost.show_and_parse("show feature status")
+    for feature in feature_status_output:
+        if feature["feature"] == "dhcp_server" and feature["state"] == "enabled":
+            pytest.skip("DHCPv4 relay is not supported when dhcp_server is enabled")
+
+
+@pytest.fixture(scope="module")
+def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
+    """ Fixture which returns a list of dictionaries where each dictionary contains
+        data necessary to test one instance of a DHCP relay agent running on the DuT.
+        This fixture is scoped to the module, as the data it gathers can be used by
+        all tests in this module. It does not need to be run before each test.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    dhcp_relay_data_list = []
+
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+    switch_loopback_ip = mg_facts['minigraph_lo_interfaces'][0]['addr']
+
+    # SONiC spawns one DHCP relay agent per VLAN interface configured on the DUT
+    vlan_dict = mg_facts['minigraph_vlans']
+    for vlan_iface_name, vlan_info_dict in list(vlan_dict.items()):
+        # Filter(remove) PortChannel interfaces from VLAN members list
+        vlan_members = [port for port in vlan_info_dict['members'] if 'PortChannel' not in port]
+
+        # Gather information about the downlink VLAN interface this relay agent is listening on
+        downlink_vlan_iface = {}
+        downlink_vlan_iface['name'] = vlan_iface_name
+
+        for vlan_interface_info_dict in mg_facts['minigraph_vlan_interfaces']:
+            if vlan_interface_info_dict['attachto'] == vlan_iface_name:
+                downlink_vlan_iface['addr'] = vlan_interface_info_dict['addr']
+                downlink_vlan_iface['mask'] = vlan_interface_info_dict['mask']
+                break
+
+        # Obtain MAC address of the VLAN interface
+        res = duthost.shell('cat /sys/class/net/{}/address'.format(vlan_iface_name))
+        downlink_vlan_iface['mac'] = res['stdout']
+
+        downlink_vlan_iface['dhcp_server_addrs'] = mg_facts['dhcp_servers']
+
+        # We choose the physical interface where our DHCP client resides to be index of first interface
+        # with alias (ignore PortChannel) in the VLAN
+        client_iface = {}
+        for port in vlan_members:
+            if port in mg_facts['minigraph_port_name_to_alias_map']:
+                break
+        else:
+            continue
+        client_iface['name'] = port
+        client_iface['alias'] = mg_facts['minigraph_port_name_to_alias_map'][client_iface['name']]
+        client_iface['port_idx'] = mg_facts['minigraph_ptf_indices'][client_iface['name']]
+
+        # Obtain uplink port indicies for this DHCP relay agent
+        uplink_interfaces = []
+        uplink_port_indices = []
+        for iface_name, neighbor_info_dict in list(mg_facts['minigraph_neighbors'].items()):
+            if neighbor_info_dict['name'] in mg_facts['minigraph_devices']:
+                neighbor_device_info_dict = mg_facts['minigraph_devices'][neighbor_info_dict['name']]
+                if 'type' in neighbor_device_info_dict and neighbor_device_info_dict['type'] in \
+                        ['LeafRouter', 'MgmtLeafRouter']:
+                    # If this uplink's physical interface is a member of a portchannel interface,
+                    # we record the name of the portchannel interface here, as this is the actual
+                    # interface the DHCP relay will listen on.
+                    iface_is_portchannel_member = False
+                    for portchannel_name, portchannel_info_dict in list(mg_facts['minigraph_portchannels'].items()):
+                        if 'members' in portchannel_info_dict and iface_name in portchannel_info_dict['members']:
+                            iface_is_portchannel_member = True
+                            if portchannel_name not in uplink_interfaces:
+                                uplink_interfaces.append(portchannel_name)
+                            break
+                    # If the uplink's physical interface is not a member of a portchannel,
+                    # add it to our uplink interfaces list
+                    if not iface_is_portchannel_member:
+                        uplink_interfaces.append(iface_name)
+                    uplink_port_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
+
+        other_client_ports_indices = []
+        for iface_name in vlan_members:
+            if mg_facts['minigraph_ptf_indices'][iface_name] == client_iface['port_idx']:
+                pass
+            else:
+                other_client_ports_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
+
+        dhcp_relay_data = {}
+        dhcp_relay_data['downlink_vlan_iface'] = downlink_vlan_iface
+        dhcp_relay_data['client_iface'] = client_iface
+        dhcp_relay_data['other_client_ports'] = other_client_ports_indices
+        dhcp_relay_data['uplink_interfaces'] = uplink_interfaces
+        dhcp_relay_data['uplink_port_indices'] = uplink_port_indices
+        dhcp_relay_data['switch_loopback_ip'] = str(switch_loopback_ip)
+
+        # Obtain MAC address of an uplink interface because vlan mac may be different than that of physical interfaces
+        res = duthost.shell('cat /sys/class/net/{}/address'.format(uplink_interfaces[0]))
+        dhcp_relay_data['uplink_mac'] = res['stdout']
+        dhcp_relay_data['default_gw_ip'] = mg_facts['minigraph_mgmt_interface']['gwaddr']
+
+        dhcp_relay_data_list.append(dhcp_relay_data)
+
+    return dhcp_relay_data_list
+
+
+@pytest.fixture(scope="module")
+def validate_dut_routes_exist(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data):
+    """Fixture to valid a route to each DHCP server exist
+    """
+    py_assert(wait_until(120, 5, 0, check_routes_to_dhcp_server, duthosts[rand_one_dut_hostname],
+                         dut_dhcp_relay_data), "Failed to find route for DHCP server")
+
+
+@pytest.fixture(scope="module")
+def testing_config(duthosts, rand_one_dut_hostname, tbinfo):
+    duthost = duthosts[rand_one_dut_hostname]
+
+    if 'dualtor' in tbinfo['topo']['name']:
+        yield DUAL_TOR_MODE, duthost
+    else:
+        yield SINGLE_TOR_MODE, duthost

--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -1,6 +1,33 @@
 import pytest
 
 
+def pytest_addoption(parser):
+    """
+    Adds options to pytest that are used by the COPP tests.
+    """
+    parser.addoption(
+        "--stress_restart_round",
+        action="store",
+        type=int,
+        default=10,
+        help="Set custom restart rounds",
+    )
+    parser.addoption(
+        "--stress_restart_duration",
+        action="store",
+        type=int,
+        default=90,
+        help="Set custom restart rounds",
+    )
+    parser.addoption(
+        "--stress_restart_pps",
+        action="store",
+        type=int,
+        default=20,
+        help="Set custom restart rounds",
+    )
+
+
 @pytest.fixture(scope="module", autouse=True)
 def skip_dhcp_relay_tests(tbinfo):
     """

--- a/tests/dhcp_relay/dhcp_relay_utils.py
+++ b/tests/dhcp_relay/dhcp_relay_utils.py
@@ -1,0 +1,45 @@
+import ipaddress
+import logging
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
+
+
+def check_routes_to_dhcp_server(duthost, dut_dhcp_relay_data):
+    """Validate there is route on DUT to each DHCP server
+    """
+    default_gw_ip = dut_dhcp_relay_data[0]['default_gw_ip']
+    dhcp_servers = set()
+    for dhcp_relay in dut_dhcp_relay_data:
+        dhcp_servers |= set(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
+
+    for dhcp_server in dhcp_servers:
+        rtInfo = duthost.get_ip_route_info(ipaddress.ip_address(dhcp_server))
+        nexthops = rtInfo["nexthops"]
+        if len(nexthops) == 0:
+            logger.info("Failed to find route to DHCP server '{0}'".format(dhcp_server))
+            return False
+        if len(nexthops) == 1:
+            # if only 1 route to dst available - check that it's not default route via MGMT iface
+            route_index_in_list = 0
+            ip_dst_index = 0
+            route_dst_ip = nexthops[route_index_in_list][ip_dst_index]
+            if route_dst_ip == ipaddress.ip_address(default_gw_ip):
+                logger.info("Found route to DHCP server via default GW(MGMT interface)")
+                return False
+    return True
+
+
+def restart_dhcp_service(duthost):
+    duthost.shell('systemctl reset-failed dhcp_relay')
+    duthost.shell('systemctl restart dhcp_relay')
+    duthost.shell('systemctl reset-failed dhcp_relay')
+
+    def _is_dhcp_relay_ready():
+        output = duthost.shell('docker exec dhcp_relay supervisorctl status | grep dhcp | awk \'{print $2}\'',
+                               module_ignore_errors=True)
+        return (not output['rc'] and output['stderr'] == '' and
+                all(element == 'RUNNING' for element in output['stdout_lines']))
+
+    pytest_assert(wait_until(60, 1, 0, _is_dhcp_relay_ready), "dhcp_relay is not ready after restarting")

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -188,12 +188,12 @@ def restart_dhcp_service(duthost):
     duthost.shell('systemctl reset-failed dhcp_relay')
 
     def _is_dhcp_relay_ready():
-        output = duthost.shell('docker exec dhcp_relay supervisorctl | grep dhcp | awk \'{print $2}\'',
+        output = duthost.shell('docker exec dhcp_relay supervisorctl status | grep dhcp | awk \'{print $2}\'',
                                module_ignore_errors=True)
         return (not output['rc'] and output['stderr'] == '' and
                 all(element == 'RUNNING' for element in output['stdout_lines']))
-    
-    pytest_assert(wait_until(30, 1, 0, _is_dhcp_relay_ready), "dhcp_relay is not ready after restarting")
+
+    pytest_assert(wait_until(60, 1, 0, _is_dhcp_relay_ready), "dhcp_relay is not ready after restarting")
 
 
 def get_subtype_from_configdb(duthost):
@@ -524,76 +524,83 @@ def test_dhcp_relay_random_sport(ptfhost, dut_dhcp_relay_data, validate_dut_rout
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log", is_python3=True)
 
 
-def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
+def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
+                                        request):
     """
     This test case is to make sure DHCPv4 relay would work well when startup with stress packets coming
     """
+    # Only test First Vlan
     pytest_require(len(dut_dhcp_relay_data) >= 1, "Skip because cannot get enough vlan data")
     testing_mode, duthost = testing_config
 
     # Unit: s, indicates duration time for sending stress packets
-    duration = 30
+    duration = request.config.getoption("--stress_restart_duration")
     # Packets sending count per second
-    pps = 20
+    pps = request.config.getoption("--stress_restart_pps")
+    test_rounds = request.config.getoption("--stress_restart_round")
 
-    # Keep sending packets and then restart dhcp_relay
-    ptf_runner(ptfhost, "ptftests", "dhcp_relay_test.DHCPContinuousStressTest", platform_dir="ptftests",
-               params={"hostname": duthost.hostname,
-                       "client_port_index": dut_dhcp_relay_data[0]['client_iface']['port_idx'],
-                        # This port is introduced to test DHCP relay packet received
-                        # on other client port
-                        "other_client_port": repr(dut_dhcp_relay_data[0]['other_client_ports']),
-                        "leaf_port_indices": repr(dut_dhcp_relay_data[0]['uplink_port_indices']),
-                        "num_dhcp_servers": len(dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs']),
-                        "server_ip": dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs'],
-                        "relay_iface_ip": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['addr']),
-                        "relay_iface_mac": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mac']),
-                        "relay_iface_netmask": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mask']),
-                        "dest_mac_address": BROADCAST_MAC,
-                        "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
-                        "switch_loopback_ip": dut_dhcp_relay_data[0]['switch_loopback_ip'],
-                        "uplink_mac": str(dut_dhcp_relay_data[0]['uplink_mac']),
-                        "testing_mode": testing_mode,
-                        "duration": duration,
-                        "pps": pps},
-               log_file="/tmp/dhcp_relay_test.DHCPContinuousStressTest.log", is_python3=True,
-               async_mode=True)
+    for _ in range(test_rounds):
+        # Keep sending packets and then restart dhcp_relay
+        ptf_runner(ptfhost, "ptftests", "dhcp_relay_test.DHCPContinuousStressTest", platform_dir="ptftests",
+                   params={"hostname": duthost.hostname,
+                           "client_port_index": dut_dhcp_relay_data[0]['client_iface']['port_idx'],
+                            # This port is introduced to test DHCP relay packet received
+                            # on other client port
+                            "other_client_port": repr(dut_dhcp_relay_data[0]['other_client_ports']),
+                            "leaf_port_indices": repr(dut_dhcp_relay_data[0]['uplink_port_indices']),
+                            "num_dhcp_servers": len(dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs']),
+                            "server_ip": dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs'],
+                            "relay_iface_ip": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['addr']),
+                            "relay_iface_mac": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mac']),
+                            "relay_iface_netmask": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mask']),
+                            "dest_mac_address": BROADCAST_MAC,
+                            "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
+                            "switch_loopback_ip": dut_dhcp_relay_data[0]['switch_loopback_ip'],
+                            "uplink_mac": str(dut_dhcp_relay_data[0]['uplink_mac']),
+                            "testing_mode": testing_mode,
+                            "duration": duration,
+                            "pps": pps},
+                   log_file="/tmp/dhcp_relay_test.DHCPContinuousStressTest.log", is_python3=True,
+                   async_mode=True)
 
-    restart_dhcp_service(duthost)
-    time.sleep(10)
-    ptfhost.shell("kill -9 $(ps aux | grep DHCPContinuousStress | grep -v 'grep' | awk '{print $2}')",
-                  module_ignore_errors=True)
+        restart_dhcp_service(duthost)
 
-    def _check_socket_buffer():
-        output = duthost.shell('ss -nlpu | grep Vlan | awk \'{print $2}\'',
-                               module_ignore_errors=True)
-        return (not output['rc'] and output['stderr'] == '' and
-                all(element == '0' for element in output['stdout_lines']))
+        # Wait packets send during and after dhcrelay starting
+        time.sleep(10)
+        # Make sure there is not stress packets sent
+        ptfhost.shell("kill -9 $(ps aux | grep DHCPContinuousStress | grep -v 'grep' | awk '{print $2}')",
+                      module_ignore_errors=True)
 
-    # Make sure there are not packets left in socket buffer.
-    pytest_assert(wait_until(30, 1, 0, _check_socket_buffer), "Socket buffer is not zero")
+        def _check_socket_buffer():
+            output = duthost.shell('ss -nlpu | grep Vlan | awk \'{print $2}\'',
+                                   module_ignore_errors=True)
+            return (not output['rc'] and output['stderr'] == '' and len(output['stdout_lines']) != 0 and
+                    all(element == '0' for element in output['stdout_lines']))
 
-    # Run the DHCP relay test on the PTF host, make sure DHCPv4 relay is functionality good
-    ptf_runner(ptfhost, "ptftests", "dhcp_relay_test.DHCPTest", platform_dir="ptftests",
-               params={"hostname": duthost.hostname,
-                       "client_port_index": dut_dhcp_relay_data[0]['client_iface']['port_idx'],
-                        # This port is introduced to test DHCP relay packet received
-                        # on other client port
-                        "other_client_port": repr(dut_dhcp_relay_data[0]['other_client_ports']),
-                        "client_iface_alias": str(dut_dhcp_relay_data[0]['client_iface']['alias']),
-                        "leaf_port_indices": repr(dut_dhcp_relay_data[0]['uplink_port_indices']),
-                        "num_dhcp_servers":
-                            len(dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs']),
-                        "server_ip": dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs'],
-                        "relay_iface_ip": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['addr']),
-                        "relay_iface_mac": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mac']),
-                        "relay_iface_netmask": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mask']),
-                        "dest_mac_address": BROADCAST_MAC,
-                        "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
-                        "switch_loopback_ip": dut_dhcp_relay_data[0]['switch_loopback_ip'],
-                        "uplink_mac": str(dut_dhcp_relay_data[0]['uplink_mac']),
-                        "testing_mode": testing_mode},
-               log_file="/tmp/dhcp_relay_test.stress.DHCPTest.log", is_python3=True)
+        # Make sure there are not packets left in socket buffer.
+        pytest_assert(wait_until(30, 1, 0, _check_socket_buffer), "Socket buffer is not zero")
+
+        # Run the DHCP relay test on the PTF host, make sure DHCPv4 relay is functionality good
+        ptf_runner(ptfhost, "ptftests", "dhcp_relay_test.DHCPTest", platform_dir="ptftests",
+                   params={"hostname": duthost.hostname,
+                           "client_port_index": dut_dhcp_relay_data[0]['client_iface']['port_idx'],
+                            # This port is introduced to test DHCP relay packet received
+                            # on other client port
+                            "other_client_port": repr(dut_dhcp_relay_data[0]['other_client_ports']),
+                            "client_iface_alias": str(dut_dhcp_relay_data[0]['client_iface']['alias']),
+                            "leaf_port_indices": repr(dut_dhcp_relay_data[0]['uplink_port_indices']),
+                            "num_dhcp_servers":
+                                len(dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs']),
+                            "server_ip": dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs'],
+                            "relay_iface_ip": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['addr']),
+                            "relay_iface_mac": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mac']),
+                            "relay_iface_netmask": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mask']),
+                            "dest_mac_address": BROADCAST_MAC,
+                            "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
+                            "switch_loopback_ip": dut_dhcp_relay_data[0]['switch_loopback_ip'],
+                            "uplink_mac": str(dut_dhcp_relay_data[0]['uplink_mac']),
+                            "testing_mode": testing_mode},
+                   log_file="/tmp/dhcp_relay_test.stress.DHCPTest.log", is_python3=True)
 
 
 def get_dhcp_relay_counter(duthost, ifname, type, dir):

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -1,4 +1,3 @@
-import ipaddress
 import pytest
 import random
 import time
@@ -11,11 +10,12 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import check_link_status
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release
 from tests.common import config_reload
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
+from tests.dhcp_relay.dhcp_relay_utils import check_routes_to_dhcp_server, restart_dhcp_service
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0'),
@@ -30,14 +30,6 @@ DUAL_TOR_MODE = 'dual'
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="module", autouse=True)
-def check_dhcp_server_enabled(duthost):
-    feature_status_output = duthost.show_and_parse("show feature status")
-    for feature in feature_status_output:
-        if feature["feature"] == "dhcp_server" and feature["state"] == "enabled":
-            pytest.skip("DHCPv4 relay is not supported when dhcp_server is enabled")
-
-
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
     """Ignore expected failures logs during test execution."""
@@ -50,169 +42,6 @@ def ignore_expected_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
         loganalyzer[rand_one_dut_hostname].ignore_regex.extend(ignoreRegex)
 
     yield
-
-
-@pytest.fixture(scope="module")
-def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
-    """ Fixture which returns a list of dictionaries where each dictionary contains
-        data necessary to test one instance of a DHCP relay agent running on the DuT.
-        This fixture is scoped to the module, as the data it gathers can be used by
-        all tests in this module. It does not need to be run before each test.
-    """
-    duthost = duthosts[rand_one_dut_hostname]
-    dhcp_relay_data_list = []
-
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-
-    switch_loopback_ip = mg_facts['minigraph_lo_interfaces'][0]['addr']
-
-    # SONiC spawns one DHCP relay agent per VLAN interface configured on the DUT
-    vlan_dict = mg_facts['minigraph_vlans']
-    for vlan_iface_name, vlan_info_dict in list(vlan_dict.items()):
-        # Filter(remove) PortChannel interfaces from VLAN members list
-        vlan_members = [port for port in vlan_info_dict['members'] if 'PortChannel' not in port]
-
-        # Gather information about the downlink VLAN interface this relay agent is listening on
-        downlink_vlan_iface = {}
-        downlink_vlan_iface['name'] = vlan_iface_name
-
-        for vlan_interface_info_dict in mg_facts['minigraph_vlan_interfaces']:
-            if vlan_interface_info_dict['attachto'] == vlan_iface_name:
-                downlink_vlan_iface['addr'] = vlan_interface_info_dict['addr']
-                downlink_vlan_iface['mask'] = vlan_interface_info_dict['mask']
-                break
-
-        # Obtain MAC address of the VLAN interface
-        res = duthost.shell('cat /sys/class/net/{}/address'.format(vlan_iface_name))
-        downlink_vlan_iface['mac'] = res['stdout']
-
-        downlink_vlan_iface['dhcp_server_addrs'] = mg_facts['dhcp_servers']
-
-        # We choose the physical interface where our DHCP client resides to be index of first interface
-        # with alias (ignore PortChannel) in the VLAN
-        client_iface = {}
-        for port in vlan_members:
-            if port in mg_facts['minigraph_port_name_to_alias_map']:
-                break
-        else:
-            continue
-        client_iface['name'] = port
-        client_iface['alias'] = mg_facts['minigraph_port_name_to_alias_map'][client_iface['name']]
-        client_iface['port_idx'] = mg_facts['minigraph_ptf_indices'][client_iface['name']]
-
-        # Obtain uplink port indicies for this DHCP relay agent
-        uplink_interfaces = []
-        uplink_port_indices = []
-        for iface_name, neighbor_info_dict in list(mg_facts['minigraph_neighbors'].items()):
-            if neighbor_info_dict['name'] in mg_facts['minigraph_devices']:
-                neighbor_device_info_dict = mg_facts['minigraph_devices'][neighbor_info_dict['name']]
-                if 'type' in neighbor_device_info_dict and neighbor_device_info_dict['type'] in \
-                        ['LeafRouter', 'MgmtLeafRouter']:
-                    # If this uplink's physical interface is a member of a portchannel interface,
-                    # we record the name of the portchannel interface here, as this is the actual
-                    # interface the DHCP relay will listen on.
-                    iface_is_portchannel_member = False
-                    for portchannel_name, portchannel_info_dict in list(mg_facts['minigraph_portchannels'].items()):
-                        if 'members' in portchannel_info_dict and iface_name in portchannel_info_dict['members']:
-                            iface_is_portchannel_member = True
-                            if portchannel_name not in uplink_interfaces:
-                                uplink_interfaces.append(portchannel_name)
-                            break
-                    # If the uplink's physical interface is not a member of a portchannel,
-                    # add it to our uplink interfaces list
-                    if not iface_is_portchannel_member:
-                        uplink_interfaces.append(iface_name)
-                    uplink_port_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
-
-        other_client_ports_indices = []
-        for iface_name in vlan_members:
-            if mg_facts['minigraph_ptf_indices'][iface_name] == client_iface['port_idx']:
-                pass
-            else:
-                other_client_ports_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
-
-        dhcp_relay_data = {}
-        dhcp_relay_data['downlink_vlan_iface'] = downlink_vlan_iface
-        dhcp_relay_data['client_iface'] = client_iface
-        dhcp_relay_data['other_client_ports'] = other_client_ports_indices
-        dhcp_relay_data['uplink_interfaces'] = uplink_interfaces
-        dhcp_relay_data['uplink_port_indices'] = uplink_port_indices
-        dhcp_relay_data['switch_loopback_ip'] = str(switch_loopback_ip)
-
-        # Obtain MAC address of an uplink interface because vlan mac may be different than that of physical interfaces
-        res = duthost.shell('cat /sys/class/net/{}/address'.format(uplink_interfaces[0]))
-        dhcp_relay_data['uplink_mac'] = res['stdout']
-        dhcp_relay_data['default_gw_ip'] = mg_facts['minigraph_mgmt_interface']['gwaddr']
-
-        dhcp_relay_data_list.append(dhcp_relay_data)
-
-    return dhcp_relay_data_list
-
-
-def check_routes_to_dhcp_server(duthost, dut_dhcp_relay_data):
-    """Validate there is route on DUT to each DHCP server
-    """
-    default_gw_ip = dut_dhcp_relay_data[0]['default_gw_ip']
-    dhcp_servers = set()
-    for dhcp_relay in dut_dhcp_relay_data:
-        dhcp_servers |= set(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
-
-    for dhcp_server in dhcp_servers:
-        rtInfo = duthost.get_ip_route_info(ipaddress.ip_address(dhcp_server))
-        nexthops = rtInfo["nexthops"]
-        if len(nexthops) == 0:
-            logger.info("Failed to find route to DHCP server '{0}'".format(dhcp_server))
-            return False
-        if len(nexthops) == 1:
-            # if only 1 route to dst available - check that it's not default route via MGMT iface
-            route_index_in_list = 0
-            ip_dst_index = 0
-            route_dst_ip = nexthops[route_index_in_list][ip_dst_index]
-            if route_dst_ip == ipaddress.ip_address(default_gw_ip):
-                logger.info("Found route to DHCP server via default GW(MGMT interface)")
-                return False
-    return True
-
-
-@pytest.fixture(scope="module")
-def validate_dut_routes_exist(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data):
-    """Fixture to valid a route to each DHCP server exist
-    """
-    pytest_assert(wait_until(120, 5, 0, check_routes_to_dhcp_server, duthosts[rand_one_dut_hostname],
-                             dut_dhcp_relay_data), "Failed to find route for DHCP server")
-
-
-def restart_dhcp_service(duthost):
-    duthost.shell('systemctl reset-failed dhcp_relay')
-    duthost.shell('systemctl restart dhcp_relay')
-    duthost.shell('systemctl reset-failed dhcp_relay')
-
-    def _is_dhcp_relay_ready():
-        output = duthost.shell('docker exec dhcp_relay supervisorctl status | grep dhcp | awk \'{print $2}\'',
-                               module_ignore_errors=True)
-        return (not output['rc'] and output['stderr'] == '' and
-                all(element == 'RUNNING' for element in output['stdout_lines']))
-
-    pytest_assert(wait_until(60, 1, 0, _is_dhcp_relay_ready), "dhcp_relay is not ready after restarting")
-
-
-def get_subtype_from_configdb(duthost):
-    # HEXISTS returns 1 if the key exists, otherwise 0
-    subtype_exist = int(duthost.shell('redis-cli -n 4 HEXISTS "DEVICE_METADATA|localhost" "subtype"')["stdout"])
-    subtype_value = ""
-    if subtype_exist:
-        subtype_value = duthost.shell('redis-cli -n 4 HGET "DEVICE_METADATA|localhost" "subtype"')["stdout"]
-    return subtype_exist, subtype_value
-
-
-@pytest.fixture(scope="module")
-def testing_config(duthosts, rand_one_dut_hostname, tbinfo):
-    duthost = duthosts[rand_one_dut_hostname]
-
-    if 'dualtor' in tbinfo['topo']['name']:
-        yield DUAL_TOR_MODE, duthost
-    else:
-        yield SINGLE_TOR_MODE, duthost
 
 
 def check_interface_status(duthost):
@@ -522,85 +351,6 @@ def test_dhcp_relay_random_sport(ptfhost, dut_dhcp_relay_data, validate_dut_rout
                            "uplink_mac": str(dhcp_relay['uplink_mac']),
                            "testing_mode": testing_mode},
                    log_file="/tmp/dhcp_relay_test.DHCPTest.log", is_python3=True)
-
-
-def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
-                                        request):
-    """
-    This test case is to make sure DHCPv4 relay would work well when startup with stress packets coming
-    """
-    # Only test First Vlan
-    pytest_require(len(dut_dhcp_relay_data) >= 1, "Skip because cannot get enough vlan data")
-    testing_mode, duthost = testing_config
-
-    # Unit: s, indicates duration time for sending stress packets
-    duration = request.config.getoption("--stress_restart_duration")
-    # Packets sending count per second
-    pps = request.config.getoption("--stress_restart_pps")
-    test_rounds = request.config.getoption("--stress_restart_round")
-
-    for _ in range(test_rounds):
-        # Keep sending packets and then restart dhcp_relay
-        ptf_runner(ptfhost, "ptftests", "dhcp_relay_test.DHCPContinuousStressTest", platform_dir="ptftests",
-                   params={"hostname": duthost.hostname,
-                           "client_port_index": dut_dhcp_relay_data[0]['client_iface']['port_idx'],
-                            # This port is introduced to test DHCP relay packet received
-                            # on other client port
-                            "other_client_port": repr(dut_dhcp_relay_data[0]['other_client_ports']),
-                            "leaf_port_indices": repr(dut_dhcp_relay_data[0]['uplink_port_indices']),
-                            "num_dhcp_servers": len(dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs']),
-                            "server_ip": dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs'],
-                            "relay_iface_ip": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['addr']),
-                            "relay_iface_mac": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mac']),
-                            "relay_iface_netmask": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mask']),
-                            "dest_mac_address": BROADCAST_MAC,
-                            "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
-                            "switch_loopback_ip": dut_dhcp_relay_data[0]['switch_loopback_ip'],
-                            "uplink_mac": str(dut_dhcp_relay_data[0]['uplink_mac']),
-                            "testing_mode": testing_mode,
-                            "duration": duration,
-                            "pps": pps},
-                   log_file="/tmp/dhcp_relay_test.DHCPContinuousStressTest.log", is_python3=True,
-                   async_mode=True)
-
-        restart_dhcp_service(duthost)
-
-        # Wait packets send during and after dhcrelay starting
-        time.sleep(10)
-        # Make sure there is not stress packets sent
-        ptfhost.shell("kill -9 $(ps aux | grep DHCPContinuousStress | grep -v 'grep' | awk '{print $2}')",
-                      module_ignore_errors=True)
-
-        def _check_socket_buffer():
-            output = duthost.shell('ss -nlpu | grep Vlan | awk \'{print $2}\'',
-                                   module_ignore_errors=True)
-            return (not output['rc'] and output['stderr'] == '' and len(output['stdout_lines']) != 0 and
-                    all(element == '0' for element in output['stdout_lines']))
-
-        # Make sure there are not packets left in socket buffer.
-        pytest_assert(wait_until(30, 1, 0, _check_socket_buffer), "Socket buffer is not zero")
-
-        # Run the DHCP relay test on the PTF host, make sure DHCPv4 relay is functionality good
-        ptf_runner(ptfhost, "ptftests", "dhcp_relay_test.DHCPTest", platform_dir="ptftests",
-                   params={"hostname": duthost.hostname,
-                           "client_port_index": dut_dhcp_relay_data[0]['client_iface']['port_idx'],
-                            # This port is introduced to test DHCP relay packet received
-                            # on other client port
-                            "other_client_port": repr(dut_dhcp_relay_data[0]['other_client_ports']),
-                            "client_iface_alias": str(dut_dhcp_relay_data[0]['client_iface']['alias']),
-                            "leaf_port_indices": repr(dut_dhcp_relay_data[0]['uplink_port_indices']),
-                            "num_dhcp_servers":
-                                len(dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs']),
-                            "server_ip": dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs'],
-                            "relay_iface_ip": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['addr']),
-                            "relay_iface_mac": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mac']),
-                            "relay_iface_netmask": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mask']),
-                            "dest_mac_address": BROADCAST_MAC,
-                            "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
-                            "switch_loopback_ip": dut_dhcp_relay_data[0]['switch_loopback_ip'],
-                            "uplink_mac": str(dut_dhcp_relay_data[0]['uplink_mac']),
-                            "testing_mode": testing_mode},
-                   log_file="/tmp/dhcp_relay_test.stress.DHCPTest.log", is_python3=True)
 
 
 def get_dhcp_relay_counter(duthost, ifname, type, dir):

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -1,3 +1,4 @@
+import pytest
 import time
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
@@ -6,6 +7,11 @@ from tests.dhcp_relay.dhcp_relay_utils import restart_dhcp_service
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 from tests.ptf_runner import ptf_runner
+
+pytestmark = [
+    pytest.mark.topology('t0', 'm0'),
+    pytest.mark.device_type('vs')
+]
 
 BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -1,0 +1,91 @@
+import time
+
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
+from tests.dhcp_relay.dhcp_relay_utils import restart_dhcp_service
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.utilities import wait_until
+from tests.ptf_runner import ptf_runner
+
+BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
+DEFAULT_DHCP_CLIENT_PORT = 68
+
+
+def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
+                                        request, setup_standby_ports_on_rand_unselected_tor,
+                                        toggle_all_simulator_ports_to_rand_selected_tor_m):      # noqa F811
+    """
+    This test case is to make sure DHCPv4 relay would work well when startup with stress packets coming
+    """
+    # Only test First Vlan
+    pytest_require(len(dut_dhcp_relay_data) >= 1, "Skip because cannot get enough vlan data")
+    testing_mode, duthost = testing_config
+
+    # Unit: s, indicates duration time for sending stress packets
+    duration = request.config.getoption("--stress_restart_duration")
+    # Packets sending count per second
+    pps = request.config.getoption("--stress_restart_pps")
+    test_rounds = request.config.getoption("--stress_restart_round")
+
+    for _ in range(test_rounds):
+        # Keep sending packets and then restart dhcp_relay
+        ptf_runner(ptfhost, "ptftests", "dhcp_relay_stress_test.DHCPContinuousStressTest", platform_dir="ptftests",
+                   params={"hostname": duthost.hostname,
+                           "client_port_index": dut_dhcp_relay_data[0]['client_iface']['port_idx'],
+                            # This port is introduced to test DHCP relay packet received
+                            # on other client port
+                            "other_client_port": repr(dut_dhcp_relay_data[0]['other_client_ports']),
+                            "leaf_port_indices": repr(dut_dhcp_relay_data[0]['uplink_port_indices']),
+                            "num_dhcp_servers": len(dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs']),
+                            "server_ip": dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs'],
+                            "relay_iface_ip": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['addr']),
+                            "relay_iface_mac": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mac']),
+                            "relay_iface_netmask": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mask']),
+                            "dest_mac_address": BROADCAST_MAC,
+                            "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
+                            "switch_loopback_ip": dut_dhcp_relay_data[0]['switch_loopback_ip'],
+                            "uplink_mac": str(dut_dhcp_relay_data[0]['uplink_mac']),
+                            "testing_mode": testing_mode,
+                            "duration": duration,
+                            "pps": pps},
+                   log_file="/tmp/dhcp_relay_stress_test.DHCPContinuousStressTest.log", is_python3=True,
+                   async_mode=True)
+
+        restart_dhcp_service(duthost)
+
+        # Wait packets send during and after dhcrelay starting
+        time.sleep(10)
+        # Make sure there is not stress packets sent
+        ptfhost.shell("kill -9 $(ps aux | grep DHCPContinuousStress | grep -v 'grep' | awk '{print $2}')",
+                      module_ignore_errors=True)
+
+        def _check_socket_buffer():
+            output = duthost.shell('ss -nlpu | grep Vlan | awk \'{print $2}\'',
+                                   module_ignore_errors=True)
+            return (not output['rc'] and output['stderr'] == '' and len(output['stdout_lines']) != 0 and
+                    all(element == '0' for element in output['stdout_lines']))
+
+        # Make sure there are not packets left in socket buffer.
+        pytest_assert(wait_until(30, 1, 0, _check_socket_buffer), "Socket buffer is not zero")
+
+        # Run the DHCP relay test on the PTF host, make sure DHCPv4 relay is functionality good
+        ptf_runner(ptfhost, "ptftests", "dhcp_relay_test.DHCPTest", platform_dir="ptftests",
+                   params={"hostname": duthost.hostname,
+                           "client_port_index": dut_dhcp_relay_data[0]['client_iface']['port_idx'],
+                            # This port is introduced to test DHCP relay packet received
+                            # on other client port
+                            "other_client_port": repr(dut_dhcp_relay_data[0]['other_client_ports']),
+                            "client_iface_alias": str(dut_dhcp_relay_data[0]['client_iface']['alias']),
+                            "leaf_port_indices": repr(dut_dhcp_relay_data[0]['uplink_port_indices']),
+                            "num_dhcp_servers":
+                                len(dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs']),
+                            "server_ip": dut_dhcp_relay_data[0]['downlink_vlan_iface']['dhcp_server_addrs'],
+                            "relay_iface_ip": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['addr']),
+                            "relay_iface_mac": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mac']),
+                            "relay_iface_netmask": str(dut_dhcp_relay_data[0]['downlink_vlan_iface']['mask']),
+                            "dest_mac_address": BROADCAST_MAC,
+                            "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
+                            "switch_loopback_ip": dut_dhcp_relay_data[0]['switch_loopback_ip'],
+                            "uplink_mac": str(dut_dhcp_relay_data[0]['uplink_mac']),
+                            "testing_mode": testing_mode},
+                   log_file="/tmp/dhcp_relay_test.stress.DHCPTest.log", is_python3=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Address test gap for this change: https://github.com/sonic-net/sonic-buildimage/pull/20021
Prevously, dhcrelay would hit the issue that it wouldn't relay any packets if there are packets come when dhcrelay startup. This issue has been fixed from image side by https://github.com/sonic-net/sonic-buildimage/pull/20021. This PR is to add test for it.

#### How did you do it?
Add stress test with dhcp_relay restart:
1) Keep sending DHCP packets
2) Restart dhcp_relay
3) Check socket buffer
4) Run general dhcp relay test.

#### How did you verify/test it?
Run test on m0/t0/dualtor topos, all passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
