### PR TITLE
Revert #14596 - Remove any null characters when parsing string in test_snmp_phy_entity

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -808,8 +808,6 @@ def redis_hgetall(duthost, db_id, key):
         return {}
     # fix to make literal_eval() work with nested dictionaries
     content = content.replace("'{", '"{').replace("}'", '}"')
-    # Remove any null characters
-    content = content.replace('\x00', '')
     return ast.literal_eval(content)
 
 


### PR DESCRIPTION
This reverts commit 701e39e0b99b61a6d68ce52419049d1e6b0a936d.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Revert #14596 as it was temporary optics

#### How did you do it?

#### How did you verify/test it?
Validate it in internal setup, TRANSCEIVER_INFO|Ethernet302 in STATE_DB is empty at the moment.

#### Any platform specific information?
str3-7060x6-64pe-1
#### Supported testbed topology if it's a new test case?
t0-standalone-32
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
