### PR TITLE
Fixed report file and summary file getting written to wrong place

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -897,7 +897,7 @@ def advanceboot_loganalyzer(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
             summary_file_name = request.node.name + "_summary.json"
 
         report_file_dir = os.path.realpath((os.path.join(os.path.dirname(__file__),
-                                           "../logs/platform_tests/")))
+                                           "../../logs/platform_tests/")))
         report_file_path = report_file_dir + "/" + report_file_name
         summary_file_path = report_file_dir + "/" + summary_file_name
         if not os.path.exists(report_file_dir):


### PR DESCRIPTION
Following the refactor in https://github.com/sonic-net/sonic-mgmt/pull/14672/files, the *_report.json and *_summary.json files are now being written to a different path. This causes them not to be collected in downstream log collection logic. This was a side-effect of the refactor and should be restored to the original functionality.

They were getting written to:
    Report file path: sonic-mgmt/tests/common/logs/platform_tests/device-name_report.json
    Summary file path: sonic-mgmt/tests/common/logs/platform_tests/device-name_summary.json

Which should have been:
    Report file path: sonic-mgmt/tests/logs/platform_tests/device-name_report.json
    Summary file path: sonic-mgmt/tests/logs/platform_tests/device-name_summary.json

This PR fixes it.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #14809

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fix CI issues
#### How did you do it?
Corrected a path which was incorrectly changed during a refactor
#### How did you verify/test it?
Tested by an operation in CI which expects these files at a certain path which was able to pick them up and archive successfully following this change.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
