### PR TITLE
Cisco-8122 fixes for T1 topology

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -406,6 +406,9 @@ class QosParamCisco(object):
                       "pkts_num_trig_pfc": self.pause_thr // self.buffer_size // packet_buffs,
                       "pkts_num_trig_ingr_drp": self.lossless_drop_thr // self.buffer_size // packet_buffs,
                       "packet_size": packet_size}
+            if dscp_pg == 4:
+                # Some control traffic maps to DSCP 4, increase margin.
+                params["pkts_num_margin"] = 8
             self.write_params("xoff_{}".format(param_i), params)
 
     def __define_pfc_xon_limit(self):
@@ -576,8 +579,8 @@ class QosParamCisco(object):
             lossy_lossless_action_thr = min(self.lossy_drop_bytes, self.pause_thr)
             pkts_num_leak_out = 0
             if self.dutAsic == "gr2":
-                # Send a burst of leakout packets to optimize runtime. Expected leakout is around 1250
-                pkts_num_leak_out = 1150
+                # Send a burst of leakout packets to optimize runtime. Expected leakout is around 950
+                pkts_num_leak_out = 800
             self.log("In __define_q_watermark_all_ports, using min lossy-drop/lossless-pause threshold of {}".format(
                 lossy_lossless_action_thr))
             params = {"ecn": 1,

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1167,6 +1167,7 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                     self.src_client, port_list['src'][src_port_id])
 
                 # send pkts with dscps that map to the same pg
+                print("Testing DSCPs mapping to PG {}".format(pg), file=sys.stderr)
                 for dscp in dscps:
                     tos = (dscp << 2)
                     tos |= 1
@@ -1195,7 +1196,7 @@ class DscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                     # pg = 0 => Some extra packets with unmarked TC
                     # pg = 4 => Extra packets for LACP/BGP packets
                     # pg = 7 => packets from cpu to front panel ports
-                    if platform_asic and platform_asic == "broadcom-dnx":
+                    if platform_asic and platform_asic in ["broadcom-dnx", "cisco-8000"]:
                         if i == pg:
                             if i == 3:
                                 assert (pg_cntrs[pg] == pg_cntrs_base[pg] + len(dscps))
@@ -5718,14 +5719,14 @@ class QWatermarkAllPortTest(sai_base_test.ThriftInterfaceDataPlane):
 
         try:
             for i in range(len(prio_list)):
-                log_message("DSCP index {}/{}".format(i + 1, len(prio_list)))
+                print("DSCP index {}/{}".format(i + 1, len(prio_list)), file=sys.stderr)
                 queue = queue_list[i]
                 for p_cnt in range(len(dst_port_ids)):
                     dst_port = dst_port_ids[p_cnt]
                     self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port])
 
                     # leakout
-                    log_message("Sending {} leakout packets".format(pkts_num_leak_out))
+                    print("Sending {} leakout packets".format(pkts_num_leak_out), file=sys.stderr)
                     send_packet(self, src_port_id, pkts[dst_port][i], pkts_num_leak_out)
                     if 'cisco-8000' in asic_type:
                         fill_leakout_plus_one(
@@ -5740,7 +5741,7 @@ class QWatermarkAllPortTest(sai_base_test.ThriftInterfaceDataPlane):
             # get all q_wm values for all port
             dst_q_wm_res_all_port = [sai_thrift_read_port_watermarks(
                 self.dst_client, port_list['dst'][sid])[0] for sid in dst_port_ids]
-            log_message("queue watermark for all port is {}".format(dst_q_wm_res_all_port))
+            print("queue watermark for all port is {}".format(dst_q_wm_res_all_port), file=sys.stderr)
             expected_wm = pkt_count * cell_occupancy
 
             def offset_text(offset):
@@ -5756,10 +5757,10 @@ class QWatermarkAllPortTest(sai_base_test.ThriftInterfaceDataPlane):
                     upper = (expected_wm + margin) * cell_size
                     msg = "Queue: {}, lower {} {} = queue_wm {} = upper {} {}".format(
                         queue, lower, offset_text(qwm - lower), qwm, upper, offset_text(qwm - upper))
-                    log_message(msg)
+                    print(msg, file=sys.stderr)
                     if not (lower <= qwm <= upper):
                         failures.append((dst_port_ids[dst_i], queue))
-                        log_message("Failed check")
+                        print("Failed check", file=sys.stderr)
             assert len(failures) == 0, "Failed on (dst port id, queue) for the following: {}".format(failures)
 
         finally:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Round of fixes for T1 topology for Cisco-8122 after initial test_qos_sai.py commit from PR #14334 

TODO: Requires the 202405 commit of the above PR to be merged first: #14907
Leaving in draft state until that merges. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
T1 topologies have some background LACP and LLDP traffic entering on PG 4, making some tests unstable. 
- testQosSaiDscpToPgMapping: Revised to use Broadcom's method with an inequality to account for the excess PG4 packets. Also revised the log_message that won't print by default to be err prints. 
- Increased margin for testQosSaiPfcXoffLimit test when DSCP 4 is being tested. 
- testQosSaiQWatermarkAllPorts: Tuned leakout base value.


#### How did you do it?

#### How did you verify/test it?
Verified test_qos_sai.py full pass (18 tests) on Cisco-8122 Backend T0 and Backend T1 topologies. 

#### Any platform specific information?
Cisco-only. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
