### PR TITLE
Skip test secure upgrade if image not specified fix

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -989,14 +989,11 @@ platform_tests/test_reload_config.py::test_reload_configuration_checks:
 #######################################
 platform_tests/test_secure_upgrade.py:
   skip:
-    reason:
-    - "Skip test_secure_upgrade for m0/mx with 202305 release / platform does not support secure upgrade"
-    - "Skip test case since parameter '--target_image_list' is not specified"
+    reason: "Skip test_secure_upgrade for m0/mx with 202305 release / platform does not support secure upgrade"
     conditions_logical_operator: or
     conditions:
       - "topo_type in ['m0', 'mx'] and release in ['202305']"
       - "'sn2' in platform or 'sn3' in platform or 'sn4' in platform"
-      - "'target_image_list' not in in session.config.option"
 
 #######################################
 #########  test_sensors.py  ###########

--- a/tests/platform_tests/test_secure_upgrade.py
+++ b/tests/platform_tests/test_secure_upgrade.py
@@ -48,6 +48,10 @@ def non_secure_image_path(request):
     :return: given non secure image path
     '''
     non_secure_img_path = request.config.getoption('target_image_list')
+
+    if not non_secure_img_path:
+        pytest.skip("Skip test case since parameter '--target_image_list' is not specified")
+
     return str(non_secure_img_path)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This PR revert the problematic PR #14573 and provide an alternative way to skip test_secure_upgrade.py

We can't do this approach because session object is simply not accessible in conditional mark.

> This test case needs to specify --target_image_list to be able to run as described in the beginning of the test. However, we don't provide this information for our nightly running (https://github.com/sonic-net/sonic-mgmt/blob/master/tests/platform_tests/test_secure_upgrade.py#L9). It's currently failing / error out for all topologies.

> Ansible will fail to run the test since src= is undefined.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified on VMS25-t2-8800
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
