### PR TITLE
[Bugfix] Fix NameError imported by PR #14672

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -43,6 +43,8 @@ FMT_YEAR = "%Y %b %d %H:%M:%S.%f"
 FMT_SHORT = "%b %d %H:%M:%S"
 FMT_ALT = "%Y-%m-%dT%H:%M:%S.%f%z"
 
+test_report = dict()
+
 
 def fanout_switch_port_lookup(fanout_switches, dut_name, dut_port):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #14672, we moved some functions from `platform_tests/verify_dut_health.py` to `common/platform/device_utils.py`, but forgot to move the defination of variable `test_report`, which will cause an NameError. In this PR, we define this variable in `common/platform/device_utils.py` to fix this issue. 

Summary:
Fixes #14672

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In PR #14672, we moved some functions from `platform_tests/verify_dut_health.py` to `common/platform/device_utils.py`, but forgot to move the defination of variable `test_report`, which will cause an NameError. In this PR, we define this variable in `common/platform/device_utils.py` to fix this issue. 

#### How did you do it?
Define the variable in `common/platform/device_utils.py` to fix this issue. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
