### PR TITLE
Workaround python_sai_thrift path issue

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -331,6 +331,13 @@ def test_update_saithrift_ptf(request, ptfhost):
     if result["failed"] or "OK" not in result["msg"]:
         pytest.skip("Download failed/error while installing python saithrift package")
     ptfhost.shell("dpkg -i {}".format(os.path.join("/root", pkg_name)))
+    # In 202405 branch, the switch_sai_thrift package is inside saithrift-0.9-py3.11.egg
+    # We need to move it out to the correct location
+    PY_PATH = "/usr/lib/python3/dist-packages/"
+    SRC_PATH = PY_PATH + "saithrift-0.9-py3.11.egg/switch_sai_thrift"
+    DST_PATH = PY_PATH + "switch_sai_thrift"
+    if ptfhost.stat(path=SRC_PATH)['stat']['exists'] and not ptfhost.stat(path=DST_PATH)['stat']['exists']:
+        ptfhost.copy(src=SRC_PATH, dest=DST_PATH, remote_src=True)
     logging.info("Python saithrift package installed successfully")
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to workaround issue https://github.com/opencomputeproject/SAI/issues/2086
The python_sai_thrift library is not installed to the right directory, which leads to qos_sai test failure.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to workaround `python_sai_thrift` path issue.

#### How did you do it?
Copy `switch_sai_thrift` folder from `saithrift-0.9-py3.11.egg` to the parent folder.
 
#### How did you verify/test it?
The change is verified by running `test_update_saithrift_ptf`.
```
collected 1 item                                                                                                                                                                                      

test_pretest.py::test_update_saithrift_ptf PASSED                                                                                                                                               [100%]
``` 
Test is passing and the Python library is installed to the right directory.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
