### PR TITLE
Fixing the failures in qos-sai on 202405.

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1617,6 +1617,12 @@ class TestQosSai(QosSaiBase):
             pktsNumFillShared = int(
                 qosConfig[pgProfile]["pkts_num_trig_egr_drp"]) - 1
 
+        if dutTestParams["basicParams"].get("platform_asic", None) \
+                == "cisco-8000":
+            if not get_src_dst_asic_and_duts['single_asic_test']:
+                if pgProfile == "wm_pg_shared_lossy":
+                    pytest.skip("The lossy test is not valid for multiAsic configuration.")
+
         self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 
         testParams = dict()

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1160,6 +1160,7 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         dst_port_id = get_rx_port(
             self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip)
         print("actual dst_port_id: %d" % (dst_port_id), file=sys.stderr)
+        time.sleep(3)
 
         try:
             for pg, dscps in list(pg_dscp_map.items()):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR addresses 2 fails in qos-sai runs on cisco-8000 platform. They are:
1. testQosSaiDscpToPgMapping: The script reads the base counters before starting the actual test loop. However, there is a pretest-packet that is sent before reading the counters. Since there is no delay between sending the pre-test packet and the reading of the base counters, the base counter doesn't include the pre-test packet. In this PR, we are adding a 3 second delay before reading the base counters.
2. wm_pg_shared_lossy failure: This test is not applicable to T2/multidut/multiasic variants. So the qos.yaml doesn't even have the required key for this test. So we are adding a skip in this PR for this test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Test qos sai failures in 202405.

#### How did you do it?
Pls see the description on how these issues are addressed.

#### How did you verify/test it?
Ran it in our TB.

#### Any platform specific information?
Cisco-8000 related.