### PR TITLE
fix: handle sanity check failure for parallel run

### DIFF
--- a/tests/common/devices/duthosts.py
+++ b/tests/common/devices/duthosts.py
@@ -5,6 +5,8 @@ from tests.common.devices.multi_asic import MultiAsicSonicHost
 from tests.common.helpers.parallel_utils import is_initial_checks_active
 
 logger = logging.getLogger(__name__)
+NON_INITIAL_CHECKS_STAGE = "non_initial_checks"
+INITIAL_CHECKS_STAGE = "initial_checks"
 
 
 class DutHosts(object):
@@ -62,7 +64,7 @@ class DutHosts(object):
         self.is_parallel_run = target_hostname is not None
         # TODO: Initialize the nodes in parallel using multi-threads?
         if self.is_parallel_run:
-            self.parallel_run_stage = "non_initial_checks"
+            self.parallel_run_stage = NON_INITIAL_CHECKS_STAGE
             self.target_hostname = target_hostname
             self.is_parallel_leader = is_parallel_leader
             self.__initialize_nodes_for_parallel()
@@ -111,17 +113,17 @@ class DutHosts(object):
     def __should_reinit_when_parallel(self):
         return (
             self.is_parallel_leader and (
-                self.parallel_run_stage == "initial_checks" and not is_initial_checks_active(self.request) or
-                self.parallel_run_stage == "non_initial_checks" and is_initial_checks_active(self.request)
+                self.parallel_run_stage == INITIAL_CHECKS_STAGE and not is_initial_checks_active(self.request) or
+                self.parallel_run_stage == NON_INITIAL_CHECKS_STAGE and is_initial_checks_active(self.request)
             )
         )
 
     def __reinit_nodes_for_parallel(self):
         if is_initial_checks_active(self.request):
-            self.parallel_run_stage = "initial_checks"
+            self.parallel_run_stage = INITIAL_CHECKS_STAGE
             self._nodes_for_parallel = self._nodes_for_parallel_initial_checks
         else:
-            self.parallel_run_stage = "non_initial_checks"
+            self.parallel_run_stage = NON_INITIAL_CHECKS_STAGE
             self._nodes_for_parallel = self._nodes_for_parallel_tests
 
         self._supervisor_nodes = self._Nodes([node for node in self._nodes_for_parallel if node.is_supervisor_node()])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2216,7 +2216,7 @@ def compare_running_config(pre_running_config, cur_running_config):
 
 @pytest.fixture(scope="module", autouse=True)
 def core_dump_and_config_check(duthosts, tbinfo, request,
-                               # make sure the tear down of sanity_check happened after core_dump_and_config_check
+                               # make sure the teardown of sanity_check happened after core_dump_and_config_check
                                sanity_check):
     '''
     Check if there are new core dump files and if the running config is modified after the test case running.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Handle sanity check teardown failures when parallel run is enabled.

Summary:
Fixes # (issue) Microsoft ADO 29787171

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
We observed that the teardown of `sanity_check` happens before the teardown of `sanity_check_full`, so we need to handle the failures in the teardown of `sanity_check_full` as a temporary solution for parallel run. Later on, we should figure out how we should properly handle this situation. Microsoft ADO 29811074 has been created for this.

#### How did you do it?

#### How did you verify/test it?
I ran the updated code and made sure it works as expected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
