### PR TITLE
Test zero source mac address handling in dualtor

### DIFF
--- a/tests/dualtor/test_zero_mac_handling.py
+++ b/tests/dualtor/test_zero_mac_handling.py
@@ -1,0 +1,71 @@
+import pprint
+import logging
+import pytest
+import random
+
+from ptf import testutils
+from tests.common.dualtor.dual_tor_mock import *                                # noqa F403
+from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
+from tests.common.dualtor.dual_tor_utils import crm_neighbor_checker
+from tests.common.dualtor.dual_tor_utils import build_packet_to_server
+from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
+from tests.common.dualtor.server_traffic_utils import ServerTrafficMonitor
+from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor    # noqa F401
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder              # noqa F401
+from tests.common.fixtures.ptfhost_utils import run_garp_service                # noqa F401
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses            # noqa F401
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import dump_scapy_packet_show_output
+from ptf.testutils import simple_icmp_packet
+
+
+pytestmark = [
+    pytest.mark.topology("dualtor")
+]
+
+ZERO_MAC_ADDR = "00:00:00:00:00:00"
+
+@pytest.fixture(scope="function")
+def send_zero_mac_packets(ptfadapter, rand_selected_dut, tbinfo):
+    """Utility fixture to send packets with zero source mac address from multiple ports."""
+
+    def _send_zero_mac_packets(test_ports):
+        dut_to_ptf_intf_map = rand_selected_dut.get_extended_minigraph_facts(tbinfo)['minigraph_ptf_indices']
+        for dut_iface in test_ports:
+            ptf_iface = dut_to_ptf_intf_map[dut_iface]
+            dut_mac = rand_selected_dut.get_dut_iface_mac(dut_iface)
+            icmp_pkt = simple_icmp_packet(
+                eth_dst=dut_mac,
+                eth_src=ZERO_MAC_ADDR,
+                ip_src="10.0.0.1",
+                ip_dst="10.0.0.2",
+                icmp_type=8,
+                icmp_code=0,
+                ip_ttl=64
+            )
+            logging.info("Send ICMP packet with zero source MAC from port %s:\n%s",
+                         dut_iface, dump_scapy_packet_show_output(icmp_pkt))
+            testutils.send(ptfadapter, int(ptf_iface), icmp_pkt, count=5)
+            # let the generator stops here to allow the caller to execute testings
+            yield
+
+    return _send_zero_mac_packets
+
+
+def test_zero_src_mac_handling(send_zero_mac_packets, apply_active_state_to_orchagent,
+                               conn_graph_facts, ptfadapter, ptfhost, rand_selected_dut,
+                               set_crm_polling_interval, tbinfo, tunnel_traffic_monitor, vmhost):
+    tor = rand_selected_dut
+    # select two random mux ports for testing
+    mux_configs = mux_cable_server_ip(tor)
+    test_ports = random.sample(list(mux_configs.keys()),2)
+    logging.info("Selected test ports: %s", pprint.pformat(test_ports))
+    # send zero source MAC ICMP packets from the selected ports
+    zero_mac_packet_sender = send_zero_mac_packets(test_ports)
+    next(zero_mac_packet_sender)  # Call the generator to send packets
+    # verify MAC table doesn't contain zero MAC
+    mac_table = tor.shell("show mac")
+    logging.info("MAC table: %s", pprint.pformat(mac_table))
+    pytest_assert(ZERO_MAC_ADDR not in mac_table["stdout"], "MAC table contains zero source MAC address")
+    logging.info("Zero source MAC handling test completed.")
+

--- a/tests/dualtor/test_zero_mac_handling.py
+++ b/tests/dualtor/test_zero_mac_handling.py
@@ -5,11 +5,7 @@ import random
 
 from ptf import testutils
 from tests.common.dualtor.dual_tor_mock import *                                # noqa F403
-from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
-from tests.common.dualtor.dual_tor_utils import crm_neighbor_checker
-from tests.common.dualtor.dual_tor_utils import build_packet_to_server
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
-from tests.common.dualtor.server_traffic_utils import ServerTrafficMonitor
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor    # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder              # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_garp_service                # noqa F401
@@ -23,7 +19,9 @@ pytestmark = [
     pytest.mark.topology("dualtor")
 ]
 
+
 ZERO_MAC_ADDR = "00:00:00:00:00:00"
+
 
 @pytest.fixture(scope="function")
 def send_zero_mac_packets(ptfadapter, rand_selected_dut, tbinfo):
@@ -68,4 +66,5 @@ def test_zero_src_mac_handling(send_zero_mac_packets, apply_active_state_to_orch
     logging.info("MAC table: %s", pprint.pformat(mac_table))
     pytest_assert(ZERO_MAC_ADDR not in mac_table["stdout"], "MAC table contains zero source MAC address")
     logging.info("Zero source MAC handling test completed.")
+
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add test case to Hackathon testgap #9344 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Cover the scenario when two servers in the same rack are down together, invalid source MAC address from two ports should not be learned by the dualtor.

#### How did you do it?
Generate and send ICMP packets with a zero source MAC address from two randomly selected ports and verify that the MAC table doesn't contain the zero MAC (the zero MAC shouldn't be learned).

#### How did you verify/test it?
Validate it in internal setup
```----------------------------------------------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/dualtor/test_zero_mac_handling.xml -----------------------------------------------------------
------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------
03:05:42 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================== 1 passed, 1 warning in 151.68s (0:02:31) ==================================================================================
```

#### Any platform specific information?
vms21-dual-t0-7260 

#### Supported testbed topology if it's a new test case?
dualtor-120
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
