### PR TITLE
[arp_update] Verify that kernel/APPL_DB MAC mismatch is corrected

### DIFF
--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -1,0 +1,68 @@
+# Test cases to validate functionality of the arp_update script
+
+import logging
+import pytest
+
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
+from tests.common.fixtures.ptfhost_utils import setup_vlan_arp_responder  # noqa: F401
+from tests.common.helpers.assertions import pytest_assert as pt_assert
+from tests.common.utilities import wait_until
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology("t0")
+]
+
+
+@pytest.fixture
+def setup(rand_selected_dut):
+    cmds = [
+        "docker exec swss supervisorctl stop arp_update",
+        "ip neigh flush all"
+    ]
+    rand_selected_dut.shell_cmds(cmds)
+    yield
+    cmds[0] = "docker exec swss supervisorctl start arp_update"
+    # rand_selected_dut.shell_cmds(cmds)
+
+
+def neighbor_learned(dut, target_ip):
+    neigh_output = dut.shell(f"ip neigh show {target_ip}")['stdout']
+    return "REACHABLE" in neigh_output or "STALE" in neigh_output
+
+
+@pytest.mark.parametrize("ip_version", [4, 6])
+def test_kernel_asic_mac_mismatch(
+    toggle_all_simulator_ports_to_rand_selected_tor, config_facts,  # noqa: F811
+    rand_selected_dut, ip_version, setup_vlan_arp_responder  # noqa: F811
+):
+    vlan_name, ipv4_base, ipv6_base = setup_vlan_arp_responder
+    if ip_version == 4:
+        target_ip = ipv4_base.ip + 2
+    else:
+        target_ip = ipv6_base.ip + 2
+
+    rand_selected_dut.shell(f"ping -c1 -W1 {target_ip}; true")
+
+    wait_until(10, 1, 0, neighbor_learned, rand_selected_dut, target_ip)
+
+    neighbor_info = rand_selected_dut.shell(f"ip neigh show {target_ip}")["stdout"].split()
+    pt_assert(neighbor_info[2] == vlan_name)
+
+    asic_db_mac = rand_selected_dut.shell(
+        f"sonic-db-cli APPL_DB hget 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh'"
+    )['stdout']
+    pt_assert(neighbor_info[4].lower() == asic_db_mac.lower())
+
+    rand_selected_dut.shell(
+        f"sonic-db-cli APPL_DB hset 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh' '00:00:00:00:00:00'"
+    )
+    asic_db_mac = rand_selected_dut.shell(
+        f"sonic-db-cli APPL_DB hget 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh'"
+    )['stdout']
+    pt_assert(neighbor_info[4].lower() != asic_db_mac.lower())
+
+    rand_selected_dut.shell("docker exec swss supervisorctl start arp_update")
+
+    wait_until(10, 1, 0, lambda dut, ip: not neighbor_learned(dut, ip), rand_selected_dut, target_ip)

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -28,13 +28,18 @@ def setup(rand_selected_dut):
 
 
 def neighbor_learned(dut, target_ip):
-    neigh_output = dut.shell(f"ip neigh show {target_ip}")['stdout']
-    return "REACHABLE" in neigh_output or "STALE" in neigh_output
+    neigh_output = dut.shell(f"ip neigh show {target_ip}")['stdout'].strip()
+    logger.info(f"DUT neighbor entry: {neigh_output}")
+    return neigh_output and ("REACHABLE" in neigh_output or "STALE" in neigh_output)
 
 
-@pytest.mark.parametrize("ip_version", [4, 6])
+def ip_version_string(version):
+    return f"ipv{version}"
+
+
+@pytest.mark.parametrize("ip_version", [4, 6], ids=ip_version_string)
 def test_kernel_asic_mac_mismatch(
-    toggle_all_simulator_ports_to_rand_selected_tor, config_facts,  # noqa: F811
+    toggle_all_simulator_ports_to_rand_selected_tor,  # noqa: F811
     rand_selected_dut, ip_version, setup_vlan_arp_responder  # noqa: F811
 ):
     vlan_name, ipv4_base, ipv6_base = setup_vlan_arp_responder

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -60,6 +60,9 @@ def test_kernel_asic_mac_mismatch(
     )['stdout']
     pt_assert(neighbor_info[4].lower() == asic_db_mac.lower())
 
+    logger.info(f"Neighbor {target_ip} has been learned, APPL_DB and kernel are in sync")
+
+    logger.info("Manually setting APPL_DB MAC address")
     rand_selected_dut.shell(
         f"sonic-db-cli APPL_DB hset 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh' '00:00:00:00:00:00'"
     )
@@ -67,6 +70,7 @@ def test_kernel_asic_mac_mismatch(
         f"sonic-db-cli APPL_DB hget 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh'"
     )['stdout']
     pt_assert(neighbor_info[4].lower() != asic_db_mac.lower())
+    logger.info("APPL_DB and kernel are out of sync (expected)")
 
     rand_selected_dut.shell("docker exec swss supervisorctl start arp_update")
 

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -180,8 +180,11 @@ def copy_arp_responder_py(ptfhost):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def setup_vlan_arp_responder(config_facts, ptfhost, rand_selected_dut, tbinfo):
+def setup_vlan_arp_responder(ptfhost, rand_selected_dut, tbinfo):
     arp_responder_cfg = {}
+    config_facts = rand_selected_dut.config_facts(
+        host=rand_selected_dut.hostname, source="running"
+    )['ansible_facts']
     vlan_intf_config = config_facts['VLAN_INTERFACE']
     for vlan, attrs in vlan_intf_config.items():
         for val in attrs:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #14525 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
It is possible for kernel neighbor information to fall out of sync with the APPL_DB neighbor table.

#### How did you do it?
Manually change the APPL_DB neighbor table entry, then verify that the `arp_update` script is able to flush the out of sync neighbor.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
