### PR TITLE
snappi: Adding a skip for global pause test in cisco-8000.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1627,6 +1627,12 @@ snappi_tests/ecn/test_red_accuracy_with_snappi:
     conditions:
       - "topo_type in ['tgen']"
 
+snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py:
+  skip:
+    reason: "Global pause is not supported in cisco-8000."
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
 #######################################
 #####            snmp             #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Cisco-8000 doesn't support global pfc pause, it ignores it. So we need to skip the global pause test in the snappi_tests.

### Type of change
Fixes # [14807](https://github.com/sonic-net/sonic-mgmt/issues/14807)
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Cisco-8000 doesn't support global pfc pause.

#### How did you do it?
Added the skip in the common skip file.

#### How did you verify/test it?
Ran it with my TB:
```
================================================================================================================== short test summary info ===================================================================================================================
SKIPPED [2] snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py:17: Global pause is not supported in cisco-8000.
=============================================================================================================== 2 skipped, 1 warning in 13.70s ===============================================================================================================
sonic@ixia-sonic-mgmt-whitebox:/data/tests$ 
```
#### Any platform specific information?
Specific to cisco-8000.