### PR TITLE
[dualtor-aa] add test to verify iptables nat rules for mux port

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -179,12 +179,14 @@
       vm_config: "{{ vm_topo_config }}"
       port_alias: "{{ port_alias }}"
       vlan_intfs: "{{ vlan_intfs }}"
+      vlan_config: "{{ vlan_config | default(None) }}"
     delegate_to: localhost
     when: "'dualtor' in topo or 'cable' in topo"
 
   - name: gather mux cable information
     mux_cable_facts:
       topo_name: "{{ topo }}"
+      vlan_config: "{{ vlan_config | default(None) }}"
     delegate_to: localhost
     when: "'dualtor' in topo"
 

--- a/ansible/library/dual_tor_facts.py
+++ b/ansible/library/dual_tor_facts.py
@@ -122,7 +122,6 @@ def main():
             port_alias=dict(required=True, default=None, type='list'),
             vlan_intfs=dict(required=True, default=None, type='list'),
             vlan_config=dict(required=False, default=None, type='str'),
-            working_dir=dict(required=False, default='.', type='str'),
         ),
         supports_check_mode=True
     )

--- a/ansible/library/mux_cable_facts.py
+++ b/ansible/library/mux_cable_facts.py
@@ -30,7 +30,7 @@ options:
 
 def load_topo_file(topo_name):
     """Load topo definition yaml file."""
-    topo_file = "vars/topo_%s.yml" % topo_name
+    topo_file = "../ansible/vars/topo_%s.yml" % topo_name
     if not os.path.exists(topo_file):
         raise ValueError("Topo file %s not exists" % topo_file)
     with open(topo_file) as fd:
@@ -42,6 +42,7 @@ def main():
         argument_spec=dict(
             topo_name=dict(required=False, type="str"),
             topology=dict(required=False, type="dict"),
+            vlan_config=dict(required=False, default=None, type="str"),
         ),
         mutually_exclusive=[["topo_name", "topology"]],
         required_one_of=[["topo_name", "topology"]]
@@ -54,7 +55,7 @@ def main():
         topology = args["topology"]
 
     try:
-        mux_cable_facts = generate_mux_cable_facts(topology=topology)
+        mux_cable_facts = generate_mux_cable_facts(topology=topology, vlan_config=args["vlan_config"])
         module.exit_json(ansible_facts={"mux_cable_facts": mux_cable_facts})
     except Exception:
         module.fail_json(msg=traceback.format_exc())

--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -100,8 +100,8 @@ RETURN = '''
 '''
 
 # Default testbed file name
-TESTBED_FILE = 'testbed.yaml'
-TESTCASE_FILE = 'roles/test/vars/testcases.yml'
+TESTBED_FILE = '../ansible/testbed.yaml'
+TESTCASE_FILE = '../ansible/roles/test/vars/testcases.yml'
 
 
 class ParseTestbedTopoinfo():

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -18,6 +18,8 @@ options:
       required: True
 '''
 
+VARS_PATH = "../ansible/vars/"
+
 
 def parse_vm_vlan_port(vlan):
     """
@@ -229,14 +231,14 @@ class ParseTestbedTopoinfo():
         if 'ptf64' in topo_name:
             topo_name = 't1-64'
         topo_name = re.sub(CLET_SUFFIX + "$", "", topo_name)
-        topo_filename = 'vars/topo_' + topo_name + '.yml'
+        topo_filename = VARS_PATH + 'topo_' + topo_name + '.yml'
 
         asic_topo_file_candidate_list = []
 
         if testbed_name:
             asic_topo_file_candidate_list.append(
-                'vars/' + testbed_name + '/topo_' + hwsku + '.yml')
-        asic_topo_file_candidate_list.append('vars/topo_' + hwsku + '.yml')
+                VARS_PATH + testbed_name + '/topo_' + hwsku + '.yml')
+        asic_topo_file_candidate_list.append(VARS_PATH + 'topo_' + hwsku + '.yml')
         vm_topo_config = dict()
         vm_topo_config['topo_type'] = None
         asic_topo_config = dict()
@@ -251,7 +253,7 @@ class ParseTestbedTopoinfo():
         # read topology definition
         if not os.path.isfile(topo_filename):
             raise Exception(
-                "cannot find topology definition file under vars/topo_%s.yml file!" % topo_name)
+                "cannot find topology definition file under ../ansible/vars/topo_%s.yml file!" % topo_name)
         else:
             with open(topo_filename) as f:
                 topo_definition = yaml.safe_load(f)

--- a/ansible/module_utils/dualtor_utils.py
+++ b/ansible/module_utils/dualtor_utils.py
@@ -13,41 +13,40 @@ def get_intf_index(intf):
         return intf
 
 
-def generate_mux_cable_facts(topology):
+def generate_mux_cable_facts(topology, vlan_config=None):
     """Generate mux cable table facts for dualtor topology."""
     mux_cable_facts = {}
-    host_interfaces = set(get_intf_index(_) for _ in topology.get("host_interfaces", []))
-    disabled_host_interfaces = set(get_intf_index(_) for _ in topology.get("disabled_host_interfaces", []))
     host_interfaces_active_active = set(get_intf_index(_) for _ in topology.get("host_interfaces_active_active", []))
-    enabled_interfaces = sorted(list(host_interfaces - disabled_host_interfaces))
 
-    vlan_config = list(
-        topology["DUT"]["vlan_configs"][topology["DUT"]["vlan_configs"]["default_vlan_config"]].values())[0]
+    if not vlan_config:
+        vlan_config = topology["DUT"]["vlan_configs"]["default_vlan_config"]
+    vlan_configs = topology["DUT"]["vlan_configs"][vlan_config]
     # NOTE: vlan prefix will be 192.168.0.1/21 and fc02:1000::1/64
-    vlan_prefix_v4 = vlan_config["prefix"]
-    vlan_prefix_v6 = vlan_config["prefix_v6"]
-    vlan_address_v4, netmask_v4 = vlan_prefix_v4.split("/")
-    vlan_address_v6, netmask_v6 = vlan_prefix_v6.split("/")
-    vlan_address_v4 = ipaddress.ip_address(six.text_type(vlan_address_v4))
-    vlan_address_v6 = ipaddress.ip_address(six.text_type(vlan_address_v6))
-    for index, intf in enumerate(enabled_interfaces):
-        if host_interfaces_active_active:
-            is_active_active = intf in host_interfaces_active_active
-            # server IPs should be even-numbered
-            mux_cable_facts[intf] = dict(
-                server_ipv4=str(vlan_address_v4 + index * 2 + 1) + "/" + netmask_v4,
-                server_ipv6=str(vlan_address_v6 + index * 2 + 1) + "/" + netmask_v6,
-                cable_type="active-standby"
-            )
-            if is_active_active:
-                mux_cable_facts[intf]["cable_type"] = "active-active"
-                # SoC IPs should be odd-numbered
-                mux_cable_facts[intf]["soc_ipv4"] = str(vlan_address_v4 + (index + 1) * 2) + "/" + netmask_v4
-        else:
-            mux_cable_facts[intf] = dict(
-                server_ipv4=str(vlan_address_v4 + index + 1) + "/" + netmask_v4,
-                server_ipv6=str(vlan_address_v6 + index + 1) + "/" + netmask_v6,
-                cable_type="active-standby"
-            )
+    for vlan, vlan_config in vlan_configs.items():
+        vlan_prefix_v4 = vlan_config["prefix"]
+        vlan_prefix_v6 = vlan_config["prefix_v6"]
+        vlan_address_v4, netmask_v4 = vlan_prefix_v4.split("/")
+        vlan_address_v6, netmask_v6 = vlan_prefix_v6.split("/")
+        vlan_address_v4 = ipaddress.ip_address(six.text_type(vlan_address_v4))
+        vlan_address_v6 = ipaddress.ip_address(six.text_type(vlan_address_v6))
+        for index, intf in enumerate(vlan_config["intfs"]):
+            if host_interfaces_active_active:
+                is_active_active = intf in host_interfaces_active_active
+                # server IPs should be even-numbered
+                mux_cable_facts[intf] = dict(
+                    server_ipv4=str(vlan_address_v4 + index * 2 + 1) + "/" + netmask_v4,
+                    server_ipv6=str(vlan_address_v6 + index * 2 + 1) + "/" + netmask_v6,
+                    cable_type="active-standby"
+                )
+                if is_active_active:
+                    mux_cable_facts[intf]["cable_type"] = "active-active"
+                    # SoC IPs should be odd-numbered
+                    mux_cable_facts[intf]["soc_ipv4"] = str(vlan_address_v4 + (index + 1) * 2) + "/" + netmask_v4
+            else:
+                mux_cable_facts[intf] = dict(
+                    server_ipv4=str(vlan_address_v4 + index + 1) + "/" + netmask_v4,
+                    server_ipv6=str(vlan_address_v6 + index + 1) + "/" + netmask_v6,
+                    cable_type="active-standby"
+                )
 
     return mux_cable_facts

--- a/tests/dualtor/templates/multivlan_ip_template.j2
+++ b/tests/dualtor/templates/multivlan_ip_template.j2
@@ -1,0 +1,73 @@
+{% set vms=vm_topo_config['vm'].keys() | sort %}
+{% set vms_number = vms | length %}
+{% set dut_index = testbed_facts['duts_map'][inventory_hostname]|int %}
+      <IPInterfaces>
+{% if (card_type is not defined or card_type != 'supervisor') and (vm_topo_config['topo_type'] != 'wan') %}
+{% for index in range(vms_number) %}
+{% if vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int] is not none %}
+        <IPInterface>
+          <Name i:nil="true"/>
+{% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
+          <AttachTo>PortChannel{{ '10' + ((index+1) |string) }}</AttachTo>
+{% else %}
+          <AttachTo>{{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
+{% endif %}
+          <Prefix>{{ vm_topo_config['vm'][vms[index]]['bgp_ipv4'][dut_index|int] }}/{{ vm_topo_config['vm'][vms[index]]['ipv4mask'][dut_index|int] }}</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+{% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
+          <AttachTo>PortChannel{{ '10' + ((index+1) |string) }}</AttachTo>
+{% else %}
+          <AttachTo>{{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
+{% endif %}
+          <Prefix>{{ vm_topo_config['vm'][vms[index]]['bgp_ipv6'][dut_index|int] }}/{{ vm_topo_config['vm'][vms[index]]['ipv6mask'][dut_index|int] }}</Prefix>
+        </IPInterface>
+{% endif %}
+{% endfor %}
+{% if 'tor' in vm_topo_config['dut_type'] | lower %}
+{% for vlan, vlan_param in vlan_configs.items() %}
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>{{ vlan }}</AttachTo>
+          <Prefix>{{ vlan_param['prefix'] }}</Prefix>
+        </IPInterface>
+{%if 'secondary_subnet' in vlan_param %}
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>{{ vlan }}</AttachTo>
+          <Prefix>{{ vlan_param['secondary_subnet'] }}</Prefix>
+        </IPInterface>
+{% endif %}
+{% endfor %}
+{% for vlan, vlan_param in vlan_configs.items() %}
+{%   if 'prefix_v6' in vlan_param %}
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>{{ vlan }}</AttachTo>
+          <Prefix>{{ vlan_param['prefix_v6'] }}</Prefix>
+        </IPInterface>
+{%   endif %}
+{% endfor %}
+{% endif %}
+{% elif vm_topo_config['topo_type'] == 'wan' and 'wan_dut_configuration' in vm_topo_config %}
+{% for ifname, params in vm_topo_config['wan_dut_configuration'][dut_index|int]['interfaces'].items() %}
+{% if ifname.startswith('PortChannel') %}
+{% if 'ipv4' in params %}
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>{{ ifname }}</AttachTo>
+          <Prefix>{{ params['ipv4'] }}</Prefix>
+        </IPInterface>
+{% endif %}
+{% if 'ipv6' in params %}
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>{{ ifname }}</AttachTo>
+          <Prefix>{{ params['ipv6'] }}</Prefix>
+        </IPInterface>
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
+      </IPInterfaces>

--- a/tests/dualtor/templates/multivlan_mux_config_template.j2
+++ b/tests/dualtor/templates/multivlan_mux_config_template.j2
@@ -1,0 +1,67 @@
+{% if mux_cable_facts is defined and mux_cable_facts %}
+{% if dual_tor_facts is defined and 'cables' in dual_tor_facts %}
+{% for cable in dual_tor_facts['cables'] %}
+{% set intf_index = port_alias.index(cable['dut_intf'])|string %}
+		<DeviceDataPlaneInfo>
+			<IPSecTunnels />
+			<LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+				<a:LoopbackIPInterface>
+					<ElementType>LoopbackInterface</ElementType>
+					<Name>HostIP</Name>
+					<AttachTo>Loopback0</AttachTo>
+					<a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+						<b:IPPrefix>{{ mux_cable_facts[intf_index]['server_ipv4'] }}</b:IPPrefix>
+					</a:Prefix>
+					<a:PrefixStr>{{ mux_cable_facts[intf_index]['server_ipv4'] }}</a:PrefixStr>
+				</a:LoopbackIPInterface>
+				<a:LoopbackIPInterface>
+					<ElementType>LoopbackInterface</ElementType>
+					<Name>HostIP1</Name>
+					<AttachTo>Loopback0</AttachTo>
+					<a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+						<b:IPPrefix>{{ mux_cable_facts[intf_index]['server_ipv6'] }}</b:IPPrefix>
+					</a:Prefix>
+					<a:PrefixStr>{{ mux_cable_facts[intf_index]['server_ipv6'] }}</a:PrefixStr>
+				</a:LoopbackIPInterface>
+{% if 'soc_ipv4' in mux_cable_facts[intf_index] %}
+				<a:LoopbackIPInterface>
+					<ElementType>LoopbackInterface</ElementType>
+					<Name>SoCHostIP0</Name>
+					<AttachTo>Servers{{ loop.index - 1 }}SOC</AttachTo>
+					<a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+						<b:IPPrefix>{{ mux_cable_facts[intf_index]['soc_ipv4'] }}</b:IPPrefix>
+					</a:Prefix>
+					<a:PrefixStr>{{ mux_cable_facts[intf_index]['soc_ipv4'] }}</a:PrefixStr>
+				</a:LoopbackIPInterface>
+{% endif %}
+{% if 'soc_ipv6' in mux_cable_facts[intf_index] %}
+				<a:LoopbackIPInterface>
+					<ElementType>LoopbackInterface</ElementType>
+					<Name>SoCHostIP1</Name>
+					<AttachTo>Servers{{ loop.index - 1 }}SOC</AttachTo>
+					<a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
+						<b:IPPrefix>{{ mux_cable_facts[intf_index]['soc_ipv6'] }}</b:IPPrefix>
+					</a:Prefix>
+					<a:PrefixStr>{{ mux_cable_facts[intf_index]['soc_ipv6'] }}</a:PrefixStr>
+				</a:LoopbackIPInterface>
+{% endif %}
+			</LoopbackIPInterfaces>
+			<ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution" />
+			<ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution" />
+			<MplsInterfaces />
+			<MplsTeInterfaces />
+			<RsvpInterfaces />
+			<Hostname>Servers{{ loop.index - 1 }}</Hostname>
+			<PortChannelInterfaces />
+			<SubInterfaces />
+			<VlanInterfaces />
+			<IPInterfaces />
+			<DataAcls />
+			<AclInterfaces />
+			<NatInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution" />
+			<DownstreamSummaries />
+			<DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution" />
+		</DeviceDataPlaneInfo>
+{% endfor %}
+{% endif %}
+{% endif %}

--- a/tests/dualtor/templates/multivlan_template.j2
+++ b/tests/dualtor/templates/multivlan_template.j2
@@ -1,0 +1,35 @@
+      <VlanInterfaces>
+{% if 'tor' in vm_topo_config['dut_type'] | lower %}
+{% for vlan, vlan_param in vlan_configs.items() %}
+        <VlanInterface>
+          <Name>{{ vlan }}</Name>
+{% set vlan_intf_str=';'.join(vlan_param['intfs'] + vlan_param['portchannels']) %}
+          <AttachTo>{{ vlan_intf_str }}</AttachTo>
+          <NoDhcpRelay>False</NoDhcpRelay>
+          <StaticDHCPRelay>0.0.0.0/0</StaticDHCPRelay>
+{% if 'type' in vlan_param %}
+{% if vlan_param['type']|lower == 'tagged'%}
+          <Type>Tagged</Type>
+{% else %}
+          <Type i:nil="true"/>
+{% endif %}
+{% endif %}
+{% set dhcp_servers_str=';'.join(dhcp_servers) %}
+          <DhcpRelays>{{ dhcp_servers_str }}</DhcpRelays>
+{% if dhcpv6_servers is defined %}
+{% set dhcpv6_servers_str=';'.join(dhcpv6_servers) %}
+          <Dhcpv6Relays>{{ dhcpv6_servers_str }}</Dhcpv6Relays>
+{% endif %}
+          <VlanID>{{ vlan_param['id'] }}</VlanID>
+          <Tag>{{ vlan_param['tag'] }}</Tag>
+          <Subnets>{{ vlan_param['prefix'] | ipaddr('network') }}/{{ vlan_param['prefix'] | ipaddr('prefix') }}</Subnets>
+{% if 'secondary_subnet' in vlan_param %}
+          <SecondarySubnets>{{ vlan_param['secondary_subnet'] | ipaddr('network') }}/{{ vlan_param['secondary_subnet'] | ipaddr('secondary_subnet') }}<SecondarySubnets>
+{% endif %}
+{% if 'mac' in vlan_param %}
+          <MacAddress>{{ vlan_param['mac'] }}</MacAddress>
+{% endif %}
+        </VlanInterface>
+{% endfor %}
+{% endif %}
+      </VlanInterfaces>

--- a/tests/dualtor/test_mux_port_iptables_entries.py
+++ b/tests/dualtor/test_mux_port_iptables_entries.py
@@ -1,0 +1,195 @@
+import ipaddress
+import logging
+import pytest
+import jinja2
+import re
+from ansible_collections.ansible.utils.plugins.filter.ipaddr import ipaddr
+
+from tests.common.config_reload import config_reload
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor  # noqa F401
+from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                  # noqa F401
+from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+        pytest.mark.topology("dualtor"),
+        pytest.mark.disable_loganalyzer,
+        ]
+
+
+# This is only supposed to be run on tor
+@pytest.fixture(scope="function")
+def setup_multiple_vlans(request, duthost, localhost, tbinfo):
+    hostname = duthost.hostname
+    # inventory = tbinfo["inv_name"]
+    topo = tbinfo["topo"]["name"]
+    hwsku = duthost.facts["hwsku"]
+    testbed_name = tbinfo["conf-name"]
+    testbed_file = request.config.option.testbed_file
+    vm_topo_config = localhost.topo_facts(topo=topo,
+                                          hwsku=hwsku,
+                                          testbed_name=testbed_name,
+                                          asics_present=[],
+                                          card_type="fixed",
+                                          )["ansible_facts"]["vm_topo_config"]
+    testbed_facts = localhost.test_facts(testbed_name=testbed_name,
+                                         testbed_file=testbed_file,
+                                         )["ansible_facts"]["testbed_facts"]
+    hostvars = duthost.host.options['variable_manager']._hostvars
+    hostvars = {hostname: dict(hostvars[hostname]) for hostname in tbinfo["duts"]}
+    port_alias = duthost.port_alias(hwsku=hwsku,
+                                    card_type="fixed",
+                                    hostname=hostname,
+                                    switchids=[],
+                                    )["ansible_facts"]["port_alias"]
+    dut_index = int(testbed_facts["duts_map"][hostname])
+    vlan_intfs = [port_alias[item] for item in vm_topo_config["host_interfaces_by_dut"][dut_index]
+                  if item not in vm_topo_config["disabled_host_interfaces_by_dut"][dut_index]]
+    vlan_cfgs = tbinfo["topo"]["properties"]["topology"]["DUT"]["vlan_configs"]
+    vlan_config = "four_vlan_a"
+    pytest_assert(vlan_config in vlan_cfgs, "device does not support {} vlan config".format(vlan_config))
+    vlan_configs = duthost.vlan_config(vm_topo_config=vm_topo_config,
+                                       port_alias=port_alias,
+                                       vlan_config=vlan_config,
+                                       )["ansible_facts"]["vlan_configs"]
+    if "dualtor" in topo:
+        dual_tor_facts = localhost.dual_tor_facts(hostname=hostname,
+                                                  testbed_facts=testbed_facts,
+                                                  hostvars=hostvars,
+                                                  vm_config=vm_topo_config,
+                                                  port_alias=port_alias,
+                                                  vlan_intfs=vlan_intfs,
+                                                  )["ansible_facts"]["dual_tor_facts"]
+        mux_cable_facts = localhost.mux_cable_facts(topo_name=topo,
+                                                    vlan_config=vlan_config,
+                                                    )["ansible_facts"]["mux_cable_facts"]
+    else:
+        dual_tor_facts = {}
+        mux_cable_facts = {}
+    variables = {
+            "vm_topo_config": vm_topo_config,
+            "port_alias": port_alias,
+            "dual_tor_facts": dual_tor_facts,
+            "mux_cable_facts": mux_cable_facts,
+            "vlan_configs": vlan_configs,
+            "testbed_facts": testbed_facts,
+            "inventory_hostname": hostname,
+            }
+    templates_loader = jinja2.FileSystemLoader(searchpath="dualtor/templates")
+    templates_env = jinja2.Environment(loader=templates_loader)
+    templates_env.filters["ipaddr"] = ipaddr
+    multivlan_xml = templates_env.get_template("multivlan_template.j2").render(variables)
+    multivlan_ip_xml = templates_env.get_template("multivlan_ip_template.j2").render(variables)
+    multivlan_mux_config_xml = templates_env.get_template("multivlan_mux_config_template.j2").render(variables)
+    minigraph_xml = duthost.command("cat /etc/sonic/minigraph.xml")["stdout"]
+    minigraph_xml = re.sub("[ \t]*<VlanInterfaces>(.|\n)*</VlanInterfaces>[ \t]*", multivlan_xml, minigraph_xml)
+    minigraph_xml = re.sub("[ \t]*<IPInterfaces>(.|\n)*</IPInterfaces>[ \t]*", multivlan_ip_xml, minigraph_xml)
+    # the first match is not about mux config
+    first_match = re.search("[ \t]*<DeviceDataPlaneInfo>(.|\n)*?</DeviceDataPlaneInfo>[ \t]*",
+                            minigraph_xml).group(0)
+    minigraph_xml = minigraph_xml.replace(first_match, "PLACEHOLDER")
+    minigraph_xml = re.sub("[ \t]*<DeviceDataPlaneInfo>(.|\n)*</DeviceDataPlaneInfo>[ \t]*",
+                           multivlan_mux_config_xml, minigraph_xml)
+    minigraph_xml = minigraph_xml.replace("PLACEHOLDER", first_match)
+    duthost.command("cp /etc/sonic/minigraph.xml /etc/sonic/minigraph.xml.bak")
+    duthost.copy(content=minigraph_xml, dest="/etc/sonic/minigraph.xml")
+    config_reload(duthost, config_source='minigraph')
+    config_facts = duthost.get_running_config_facts()
+    pytest_assert(len(config_facts['VLAN_INTERFACE']) == 4, "Configuring multivlan is not successful")
+
+    yield
+
+    duthost.command("cp /etc/sonic/minigraph.xml.bak /etc/sonic/minigraph.xml")
+    config_reload(duthost, config_source='minigraph')
+
+
+def verify_mux_port_iptables_entries(duthost):
+    expected_iptables_rules, expected_ip6tables_rules = \
+         generate_nat_expected_rules(duthost)
+    stdout = duthost.command("sudo iptables -t nat -S")["stdout"]
+    actual_iptables_rules = stdout.strip().split("\n")
+
+    # Ensure all expected iptables rules are present on the DuT
+    missing_iptables_rules = set(expected_iptables_rules) - set(actual_iptables_rules)
+    pytest_assert(len(missing_iptables_rules) == 0, "Missing expected iptables nat rules: {}"
+                  .format(repr(missing_iptables_rules)))
+
+    # Ensure there are no unexpected iptables rules present on the DuT
+    unexpected_iptables_rules = set(actual_iptables_rules) - set(expected_iptables_rules)
+    pytest_assert(len(unexpected_iptables_rules) == 0, "Unexpected iptables nat rules: {}"
+                  .format(repr(unexpected_iptables_rules)))
+
+    stdout = duthost.command("sudo ip6tables -t nat -S")["stdout"]
+    actual_ip6tables_rules = stdout.strip().split("\n")
+
+    # Ensure all expected ip6tables rules are present on the DuT
+    missing_ip6tables_rules = set(expected_ip6tables_rules) - set(actual_ip6tables_rules)
+    pytest_assert(len(missing_ip6tables_rules) == 0, "Missing expected ip6tables nat rules: {}"
+                  .format(repr(missing_ip6tables_rules)))
+
+    # Ensure there are no unexpected ip6tables rules present on the DuT
+    unexpected_ip6tables_rules = set(actual_ip6tables_rules) - set(expected_ip6tables_rules)
+    pytest_assert(len(unexpected_ip6tables_rules) == 0, "Unexpected ip6tables nat rules: {}"
+                  .format(repr(unexpected_ip6tables_rules)))
+
+
+def generate_nat_expected_rules(duthost):
+    iptables_natrules = []
+    ip6tables_natrules = []
+
+    # Default policies
+    iptables_natrules.append("-P PREROUTING ACCEPT")
+    iptables_natrules.append("-P INPUT ACCEPT")
+    iptables_natrules.append("-P OUTPUT ACCEPT")
+    iptables_natrules.append("-P POSTROUTING ACCEPT")
+    ip6tables_natrules.append("-P PREROUTING ACCEPT")
+    ip6tables_natrules.append("-P INPUT ACCEPT")
+    ip6tables_natrules.append("-P OUTPUT ACCEPT")
+    ip6tables_natrules.append("-P POSTROUTING ACCEPT")
+
+    config_facts = duthost.get_running_config_facts()
+
+    vlan_table = config_facts['VLAN_INTERFACE']
+    vlan_intfs_ipv4 = []
+    vlan_intfs_ipv6 = []
+    for val in vlan_table.values():
+        for key in val.keys():
+            try:
+                intf = ipaddress.ip_interface(key)
+                if intf.version == 4:
+                    vlan_intfs_ipv4.append(intf)
+                elif intf.version == 6:
+                    vlan_intfs_ipv6.append(intf)
+            except Exception:
+                pass
+
+    loopback_table = config_facts["LOOPBACK_INTERFACE"]
+    for key in loopback_table["Loopback3"].keys():
+        intf = ipaddress.ip_interface(key)
+        if intf.version == 4:
+            loopback3_ipv4 = intf.ip
+        elif intf.version == 6:
+            loopback3_ipv6 = intf.ip
+
+    mux_cable_table = config_facts['MUX_CABLE']
+    rule_template_ipv4 = "-A POSTROUTING -s {}/32 -d {} -j SNAT --to-source {}"
+    rule_template_ipv6 = "-A POSTROUTING -s {}/128 -d {} -j SNAT --to-source {}"
+    for _, config in mux_cable_table.items():
+        if "soc_ipv4" in config:
+            soc_ipv4 = ipaddress.ip_interface(config["soc_ipv4"])
+            for vlan_intf in filter(lambda vlan_intf: soc_ipv4 in vlan_intf.network, vlan_intfs_ipv4):
+                iptables_natrules.append(rule_template_ipv4.format(vlan_intf.ip, soc_ipv4, loopback3_ipv4))
+        if "soc_ipv6" in config:
+            soc_ipv6 = ipaddress.ip_interface(config["soc_ipv6"])
+            for vlan_intf in filter(lambda vlan_intf: soc_ipv6 in vlan_intf.network, vlan_intfs_ipv6):
+                ip6tables_natrules.append(rule_template_ipv6.format(vlan_intf.ip, soc_ipv6, loopback3_ipv6))
+    return iptables_natrules, ip6tables_natrules
+
+
+def test_mux_port_iptables_entries(duthost):
+    verify_mux_port_iptables_entries(duthost)
+
+
+def test_multivlan_mux_port_iptables_entries(setup_multiple_vlans, duthost):
+    verify_mux_port_iptables_entries(duthost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Covers test gap https://github.com/sonic-net/sonic-mgmt/issues/11436 which is raised to cover this issue https://github.com/sonic-net/sonic-host-services/pull/95. The test will check nat rules and make sure vlan ip to mux cable soc_ip snat is correct, and in the case of multivlan, only vlan ip of the vlan as soc_ip is used.

Summary:
Fixes #11436 

## Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Covers test gap https://github.com/sonic-net/sonic-mgmt/issues/11436.

#### How did you do it?

#### How did you verify/test it?
Run test on dualtor aa testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
