### PR TITLE
Add skip by GitHub issue for warm-reboot sad test cases

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1133,6 +1133,13 @@ platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset:
       - "(platform in ['x86_64-cel_e1031-r0'] or 't2' in topo_name) and https://github.com/sonic-net/sonic-mgmt/issues/6218"
       - "asic_type in ['nvidia-bluefield']"
 
+platform_tests/test_advanced_reboot.py::test_warm_reboot_sad[sad_lag_member:
+  skip:
+    reason: "Testcase ignored due to https://github.com/sonic-net/sonic-buildimage/issues/20381 on SN5600 or SN4700"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/20381"
+      - "'sn5600' in platform or 'sn4700' in platform"
+
 platform_tests/test_auto_negotiation.py:
   skip:
     reason: "auto negotiation test highly depends on test enviroments, file issue to track and skip for now"


### PR DESCRIPTION
Skip the warm-reboot sad test cases before the issue resolved: https://github.com/sonic-net/sonic-buildimage/issues/20381, only for the 202405 branch for the SN4700 and SN5600
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
