### PR TITLE
[T2] [Chassis] Skip override_config_table_masic test for upstream line card

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1716,16 +1716,16 @@ def enum_rand_one_frontend_asic_index(request):
 
 @pytest.fixture(scope='module')
 def enum_upstream_dut_hostname(duthosts, tbinfo):
+    if tbinfo["topo"]["type"] == "t0":
+        upstream_nbr_type = "T1"
+    elif tbinfo["topo"]["type"] == "t1":
+        upstream_nbr_type = "T2"
+    else:
+        upstream_nbr_type = "T3"
+
     for a_dut in duthosts.frontend_nodes:
         minigraph_facts = a_dut.get_extended_minigraph_facts(tbinfo)
         minigraph_neighbors = minigraph_facts['minigraph_neighbors']
-        if tbinfo["topo"]["type"] == "t0":
-            upstream_nbr_type = "T1"
-        elif tbinfo["topo"]["type"] == "t1":
-            upstream_nbr_type = "T2"
-        else:
-            upstream_nbr_type = "T3"
-
         for key, value in minigraph_neighbors.items():
             if upstream_nbr_type in value['name']:
                 return a_dut.hostname

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1714,6 +1714,26 @@ def enum_rand_one_frontend_asic_index(request):
     return request.param
 
 
+@pytest.fixture(scope='module')
+def enum_upstream_dut_hostname(duthosts, tbinfo):
+    for a_dut in duthosts.frontend_nodes:
+        minigraph_facts = a_dut.get_extended_minigraph_facts(tbinfo)
+        minigraph_neighbors = minigraph_facts['minigraph_neighbors']
+        if tbinfo["topo"]["type"] == "t0":
+            upstream_nbr_type = "T1"
+        elif tbinfo["topo"]["type"] == "t1":
+            upstream_nbr_type = "T2"
+        else:
+            upstream_nbr_type = "T3"
+
+        for key, value in minigraph_neighbors.items():
+            if upstream_nbr_type in value['name']:
+                return a_dut.hostname
+
+    pytest.fail("Did not find a dut in duthosts that for topo type {} that has upstream nbr type {}".
+                format(tbinfo["topo"]["type"], upstream_nbr_type))
+
+
 @pytest.fixture(scope="module")
 def duthost_console(duthosts, enum_supervisor_dut_hostname, localhost, conn_graph_facts, creds):   # noqa F811
     duthost = duthosts[enum_supervisor_dut_hostname]

--- a/tests/override_config_table/test_override_config_table_masic.py
+++ b/tests/override_config_table/test_override_config_table_masic.py
@@ -220,7 +220,7 @@ def load_minigraph_with_golden_empty_table_removal(duthost):
     )
 
 
-def test_load_minigraph_with_golden_config(duthosts, setup_env,
+def test_load_minigraph_with_golden_config(duthosts, setup_env, tbinfo, enum_upstream_dut_hostname,
                                            enum_rand_one_per_hwsku_frontend_hostname):
     """
     Test Golden Config override during load minigraph
@@ -228,10 +228,15 @@ def test_load_minigraph_with_golden_config(duthosts, setup_env,
     don't have CLI to get new golden config that contains 'localhost' and 'asicxx'
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost_up = duthosts[enum_upstream_dut_hostname]
     if not duthost.is_multi_asic:
         pytest.skip("Skip override-config-table multi-asic testing on single-asic platforms,\
                     test provided golden config format is not compatible with single-asics")
-    load_minigraph_with_golden_empty_input(duthost)
+    topo_type = tbinfo["topo"]["type"]
+    if topo_type == 't2' and duthost != duthost_up:
+        # Skip empty golden-config testing on upstream linecards,
+        # since the handling of empty golden config doesn't work on upstream linecards
+        load_minigraph_with_golden_empty_input(duthost)
     load_minigraph_with_golden_partial_config(duthost)
     load_minigraph_with_golden_new_feature(duthost)
     load_minigraph_with_golden_empty_table_removal(duthost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR fixes '_test_override_config_table_masic-test_load_minigraph_with_golden_config_' failure on upstream line card on T2 topo Chassis.

The above test fails with the following issue on _DEVICE_METADATA_ table when 'config _load_minigraph_' is done with empty golden config input. 

>    
        host_current_config = get_running_config(duthost)
        for table in initial_host_config:
            if table in NON_USER_CONFIG_TABLES:
                continue
            pytest_assert(
                initial_host_config[table] == host_current_config[table],
               "empty input compare fail! {}".format(table)
            )
         E           Failed: empty input compare fail! DEVICE_METADATA

The test passes on downstream linecards.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

- '_test_override_config_table_masic-test_load_minigraph_with_golden_config_' fails on upstream line card on T2 topo Chassis.
- '_subtype_' changes to 'DownstreamLC' from 'UpstreamLC' in DEVICE_METADATA for Upstream LC after load_minigraph with empty golden_config as input. 

#### How did you do it?
- Skip the empty input golden config check for upstream line card and do the other checks for upstream line card. 
- Perform the empty input test only if it is downstream line card and verify the golden config functionality. 

#### How did you verify/test it?
Run '_test_override_config_table_masic-test_load_minigraph_with_golden_config_' on T2 chassis and verify the test passes without any issues.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/user-attachments/assets/b6e9df72-8750-43e0-8753-3f97bc496cac)

