### PR TITLE
MIGSMSFT-647 improve qos/test_qos_sai.py to have different longlink/shortlink combinations

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -591,7 +591,10 @@ class QosSaiBase(QosBase):
                     docker.restore_default_syncd(duthost, new_creds)
 
     @pytest.fixture(scope='class', name="select_src_dst_dut_and_asic",
-                    params=("single_asic", "single_dut_multi_asic", "multi_dut"))
+                    params=["single_asic", "single_dut_multi_asic",
+                            "multi_dut_longlink_to_shortlink",
+                            "multi_dut_shortlink_to_shortlink",
+                            "multi_dut_shortlink_to_longlink"])
     def select_src_dst_dut_and_asic(self, duthosts, request, tbinfo, lower_tor_host): # noqa F811
         test_port_selection_criteria = request.param
         logger.info("test_port_selection_criteria is {}".format(test_port_selection_criteria))
@@ -646,8 +649,29 @@ class QosSaiBase(QosBase):
             if (len(duthosts.frontend_nodes)) < 2:
                 pytest.skip("Don't have 2 frontend nodes - so can't run multi_dut tests")
 
-            src_dut_index = 0
-            dst_dut_index = 1
+            number_of_duts = len(duthosts.frontend_nodes)
+            is_longlink_list = [False] * number_of_duts
+            for i in range(number_of_duts):
+                if self.isLonglink(duthosts.frontend_nodes[i]):
+                    is_longlink_list[i] = True
+
+            if test_port_selection_criteria == 'multi_dut_shortlink_to_shortlink':
+                if is_longlink_list.count(False) < 2:
+                    pytest.skip("Don't have 2 shortlink frontend nodes - so can't run {}"
+                                "tests".format(test_port_selection_criteria))
+                src_dut_index = is_longlink_list.index(False)
+                dst_dut_index = is_longlink_list.index(False, src_dut_index + 1)
+            else:
+                if is_longlink_list.count(False) == 0 or is_longlink_list.count(True) == 0:
+                    pytest.skip("Don't have longlink or shortlink frontend nodes - so can't"
+                                "run {} tests".format(test_port_selection_criteria))
+                if test_port_selection_criteria == 'multi_dut_longlink_to_shortlink':
+                    src_dut_index = is_longlink_list.index(True)
+                    dst_dut_index = is_longlink_list.index(False)
+                else:
+                    src_dut_index = is_longlink_list.index(False)
+                    dst_dut_index = is_longlink_list.index(True)
+
             src_asic_index = 0
             dst_asic_index = 0
 
@@ -2497,3 +2521,18 @@ class QosSaiBase(QosBase):
         for dscp, tc in dscp_to_tc_map.items():
             tc_to_dscp_count_map[int(tc)] += 1
         yield tc_to_dscp_count_map
+
+    def isLonglink(self, dut_host):
+        config_facts = dut_host.asics[0].config_facts(source="running")["ansible_facts"]
+        buffer_pg = config_facts["BUFFER_PG"]
+        for intf, value_of_intf in buffer_pg.items():
+            for _, v in value_of_intf.items():
+                if "pg_lossless" in v['profile']:
+                    profileName = v['profile']
+                    logger.info("Lossless Buffer profile is {}".format(profileName))
+                    m = re.search("^pg_lossless_[0-9]+_([0-9]+)m_profile", profileName)
+                    pytest_assert(m.group(1), "Cannot find cable length")
+                    cable_length = int(m.group(1))
+                    if cable_length >= 120000:
+                        return True
+        return False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes [MIGSMSFT-647](https://migsonic.atlassian.net/browse/MIGSMSFT-647)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Have different combinations of longlink and shortlink in test_qos_sai.py.

#### How did you do it?
Extend params in select_src_dst_dut_and_asic.

#### How did you verify/test it?
Verified on T2 testbed which has 3 linecards, 1st linecard longlink, 2nd linecard shortlink, 3rd linecard shortlink.
```
---------------------------------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testParameter_2024-09-25-20-41-38.xml -----------------------------------------------
----------------------------------------------------------------------------------- live log sessionfinish -----------------------------------------------------------------------------------
21:08:01 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================== short test summary info ===================================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[single_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[single_dut_multi_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[multi_dut_longlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[multi_dut_shortlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[multi_dut_shortlink_to_longlink]
========================================================================= 5 passed, 1 warning in 1581.20s (0:26:21) ==========================================================================
INFO:root:Can not get Allure report URL. Please check logs
sonic@sonic-ucs-m6-4:/data/tests$ 

[multi_dut_longlink_to_shortlink]: src_dut_index=0;src_asic_index=0;dst_dut_index=1;dst_asic_index=0
[multi_dut_shortlink_to_shortlink]: src_dut_index=1;src_asic_index=0;dst_dut_index=2;dst_asic_index=0
[multi_dut_shortlink_to_longlink]: src_dut_index=1;src_asic_index=0;dst_dut_index=0;dst_asic_index=0
```
Verified on T1, no impact on T1.
```
------------------------------------------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testParameter_2024-09-27-18-34-12.xml -------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------
18:38:06 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
===================================================================================== short test summary info =====================================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[single_asic]
SKIPPED [1] qos/test_qos_sai.py:315: Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests
SKIPPED [3] qos/test_qos_sai.py:315: multi-dut is not supported on T1 topologies
======================================================================= 1 passed, 4 skipped, 1 warning in 232.24s (0:03:52) =======================================================================
sonic@sonic-ucs-m5-8:/data/tests$ 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
