### PR TITLE
Fix error in qos_param_generator

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -82,12 +82,12 @@ class QosParamCisco(object):
             self.log("Pre-pad drop thr bytes:    {}".format(pre_pad_drop))
             self.log("Drop thr bytes:            {}".format(self.drop_thr))
             self.log("Reduced pause thr bytes:   {}".format(self.reduced_pause_thr))
-        self.config_facts = duthost.get_running_config_facts()
-        # DSCP value for lossy
-        self.dscp_queue0 = self.get_one_dscp_from_queue(0)
-        self.dscp_queue1 = self.get_one_dscp_from_queue(1)
-        # DSCP, queue, weight list
-        self.dscp_list, self.q_list, self.weight_list = self.get_dscp_q_weight_list()
+            self.config_facts = duthost.asics[0].config_facts(source="running")["ansible_facts"]
+            # DSCP value for lossy
+            self.dscp_queue0 = self.get_one_dscp_from_queue(0)
+            self.dscp_queue1 = self.get_one_dscp_from_queue(1)
+            # DSCP, queue, weight list
+            self.dscp_list, self.q_list, self.weight_list = self.get_dscp_q_weight_list()
 
     def get_one_dscp_from_queue(self, queue):
         '''

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -82,7 +82,7 @@ class QosParamCisco(object):
             self.log("Pre-pad drop thr bytes:    {}".format(pre_pad_drop))
             self.log("Drop thr bytes:            {}".format(self.drop_thr))
             self.log("Reduced pause thr bytes:   {}".format(self.reduced_pause_thr))
-            self.config_facts = duthost.asics[0].config_facts(source="running")["ansible_facts"]
+            self.config_facts = duthost.asic_instance().config_facts(source="running")["ansible_facts"]
             # DSCP value for lossy
             self.dscp_queue0 = self.get_one_dscp_from_queue(0)
             self.dscp_queue1 = self.get_one_dscp_from_queue(1)

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2492,7 +2492,7 @@ class QosSaiBase(QosBase):
         tc_to_dscp_count_map = {}
         for tc in range(8):
             tc_to_dscp_count_map[tc] = 0
-        config_facts = duthost.get_running_config_facts()
+        config_facts = duthost.asic_instance().config_facts(source="running")["ansible_facts"]
         dscp_to_tc_map = config_facts['DSCP_TO_TC_MAP']['AZURE']
         for dscp, tc in dscp_to_tc_map.items():
             tc_to_dscp_count_map[int(tc)] += 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Error seen when running on T2 testbed.
```
21:32:22 base._run                                L0118 DEBUG  | /data/tests/common/devices/sonic.py::get_running_config_facts#1774: [sfd-lt2-lc0] AnsibleModule::config_facts done, is_failed=False, rc=None
21:32:22 __init__._fixture_generator_decorator    L0088 ERROR  | 
KeyError('DSCP_TO_TC_MAP')
Traceback (most recent call last):
  File "/data/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/data/tests/qos/qos_sai_base.py", line 1671, in dutQosConfig
    qpm = qos_param_generator.QosParamCisco(
  File "/data/tests/qos/files/cisco/qos_param_generator.py", line 87, in __init__
    self.dscp_queue0 = self.get_one_dscp_from_queue(0)
  File "/data/tests/qos/files/cisco/qos_param_generator.py", line 96, in get_one_dscp_from_queue
    dscp_to_tc_map = self.config_facts['DSCP_TO_TC_MAP']['AZURE']
KeyError: 'DSCP_TO_TC_MAP'
```
self.config_facts['DSCP_TO_TC_MAP'] doesn't exist, since it reads the running-config for host, not for asic.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fix script error when running on T2 testbed.

#### How did you do it?
Read configuration for asic, also move those statements under if support_autogen.

#### How did you verify/test it?
Verified there is no error when running on T2 testbed.
```
---------------------------------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testParameter_2024-09-25-20-41-38.xml -----------------------------------------------
----------------------------------------------------------------------------------- live log sessionfinish -----------------------------------------------------------------------------------
21:08:01 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================== short test summary info ===================================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[single_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[single_dut_multi_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[multi_dut_longlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[multi_dut_shortlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[multi_dut_shortlink_to_longlink]
========================================================================= 5 passed, 1 warning in 1581.20s (0:26:21) ==========================================================================
INFO:root:Can not get Allure report URL. Please check logs
sonic@sonic-ucs-m6-4:/data/tests$ 
```
Verified there is no error on T0 testbed.
```
------------------------------------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testParameter_2024-09-25-23-05-30.xml -------------------------------------------------
------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
23:08:20 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
===================================================================================== short test summary info =====================================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[single_asic]
SKIPPED [1] qos/test_qos_sai.py:315: single_dut_multi_asic is not supported on T0 topologies
SKIPPED [3] qos/test_qos_sai.py:315: multi-dut is not supported on T0 topologies
====================================================================== 1 passed, 4 skipped, 2 warnings in 168.11s (0:02:48) =======================================================================
INFO:root:Can not get Allure report URL. Please check logs
sonic@sonic-ucs-m5-9:/data/tests$ 
```

#### Any platform specific information?
The error is only seen on T2.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
