### PR TITLE
add ptfhost check to prevent failure on test_posttest.py

### DIFF
--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -92,6 +92,8 @@ def test_enable_startup_tsa_tsb_service(duthosts, localhost):
 
 
 def test_collect_ptf_logs(ptfhost):
+    if ptfhost is None:
+        return
     log_files = ptfhost.shell('ls /tmp/*.log')['stdout'].split()
     if not os.path.exists('logs/ptf'):
         os.makedirs('logs/ptf')


### PR DESCRIPTION
PTFHost can be None in some cases (eg. ixia) and this was not handled correctly in test_collect_ptf_logs. Add ptfhost check to prevent error caused by None value.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
PTFHost can be None in some cases (eg. ixia) and this was not handled correctly in test_collect_ptf_logs. Add ptfhost check to prevent error caused by None value.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Resolve unexpected error during log collection
#### How did you do it?
check for None value
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
