### PR TITLE
Extended the SingleHop BFD skip to other cisco platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -76,15 +76,15 @@ bfd/test_bfd.py:
 
 bfd/test_bfd.py::test_bfd_basic:
   skip:
-    reason: "Test not supported for cisco-8102 as it doesnt support single hop BFD. Skipping the test"
+    reason: "Test not supported for cisco as it doesnt support single hop BFD. Skipping the test"
     conditions:
-      - "platform in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0']"
+      - "platform in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-8111_32eh_o-r0', 'x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
 
 bfd/test_bfd.py::test_bfd_scale:
   skip:
-    reason: "Test not supported for cisco-8102 as it doesnt support single hop BFD. Skipping the test"
+    reason: "Test not supported for cisco as it doesnt support single hop BFD. Skipping the test"
     conditions:
-      - "platform in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0']"
+      - "platform in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-8111_32eh_o-r0', 'x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
 
 bfd/test_bfd_static_route.py:
   skip:


### PR DESCRIPTION

### Description of PR
Extended the SingleHop BFD skip to other cisco platforms

Summary:
Fixes # (issue)

### Type of change


- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Ran sonic-mgmt to validate the change
bfd/test_bfd.py::test_bfd_basic[ipv4-dut_init_first] INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv4-dut_init_first] setup ====================
SKIPPED (Test not supported for cisco as it doesnt support single hop BFD. Skipping the test)INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv4-dut_init_first] teardown ====================

bfd/test_bfd.py::test_bfd_basic[ipv4-ptf_init_first] INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv4-ptf_init_first] setup ====================
SKIPPED (Test not supported for cisco as it doesnt support single hop BFD. Skipping the test)INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv4-ptf_init_first] teardown ====================

bfd/test_bfd.py::test_bfd_basic[ipv6-dut_init_first] INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv6-dut_init_first] setup ====================
SKIPPED (Test not supported for cisco as it doesnt support single hop BFD. Skipping the test)INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv6-dut_init_first] teardown ====================

bfd/test_bfd.py::test_bfd_basic[ipv6-ptf_init_first] INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv6-ptf_init_first] setup ====================
SKIPPED (Test not supported for cisco as it doesnt support single hop BFD. Skipping the test)INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv6-ptf_init_first] teardown ====================



#### Any platform specific information?
Skipped for cisco specific platforms

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
