### PR TITLE
[202405] Xfail copp add/remove trap tests on 7050CX3 SKUs

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -230,11 +230,25 @@ copp/test_copp.py::TestCOPP::test_add_new_trap:
     conditions:
       - "is_multi_asic==True"
 
+  xfail:
+    reason: "Can't install trap on broadcom 7050CX3 SKUs successfully"
+    conditions:
+      - "hwsku in ['Arista-7050CX3-32C-C32', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
+      - "release in ['202405']"
+      - https://github.com/sonic-net/sonic-buildimage/issues/20081
+
 copp/test_copp.py::TestCOPP::test_remove_trap:
   skip:
     reason: "Copp test_remove_trap is not yet supported on multi-asic platform"
     conditions:
       - "is_multi_asic==True"
+
+  xfail:
+    reason: "Can't uninstall trap on broadcom 7050CX3 SKUs successfully"
+    conditions:
+      - "hwsku in ['Arista-7050CX3-32C-C32', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
+      - "release in ['202405']"
+      - https://github.com/sonic-net/sonic-buildimage/issues/20081
 
 copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
   skip:


### PR DESCRIPTION
-->
### Description of PR
Adding and removing traps still unsupported for 7050CX3 SKUs in 202405 as well, so should continue to xfail tests.

Same as https://github.com/sonic-net/sonic-mgmt/pull/14219 but for 202405 since tests should continue to be xfailed

Summary:
Fixes https://github.com/aristanetworks/sonic-qual.msft/issues/200

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

