### PR TITLE
[dhcp_relay] Skip dhcp_relay test via feature status rather than topo

### DIFF
--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -36,26 +36,17 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def skip_dhcp_relay_tests(tbinfo):
-    """
-    Skip dhcp relay tests on certain testbed types
-
-    Args:
-        tbinfo(fixture): testbed related info fixture
-
-    Yields:
-        None
-    """
-    if 'backend' in tbinfo['topo']['name']:
-        pytest.skip("Skipping dhcp relay tests. Unsupported topology {}".format(tbinfo['topo']['name']))
-
-
-@pytest.fixture(scope="module", autouse=True)
-def check_dhcp_server_enabled(duthost):
+def check_dhcp_feature_status(duthost):
     feature_status_output = duthost.show_and_parse("show feature status")
+    dhcp_relay_enabled = False
     for feature in feature_status_output:
         if feature["feature"] == "dhcp_server" and feature["state"] == "enabled":
             pytest.skip("DHCPv4 relay is not supported when dhcp_server is enabled")
+        if feature["feature"] == "dhcp_relay" and feature["state"] == "enabled":
+            dhcp_relay_enabled = True
+            
+    if not dhcp_relay_enabled:
+        pytest.skip("dhcp_relay is not enabled")
 
 
 @pytest.fixture(scope="module")

--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -38,15 +38,11 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="module", autouse=True)
 def check_dhcp_feature_status(duthost):
     feature_status_output = duthost.show_and_parse("show feature status")
-    dhcp_relay_enabled = False
     for feature in feature_status_output:
         if feature["feature"] == "dhcp_server" and feature["state"] == "enabled":
             pytest.skip("DHCPv4 relay is not supported when dhcp_server is enabled")
-        if feature["feature"] == "dhcp_relay" and feature["state"] == "enabled":
-            dhcp_relay_enabled = True
-            
-    if not dhcp_relay_enabled:
-        pytest.skip("dhcp_relay is not enabled")
+        if feature["feature"] == "dhcp_relay" and feature["state"] != "enabled":
+            pytest.skip("dhcp_relay is not enabled")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Skip dhcp_relay test by feature status rather than topo

#### How did you do it?
Skip dhcp_relay test by feature status rather than topo

#### How did you verify/test it?
Run tests
```
collected 1 item                                                                                                                                                                                                                                                

dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default SKIPPED (dhcp_relay is not enabled)                           
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
