### PR TITLE
Fix for test_dhcp_relay failures on hwsku of Cisco-8111-O64

### DIFF
--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -113,7 +113,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
             if neighbor_info_dict['name'] in mg_facts['minigraph_devices']:
                 neighbor_device_info_dict = mg_facts['minigraph_devices'][neighbor_info_dict['name']]
                 if 'type' in neighbor_device_info_dict and neighbor_device_info_dict['type'] in \
-                        ['LeafRouter', 'MgmtLeafRouter']:
+                        ['LeafRouter', 'MgmtLeafRouter', 'BackEndLeafRouter']:
                     # If this uplink's physical interface is a member of a portchannel interface,
                     # we record the name of the portchannel interface here, as this is the actual
                     # interface the DHCP relay will listen on.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: All TCs in `test_dhcp_relay` fails for `202405` image on device with `hwsku` of `Cisco-8111-O64`. 

Fixes # (issue)  
Add `BackEndLeafRouter` in `minigraph_devices` `type` expected.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The `type` of `minigraph_devices` set in `202405` is `BackEndLeafRouter` ; whereas in `202311` it was `LeafRouter` ; TC expects `type` to be `LeafRouter` / `MgmtLeafRouter` to set `uplink_interfaces` variable, else, it doesn’t set due to which in `202405` `uplink_interfaces` are empty & when they try to obtain the mac address of uplink interface for `dhcp_relay_data`, script errors out.

Minigraph sets the `type` for the devices, In [PR : enable compute-ai for 8111-t1](https://github.com/sonic-net/sonic-mgmt/pull/11019) for `hwsku` of `Cisco-8111-O64` , `dut_type` set for `t0` , `t1` is `BackEndLeafRouter`. Same changes has been [cherry picked to 202305](https://github.com/sonic-net/sonic-mgmt/pull/11019#issuecomment-1877150143).  But in `202311` these changes have not been added, this is the reason all TCs passes in `202311` but fails for `202405`.

#### How did you do it?
Add `BackEndLeafRouter` in `minigraph_devices` `type` expected.

#### How did you verify/test it?
Run changes with `202405` image on device with `hwsku` of `Cisco-8111-O64`. All TCs passed.

