### PR TITLE
[Snappi] enable safe reboot for multidut snappi cases.

### DIFF
--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -257,7 +257,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
 
     for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
         logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-        reboot(duthost, localhost, reboot_type=reboot_type)
+        reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
         logger.info("Wait until the system is stable")
         wait_until(180, 20, 0, duthost.critical_services_fully_started)
 
@@ -346,7 +346,7 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noq
 
     for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
         logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-        reboot(duthost, localhost, reboot_type=reboot_type)
+        reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
         logger.info("Wait until the system is stable")
         wait_until(180, 20, 0, duthost.critical_services_fully_started)
 

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -245,7 +245,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
 
     for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
         logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-        reboot(duthost, localhost, reboot_type=reboot_type)
+        reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
         logger.info("Wait until the system is stable")
         wait_until(180, 20, 0, duthost.critical_services_fully_started)
 
@@ -334,7 +334,7 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
 
     for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
         logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-        reboot(duthost, localhost, reboot_type=reboot_type)
+        reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
         logger.info("Wait until the system is stable")
         wait_until(180, 20, 0, duthost.critical_services_fully_started)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Current snappi multidut tests wait 15 minutes to finish a reboot as the default waiting time is 900 seconds for chassis.
However, when using safe reload, it will finish the reboot in 10 minutes. Also, existing non multidut test cases have changed to use safe reboot as well. 
Therefore, setting multidut cases to use safe reboot.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
reduce reboot time for multidut snappi cases.

#### How did you do it?
Use safe reboot.

#### How did you verify/test it?
Tested on lab devices.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
