### PR TITLE
fix for test_snmp_numpsu failure

### DIFF
--- a/tests/snmp/test_snmp_psu.py
+++ b/tests/snmp/test_snmp_psu.py
@@ -31,8 +31,14 @@ def test_snmp_numpsu(duthosts, enum_supervisor_dut_hostname, localhost, creds_al
 
     assert int(res['rc']) == 0, "Failed to get number of PSUs"
 
-    numpsus = int(res['stdout'])
-    assert numpsus == len(snmp_facts['snmp_psu'])
+    output = res["stdout_lines"]
+    numpsus = None
+    if len(output):
+        try:
+            numpsus = int(output[-1])
+        except (IndexError, ValueError):
+            pass
+    assert numpsus == len(snmp_facts['snmp_psu']), "PSUs count doesn't match"
 
 
 @pytest.mark.bsl


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: `test_snmp_numpsu` TC fails because of change in `stdout` output, observed in `202405` & `202311`.

Fixes # (issue)
`stdout_lines` will be use to fetch the `numpsus` value, if the `stdout_lines` is empty / the value can't be typecasted; then in all scenarios TC wouldn't break, instead it will Error out gracefully. Sample `stdout_lines` considered -
```
1. ["PSU0: Topology teardown completed successfully upon PSU removal", "2"]
2. ["2"]
3. []
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Observed `test_snmp_psu` failing in `202405` & `202311` images due to change in the `stdout` structure.

#### How did you do it?
Earlier `stdout` output was simply getting typecasted, instead now it will use `stdout_lines` & check its length, if it has a non-zero length, then it will pick the last element & try typecasting it; `numpsus` count if exists, will always be the last element in the output.

#### How did you verify/test it?
Run changes with `202405` & `202311` images on a `T0` setup and all of them passed.
