### PR TITLE
Revert PR:12186 crm_stats_ipv6_route_available counter was not decremented, as we have a fix in platform side of code

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -517,10 +517,6 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
         logging.info("route add cmd: {}".format(route_add))
         duthost.command(route_add)
 
-    if is_cisco_device(duthost):
-        # Sleep more time after route add
-        time.sleep(10)
-
     check_available_counters = True
     if duthost.facts['asic_type'] == 'broadcom':
         check_available_counters = False
@@ -546,9 +542,7 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
             RESTORE_CMDS["test_crm_route"].append(route_del_cmd.format(asichost.ip_cmd, i, nh_ip))
         pytest.fail("\"crm_stats_ipv{}_route_used\" counter was not incremented".format(ip_ver))
     # Verify "crm_stats_ipv[4/6]_route_available" counter was decremented
-    # For Cisco-8000 devices, hardware counters are statistical-based with +/- 1 entry tolerance.
-    # Hence, the available counter may not increase as per initial value.
-    if check_available_counters and not (crm_stats_route_available - new_crm_stats_route_available > 1):
+    if check_available_counters and not (crm_stats_route_available - new_crm_stats_route_available >= 1):
         if is_mellanox_device(duthost):
             # Get sai sdk dump file in case test fail, we can get the LPM tree information
             get_sai_sdk_dump_file(duthost, f"sai_sdk_dump_after_add_v{ip_ver}_router")


### PR DESCRIPTION
### Description of PR
https://github.com/sonic-net/sonic-mgmt/pull/14104
Reverting this PR as we have fix on the platform side to take care of the CRM route resource usage related issue.

This change is merged in master https://github.com/sonic-net/sonic-mgmt/pull/14602
This is a conflict merge to 202405 branch.

Summary:
Fixes # (issue)

CRM route resource fix is committed in the platform side of code. the additional delay and checks added part of the PR/14104 is no longer needed.

### Type of change


- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Revert the cisco specific change added in sonic-mgmt code.


#### How did you do it?

#### How did you verify/test it?
Verified running sonic mgmt tests/test_crm.py::test_crm_route


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
