### PR TITLE
[test gap] Test gap to cover advertising through network command in BGP

### DIFF
--- a/tests/bgp/test_bgp_route_neigh_learning.py
+++ b/tests/bgp/test_bgp_route_neigh_learning.py
@@ -1,0 +1,78 @@
+import pytest
+import logging
+from tests.common.helpers.assertions import pytest_assert as py_assert
+pytestmark = [
+    pytest.mark.topology('t0'),
+    pytest.mark.device_type('vs')
+]
+
+Logger = logging.getLogger(__name__)
+
+V4_PREFIX = "77.88.99.1"
+V4_MASK = "32"
+
+
+@pytest.fixture(name="setUp", scope="module")
+def fixture_setUp(nbrhosts):
+    '''
+    This fixture setup filters the T1 neigbor names from the nbrhosts. and T the end cleans up the routes
+    from the T1 neighbors.
+    '''
+    data = {}
+    data['nbr'] = nbrhosts
+    data['T1'] = []
+    nbrnames = list(nbrhosts.keys())
+    count = 2
+    for name in nbrnames:
+        if 'T1' in name:
+            data['T1'].append(name)
+            count -= 1
+        if count == 0:
+            break
+    yield data
+
+    Logger.info("Performing cleanup")
+    for name in data['T1']:
+        # remove the route in the neighbor T1 eos device
+        cmds = ["configure",
+                "router bgp 64600",
+                "address-family ipv4",
+                "no network {}/{}".format(V4_PREFIX, V4_MASK),
+                "no interface loopback 1",
+                "exit"
+                ]
+        Logger.info("Route, IP and Loopback 1 remvoed from %s", name)
+        data['nbr'][name]['host'].run_command_list(cmds)
+
+
+def run_bgp_neighbor_route_learning(duthosts, enum_frontend_dut_hostname, data):
+    """ Route added on All neighbor should be learned by the DUT"""
+    Logger.info("Adding routes on neighbors")
+
+    for name in data['T1']:
+        # add a route in the neighbor T1 eos device
+        cmds = ["configure",
+                "interface loopback 1",
+                "ip address {}/{}".format(V4_PREFIX, V4_MASK),
+                "exit",
+                "router bgp 64600",
+                "address-family ipv4",
+                "network {}/{}".format(V4_PREFIX, V4_MASK),
+                "exit"
+                ]
+        data['nbr'][name]['host'].run_command_list(cmds)
+        Logger.info("Route %s added to :%s", V4_PREFIX, name)
+
+    duthost = duthosts[enum_frontend_dut_hostname]
+    #  redis-cli -n 0  hget "ROUTE_TABLE:99.99.99.99" 'nexthop'
+    Logger.info("checking  DUT for route %s", V4_PREFIX)
+    cmd = "redis-cli -n 0  hget \"ROUTE_TABLE:{}\" 'nexthop'".format(V4_PREFIX)
+    result = duthost.shell(cmd)
+    result = result['stdout']
+    Logger.info("Route table nexthops are %s", result)
+    py_assert(result != "", "The route has not propogated to the DUT")
+    py_assert(len(result.split(",")) == len(data['T1']), "Some Neighbor did not propogate route to the DUT")
+
+
+def test_bgp_neighbor_route_learnning(duthosts, enum_frontend_dut_hostname, setUp):
+    run_bgp_neighbor_route_learning(duthosts, enum_frontend_dut_hostname, setUp)

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -313,6 +313,9 @@ class EosHost(AnsibleHostBase):
             'output': 'json'
         }])['stdout'][0]
 
+    def run_command_list(self, cmd):
+        return self.eos_command(commands=cmd)
+
     def get_auto_negotiation_mode(self, interface_name):
         output = self.eos_command(commands=[{
             'command': 'show interfaces %s status' % interface_name,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/10837
### Type of change
Added anew test
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
advertising through network command might result in issue https://github.com/sonic-net/sonic-buildimage/issues/17183. 
#### How did you do it?
Add same route on 2 T1 neighbors of a TOR and advertise them. Then check on the DUT the routes are learnt and added to ROUTE_TABLE.
#### How did you verify/test it?
![image](https://github.com/user-attachments/assets/63095b80-3a29-4fb8-afa4-cf74c6cb6fe2)
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T0 and Vs
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
