### PR TITLE
[Snappi] Fixing hardcoded port_speed and cleanup from bgp/lacp cases

### DIFF
--- a/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
@@ -21,7 +21,7 @@ def run_bgp_local_link_failover_test(cvg_api,
                                      multipath,
                                      number_of_routes,
                                      route_type,
-                                     port_speed,):
+                                     ):
     """
     Run Local link failover test
 
@@ -33,7 +33,6 @@ def run_bgp_local_link_failover_test(cvg_api,
         multipath: ecmp value for BGP config
         number_of_routes:  Number of IPv4/IPv6 Routes
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     port_count = multipath+1
 
@@ -48,7 +47,7 @@ def run_bgp_local_link_failover_test(cvg_api,
                                         port_count,
                                         number_of_routes,
                                         route_type,
-                                        port_speed,)
+                                        )
 
     """
         Run the convergence test by flapping all the rx
@@ -61,9 +60,6 @@ def run_bgp_local_link_failover_test(cvg_api,
                                             number_of_routes,
                                             route_type,)
 
-    """ Cleanup the dut configs after getting the convergence numbers """
-    cleanup_config(duthost)
-
 
 def run_bgp_remote_link_failover_test(cvg_api,
                                       duthost,
@@ -72,7 +68,7 @@ def run_bgp_remote_link_failover_test(cvg_api,
                                       multipath,
                                       number_of_routes,
                                       route_type,
-                                      port_speed,):
+                                      ):
     """
     Run Remote link failover test
 
@@ -83,7 +79,6 @@ def run_bgp_remote_link_failover_test(cvg_api,
         iteration: number of iterations for running convergence test on a port
         multipath: ecmp value for BGP config
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     port_count = multipath+1
     """ Create bgp config on dut """
@@ -97,7 +92,7 @@ def run_bgp_remote_link_failover_test(cvg_api,
                                         port_count,
                                         number_of_routes,
                                         route_type,
-                                        port_speed,)
+                                        )
 
     """
         Run the convergence test by withdrawing all the route ranges
@@ -110,9 +105,6 @@ def run_bgp_remote_link_failover_test(cvg_api,
                                              number_of_routes,
                                              route_type,)
 
-    """ Cleanup the dut configs after getting the convergence numbers """
-    cleanup_config(duthost)
-
 
 def run_rib_in_convergence_test(cvg_api,
                                 duthost,
@@ -121,7 +113,7 @@ def run_rib_in_convergence_test(cvg_api,
                                 multipath,
                                 number_of_routes,
                                 route_type,
-                                port_speed,):
+                                ):
     """
     Run RIB-IN Convergence test
 
@@ -133,7 +125,6 @@ def run_rib_in_convergence_test(cvg_api,
         multipath: ecmp value for BGP config
         number_of_routes:  Number of IPv4/IPv6 Routes
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     port_count = multipath+1
 
@@ -148,7 +139,7 @@ def run_rib_in_convergence_test(cvg_api,
                                         port_count,
                                         number_of_routes,
                                         route_type,
-                                        port_speed,)
+                                        )
 
     """
         Run the convergence test by withdrawing all routes at once and
@@ -161,9 +152,6 @@ def run_rib_in_convergence_test(cvg_api,
                            number_of_routes,
                            route_type,)
 
-    """ Cleanup the dut configs after getting the convergence numbers """
-    cleanup_config(duthost)
-
 
 def run_RIB_IN_capacity_test(cvg_api,
                              duthost,
@@ -172,7 +160,7 @@ def run_RIB_IN_capacity_test(cvg_api,
                              start_value,
                              step_value,
                              route_type,
-                             port_speed,):
+                             ):
     """
     Run RIB-IN Capacity test
 
@@ -184,7 +172,6 @@ def run_RIB_IN_capacity_test(cvg_api,
         start_value: start value of number of routes
         step_value: step value of routes to be incremented at every iteration
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     port_count = multipath+1
     """ Create bgp config on dut """
@@ -199,10 +186,7 @@ def run_RIB_IN_capacity_test(cvg_api,
                         start_value,
                         step_value,
                         route_type,
-                        port_speed,)
-
-    """ Cleanup the dut configs after getting the convergence numbers """
-    cleanup_config(duthost)
+                        )
 
 
 def duthost_bgp_config(duthost,
@@ -295,7 +279,7 @@ def __tgen_bgp_config(cvg_api,
                       port_count,
                       number_of_routes,
                       route_type,
-                      port_speed,):
+                      ):
     """
     Creating  BGP config on TGEN
 
@@ -304,7 +288,6 @@ def __tgen_bgp_config(cvg_api,
         port_count: multipath + 1
         number_of_routes:  Number of IPv4/IPv6 Routes
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     global NG_LIST
     conv_config = cvg_api.convergence_config()
@@ -331,7 +314,7 @@ def __tgen_bgp_config(cvg_api,
     layer1.ieee_media_defaults = False
     layer1.auto_negotiation.rs_fec = True
     layer1.auto_negotiation.link_training = False
-    layer1.speed = port_speed
+    layer1.speed = temp_tg_port[0]['speed']
     layer1.auto_negotiate = False
 
     def create_v4_topo():
@@ -751,7 +734,7 @@ def get_RIB_IN_capacity(cvg_api,
                         start_value,
                         step_value,
                         route_type,
-                        port_speed,):
+                        ):
     """
     Args:
         cvg_api (pytest fixture): snappi API
@@ -760,7 +743,6 @@ def get_RIB_IN_capacity(cvg_api,
         start_value:  Start value of the number of BGP routes
         step_value: Step value of the number of BGP routes to be incremented
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used in test
     """
     def tgen_capacity(routes):
         conv_config = cvg_api.convergence_config()
@@ -787,7 +769,7 @@ def get_RIB_IN_capacity(cvg_api,
         layer1.ieee_media_defaults = False
         layer1.auto_negotiation.rs_fec = True
         layer1.auto_negotiation.link_training = False
-        layer1.speed = port_speed
+        layer1.speed = temp_tg_port[0]['speed']
         layer1.auto_negotiate = False
 
         def create_v4_topo():
@@ -980,19 +962,3 @@ def get_RIB_IN_capacity(cvg_api,
         columns = ['Test Name', 'Maximum no. of Routes']
         logger.info("\n%s" % tabulate(
             [['RIB-IN Capacity Test', max_routes]], headers=columns, tablefmt="psql"))
-
-
-def cleanup_config(duthost):
-    """
-    Cleaning up dut config at the end of the test
-
-    Args:
-        duthost (pytest fixture): duthost fixture
-    """
-    duthost.command("sudo cp {} {}".format(
-        "/etc/sonic/config_db_backup.json", "/etc/sonic/config_db.json"))
-    duthost.shell("sudo config reload -y \n")
-    logger.info("Wait until all critical services are fully started")
-    pytest_assert(wait_until(360, 10, 1, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
-    logger.info('Convergence Test Completed')

--- a/tests/snappi_tests/bgp/test_bgp_local_link_failover.py
+++ b/tests/snappi_tests/bgp/test_bgp_local_link_failover.py
@@ -12,7 +12,6 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('convergence_test_iterations', [1])
 @pytest.mark.parametrize('number_of_routes', [1000])
 @pytest.mark.parametrize('route_type', ['IPv4'])
-@pytest.mark.parametrize('port_speed', ['speed_100_gbps'])
 def test_bgp_convergence_for_local_link_failover(cvg_api,                   # noqa F811
                                                  duthost,
                                                  tgen_ports,                # noqa F811
@@ -22,7 +21,7 @@ def test_bgp_convergence_for_local_link_failover(cvg_api,                   # no
                                                  convergence_test_iterations,
                                                  number_of_routes,
                                                  route_type,
-                                                 port_speed,):
+                                                 ):
     """
     Topo:
     TGEN1 --- DUT --- TGEN(2..N)
@@ -51,7 +50,6 @@ def test_bgp_convergence_for_local_link_failover(cvg_api,                   # no
         convergence_test_iterations: number of iterations the link failure test has to be run for a port
         number_of_routes:  Number of IPv4/IPv6 Routes
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     # convergence_test_iterations, multipath, number_of_routes and
     # route_type parameters can be modified as per user preference
@@ -62,4 +60,4 @@ def test_bgp_convergence_for_local_link_failover(cvg_api,                   # no
                                      multipath,
                                      number_of_routes,
                                      route_type,
-                                     port_speed,)
+                                     )

--- a/tests/snappi_tests/bgp/test_bgp_remote_link_failover.py
+++ b/tests/snappi_tests/bgp/test_bgp_remote_link_failover.py
@@ -12,7 +12,6 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('convergence_test_iterations', [1])
 @pytest.mark.parametrize('number_of_routes', [1000])
 @pytest.mark.parametrize('route_type', ['IPv4'])
-@pytest.mark.parametrize('port_speed', ['speed_100_gbps'])
 def test_bgp_convergence_for_remote_link_failover(cvg_api,                  # noqa F811
                                                   duthost,
                                                   tgen_ports,               # noqa F811
@@ -22,7 +21,7 @@ def test_bgp_convergence_for_remote_link_failover(cvg_api,                  # no
                                                   convergence_test_iterations,
                                                   number_of_routes,
                                                   route_type,
-                                                  port_speed,):
+                                                  ):
     """
     Topo:
     TGEN1 --- DUT --- TGEN(2..N)
@@ -51,10 +50,9 @@ def test_bgp_convergence_for_remote_link_failover(cvg_api,                  # no
         convergence_test_iterations: number of iterations the cp/dp convergence test has to be run for a port
         number_of_routes:  Number of IPv4/IPv6 Routes
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     # convergence_test_iterations, multipath, number_of_routes,
-    # port_speed and route_type parameters can be modified as per user preference
+    # route_type parameters can be modified as per user preference
     run_bgp_remote_link_failover_test(cvg_api,
                                       duthost,
                                       tgen_ports,
@@ -62,4 +60,4 @@ def test_bgp_convergence_for_remote_link_failover(cvg_api,                  # no
                                       multipath,
                                       number_of_routes,
                                       route_type,
-                                      port_speed,)
+                                      )

--- a/tests/snappi_tests/bgp/test_bgp_rib_in_capacity.py
+++ b/tests/snappi_tests/bgp/test_bgp_rib_in_capacity.py
@@ -10,9 +10,8 @@ pytestmark = [pytest.mark.topology('tgen')]
 
 @pytest.mark.parametrize('multipath', [2])
 @pytest.mark.parametrize('start_value', [1000])
-@pytest.mark.parametrize('step_value', [1000])
+@pytest.mark.parametrize('step_value', [10000])
 @pytest.mark.parametrize('route_type', ['IPv4'])
-@pytest.mark.parametrize('port_speed', ['speed_100_gbps'])
 def test_RIB_IN_capacity(cvg_api,                   # noqa F811
                          duthost,
                          tgen_ports,                # noqa F811
@@ -22,7 +21,7 @@ def test_RIB_IN_capacity(cvg_api,                   # noqa F811
                          start_value,
                          step_value,
                          route_type,
-                         port_speed,):
+                         ):
     """
     Topo:
     TGEN1 --- DUT --- TGEN(2..N)
@@ -51,9 +50,8 @@ def test_RIB_IN_capacity(cvg_api,                   # noqa F811
         start_value:  Start value of the number of BGP routes
         step_value: Step value of the number of BGP routes to be incremented
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
-    # multipath, start_value, step_value and route_type, port_speed parameters can be modified as per user preference
+    # multipath, start_value, step_value and route_type parameters can be modified as per user preference
     run_RIB_IN_capacity_test(cvg_api,
                              duthost,
                              tgen_ports,
@@ -61,4 +59,4 @@ def test_RIB_IN_capacity(cvg_api,                   # noqa F811
                              start_value,
                              step_value,
                              route_type,
-                             port_speed,)
+                             )

--- a/tests/snappi_tests/bgp/test_bgp_rib_in_convergence.py
+++ b/tests/snappi_tests/bgp/test_bgp_rib_in_convergence.py
@@ -12,7 +12,6 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('convergence_test_iterations', [1])
 @pytest.mark.parametrize('number_of_routes', [1000])
 @pytest.mark.parametrize('route_type', ['IPv4'])
-@pytest.mark.parametrize('port_speed', ['speed_100_gbps'])
 def test_rib_in_convergence(cvg_api,                    # noqa F811
                             duthost,
                             tgen_ports,                 # noqa F811
@@ -22,7 +21,7 @@ def test_rib_in_convergence(cvg_api,                    # noqa F811
                             convergence_test_iterations,
                             number_of_routes,
                             route_type,
-                            port_speed,):
+                            ):
     """
     Topo:
     TGEN1 --- DUT --- TGEN(2..N)
@@ -52,9 +51,8 @@ def test_rib_in_convergence(cvg_api,                    # noqa F811
         convergence_test_iterations: number of iterations the link failure test has to be run for a port
         number_of_routes:  Number of IPv4/IPv6 Routes
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
-    # convergence_test_iterations, multipath, number_of_routes port_speed and
+    # convergence_test_iterations, multipath, number_of_routes and
     # route_type parameters can be modified as per user preference
     run_rib_in_convergence_test(cvg_api,
                                 duthost,
@@ -63,4 +61,4 @@ def test_rib_in_convergence(cvg_api,                    # noqa F811
                                 multipath,
                                 number_of_routes,
                                 route_type,
-                                port_speed,)
+                                )

--- a/tests/snappi_tests/lacp/test_add_remove_link_from_dut.py
+++ b/tests/snappi_tests/lacp/test_add_remove_link_from_dut.py
@@ -9,10 +9,10 @@ import pytest
 pytestmark = [pytest.mark.topology('tgen')]
 
 
-@pytest.mark.parametrize('port_count', [4])
+@pytest.mark.parametrize('port_count', [3])
 @pytest.mark.parametrize('number_of_routes', [1000])
 @pytest.mark.parametrize('iterations', [1])
-@pytest.mark.parametrize('port_speed', ['speed_100_gbps'])
+@pytest.mark.parametrize('traffic_type', ['IPv4'])
 def test_lacp_add_remove_link_from_dut(snappi_api,                      # noqa F811
                                        duthost,
                                        tgen_ports,                      # noqa F811
@@ -21,7 +21,7 @@ def test_lacp_add_remove_link_from_dut(snappi_api,                      # noqa F
                                        fanout_graph_facts,              # noqa F811
                                        port_count,
                                        number_of_routes,
-                                       port_speed,):
+                                       traffic_type):
     """
     Topo:
     LAG1 --- DUT --- LAG2 (N-1 TGEN Ports)
@@ -48,13 +48,13 @@ def test_lacp_add_remove_link_from_dut(snappi_api,                      # noqa F
         port_count: Total no of ports used in the test
         iterations: no of iterations to run the link flap test
         number_of_routes:  Number of IPv4/IPv6 Routes
-        port_speed: speed of the port used for test
+        traffic_type: IPv4 or IPv6 traffic flow
     """
-    # port_count, number_of_routes ,iterations and port_speed parameters can be modified as per user preference
+    # port_count, number_of_routes ,iterations parameters can be modified as per user preference
     run_lacp_add_remove_link_from_dut(snappi_api,
                                       duthost,
                                       tgen_ports,
                                       iterations,
                                       port_count,
                                       number_of_routes,
-                                      port_speed,)
+                                      traffic_type)

--- a/tests/snappi_tests/lacp/test_add_remove_link_physically.py
+++ b/tests/snappi_tests/lacp/test_add_remove_link_physically.py
@@ -9,10 +9,10 @@ import pytest
 pytestmark = [pytest.mark.topology('tgen')]
 
 
-@pytest.mark.parametrize('port_count', [4])
+@pytest.mark.parametrize('port_count', [3])
 @pytest.mark.parametrize('number_of_routes', [1000])
 @pytest.mark.parametrize('iterations', [1])
-@pytest.mark.parametrize('port_speed', ['speed_100_gbps'])
+@pytest.mark.parametrize('traffic_type', ['IPv4'])
 def test_lacp_add_remove_link_physically(cvg_api,                   # noqa F811
                                          duthost,
                                          tgen_ports,                # noqa F811
@@ -21,7 +21,7 @@ def test_lacp_add_remove_link_physically(cvg_api,                   # noqa F811
                                          fanout_graph_facts,        # noqa F811
                                          port_count,
                                          number_of_routes,
-                                         port_speed,):
+                                         traffic_type):
     """
     Topo:
     LAG1 --- DUT --- LAG2 (N-1 TGEN Ports)
@@ -49,15 +49,15 @@ def test_lacp_add_remove_link_physically(cvg_api,                   # noqa F811
         port_count: Total no of ports used in the test
         iterations: no of iterations to run the link flap test
         number_of_routes:  Number of IPv4/IPv6 Routes
-        port_speed: speed of the port used for test
         lacpdu_interval_period: LACP update packet interval ( 0 - Auto, 1- Fast, 30 - Slow )
         lacpdu_timeout: LACP Timeout value (0 - Auto, 3 - Short, 90 - Long)
+        traffic_type: IPv4 or IPv6 traffic flow
     """
-    # port_count, number_of_routes ,iterations and port_speed parameters can be modified as per user preference
+    # port_count, number_of_routes ,iterations parameters can be modified as per user preference
     run_lacp_add_remove_link_physically(cvg_api,
                                         duthost,
                                         tgen_ports,
                                         iterations,
                                         port_count,
                                         number_of_routes,
-                                        port_speed,)
+                                        traffic_type)

--- a/tests/snappi_tests/lacp/test_lacp_timers_effect.py
+++ b/tests/snappi_tests/lacp/test_lacp_timers_effect.py
@@ -9,12 +9,12 @@ import pytest
 pytestmark = [pytest.mark.topology('tgen')]
 
 
-@pytest.mark.parametrize('port_count', [4])
+@pytest.mark.parametrize('port_count', [3])
 @pytest.mark.parametrize('number_of_routes', [1000])
 @pytest.mark.parametrize('iterations', [1])
-@pytest.mark.parametrize('port_speed', ['speed_100_gbps'])
 @pytest.mark.parametrize('lacpdu_interval_period', [1])
 @pytest.mark.parametrize('lacpdu_timeout', [90])
+@pytest.mark.parametrize('traffic_type', ['IPv4'])
 def test_lacp_timers(cvg_api,                       # noqa F811
                      duthost,
                      tgen_ports,                    # noqa F811
@@ -23,9 +23,9 @@ def test_lacp_timers(cvg_api,                       # noqa F811
                      fanout_graph_facts,            # noqa F811
                      port_count,
                      number_of_routes,
-                     port_speed,
                      lacpdu_interval_period,
-                     lacpdu_timeout,):
+                     lacpdu_timeout,
+                     traffic_type):
     """
     Topo:
     LAG1 --- DUT --- LAG2 (N-1 TGEN Ports)
@@ -54,11 +54,11 @@ def test_lacp_timers(cvg_api,                       # noqa F811
         port_count: Total no of ports used in the test
         iterations: no of iterations to run the link flap test
         number_of_routes:  Number of IPv4/IPv6 Routes
-        port_speed: speed of the port used for test
         lacpdu_interval_period: LACP update packet interval ( 0 - Auto, 1- Fast, 30 - Slow )
         lacpdu_timeout: LACP Timeout value (0 - Auto, 3 - Short, 90 - Long)
+        traffic_type: IPv4 or IPv6 traffic flow
     """
-    # port_count, number_of_routes ,iterations, port_speed, lacpdu_interval_period,
+    # port_count, number_of_routes ,iterations lacpdu_interval_period,
     # lacpdu_timeout parameters can be modified as per user preference
     run_lacp_timers_effect(cvg_api,
                            duthost,
@@ -66,6 +66,6 @@ def test_lacp_timers(cvg_api,                       # noqa F811
                            iterations,
                            port_count,
                            number_of_routes,
-                           port_speed,
                            lacpdu_interval_period,
-                           lacpdu_timeout,)
+                           lacpdu_timeout,
+                           traffic_type)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Fixing hardcoded port_speed and cleanup from lacp cases
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
To make the script agnostic for all speed modes
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
