### PR TITLE
TC-specific ignore SAI_SWITCH_ATTR, SAI_OBJECT_TYPE logs

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -45,6 +45,18 @@ COMBINED_L2L3_DROP_COUNTER = False
 COMBINED_ACL_DROP_COUNTER = False
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loganalyzer):
+    # Ignore time span WD exceeded error, and contextual log event messages
+    SAISwitchIgnoreRegex = [
+        ".* ERR syncd.*#syncd.*logEventData:.*SAI_SWITCH_ATTR.*",
+        ".* ERR syncd.*#syncd.*logEventData:.*SAI_OBJECT_TYPE_SWITCH.*"
+    ]
+    duthost = duthosts[rand_one_dut_hostname]
+    if loganalyzer:  # Skip if loganalyzer is disabled
+        loganalyzer[duthost.hostname].ignore_regex.extend(SAISwitchIgnoreRegex)
+
+
 @pytest.fixture(autouse=True, scope="module")
 def enable_counters(duthosts):
     """ Fixture which enables RIF and L2 counters """


### PR DESCRIPTION
…list

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

We are seeing the following log errors in syslog, after config reload, capture during sonic-mgmt runs - 

`May 29 14:37:42.975414 LVL02-0101-0835-17T1 ERR syncd#syncd#syncd: :- logEventData: op: create, key: SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000`
`May 29 14:37:42.975414 LVL02-0101-0835-17T1 ERR syncd#syncd#syncd: :- logEventData: fv:SAI_SWITCH_ATTR_INIT_SWITCH: true`
`May 29 14:37:42.975414 LVL02-0101-0835-17T1 ERR syncd#syncd#syncd: :- logEventData: fv: SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY: 0x5649f8a0a650`
`May 29 14:37:42.975440 LVL02-0101-0835-17T1 ERR syncd#syncd#syncd: :- logEventData: fv: SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY: 0x5649f8a0a660`
`May 29 14:37:42.975440 LVL02-0101-0835-17T1 ERR syncd#syncd#syncd: :- logEventData: fv: SAI_SWITCH_ATTR_SWITCH_SHUTDOWN_REQUEST_NOTIFY: 0x5649f8a0a680`
`May 29 14:37:42.975461 LVL02-0101-0835-17T1 ERR syncd#syncd#syncd: :- logEventData: fv: SAI_SWITCH_ATTR_SRC_MAC_ADDRESS: 4C:EC:0F:A3:C0:00
`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [X] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
The primary loganalyzer error - time span WD exceeded – has already been included in the upstream loganalyzer common ignore list, and the following messages are printed to contextualize the above error with additional data, and not as seperate errors.

(we see this in sonic-sairedis in the TimerWatchdog.cpp in the TimerWatchdog::threadFunction(), where when the time span measured by TimerWatchdog exceeds the m_warnTimespan, we print the SWSS_LOG_ERROR - …time span WD exceeded.. which is followed by the logEventData which prints some additional data relevant to the error)

That is, the additional errors - the ones that are currently being captured by loganalyzer in sonic-mgmt runs - are not separate errors, but just additional information pertaining to an error that has already been added to the upstream ignore list, that has no actual functional impact, since the device initialization that this error claims to have timed out, executes successfully on average about 5 seconds later (which is is well within the SAI init timeout of 60s).

We want to add the above log errors into a test case specific ignore list, since these have no consequence to this TC. 


#### How did you do it?

#### How did you verify/test it?
[test_drop_counters.log](https://github.com/user-attachments/files/16768198/test_drop_counters.log)

The above sonic-mgmt TC run no longer captures these logs in loganalyzer errors

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
