### PR TITLE
sonic-mgmt: Initial support for Arista-7060X6-64PE-C256S2

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -15,7 +15,7 @@ broadcom_th_hwskus: ['Force10-S6100', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32
 broadcom_th2_hwskus: ['Arista-7260CX3-D108C8',  'Arista-7260CX3-C64', 'Arista-7260CX3-Q64']
 broadcom_th3_hwskus: ['DellEMC-Z9332f-M-O16C64',  'DellEMC-Z9332f-O32']
 broadcom_th4_hwskus: ['Arista-7060DX5-32', 'Arista-7060DX5-64S']
-broadcom_th5_hwskus: ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-128x400G', 'Arista-7060X6-64PE-256x200G']
+broadcom_th5_hwskus: ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-128x400G', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2']
 broadcom_j2c+_hwskus: ['Nokia-IXR7250E-36x100G', 'Nokia-IXR7250E-36x400G', 'Arista-7800R3A-36DM2-C36', 'Arista-7800R3A-36DM2-D36', 'Arista-7800R3AK-36DM2-C36', 'Arista-7800R3AK-36DM2-D36']
 broadcom_jr2_hwskus: ['Arista-7800R3-48CQ2-C48', 'Arista-7800R3-48CQM2-C48']
 

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -124,6 +124,12 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
                     port_alias_to_name_map["Ethernet%d/%d" % (i, j)] = "Ethernet%d" % ((i - 1) * 8 + j - 1)
             port_alias_to_name_map["Ethernet65"] = "Ethernet512"
             port_alias_to_name_map["Ethernet66"] = "Ethernet513"
+        elif hwsku == "Arista-7060X6-64PE-C256S2":
+            for i in range(1, 65, 2): # This hwsku uses every second OSFP port.
+                for j in range(1, 9):
+                    port_alias_to_name_map["Ethernet%d/%d" % (i, j)] = "Ethernet%d" % ((i - 1) * 8 + j - 1)
+            port_alias_to_name_map["Ethernet65"] = "Ethernet512"
+            port_alias_to_name_map["Ethernet66"] = "Ethernet513"
         elif hwsku == "Arista-7050QX32S-Q32":
             for i in range(5, 29):
                 port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 5) * 4)

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -125,7 +125,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             port_alias_to_name_map["Ethernet65"] = "Ethernet512"
             port_alias_to_name_map["Ethernet66"] = "Ethernet513"
         elif hwsku == "Arista-7060X6-64PE-C256S2":
-            for i in range(1, 65, 2): # This hwsku uses every second OSFP port.
+            for i in range(1, 65, 2):  # This hwsku uses every second OSFP port.
                 for j in range(1, 9):
                     port_alias_to_name_map["Ethernet%d/%d" % (i, j)] = "Ethernet%d" % ((i - 1) * 8 + j - 1)
             port_alias_to_name_map["Ethernet65"] = "Ethernet512"


### PR DESCRIPTION
### Description of PR
Summary: Added port configuration and th5 asic entry for Arista-7060X6-64PE-C256S2.

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Support for Arista-7060X6-64PE-C256S2 HwSku.

#### How did you do it?
Added port configuration and th5 asic entry for Arista-7060X6-64PE-C256S2.

#### How did you verify/test it?
Verified that a testbed can be initialized under a t0 topo and sonic-mgmt tests can be run.

#### Any platform specific information?
Specific to the Arista-7060X6-64PE-C256S2 HwSku.