### PR TITLE
Capture before warm-reboot device logs

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -435,6 +435,11 @@ class AdvancedReboot:
             os.makedirs(log_dir)
         log_dir = log_dir + "/"
 
+        # Create a sub-directory to store the logs before the reboot happened
+        log_dir_before_reboot = log_dir + "before_reboot/"
+        if not os.path.exists(log_dir_before_reboot):
+            os.makedirs(log_dir_before_reboot)
+
         if "warm" in self.rebootType:
             # normalize "warm-reboot -f", "warm-reboot -c" to "warm-reboot" for report collection
             reboot_file_prefix = "warm-reboot"
@@ -481,6 +486,11 @@ class AdvancedReboot:
                 {'src': syslogFile, 'dest': log_dir, 'flat': True},
                 {'src': sairedisRec, 'dest': log_dir, 'flat': True},
                 {'src': swssRec, 'dest': log_dir, 'flat': True},
+                # Logs from before reboot
+                {'src': '/host/syslog.99', 'dest': log_dir_before_reboot, 'flat': True, 'fail_on_missing': True},
+                {'src': '/host/sairedis.rec.99', 'dest': log_dir_before_reboot, 'flat': True, 'fail_on_missing': True},
+                {'src': '/host/swss.rec.99', 'dest': log_dir_before_reboot, 'flat': True, 'fail_on_missing': True},
+                {'src': '/host/bgpd.log.99', 'dest': log_dir_before_reboot, 'flat': True, 'fail_on_missing': True},
             ],
         }
         for host, logs in list(logFiles.items()):

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -436,7 +436,7 @@ class AdvancedReboot:
         log_dir = log_dir + "/"
 
         # Create a sub-directory to store the logs before the reboot happened
-        log_dir_before_reboot = log_dir + "before_reboot/"
+        log_dir_before_reboot = os.path.join(log_dir, "before_reboot/")
         if not os.path.exists(log_dir_before_reboot):
             os.makedirs(log_dir_before_reboot)
 
@@ -487,10 +487,11 @@ class AdvancedReboot:
                 {'src': sairedisRec, 'dest': log_dir, 'flat': True},
                 {'src': swssRec, 'dest': log_dir, 'flat': True},
                 # Logs from before reboot
-                {'src': '/host/syslog.99', 'dest': log_dir_before_reboot, 'flat': True, 'fail_on_missing': True},
-                {'src': '/host/sairedis.rec.99', 'dest': log_dir_before_reboot, 'flat': True, 'fail_on_missing': True},
-                {'src': '/host/swss.rec.99', 'dest': log_dir_before_reboot, 'flat': True, 'fail_on_missing': True},
-                {'src': '/host/bgpd.log.99', 'dest': log_dir_before_reboot, 'flat': True, 'fail_on_missing': True},
+                {'src': '/host/syslog.99', 'dest': log_dir_before_reboot, 'flat': True, 'fail_on_missing': False},
+                {'src': '/host/sairedis.rec.99', 'dest': log_dir_before_reboot, 'flat': True,
+                 'fail_on_missing': False},
+                {'src': '/host/swss.rec.99', 'dest': log_dir_before_reboot, 'flat': True, 'fail_on_missing': False},
+                {'src': '/host/bgpd.log.99', 'dest': log_dir_before_reboot, 'flat': True, 'fail_on_missing': False},
             ],
         }
         for host, logs in list(logFiles.items()):

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -795,6 +795,7 @@ def advanceboot_loganalyzer(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         base_os_version.append(get_current_sonic_version(duthost))
         bgpd_log = bgpd_log_handler(preboot=True)
         if platform in LOGS_ON_TMPFS_PLATFORMS or (len(logs_in_tmpfs) > 0 and logs_in_tmpfs[0] is True):
+            logger.info("Inserting step to back up logs to /host/ before reboot")
             # For small disk devices, /var/log in mounted in tmpfs.
             # Hence, after reboot the preboot logs are lost.
             # For log_analyzer to work, it needs logs from the shutdown path
@@ -817,6 +818,7 @@ def advanceboot_loganalyzer(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     def post_reboot_analysis(marker, event_counters=None, reboot_oper=None, log_dir=None):
         bgpd_log_handler()
         if platform in LOGS_ON_TMPFS_PLATFORMS or (len(logs_in_tmpfs) > 0 and logs_in_tmpfs[0] is True):
+            logger.info("Restoring log backup from /host/ after reboot")
             restore_backup = "mv /host/syslog.99 /var/log/; " +\
                 "mv /host/sairedis.rec.99 /var/log/swss/; " +\
                 "mv /host/swss.rec.99 /var/log/swss/; " +\


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The logs on the system before a warm-reboot were being stored on the device however weren't being transferred to the sonic-mgmt host upon the completion of the reboot. These are useful for diagnosing issues in the event of failures.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Have experienced issues in the reboot tests and were unable to diagnose due to a lack of information in the warm-reboot sequence.

#### How did you do it?
Copied across the logs that were already preserved on the device across reboots.

#### How did you verify/test it?
Tested internally on A->B and multl-hop upgrade scenarios.

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A