### PR TITLE
202405: Update test_startup_tsa_tsb_service.py - add more guiderails

### DIFF
--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -269,9 +269,8 @@ def test_tsa_tsb_service_with_dut_cold_reboot(duthosts, localhost, enum_rand_one
                       "Not all ports that are admin up on are operationally up")
 
         # verify sessions are established
-        pytest_assert(wait_until(600, 10, 0, duthost.check_bgp_session_state_all_asics,
-                                 up_bgp_neighbors, "established"),
-                                 "All BGP sessions are not up. No point in continuing the test")
+        pytest_assert(wait_until(600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+                      "All BGP sessions are not up. No point in continuing the test")
 
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
             duthosts, duthost, dut_nbrhosts, traffic_shift_community), "Failed to verify routes on nbr in TSA")

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -10,7 +10,8 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
-from traffic_checker import get_traffic_shift_state, check_tsa_persistence_support
+from traffic_checker import get_traffic_shift_state, check_tsa_persistence_support, \
+    check_traffic_shift_state
 from route_checker import parse_routes_on_neighbors, check_and_log_routes_diff, \
     verify_current_routes_announced_to_neighs, verify_only_loopback_routes_are_announced_to_neighs
 from tests.bgp.constants import TS_NORMAL, TS_MAINTENANCE
@@ -201,13 +202,6 @@ def exec_tsa_tsb_cmd_on_supervisor(duthosts, enum_supervisor_dut_hostname, creds
         pytest.fail("Timeout reached")
     except Exception as e:
         pytest.fail("Cannot connect to DUT {} host via SSH: {}".format(suphost.hostname, e))
-
-
-def check_traffic_shift_state(duthost, state):
-    if state != get_traffic_shift_state(duthost):
-        return False
-    else:
-        return True
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -205,6 +205,7 @@ def exec_tsa_tsb_cmd_on_supervisor(duthosts, enum_supervisor_dut_hostname, creds
     except Exception as e:
         pytest.fail("Cannot connect to DUT {} host via SSH: {}".format(suphost.hostname, e))
 
+
 def check_traffic_shift_state(duthost, state):
     if state != get_traffic_shift_state(duthost):
         return False
@@ -268,8 +269,8 @@ def test_tsa_tsb_service_with_dut_cold_reboot(duthosts, localhost, enum_rand_one
                       "Not all ports that are admin up on are operationally up")
 
         # verify sessions are established
-        pytest_assert(wait_until(600, 10, 0,
-                                 duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+        pytest_assert(wait_until(600, 10, 0, duthost.check_bgp_session_state_all_asics,
+                                 up_bgp_neighbors, "established"),
                                  "All BGP sessions are not up. No point in continuing the test")
 
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
@@ -385,8 +386,8 @@ def test_tsa_tsb_service_with_dut_abnormal_reboot(duthosts, localhost, enum_rand
                       "Not all ports that are admin up on are operationally up")
 
         # verify sessions are established
-        pytest_assert(wait_until(600, 10, 0,
-                                 duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+        pytest_assert(wait_until(600, 10, 0, duthost.check_bgp_session_state_all_asics,
+                                 up_bgp_neighbors, "established"),
                                  "All BGP sessions are not up. No point in continuing the test")
 
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
@@ -427,10 +428,12 @@ def test_tsa_tsb_service_with_dut_abnormal_reboot(duthosts, localhost, enum_rand
         reboot_cause = get_reboot_cause(duthost)
         if "Enabled" not in out["stdout"]:
             pytest_assert(reboot_cause == UNKNOWN_REBOOT_CAUSE,
-                        "Reboot cause {} did not match the trigger {}".format(reboot_cause, UNKNOWN_REBOOT_CAUSE))
+                        "Reboot cause {} did not match the trigger {}"
+                        .format(reboot_cause, UNKNOWN_REBOOT_CAUSE))
         else:
             pytest_assert(reboot_cause == KERNEL_PANIC_REBOOT_CAUSE,
-                        "Reboot cause {} did not match the trigger {}".format(reboot_cause, KERNEL_PANIC_REBOOT_CAUSE))
+                          "Reboot cause {} did not match the trigger {}"
+                          .format(reboot_cause, KERNEL_PANIC_REBOOT_CAUSE))
 
 
 @pytest.mark.disable_loganalyzer
@@ -499,7 +502,8 @@ def test_tsa_tsb_service_with_supervisor_cold_reboot(duthosts, localhost, enum_s
 
             # verify sessions are established
             pytest_assert(wait_until(600, 10, 0,
-                                 linecard.check_bgp_session_state_all_asics, up_bgp_neighbors[linecard], "established"),
+                                 linecard.check_bgp_session_state_all_asics,
+                                 up_bgp_neighbors[linecard], "established"),
                                  "All BGP sessions are not up. No point in continuing the test")
 
             pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
@@ -543,13 +547,16 @@ def test_tsa_tsb_service_with_supervisor_cold_reboot(duthosts, localhost, enum_s
             logger.info("Check reboot cause of the dut {}".format(linecard))
             reboot_cause = get_reboot_cause(linecard)
             pytest_assert(reboot_cause == SUP_REBOOT_CAUSE,
-                          "Reboot cause {} did not match the trigger {}".format(reboot_cause, SUP_REBOOT_CAUSE))
+                          "Reboot cause {} did not match the trigger {}"
+                          .format(reboot_cause, SUP_REBOOT_CAUSE))
 
         # Make sure the Supervisor's reboot cause is as expected
         logger.info("Check reboot cause of the supervisor")
         reboot_cause = get_reboot_cause(suphost)
         pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
-                      "Reboot cause {} did not match the trigger {}".format(reboot_cause, COLD_REBOOT_CAUSE))
+                      "Reboot cause {} did not match the trigger {}"
+                      .format(reboot_cause, COLD_REBOOT_CAUSE))
+
 
 @pytest.mark.disable_loganalyzer
 def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, enum_supervisor_dut_hostname, ptfhost,
@@ -635,7 +642,8 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
 
             # verify sessions are established
             pytest_assert(wait_until(600, 10, 0,
-                                 linecard.check_bgp_session_state_all_asics, up_bgp_neighbors[linecard], "established"),
+                                 linecard.check_bgp_session_state_all_asics,
+                                 up_bgp_neighbors[linecard], "established"),
                                  "All BGP sessions are not up. No point in continuing the test")
 
             pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
@@ -680,7 +688,8 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
             logger.info("Check reboot cause of the dut {}".format(linecard))
             reboot_cause = get_reboot_cause(linecard)
             pytest_assert(reboot_cause == SUP_HEARTBEAT_LOSS_CAUSE,
-                          "Reboot cause {} did not match the trigger {}".format(reboot_cause, SUP_HEARTBEAT_LOSS_CAUSE))
+                          "Reboot cause {} did not match the trigger {}"
+                          .format(reboot_cause, SUP_HEARTBEAT_LOSS_CAUSE))
 
         # Make sure the Supervisor's reboot cause is as expected
         logger.info("Check reboot cause of the supervisor")
@@ -688,10 +697,12 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
         reboot_cause = get_reboot_cause(suphost)
         if "Enabled" not in out["stdout"]:
             pytest_assert(reboot_cause == UNKNOWN_REBOOT_CAUSE,
-                        "Reboot cause {} did not match the trigger {}".format(reboot_cause, UNKNOWN_REBOOT_CAUSE))
+                        "Reboot cause {} did not match the trigger {}"
+                        .format(reboot_cause, UNKNOWN_REBOOT_CAUSE))
         else:
             pytest_assert(reboot_cause == KERNEL_PANIC_REBOOT_CAUSE,
-                        "Reboot cause {} did not match the trigger {}".format(reboot_cause, KERNEL_PANIC_REBOOT_CAUSE))
+                        "Reboot cause {} did not match the trigger {}"
+                        .format(reboot_cause, KERNEL_PANIC_REBOOT_CAUSE))
 
 
 @pytest.mark.disable_loganalyzer
@@ -756,7 +767,8 @@ def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, enum_rand_one_p
 
         # verify sessions are established
         pytest_assert(wait_until(600, 10, 0,
-                                 duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+                                 duthost.check_bgp_session_state_all_asics,
+                                 up_bgp_neighbors, "established"),
                                  "All BGP sessions are not up. No point in continuing the test")
 
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
@@ -782,7 +794,8 @@ def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, enum_rand_one_p
 
         # verify sessions are established
         pytest_assert(wait_until(600, 10, 0,
-                                 duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+                                 duthost.check_bgp_session_state_all_asics,
+                                 up_bgp_neighbors, "established"),
                                  "All BGP sessions are not up. No point in continuing the test")
 
         # Verify that all routes advertised to neighbor at the start of the test
@@ -800,7 +813,8 @@ def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, enum_rand_one_p
         logger.info("Check reboot cause of the dut")
         reboot_cause = get_reboot_cause(duthost)
         pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
-                      "Reboot cause {} did not match the trigger {}".format(reboot_cause, COLD_REBOOT_CAUSE))
+                      "Reboot cause {} did not match the trigger {}"
+                      .format(reboot_cause, COLD_REBOOT_CAUSE))
 
 
 @pytest.mark.disable_loganalyzer
@@ -875,7 +889,8 @@ def test_user_init_tsa_while_service_run_on_dut(duthosts, localhost, enum_rand_o
 
         # verify sessions are established
         pytest_assert(wait_until(600, 10, 0,
-                                 duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+                                 duthost.check_bgp_session_state_all_asics,
+                                 up_bgp_neighbors, "established"),
                                  "All BGP sessions are not up. No point in continuing the test")
 
 
@@ -913,7 +928,8 @@ def test_user_init_tsa_while_service_run_on_dut(duthosts, localhost, enum_rand_o
         logger.info("Check reboot cause of the dut")
         reboot_cause = get_reboot_cause(duthost)
         pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
-                      "Reboot cause {} did not match the trigger {}".format(reboot_cause, COLD_REBOOT_CAUSE))
+                      "Reboot cause {} did not match the trigger {}"
+                      .format(reboot_cause, COLD_REBOOT_CAUSE))
 
 
 @pytest.mark.disable_loganalyzer
@@ -985,7 +1001,8 @@ def test_user_init_tsb_while_service_run_on_dut(duthosts, localhost, enum_rand_o
 
         # verify sessions are established
         pytest_assert(wait_until(600, 10, 0,
-                                 duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+                                 duthost.check_bgp_session_state_all_asics,
+                                 up_bgp_neighbors, "established"),
                                  "All BGP sessions are not up. No point in continuing the test")
 
         # Wait until all routes are announced to neighbors
@@ -1012,7 +1029,8 @@ def test_user_init_tsb_while_service_run_on_dut(duthosts, localhost, enum_rand_o
         logger.info("Check reboot cause of the dut")
         reboot_cause = get_reboot_cause(duthost)
         pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
-                      "Reboot cause {} did not match the trigger {}".format(reboot_cause, COLD_REBOOT_CAUSE))
+                      "Reboot cause {} did not match the trigger {}"
+                      .format(reboot_cause, COLD_REBOOT_CAUSE))
 
 
 @pytest.mark.disable_loganalyzer
@@ -1083,7 +1101,8 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost,
 
             # verify sessions are established
             pytest_assert(wait_until(600, 10, 0,
-                                     linecard.check_bgp_session_state_all_asics, up_bgp_neighbors[linecard], "established"),
+                                     linecard.check_bgp_session_state_all_asics,
+                                     up_bgp_neighbors[linecard], "established"),
                                      "All BGP sessions are not up. No point in continuing the test")
 
             pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
@@ -1111,7 +1130,8 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost,
 
             # verify sessions are established
             pytest_assert(wait_until(600, 10, 0,
-                                     linecard.check_bgp_session_state_all_asics, up_bgp_neighbors[linecard], "established"),
+                                     linecard.check_bgp_session_state_all_asics,
+                                     up_bgp_neighbors[linecard], "established"),
                                      "All BGP sessions are not up. No point in continuing the test")
 
             # Verify that all routes advertised to neighbor at the start of the test
@@ -1140,13 +1160,15 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost,
             logger.info("Check reboot cause of the dut {}".format(linecard))
             reboot_cause = get_reboot_cause(linecard)
             pytest_assert(reboot_cause == SUP_REBOOT_CAUSE,
-                          "Reboot cause {} did not match the trigger {}".format(reboot_cause, SUP_REBOOT_CAUSE))
+                          "Reboot cause {} did not match the trigger {}"
+                          .format(reboot_cause, SUP_REBOOT_CAUSE))
 
         # Make sure the Supervisor's reboot cause is as expected
         logger.info("Check reboot cause of the supervisor")
         reboot_cause = get_reboot_cause(suphost)
         pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
-                      "Reboot cause {} did not match the trigger {}".format(reboot_cause, COLD_REBOOT_CAUSE))
+                      "Reboot cause {} did not match the trigger {}"
+                      .format(reboot_cause, COLD_REBOOT_CAUSE))
 
 
 @pytest.mark.disable_loganalyzer
@@ -1204,7 +1226,8 @@ def test_tsa_tsb_timer_efficiency(duthosts, localhost, enum_rand_one_per_hwsku_f
                       "Not all ports that are admin up on are operationally up")
 
         pytest_assert(wait_until(600, 10, 0,
-                                 duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+                                 duthost.check_bgp_session_state_all_asics,
+                                 up_bgp_neighbors, "established"),
                                  "All BGP sessions are not up. No point in continuing the test")
 
         stability_check_time = datetime.datetime.now()
@@ -1253,4 +1276,5 @@ def test_tsa_tsb_timer_efficiency(duthosts, localhost, enum_rand_one_per_hwsku_f
         logger.info("Check reboot cause of the dut")
         reboot_cause = get_reboot_cause(duthost)
         pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
-                      "Reboot cause {} did not match the trigger {}".format(reboot_cause, COLD_REBOOT_CAUSE))
+                      "Reboot cause {} did not match the trigger {}"
+                      .format(reboot_cause, COLD_REBOOT_CAUSE))

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -541,8 +541,9 @@ def test_tsa_tsb_service_with_supervisor_cold_reboot(duthosts, localhost, enum_s
     finally:
         for linecard in duthosts.frontend_nodes:
             # Verify DUT is in normal state.
-            pytest_assert(wait_until(120, 20, 0, check_traffic_shift_state, linecard, TS_NORMAL),
-                      "DUT {} is not in normal state".format(linecard))
+            pytest_assert(
+                wait_until(120, 20, 0, check_traffic_shift_state, linecard, TS_NORMAL),
+                "DUT {} is not in normal state".format(linecard))
             # Make sure the dut's reboot cause is as expected
             logger.info("Check reboot cause of the dut {}".format(linecard))
             reboot_cause = get_reboot_cause(linecard)
@@ -681,8 +682,9 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
     finally:
         for linecard in duthosts.frontend_nodes:
             # Verify DUT is in normal state.
-            pytest_assert(wait_until(120, 20, 0, check_traffic_shift_state, linecard, TS_NORMAL),
-                      "DUT {} is not in normal state".format(linecard))
+            pytest_assert(
+                wait_until(120, 20, 0, check_traffic_shift_state, linecard, TS_NORMAL),
+                "DUT {} is not in normal state".format(linecard))
 
             # Make sure the dut's reboot cause is as expected
             logger.info("Check reboot cause of the dut {}".format(linecard))
@@ -696,12 +698,12 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
         reboot_cause = get_reboot_cause(suphost)
         if "Enabled" not in out["stdout"]:
             pytest_assert(reboot_cause == UNKNOWN_REBOOT_CAUSE,
-                          "Reboot cause {} did not match the trigger {}"
-                        .format(reboot_cause, UNKNOWN_REBOOT_CAUSE))
+              "Reboot cause {} did not match the trigger {}"
+              .format(reboot_cause, UNKNOWN_REBOOT_CAUSE))
         else:
             pytest_assert(reboot_cause == KERNEL_PANIC_REBOOT_CAUSE,
-                          "Reboot cause {} did not match the trigger {}"
-                        .format(reboot_cause, KERNEL_PANIC_REBOOT_CAUSE))
+              "Reboot cause {} did not match the trigger {}"
+              .format(reboot_cause, KERNEL_PANIC_REBOOT_CAUSE))
 
 
 @pytest.mark.disable_loganalyzer
@@ -795,7 +797,7 @@ def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, enum_rand_one_p
         pytest_assert(
             wait_until(
                 600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
-                "All BGP sessions are not up. No point in continuing the test")
+            "All BGP sessions are not up. No point in continuing the test")
 
         # Verify that all routes advertised to neighbor at the start of the test
         if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs, duthost, nbrhosts,
@@ -891,7 +893,6 @@ def test_user_init_tsa_while_service_run_on_dut(duthosts, localhost, enum_rand_o
             wait_until(
                 600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
             "All BGP sessions are not up. No point in continuing the test")
-
 
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
             duthosts, duthost, dut_nbrhosts, traffic_shift_community),
@@ -1102,7 +1103,7 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost,
             pytest_assert(
                 wait_until(
                     600, 10, 0, linecard.check_bgp_session_state_all_asics, up_bgp_neighbors[linecard], "established"),
-                    "All BGP sessions are not up. No point in continuing the test")
+                "All BGP sessions are not up. No point in continuing the test")
 
             pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
                 duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
@@ -1153,7 +1154,7 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost,
             linecard.shell('sudo config save -y')
             # Verify DUT is in normal state.
             pytest_assert(wait_until(120, 20, 0, check_traffic_shift_state, linecard, TS_NORMAL),
-                      "DUT {} is not in normal state".format(linecard))
+                          "DUT {} is not in normal state".format(linecard))
 
             # Make sure the dut's reboot cause is as expected
             logger.info("Check reboot cause of the dut {}".format(linecard))

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -269,8 +269,9 @@ def test_tsa_tsb_service_with_dut_cold_reboot(duthosts, localhost, enum_rand_one
                       "Not all ports that are admin up on are operationally up")
 
         # verify sessions are established
-        pytest_assert(wait_until(600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
-                      "All BGP sessions are not up. No point in continuing the test")
+        pytest_assert(
+            wait_until(600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+            "All BGP sessions are not up. No point in continuing the test")
 
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
             duthosts, duthost, dut_nbrhosts, traffic_shift_community), "Failed to verify routes on nbr in TSA")
@@ -385,9 +386,9 @@ def test_tsa_tsb_service_with_dut_abnormal_reboot(duthosts, localhost, enum_rand
                       "Not all ports that are admin up on are operationally up")
 
         # verify sessions are established
-        pytest_assert(wait_until(600, 10, 0, duthost.check_bgp_session_state_all_asics,
-                                 up_bgp_neighbors, "established"),
-                                 "All BGP sessions are not up. No point in continuing the test")
+        pytest_assert(
+            wait_until(600, 10, 0, duthost.check_bgp_session_state_all_asics,up_bgp_neighbors, "established"),
+            "All BGP sessions are not up. No point in continuing the test")
 
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
             duthosts, duthost, dut_nbrhosts, traffic_shift_community), "Failed to verify routes on nbr in TSA")
@@ -500,10 +501,10 @@ def test_tsa_tsb_service_with_supervisor_cold_reboot(duthosts, localhost, enum_s
                           "Not all ports that are admin up on are operationally up")
 
             # verify sessions are established
-            pytest_assert(wait_until(600, 10, 0,
-                                 linecard.check_bgp_session_state_all_asics,
-                                 up_bgp_neighbors[linecard], "established"),
-                                 "All BGP sessions are not up. No point in continuing the test")
+            pytest_assert(
+                wait_until(600, 10, 0, linecard.check_bgp_session_state_all_asics,
+                           up_bgp_neighbors[linecard], "established"),
+                           "All BGP sessions are not up. No point in continuing the test")
 
             pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
                 duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -427,10 +427,12 @@ def test_tsa_tsb_service_with_dut_abnormal_reboot(duthosts, localhost, enum_rand
         out = duthost.command('show kdump config')
         reboot_cause = get_reboot_cause(duthost)
         if "Enabled" not in out["stdout"]:
-            pytest_assert(reboot_cause == UNKNOWN_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
-                        .format(reboot_cause, UNKNOWN_REBOOT_CAUSE))
+            pytest_assert(reboot_cause == UNKNOWN_REBOOT_CAUSE,
+                          "Reboot cause {} did not match the trigger {}"
+                          .format(reboot_cause, UNKNOWN_REBOOT_CAUSE))
         else:
-            pytest_assert(reboot_cause == KERNEL_PANIC_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
+            pytest_assert(reboot_cause == KERNEL_PANIC_REBOOT_CAUSE,
+                          "Reboot cause {} did not match the trigger {}"
                           .format(reboot_cause, KERNEL_PANIC_REBOOT_CAUSE))
 
 
@@ -502,7 +504,7 @@ def test_tsa_tsb_service_with_supervisor_cold_reboot(duthosts, localhost, enum_s
             pytest_assert(
                 wait_until(
                     600, 10, 0, linecard.check_bgp_session_state_all_asics, up_bgp_neighbors[linecard], "established"),
-                    "All BGP sessions are not up. No point in continuing the test")
+                "All BGP sessions are not up. No point in continuing the test")
 
             pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
                 duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
@@ -544,13 +546,15 @@ def test_tsa_tsb_service_with_supervisor_cold_reboot(duthosts, localhost, enum_s
             # Make sure the dut's reboot cause is as expected
             logger.info("Check reboot cause of the dut {}".format(linecard))
             reboot_cause = get_reboot_cause(linecard)
-            pytest_assert(reboot_cause == SUP_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
+            pytest_assert(reboot_cause == SUP_REBOOT_CAUSE,
+                          "Reboot cause {} did not match the trigger {}"
                           .format(reboot_cause, SUP_REBOOT_CAUSE))
 
         # Make sure the Supervisor's reboot cause is as expected
         logger.info("Check reboot cause of the supervisor")
         reboot_cause = get_reboot_cause(suphost)
-        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
+        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
+                      "Reboot cause {} did not match the trigger {}"
                       .format(reboot_cause, COLD_REBOOT_CAUSE))
 
 
@@ -640,7 +644,7 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
             pytest_assert(
                 wait_until(
                     600, 10, 0, linecard.check_bgp_session_state_all_asics, up_bgp_neighbors[linecard], "established"),
-                    "All BGP sessions are not up. No point in continuing the test")
+                "All BGP sessions are not up. No point in continuing the test")
 
             pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
                 duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
@@ -691,10 +695,12 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
         out = suphost.command('show kdump config')
         reboot_cause = get_reboot_cause(suphost)
         if "Enabled" not in out["stdout"]:
-            pytest_assert(reboot_cause == UNKNOWN_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
+            pytest_assert(reboot_cause == UNKNOWN_REBOOT_CAUSE,
+                          "Reboot cause {} did not match the trigger {}"
                         .format(reboot_cause, UNKNOWN_REBOOT_CAUSE))
         else:
-            pytest_assert(reboot_cause == KERNEL_PANIC_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
+            pytest_assert(reboot_cause == KERNEL_PANIC_REBOOT_CAUSE,
+                          "Reboot cause {} did not match the trigger {}"
                         .format(reboot_cause, KERNEL_PANIC_REBOOT_CAUSE))
 
 
@@ -762,7 +768,7 @@ def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, enum_rand_one_p
         pytest_assert(
             wait_until(
                 600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
-                "All BGP sessions are not up. No point in continuing the test")
+            "All BGP sessions are not up. No point in continuing the test")
 
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
             duthosts, duthost, dut_nbrhosts, traffic_shift_community),
@@ -805,7 +811,8 @@ def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, enum_rand_one_p
         # Make sure the dut's reboot cause is as expected
         logger.info("Check reboot cause of the dut")
         reboot_cause = get_reboot_cause(duthost)
-        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
+        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
+                      "Reboot cause {} did not match the trigger {}"
                       .format(reboot_cause, COLD_REBOOT_CAUSE))
 
 
@@ -883,7 +890,7 @@ def test_user_init_tsa_while_service_run_on_dut(duthosts, localhost, enum_rand_o
         pytest_assert(
             wait_until(
                 600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
-                "All BGP sessions are not up. No point in continuing the test")
+            "All BGP sessions are not up. No point in continuing the test")
 
 
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
@@ -919,7 +926,8 @@ def test_user_init_tsa_while_service_run_on_dut(duthosts, localhost, enum_rand_o
         # Make sure the dut's reboot cause is as expected
         logger.info("Check reboot cause of the dut")
         reboot_cause = get_reboot_cause(duthost)
-        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
+        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
+                      "Reboot cause {} did not match the trigger {}"
                       .format(reboot_cause, COLD_REBOOT_CAUSE))
 
 
@@ -994,7 +1002,7 @@ def test_user_init_tsb_while_service_run_on_dut(duthosts, localhost, enum_rand_o
         pytest_assert(
             wait_until(
                 600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
-                "All BGP sessions are not up. No point in continuing the test")
+            "All BGP sessions are not up. No point in continuing the test")
 
         # Wait until all routes are announced to neighbors
         cur_v4_routes = {}
@@ -1019,7 +1027,8 @@ def test_user_init_tsb_while_service_run_on_dut(duthosts, localhost, enum_rand_o
         # Make sure the dut's reboot cause is as expected
         logger.info("Check reboot cause of the dut")
         reboot_cause = get_reboot_cause(duthost)
-        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
+        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
+                      "Reboot cause {} did not match the trigger {}"
                       .format(reboot_cause, COLD_REBOOT_CAUSE))
 
 
@@ -1122,7 +1131,7 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost,
             pytest_assert(
                 wait_until(
                     600, 10, 0, linecard.check_bgp_session_state_all_asics, up_bgp_neighbors[linecard], "established"),
-                    "All BGP sessions are not up. No point in continuing the test")
+                "All BGP sessions are not up. No point in continuing the test")
 
             # Verify that all routes advertised to neighbor at the start of the test
             if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs, linecard, dut_nbrhosts[linecard],
@@ -1149,13 +1158,15 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost,
             # Make sure the dut's reboot cause is as expected
             logger.info("Check reboot cause of the dut {}".format(linecard))
             reboot_cause = get_reboot_cause(linecard)
-            pytest_assert(reboot_cause == SUP_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
+            pytest_assert(reboot_cause == SUP_REBOOT_CAUSE,
+                          "Reboot cause {} did not match the trigger {}"
                           .format(reboot_cause, SUP_REBOOT_CAUSE))
 
         # Make sure the Supervisor's reboot cause is as expected
         logger.info("Check reboot cause of the supervisor")
         reboot_cause = get_reboot_cause(suphost)
-        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
+        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
+                      "Reboot cause {} did not match the trigger {}"
                       .format(reboot_cause, COLD_REBOOT_CAUSE))
 
 
@@ -1216,7 +1227,7 @@ def test_tsa_tsb_timer_efficiency(duthosts, localhost, enum_rand_one_per_hwsku_f
         pytest_assert(
             wait_until(
                 600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
-                "All BGP sessions are not up. No point in continuing the test")
+            "All BGP sessions are not up. No point in continuing the test")
 
         stability_check_time = datetime.datetime.now()
         time_to_stabilize = (stability_check_time - service_uptime).total_seconds()
@@ -1263,5 +1274,6 @@ def test_tsa_tsb_timer_efficiency(duthosts, localhost, enum_rand_one_per_hwsku_f
         # Make sure the dut's reboot cause is as expected
         logger.info("Check reboot cause of the dut")
         reboot_cause = get_reboot_cause(duthost)
-        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
+        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
+                      "Reboot cause {} did not match the trigger {}"
                       .format(reboot_cause, COLD_REBOOT_CAUSE))

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -23,6 +23,7 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 COLD_REBOOT_CAUSE = 'cold'
+KERNEL_PANIC_REBOOT_CAUSE = "Kernel Panic"
 UNKNOWN_REBOOT_CAUSE = "Unknown"
 SUP_REBOOT_CAUSE = 'Reboot from Supervisor'
 SUP_HEARTBEAT_LOSS_CAUSE = 'Heartbeat with the Supervisor card lost'
@@ -694,12 +695,12 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
         reboot_cause = get_reboot_cause(suphost)
         if "Enabled" not in out["stdout"]:
             pytest_assert(reboot_cause == UNKNOWN_REBOOT_CAUSE,
-              "Reboot cause {} did not match the trigger {}"
-              .format(reboot_cause, UNKNOWN_REBOOT_CAUSE))
+                          "Reboot cause {} did not match the trigger {}"
+                          .format(reboot_cause, UNKNOWN_REBOOT_CAUSE))
         else:
             pytest_assert(reboot_cause == KERNEL_PANIC_REBOOT_CAUSE,
-              "Reboot cause {} did not match the trigger {}"
-              .format(reboot_cause, KERNEL_PANIC_REBOOT_CAUSE))
+                          "Reboot cause {} did not match the trigger {}"
+                          .format(reboot_cause, KERNEL_PANIC_REBOOT_CAUSE))
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -387,7 +387,7 @@ def test_tsa_tsb_service_with_dut_abnormal_reboot(duthosts, localhost, enum_rand
 
         # verify sessions are established
         pytest_assert(
-            wait_until(600, 10, 0, duthost.check_bgp_session_state_all_asics,up_bgp_neighbors, "established"),
+            wait_until(600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
             "All BGP sessions are not up. No point in continuing the test")
 
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
@@ -427,12 +427,10 @@ def test_tsa_tsb_service_with_dut_abnormal_reboot(duthosts, localhost, enum_rand
         out = duthost.command('show kdump config')
         reboot_cause = get_reboot_cause(duthost)
         if "Enabled" not in out["stdout"]:
-            pytest_assert(reboot_cause == UNKNOWN_REBOOT_CAUSE,
-                        "Reboot cause {} did not match the trigger {}"
+            pytest_assert(reboot_cause == UNKNOWN_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
                         .format(reboot_cause, UNKNOWN_REBOOT_CAUSE))
         else:
-            pytest_assert(reboot_cause == KERNEL_PANIC_REBOOT_CAUSE,
-                          "Reboot cause {} did not match the trigger {}"
+            pytest_assert(reboot_cause == KERNEL_PANIC_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
                           .format(reboot_cause, KERNEL_PANIC_REBOOT_CAUSE))
 
 
@@ -502,9 +500,9 @@ def test_tsa_tsb_service_with_supervisor_cold_reboot(duthosts, localhost, enum_s
 
             # verify sessions are established
             pytest_assert(
-                wait_until(600, 10, 0, linecard.check_bgp_session_state_all_asics,
-                           up_bgp_neighbors[linecard], "established"),
-                           "All BGP sessions are not up. No point in continuing the test")
+                wait_until(
+                    600, 10, 0, linecard.check_bgp_session_state_all_asics, up_bgp_neighbors[linecard], "established"),
+                    "All BGP sessions are not up. No point in continuing the test")
 
             pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
                 duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
@@ -546,15 +544,13 @@ def test_tsa_tsb_service_with_supervisor_cold_reboot(duthosts, localhost, enum_s
             # Make sure the dut's reboot cause is as expected
             logger.info("Check reboot cause of the dut {}".format(linecard))
             reboot_cause = get_reboot_cause(linecard)
-            pytest_assert(reboot_cause == SUP_REBOOT_CAUSE,
-                          "Reboot cause {} did not match the trigger {}"
+            pytest_assert(reboot_cause == SUP_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
                           .format(reboot_cause, SUP_REBOOT_CAUSE))
 
         # Make sure the Supervisor's reboot cause is as expected
         logger.info("Check reboot cause of the supervisor")
         reboot_cause = get_reboot_cause(suphost)
-        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
-                      "Reboot cause {} did not match the trigger {}"
+        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
                       .format(reboot_cause, COLD_REBOOT_CAUSE))
 
 
@@ -641,10 +637,10 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
                           "Not all ports that are admin up on are operationally up")
 
             # verify sessions are established
-            pytest_assert(wait_until(600, 10, 0,
-                                 linecard.check_bgp_session_state_all_asics,
-                                 up_bgp_neighbors[linecard], "established"),
-                                 "All BGP sessions are not up. No point in continuing the test")
+            pytest_assert(
+                wait_until(
+                    600, 10, 0, linecard.check_bgp_session_state_all_asics, up_bgp_neighbors[linecard], "established"),
+                    "All BGP sessions are not up. No point in continuing the test")
 
             pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
                 duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
@@ -687,8 +683,7 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
             # Make sure the dut's reboot cause is as expected
             logger.info("Check reboot cause of the dut {}".format(linecard))
             reboot_cause = get_reboot_cause(linecard)
-            pytest_assert(reboot_cause == SUP_HEARTBEAT_LOSS_CAUSE,
-                          "Reboot cause {} did not match the trigger {}"
+            pytest_assert(reboot_cause == SUP_HEARTBEAT_LOSS_CAUSE, "Reboot cause {} did not match the trigger {}"
                           .format(reboot_cause, SUP_HEARTBEAT_LOSS_CAUSE))
 
         # Make sure the Supervisor's reboot cause is as expected
@@ -696,12 +691,10 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
         out = suphost.command('show kdump config')
         reboot_cause = get_reboot_cause(suphost)
         if "Enabled" not in out["stdout"]:
-            pytest_assert(reboot_cause == UNKNOWN_REBOOT_CAUSE,
-                        "Reboot cause {} did not match the trigger {}"
+            pytest_assert(reboot_cause == UNKNOWN_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
                         .format(reboot_cause, UNKNOWN_REBOOT_CAUSE))
         else:
-            pytest_assert(reboot_cause == KERNEL_PANIC_REBOOT_CAUSE,
-                        "Reboot cause {} did not match the trigger {}"
+            pytest_assert(reboot_cause == KERNEL_PANIC_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
                         .format(reboot_cause, KERNEL_PANIC_REBOOT_CAUSE))
 
 
@@ -766,10 +759,10 @@ def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, enum_rand_one_p
                       "Not all ports that are admin up on are operationally up")
 
         # verify sessions are established
-        pytest_assert(wait_until(600, 10, 0,
-                                 duthost.check_bgp_session_state_all_asics,
-                                 up_bgp_neighbors, "established"),
-                                 "All BGP sessions are not up. No point in continuing the test")
+        pytest_assert(
+            wait_until(
+                600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+                "All BGP sessions are not up. No point in continuing the test")
 
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
             duthosts, duthost, dut_nbrhosts, traffic_shift_community),
@@ -793,10 +786,10 @@ def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, enum_rand_one_p
         cur_v6_routes = {}
 
         # verify sessions are established
-        pytest_assert(wait_until(600, 10, 0,
-                                 duthost.check_bgp_session_state_all_asics,
-                                 up_bgp_neighbors, "established"),
-                                 "All BGP sessions are not up. No point in continuing the test")
+        pytest_assert(
+            wait_until(
+                600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+                "All BGP sessions are not up. No point in continuing the test")
 
         # Verify that all routes advertised to neighbor at the start of the test
         if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs, duthost, nbrhosts,
@@ -812,8 +805,7 @@ def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, enum_rand_one_p
         # Make sure the dut's reboot cause is as expected
         logger.info("Check reboot cause of the dut")
         reboot_cause = get_reboot_cause(duthost)
-        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
-                      "Reboot cause {} did not match the trigger {}"
+        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
                       .format(reboot_cause, COLD_REBOOT_CAUSE))
 
 
@@ -888,10 +880,10 @@ def test_user_init_tsa_while_service_run_on_dut(duthosts, localhost, enum_rand_o
                       "Not all ports that are admin up on are operationally up")
 
         # verify sessions are established
-        pytest_assert(wait_until(600, 10, 0,
-                                 duthost.check_bgp_session_state_all_asics,
-                                 up_bgp_neighbors, "established"),
-                                 "All BGP sessions are not up. No point in continuing the test")
+        pytest_assert(
+            wait_until(
+                600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+                "All BGP sessions are not up. No point in continuing the test")
 
 
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
@@ -927,8 +919,7 @@ def test_user_init_tsa_while_service_run_on_dut(duthosts, localhost, enum_rand_o
         # Make sure the dut's reboot cause is as expected
         logger.info("Check reboot cause of the dut")
         reboot_cause = get_reboot_cause(duthost)
-        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
-                      "Reboot cause {} did not match the trigger {}"
+        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
                       .format(reboot_cause, COLD_REBOOT_CAUSE))
 
 
@@ -1000,10 +991,10 @@ def test_user_init_tsb_while_service_run_on_dut(duthosts, localhost, enum_rand_o
             "Not all critical services are fully started on {}".format(duthost.hostname)
 
         # verify sessions are established
-        pytest_assert(wait_until(600, 10, 0,
-                                 duthost.check_bgp_session_state_all_asics,
-                                 up_bgp_neighbors, "established"),
-                                 "All BGP sessions are not up. No point in continuing the test")
+        pytest_assert(
+            wait_until(
+                600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+                "All BGP sessions are not up. No point in continuing the test")
 
         # Wait until all routes are announced to neighbors
         cur_v4_routes = {}
@@ -1028,8 +1019,7 @@ def test_user_init_tsb_while_service_run_on_dut(duthosts, localhost, enum_rand_o
         # Make sure the dut's reboot cause is as expected
         logger.info("Check reboot cause of the dut")
         reboot_cause = get_reboot_cause(duthost)
-        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
-                      "Reboot cause {} did not match the trigger {}"
+        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
                       .format(reboot_cause, COLD_REBOOT_CAUSE))
 
 
@@ -1100,10 +1090,10 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost,
             wait_critical_processes(linecard)
 
             # verify sessions are established
-            pytest_assert(wait_until(600, 10, 0,
-                                     linecard.check_bgp_session_state_all_asics,
-                                     up_bgp_neighbors[linecard], "established"),
-                                     "All BGP sessions are not up. No point in continuing the test")
+            pytest_assert(
+                wait_until(
+                    600, 10, 0, linecard.check_bgp_session_state_all_asics, up_bgp_neighbors[linecard], "established"),
+                    "All BGP sessions are not up. No point in continuing the test")
 
             pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
                 duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
@@ -1129,10 +1119,10 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost,
             cur_v6_routes = {}
 
             # verify sessions are established
-            pytest_assert(wait_until(600, 10, 0,
-                                     linecard.check_bgp_session_state_all_asics,
-                                     up_bgp_neighbors[linecard], "established"),
-                                     "All BGP sessions are not up. No point in continuing the test")
+            pytest_assert(
+                wait_until(
+                    600, 10, 0, linecard.check_bgp_session_state_all_asics, up_bgp_neighbors[linecard], "established"),
+                    "All BGP sessions are not up. No point in continuing the test")
 
             # Verify that all routes advertised to neighbor at the start of the test
             if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs, linecard, dut_nbrhosts[linecard],
@@ -1159,15 +1149,13 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost,
             # Make sure the dut's reboot cause is as expected
             logger.info("Check reboot cause of the dut {}".format(linecard))
             reboot_cause = get_reboot_cause(linecard)
-            pytest_assert(reboot_cause == SUP_REBOOT_CAUSE,
-                          "Reboot cause {} did not match the trigger {}"
+            pytest_assert(reboot_cause == SUP_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
                           .format(reboot_cause, SUP_REBOOT_CAUSE))
 
         # Make sure the Supervisor's reboot cause is as expected
         logger.info("Check reboot cause of the supervisor")
         reboot_cause = get_reboot_cause(suphost)
-        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
-                      "Reboot cause {} did not match the trigger {}"
+        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
                       .format(reboot_cause, COLD_REBOOT_CAUSE))
 
 
@@ -1225,10 +1213,10 @@ def test_tsa_tsb_timer_efficiency(duthosts, localhost, enum_rand_one_per_hwsku_f
         pytest_assert(wait_until(600, 20, 0, check_interface_status_of_up_ports, duthost),
                       "Not all ports that are admin up on are operationally up")
 
-        pytest_assert(wait_until(600, 10, 0,
-                                 duthost.check_bgp_session_state_all_asics,
-                                 up_bgp_neighbors, "established"),
-                                 "All BGP sessions are not up. No point in continuing the test")
+        pytest_assert(
+            wait_until(
+                600, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+                "All BGP sessions are not up. No point in continuing the test")
 
         stability_check_time = datetime.datetime.now()
         time_to_stabilize = (stability_check_time - service_uptime).total_seconds()
@@ -1275,6 +1263,5 @@ def test_tsa_tsb_timer_efficiency(duthosts, localhost, enum_rand_one_per_hwsku_f
         # Make sure the dut's reboot cause is as expected
         logger.info("Check reboot cause of the dut")
         reboot_cause = get_reboot_cause(duthost)
-        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
-                      "Reboot cause {} did not match the trigger {}"
+        pytest_assert(reboot_cause == COLD_REBOOT_CAUSE, "Reboot cause {} did not match the trigger {}"
                       .format(reboot_cause, COLD_REBOOT_CAUSE))

--- a/tests/bgp/traffic_checker.py
+++ b/tests/bgp/traffic_checker.py
@@ -47,3 +47,10 @@ def check_tsa_persistence_support(duthost):
     if not tsa_in_configdb:
         return False
     return True
+
+
+def check_traffic_shift_state(duthost, state):
+    if state != get_traffic_shift_state(duthost):
+        return False
+    else:
+        return True

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -55,15 +55,6 @@ reboot_ctrl_dict = {
         "cause": "Power Loss",
         "test_reboot_cause_only": True
     },
-    REBOOT_TYPE_COLD: {
-        "command": "reboot",
-        "timeout": 300,
-        "wait": 120,
-        # We are searching two types of reboot cause.
-        # This change relates to changes of PR #6130 in sonic-buildimage repository
-        "cause": r"'reboot'|Non-Hardware \(reboot|^reboot",
-        "test_reboot_cause_only": False
-    },
     REBOOT_TYPE_SOFT: {
         "command": "soft-reboot",
         "timeout": 300,
@@ -125,7 +116,7 @@ reboot_ctrl_dict = {
         "timeout": 300,
         "wait": 120,
         # When linecards are rebooted due to supervisor cold reboot
-        "cause": "reboot from Supervisor",
+        "cause": r"^Reboot from Supervisor$|^reboot from Supervisor$",
         "test_reboot_cause_only": False
     },
     REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS: {
@@ -133,7 +124,16 @@ reboot_ctrl_dict = {
         "timeout": 300,
         "wait": 120,
         # When linecards are rebooted due to supervisor crash/abnormal reboot
-        "cause": "Heartbeat",
+        "cause": r"Heartbeat|headless",
+        "test_reboot_cause_only": False
+    },
+    REBOOT_TYPE_COLD: {
+        "command": "reboot",
+        "timeout": 300,
+        "wait": 120,
+        # We are searching two types of reboot cause.
+        # This change relates to changes of PR #6130 in sonic-buildimage repository
+        "cause": r"'reboot'|Non-Hardware \(reboot|^reboot",
         "test_reboot_cause_only": False
     }
 }


### PR DESCRIPTION
### Description of PR
We have updated test_startup_tsa_tsb_service.py based on our testing. 

Checks to see:
1. if bgp sessions are up before checking for the routes, 
2. Checking for state of the DUT before executing the test. Skipping the test if it is in maintenance mode instead of failing for the wrong reason.
3. Changing the reboot cause in case kdump is enabled.
4. Increasing the time to check if startup service has started.
5. Made small changes in reboot.py since cold reboot was becoming a catchall statement. 
6. Added reboot cause to support Hearbeat and Headless in case of supervisor heartbeat loss case

Summary:
Fixes # (issue)

### Type of change

- Fill x for your type of change.
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
We have updated test_startup_tsa_tsb_service.py based on our testing. 

#### How did you do it?

#### How did you verify/test it?
Verified it on T2 profile for Cisco chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
