### PR TITLE
Adding fixes for the docker0 ipv6 issue.

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1847,6 +1847,9 @@ class QosSaiBase(QosBase):
                     duthost.shell("sudo ip -6  addr show dev docker0 | grep global" + " | awk '{print $2}'")[
                         "stdout_lines"][0]
             except IndexError:
+                logger.info(
+                    "Couldnot get the ipv6 address for docker0 for the"
+                    " host:{}".format(duthost.hostname))
                 all_docker0_ipv6_addrs[duthost.hostname] = None
 
             duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=1")

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1840,19 +1840,25 @@ class QosSaiBase(QosBase):
     @pytest.fixture(scope='class', autouse=True)
     def dut_disable_ipv6(self, duthosts, get_src_dst_asic_and_duts, tbinfo, lower_tor_host, # noqa F811
                          swapSyncd_on_selected_duts):
+        all_docker0_ipv6_addrs = {}
         for duthost in get_src_dst_asic_and_duts['all_duts']:
-            docker0_ipv6_addr = \
-                duthost.shell("sudo ip -6  addr show dev docker0 | grep global" + " | awk '{print $2}'")[
-                    "stdout_lines"][0]
+            try:
+                all_docker0_ipv6_addrs[duthost.hostname] = \
+                    duthost.shell("sudo ip -6  addr show dev docker0 | grep global" + " | awk '{print $2}'")[
+                        "stdout_lines"][0]
+            except IndexError:
+                all_docker0_ipv6_addrs[duthost.hostname] = None
+
             duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=1")
 
         yield
 
         for duthost in get_src_dst_asic_and_duts['all_duts']:
             duthost.shell("sysctl -w net.ipv6.conf.all.disable_ipv6=0")
-            logger.info("Adding docker0's IPv6 address since it was removed when disabing IPv6")
-            duthost.shell("ip -6 addr add {} dev docker0".format(docker0_ipv6_addr))
-            config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
+            if all_docker0_ipv6_addrs[duthost.hostname] is not None:
+                logger.info("Adding docker0's IPv6 address since it was removed when disabing IPv6")
+                duthost.shell("ip -6 addr add {} dev docker0".format(all_docker0_ipv6_addrs[duthost.hostname]))
+                config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
 
     @pytest.fixture(scope='class', autouse=True)
     def sharedHeadroomPoolSize(

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1861,7 +1861,10 @@ class QosSaiBase(QosBase):
             if all_docker0_ipv6_addrs[duthost.hostname] is not None:
                 logger.info("Adding docker0's IPv6 address since it was removed when disabing IPv6")
                 duthost.shell("ip -6 addr add {} dev docker0".format(all_docker0_ipv6_addrs[duthost.hostname]))
-                config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
+
+        # TODO: parallelize this step.. Do we really need this ?
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
 
     @pytest.fixture(scope='class', autouse=True)
     def sharedHeadroomPoolSize(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In qos-sai-base, there is a docker0 ipv6 checking function, which fails if the DUT has no ipv6 address. The failure signature is as below:
```
14:50:01 __init__._fixture_generator_decorator    L0088 ERROR  | 
IndexError('list index out of range')
Traceback (most recent call last):
  File "/data/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/data/tests/qos/qos_sai_base.py", line 1824, in dut_disable_ipv6
    duthost.shell("sudo ip -6  addr show dev docker0 | grep global" + " | awk '{print $2}'")[
IndexError: list index out of range
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
The failure of the ipv6 disabling fixture.

#### How did you do it?
Check if the docker0 has ipv6 address or not.

#### How did you verify/test it?
Ran it on my TB:
```
----------------------------------------------------------------------------- live log sessionfinish -----------------------------------------------------------------------------
07:42:47 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
============================================================================ short test summary info =============================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[single_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[single_dut_multi_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[multi_dut_longlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[multi_dut_shortlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[multi_dut_shortlink_to_longlink]
=================================================================== 5 passed, 1 warning in 5246.68s (1:27:26) ====================================================================
sonic@202405-qos-sonic-mgmt-prod:/data/tests$ 
```