### PR TITLE
[T2] [Chassis] Route flap fix on upstream LC for AZNG route changes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1714,6 +1714,26 @@ def enum_rand_one_frontend_asic_index(request):
     return request.param
 
 
+@pytest.fixture(scope='module')
+def enum_upstream_dut_hostname(duthosts, tbinfo):
+    if tbinfo["topo"]["type"] == "t0":
+        upstream_nbr_type = "T1"
+    elif tbinfo["topo"]["type"] == "t1":
+        upstream_nbr_type = "T2"
+    else:
+        upstream_nbr_type = "T3"
+
+    for a_dut in duthosts.frontend_nodes:
+        minigraph_facts = a_dut.get_extended_minigraph_facts(tbinfo)
+        minigraph_neighbors = minigraph_facts['minigraph_neighbors']
+        for key, value in minigraph_neighbors.items():
+            if upstream_nbr_type in value['name']:
+                return a_dut.hostname
+
+    pytest.fail("Did not find a dut in duthosts that for topo type {} that has upstream nbr type {}".
+                format(tbinfo["topo"]["type"], upstream_nbr_type))
+
+
 @pytest.fixture(scope="module")
 def duthost_console(duthosts, enum_supervisor_dut_hostname, localhost, conn_graph_facts, creds):   # noqa F811
     duthost = duthosts[enum_supervisor_dut_hostname]

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -208,6 +208,9 @@ def check_route(duthost, route, dev_port, operation):
         cmd = ' -c "show ip route {} json"'.format(route)
         for asichost in duthost.frontend_asics:
             out = json.loads(asichost.run_vtysh(cmd)['stdout'])
+            if len(out) == 0:
+                logger.info("Route table empty on asic {}, check other asic".format(asichost.asic_index))
+                continue
             nexthops = out[route][0]['nexthops']
             routes_per_asic = [hop['interfaceName'] for hop in nexthops if 'interfaceName' in hop.keys()]
             result.extend(routes_per_asic)
@@ -376,7 +379,8 @@ def get_dev_port_and_route(duthost, asichost, dst_prefix_set):
 
 def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
                     get_function_completeness_level, announce_default_routes,
-                    enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index,
+                    enum_rand_one_per_hwsku_frontend_hostname,
+                    enum_upstream_dut_hostname, enum_rand_one_frontend_asic_index,
                     setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m,                     # noqa F811
                     toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m, loganalyzer):    # noqa F811
     ptf_ip = tbinfo['ptf_ip']
@@ -385,6 +389,7 @@ def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
     nexthop = common_config.get('nhipv4', NHIPV4)
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
+    duthost_upstream = duthosts[enum_upstream_dut_hostname]
     if loganalyzer:
         ignoreRegex = [
             ".*ERR.*\"missed_FRR_routes\".*"
@@ -441,7 +446,10 @@ def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
     neighbor_type = get_neighbor_info(duthost, dev_port, tbinfo)
     recv_neigh_list = get_all_recv_neigh(duthosts, neighbor_type)
     logger.info("Receiving ports neighbor list : {}".format(recv_neigh_list))
-    ptf_recv_ports = get_all_ptf_recv_ports(duthosts, tbinfo, recv_neigh_list)
+    if 't2' in tbinfo["topo"]["type"] and duthost == duthost_upstream:
+        ptf_recv_ports = get_ptf_recv_ports(duthost, tbinfo)
+    else:
+        ptf_recv_ports = get_all_ptf_recv_ports(duthosts, tbinfo, recv_neigh_list)
     logger.info("Receiving ptf ports list : {}".format(ptf_recv_ports))
 
     exabgp_port = get_exabgp_port(duthost, tbinfo, dev_port)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- With recent changes for AZNG routes on upstream LC, '_test_route_flap_' test case fails for upstream T2 line card.
- This PR fixes the above issue for T2 upstream line card.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
- With recent changes for AZNG routes on upstream LC, '_test_route_flap_' test case fails for upstream T2 line card with the following issue.

```
>     def fail(self, msg=None):
        """Fail immediately, with the given message."""
       raise self.failureException(msg)
E       AssertionError: Received expected packet on port 13 for device 0, but it should have arrived on one of these ports: [23, 31, 30, 21, 18, 20, 28, 7, 16, 19, 17, 6, 29, 22].
```
- This PR fixes the above issue for upstream T2 line card.

#### How did you do it?
- Update the _ptf_receiving_ports_ list if the duthost is upstream T2 line card.

#### How did you verify/test it?
- Verify that the test case passes for both upstream and downstream T2 line cards.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/user-attachments/assets/c348990a-eec3-400d-b70a-46f6ea4985d6)
