### PR TITLE
Fix python-setuptools package name for bookwork 

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -214,14 +214,14 @@ def _install_nano_bookworm(dut, creds, syncd_docker_name):
                 && rm -rf /var/lib/apt/lists/* \
                 && apt-get update \
                 && apt-get install -y python3-pip build-essential libssl-dev libffi-dev \
-                python3-dev wget libnanomsg-dev python-is-python3 \
+                python3-dev python3-setuptools wget libnanomsg-dev python-is-python3 \
                 && pip3 install cffi==1.16.0 && pip3 install nnpy \
                 && mkdir -p /opt && cd /opt && wget \
                 https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
                 && mkdir ptf && cd ptf && wget \
                 https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
                 && apt-get -y purge build-essential libssl-dev libffi-dev python3-dev \
-                wget \
+                python3-setuptools wget \
                 " '''.format(http_proxy, https_proxy, syncd_docker_name)
         dut.command(cmd)
 

--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -214,14 +214,14 @@ def _install_nano_bookworm(dut, creds, syncd_docker_name):
                 && rm -rf /var/lib/apt/lists/* \
                 && apt-get update \
                 && apt-get install -y python3-pip build-essential libssl-dev libffi-dev \
-                python3-dev python-setuptools wget libnanomsg-dev python-is-python3 \
+                python3-dev wget libnanomsg-dev python-is-python3 \
                 && pip3 install cffi==1.16.0 && pip3 install nnpy \
                 && mkdir -p /opt && cd /opt && wget \
                 https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
                 && mkdir ptf && cd ptf && wget \
                 https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
                 && apt-get -y purge build-essential libssl-dev libffi-dev python3-dev \
-                python-setuptools wget \
+                wget \
                 " '''.format(http_proxy, https_proxy, syncd_docker_name)
         dut.command(cmd)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to change package name from `python-setuptools`  to `python3-setuptools` for bookworm.

The attempt to install `python-setuptools` leads to `test_copp` failure.
The error message is
```
......
"Get:18 http://deb.debian.org/debian bookworm-backports/main amd64 Packages [247 kB]", "Get:19 http://deb.debian.org/debian bookworm-backports/non-free-firmware amd64 Packages [3852 B]", "Get:20 http://deb.debian.org/debian-security bookworm-security/contrib Sources [856 B]", "Get:21 http://deb.debian.org/debian-security bookworm-security/non-free-firmware Sources [796 B]", "Get:22 http://deb.debian.org/debian-security bookworm-security/main Sources [114 kB]", "Get:23 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [186 kB]", "Get:24 http://deb.debian.org/debian-security bookworm-security/contrib amd64 Packages [644 B]", "Get:25 http://deb.debian.org/debian-security bookworm-security/non-free-firmware amd64 Packages [688 B]", "Fetched 19.3 MB in 7s (2881 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "Package python-setuptools is not available, but is referred to by another package.", "This may mean that the package is missing, has been obsoleted, or", "is only available from another source"]
```


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to skip installing `python-setuptools` for bookworm.

#### How did you do it?
Skip installing `python-setuptools` for bookworm.

#### How did you verify/test it?
The change is verified on 202405 branch. Teat can pass after this change.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
