### PR TITLE
Wait for service to fix flaky memory_checker test

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -547,6 +547,9 @@ def consumes_memory_and_checks_container_restart(duthost, container):
         container.wait_monit_mem_failed(timeout_monit_fail)
         logger.info("Container %s should now be restarting", container.name)
         container.wait_monit_mem_ok(CONTAINER_RESTART_THRESHOLD_SECS)
+        # Wait until the service has started, then the loganalyzer will capture all the expected messages
+        wait_until(CONTAINER_RESTART_THRESHOLD_SECS, CONTAINER_CHECK_INTERVAL_SECS, 0,
+                   duthost.is_host_service_running, container.name)
 
     logger.info("Container %s restarted.", container.name)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Microsoft ADO: 29720467

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
test_memory_checker is flaky.
This test failed to capture this message: "2024 Oct  8 11:30:39.182886 vlab-01 INFO systemd[1]: Started gnmi.service - GNMI container."

#### How did you do it?
loganalyzer needs to check all the syslog in this time frame, now we wait until gnmi service is running to give loganalyzer enough time to find expected messages.

#### How did you verify/test it?
Run test_memory_checker for serveral times.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
