### PR TITLE
change ptf container memory in restart-ptf to 16G as same as add-topo

### DIFF
--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -118,8 +118,8 @@
       capabilities:
         - net_admin
       privileged: yes
-      memory: 8G
-      memory_swap: 8G
+      memory: 16G
+      memory_swap: 32G
     become: yes
 
   - name: Enable ipv6 for docker container ptf_{{ vm_set_name }}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
PTF container's memory limit is 16G in add-topo after the change in #7413.
But it's still 8G when doing `restart-ptf`. 

In current code base:

```
:~$ docker stats --no-stream | grep ptf
b303f551ff99   ptf_ptf-01            121.43%   1.26GiB / 16GiB     7.88%     0B / 0B   0B / 618kB        69

# after restart-ptf

:~$ docker stats --no-stream | grep ptf
1c4e10810aff   ptf_ptf-01            0.09%     21.98MiB / 8GiB     0.27%     0B / 0B   0B / 0B           4
:~$ 
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Keep the same memory limit for add-topo and restart-ptf

#### How did you do it?

#### How did you verify/test it?
Tested in physical testbed.  PTF memory stays at 16G after `restart-ptf`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
