### PR TITLE
Change behaviour of wait and timeout assignment for T2 devices

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -256,7 +256,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
             timeout = plt_reboot_ctrl.get('timeout', timeout)
         if warmboot_finalizer_timeout == 0 and 'warmboot_finalizer_timeout' in reboot_ctrl:
             warmboot_finalizer_timeout = reboot_ctrl['warmboot_finalizer_timeout']
-        if duthost.get_facts().get("modular_chassis"):
+        if duthost.get_facts().get("modular_chassis") and safe_reboot:
             wait = max(wait, 900)
             timeout = max(timeout, 600)
     except KeyError:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #14840

Changed behaviour of forcing minimum `wait` and `timeout` times for reboot on T2 devices to only trigger when `safe_reboot == True`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Tests were failing when because of the minimum 900s wait time during reboot for T2 devices, despite explicitly setting wait time.
#### How did you do it?
Changed behaviour of forcing minimum `wait` and `timeout` times for reboot on T2 devices to only trigger when `safe_reboot == True`
#### How did you verify/test it?
Tested on T2 testbed to confirm that the effective priority to define `wait` and `timeout` variables would now be:
900, 600 for T2 DUT & safe reboot >
values defined in inv >
explicitly defined `wait` and `timeout` during function call >
default values in `reboot_ctrl_dict`
#### Any platform specific information?
Platform agnostic
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A