### PR TITLE
Improve the error tolerance for drop counters test

### DIFF
--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -115,10 +115,16 @@ def verify_drop_counters(duthosts, asic_index, dut_iface, get_cnt_cli_cmd, colum
 
     if not wait_until(25, 1, 0, _check_drops_on_dut):
         # We were seeing a few more drop counters than expected, so we are allowing a small margin of error
-        DEOP_MARGIN = 10
+        # The max number of unexpected drop we see equals to the number of vlan members in t0 topology
+        duthost = duthosts.frontend_nodes[0]
+        mg_facts = duthost.minigraph_facts(host=duthost.hostname)["ansible_facts"]
+        DROP_MARGIN = 0 if mg_facts['minigraph_vlans'] else 10
+        for vlan in mg_facts['minigraph_vlans']:
+            DROP_MARGIN += len(mg_facts['minigraph_vlans'][vlan]['members'])
+        logger.info(f"The DROP_MARGIN is {DROP_MARGIN}")
         actual_drop = _get_drops_across_all_duthosts()
         for drop in actual_drop:
-            if drop >= packets_count and drop <= packets_count + DEOP_MARGIN:
+            if drop >= packets_count and drop <= packets_count + DROP_MARGIN:
                 logger.warning("Actual drops {} exceeded expected drops {} on iface {}\n".format(
                     actual_drop, packets_count, dut_iface))
                 break


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
On T0 testbed, sometimes we observed additional drops which equals to the number of vlan members.
Those drops are caused by the background packets in the test environment and should be tolerated in the test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To improve the error tolerance for drop counters test.
#### How did you do it?
Increase the DROP_MARGIN to the number of vlan members for t0 topology.
#### How did you verify/test it?
Run the test in our regression for weeks, it is passing.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
