### PR TITLE
[Console Recovery] Use sonic_installer to adapt elder SONiC images

### DIFF
--- a/.azure-pipelines/recover_testbed/common.py
+++ b/.azure-pipelines/recover_testbed/common.py
@@ -245,7 +245,7 @@ def check_sonic_installer(sonichost, sonic_username, sonic_password, sonic_ip, i
     client.expect("admin@{}'s password:".format(sonic_ip))
     client.sendline(sonic_password)
     client.expect(["admin@sonic", "admin@{}".format(sonichost.hostname)])
-    client.sendline("sudo sonic-installer install {}"
+    client.sendline("sudo sonic_installer install {}"
                     .format(image_url))
     client.expect("New image will be installed")
     client.close()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Auto-Recovery failed on DUTs running 201911 and earlier images because `sonic-installer` cannot be found. (Sample ElasticTest TestPlan ID: 670534543331ab71a12f5e93) Creating this PR to resolve this issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Auto-Recovery failed on DUTs running 201911 and earlier images because `sonic-installer` cannot be found. (Sample ElasticTest TestPlan ID: 670534543331ab71a12f5e93) Creating this PR to resolve this issue.

#### How did you do it?
Auto-Recovery failed on DUTs running 201911 and earlier images because `sonic-installer` cannot be found. (Sample ElasticTest ID: 670534543331ab71a12f5e93) Creating this PR to resolve this issue.

#### How did you verify/test it?
Verified on SN2700 with SONiC.201911 installed:
```
zhijianli@sonic-mgmt-zhijianli:~/mgmt/sonic-mgmt-int/ansible$ python3 ../.azure-pipelines/recover_testbed/recover_testbed.py -i bjw veos -t testbed-bjw-can-2700-2 --tbfile testbed.yaml --log-level info --image sonic-mellanox-20230531.22.bin --hwsku Mellanox-SN2700
/usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
2024-10-08 14:06:37,362 recover_testbed.py#135 INFO - Initializing hosts
Tuesday 08 October 2024  14:06:43 +0000 (0:00:00.070)       0:00:00.070 *******
2024-10-08 14:06:44,385 dut_connection.py#33 INFO - dut bjw-can-2700-2 belongs to groups ['bjw', 'sonic', 'sonic_mlnx_sn2700', 'fanout']
2024-10-08 14:06:44,394 dut_connection.py#57 INFO - skip empty var file group_vars/all/corefile_uploader.yml
2024-10-08 14:06:44,397 dut_connection.py#57 INFO - skip empty var file group_vars/all/README.yml
2024-10-08 14:06:45,168 transport.py#1873 INFO - Connected (version 2.0, client OpenSSH_7.4p1)
2024-10-08 14:06:50,186 transport.py#1873 INFO - Authentication (password) failed.
2024-10-08 14:06:50,199 transport.py#1873 INFO - Connected (version 2.0, client OpenSSH_7.4p1)
2024-10-08 14:06:53,275 transport.py#1873 INFO - Authentication (password) failed.
2024-10-08 14:06:53,288 transport.py#1873 INFO - Connected (version 2.0, client OpenSSH_7.4p1)
2024-10-08 14:06:54,500 transport.py#1873 INFO - Authentication (password) successful!
2024-10-08 14:06:54,500 recover_testbed.py#71 INFO - SSH success.
Tuesday 08 October 2024  14:06:54 +0000 (0:00:11.122)       0:00:11.193 *******
Tuesday 08 October 2024  14:07:07 +0000 (0:00:12.621)       0:00:23.814 *******
Tuesday 08 October 2024  14:07:08 +0000 (0:00:01.449)       0:00:25.264 *******
Tuesday 08 October 2024  14:07:09 +0000 (0:00:01.058)       0:00:26.323 *******
Tuesday 08 October 2024  14:07:10 +0000 (0:00:00.599)       0:00:26.923 *******
zhijianli@sonic-mgmt-zhijianli:~/mgmt/sonic-mgmt-int/ansible$ echo $?
0
```

Confirmed will not break auto-recovery on DUT with 202012 and later images.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
