### PR TITLE
Modifying date time pattern match to pass clock test case

### DIFF
--- a/tests/clock/test_clock.py
+++ b/tests/clock/test_clock.py
@@ -100,13 +100,13 @@ class ClockUtils:
         """
         with allure.step('Verify output of show clock'):
             try:
-                timezone_str = show_clock_output.split()[-1].strip()
+                timezone_str = show_clock_output.split()[-2].strip()
                 logging.info(f'Timezone str: "{timezone_str}"')
 
                 date_time_to_parse = show_clock_output.replace(timezone_str, '').strip()
                 logging.info(f'Time and date to parse: "{date_time_to_parse}"')
 
-                datetime_obj = dt.datetime.strptime(date_time_to_parse, '%a %d %b %Y %I:%M:%S %p')
+                datetime_obj = dt.datetime.strptime(date_time_to_parse, '%a %b %d %H:%M:%S %p %Y')
                 logging.info(f'Datetime object: "{datetime_obj}"\t|\tType: {type(datetime_obj)}')
             except ValueError:
                 pytest.fail(f'Show clock output is not valid.\nOutput: "{show_clock_output}"')


### PR DESCRIPTION
### Description of PR
Clock module test cases failing as the show clock command output format is changed.
Modifying date time pattern match as per latest sonic show clock output

Summary:
Show clock command output format has been changed in master and 202405 sonic.
In 202405 and master shows as below

`root@sonic:~# show clock
Tue Sep 17 04:47:53 PM IDT 2024`

but test case is trying to match for the below pattern that shown in earlier version of sonic
In earlier version of sonic,
`admin@sonic:~$ show clock
Tue 17 Sep 2024 01:56:33 PM UTC`

Test case pattern match need change and same is done in this PR.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [*] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [*] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
