### PR TITLE
Fix test_vlan_ping

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -127,7 +127,7 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo, 
                             portchannel = intf['attachto']
                             for iface in mg_facts['minigraph_portchannels'][portchannel]['members']:
                                 ifaces_list.append(mg_facts['minigraph_ptf_indices'][iface])
-                        break
+                            break
                 vm_host_info['port_index_list'] = ifaces_list
             break
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to fix code issue in `test_vlan_ping`.
The test is flaky because the incorrect indention. `port_index_list` is empty because of the early break.
```
E       AssertionError: Received expected packet on port 29 for device 0, but it should have arrived on one of these ports: [].
INFO:root:Can not get Allure report URL. Please check logs
E       ========== RECEIVED ==========
E       0000  62 72 C3 B6 7F 81 50 6B 4B 93 96 00 08 00 45 00  br....PkK.....E.
E       0010  00 2E 00 01 00 00 3F 01 B0 E9 C0 A8 00 02 0A 00  ......?.........
E       0020  00 3B 08 00 46 4E 00 00 00 00 30 30 30 30 30 30  .;..FN....000000
E       0030  30 30 30 30 30 30 30 30 30 30 30 30              000000000000
E       ==============================
```
The issue was introduced by PR https://github.com/sonic-net/sonic-mgmt/pull/12306




### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to fix code issue in `test_vlan_ping`.

#### How did you do it?
Fix the indention issue.

#### How did you verify/test it?
The change is verified on a physical testbed. Test is passing consistently.
```
collected 1 item                                                                                                                                                                                      

vlan/test_vlan_ping.py::test_vlan_ping PASSED                                                                                                                                                   [100%]

```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
