### PR TITLE
Fix regression on test_vlan_tc5_untagged_unicast

### DIFF
--- a/tests/vlan/test_vlan.py
+++ b/tests/vlan/test_vlan.py
@@ -344,8 +344,7 @@ def test_vlan_tc5_untagged_unicast(ptfadapter, duthosts, rand_one_dut_hostname, 
 
         # take two untagged ports for test
         src_port = ports_for_test[0]
-        # dst_port = ports_for_test[-1]
-        dst_port = [6]
+        dst_port = ports_for_test[-1]
 
         src_mac = ptfadapter.dataplane.get_mac(0, src_port[0])
         dst_mac = ptfadapter.dataplane.get_mac(0, dst_port[0])


### PR DESCRIPTION
Fix test_vlan_tc5_untagged_unicast by reverting the dst_port change in https://github.com/sonic-net/sonic-mgmt/pull/12204

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #14927 (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
We found error below in running the testcase test_vlan_tc5_untagged_unicast
AssertionError: Received packet that we expected not to receive on device 0, port 43

#### How did you do it?
Revert the dst_port change in
https://github.com/sonic-net/sonic-mgmt/pull/12204

#### How did you verify/test it?
Tested that the test case can pass after this change. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
