### PR TITLE
[202405][PR:14597] RX_DROP counter if destination MAC is not the router MAC on L3 interface

### DIFF
--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -1,6 +1,7 @@
 import re
 import time
 import logging
+import random
 
 import ipaddress
 import ptf.testutils as testutils
@@ -106,6 +107,12 @@ class TestIPPacket(object):
 
         return results
 
+    @staticmethod
+    def random_mac():
+        return "02:00:00:%02x:%02x:%02x" % (random.randint(0, 255),
+                                            random.randint(0, 255),
+                                            random.randint(0, 255))
+
     @pytest.fixture(scope="class")
     def common_param(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
@@ -114,6 +121,7 @@ class TestIPPacket(object):
         # generate peer_ip and port channel pair, be like:[("10.0.0.57", "PortChannel0001")]
         peer_ip_pc_pair = [(pc["peer_addr"], pc["attachto"]) for pc in mg_facts["minigraph_portchannel_interfaces"]
                            if ipaddress.ip_address(pc['peer_addr']).version == 4]
+        # generate port channel and member ports pair, be like:{"PortChannel0001": ["Ethernet48", "Ethernet56"]}
         pc_ports_map = {pair[1]: mg_facts["minigraph_portchannels"][pair[1]]["members"] for pair in
                         peer_ip_pc_pair}
 
@@ -653,3 +661,58 @@ class TestIPPacket(object):
                       "Forwarded {} packets in tx, not in expected range".format(tx_ok))
         pytest_assert(max(tx_drp, tx_err) <= self.PKT_NUM_ZERO,
                       "Dropped {} packets in tx, not in expected range".format(tx_err))
+
+    def test_drop_l3_ip_packet_non_dut_mac(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                           ptfadapter, common_param, skip_traffic_test):  # noqa F811
+        # GIVEN a random normal ip packet, and random dest mac address
+        # WHEN send the packet to DUT with dst_mac != ingress_router_mac to a layer 3 interface
+        # THEN DUT should drop it and add drop count
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        (peer_ip_ifaces_pair, rif_rx_ifaces, rif_support, ptf_port_idx,
+         pc_ports_map, _, ingress_router_mac) = common_param
+
+        dst_mac = TestIPPacket.random_mac()
+        while dst_mac == ingress_router_mac:
+            dst_mac = TestIPPacket.random_mac()
+
+        pkt = testutils.simple_ip_packet(
+            eth_dst=dst_mac,
+            eth_src=ptfadapter.dataplane.get_mac(0, ptf_port_idx),
+            ip_src=peer_ip_ifaces_pair[0][0],
+            ip_dst=peer_ip_ifaces_pair[1][0])
+
+        out_rif_ifaces, out_ifaces = TestIPPacket.parse_interfaces(
+            duthost.command("show ip route %s" % peer_ip_ifaces_pair[1][0])["stdout_lines"], pc_ports_map)
+
+        duthost.command("portstat -c")
+        if rif_support:
+            duthost.command("sonic-clear rifcounters")
+        ptfadapter.dataplane.flush()
+
+        testutils.send(ptfadapter, ptf_port_idx, pkt, self.PKT_NUM)
+        time.sleep(5)
+
+        portstat_out = parse_portstat(duthost.command("portstat")["stdout_lines"])
+        if rif_support:
+            rif_counter_out = TestIPPacket.parse_rif_counters(
+                duthost.command("show interfaces counters rif")["stdout_lines"])
+
+        # rx_ok counter to increase to show packets are being received correctly at layer 2
+        # rx_drp counter to increase to show packets are being dropped
+        # tx_ok, tx_drop, tx_err counter to zero to show no packets are being forwarded
+        rx_ok = int(portstat_out[peer_ip_ifaces_pair[0][1][0]]["rx_ok"].replace(",", ""))
+        rx_drp = int(portstat_out[peer_ip_ifaces_pair[0][1][0]]["rx_drp"].replace(",", ""))
+        tx_ok = TestIPPacket.sum_ifaces_counts(portstat_out, out_ifaces, "tx_ok")
+        tx_drp = TestIPPacket.sum_ifaces_counts(portstat_out, out_ifaces, "tx_drp")
+        tx_rif_err = TestIPPacket.sum_ifaces_counts(rif_counter_out, out_rif_ifaces, "tx_err") if rif_support else 0
+
+        if skip_traffic_test is True:
+            return
+        pytest_assert(rx_ok >= self.PKT_NUM_MIN,
+                      "Received {} packets in rx, not in expected range".format(rx_ok))
+        pytest_assert(rx_drp >= self.PKT_NUM_MIN,
+                      "Dropped {} packets in rx, not in expected range".format(rx_drp))
+        pytest_assert(tx_ok <= self.PKT_NUM_ZERO,
+                      "Forwarded {} packets in tx, not in expected range".format(tx_ok))
+        pytest_assert(max(tx_drp, tx_rif_err) <= self.PKT_NUM_ZERO,
+                      "Dropped {} packets in tx, tx_rif_err {}, not in expected range".format(tx_drp, tx_rif_err))

--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -663,7 +663,7 @@ class TestIPPacket(object):
                       "Dropped {} packets in tx, not in expected range".format(tx_err))
 
     def test_drop_l3_ip_packet_non_dut_mac(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                           ptfadapter, common_param, skip_traffic_test):  # noqa F811
+                                           ptfadapter, common_param):  # noqa F811
         # GIVEN a random normal ip packet, and random dest mac address
         # WHEN send the packet to DUT with dst_mac != ingress_router_mac to a layer 3 interface
         # THEN DUT should drop it and add drop count
@@ -706,8 +706,6 @@ class TestIPPacket(object):
         tx_drp = TestIPPacket.sum_ifaces_counts(portstat_out, out_ifaces, "tx_drp")
         tx_rif_err = TestIPPacket.sum_ifaces_counts(rif_counter_out, out_rif_ifaces, "tx_err") if rif_support else 0
 
-        if skip_traffic_test is True:
-            return
         pytest_assert(rx_ok >= self.PKT_NUM_MIN,
                       "Received {} packets in rx, not in expected range".format(rx_ok))
         pytest_assert(rx_drp >= self.PKT_NUM_MIN,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Cherry pick #14597 into 202405, removed skip_traffic_test check as it's not available in 202405 branch.
Summary:
Fix #10638 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Check RX_DRP counter if destination MAC is not the router MAC on L3 interface

#### How did you do it?
Send layer 3 packets with non-DUT MAC

#### How did you verify/test it?
Tested it on Cisco and broadcom platform, all passed.  
```
ip/test_ip_packet.py::TestIPPacket::test_drop_l3_ip_packet_non_dut_mac[xxx-7060cx-32s-xxx] PASSED [100%]

ip/test_ip_packet.py::TestIPPacket::test_drop_l3_ip_packet_non_dut_mac[xxx-8101-x] PASSED [100%]
```

It failed on Mellanox platform. Mellanox does not log rx_drp or rx_err counter if destination MAC is not DUT MAC. We can add specific check if Mellanox is not planning to support this test case.
```
ip/test_ip_packet.py::TestIPPacket::test_drop_l3_ip_packet_non_dut_mac[xxx-4600c-xx] FAILED [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
