### PR TITLE
Add dhcp-relay structured events tests (#13504)

### DIFF
--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -164,7 +164,8 @@ def do_init(duthost):
 
 
 @pytest.fixture(scope="module")
-def test_eventd_healthy(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, gnxi_path):
+def test_eventd_healthy(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, ptfadapter,
+                        setup_streaming_telemetry, gnxi_path):
     """
     @summary: Test eventd heartbeat before testing all testcases
     """
@@ -182,6 +183,6 @@ def test_eventd_healthy(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, set
 
     module = __import__("eventd_events")
 
-    module.test_event(duthost, gnxi_path, ptfhost, DATA_DIR, None)
+    module.test_event(duthost, gnxi_path, ptfhost, ptfadapter, DATA_DIR, None)
 
     logger.info("Completed test file: {}".format("eventd_events test completed."))

--- a/tests/telemetry/events/bgp_events.py
+++ b/tests/telemetry/events/bgp_events.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 tag = "sonic-events-bgp"
 
 
-def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
+def test_event(duthost, gnxi_path, ptfhost, ptfadapter, data_dir, validate_yang):
     run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, drop_tcp_packets,
              "bgp_notification.json", "sonic-events-bgp:notification", tag)
     run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, shutdown_bgp_neighbors,

--- a/tests/telemetry/events/dhcp-relay_events.py
+++ b/tests/telemetry/events/dhcp-relay_events.py
@@ -1,0 +1,110 @@
+#! /usr/bin/env python3
+
+import pytest
+import logging
+import time
+import ptf.testutils as testutils
+
+from tests.common.helpers.assertions import pytest_assert as py_assert
+from tests.common.utilities import wait_until
+from run_events_test import run_test
+from event_utils import find_test_vlan, find_test_port_and_mac, create_dhcp_discover_packet
+
+logger = logging.getLogger(__name__)
+tag = "sonic-events-dhcp-relay"
+
+
+def test_event(duthost, gnxi_path, ptfhost, ptfadapter, data_dir, validate_yang):
+    features_states, succeeded = duthost.get_feature_status()
+    if not succeeded or features_states["dhcp_relay"] != "enabled":
+        pytest.skip("dhcp_relay is not enabled, skipping dhcp_relay events")
+    logger.info("Beginning to test dhcp-relay events")
+    run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, trigger_dhcp_relay_discard,
+             "dhcp_relay_discard.json", "sonic-events-dhcp-relay:dhcp-relay-discard", tag, False, 30, ptfadapter)
+    run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, trigger_dhcp_relay_disparity,
+             "dhcp_relay_disparity.json", "sonic-events-dhcp-relay:dhcp-relay-disparity", tag, False, 30, ptfadapter)
+    run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, trigger_dhcp_relay_bind_failure,
+             "dhcp_relay_bind_failure.json", "sonic-events-dhcp-relay:dhcp-relay-bind-failure", tag, False, 30)
+
+
+def trigger_dhcp_relay_discard(duthost, ptfadapter):
+    send_dhcp_discover_packets(duthost, ptfadapter)
+
+
+def trigger_dhcp_relay_disparity(duthost, ptfadapter):
+    """11 packets because dhcpmon process will store up to 10 unhealthy status events
+    https://github.com/sonic-net/sonic-dhcpmon/blob/master/src/dhcp_mon.cpp#L94
+    static int dhcp_unhealthy_max_count = 10;
+    Sending at interval of 18 seconds because dhcpmon process will check health at that interval
+    static int window_interval_sec = 18;
+    """
+    send_dhcp_discover_packets(duthost, ptfadapter, 11, 18)
+
+
+def trigger_dhcp_relay_bind_failure(duthost):
+    # Flush ipv6 vlan address and restart dhc6relay process
+    py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "dhcp_relay"),
+              "dhcp_relay container not started")
+
+    # Get Vlan with IPv6 address configured
+    dhcp_test_info = find_test_vlan(duthost)
+    py_assert(len(dhcp_test_info) != 0, "Unable to find vlan for test")
+
+    vlan = dhcp_test_info["vlan"]
+    dhcp6_relay_process = dhcp_test_info["dhcp6relay_process"]
+    ipv6_ip = dhcp_test_info["ipv6_address"]
+
+    try:
+        # Flush ipv6 address from vlan
+        duthost.shell("ip -6 address flush dev {}".format(vlan))
+
+        # Restart dhcrelay process
+        duthost.shell("docker exec dhcp_relay supervisorctl restart {}".format(dhcp6_relay_process))
+
+    finally:
+        # Add back ipv6 address to vlan
+        duthost.shell("ip address add {} dev {}".format(ipv6_ip, vlan))
+
+        # Restart dhcrelay process
+        duthost.shell("docker exec dhcp_relay supervisorctl restart {}".format(dhcp6_relay_process))
+
+
+def send_dhcp_discover_packets(duthost, ptfadapter, packets_to_send=5, interval=1):
+    py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, "dhcp_relay"),
+              "dhcp_relay container not started")
+
+    # Get Vlan with IPv4 address configured
+    dhcp_test_info = find_test_vlan(duthost)
+    py_assert(len(dhcp_test_info) != 0, "Unable to find vlan for test")
+
+    vlan = dhcp_test_info["vlan"]
+    dhcrelay_process = dhcp_test_info["dhcrelay_process"]
+    ipv4_ip = dhcp_test_info["ipv4_address"]
+    member_interfaces = dhcp_test_info["member_interface"]
+
+    try:
+        # Flush ipv4 address from vlan
+        duthost.shell("ip -4 address flush dev {}".format(vlan))
+
+        # Restart dhcrelay process
+        duthost.shell("docker exec dhcp_relay supervisorctl restart {}".format(dhcrelay_process))
+
+        # Send packets
+
+        # results contains up to 5 tuples of member interfaces from vlan (port, mac address)
+        results = find_test_port_and_mac(duthost, member_interfaces, 5)
+
+        for i in range(packets_to_send):
+            result = results[i % len(results)]
+            port = result[0]
+            client_mac = result[1]
+            packet = create_dhcp_discover_packet(client_mac)
+            testutils.send_packet(ptfadapter, port, packet)
+            time.sleep(interval)
+
+    finally:
+        # Add back ipv4 address to vlan
+        duthost.shell("ip address add {} dev {}".format(ipv4_ip, vlan))
+
+        # Restart dhcrelay process
+        duthost.shell("docker exec dhcp_relay supervisorctl restart {}".format(dhcrelay_process))

--- a/tests/telemetry/events/eventd_events.py
+++ b/tests/telemetry/events/eventd_events.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 tag = "sonic-events-eventd"
 
 
-def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
+def test_event(duthost, gnxi_path, ptfhost, ptfadapter, data_dir, validate_yang):
     logger.info("Beginning to test eventd heartbeat")
     run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, None,
              "heartbeat.json", "sonic-events-eventd:heartbeat", tag, True)

--- a/tests/telemetry/events/host_events.py
+++ b/tests/telemetry/events/host_events.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 tag = "sonic-events-host"
 
 
-def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
+def test_event(duthost, gnxi_path, ptfhost, ptfadapter, data_dir, validate_yang):
     logger.info("Beginning to test host events")
     run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, trigger_kernel_event,
              "event_kernel.json", "sonic-events-host:event-kernel", tag, False)

--- a/tests/telemetry/events/run_events_test.py
+++ b/tests/telemetry/events/run_events_test.py
@@ -11,10 +11,13 @@ logger = logging.getLogger(__name__)
 
 
 def run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, trigger, json_file,
-             filter_event_regex, tag, heartbeat=False, thread_timeout=30):
+             filter_event_regex, tag, heartbeat=False, thread_timeout=30, ptfadapter=None):
     op_file = os.path.join(data_dir, json_file)
     if trigger is not None:  # no trigger for heartbeat
-        trigger(duthost)  # add events to cache
+        if ptfadapter is None:
+            trigger(duthost)  # add events to cache
+        else:
+            trigger(duthost, ptfadapter)
     listen_for_events(duthost, gnxi_path, ptfhost, filter_event_regex, op_file,
                       thread_timeout)  # listen from cache
     data = {}

--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -28,7 +28,7 @@ CRM_TEST_ACL_GROUP_HIGH = 0
 WAIT_TIME = 3
 
 
-def test_event(duthost, gnxi_path, ptfhost, data_dir, validate_yang):
+def test_event(duthost, gnxi_path, ptfhost, ptfadapter, data_dir, validate_yang):
     if duthost.topo_type.lower() in ["m0", "mx"]:
         logger.info("Skipping swss events test on MGFX topologies")
         return

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -37,7 +37,7 @@ def validate_yang(duthost, op_file="", yang_file=""):
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 @pytest.mark.disable_loganalyzer
-def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_streaming_telemetry, gnxi_path,
+def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, ptfadapter, setup_streaming_telemetry, gnxi_path,
                 test_eventd_healthy):
     """ Run series of events inside duthost and validate that output is correct
     and conforms to YANG schema"""
@@ -50,7 +50,7 @@ def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_strea
     for file in os.listdir(EVENTS_TESTS_PATH):
         if file.endswith("_events.py") and not file.endswith("eventd_events.py"):
             module = __import__(file[:len(file)-3])
-            module.test_event(duthost, gnxi_path, ptfhost, DATA_DIR, validate_yang)
+            module.test_event(duthost, gnxi_path, ptfhost, ptfadapter, DATA_DIR, validate_yang)
             logger.info("Completed test file: {}".format(os.path.join(EVENTS_TESTS_PATH, file)))
 
 


### PR DESCRIPTION
Cherry-pick #13504 

telemetry/test_events.py::test_events[vlab-01-False] PASSED              [ 33%]
telemetry/test_events.py::test_events_cache[vlab-01-False] PASSED        [ 66%]
telemetry/test_events.py::test_events_cache_overflow[vlab-01-False] PASSED [100%]

Test Results:

22/10/2024 00:44:06 run_events_test.run_test                 L0027 INFO   | events received:
```
([
    {
        "sonic-events-dhcp-relay:dhcp-relay-discard": {
            "ifname": "eth4",
            "timestamp": "2024-10-22T00:43:56.334060Z"
        }
    }
])
```
  22/10/2024 00:47:47 run_events_test.run_test                 L0027 INFO   | events received:
 ```
([
      {
          "sonic-events-dhcp-relay:dhcp-relay-disparity": {
              "duration": "198",
              "timestamp": "2024-10-22T00:47:12.924422Z",
              "vlan": "Agg-Vlan1000"
          }
    }
])
```
22/10/2024 00:48:26 run_events_test.run_test                 L0027 INFO   | events received: 
```
([
    {
        "sonic-events-dhcp-relay:dhcp-relay-bind-failure": {
            "timestamp": "2024-10-22T00:48:25.445207Z",
            "type": "local",
            "vlan": "Vlan1000"
        }
    }
])
```

Add support for dhcp-relay-discard event, which we use ptfadapter to and ptf.testutils to send a dhcp discover packet to a port that has no ipv4 address assigned.

Add support for dhcp-relay-disparity event which uses same repro for dhcp-relay-disparity but at greater intervals and packets sent due to dhcpmon configuration

Added new testcase that triggered sending dhcp discover packet which will trigger event.

Pipeline/Manual test

run_events_test.run_test                 L0027 INFO   | events received:
```json
    {
        "sonic-events-dhcp-relay:dhcp-relay-discard": {
            "ifname": "Vlan1000",
            "timestamp": "2024-07-09T01:27:30.395216Z"
        }
    }
```
run_events_test.run_test                 L0027 INFO   | events received:
```json
    {
        "sonic-events-dhcp-relay:dhcp-relay-disparity": {
            "duration": "198",
            "timestamp": "2024-07-09T01:30:43.711312Z",
            "vlan": "Agg-Vlan1000"
        }
    }
```
run_events_test.run_test                 L0027 INFO   | events received:
```json
    {
        "sonic-events-dhcp-relay:dhcp-relay-bind-failure": {
            "timestamp": "2024-07-09T01:32:27.667714Z",
            "type": "local",
            "vlan": "Vlan1000"
        }
    }
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 26636373

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

Add support for dhcp-relay-discard event, which we use ptfadapter to and ptf.testutils to send a dhcp discover packet to a port that has no ipv4 address assigned.

Add support for dhcp-relay-disparity event which uses same repro for dhcp-relay-disparity but at greater intervals and packets sent due to dhcpmon configuration

#### How did you do it?

Added new testcase that triggered sending dhcp discover packet which will trigger event.

#### How did you verify/test it?

Pipeline/Manual test

#### Any platform specific information?

No

#### Supported testbed topology if it's a new test case?

T0

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
