### PR TITLE
Fix SyntaxError for test_lldp_syncd

### DIFF
--- a/tests/common/helpers/sonic_db.py
+++ b/tests/common/helpers/sonic_db.py
@@ -115,7 +115,8 @@ class SonicDbCli(object):
                 v = result['stdout'].decode('unicode-escape')
             else:
                 v = result['stdout']
-            v_dict = ast.literal_eval(v)
+            v_sanitized = v.replace('\n', '\\n')
+            v_dict = ast.literal_eval(v_sanitized)
             return v_dict
 
     def get_and_check_key_value(self, key, value, field=None):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fix the following error:
```
E         File "<unknown>", line 1
E           {'lldp_rem_time_mark': '845', 'lldp_rem_sys_desc': 'Cisco Nexus Operating System (NX-OS) Software 6.0(2)U6(5c)
E                                                                                                                        ^
E       SyntaxError: EOL while scanning string literal

/usr/lib/python3.8/ast.py:47: SyntaxError
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

The output of sonic-db-cli has newline characters which caused `SyntaxError: EOL while scanning string literal`
```
admin@str2-7050cx3-acs-10:~$ sudo sonic-db-cli APPL_DB hgetall LLDP_ENTRY_TABLE:eth0
{'lldp_rem_time_mark': '61', 'lldp_rem_sys_desc': 'Cisco Nexus Operating System (NX-OS) Software 6.0(2)U6(5c)
TAC support: http://www.cisco.com/tac
Copyright (c) 2002-2016, Cisco Systems, Inc. All rights reserved.', 'lldp_rem_sys_cap_supported': '28 00', 'lldp_rem_port_desc': 'Ethernet1/15', 'lldp_rem_port_id_subtype': '5', 'lldp_rem_chassis_id_subtype': '4', 'lldp_rem_man_addr': '', 'lldp_rem_port_id': 'Ethernet1/15', 'lldp_rem_index': '5', 'lldp_rem_sys_cap_enabled': '28 00', 'lldp_rem_sys_name': 'STR-MGSW-203-D18.ntwk.msn.net', 'lldp_rem_chassis_id': '50:2f:a8:ca:92:76'}
```

```
admin@str2-7050cx3-acs-10:~$ docker exec lldp lldpctl -f json
{
  "lldp": {
    "interface": [
      {
        "eth0": {
          "via": "LLDP",
          "rid": "5",
          "age": "0 day, 00:01:42",
          "chassis": {
            "STR-MGSW-203-D18.ntwk.msn.net": {
              "id": {
                "type": "mac",
                "value": "50:2f:a8:ca:92:76"
              },
              "descr": "Cisco Nexus Operating System (NX-OS) Software 6.0(2)U6(5c)\nTAC support: http://www.cisco.com/tac\nCopyright (c) 2002-2016, Cisco Systems, Inc. All rights reserved.",
              "capability": [
                {
                  "type": "Bridge",
                  "enabled": true
                },
                {
                  "type": "Router",
                  "enabled": true
                }
              ]
            }
          }
...
```

#### How did you do it?
With replacement, it ensures it can parse multi-line strings without triggering a SyntaxError due to newline characters.

#### How did you verify/test it?
run `lldp/test_lldp_syncd.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
