### PR TITLE
Conflict resolve 202311 branch cherry-pick #14458

### DIFF
--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -45,6 +45,17 @@ COMBINED_L2L3_DROP_COUNTER = False
 COMBINED_ACL_DROP_COUNTER = False
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loganalyzer):
+    # Ignore syslog error from xcvrd while using copper cables
+    CopperCableIgnoreRegex = [
+        ".* ERR pmon#xcvrd.*no suitable app for the port appl.*host_lane_count.*host_speed.*"
+    ]
+    duthost = duthosts[rand_one_dut_hostname]
+    if loganalyzer:  # Skip if loganalyzer is enabled
+        loganalyzer[duthost.hostname].ignore_regex.extend(CopperCableIgnoreRegex)
+
+
 @pytest.fixture(autouse=True, scope="module")
 def enable_counters(duthosts):
     """ Fixture which enables RIF and L2 counters """


### PR DESCRIPTION
Extract from orignal PR:

### Description of PR
Ignore below expected xcvrd errors that gets logged when using copper cables.
```
Jul  3 15:24:06.737771 str3-8101-02 ERR pmon#xcvrd[30]: CMIS: Ethernet36: no suitable app for the port appl 0 host_lane_count 4 host_speed 100000
```

Summary:
Ignore below expected xcvrd errors when using copper cables.

Fixes # 

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
These errors expected when using copper cables and should be ignored.

#### How did you do it?
Added this error in ignore list.

#### How did you verify/test it?
Verification with different speed/lane is work in progress

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
NA