### PR TITLE
Revert "Broadcom ASIC only supports RED threshold. Fix helper config_…

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -470,43 +470,34 @@ def config_wred(host_ans, kmin, kmax, pmax, profile=None, asic_value=None):
     if profile is not None and profile not in profiles:
         return False
 
-    color = 'green'
-
-    # Broadcom ASIC only supports RED.
-    if asic_type == 'broadcom':
-        color = 'red'
-
-    kmax_arg = '-{}max' % color[0]
-    kmin_arg = '-{}min' % color[0]
-
     for p in profiles:
         """ This is not the profile to configure """
         if profile is not None and profile != p:
             continue
 
-        kmin_old = int(profiles[p]['{}_min_threshold' % color])
-        kmax_old = int(profiles[p]['{}_max_threshold' % color])
+        kmin_old = int(profiles[p]['green_min_threshold'])
+        kmax_old = int(profiles[p]['green_max_threshold'])
 
         if kmin_old > kmax_old:
             return False
 
         """ Ensure that Kmin is no larger than Kmax during the update """
 
-        kmax_cmd = ' '.join(['sudo ecnconfig -p {}', kmax_arg, '{}'])
-        kmin_cmd = ' '.join(['sudo ecnconfig -p {}', kmin_arg, '{}'])
+        gmax_cmd = 'sudo ecnconfig -p {} -gmax {}'
+        gmin_cmd = 'sudo ecnconfig -p {} -gmin {}'
 
         if asic_value is not None:
-            kmax_cmd = ' '.join(['sudo ip netns exec', asic_value, 'ecnconfig -p {}', kmax_arg, '{}'])
-            kmin_cmd = ' '.join(['sudo ip netns exec', asic_value, 'ecnconfig -p {}', kmin_arg, '{}'])
+            gmax_cmd = 'sudo ip netns exec %s ecnconfig -p {} -gmax {}' % asic_value
+            gmin_cmd = 'sudo ip netns exec %s ecnconfig -p {} -gmin {}' % asic_value
             if asic_type == 'broadcom':
                 disable_packet_aging(host_ans, asic_value)
 
         if kmin > kmin_old:
-            host_ans.shell(kmax_cmd.format(p, kmax))
-            host_ans.shell(kmin_cmd.format(p, kmin))
+            host_ans.shell(gmax_cmd.format(p, kmax))
+            host_ans.shell(gmin_cmd.format(p, kmin))
         else:
-            host_ans.shell(kmin_cmd.format(p, kmin))
-            host_ans.shell(kmax_cmd.format(p, kmax))
+            host_ans.shell(gmin_cmd.format(p, kmin))
+            host_ans.shell(gmax_cmd.format(p, kmax))
 
     return True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Revert back the change in #14498 as we are seeing the following error on T0/T1 testbed.

```
        # Broadcom ASIC only supports RED.
        if asic_type == 'broadcom':
            color = 'red'
    
>       kmax_arg = '-{}max' % color[0]
E       TypeError: not all arguments converted during string formatting

asic_type  = 'broadcom'
asic_value = None
color      = 'red'
host_ans   = <MultiAsicSonicHost xxxxx>
kmax       = 51000
kmin       = 50000
pmax       = 100
profile    = None
profiles   = {'AZURE_LOSSLESS': {'ecn': 'ecn_all', 'green_drop_probability': '5', 'green_max_threshold': '2097152', 'green_min_threshold': '1048576', ...}}
```

Even after fixing the above syntax error, the case still fails on 7050 platform with the following which is different with existing error.  Hence reverting it back first.
```
        # Check if the first packet is ECN marked
>       pytest_assert(is_ecn_marked(ip_pkts[0]), "The first packet should be marked")
E       Failed: The first packet should be marked

```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix script error.

#### How did you do it?

#### How did you verify/test it?
Tested on 7050 platform,  syntax error doesn't exist anymore.  Test case failure is same as existing code base.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
