### PR TITLE
[Test gap]: Add test to simulate the case when macsec session goes down due to non-link down related issues

### DIFF
--- a/tests/macsec/macsec_platform_helper.py
+++ b/tests/macsec/macsec_platform_helper.py
@@ -126,6 +126,11 @@ def get_portchannel(host):
     return portchannel_list
 
 
+def get_portchannel_members(host, portchannel):
+    pc = get_portchannel(host)
+    return pc[portchannel]["members"]
+
+
 def find_portchannel_from_member(port_name, portchannel_list):
     for k, v in list(portchannel_list.items()):
         if port_name in v["members"]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Add test gap: https://github.com/sonic-net/sonic-mgmt/issues/13195
#### How did you do it?
To disable MACsec on the port to simulate the MACsec session goes down. We expect the port should be removed from the portchannel.

#### How did you verify/test it?
Check Azp

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
