### PR TITLE
Fix the Fib/ipdecap test case for new change where AZNG routes on ups…

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -215,7 +215,7 @@ class FibTest(BaseTest):
                     continue
                 if self.switch_type == "chassis-packet":
                     exp_port_lists = self.check_same_asic(src_port, exp_port_lists)
-                elif self.switch_type == "voq" and exp_port_lists[0]:
+                elif self.single_fib == "single-fib-single-hop" and exp_port_lists[0]:
                     dest_port_dut_index = self.ptf_test_port_map[str(exp_port_lists[0][0])]['target_dut'][0]
                     src_port_dut_index = self.ptf_test_port_map[str(src_port)]['target_dut'][0]
                     if src_port_dut_index == 0 and dest_port_dut_index == 0:

--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -215,6 +215,15 @@ class FibTest(BaseTest):
                     continue
                 if self.switch_type == "chassis-packet":
                     exp_port_lists = self.check_same_asic(src_port, exp_port_lists)
+                elif self.switch_type == "voq" and exp_port_lists[0]:
+                    dest_port_dut_index = self.ptf_test_port_map[str(exp_port_lists[0][0])]['target_dut'][0]
+                    src_port_dut_index = self.ptf_test_port_map[str(src_port)]['target_dut'][0]
+                    if src_port_dut_index == 0 and dest_port_dut_index == 0:
+                        ptf_non_upstream_ports = []
+                        for ptf_port, ptf_port_info in self.ptf_test_port_map.items():
+                            if ptf_port_info['target_dut'][0] != 0:
+                                ptf_non_upstream_ports.append(ptf_port)
+                        src_port = int(random.choice(ptf_non_upstream_ports))
                 logging.info('src_port={}, exp_port_lists={}, active_dut_indexes={}'.format(
                     src_port, exp_port_lists, active_dut_indexes))
                 break

--- a/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
@@ -492,6 +492,16 @@ class DecapPacketTest(BaseTest):
                 if src_port in exp_port_list:
                     break
             else:
+                if self.single_fib == "single-fib-single-hop" and exp_port_lists[0]:
+                    dest_port_dut_index = self.ptf_test_port_map[str(exp_port_lists[0][0])]['target_dut'][0]
+                    src_port_dut_index = self.ptf_test_port_map[str(src_port)]['target_dut'][0]
+                    if src_port_dut_index == 0 and dest_port_dut_index == 0:
+                        ptf_non_upstream_ports = []
+                        for ptf_port, ptf_port_info in self.ptf_test_port_map.items():
+                            if ptf_port_info['target_dut'][0] != 0:
+                                ptf_non_upstream_ports.append(ptf_port)
+                        src_port = int(random.choice(ptf_non_upstream_ports))
+ 
                 logging.info('src_port={}, exp_port_lists={}, active_dut_index={}'.format(
                     src_port, exp_port_lists, active_dut_indexes))
                 break

--- a/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
@@ -501,7 +501,6 @@ class DecapPacketTest(BaseTest):
                             if ptf_port_info['target_dut'][0] != 0:
                                 ptf_non_upstream_ports.append(ptf_port)
                         src_port = int(random.choice(ptf_non_upstream_ports))
- 
                 logging.info('src_port={}, exp_port_lists={}, active_dut_index={}'.format(
                     src_port, exp_port_lists, active_dut_indexes))
                 break

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -128,7 +128,7 @@ class HashTest(BaseTest):
                 if src_port in exp_port_list:
                     break
             else:
-                if self.switch_type == "voq" and exp_port_lists[0]:
+                if self.single_fib == "single-fib-single-hop" and exp_port_lists[0]:
                     dest_port_dut_index = self.ptf_test_port_map[str(exp_port_lists[0][0])]['target_dut'][0]
                     src_port_dut_index = self.ptf_test_port_map[str(src_port)]['target_dut'][0]
                     if src_port_dut_index == 0 and dest_port_dut_index == 0:

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -128,6 +128,16 @@ class HashTest(BaseTest):
                 if src_port in exp_port_list:
                     break
             else:
+                if self.switch_type == "voq" and exp_port_lists[0]:
+                    dest_port_dut_index = self.ptf_test_port_map[str(exp_port_lists[0][0])]['target_dut'][0]
+                    src_port_dut_index = self.ptf_test_port_map[str(src_port)]['target_dut'][0]
+                    if src_port_dut_index == 0 and dest_port_dut_index == 0:
+                        ptf_non_upstream_ports = []
+                        for ptf_port, ptf_port_info in self.ptf_test_port_map.items():
+                            if ptf_port_info['target_dut'][0] != 0:
+                                ptf_non_upstream_ports.append(ptf_port)
+                        src_port = int(random.choice(ptf_non_upstream_ports))
+
                 break
         return src_port, exp_port_lists, next_hops
 


### PR DESCRIPTION
What I did:
Fix the Fib/ipdecap test case for new change where AZNG routes on upstream LC are not programmed in upstream LC.
So we make the change for destination routes as AZNG routes select source port from downstream LC's.


How I verify:
After making this change test cases are passing.
