### PR TITLE
dhcp storm stress test

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
@@ -44,7 +44,7 @@ class DHCPContinuousStressTest(DHCPTest):
 class DHCPStressDiscoverTest(DHCPTest):
     def __init__(self):
         DHCPTest.__init__(self)
-    
+
     def setUp(self):
         DHCPTest.setUp(self)
         self.packets_send_duration = self.test_params["packets_send_duration"]
@@ -103,7 +103,7 @@ class DHCPStressDiscoverTest(DHCPTest):
 class DHCPStressOfferTest(DHCPTest):
     def __init__(self):
         DHCPTest.__init__(self)
-    
+
     def setUp(self):
         DHCPTest.setUp(self)
         self.packets_send_duration = self.test_params["packets_send_duration"]
@@ -159,7 +159,7 @@ class DHCPStressOfferTest(DHCPTest):
 class DHCPStressRequestTest(DHCPTest):
     def __init__(self):
         DHCPTest.__init__(self)
-    
+
     def setUp(self):
         DHCPTest.setUp(self)
         self.packets_send_duration = self.test_params["packets_send_duration"]
@@ -215,10 +215,10 @@ class DHCPStressRequestTest(DHCPTest):
             result_file.write(str(request_cnt))
 
 
-class DHCPStressAckTest(DHCPTest):   
+class DHCPStressAckTest(DHCPTest):
     def __init__(self):
         DHCPTest.__init__(self)
-    
+
     def setUp(self):
         DHCPTest.setUp(self)
         self.packets_send_duration = self.test_params["packets_send_duration"]

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
@@ -1,7 +1,8 @@
 import time
 import ptf.testutils as testutils
+import ptf.packet as scapy
+from ptf.mask import Mask
 from dhcp_relay_test import DHCPTest
-
 
 class DHCPContinuousStressTest(DHCPTest):
     """
@@ -37,3 +38,233 @@ class DHCPContinuousStressTest(DHCPTest):
                 self.send_packet_with_interval(dhcp_request, client_port)
             for server_port in self.server_port_indices:
                 self.send_packet_with_interval(dhcp_ack, server_port)
+
+
+class DHCPStressDiscoverTest(DHCPTest):
+    def __init__(self):
+        DHCPTest.__init__(self)
+    
+    def setUp(self):
+        DHCPTest.setUp(self)
+        self.packets_send_duration = self.test_params["packets_send_duration"]
+        self.client_packets_per_sec = self.test_params["client_packets_per_sec"]
+
+    # Simulate client coming on VLAN and broadcasting a DHCPDISCOVER message
+    def client_send_discover_stress(self, dst_mac, src_port):
+        # Form and send DHCPDISCOVER packet
+        dhcp_discover = self.create_dhcp_discover_packet(dst_mac, src_port)
+        end_time = time.time() + self.packets_send_duration
+        while time.time() < end_time:
+            testutils.send_packet(self, self.client_port_index, dhcp_discover)
+            time.sleep(1/self.client_packets_per_sec)
+
+    def count_relayed_discover(self):
+        # Create a packet resembling a relayed DCHPDISCOVER packet
+        dhcp_discover_relayed = self.create_dhcp_discover_relayed_packet()
+
+        # Mask off fields we don't care about matching
+        masked_discover = Mask(dhcp_discover_relayed)
+        masked_discover.set_do_not_care_scapy(scapy.Ether, "dst")
+
+        masked_discover.set_do_not_care_scapy(scapy.IP, "version")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "ihl")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "tos")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "len")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "id")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "flags")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "frag")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "ttl")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "proto")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "chksum")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "src")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "dst")
+        masked_discover.set_do_not_care_scapy(scapy.IP, "options")
+
+        masked_discover.set_do_not_care_scapy(scapy.UDP, "chksum")
+        masked_discover.set_do_not_care_scapy(scapy.UDP, "len")
+
+        masked_discover.set_do_not_care_scapy(scapy.BOOTP, "sname")
+        masked_discover.set_do_not_care_scapy(scapy.BOOTP, "file")
+
+        discover_count = testutils.count_matched_packets_all_ports(
+            self, masked_discover, self.server_port_indices)
+        return discover_count
+
+    def runTest(self):
+        self.client_send_discover_stress(self.dest_mac_address, self.client_udp_src_port)
+        discover_cnt = self.count_relayed_discover()
+
+        # At the end of the test, overwrite the file with discover count.
+        with open('/tmp/dhcp_stress_test_discover.json', 'w') as result_file:
+            result_file.write(str(discover_cnt))
+
+
+class DHCPStressOfferTest(DHCPTest):
+    def __init__(self):
+        DHCPTest.__init__(self)
+    
+    def setUp(self):
+        DHCPTest.setUp(self)
+        self.packets_send_duration = self.test_params["packets_send_duration"]
+        self.client_packets_per_sec = self.test_params["client_packets_per_sec"]
+
+    # Simulate client coming on VLAN and broadcasting a DHCPOFFER message
+    def client_send_offer_stress(self):
+        dhcp_offer = self.create_dhcp_offer_packet()
+        end_time = time.time() + self.packets_send_duration
+        while time.time() < end_time:
+            testutils.send_packet(self, self.server_port_indices[0], dhcp_offer)
+            time.sleep(1/self.client_packets_per_sec)
+
+    def count_relayed_offer(self):
+        # Create a packet resembling a relayed DCHPOFFER packet
+        dhcp_offer_relayed = self.create_dhcp_offer_relayed_packet()
+
+        # Mask off fields we don't care about matching
+        masked_offer = Mask(dhcp_offer_relayed)
+
+        masked_offer.set_do_not_care_scapy(scapy.IP, "version")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "ihl")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "tos")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "len")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "id")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "flags")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "frag")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "ttl")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "proto")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "chksum")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "options")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "src")
+        masked_offer.set_do_not_care_scapy(scapy.IP, "dst")
+
+        masked_offer.set_do_not_care_scapy(scapy.UDP, "len")
+        masked_offer.set_do_not_care_scapy(scapy.UDP, "chksum")
+
+        masked_offer.set_do_not_care_scapy(scapy.BOOTP, "sname")
+        masked_offer.set_do_not_care_scapy(scapy.BOOTP, "file")
+
+        offer_count = testutils.count_matched_packets(self, masked_offer, self.client_port_index)
+        return offer_count
+
+    def runTest(self):
+        self.client_send_offer_stress()
+        offer_cnt = self.count_relayed_offer()
+
+        # At the end of the test, overwrite the file with offer count.
+        with open('/tmp/dhcp_stress_test_offer.json', 'w') as result_file:
+            result_file.write(str(offer_cnt))
+
+
+class DHCPStressRequestTest(DHCPTest):
+    def __init__(self):
+        DHCPTest.__init__(self)
+    
+    def setUp(self):
+        DHCPTest.setUp(self)
+        self.packets_send_duration = self.test_params["packets_send_duration"]
+        self.client_packets_per_sec = self.test_params["client_packets_per_sec"]
+
+    # Simulate client coming on VLAN and broadcasting a DHCPREQUEST message
+    def client_send_request_stress(self, dst_mac, src_port):
+        # Form and send DHCPREQUEST packet
+        dhcp_request = self.create_dhcp_request_packet(dst_mac, src_port)
+        end_time = time.time() + self.packets_send_duration
+        while time.time() < end_time:
+            testutils.send_packet(self, self.client_port_index, dhcp_request)
+            time.sleep(1/self.client_packets_per_sec)
+
+    def count_relayed_request(self):
+        # Create a packet resembling a relayed DCHPREQUEST packet
+        dhcp_request_relayed = self.create_dhcp_request_relayed_packet()
+
+        # Mask off fields we don't care about matching
+        masked_request = Mask(dhcp_request_relayed)
+        masked_request.set_do_not_care_scapy(scapy.Ether, "dst")
+
+        masked_request.set_do_not_care_scapy(scapy.IP, "version")
+        masked_request.set_do_not_care_scapy(scapy.IP, "ihl")
+        masked_request.set_do_not_care_scapy(scapy.IP, "tos")
+        masked_request.set_do_not_care_scapy(scapy.IP, "len")
+        masked_request.set_do_not_care_scapy(scapy.IP, "id")
+        masked_request.set_do_not_care_scapy(scapy.IP, "flags")
+        masked_request.set_do_not_care_scapy(scapy.IP, "frag")
+        masked_request.set_do_not_care_scapy(scapy.IP, "ttl")
+        masked_request.set_do_not_care_scapy(scapy.IP, "proto")
+        masked_request.set_do_not_care_scapy(scapy.IP, "chksum")
+        masked_request.set_do_not_care_scapy(scapy.IP, "src")
+        masked_request.set_do_not_care_scapy(scapy.IP, "dst")
+        masked_request.set_do_not_care_scapy(scapy.IP, "options")
+
+        masked_request.set_do_not_care_scapy(scapy.UDP, "chksum")
+        masked_request.set_do_not_care_scapy(scapy.UDP, "len")
+
+        masked_request.set_do_not_care_scapy(scapy.BOOTP, "sname")
+        masked_request.set_do_not_care_scapy(scapy.BOOTP, "file")
+
+        request_count = testutils.count_matched_packets_all_ports(
+            self, masked_request, self.server_port_indices)
+        return request_count
+
+    def runTest(self):
+        self.client_send_request_stress(self.dest_mac_address, self.client_udp_src_port)
+        request_cnt = self.count_relayed_request()
+
+        # At the end of the test, overwrite the file with request count.
+        with open('/tmp/dhcp_stress_test_request.json', 'w') as result_file:
+            result_file.write(str(request_cnt))
+
+
+class DHCPStressAckTest(DHCPTest):   
+    def __init__(self):
+        DHCPTest.__init__(self)
+    
+    def setUp(self):
+        DHCPTest.setUp(self)
+        self.packets_send_duration = self.test_params["packets_send_duration"]
+        self.client_packets_per_sec = self.test_params["client_packets_per_sec"]
+
+    # Simulate client coming on VLAN and broadcasting a DHCPACK message
+    def client_send_ack_stress(self):
+        dhcp_ack = self.create_dhcp_ack_packet()
+        end_time = time.time() + self.packets_send_duration
+        while time.time() < end_time:
+            testutils.send_packet(self, self.server_port_indices[0], dhcp_ack)
+            time.sleep(1/self.client_packets_per_sec)
+
+    def count_relayed_ack(self):
+        # Create a packet resembling a relayed DCHPACK packet
+        dhcp_ack_relayed = self.create_dhcp_ack_relayed_packet()
+
+        # Mask off fields we don't care about matching
+        masked_ack = Mask(dhcp_ack_relayed)
+
+        masked_ack.set_do_not_care_scapy(scapy.IP, "version")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "ihl")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "tos")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "len")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "id")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "flags")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "frag")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "ttl")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "proto")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "chksum")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "options")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "src")
+        masked_ack.set_do_not_care_scapy(scapy.IP, "dst")
+
+        masked_ack.set_do_not_care_scapy(scapy.UDP, "len")
+        masked_ack.set_do_not_care_scapy(scapy.UDP, "chksum")
+
+        masked_ack.set_do_not_care_scapy(scapy.BOOTP, "sname")
+        masked_ack.set_do_not_care_scapy(scapy.BOOTP, "file")
+
+        ack_count = testutils.count_matched_packets(self, masked_ack, self.client_port_index)
+        return ack_count
+
+    def runTest(self):
+        self.client_send_ack_stress()
+        ack_cnt = self.count_relayed_ack()
+
+        # At the end of the test, overwrite the file with ack count.
+        with open('/tmp/dhcp_stress_test_ack.json', 'w') as result_file:
+            result_file.write(str(ack_cnt))

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
@@ -1,8 +1,11 @@
 import time
+import logging
 import ptf.testutils as testutils
 import ptf.packet as scapy
 from ptf.mask import Mask
 from dhcp_relay_test import DHCPTest
+
+logger = logging.getLogger(__name__)
 
 
 class DHCPContinuousStressTest(DHCPTest):
@@ -96,8 +99,11 @@ class DHCPStressDiscoverTest(DHCPTest):
         discover_cnt = self.count_relayed_discover()
 
         # At the end of the test, overwrite the file with discover count.
-        with open('/tmp/dhcp_stress_test_discover.json', 'w') as result_file:
-            result_file.write(str(discover_cnt))
+        try:
+            with open('/tmp/dhcp_stress_test_discover.json', 'w') as result_file:
+                result_file.write(str(discover_cnt))
+        except Exception as e:
+            logger.error("Failed to write to the discover file: %s", repr(e))
 
 
 class DHCPStressOfferTest(DHCPTest):
@@ -152,8 +158,11 @@ class DHCPStressOfferTest(DHCPTest):
         offer_cnt = self.count_relayed_offer()
 
         # At the end of the test, overwrite the file with offer count.
-        with open('/tmp/dhcp_stress_test_offer.json', 'w') as result_file:
-            result_file.write(str(offer_cnt))
+        try:
+            with open('/tmp/dhcp_stress_test_offer.json', 'w') as result_file:
+                result_file.write(str(offer_cnt))
+        except Exception as e:
+            logger.error("Failed to write to the offer file: %s", repr(e))
 
 
 class DHCPStressRequestTest(DHCPTest):
@@ -211,8 +220,11 @@ class DHCPStressRequestTest(DHCPTest):
         request_cnt = self.count_relayed_request()
 
         # At the end of the test, overwrite the file with request count.
-        with open('/tmp/dhcp_stress_test_request.json', 'w') as result_file:
-            result_file.write(str(request_cnt))
+        try:
+            with open('/tmp/dhcp_stress_test_request.json', 'w') as result_file:
+                result_file.write(str(request_cnt))
+        except Exception as e:
+            logger.error("Failed to write to the request file: %s", repr(e))
 
 
 class DHCPStressAckTest(DHCPTest):
@@ -267,5 +279,8 @@ class DHCPStressAckTest(DHCPTest):
         ack_cnt = self.count_relayed_ack()
 
         # At the end of the test, overwrite the file with ack count.
-        with open('/tmp/dhcp_stress_test_ack.json', 'w') as result_file:
-            result_file.write(str(ack_cnt))
+        try:
+            with open('/tmp/dhcp_stress_test_ack.json', 'w') as result_file:
+                result_file.write(str(ack_cnt))
+        except Exception as e:
+            logger.error("Failed to write to the ack file: %s", repr(e))

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
@@ -4,6 +4,7 @@ import ptf.packet as scapy
 from ptf.mask import Mask
 from dhcp_relay_test import DHCPTest
 
+
 class DHCPContinuousStressTest(DHCPTest):
     """
     Keep sending packets, but don't verify form ptf side.

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -339,6 +339,24 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac:
     conditions:
       - "'dualtor' in topo_name and release in ['201811', '201911']"
 
+dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress:
+  skip:
+    reason: "Need to skip for platform x86_64-8111_32eh_o-r0"
+    conditions:
+      - "platform in ['x86_64-8111_32eh_o-r0']"
+
+dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[discover]:
+  skip:
+    reason: "Testcase ignored due to github issue: https://github.com/sonic-net/sonic-mgmt/issues/14851"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/14851"
+
+dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[request]:
+  skip:
+    reason: "Testcase ignored due to github issue: https://github.com/sonic-net/sonic-mgmt/issues/14851"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/14851"
+
 dhcp_relay/test_dhcpv6_relay.py:
   skip:
     reason: "Need to skip for platform x86_64-8111_32eh_o-r0"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -341,9 +341,9 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac:
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress:
   skip:
-    reason: "Need to skip for platform x86_64-8111_32eh_o-r0"
+    reason: "Need to skip for platform armhf-nokia_ixs7215_52x-r0 due to buffer issues"
     conditions:
-      - "platform in ['x86_64-8111_32eh_o-r0']"
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[discover]:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -341,9 +341,11 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac:
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress:
   skip:
-    reason: "Need to skip for platform armhf-nokia_ixs7215_52x-r0 due to buffer issues"
+    reason: "1. Need to skip for platform armhf-nokia_ixs7215_52x-r0 due to buffer issues
+             2. Need to skip for KVM due to low performance"
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - "asic_type in ['vs']"
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[discover]:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -343,6 +343,7 @@ dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress:
   skip:
     reason: "1. Need to skip for platform armhf-nokia_ixs7215_52x-r0 due to buffer issues
              2. Need to skip for KVM due to low performance"
+    conditions_logical_operator: or
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - "asic_type in ['vs']"

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -103,7 +103,8 @@ def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_d
 def check_dhcp_stress_status(duthost, test_duration_seconds):
     # Monitor DHCP status during the test
     start_time = time.time()
-    while time.time() - start_time < test_duration_seconds:
+    sleep_time = 30
+    while time.time() - start_time < test_duration_seconds - sleep_time:
         # Check the status of the DHCP container
         dhcp_container_status = duthost.shell('docker ps | grep dhcp_relay')["stdout"]
         if dhcp_container_status == "":
@@ -118,12 +119,13 @@ def check_dhcp_stress_status(duthost, test_duration_seconds):
             assert cpu_usage_float < 50.0, "DHCP CPU usage is too high: {}%".format(cpu_usage_float)
 
         # Check the status of multiple DHCP processes inside the container
-        dhcp_process_status = duthost.shell('docker exec dhcp_relay supervisorctl status | grep dhcp | awk \'{print $2}\'')["stdout"]
+        dhcp_process_status = duthost.shell(
+             'docker exec dhcp_relay supervisorctl status | grep dhcp | awk \'{print $2}\'')["stdout"]
         if dhcp_process_status:
             dhcp_process_status_lines = dhcp_process_status.splitlines()
             for process_status in dhcp_process_status_lines:
                 assert process_status == "RUNNING", "DHCP related process is not running!"
-        time.sleep(30)
+        time.sleep(sleep_time)
 
 
 def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
@@ -166,75 +168,63 @@ def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_du
         }
 
         def verify_server_packets(pkts):
-                actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == test_xid])
-                lower_bound = int(exp_count * 0.9)
-                upper_bound = int(exp_count * 1.1)
-                pytest_assert(lower_bound <= actual_count * num_dhcp_servers <= upper_bound, 
-                              "Mismatch: Actual count = {}, Expected count = {}.".format(actual_count, exp_count))
+            actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == test_xid])
+            lower_bound = int(exp_count * 0.9)
+            upper_bound = int(exp_count * 1.1)
+            pytest_assert(lower_bound <= actual_count * num_dhcp_servers <= upper_bound, 
+                          "Mismatch: Actual count = {}, Expected count = {}.".format(actual_count, exp_count))
 
         def verify_client_packets(pkts):
-                actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == test_xid])
-                lower_bound = int(exp_count * 0.9)
-                upper_bound = int(exp_count * 1.1)
-                pytest_assert(lower_bound <= actual_count <= upper_bound, 
-                              "Mismatch: Actual count = {}, Expected count = {}.".format(actual_count, exp_count))
+            actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == test_xid])
+            lower_bound = int(exp_count * 0.9)
+            upper_bound = int(exp_count * 1.1)
+            pytest_assert(lower_bound <= actual_count <= upper_bound, 
+                          "Mismatch: Actual count = {}, Expected count = {}.".format(actual_count, exp_count))
 
         with capture_and_check_packet_on_dut(
-                duthost=duthost, interface=client_port_name,
-                pkts_filter="ether src %s and udp dst port %s" % (client_mac, DEFAULT_DHCP_SERVER_PORT),
-                pkts_validator=verify_server_packets
-            ):
-                ptf_runner(ptfhost,
-                        "ptftests",
-                        "dhcp_relay_test.DHCPStressDiscoverTest",
-                        platform_dir="ptftests",
-                        params=params,
-                        log_file="/tmp/dhcp_relay_test.DHCPStressTest.log",
-                        qlen=100000, is_python3=True, async_mode=True)
-                check_dhcp_stress_status(duthost, packets_send_duration)
-                exp_count = int(ptfhost.shell('cat /tmp/dhcp_stress_test_discover.json')['stdout'].strip())
+            duthost=duthost, interface=client_port_name,
+            pkts_filter="ether src %s and udp dst port %s" % (client_mac, DEFAULT_DHCP_SERVER_PORT),
+            pkts_validator=verify_server_packets
+        ):
+            ptf_runner(ptfhost, "ptftests", "dhcp_relay_stress_test.DHCPStressDiscoverTest",
+                       platform_dir="ptftests", params=params,
+                       log_file="/tmp/dhcp_relay_stress_test.DHCPStressTest.log",
+                       qlen=100000, is_python3=True, async_mode=True)
+            check_dhcp_stress_status(duthost, packets_send_duration)
+            exp_count = int(ptfhost.shell('cat /tmp/dhcp_stress_test_discover.json')['stdout'].strip())
 
         with capture_and_check_packet_on_dut(
-                duthost=duthost, interface=server_port_name,
-                pkts_filter="ether src %s and udp dst port %s" % (server_mac, DEFAULT_DHCP_SERVER_PORT),
-                pkts_validator=verify_client_packets
-            ):
-                ptf_runner(ptfhost,
-                        "ptftests",
-                        "dhcp_relay_test.DHCPStressOfferTest",
-                        platform_dir="ptftests",
-                        params=params,
-                        log_file="/tmp/dhcp_relay_test.DHCPStressTest.log",
-                        qlen=100000, is_python3=True, async_mode=True)
-                check_dhcp_stress_status(duthost, packets_send_duration)
-                exp_count = int(ptfhost.shell('cat /tmp/dhcp_stress_test_offer.json')['stdout'].strip())
+            duthost=duthost, interface=server_port_name,
+            pkts_filter="ether src %s and udp dst port %s" % (server_mac, DEFAULT_DHCP_SERVER_PORT),
+            pkts_validator=verify_client_packets
+        ):
+            ptf_runner(ptfhost, "ptftests", "dhcp_relay_stress_test.DHCPStressOfferTest",
+                       platform_dir="ptftests", params=params,
+                       log_file="/tmp/dhcp_relay_stress_test.DHCPStressTest.log",
+                       qlen=100000, is_python3=True, async_mode=True)
+            check_dhcp_stress_status(duthost, packets_send_duration)
+            exp_count = int(ptfhost.shell('cat /tmp/dhcp_stress_test_offer.json')['stdout'].strip())
 
         with capture_and_check_packet_on_dut(
-                duthost=duthost, interface=client_port_name,
-                pkts_filter="ether src %s and udp dst port %s" % (client_mac, DEFAULT_DHCP_SERVER_PORT),
-                pkts_validator=verify_server_packets
-            ):
-                ptf_runner(ptfhost,
-                        "ptftests",
-                        "dhcp_relay_test.DHCPStressRequestTest",
-                        platform_dir="ptftests",
-                        params=params,
-                        log_file="/tmp/dhcp_relay_test.DHCPStressTest.log",
-                        qlen=100000, is_python3=True, async_mode=True)
-                check_dhcp_stress_status(duthost, packets_send_duration)
-                exp_count = int(ptfhost.shell('cat /tmp/dhcp_stress_test_request.json')['stdout'].strip())
+            duthost=duthost, interface=client_port_name,
+            pkts_filter="ether src %s and udp dst port %s" % (client_mac, DEFAULT_DHCP_SERVER_PORT),
+            pkts_validator=verify_server_packets
+        ):
+            ptf_runner(ptfhost, "ptftests", "dhcp_relay_stress_test.DHCPStressRequestTest",
+                       platform_dir="ptftests", params=params,
+                       log_file="/tmp/dhcp_relay_stress_test.DHCPStressTest.log",
+                       qlen=100000, is_python3=True, async_mode=True)
+            check_dhcp_stress_status(duthost, packets_send_duration)
+            exp_count = int(ptfhost.shell('cat /tmp/dhcp_stress_test_request.json')['stdout'].strip())
 
         with capture_and_check_packet_on_dut(
-                duthost=duthost, interface=server_port_name,
-                pkts_filter="ether src %s and udp dst port %s" % (server_mac, DEFAULT_DHCP_SERVER_PORT),
-                pkts_validator=verify_client_packets
-            ):
-                ptf_runner(ptfhost,
-                        "ptftests",
-                        "dhcp_relay_test.DHCPStressAckTest",
-                        platform_dir="ptftests",
-                        params=params,
-                        log_file="/tmp/dhcp_relay_test.DHCPStressTest.log",
-                        qlen=100000, is_python3=True, async_mode=True)
-                check_dhcp_stress_status(duthost, packets_send_duration)
-                exp_count = int(ptfhost.shell('cat /tmp/dhcp_stress_test_ack.json')['stdout'].strip())
+            duthost=duthost, interface=server_port_name,
+            pkts_filter="ether src %s and udp dst port %s" % (server_mac, DEFAULT_DHCP_SERVER_PORT),
+            pkts_validator=verify_client_packets
+        ):
+            ptf_runner(ptfhost, "ptftests", "dhcp_relay_stress_test.DHCPStressAckTest",
+                       platform_dir="ptftests", params=params,
+                       log_file="/tmp/dhcp_relay_stress_test.DHCPStressTest.log",
+                       qlen=100000, is_python3=True, async_mode=True)
+            check_dhcp_stress_status(duthost, packets_send_duration)
+            exp_count = int(ptfhost.shell('cat /tmp/dhcp_stress_test_ack.json')['stdout'].strip())

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -171,14 +171,14 @@ def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_du
             actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == test_xid])
             lower_bound = int(exp_count * 0.9)
             upper_bound = int(exp_count * 1.1)
-            pytest_assert(lower_bound <= actual_count * num_dhcp_servers <= upper_bound, 
+            pytest_assert(lower_bound <= actual_count * num_dhcp_servers <= upper_bound,
                           "Mismatch: Actual count = {}, Expected count = {}.".format(actual_count, exp_count))
 
         def verify_client_packets(pkts):
             actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == test_xid])
             lower_bound = int(exp_count * 0.9)
             upper_bound = int(exp_count * 1.1)
-            pytest_assert(lower_bound <= actual_count <= upper_bound, 
+            pytest_assert(lower_bound <= actual_count <= upper_bound,
                           "Mismatch: Actual count = {}, Expected count = {}.".format(actual_count, exp_count))
 
         with capture_and_check_packet_on_dut(

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -6,7 +6,7 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 from tests.dhcp_relay.dhcp_relay_utils import restart_dhcp_service
 from tests.common.helpers.assertions import pytest_assert, pytest_require
-from tests.common.utilities import skip_release, wait_until, capture_and_check_packet_on_dut
+from tests.common.utilities import wait_until, capture_and_check_packet_on_dut
 from tests.ptf_runner import ptf_runner
 
 pytestmark = [
@@ -17,7 +17,6 @@ pytestmark = [
 BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68
 DEFAULT_DHCP_SERVER_PORT = 67
-DUAL_TOR_MODE = 'dual'
 
 
 def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
@@ -135,9 +134,6 @@ def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_du
     testing_mode, duthost = testing_config
     packets_send_duration = 120
     client_packets_per_sec = 10000
-
-    if testing_mode == DUAL_TOR_MODE:
-        skip_release(duthost, ["201811", "201911"])
 
     for dhcp_relay in dut_dhcp_relay_data:
         client_port_name = str(dhcp_relay['client_iface']['name'])

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -1,11 +1,12 @@
 import pytest
 import time
+import ptf.packet as scapy
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 from tests.dhcp_relay.dhcp_relay_utils import restart_dhcp_service
 from tests.common.helpers.assertions import pytest_assert, pytest_require
-from tests.common.utilities import wait_until
+from tests.common.utilities import skip_release, wait_until, capture_and_check_packet_on_dut
 from tests.ptf_runner import ptf_runner
 
 pytestmark = [
@@ -15,6 +16,8 @@ pytestmark = [
 
 BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68
+DEFAULT_DHCP_SERVER_PORT = 67
+DUAL_TOR_MODE = 'dual'
 
 
 def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
@@ -95,3 +98,143 @@ def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_d
                             "uplink_mac": str(dut_dhcp_relay_data[0]['uplink_mac']),
                             "testing_mode": testing_mode},
                    log_file="/tmp/dhcp_relay_test.stress.DHCPTest.log", is_python3=True)
+
+
+def check_dhcp_stress_status(duthost, test_duration_seconds):
+    # Monitor DHCP status during the test
+    start_time = time.time()
+    while time.time() - start_time < test_duration_seconds:
+        # Check the status of the DHCP container
+        dhcp_container_status = duthost.shell('docker ps | grep dhcp_relay')["stdout"]
+        if dhcp_container_status == "":
+            assert False, "DHCP container is NOT running."
+
+        # Check CPU usage of the DHCP process
+        dhcp_cpu_usage = duthost.shell('show processes cpu --verbose | grep dhcp | awk \'{print $9}\'')["stdout"]
+        if dhcp_cpu_usage:
+            dhcp_cpu_usage_lines = dhcp_cpu_usage.splitlines()
+            for cpu_usage in dhcp_cpu_usage_lines:
+                cpu_usage_float = float(cpu_usage)
+            assert cpu_usage_float < 50.0, "DHCP CPU usage is too high: {}%".format(cpu_usage_float)
+
+        # Check the status of multiple DHCP processes inside the container
+        dhcp_process_status = duthost.shell('docker exec dhcp_relay supervisorctl status | grep dhcp | awk \'{print $2}\'')["stdout"]
+        if dhcp_process_status:
+            dhcp_process_status_lines = dhcp_process_status.splitlines()
+            for process_status in dhcp_process_status_lines:
+                assert process_status == "RUNNING", "DHCP related process is not running!"
+        time.sleep(30)
+
+
+def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
+    """Test DHCP relay functionality on T0 topology
+       and verify that HCP relay service can handle the maximum load without failure.
+    """
+    testing_mode, duthost = testing_config
+    packets_send_duration = 120
+    client_packets_per_sec = 10000
+
+    if testing_mode == DUAL_TOR_MODE:
+        skip_release(duthost, ["201811", "201911"])
+
+    for dhcp_relay in dut_dhcp_relay_data:
+        client_port_name = str(dhcp_relay['client_iface']['name'])
+        client_port_id = dhcp_relay['client_iface']['port_idx']
+        client_mac = ptfadapter.dataplane.get_mac(0, client_port_id).decode('utf-8')
+        server_port_name = dhcp_relay['uplink_interfaces'][0]
+        server_mac = ptfadapter.dataplane.get_mac(0, dhcp_relay['uplink_port_indices'][0]).decode('utf-8')
+        num_dhcp_servers = len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
+        test_xid = 0
+        params = {
+            "hostname": duthost.hostname,
+            "client_port_index": client_port_id,
+            "client_iface_alias": str(dhcp_relay['client_iface']['alias']),
+            "other_client_ports": repr(dhcp_relay['other_client_ports']),
+            "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
+            "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs']),
+            "server_ip": dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'],
+            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
+            "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask']),
+            "dest_mac_address": BROADCAST_MAC,
+            "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
+            "switch_loopback_ip": dhcp_relay['switch_loopback_ip'],
+            "uplink_mac": str(dhcp_relay['uplink_mac']),
+            "packets_send_duration": packets_send_duration,
+            "client_packets_per_sec": client_packets_per_sec,
+            "testing_mode": testing_mode
+        }
+
+        def verify_server_packets(pkts):
+                actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == test_xid])
+                lower_bound = int(exp_count * 0.9)
+                upper_bound = int(exp_count * 1.1)
+                pytest_assert(lower_bound <= actual_count * num_dhcp_servers <= upper_bound, 
+                              "Mismatch: Actual count = {}, Expected count = {}.".format(actual_count, exp_count))
+
+        def verify_client_packets(pkts):
+                actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == test_xid])
+                lower_bound = int(exp_count * 0.9)
+                upper_bound = int(exp_count * 1.1)
+                pytest_assert(lower_bound <= actual_count <= upper_bound, 
+                              "Mismatch: Actual count = {}, Expected count = {}.".format(actual_count, exp_count))
+
+        with capture_and_check_packet_on_dut(
+                duthost=duthost, interface=client_port_name,
+                pkts_filter="ether src %s and udp dst port %s" % (client_mac, DEFAULT_DHCP_SERVER_PORT),
+                pkts_validator=verify_server_packets
+            ):
+                ptf_runner(ptfhost,
+                        "ptftests",
+                        "dhcp_relay_test.DHCPStressDiscoverTest",
+                        platform_dir="ptftests",
+                        params=params,
+                        log_file="/tmp/dhcp_relay_test.DHCPStressTest.log",
+                        qlen=100000, is_python3=True, async_mode=True)
+                check_dhcp_stress_status(duthost, packets_send_duration)
+                exp_count = int(ptfhost.shell('cat /tmp/dhcp_stress_test_discover.json')['stdout'].strip())
+
+        with capture_and_check_packet_on_dut(
+                duthost=duthost, interface=server_port_name,
+                pkts_filter="ether src %s and udp dst port %s" % (server_mac, DEFAULT_DHCP_SERVER_PORT),
+                pkts_validator=verify_client_packets
+            ):
+                ptf_runner(ptfhost,
+                        "ptftests",
+                        "dhcp_relay_test.DHCPStressOfferTest",
+                        platform_dir="ptftests",
+                        params=params,
+                        log_file="/tmp/dhcp_relay_test.DHCPStressTest.log",
+                        qlen=100000, is_python3=True, async_mode=True)
+                check_dhcp_stress_status(duthost, packets_send_duration)
+                exp_count = int(ptfhost.shell('cat /tmp/dhcp_stress_test_offer.json')['stdout'].strip())
+
+        with capture_and_check_packet_on_dut(
+                duthost=duthost, interface=client_port_name,
+                pkts_filter="ether src %s and udp dst port %s" % (client_mac, DEFAULT_DHCP_SERVER_PORT),
+                pkts_validator=verify_server_packets
+            ):
+                ptf_runner(ptfhost,
+                        "ptftests",
+                        "dhcp_relay_test.DHCPStressRequestTest",
+                        platform_dir="ptftests",
+                        params=params,
+                        log_file="/tmp/dhcp_relay_test.DHCPStressTest.log",
+                        qlen=100000, is_python3=True, async_mode=True)
+                check_dhcp_stress_status(duthost, packets_send_duration)
+                exp_count = int(ptfhost.shell('cat /tmp/dhcp_stress_test_request.json')['stdout'].strip())
+
+        with capture_and_check_packet_on_dut(
+                duthost=duthost, interface=server_port_name,
+                pkts_filter="ether src %s and udp dst port %s" % (server_mac, DEFAULT_DHCP_SERVER_PORT),
+                pkts_validator=verify_client_packets
+            ):
+                ptf_runner(ptfhost,
+                        "ptftests",
+                        "dhcp_relay_test.DHCPStressAckTest",
+                        platform_dir="ptftests",
+                        params=params,
+                        log_file="/tmp/dhcp_relay_test.DHCPStressTest.log",
+                        qlen=100000, is_python3=True, async_mode=True)
+                check_dhcp_stress_status(duthost, packets_send_duration)
+                exp_count = int(ptfhost.shell('cat /tmp/dhcp_stress_test_ack.json')['stdout'].strip())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
The purpose of this test is to conduct a DHCP stress test with CoPP policy, ensuring that the DHCP relay service can withstand the maximum load applied to the CPU

#### How did you do it?
In the test, we will generate packets at a rate of 10,000 packets per second for 120 seconds to ensure the DHCP relay service can handle the maximum load without failure.

#### How did you verify/test it?
By monitoring the status of the DHCP container, resource utilization, and verify that the DHCP processes are running.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
