### PR TITLE
[Qos]Updating J2C+ qos yaml for 400G lossy profile

### DIFF
--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -481,7 +481,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 2179900
+                    pkts_num_trig_egr_drp: 2179770
                     pkts_num_margin: 100
                 wm_pg_shared_lossless:
                     dscp: 3
@@ -497,7 +497,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2179900
+                    pkts_num_trig_egr_drp: 2179770
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -523,7 +523,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 2179900
+                    pkts_num_trig_egr_drp: 2179770
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fixing intermittent failure in lossy queue by adjusting the pkts_num_trig_egr_drp for 'broadcom-dnx' t2 chassis.
Updation on the original PR # https://github.com/sonic-net/sonic-mgmt/pull/14585
 
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [x] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Since the pkts_num_leakout  is more for 100G.Adjusting the count of pkt sent to trigger egress drop.
#### How did you verify/test it?
Executed the qos test and verify.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
