### PR TITLE
feat: fix config_db dump post test for ntp_helper

### DIFF
--- a/tests/common/helpers/sonic_db.py
+++ b/tests/common/helpers/sonic_db.py
@@ -118,6 +118,32 @@ class SonicDbCli(object):
             v_dict = ast.literal_eval(v)
             return v_dict
 
+    def hset(self, key, *args):
+        """
+        Executes a sonic-db-cli HSET command.
+
+        Args:
+            key: full name of the key to set.
+            args: pair of field-value to set
+
+        Returns:
+            The corresponding value of the key.
+        Raises:
+            SonicDbKeyNotFound: If the key or field has no value or is not present.
+        """
+        if len(args) % 2 != 0 or len(args) < 2:
+            raise ValueError("The number of key-value argument must be even and at least of size 2")
+
+        cmd = self._cli_prefix() + "HSET {} {}".format(key, " ".join(args))
+        result = self._run_and_check(cmd)
+        if result == {}:
+            raise SonicDbKeyNotFound("Key: %s not found in sonic-db cmd: %s" % (key, cmd))
+        else:
+            if six.PY2:
+                return result['stdout'].decode('unicode-escape')
+            else:
+                return result['stdout']
+
     def get_and_check_key_value(self, key, value, field=None):
         """
         Executes a sonic-db CLI get or hget and validates the response against a provided field.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fix config_db core dump check failure after the test
Fixes # (issue) 29753940

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The reason for the config_db failure is because in `config ntp add` we will also set the value of `{'resolve_as':..., 'association_type': 'server'}` 

![image](https://github.com/user-attachments/assets/a948302e-dacc-4359-b683-5b65cadd9bbc)

This will not guarantee that the setting is exactly before the check. Therefore, we extract the value directly from key and set it as it


#### How did you do it?

#### How did you verify/test it?
Verified on modular switch

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
