### PR TITLE
chore: change link toggle command in BFD

### DIFF
--- a/tests/bfd/bfd_helpers.py
+++ b/tests/bfd/bfd_helpers.py
@@ -173,13 +173,7 @@ def batch_control_interface_state(dut, asic, interfaces, action):
         oper_state = int_status[interface]["oper_state"]
         if oper_state != target_state:
             command = "shutdown" if action == "shutdown" else "startup"
-            exec_cmd = "sudo ip netns exec asic{} config interface -n asic{} {} {}".format(
-                asic.asic_index,
-                asic.asic_index,
-                command,
-                interface,
-            )
-
+            exec_cmd = "sudo config interface -n asic{} {} {}".format(asic.asic_index, command, interface)
             cmds.append(exec_cmd)
             logger.info("Target state for interface {} is {}. Command: {}".format(
                 interface,
@@ -492,13 +486,7 @@ def ensure_interfaces_are_up(dut, asic, interfaces):
     cmds = []
     for interface in interfaces:
         if int_status[interface]["oper_state"] == "down":
-            cmds.append(
-                "sudo ip netns exec asic{} config interface -n asic{} startup {}".format(
-                    asic.asic_index,
-                    asic.asic_index,
-                    interface,
-                )
-            )
+            cmds.append("sudo config interface -n asic{} startup {}".format(asic.asic_index, interface))
 
     toggle_interfaces_in_parallel(cmds, dut, asic, interfaces, "up")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Remove the `ip netns exec asicX` part from the link toggle command in BFD tests as the `-n` option in `config interface` takes care of the namespace.

Summary:
Fixes # (issue) Microsoft ADO 29752063

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
We are seeing some flaky issue when toggling the interface with `ip netns exec asicX` in the command. Cisco suggests to remove this part from the command as the `-n` option already takes care of the namespace.

#### How did you do it?

#### How did you verify/test it?
I ran the updated code and can confirm it's working as expected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
