### PR TITLE
[arp] add conntrack table test for incomplete neighbor

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -320,7 +320,7 @@ def test_ipv6_nd_incomplete(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_
             thread.join(timeout=5)
         logger.info("stopped process to keep sending neighbour-solicitation from ptf to dut")
 
-        duthost.command("echo {} > /proc/sys/net/netfilter/nf_conntrack_icmpv6_timeout"
-                        .format(orig_conntrack_icmpv6_timeout))
+        duthost.shell("echo {} > /proc/sys/net/netfilter/nf_conntrack_icmpv6_timeout"
+                      .format(orig_conntrack_icmpv6_timeout))
         logger.info("setting nf_conntrack_icmpv6_timeout back to {}".format(orig_conntrack_icmpv6_timeout))
         clear_dut_arp_cache(duthost)

--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -219,6 +219,9 @@ def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
             time.sleep(10)
 
 
+# This is similar to function add_nd except it will keep adding nd entry until a stop event
+# is set. A neighbor solicitation will be generated, and the packet will be sent to dut
+# from ptf
 def add_nd_nonstop(ptfadapter, ip_and_intf_info, ptf_intf_index, nd_available, stop_event):
     while not stop_event.is_set():
         entry = random.randrange(0, nd_available)
@@ -265,9 +268,8 @@ def test_ipv6_nd_incomplete(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_
         logger.info("neighbors in INCOMPLETE state: {}"
                     .format(duthost.command("ip -6 neigh")["stdout"].count("INCOMPLETE")))
 
-        if not skip_traffic_test:
-            pytest_assert("[UNREPLIED]" not in duthost.command("conntrack -f ipv6 -L dying")["stdout"],
-                          "unreplied icmpv6 requests ended up in the dying list")
+        pytest_assert("[UNREPLIED]" not in duthost.command("conntrack -f ipv6 -L dying")["stdout"],
+                      "unreplied icmpv6 requests ended up in the dying list")
     finally:
         stop_event.set()
         if thread.is_alive():

--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -240,8 +240,7 @@ def send_ipv6_echo_request(ptfadapter, dut_mac, ip_and_intf_info, ptf_intf_index
 
 
 def test_ipv6_nd_incomplete(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
-                            ptfadapter, get_function_completeness_level, proxy_arp_enabled,
-                            skip_traffic_test):    # noqa F811
+                            ptfadapter, get_function_completeness_level, proxy_arp_enabled):
     _, _, ptf_intf_ipv6_addr, _, ptf_intf_index = ip_and_intf_info
     ptf_intf_ipv6_addr = increment_ipv6_addr(ptf_intf_ipv6_addr)
     pytest_require(proxy_arp_enabled, 'Proxy ARP not enabled for all VLANs')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

icmpv6 connection tracking can cause conntrack table in kernel to grow rapidly
and lead to packets being dropped, making the device unresponsive to connection
requests. The signature seen when this happens is the following:

"kernel: nf_conntrack: nf_conntrack: table full, dropping packet”

An investigation on this identified that most of the entries in conntrack table were due to unreplied icmpv6 requests which ended up in the dying list.

Snippet of "conntrack -f ipv6 -L dying " on a device with the issue:

icmpv6 58 0 src=2603:10b0:105:1065::1 dst=2603:10b0:105:1065:0:3de0:f090:e3e0 type=128 code=0 id=56516 [UNREPLIED] src=2603:10b0:105:1065:0:3de0:f090:e3e0 dst=2603:10b0:105:1065::1 type=129 code=0 id=56516 mark=0 use=1
icmpv6 58 0 src=2603:10b0:105:1065::1 dst=2603:10b0:105:1065:8:9e9a:fa90:e3d0 type=128 code=0 id=49585 [UNREPLIED] src=2603:10b0:105:1065:8:9e9a:fa90:e3d0 dst=2603:10b0:105:1065::1 type=129 code=0 id=49585 mark=0 use=1
icmpv6 58 0 src=2603:10b0:105:1065::1 dst=2603:10b0:105:1065:1:6af9:fd90:e3cc type=128 code=0 id=50650 [UNREPLIED] src=2603:10b0:105:1065:1:6af9:fd90:e3cc dst=2603:10b0:105:1065::1 type=129 code=0 id=50650 mark=0 use=2
icmpv6 58 0 src=2603:10b0:105:1065::1 dst=2603:10b0:105:1065:1:21fb:f090:e3c4 type=128 code=0 id=37425 [UNREPLIED] src=2603:10b0:105:1065:1:21fb:f090:e3c4 dst=2603:10b0:105:1065::1 type=129 code=0 id=37425 mark=0 use=1
icmpv6 58 0 src=2603:10b0:105:1065::1 dst=2603:10b0:105:1065:0:8715:f690:e3cc type=128 code=0 id=49153 [UNREPLIED] src=2603:10b0:105:1065:0:8715:f690:e3cc dst=2603:10b0:105:1065::1 type=129 code=0 id=49153 mark=0 use=1
icmpv6 58 0 src=2603:10b0:105:1065::1 dst=2603:10b0:105:1065:0:4b95:f790:e3c4 type=128 code=0 id=12475 [UNREPLIED] src=2603:10b0:105:1065:0:4b95:f790:e3c4 dst=2603:10b0:105:1065::1 type=129 code=0 id=12475 mark=0 use=1
icmpv6 58 0 src=2603:10b0:105:1065::1 dst=2603:10b0:105:1065:0:453e:f090:e3d4 type=128 code=0 id=57081 [UNREPLIED] src=2603:10b0:105:1065:0:453e:f090:e3d4 dst=2603:10b0:105:1065::1 type=129 code=0 id=57081 mark=0 use=1

Need a test to make sure that conntrack tables on T0s don't get excessively large due to neighbors which remain in "INCOMPLETE" state.

Summary:
Fixes #14350

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Need test to test conntrack table size when there is neighbor in incomplete state.

#### How did you do it?
Create neighbor in incomplete state, ping to create icmpv6 packets, and check conntrack table size.

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
