### PR TITLE
Skip test incremental qos on dualtor testbed

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -715,6 +715,12 @@ generic_config_updater/test_eth_interface.py::test_update_valid_invalid_index[33
       - "asic_type in ['mellanox']"
       - https://github.com/sonic-net/sonic-mgmt/issues/7733
 
+generic_config_updater/test_incremental_qos.py:
+  skip:
+    reason: "Does not support dualtor right now, due to issue https://github.com/sonic-net/sonic-mgmt/issues/14865"
+    conditions:
+      - "'dualtor' in topo_name"
+
 generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates:
   skip:
     reason: "This test is not run on this hwsku/asic type or version currently"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Resolve conflict from PR https://github.com/sonic-net/sonic-mgmt/pull/14866
Skip the generic_config_updater/test_incremental_qos.py, since it does not support dualtor. Issue link: https://github.com/sonic-net/sonic-mgmt/issues/14865

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
To skip a test case that does not support dualtor, so we don't waste time running it

#### How did you do it?
By edited the tests/common/plugins/conditional_mark/tests_mark_conditions.yaml

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

The test https://github.com/sonic-net/sonic-mgmt/blob/master/tests/generic_config_updater/test_incremental_qos.py is not ready for Dual Tor.

`generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[add-ingress_lossless_pool/xoff] `

As of right now, the test will error out during

```
  File "/tests/generic_config_updater/test_incremental_qos.py", line 158, in calculate_field_value
    uplink, downlink = get_uplink_downlink_count(duthost, tbinfo)
TypeError: cannot unpack non-iterable NoneType object
Which is caused by

```
[sonic-mgmt/tests/generic_config_updater/test_incremental_qos.py](https://github.com/sonic-net/sonic-mgmt/blob/bceeba64513d09db9cfb1bae30ef087973c5c19b/tests/generic_config_updater/test_incremental_qos.py#L58)

Line 58 in [bceeba6](https://github.com/sonic-net/sonic-mgmt/commit/bceeba64513d09db9cfb1bae30ef087973c5c19b)

```
 def get_uplink_downlink_count(duthost, tbinfo): 

```
It will only return if t0 or t1 in topo name.
Even if add dualtor to the t0 condition, the test won't work. Since the overall test steps doesn't seem support dualtor yet.