### PR TITLE
[Modify] Migrate vconfig to ip(route2)

### DIFF
--- a/ansible/roles/vm_set/library/vlan_port.py
+++ b/ansible/roles/vm_set/library/vlan_port.py
@@ -57,7 +57,7 @@ class VlanPort(object):
         except Exception:
             pass
 
-        VlanPort.cmd('vconfig add %s %d' % (port, vlan_id))
+        VlanPort.cmd('ip link add link %s name %s type vlan id %d' % (port, vlan_port, vlan_id))
         VlanPort.iface_up(vlan_port)
 
         return

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -674,7 +674,7 @@ class VMTopology(object):
                            (ext_if, t_int_if))
             if create_vlan_subintf:
                 VMTopology.cmd("ip link add link %s name %s type vlan id %d" %
-                               (t_int_if,t_int_sub_if ,vlan_subintf_vlan_id))
+                               (t_int_if, t_int_sub_if, vlan_subintf_vlan_id))
 
         if self.fp_mtu != DEFAULT_MTU:
             VMTopology.cmd("ip link set dev %s mtu %d" % (ext_if, self.fp_mtu))

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -673,8 +673,8 @@ class VMTopology(object):
             VMTopology.cmd("ip link add %s type veth peer name %s" %
                            (ext_if, t_int_if))
             if create_vlan_subintf:
-                VMTopology.cmd("vconfig add %s %s" %
-                               (t_int_if, vlan_subintf_vlan_id))
+                VMTopology.cmd("ip link add link %s name %s type vlan id %d" %
+                               (t_int_if,t_int_sub_if ,vlan_subintf_vlan_id))
 
         if self.fp_mtu != DEFAULT_MTU:
             VMTopology.cmd("ip link set dev %s mtu %d" % (ext_if, self.fp_mtu))


### PR DESCRIPTION
Warning: vconfig is deprecated and might be removed in the future, please migrate to ip(route2) as soon as possible!
1. sonic-mgmt/ansible/roles/vm_set/library/vlan_port.py
2. sonic-mgmt/ansible/roles/vm_set/library/vm_topology.py

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
When use vconfig will get the Warring(Warning: vconfig is deprecated and might be removed in the future, please migrate to ip(route2) as soon as possible!)

Migrate vconfig to ip(route2)

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Migrate vconfig to ip(route2)
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
vconfig is deprecated and might be removed in the future

#### How did you do it?
Use ip(route2) to replace vconfig

#### How did you verify/test it?
- Executed add/remove topo
- At t0 topo send the packet from Docker-Ptf and confirm that the corresponding DUT Port has received the packet.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
