### PR TITLE
Add skip for non vs topologies in test_vs_chassis_setup.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1662,6 +1662,15 @@ test_pktgen.py:
       - "https://github.com/sonic-net/sonic-mgmt/issues/13804"
 
 #######################################
+#####         vs_chassis          #####
+#######################################
+test_vs_chassis_setup.py:
+  skip:
+    reason: "Skip vs_chassis setup on non-vs testbeds"
+    conditions:
+      - "asic_type not in ['vs']"
+
+#######################################
 #####            vlan             #####
 #######################################
 vlan/test_vlan.py::test_vlan_tc7_tagged_qinq_switch_on_outer_tag:

--- a/tests/test_vs_chassis_setup.py
+++ b/tests/test_vs_chassis_setup.py
@@ -25,6 +25,7 @@ def setup(duthosts, tbinfo, localhost):
 
     dut_topo_info = tbinfo['topo']['properties']['topology']['DUT']
     if 'vs_chassis' not in dut_topo_info:
+        pytest.skip("Topology is not 'vs_chassis'")
         return
 
     for dut_index, duthost in enumerate(duthosts):

--- a/tests/test_vs_chassis_setup.py
+++ b/tests/test_vs_chassis_setup.py
@@ -25,7 +25,6 @@ def setup(duthosts, tbinfo, localhost):
 
     dut_topo_info = tbinfo['topo']['properties']['topology']['DUT']
     if 'vs_chassis' not in dut_topo_info:
-        pytest.skip("Topology is not 'vs_chassis'")
         return
 
     for dut_index, duthost in enumerate(duthosts):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #14722 (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Stop tests in test_vs_chassis_setup from failing on non vs_chassis.

#### How did you do it?
Add pytest skip flag in test setup if 'vs_chassis' not in DUT topo properties.

#### How did you verify/test it?
Ran test on physical T2 testbed to verify it skips.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
