### PR TITLE
Skip pfcwd_all_port_storm test on Arista-7060X6-64PE-256x200G

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1139,6 +1139,13 @@ pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg:
      conditions:
         - "asic_type in ['cisco-8000']"
 
+pfcwd/test_pfcwd_all_port_storm.py:
+   skip:
+     reason: "Slow pfc generation rate on 7060x6 200Gb,
+              pfc generation function on the Arista fanout device need to be improved by Arista"
+     conditions:
+      - "hwsku in ['Arista-7060X6-64PE-256x200G']"
+
 pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic:
    skip:
      reason: "This test is applicable only for cisco-8000"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip ```pfcwd/test_pfcwd_all_port_storm.py``` test on Arista-7060X6-64PE-256x200G, the pfc generation function on the Arista fanout device need to be improved by Arista.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently, the test uses the python script to send the PFC frames, but the performance does not meet the requirements, and sometimes fails to trigger the PFC storm immediately. Slow pfc generation rate on 7060x6 200Gb. 
#### How did you do it?
To address this, waiting for Arista to to improve the pfc generation function on the Arista fanout device. It would be better to use an Asic based pfc generation function.
#### How did you verify/test it?
```
======================================================================================== short test summary info =========================================================================================
SKIPPED [1] pfcwd/test_pfcwd_all_port_storm.py: Slow pfc generation rate on 7060x6 200Gb, pfc generation function on the Arista fanout device need to be improved by Arista
===================================================================================== 1 skipped, 1 warning in 29.87s =====================================================================================
```
#### Any platform specific information?
str3-7060x6-64pe-1
#### Supported testbed topology if it's a new test case?
t0-standalone-32
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
