### PR TITLE
[dhcp_relay] Use restart_dhcp_service instead of simple restart dhcp_…

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -80,7 +80,7 @@ def enable_source_port_ip_in_relay(duthosts, rand_one_dut_hostname, tbinfo):
         create_checkpoint(duthost, check_point)
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         expect_op_success(duthost, output)
-        duthost.restart_service("dhcp_relay")
+        restart_dhcp_service(duthost)
 
         def dhcp_ready(enable_source_port_ip_in_relay):
             dhcp_relay_running = duthost.is_service_fully_started("dhcp_relay")
@@ -98,7 +98,7 @@ def enable_source_port_ip_in_relay(duthosts, rand_one_dut_hostname, tbinfo):
         logger.info("Rolled back to original checkpoint")
         rollback_or_reload(duthost, check_point)
         delete_checkpoint(duthost, check_point)
-        duthost.restart_service("dhcp_relay")
+        restart_dhcp_service(duthost)
         pytest_assert(wait_until(60, 2, 0, dhcp_ready, False), "Source port ip in relay is not disabled!")
 
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -86,11 +86,14 @@ def enable_source_port_ip_in_relay(duthosts, rand_one_dut_hostname, tbinfo):
             dhcp_relay_running = duthost.is_service_fully_started("dhcp_relay")
             dhcp_relay_process = duthost.shell("ps -ef |grep dhcrelay|grep -v grep",
                                                module_ignore_errors=True)["stdout"]
+            dhcp_mon_process = duthost.shell("ps -ef |grep dhcpmon|grep -v grep",
+                                             module_ignore_errors=True)["stdout"]
+            dhcp_mon_process_running = "dhcpmon" in dhcp_mon_process
             if enable_source_port_ip_in_relay:
                 dhcp_relay_process_ready = "-si" in dhcp_relay_process and "dhcrelay" in dhcp_relay_process
             else:
                 dhcp_relay_process_ready = "-si" not in dhcp_relay_process and "dhcrelay" in dhcp_relay_process
-            return dhcp_relay_running and dhcp_relay_process_ready
+            return dhcp_relay_running and dhcp_relay_process_ready and dhcp_mon_process_running
         pytest_assert(wait_until(60, 2, 0, dhcp_ready, True), "Source port ip in relay is not enabled!")
         yield
     finally:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
[dhcp_relay] Use restart_dhcp_service instead of simple restart dhcp_relay
Summary:
Fixes # (issue)
Fix the flaky of dhcpmon not ready failure in testing.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fix the flaky of dhcpmon not ready failure in testing.
#### How did you do it?
Use restart_dhcp_service instead of simple restart dhcp_relay
#### How did you verify/test it?
Multiple run with Elasictest test plan
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
