### PR TITLE
[CI]Fix get build 202205 failed by remove url param 'resultFilter=succeeded'

### DIFF
--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -158,6 +158,10 @@ def find_latest_build_id(branch, success_flag="succeeded"):
     builds_url = "https://dev.azure.com/mssonic/build/_apis/build/builds?definitions=1&branchName=refs/heads/{}" \
                  "&resultFilter={}&statusFilter=completed&api-version=6.0".format(branch, success_flag)
 
+    if branch == "202205":
+        builds_url = "https://dev.azure.com/mssonic/build/_apis/build/builds?definitions=1&branchName=refs/heads" \
+                      "/202205&statusFilter=completed&api-version=6.0"
+
     resp = urlopen(builds_url)
 
     j = json.loads(resp.read().decode('utf-8'))

--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -156,11 +156,7 @@ def find_latest_build_id(branch, success_flag="succeeded"):
     """find latest successful build id for a branch"""
 
     builds_url = "https://dev.azure.com/mssonic/build/_apis/build/builds?definitions=1&branchName=refs/heads/{}" \
-                 "&resultFilter={}&statusFilter=completed&api-version=6.0".format(branch, success_flag)
-
-    if branch == "202205":
-        builds_url = "https://dev.azure.com/mssonic/build/_apis/build/builds?definitions=1&branchName=refs/heads" \
-                      "/202205&statusFilter=completed&api-version=6.0"
+                 "&statusFilter=completed&api-version=6.0".format(branch)
 
     resp = urlopen(builds_url)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
