### PR TITLE
tacacs/test_ro_disk.py: Increase wait time for modular chassis after reboot

### DIFF
--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -102,7 +102,7 @@ def do_reboot(duthost, localhost, duthosts):
 
 def post_reboot_healthcheck(duthost, localhost, duthosts, wait_time):
     timeout=300
-    if duthost.get_facts().get("modular_chassis"):
+    if duthost.get_facts().get("modular_chassis") and duthost.is_supervisor_node():
         wait_time = max(wait_time, 900)
         timeout = max(timeout, 600)
         localhost.wait_for(host=duthost.mgmt_ip, port=22, state="started", delay=10, timeout=timeout)

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -101,7 +101,7 @@ def do_reboot(duthost, localhost, duthosts):
 
 
 def post_reboot_healthcheck(duthost, localhost, duthosts, wait_time):
-    timeout=300
+    timeout = 300
     if duthost.get_facts().get("modular_chassis") and duthost.is_supervisor_node():
         wait_time = max(wait_time, 900)
         timeout = max(timeout, 600)

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -102,7 +102,7 @@ def do_reboot(duthost, localhost, duthosts):
 
 def post_reboot_healthcheck(duthost, localhost, duthosts, wait_time):
     timeout = 300
-    if duthost.get_facts().get("modular_chassis") and duthost.is_supervisor_node():
+    if duthost.get_facts().get("modular_chassis"):
         wait_time = max(wait_time, 900)
         timeout = max(timeout, 600)
         localhost.wait_for(host=duthost.mgmt_ip, port=22, state="started", delay=10, timeout=timeout)

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -101,7 +101,13 @@ def do_reboot(duthost, localhost, duthosts):
 
 
 def post_reboot_healthcheck(duthost, localhost, duthosts, wait_time):
-    localhost.wait_for(host=duthost.mgmt_ip, port=22, state="started", delay=10, timeout=300)
+    timeout=300
+    if duthost.get_facts().get("modular_chassis"):
+        wait_time = max(wait_time, 900)
+        timeout = max(timeout, 600)
+        localhost.wait_for(host=duthost.mgmt_ip, port=22, state="started", delay=10, timeout=timeout)
+    else:
+        localhost.wait_for(host=duthost.mgmt_ip, port=22, state="started", delay=10, timeout=timeout)
     wait(wait_time, msg="Wait {} seconds for system to be stable.".format(wait_time))
     if not wait_until(300, 20, 0, duthost.critical_services_fully_started):
         logger.error("Not all critical services fully started!")


### PR DESCRIPTION
### Description of PR
The testcase only waits for 5 mins after Supervisor reboot, this is not enough in case of modular chassis. This causes all testcases to fail after this test stating that Host is unavailable.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Wait time of 5 minutes is not enough for supervisor node. Especially in this testcase where ssh check is disabled.

#### How did you do it?
Increased the time for supervisor node.

#### How did you verify/test it?
Validated on modular chassis with T2 profile

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
