### PR TITLE
[Test Gap] Add a test script to cover show ip bgp nettwork

### DIFF
--- a/tests/bgp/test_bgp_command.py
+++ b/tests/bgp/test_bgp_command.py
@@ -39,15 +39,32 @@ def test_bgp_network_command(
         bgp_network_cmd = "show ipv6 bgp network"
         bgp_docker_cmd = 'docker exec -i bgp vtysh -c "show bgp ipv6 all"'
 
-    bgp_network_output = duthost.shell(bgp_network_cmd)["stdout"]
+    bgp_network_result = duthost.shell(bgp_network_cmd)
+    bgp_network_output = bgp_network_result["stdout"]
     pytest_assert(
-        "*=" in bgp_network_output, "Failed to run '{}' command".format(bgp_network_cmd)
+        bgp_network_result["rc"] == 0,
+        "{} return value is not 0, output={}".format(
+            bgp_network_cmd, bgp_network_output
+        ),
+    )
+    pytest_assert(
+        "*=" in bgp_network_output,
+        "Failed to run '{}' command, output={}".format(
+            bgp_network_cmd, bgp_network_output
+        ),
     )
 
-    bgp_docker_output = duthost.shell(bgp_docker_cmd)["stdout"]
+    bgp_docker_result = duthost.shell(bgp_docker_cmd)
+    bgp_docker_output = bgp_docker_result["stdout"]
+    pytest_assert(
+        bgp_docker_result["rc"] == 0,
+        "{} return value is not 0, output:{}".format(bgp_docker_cmd, bgp_docker_output),
+    )
     pytest_assert(
         "*=" in bgp_docker_output,
-        "Failed to run '{}' command".format(bgp_docker_output),
+        "Failed to run '{}' command, output={}".format(
+            bgp_docker_cmd, bgp_docker_output
+        ),
     )
     # Remove the first two lines from the docker command output
     bgp_docker_output_lines = bgp_docker_output.splitlines()[2:]

--- a/tests/bgp/test_bgp_command.py
+++ b/tests/bgp/test_bgp_command.py
@@ -5,7 +5,10 @@ import re
 from tests.common.helpers.assertions import pytest_assert
 
 
-pytestmark = [pytest.mark.topology("any")]
+pytestmark = [
+    pytest.mark.topology("t0", "t1", "m0", "mx"),
+    pytest.mark.device_type('vs')
+]
 
 logger = logging.getLogger(__name__)
 

--- a/tests/bgp/test_bgp_command.py
+++ b/tests/bgp/test_bgp_command.py
@@ -1,0 +1,85 @@
+import pytest
+import logging
+import re
+
+from tests.common.helpers.assertions import pytest_assert
+
+
+pytestmark = [pytest.mark.topology("any")]
+
+logger = logging.getLogger(__name__)
+
+
+# Function to parse the "Displayed X routes and Y total paths" line
+def parse_routes_and_paths(output):
+    match = re.search(r"Displayed\s+(\d+)\s+routes\s+and\s+(\d+)\s+total paths", output)
+    if match:
+        routes = int(match.group(1))
+        paths = int(match.group(2))
+        return routes, paths
+    return None
+
+
+@pytest.mark.parametrize("ip_version", ["ipv4", "ipv6"])
+def test_bgp_network_command(
+    duthosts, enum_rand_one_per_hwsku_frontend_hostname, ip_version
+):
+    """
+    @summary: This test case is to verify the output of "show ip bgp network" command
+    if it matches the output of "docker exec -i bgp vtysh -c show bgp ipv4 all" command
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    if ip_version == "ipv4":
+        bgp_network_cmd = "show ip bgp network"
+        bgp_docker_cmd = 'docker exec -i bgp vtysh -c "show bgp ipv4 all"'
+    elif ip_version == "ipv6":
+        bgp_network_cmd = "show ipv6 bgp network"
+        bgp_docker_cmd = 'docker exec -i bgp vtysh -c "show bgp ipv6 all"'
+
+    bgp_network_output = duthost.shell(bgp_network_cmd)["stdout"]
+    pytest_assert(
+        "*=" in bgp_network_output, "Failed to run '{}' command".format(bgp_network_cmd)
+    )
+
+    bgp_docker_output = duthost.shell(bgp_docker_cmd)["stdout"]
+    pytest_assert(
+        "*=" in bgp_docker_output,
+        "Failed to run '{}' command".format(bgp_docker_output),
+    )
+    # Remove the first two lines from the docker command output
+    bgp_docker_output_lines = bgp_docker_output.splitlines()[2:]
+    bgp_docker_output_modified = "\n".join(bgp_docker_output_lines)
+
+    pytest_assert(
+        bgp_network_output == bgp_docker_output_modified,
+        "The output of {} and {} mismatch".format(bgp_network_cmd, bgp_docker_cmd),
+    )
+
+    # Parse routes and paths from both outputs
+    bgp_network_routes_and_paths = parse_routes_and_paths(bgp_network_output)
+    bgp_docker_routes_and_paths = parse_routes_and_paths(bgp_docker_output)
+    logger.info(
+        "Routes and paths from '{}': {}".format(
+            bgp_network_cmd, bgp_network_routes_and_paths
+        )
+    )
+    logger.info(
+        "Routes and paths from '{}': {}".format(
+            bgp_docker_cmd, bgp_docker_routes_and_paths
+        )
+    )
+
+    if bgp_network_routes_and_paths is None or bgp_docker_routes_and_paths is None:
+        pytest_assert(
+            bgp_network_routes_and_paths is not None
+            and bgp_docker_routes_and_paths is not None,
+            "Failed to parse routes and paths from one of the outputs.",
+        )
+
+    # Compare the routes and paths
+    pytest_assert(
+        bgp_network_routes_and_paths == bgp_docker_routes_and_paths,
+        "Routes and total path value are mismatched: {} != {}".format(
+            bgp_network_routes_and_paths, bgp_docker_routes_and_paths
+        ),
+    )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Address test gap https://github.com/sonic-net/sonic-mgmt/issues/5069
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To address test gap https://github.com/sonic-net/sonic-mgmt/issues/5069
#### How did you do it?

1. Compare the output of show ip bgp network and docker exec -i bgp vtysh -c "show bgp ipv4 all"
2. Compare the routes and total path value is equal or not for both command
3. Both cover ipv4 and ipv6 command.

#### How did you verify/test it?
Run `bgp/test_bgp_command.py`

#### Any platform specific information?
All platforms

#### Supported testbed topology if it's a new test case?
All topologies

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
