### PR TITLE
Skipping EverflowV4 EgressAcl EgressMirror for Cisco-8000

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -692,25 +692,27 @@ everflow/test_everflow_testbed.py::EverflowIPv4Tests::test_everflow_dscp_with_po
 
 everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror:
   skip:
-    reason: "Due to HW resource limitation, need to skip the test on the Mellanox t0-120 setup"
+    reason: "For Mellanox t0-120 setup - Need to skip the test due to HW resource limitation
+             For Cisco-8000 - EverflowV4 EgressAcl EgressMirror - is not yet fully supported on cisco chassis. Skipping it till it is fully validated"
+    conditions_logical_operator: "OR"
     conditions:
+      - "asic_type in ['cisco-8000']"
       - "'t0-120' in topo_name and asic_type in ['mellanox']"
 
 everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_dscp_with_policer:
   skip:
-    reason: "Skipping test since mirror with policer is not supported on Broadcom DNX platforms."
+    reason: "Skipping test since mirror with policer is not supported on Cisco 8000 platforms and Broadcom DNX platforms."
+    conditions_logical_operator: "OR"
     conditions:
       - "asic_subtype in ['broadcom-dnx']"
+      - "asic_type in ['cisco-8000']"
 
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer:
-  xfail:
-    strict: True
-    reason: "Skipping test since mirror with policer is not supported on Cisco 8000 platforms."
-    conditions:
-      - "asic_type=='cisco-8000'"
   skip:
-    reason: "Skipping test since mirror with policer is not supported on Broadcom DNX platforms."
+    reason: "Skipping test since mirror with policer is not supported on Cisco 8000 platforms and Broadcom DNX platforms."
+    conditions_logical_operator: "OR"
     conditions:
+      - "asic_type in ['cisco-8000']"
       - "asic_subtype in ['broadcom-dnx']"
 
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -692,8 +692,8 @@ everflow/test_everflow_testbed.py::EverflowIPv4Tests::test_everflow_dscp_with_po
 
 everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror:
   skip:
-    reason: "For Mellanox t0-120 setup - Need to skip the test due to HW resource limitation
-             For Cisco-8000 - EverflowV4 EgressAcl EgressMirror - is not yet fully supported on cisco chassis. Skipping it till it is fully validated"
+    reason: "For Mellanox t0-120 setup - Need to skip the test due to HW resource limitation.
+             For Cisco-8000 - EverflowV4 EgressAcl EgressMirror - is not yet fully supported on cisco chassis. Skipping it till it is fully validated."
     conditions_logical_operator: "OR"
     conditions:
       - "asic_type in ['cisco-8000']"


### PR DESCRIPTION
### Description of PR

Skipping EverflowV4 EgressAcl EgressMirror for Cisco-8000 as the feature is currently not fully supported. Will remove the fix once the feature is validated. 

Replacing Xfail with Skip for test mirror with policer since it is not supported on Cisco 8000 platforms. Xfail was causing the test to run and then xfail which is not desirable, since the testcase is not supported.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
For Cisco Platforms

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
