### PR TITLE
[Snappi]: New base config function to accomodate mixed-speed ingress and egress tests.

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -551,9 +551,9 @@ def cvg_api(snappi_api_serv_ip,
         api.assistant.Session.remove()
 
 
-def snappi_sys_base_config(duthost_list,
-                           snappi_ports,
-                           snappi_api):
+def snappi_multi_base_config(duthost_list,
+                             snappi_ports,
+                             snappi_api):
     """
     Generate snappi API config and port config information for the testbed
     This function takes care of mixed-speed interfaces by removing assert and printing info log.

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -553,7 +553,8 @@ def cvg_api(snappi_api_serv_ip,
 
 def snappi_multi_base_config(duthost_list,
                              snappi_ports,
-                             snappi_api):
+                             snappi_api,
+                             setup=True):
     """
     Generate snappi API config and port config information for the testbed
     This function takes care of mixed-speed interfaces by removing assert and printing info log.
@@ -563,6 +564,7 @@ def snappi_multi_base_config(duthost_list,
         duthost_list (pytest fixture): list of DUTs
         snappi_ports: list of snappi ports
         snappi_api(pytest fixture): Snappi API fixture
+        setup (bool): Indicates if functionality is called to create or clear the setup.
     Returns:
         - config (obj): Snappi API config of the testbed
         - port_config_list (list): list of port configuration information
@@ -618,14 +620,13 @@ def snappi_multi_base_config(duthost_list,
                 pytest_assert(False, 'pfcQueueGroupSize value is not 4 or 8')
 
     port_config_list = []
-    for index, duthost in enumerate(duthost_list):
-        config_result = __intf_config_multidut(config=config,
-                                               port_config_list=port_config_list,
-                                               duthost=duthost,
-                                               snappi_ports=new_snappi_ports)
-        pytest_assert(config_result is True, 'Fail to configure IP interfaces')
 
-    return config, port_config_list, new_snappi_ports
+    return (setup_dut_ports(
+        setup=setup,
+        duthost_list=duthost_list,
+        config=config,
+        port_config_list=port_config_list,
+        snappi_ports=new_snappi_ports))
 
 
 def snappi_dut_base_config(duthost_list,

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -551,6 +551,83 @@ def cvg_api(snappi_api_serv_ip,
         api.assistant.Session.remove()
 
 
+def snappi_sys_base_config(duthost_list,
+                           snappi_ports,
+                           snappi_api):
+    """
+    Generate snappi API config and port config information for the testbed
+    This function takes care of mixed-speed interfaces by removing assert and printing info log.
+    l1_config is added to both the snappi_ports instead of just one.
+
+    Args:
+        duthost_list (pytest fixture): list of DUTs
+        snappi_ports: list of snappi ports
+        snappi_api(pytest fixture): Snappi API fixture
+    Returns:
+        - config (obj): Snappi API config of the testbed
+        - port_config_list (list): list of port configuration information
+        - snappi_ports (list): list of snappi_ports selected for the test.
+    """
+
+    """ Generate L1 config """
+
+    config = snappi_api.config()
+    tgen_ports = [port['location'] for port in snappi_ports]
+
+    new_snappi_ports = [dict(list(sp.items()) + [('port_id', i)])
+                        for i, sp in enumerate(snappi_ports) if sp['location'] in tgen_ports]
+
+    # Printing info level if ingress and egress interfaces are of different speeds.
+    if (len(set([sp['speed'] for sp in new_snappi_ports])) > 1):
+        logger.info('Rx and  Tx ports have different link speeds')
+    [config.ports.port(name='Port {}'.format(sp['port_id']), location=sp['location']) for sp in new_snappi_ports]
+
+    # Generating L1 config for both the snappi_ports.
+    for port in config.ports:
+        for index, snappi_port in enumerate(new_snappi_ports):
+            if snappi_port['location'] == port.location:
+                l1_config = config.layer1.layer1()[-1]
+                l1_config.name = 'L1 config {}'.format(index)
+                l1_config.port_names = [port.name]
+                l1_config.speed = 'speed_'+str(int(int(snappi_port['speed'])/1000))+'_gbps'
+                l1_config.ieee_media_defaults = False
+                l1_config.auto_negotiate = False
+                l1_config.auto_negotiation.link_training = False
+                l1_config.auto_negotiation.rs_fec = True
+                pfc = l1_config.flow_control.ieee_802_1qbb
+                pfc.pfc_delay = 0
+            if pfcQueueGroupSize == 8:
+                pfc.pfc_class_0 = 0
+                pfc.pfc_class_1 = 1
+                pfc.pfc_class_2 = 2
+                pfc.pfc_class_3 = 3
+                pfc.pfc_class_4 = 4
+                pfc.pfc_class_5 = 5
+                pfc.pfc_class_6 = 6
+                pfc.pfc_class_7 = 7
+            elif pfcQueueGroupSize == 4:
+                pfc.pfc_class_0 = pfcQueueValueDict[0]
+                pfc.pfc_class_1 = pfcQueueValueDict[1]
+                pfc.pfc_class_2 = pfcQueueValueDict[2]
+                pfc.pfc_class_3 = pfcQueueValueDict[3]
+                pfc.pfc_class_4 = pfcQueueValueDict[4]
+                pfc.pfc_class_5 = pfcQueueValueDict[5]
+                pfc.pfc_class_6 = pfcQueueValueDict[6]
+                pfc.pfc_class_7 = pfcQueueValueDict[7]
+            else:
+                pytest_assert(False, 'pfcQueueGroupSize value is not 4 or 8')
+
+    port_config_list = []
+    for index, duthost in enumerate(duthost_list):
+        config_result = __intf_config_multidut(config=config,
+                                               port_config_list=port_config_list,
+                                               duthost=duthost,
+                                               snappi_ports=new_snappi_ports)
+        pytest_assert(config_result is True, 'Fail to configure IP interfaces')
+
+    return config, port_config_list, new_snappi_ports
+
+
 def snappi_dut_base_config(duthost_list,
                            snappi_ports,
                            snappi_api,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Existing snappi_dut_base_config in tests/common/snappi_tests/snappi_fixtures.py has an assert in case, mixed-speed ingress and egress interfaces are selected.

Since the interface speeds were same, the L1 configuration was done ONLY once.

With mixed-speed interfaces being used as ingress and egress, the assert needs to be removed. 

Second issue with existing snappi_multi_base_config was that speed was set to ONLY one of the interfaces being used for the test.  This was incorrect for mixed speed interfaces, causing Snappi API itself to crash.

Fixes # (issue)
#12966 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Existing snappi_dut_base_config asserts when ingress and egress interface speeds are different.

Furthermore, snappi framework itself did not support mixed-speed interfaces for the test and crashed (Please see issue #12966 ) for the same.

#### How did you do it?
Added a new function - snappi_sys_base_config which replaces the assert with info level log indicating that interfaces are of different speeds.

The L1 configuration is done for all the snappi_ports and set appropriate speed for all the snappi_ports. Ideally, existing snappi_dut_base_config could be modified with additional argument mixed-speed=NONE, and then selectively run the code for the mixed-speed=TRUE. However, this being frequently used function, I will keep it as is, and add a new function to ensure, existing function is not broken.

#### How did you verify/test it?
Ran on the local clone with mixed and same speed interfaces. No issues seen.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
