### PR TITLE
[Nokia-7215] Improve test_reboot stability at teardown stage

### DIFF
--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -54,6 +54,8 @@ def teardown_module(duthosts, enum_rand_one_per_hwsku_hostname,
         "Tearing down: to make sure all the critical services, interfaces and transceivers are good")
     interfaces = conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {})
     wait_for_startup(duthost, localhost, delay=10, timeout=300)
+    if duthost.facts['hwsku'] in {"Nokia-M0-7215", "Nokia-7215"}:
+        wait_critical_processes(duthost)
     check_critical_processes(duthost, watch_secs=10)
     check_interfaces_and_services(duthost, interfaces, xcvr_skip_list)
     if duthost.is_supervisor_node():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Nokia-7215 has low performance. After device reboot, it's critical processes may not be fully up at the time SSH is reachable. For this platform, I add `wait_critical_processes` at teardown stage to improve the test stability.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Improve the test_reboot stability on Nokia-7215 platform.

#### How did you do it?
Add `wait_critical_processes` at teardown stage.

#### How did you verify/test it?
Verified on Nokia-7215 M0 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
