### PR TITLE
Fix image URLs passed in on command line not being recognized

### DIFF
--- a/ansible/roles/vm_set/tasks/start.yml
+++ b/ansible/roles/vm_set/tasks/start.yml
@@ -35,7 +35,7 @@
         set_fact:
           veos_hdd_image_urls:
             - "{{ veos_hdd_image_url }}"
-        when: veos_hdd_image_url | type_debug == 'string'
+        when: veos_hdd_image_url | type_debug == 'string' or veos_hdd_image_url | type_debug == 'unicode'
 
       - name: Init veos_hdd_image_urls when veos_hdd_image_url value type is list
         set_fact:
@@ -83,7 +83,7 @@
         set_fact:
           veos_cd_image_urls:
             - "{{ veos_cd_image_url }}"
-        when: veos_cd_image_url | type_debug == 'string'
+        when: veos_cd_image_url | type_debug == 'string' or veos_cd_image_url | type_debug == 'unicode'
 
       - name: Init veos_cd_image_urls when veos_cd_image_url value type is list
         set_fact:
@@ -138,7 +138,7 @@
         set_fact:
           vsonic_image_urls:
             - "{{ vsonic_image_url }}"
-        when: vsonic_image_url | type_debug == 'string'
+        when: vsonic_image_url | type_debug == 'string' or vsonic_image_url | type_debug == 'unicode'
 
       - name: Init vsonic_image_urls when vsonic_image_url value type is list
         set_fact:
@@ -211,7 +211,7 @@
         set_fact:
           vcisco_image_urls:
             - "{{ vcisco_image_url }}"
-        when: vcisco_image_url | type_debug == 'string'
+        when: vcisco_image_url | type_debug == 'string' or vcisco_image_url | type_debug == 'unicode'
 
       - name: Init vcisco_image_urls when vcisco_image_url value type is list
         set_fact:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

For start-topo-vms, an image URL can be passed in so that if the image doesn't exist on disk, it can be downloaded. However, the type filter for this seems to treat this type as `unicode` instead of `string`. This could be due to some Python 2 vs Python 3 differences, but I'm not certain on this.

#### How did you do it?

Fix this by checking for both unicode and string types.

#### How did you verify/test it?

Run start-topo-vms locally with some random filename and URL, and verify that ansible does execute the steps to initialize the `vsonic_image_urls` variable.

```
TASK [vm_set : Fail if skip_vsonic_image_downloading is true] ******************************************************************************************************************************************************************************************************************************
Thursday 10 October 2024  22:57:22 +0000 (0:00:00.021)       0:00:07.182 ******
skipping: [STR-ACS-VSERV-01]

TASK [vm_set : Init vsonic_image_urls when vsonic_image_url value type is string] **********************************************************************************************************************************************************************************************************
Thursday 10 October 2024  22:57:22 +0000 (0:00:00.019)       0:00:07.201 ******
ok: [STR-ACS-VSERV-01]

TASK [vm_set : Init vsonic_image_urls when vsonic_image_url value type is list] ************************************************************************************************************************************************************************************************************
Thursday 10 October 2024  22:57:22 +0000 (0:00:00.025)       0:00:07.227 ******
skipping: [STR-ACS-VSERV-01]

TASK [vm_set : Init working_image_urls list] ***********************************************************************************************************************************************************************************************************************************************
Thursday 10 October 2024  22:57:22 +0000 (0:00:00.020)       0:00:07.247 ******
ok: [STR-ACS-VSERV-01]

TASK [vm_set : Loop vsonic_image_urls to find out working URLs] ****************************************************************************************************************************************************************************************************************************
Thursday 10 October 2024  22:57:22 +0000 (0:00:00.021)       0:00:07.269 ******
included: /var/src/sonic-mgmt/ansible/roles/vm_set/tasks/probe_image_url.yml for STR-ACS-VSERV-01

TASK [vm_set : Probe if the URL works] *****************************************************************************************************************************************************************************************************************************************************
Thursday 10 October 2024  22:57:22 +0000 (0:00:00.036)       0:00:07.306 ******
ok: [STR-ACS-VSERV-01]

TASK [vm_set : Append working URL to working_image_urls list] ******************************************************************************************************************************************************************************************************************************
Thursday 10 October 2024  22:57:23 +0000 (0:00:00.728)       0:00:08.034 ******
skipping: [STR-ACS-VSERV-01]

TASK [vm_set : Fail if no working SONiC image download url is found] ***********************************************************************************************************************************************************************************************************************
Thursday 10 October 2024  22:57:23 +0000 (0:00:00.022)       0:00:08.057 ******
fatal: [STR-ACS-VSERV-01]: FAILED! => {"changed": false, "msg": ["Failed, no working SONiC image download URL is found. There are 2 options to fix it:", "  1. Fix vsonic_image_url defined in ansible/group_vars/vm_host/sonic.yml", "  2. Manually put SONiC image to /home/sarcot/veos-vm/images/sonic-vs-tbtk5-t0-2700-4.img"]}
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
