### PR TITLE
[Bugfix] Restoring wan-pub topology mapping in test scripts validation. 

### DIFF
--- a/.azure-pipelines/testscripts_analyse/constant.py
+++ b/.azure-pipelines/testscripts_analyse/constant.py
@@ -18,6 +18,7 @@ PR_TOPOLOGY_MAPPING = {
         "t1-lag": "t1",
         "multi-asic-t1-lag": "t1",
         "t2": "t2",
+        "wan-pub": "wan",
         "dpu": "dpu",
         "tgen": "tgen",
         "multidut-tgen": "tgen",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #14437, we removed the mapping for the `wan-pub` topology name during test script validation, as there is no WAN checker in our PR test. However, this removal resulted in skipped scripts for that topology not being collected. In this PR, we are restoring the mapping to address this issue.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In PR #14437, we removed the mapping for the `wan-pub` topology name during test script validation, as there is no WAN checker in our PR test. However, this removal resulted in skipped scripts for that topology not being collected. In this PR, we are restoring the mapping to address this issue.

#### How did you do it?
Restore the mapping. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
