### PR TITLE
Remove cause of TypeError in get_tsa_tsb_service_uptime

### DIFF
--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -102,8 +102,8 @@ def get_tsa_tsb_service_uptime(duthost):
     service_status = duthost.shell("sudo systemctl status startup_tsa_tsb.service | grep 'Active'")
     for line in service_status["stdout_lines"]:
         if 'active' in line:
-            tmp_time = line.split('since')[1].strip().encode('utf-8')
-            act_time = tmp_time.split('UTC')[0].strip().encode('utf-8')
+            tmp_time = line.split('since')[1].strip()
+            act_time = tmp_time.split('UTC')[0].strip()
             service_uptime = datetime.datetime.strptime(act_time[4:], '%Y-%m-%d %H:%M:%S')
             return service_uptime
     return service_uptime


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #14847

Remove unnecessary encode in `get_tsa_tsb_service_uptime` function causing test failures due to `TypeError` in `test_startup_tsa_tsb_service.py`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To fix test failures in `test_startup_tsa_tsb_service.py`.
#### How did you do it?
Remove encode causing `TestError` in `get_tsa_tsb_service_uptime` function.
#### How did you verify/test it?
Tested on T2 testbed that TypeError is no longer raised, and `get_tsa_tsb_service_uptime` continues to function as intended.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A