### PR TITLE
Fixing reboot-cause for LCs during Kernel Panic testcase

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -55,15 +55,6 @@ reboot_ctrl_dict = {
         "cause": "Power Loss",
         "test_reboot_cause_only": True
     },
-    REBOOT_TYPE_COLD: {
-        "command": "reboot",
-        "timeout": 300,
-        "wait": 120,
-        # We are searching two types of reboot cause.
-        # This change relates to changes of PR #6130 in sonic-buildimage repository
-        "cause": r"'reboot'|Non-Hardware \(reboot|^reboot",
-        "test_reboot_cause_only": False
-    },
     REBOOT_TYPE_SOFT: {
         "command": "soft-reboot",
         "timeout": 300,
@@ -125,7 +116,7 @@ reboot_ctrl_dict = {
         "timeout": 300,
         "wait": 120,
         # When linecards are rebooted due to supervisor cold reboot
-        "cause": "reboot from Supervisor",
+        "cause": r"^Reboot from Supervisor$|^reboot from Supervisor$",
         "test_reboot_cause_only": False
     },
     REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS: {
@@ -133,7 +124,16 @@ reboot_ctrl_dict = {
         "timeout": 300,
         "wait": 120,
         # When linecards are rebooted due to supervisor crash/abnormal reboot
-        "cause": "Heartbeat",
+        "cause": r"Heartbeat|headless",
+        "test_reboot_cause_only": False
+    },
+    REBOOT_TYPE_COLD: {
+        "command": "reboot",
+        "timeout": 300,
+        "wait": 120,
+        # We are searching two types of reboot cause.
+        # This change relates to changes of PR #6130 in sonic-buildimage repository
+        "cause": r"'reboot'|Non-Hardware \(reboot|^reboot",
         "test_reboot_cause_only": False
     }
 }

--- a/tests/platform_tests/test_kdump.py
+++ b/tests/platform_tests/test_kdump.py
@@ -27,7 +27,8 @@ class TestKernelPanic:
     def wait_lc_healthy_if_sup(self, duthost, duthosts, localhost, conn_graph_facts, xcvr_skip_list):
         # For sup, we also need to ensure linecards are back and healthy for following tests
         is_sup = duthost.get_facts().get("modular_chassis") and duthost.is_supervisor_node()
-        if 'chassis-packet' in duthost.facts.get('switch_type'):
+        if (duthost.facts["hwsku"] ==
+        if 'Cisco-8800-RP' in duthost.facts.get('hwsku'):    
             reboot_type = REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS
         else:
             reboot_type = REBOOT_TYPE_COLD

--- a/tests/platform_tests/test_kdump.py
+++ b/tests/platform_tests/test_kdump.py
@@ -27,12 +27,12 @@ class TestKernelPanic:
     def wait_lc_healthy_if_sup(self, duthost, duthosts, localhost, conn_graph_facts, xcvr_skip_list):
         # For sup, we also need to ensure linecards are back and healthy for following tests
         is_sup = duthost.get_facts().get("modular_chassis") and duthost.is_supervisor_node()
-        if (duthost.facts["hwsku"] ==
-        if 'Cisco-8800-RP' in duthost.facts.get('hwsku'):    
-            reboot_type = REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS
-        else:
-            reboot_type = REBOOT_TYPE_COLD
         if is_sup:
+            if 'Cisco-8800-RP' in duthost.facts.get('hwsku'):
+                reboot_type = REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS
+            else:
+                reboot_type = REBOOT_TYPE_COLD
+
             for lc in duthosts.frontend_nodes:
                 wait_for_startup(lc, localhost, delay=10, timeout=300)
                 wait_critical_processes(lc)


### PR DESCRIPTION
### Description of PR
In case of Cisco chassis, when supervisor goes for kernel panic based reboot, all LCs are rebooted and the reboot cause is due to Heartbeat loss. Changed the testcase to check the right reboot cause

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
In case of Cisco chassis, when supervisor goes for kernel panic based reboot, all LCs are rebooted and the reboot cause is due to Heartbeat loss. Changed the testcase to check the right reboot cause

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
Validated the testcase on Cisco platform

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
