### PR TITLE
[github] Fix automerge github action issue when close&reopen PR.

### DIFF
--- a/.github/workflows/automerge_scan.yml
+++ b/.github/workflows/automerge_scan.yml
@@ -47,6 +47,7 @@ jobs:
             # Others success flag:   conclusion in SUCCESS,NEUTRAL
             # Ignore Azure.sonic-mgmt stage check result. It may be set continueOnError
             echo "$name" | grep "Azure.sonic-mgmt (" && continue
+            echo "$name" | grep "cherry_pick" && continue
             # rerun Azure.sonic-mgmt per day
             if [[ "$name" == "Azure.sonic-mgmt" ]] && [[ "$conclusion" == "FAILURE" ]];then
               completedAt=$(echo $check | jq -r '.completedAt')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
When auto cherry pick PR is closed&reopen to rerun validation. post_cherry_pick action will be skipped.
Auto-merge scaning action will not merge that PR.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
