### PR TITLE
Fix customMsg from unexpected sanity failure

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -19,13 +19,7 @@ logger = logging.getLogger(__name__)
 SUPPORTED_CHECKS = checks.CHECK_ITEMS
 DUT_CHEK_LIST = ['core_dump_check_pass', 'config_db_check_pass']
 CACHE_LIST = ['core_dump_check_pass', 'config_db_check_pass',
-              'pre_sanity_check_failed', 'post_sanity_check_failed',
               'pre_sanity_recovered', 'post_sanity_recovered']
-
-
-def reset_cache_list(request):
-    for item in CACHE_LIST:
-        request.config.cache.set(item, None)
 
 
 def pytest_sessionfinish(session, exitstatus):
@@ -169,8 +163,6 @@ def log_custom_msg(request):
             if customMsgDict:
                 logger.debug("customMsgDict: {}".format(customMsgDict))
                 item.user_properties.append(('CustomMsg', json.dumps(customMsgDict)))
-
-    reset_cache_list(request)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
New feature delivered recently, add customMsg for sanity check failures, was causing unexpected sanity_check results. This was due to premature cache key reset of pre_sanity_check_failed and post_sanity_check_failed. Removed those two keys from getting reset before sessionfinish to resolve the issue

Important cache keys, used to determine session exit status:
pre_sanity_check_failed & post_sanity_check_failed => These combination of keys will return exit status 10, 11, 12
10 = PRE_SANITY_CHECK_FAILED_RC
11 = POST_SANITY_CHECK_FAILED_RC
12 = SANITY_CHECK_FAILED_RC

duthosts_fixture_failed => If this is true, we return exit status code 15
15 = DUTHOSTS_FIXTURE_FAILED_RC
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
New feature delivered recently, add customMsg for sanity check failures, was causing unexpected sanity_check results. This was due to premature cache key reset of pre_sanity_check_failed and post_sanity_check_failed. Removed those two keys from getting reset before sessionfinish to resolve the issue

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Remove premature cache reset of pre_sanity_check_failed and post_sanity_check_failed, before it reaches sessionfinish
#### How did you verify/test it?
Manually tested, simulating pre_sanity_checked_failed and post_sanity_check_failed, to observe expected exit satus codes from 10,11, and 12.
Exit status code can be retrieved and displayed, using 'echo $?'
eg: 
![image](https://github.com/user-attachments/assets/256279e6-34a1-4193-9af3-6a431a264cf1)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
