### PR TITLE
Retry test_psu.py::TestPsuApi::test_power if power not within tolerance

### DIFF
--- a/tests/platform_tests/api/platform_api_test_base.py
+++ b/tests/platform_tests/api/platform_api_test_base.py
@@ -30,3 +30,6 @@ class PlatformApiTestBase(object):
             # TODO: When we move to Python 3.3+, we can use self.failed_expectations.clear() instead
             del self.failed_expectations[:]
             pytest_assert(False, err_msg)
+
+    def get_len_failed_expectations(self):
+        return len(self.failed_expectations)

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -240,7 +240,7 @@ class TestPsuApi(PlatformApiTestBase):
                                        "Failed to retrieve maximum supplied power of PSU {}".format(psu_id)):
                             self.expect(isinstance(max_supp_power, float),
                                         "PSU {} maximum supplied power appears incorrect".format(psu_id))
-                    
+
                     failure_occured = self.get_len_failed_expectations() > failure_count
 
                     if current is not None and voltage is not None and power is not None:

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -207,7 +207,7 @@ class TestPsuApi(PlatformApiTestBase):
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
 
         for psu_id in range(self.num_psus):
-            for i in range(0,MAX_ATTEMPTS):
+            for i in range(0, MAX_ATTEMPTS):
                 name = psu.get_name(platform_api_conn, psu_id)
                 if name in self.psu_skip_list:
                     logger.info("skipping check for {}".format(name))
@@ -235,7 +235,7 @@ class TestPsuApi(PlatformApiTestBase):
                     if max_power_supported:
                         max_supp_power = psu.get_maximum_supplied_power(platform_api_conn, psu_id)
                         if self.expect(max_supp_power is not None,
-                                    "Failed to retrieve maximum supplied power of PSU {}".format(psu_id)):
+                                       "Failed to retrieve maximum supplied power of PSU {}".format(psu_id)):
                             self.expect(isinstance(max_supp_power, float),
                                         "PSU {} maximum supplied power appears incorrect".format(psu_id))
 
@@ -249,15 +249,16 @@ class TestPsuApi(PlatformApiTestBase):
 
                     powergood_status = psu.get_powergood_status(platform_api_conn, psu_id)
                     if self.expect(powergood_status is not None,
-                                "Failed to retrieve operational status of PSU {}".format(psu_id)):
+                                   "Failed to retrieve operational status of PSU {}".format(psu_id)):
                         self.expect(powergood_status is True, "PSU {} is not operational".format(psu_id))
 
                     high_threshold = None
-                    voltage_high_threshold_supported = self.get_psu_facts(duthost, psu_id, True, "voltage_high_threshold")
+                    voltage_high_threshold_supported = self.get_psu_facts(duthost, psu_id, True,
+                                                                          "voltage_high_threshold")
                     if voltage_high_threshold_supported:
                         high_threshold = psu.get_voltage_high_threshold(platform_api_conn, psu_id)
                         if self.expect(high_threshold is not None,
-                                    "Failed to retrieve the high voltage threshold of PSU {}".format(psu_id)):
+                                       "Failed to retrieve the high voltage threshold of PSU {}".format(psu_id)):
                             self.expect(isinstance(high_threshold, float),
                                         "PSU {} voltage high threshold appears incorrect".format(psu_id))
                     low_threshold = None
@@ -265,16 +266,16 @@ class TestPsuApi(PlatformApiTestBase):
                     if voltage_low_threshold_supported:
                         low_threshold = psu.get_voltage_low_threshold(platform_api_conn, psu_id)
                         if self.expect(low_threshold is not None,
-                                    "Failed to retrieve the low voltage threshold of PSU {}".format(psu_id)):
+                                       "Failed to retrieve the low voltage threshold of PSU {}".format(psu_id)):
                             self.expect(isinstance(low_threshold, float),
                                         "PSU {} voltage low threshold appears incorrect".format(psu_id))
                     if high_threshold is not None and low_threshold is not None:
                         self.expect(voltage < high_threshold and voltage > low_threshold,
                                     "Voltage {} of PSU {} is not in between {} and {}"
                                     .format(voltage, psu_id, low_threshold, high_threshold))
-                
+
                 break
-            
+
         self.assert_expectations()
 
     def test_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -32,6 +32,7 @@ STATUS_LED_COLOR_GREEN = "green"
 STATUS_LED_COLOR_AMBER = "amber"
 STATUS_LED_COLOR_RED = "red"
 STATUS_LED_COLOR_OFF = "off"
+MAX_ATTEMPTS = 3
 
 
 class TestPsuApi(PlatformApiTestBase):
@@ -206,66 +207,74 @@ class TestPsuApi(PlatformApiTestBase):
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
 
         for psu_id in range(self.num_psus):
-            name = psu.get_name(platform_api_conn, psu_id)
-            if name in self.psu_skip_list:
-                logger.info("skipping check for {}".format(name))
-            else:
-                voltage = None
-                voltage_supported = self.get_psu_facts(duthost, psu_id, True, "voltage")
-                if voltage_supported:
-                    voltage = psu.get_voltage(platform_api_conn, psu_id)
-                    if self.expect(voltage is not None, "Failed to retrieve voltage of PSU {}".format(psu_id)):
-                        self.expect(isinstance(voltage, float), "PSU {} voltage appears incorrect".format(psu_id))
-                current = None
-                current_supported = self.get_psu_facts(duthost, psu_id, True, "current")
-                if current_supported:
-                    current = psu.get_current(platform_api_conn, psu_id)
-                    if self.expect(current is not None, "Failed to retrieve current of PSU {}".format(psu_id)):
-                        self.expect(isinstance(current, float), "PSU {} current appears incorrect".format(psu_id))
-                power = None
-                power_supported = self.get_psu_facts(duthost, psu_id, True, "power")
-                if power_supported:
-                    power = psu.get_power(platform_api_conn, psu_id)
-                    if self.expect(power is not None, "Failed to retrieve power of PSU {}".format(psu_id)):
-                        self.expect(isinstance(power, float), "PSU {} power appears incorrect".format(psu_id))
-                max_supp_power = None
-                max_power_supported = self.get_psu_facts(duthost, psu_id, True, "max_power")
-                if max_power_supported:
-                    max_supp_power = psu.get_maximum_supplied_power(platform_api_conn, psu_id)
-                    if self.expect(max_supp_power is not None,
-                                   "Failed to retrieve maximum supplied power power of PSU {}".format(psu_id)):
-                        self.expect(isinstance(max_supp_power, float),
-                                    "PSU {} maximum supplied power appears incorrect".format(psu_id))
+            for i in range(0,MAX_ATTEMPTS):
+                name = psu.get_name(platform_api_conn, psu_id)
+                if name in self.psu_skip_list:
+                    logger.info("skipping check for {}".format(name))
+                else:
+                    voltage = None
+                    voltage_supported = self.get_psu_facts(duthost, psu_id, True, "voltage")
+                    if voltage_supported:
+                        voltage = psu.get_voltage(platform_api_conn, psu_id)
+                        if self.expect(voltage is not None, "Failed to retrieve voltage of PSU {}".format(psu_id)):
+                            self.expect(isinstance(voltage, float), "PSU {} voltage appears incorrect".format(psu_id))
+                    current = None
+                    current_supported = self.get_psu_facts(duthost, psu_id, True, "current")
+                    if current_supported:
+                        current = psu.get_current(platform_api_conn, psu_id)
+                        if self.expect(current is not None, "Failed to retrieve current of PSU {}".format(psu_id)):
+                            self.expect(isinstance(current, float), "PSU {} current appears incorrect".format(psu_id))
+                    power = None
+                    power_supported = self.get_psu_facts(duthost, psu_id, True, "power")
+                    if power_supported:
+                        power = psu.get_power(platform_api_conn, psu_id)
+                        if self.expect(power is not None, "Failed to retrieve power of PSU {}".format(psu_id)):
+                            self.expect(isinstance(power, float), "PSU {} power appears incorrect".format(psu_id))
+                    max_supp_power = None
+                    max_power_supported = self.get_psu_facts(duthost, psu_id, True, "max_power")
+                    if max_power_supported:
+                        max_supp_power = psu.get_maximum_supplied_power(platform_api_conn, psu_id)
+                        if self.expect(max_supp_power is not None,
+                                    "Failed to retrieve maximum supplied power of PSU {}".format(psu_id)):
+                            self.expect(isinstance(max_supp_power, float),
+                                        "PSU {} maximum supplied power appears incorrect".format(psu_id))
 
-                if current is not None and voltage is not None and power is not None:
-                    self.expect(abs(power - (voltage*current)) < power*0.1, "PSU {} reading does not make sense \
-                        (power:{}, voltage:{}, current:{})".format(psu_id, power, voltage, current))
+                    if current is not None and voltage is not None and power is not None:
+                        is_within_tolerance = abs(power - (voltage*current)) < power*0.1
+                        if not is_within_tolerance and i < MAX_ATTEMPTS - 1:
+                            logger.info("Retrying test for {} as readings not within tolerance level".format(name))
+                            continue
+                        self.expect(is_within_tolerance, "PSU {} reading does not make sense \
+                            (power:{}, voltage:{}, current:{})".format(psu_id, power, voltage, current))
 
-                powergood_status = psu.get_powergood_status(platform_api_conn, psu_id)
-                if self.expect(powergood_status is not None,
-                               "Failed to retrieve operational status of PSU {}".format(psu_id)):
-                    self.expect(powergood_status is True, "PSU {} is not operational".format(psu_id))
+                    powergood_status = psu.get_powergood_status(platform_api_conn, psu_id)
+                    if self.expect(powergood_status is not None,
+                                "Failed to retrieve operational status of PSU {}".format(psu_id)):
+                        self.expect(powergood_status is True, "PSU {} is not operational".format(psu_id))
 
-                high_threshold = None
-                voltage_high_threshold_supported = self.get_psu_facts(duthost, psu_id, True, "voltage_high_threshold")
-                if voltage_high_threshold_supported:
-                    high_threshold = psu.get_voltage_high_threshold(platform_api_conn, psu_id)
-                    if self.expect(high_threshold is not None,
-                                   "Failed to retrieve the high voltage threshold of PSU {}".format(psu_id)):
-                        self.expect(isinstance(high_threshold, float),
-                                    "PSU {} voltage high threshold appears incorrect".format(psu_id))
-                low_threshold = None
-                voltage_low_threshold_supported = self.get_psu_facts(duthost, psu_id, True, "voltage_low_threshold")
-                if voltage_low_threshold_supported:
-                    low_threshold = psu.get_voltage_low_threshold(platform_api_conn, psu_id)
-                    if self.expect(low_threshold is not None,
-                                   "Failed to retrieve the low voltage threshold of PSU {}".format(psu_id)):
-                        self.expect(isinstance(low_threshold, float),
-                                    "PSU {} voltage low threshold appears incorrect".format(psu_id))
-                if high_threshold is not None and low_threshold is not None:
-                    self.expect(voltage < high_threshold and voltage > low_threshold,
-                                "Voltage {} of PSU {} is not in between {} and {}"
-                                .format(voltage, psu_id, low_threshold, high_threshold))
+                    high_threshold = None
+                    voltage_high_threshold_supported = self.get_psu_facts(duthost, psu_id, True, "voltage_high_threshold")
+                    if voltage_high_threshold_supported:
+                        high_threshold = psu.get_voltage_high_threshold(platform_api_conn, psu_id)
+                        if self.expect(high_threshold is not None,
+                                    "Failed to retrieve the high voltage threshold of PSU {}".format(psu_id)):
+                            self.expect(isinstance(high_threshold, float),
+                                        "PSU {} voltage high threshold appears incorrect".format(psu_id))
+                    low_threshold = None
+                    voltage_low_threshold_supported = self.get_psu_facts(duthost, psu_id, True, "voltage_low_threshold")
+                    if voltage_low_threshold_supported:
+                        low_threshold = psu.get_voltage_low_threshold(platform_api_conn, psu_id)
+                        if self.expect(low_threshold is not None,
+                                    "Failed to retrieve the low voltage threshold of PSU {}".format(psu_id)):
+                            self.expect(isinstance(low_threshold, float),
+                                        "PSU {} voltage low threshold appears incorrect".format(psu_id))
+                    if high_threshold is not None and low_threshold is not None:
+                        self.expect(voltage < high_threshold and voltage > low_threshold,
+                                    "Voltage {} of PSU {} is not in between {} and {}"
+                                    .format(voltage, psu_id, low_threshold, high_threshold))
+                
+                break
+            
         self.assert_expectations()
 
     def test_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -207,6 +207,8 @@ class TestPsuApi(PlatformApiTestBase):
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
 
         for psu_id in range(self.num_psus):
+            failure_count = self.get_len_failed_expectations()
+            failure_occured = False
             for i in range(0, MAX_ATTEMPTS):
                 name = psu.get_name(platform_api_conn, psu_id)
                 if name in self.psu_skip_list:
@@ -238,10 +240,12 @@ class TestPsuApi(PlatformApiTestBase):
                                        "Failed to retrieve maximum supplied power of PSU {}".format(psu_id)):
                             self.expect(isinstance(max_supp_power, float),
                                         "PSU {} maximum supplied power appears incorrect".format(psu_id))
+                    
+                    failure_occured = self.get_len_failed_expectations() > failure_count
 
                     if current is not None and voltage is not None and power is not None:
                         is_within_tolerance = abs(power - (voltage*current)) < power*0.1
-                        if not is_within_tolerance and i < MAX_ATTEMPTS - 1:
+                        if not failure_occured and not is_within_tolerance and i < MAX_ATTEMPTS - 1:
                             logger.info("Retrying test for {} as readings not within tolerance level".format(name))
                             continue
                         self.expect(is_within_tolerance, "PSU {} reading does not make sense \


### PR DESCRIPTION
<!--Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
If `test_psu.py::TestPsuApi::test_power`  fails on `abs(power - (voltage*current)) < power*0.1` then retry the test.  The test is repeated for a maximum of three times until it passes, else it is failed. This change is introduced to account for the stringent tolerance level of 10% and the errors that might be caused due to time differences in reading each of the parameters (current, voltage and power). 

Fixes # (issue)
Addresses issue: https://github.com/aristanetworks/sonic-qual.msft/issues/209 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Improve the test to account for stringent tolerance level and asymmetric reading of parameters for power calculation. 
#### How did you do it?
If the test fails for the condition `abs(power - (voltage*current)) < power*0.1`, the test will collect fresh parameters (voltage, current and power) from the PSU telemetry and recheck the condition. It is limited to a maximum of 3 attempts. 
#### How did you verify/test it?
Tested internally by varying the tolerance level and verifying the number of api calls. 
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
N/A
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
