### PR TITLE
[T2] [Chassis]- Exclude BGP test suites from new long reboot wait, timeout

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -256,7 +256,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
             timeout = plt_reboot_ctrl.get('timeout', timeout)
         if warmboot_finalizer_timeout == 0 and 'warmboot_finalizer_timeout' in reboot_ctrl:
             warmboot_finalizer_timeout = reboot_ctrl['warmboot_finalizer_timeout']
-        if duthost.get_facts().get("modular_chassis"):
+        if duthost.get_facts().get("modular_chassis") and tc_name.split('/')[0] not in ['bgp']:
             wait = max(wait, 900)
             timeout = max(timeout, 600)
     except KeyError:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR has a workaround fix for issue #14603 introduced as part of #14552.

`Not all the test cases use _safe_reboot_ option for rebooting the modular chassis DUTs. For now, excluding only BGP tests from this additional wait time until we triage the code introduced as part of #14552 .`

With the PR https://github.com/sonic-net/sonic-mgmt/pull/14552 changes, for modular chassis a new prolonged wait of minimum 15 minutes is added for DUT reboot test flow.

This introduced new issues with BGP test suites/cases which are dependent on reboot flow. For example, T2 chassis test cases under test suites like bgp '_test_startup_tsa_tsb_service.py_' and bgp '_test_reliable_tsa.py_' are failing.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

- Test cases under BGP test suites like '_test_startup_tsa_tsb_service.py_' and '_test_reliable_tsa.py_' are failing saying DUT is not in the expected functional state after reboot.
- This is because for modular chassis, a new prolonged wait of minimum 15 minutes is added for DUT reboot test flow.

#### How did you do it?

- Exclude BGP test cases from the prolonged new wait and timeout time for modular chassis.
- Not all the test cases use _safe_reboot_ option for rebooting the modular chassis DUTs. For now, excluding only BGP tests from this additional wait time until we triage the code introduced as part of #14552 .

#### How did you verify/test it?
- Ran all the BGP test suites and make sure they are working as expected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
