### PR TITLE
Support hget_all in SonicDbCli

### DIFF
--- a/tests/common/helpers/sonic_db.py
+++ b/tests/common/helpers/sonic_db.py
@@ -1,6 +1,7 @@
 import logging
 import json
 import six
+import ast
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.devices.sonic_asic import SonicAsic
 
@@ -92,6 +93,30 @@ class SonicDbCli(object):
                 return result['stdout'].decode('unicode-escape')
             else:
                 return result['stdout']
+
+    def hget_all(self, key):
+        """
+        Executes a sonic-db-cli HGETALL command.
+        Args:
+            key: full name of the key to get.
+        Returns:
+            The corresponding value of the key.
+        Raises:
+            SonicDbKeyNotFound: If the key is not found.
+        """
+
+        cmd = self._cli_prefix() + "HGETALL {}".format(key)
+        result = self._run_and_check(cmd)
+        if result == {}:
+            raise SonicDbKeyNotFound("Key: %s not found in sonic-db cmd: %s" % (key, cmd))
+        else:
+            v = None
+            if six.PY2:
+                v = result['stdout'].decode('unicode-escape')
+            else:
+                v = result['stdout']
+            v_dict = ast.literal_eval(v)
+            return v_dict
 
     def get_and_check_key_value(self, key, value, field=None):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix https://github.com/sonic-net/sonic-mgmt/issues/14816

The PR takes the implementation from PR https://github.com/sonic-net/sonic-mgmt/pull/13574
PR #13574 was reverted, but the function `hget_all` has been referenced in some other code.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to add support for `hget_all` in SonicDbCli.

#### How did you do it?
Implement `hget_all` funciton.

#### How did you verify/test it?
The change is verified by running `test_lldp_syncd`.
collected 5 items                                                                                                                                                                                     

lldp/test_lldp_syncd.py::test_lldp_entry_table_keys[str-msn2700a1-03] PASSED                                                                                                                    [ 20%]
lldp/test_lldp_syncd.py::test_lldp_entry_table_content[str-msn2700a1-03] PASSED                                                                                                                 [ 40%]
lldp/test_lldp_syncd.py::test_lldp_entry_table_after_flap[str-msn2700a1-03] SKIPPED (Skipping test for eth0 interface)                                                                          [ 60%]
lldp/test_lldp_syncd.py::test_lldp_entry_table_after_lldp_restart[str-msn2700a1-03] PASSED                                                                                                      [ 80%]
lldp/test_lldp_syncd.py::test_lldp_entry_table_after_reboot[str-msn2700a1-03]  ^HPASSED                                                                                                            [100%]
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
