### PR TITLE
Save the config before rebooting DUT.

### DIFF
--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -257,6 +257,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
 
     for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
         logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
+        duthost.shell("sudo config save -y")
         reboot(duthost, localhost, reboot_type=reboot_type)
         logger.info("Wait until the system is stable")
         wait_until(180, 20, 0, duthost.critical_services_fully_started)
@@ -346,6 +347,7 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noq
 
     for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
         logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
+        duthost.shell("sudo config save -y")
         reboot(duthost, localhost, reboot_type=reboot_type)
         logger.info("Wait until the system is stable")
         wait_until(180, 20, 0, duthost.critical_services_fully_started)

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -245,6 +245,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
 
     for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
         logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
+        duthost.shell("sudo config save -y")
         reboot(duthost, localhost, reboot_type=reboot_type)
         logger.info("Wait until the system is stable")
         wait_until(180, 20, 0, duthost.critical_services_fully_started)
@@ -334,6 +335,7 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
 
     for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
         logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
+        duthost.shell("sudo config save -y")
         reboot(duthost, localhost, reboot_type=reboot_type)
         logger.info("Wait until the system is stable")
         wait_until(180, 20, 0, duthost.critical_services_fully_started)

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
@@ -225,6 +225,7 @@ def test_pfcwd_basic_single_lossless_prio_reboot(snappi_api,                # no
 
     for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
         logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
+        duthost.shell("sudo config save -y")
         reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
         logger.info("Wait until the system is stable")
         pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
@@ -304,6 +305,7 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
 
     for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
         logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
+        duthost.shell("sudo config save -y")
         reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
         logger.info("Wait until the system is stable")
         pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Snappi reboot testcases don't save the config before rebooting the DUT. This causes the DUT to loose all the config, and the test fails with "ARP is not resolved" errors.

This PR addresses this issue by saving the config before any reboot.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

@sdszhang , @selldinesh , @kamalsahu0001 : Pls review.