### PR TITLE
[tests-cacl] Add acl-loader test and validation function

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -153,6 +153,115 @@ def clean_scale_rules(duthosts, enum_rand_one_per_hwsku_hostname, collect_ignore
     config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
 
+@pytest.fixture(scope="function")
+def dummy_acl_rules(duthosts, enum_rand_one_per_hwsku_hostname):
+    """
+    Generate dummy acl rules for SNMP-ACL, ssh-only, NTP-ACL tables with template json file,
+    which contains both DROP and ACCEPT rules, and both IPv4 and IPv6 addresses.
+
+    Returns:
+        file_path: path to the generated ACL JSON file on the DUT
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    file_path = "/tmp/generated_acl.json"
+
+    rules_data = {}
+    snmp_acl_entry = {}
+    ssh_acl_entry = {}
+    ntp_acl_entry = {}
+
+    for index in range(1, 22):
+        acl_entry = {}
+
+        # Alternate between IPv4 and IPv6 addresses (should be 2 IPv4 for every IPv6)
+        src_ip = f"20.0.0.{1 + index}/32" if index % 3 else f"2001::{1 + index}/128"
+
+        # Alternate between accept and drop for each rule
+        action = "ACCEPT" if index % 2 else "DROP"
+
+        acl_entry[index] = {
+            "actions": {
+                "config": {
+                    "forwarding-action": action
+                }
+            },
+            "config": {
+                "sequence-id": index
+            },
+            "ip": {
+                "config": {
+                    "source-ip-address": src_ip
+                }
+            }
+        }
+
+        snmp_acl_entry.update(acl_entry)
+        ssh_acl_entry.update(acl_entry)
+        ntp_acl_entry.update(acl_entry)
+
+    rules_data['acl'] = {
+        "acl-sets": {
+            "acl-set": {
+                "SNMP-ACL": {
+                    "acl-entries": {
+                        "acl-entry": snmp_acl_entry
+                    },
+                    "config": {
+                        "name": "SNMP-ACL"
+                    }
+                },
+                "ssh-only": {
+                    "acl-entries": {
+                        "acl-entry": ssh_acl_entry
+                    },
+                    "config": {
+                        "name": "ssh-only"
+                    }
+                },
+                "ntp-acl": {
+                    "acl-entries": {
+                        "acl-entry": ntp_acl_entry
+                    },
+                    "config": {
+                        "name": "ntp-acl"
+                    }
+                }
+            }
+        }
+    }
+
+    duthost.copy(content=json.dumps(rules_data, indent=4), dest=file_path)
+
+    cmds = 'acl-loader update full {}'.format(file_path)
+    duthost.command(cmds)
+
+    logger.info('Waiting for all rules to be applied...')
+    # "acl-loader update full **.json" command will refresh iptables, we have to
+    # add the ACCEPT SSH iptables rule after acl-loader command. But on multi-asic
+    # testbed, it always costs minutes to sync iptables rules after updating cacl
+    # rules, if sleep for more than 3 mins with time.sleep, then, the process tries to
+    # add the ACCEPT SSH rule, at this point, SSH connection is disconnected now
+    # because the default SSH timeout is 30s, next duthost.command will try to reconnect
+    # to DUT, it will trigger ssh login, it will be rejected by default CACL DENY rule,
+    # test will fail. We have wait_until to solve this problem, here add wail_until
+    # to call check_iptable_rules every 10s to keep ssh session alive, it just calls
+    # duthost.command to active ssh connection.
+    # In this way, we can active ssh connection and wait as long as we want.
+
+    # It has to wait cacl rules to be effective.
+    wait_until(200, 10, 2, check_iptable_rules, duthost)
+    # add ACCEPT rule for SSH to make sure testbed access
+    duthost.command("iptables -I INPUT 3 -p tcp -m tcp --dport 22 -j ACCEPT")
+
+    yield file_path
+
+    logger.info(f"Deleting {file_path}...")
+    duthost.file(path=file_path, state='absent')
+
+    logger.info("Reloading config to recover original ACL configuration...")
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+
+
 def is_acl_rule_empty(duthost):
     """
     Check the output of "show acl rule", return True if rules are cleaned.
@@ -835,6 +944,124 @@ def generate_scale_rules(duthost, ip_type):
     duthost.command("iptables -I INPUT 3 -p tcp -m tcp --dport 22 -j ACCEPT")
 
 
+def verify_cacl_show_acl_rule(duthost, acl_file):
+    """
+    Converts the CACL rules in the provided acl_file into a dict,
+    and verifies that they match the applied acl rules through the `show acl
+    rule` command.
+    """
+
+    acl_json = duthost.command(f"cat {acl_file}")["stdout_lines"]
+    acl_rules_expected_dict = json.loads("".join(acl_json))
+
+    acl_sets_extracted = acl_rules_expected_dict["acl"].get("acl-sets", {}).get("acl-set", {})
+    acl_rules_expected = {}
+
+    # Reconstruct the dict such that we can index easily using the actual rules
+    for acl_table, acl_table_conf in acl_sets_extracted.items():
+        # Reformat name as produced by acl-loader
+        acl_table_name = acl_table.upper().replace("-", "_")
+        acl_table_rules = {}
+
+        for acl_entry_num, acl_entry_conf in acl_table_conf['acl-entries']['acl-entry'].items():
+            acl_entry_name = f"RULE_{acl_entry_num}"
+            acl_table_rules[acl_entry_name] = acl_entry_conf
+
+        acl_rules_expected[acl_table_name] = acl_table_rules
+
+    logger.debug(f"Expected rules: {acl_rules_expected}")
+
+    acl_rules_actual_list = get_cacl_tables_and_rules(duthost)
+    acl_rules_actual = {}
+
+    # Reconstruct the list of actual rules for easy indexation
+    for acl_table in acl_rules_actual_list:
+        acl_table_name = acl_table["name"].strip()
+        acl_table_rules = {}
+        for acl_rule in acl_table["rules"]:
+            acl_rule_name = acl_rule["name"].strip()
+            acl_table_rules[acl_rule_name] = acl_rule
+
+        acl_rules_actual[acl_table_name] = acl_table_rules
+
+    logger.debug(f"Actual rules: {acl_rules_actual}")
+
+    incorrect_rules = []
+    missing_rules = []
+
+    # Check that each table expected exactly matches actual
+    table_set_actual = set(acl_rules_actual.keys())
+    table_set_expected = set(acl_rules_expected.keys())
+
+    missing_tables_expected = table_set_actual - table_set_expected
+    missing_tables_actual = table_set_expected - table_set_actual
+
+    pytest_assert(
+        len(missing_tables_expected) == 0 and len(missing_tables_actual) == 0,
+        f"Missing tables in expected: {missing_tables_expected}, missing tables in actual: {missing_tables_actual}"
+    )
+
+    # Check each rule in each ACL table on the DUT
+    for table_name, expected_rules in acl_rules_expected.items():
+        actual_rules = acl_rules_actual[table_name]
+
+        # First ensure that there are no missing rules from either actual or expected rules
+        rule_set_actual = set(actual_rules.keys())
+        rule_set_expected = set(expected_rules.keys())
+
+        missing_rules_actual = rule_set_expected - rule_set_actual
+        missing_rules_expected = rule_set_actual - rule_set_expected
+
+        if len(missing_rules_actual) > 0:
+            missing_rule_str = f"{table_name}: Missing rules from actual: {missing_rules_actual}"
+            missing_rules.append(missing_rule_str)
+
+        if len(missing_rules_expected) > 0:
+            missing_rule_str = f"{table_name}: Missing rules from expected: {missing_rules_expected}"
+            missing_rules.append(missing_rule_str)
+
+        if len(missing_rules_actual) > 0 or len(missing_rules_expected) > 0:
+            # Skip the rule checks, as they will throw KeyErrors (so that we can check later tables as well)
+            continue
+
+        # Ensure that each rule is configured correctly
+        for rule_name, rule_conf_expected in expected_rules.items():
+            rule_issues = []
+            rule_conf_actual = actual_rules[rule_name]
+
+            ip_key = "SRC_IP" if "SRC_IP" in rule_conf_actual else "SRC_IPV6"
+            if rule_conf_actual[ip_key] != rule_conf_expected["ip"]["config"]["source-ip-address"]:
+                actual = rule_conf_actual[ip_key]
+                expected = rule_conf_expected["ip"]["config"]["source-ip-address"]
+                rule_issues.append(f"  - {rule_name}: Expected IP {expected} does not match {actual}")
+
+            if rule_conf_actual["action"] != rule_conf_expected["actions"]["config"]["forwarding-action"]:
+                actual = rule_conf_actual["action"]
+                expected = rule_conf_expected["actions"]["config"]["forwarding-action"]
+                rule_issues.append(f"  - {rule_name}: Expected action {expected} does not match {actual}")
+
+            if int(rule_conf_actual["priority"]) != (10000 - int(rule_conf_expected["config"]["sequence-id"])):
+                actual = int(rule_conf_actual["priority"])
+                expected = (10000 - int(rule_conf_expected["config"]["sequence-id"]))
+                rule_issues.append(f"  - {rule_name}: Expected priority {expected} does not match {actual}")
+
+            if rule_issues:
+                rule_issues_str = '\n'.join(rule_issues)
+                incorrect_rules.append("{}: The following rules had issues:\n{}".format(table_name, rule_issues_str))
+
+    issues = []
+    if len(incorrect_rules) > 0:
+        incorrect_rules_str = '\n'.join(incorrect_rules)
+        issues.append("Incorrectly configured ACL rules found: \n{}".format(incorrect_rules_str))
+    if len(missing_rules) > 0:
+        issues.append("Tables with missing rules found: {}".format(missing_rules))
+
+    pytest_assert(
+        len(issues) == 0,
+        "Issues detected: \n{}".format('\n'.join(issues))
+    )
+
+
 def verify_cacl(duthost, tbinfo, localhost, creds, docker_network,
                 expected_dhcp_rules_for_standby=None, asic_index=None):
     expected_iptables_rules, expected_ip6tables_rules = \
@@ -1033,3 +1260,22 @@ def test_cacl_scale_rules_ipv6(duthosts, enum_rand_one_per_hwsku_hostname, colle
         set(ignored_iptable_rules_v6)
     pytest_assert(len(unexpected_ip6tables_rules) == 0, "Unexpected ip6tables rules: {}"
                   .format(repr(unexpected_ip6tables_rules)))
+
+
+def test_cacl_acl_loader(duthosts, enum_rand_one_per_hwsku_hostname, dummy_acl_rules):
+    """
+    Test case to verify that acl-loader has correctly loaded all rules and tables within
+    a given acl.json file.
+
+    This is accomplished by first generating rules for the SNMP-ACL, SSH-ONLY and NTP-ACL
+    tables, applying them using acl-loader.
+    From there, we then turn the contents of the generated acl.json into a dictionary,
+    representing the expected values that the DUT should now be populated with.
+    We then collate the rules contained within each of the tables on the DUT using `show
+    acl rule`, and comparing both the amount of rules, along with the configuration of
+    the rules, to determine the operation's success.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    # Verify that the applied rules match the expected rules based on the generated file
+    verify_cacl_show_acl_rule(duthost, dummy_acl_rules)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR addresses the test gap for verifying that control ACL rules loaded into a DUT through acl-loader and a given acl.json.


#### Summary:
Addresses #10516:
-  Introduces a test to verify cacl rules are correct after acl-loader loads rules from an acl.json file

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Currently, there is no test to cover verification that cacl rules are correct after acl-loader loads rules from an acl.json file.
This PR intends to address that by adding one.

#### How did you do it?
Introduced a test, which loads dummy cacl rules from a generated acl.json file, and then validates that the applied rules are the same as is defined in the generated acl.json (i.e. the expected configuration).

#### How did you verify/test it?
Ran the test on a number of testbeds, confirming that the test correctly reports success in loading and verifying the supplied acl rules.

##### Sample success:
```
------------------------------------------------------------------------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------------------------------------------------------------------------
03:45:03 test_cacl_application.generate_scale_rul L0925 INFO   | Waiting all rules to be applied
PASSED                                                                                                                                                                                                                                                                                                                                       [100%]
---------------------------------------------------------------------------------------------------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------------------------------------------------------------------------------------------------
```

##### Sample failure (manually adding a dummy 'TESTFAIL' table to dict of actual tables)
```
============================================================================================================================================================= short test summary info ==============================================================================================================================================================
FAILED cacl/test_cacl_application.py::test_cacl_acl_loader[str3-8111-01] - Failed: Missing tables in expected: {'TESTFAIL'}, missing tables in actual: set()                                                                                                                                                                                        
===================================================================================================================================================== 1 failed, 1 warning in 955.67s (0:15:55) =====================================================================================================================================================
```
##### Sample failure (manually editing expected rules):
```
>       pytest_assert(
            len(issues) == 0,
            "Issues detected: \n{}".format('\n'.join(issues))
        )
E       Failed: Issues detected:
E       Incorrectly configured ACL rules found:
E       NTP_ACL: The following rules had issues:
E         - RULE_2: Expected IP 20.0.0.3/32 does not match WRONG IP
...
cacl/test_cacl_application.py:1018: Failed
```

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
Any topology, as it is with the rest of the cacl testcases, as it leverages common functionality found within the test suite (generation of acl.json, and retrieving `show acl rule` output).

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A, will open a separate PR to cover all of the cacl tests