### PR TITLE
Update test_startup_tsa_tsb_service.py - add more guiderails

### DIFF
--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -106,12 +106,8 @@ def get_tsa_tsb_service_uptime(duthost):
     service_status = duthost.shell("sudo systemctl status startup_tsa_tsb.service | grep 'Active'")
     for line in service_status["stdout_lines"]:
         if 'active' in line:
-            if sys.version_info.major < 3:
-                tmp_time = line.split('since')[1].strip().encode('utf-8')
-                act_time = tmp_time.split('UTC')[0].strip().encode('utf-8')
-            else:
-                tmp_time = line.split('since')[1].strip()
-                act_time = tmp_time.split('UTC')[0].strip()
+            tmp_time = line.split('since')[1].strip()
+            act_time = tmp_time.split('UTC')[0].strip()
             service_uptime = datetime.datetime.strptime(act_time[4:], '%Y-%m-%d %H:%M:%S')
             return service_uptime
     return service_uptime

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -1,7 +1,6 @@
 import logging
 import datetime
 import pexpect
-import sys
 
 import pytest
 from tests.common import reboot, config_reload

--- a/tests/bgp/traffic_checker.py
+++ b/tests/bgp/traffic_checker.py
@@ -47,3 +47,10 @@ def check_tsa_persistence_support(duthost):
     if not tsa_in_configdb:
         return False
     return True
+
+
+def check_traffic_shift_state(duthost, state):
+    if state != get_traffic_shift_state(duthost):
+        return False
+    else:
+        return True

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -55,15 +55,6 @@ reboot_ctrl_dict = {
         "cause": "Power Loss",
         "test_reboot_cause_only": True
     },
-    REBOOT_TYPE_COLD: {
-        "command": "reboot",
-        "timeout": 300,
-        "wait": 120,
-        # We are searching two types of reboot cause.
-        # This change relates to changes of PR #6130 in sonic-buildimage repository
-        "cause": r"'reboot'|Non-Hardware \(reboot|^reboot",
-        "test_reboot_cause_only": False
-    },
     REBOOT_TYPE_SOFT: {
         "command": "soft-reboot",
         "timeout": 300,
@@ -125,7 +116,7 @@ reboot_ctrl_dict = {
         "timeout": 300,
         "wait": 120,
         # When linecards are rebooted due to supervisor cold reboot
-        "cause": "reboot from Supervisor",
+        "cause": r"^Reboot from Supervisor$|^reboot from Supervisor$",
         "test_reboot_cause_only": False
     },
     REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS: {
@@ -133,7 +124,16 @@ reboot_ctrl_dict = {
         "timeout": 300,
         "wait": 120,
         # When linecards are rebooted due to supervisor crash/abnormal reboot
-        "cause": "Heartbeat",
+        "cause": r"Heartbeat|headless",
+        "test_reboot_cause_only": False
+    },
+    REBOOT_TYPE_COLD: {
+        "command": "reboot",
+        "timeout": 300,
+        "wait": 120,
+        # We are searching two types of reboot cause.
+        # This change relates to changes of PR #6130 in sonic-buildimage repository
+        "cause": r"'reboot'|Non-Hardware \(reboot|^reboot",
         "test_reboot_cause_only": False
     }
 }


### PR DESCRIPTION
### Description of PR
We have updated test_startup_tsa_tsb_service.py based on our testing.

Checks to see:

- if bgp sessions are up before checking for the routes,
- Checking for state of the DUT before executing the test. Skipping the test if it is in maintenance mode instead of failing for the wrong reason.
- Changing the reboot cause in case kdump is enabled.
- Increasing the time to check if startup service has started. 
- Made small changes in reboot.py since cold reboot was becoming a catchall statement.
- Added reboot cause to support Hearbeat and Headless in case of supervisor heartbeat loss case

Summary:
Fixes # (issue)

### Type of change

- [] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
We have updated test_startup_tsa_tsb_service.py based on our testing.

#### How did you do it?

#### How did you verify/test it?
Verified it on T2 profile for Cisco chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
