### PR TITLE
[Refine] Use multi-thread to recover chassis

### DIFF
--- a/tests/common/helpers/parallel_utils.py
+++ b/tests/common/helpers/parallel_utils.py
@@ -7,15 +7,10 @@ from enum import Enum
 from threading import Lock
 from typing import Tuple
 
-from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
-
-
-def config_reload_parallel_compatible(node, results, *args, **kwargs):
-    return config_reload(node, *args, **kwargs)
 
 
 def is_initial_checks_active(request):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2483,11 +2483,10 @@ def core_dump_and_config_check(duthosts, tbinfo, request,
 
                 is_modular_chassis = duthosts[0].get_facts().get("modular_chassis")
                 if is_modular_chassis:
-                    results = recover_chassis(duthosts)
+                    recover_chassis(duthosts)
                 else:
                     results = parallel_run(__dut_reload, (), {"duts_data": duts_data}, duthosts, timeout=360)
-
-                logger.debug('Results of dut reload: {}'.format(json.dumps(dict(results))))
+                    logger.debug('Results of dut reload: {}'.format(json.dumps(dict(results))))
             else:
                 logger.info("Core dump and config check passed for {}".format(module_name))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
We're using multi process to reload and recover the chassis.
But the error is not caught well if the issue is happening during recover.
Use multi-thread to obtain better visibility of errors.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
We're using multi process to reload and recover the chassis.
But the error is not caught well if the issue is happening during recover.
Use multi-thread to obtain better visibility of errors.

#### How did you do it?
Use multi-thread instead of multi-process
#### How did you verify/test it?
Test it on physical testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
