### PR TITLE
Extended the SingleHop BFD skip to other cisco platforms Doublecommit#14862

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -80,17 +80,17 @@ bfd/test_bfd.py::test_bfd_basic:
              and not supported for platforms other than Nvidia 4600c/4700/5600 and cisco-8102. Skipping the test"
     conditions_logical_operator: or
     conditions:
-      - "platform in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0']"
+      - "platform in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-8111_32eh_o-r0', 'x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
       - "platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0']"
       - "release in ['201811', '201911']"
 
 bfd/test_bfd.py::test_bfd_scale:
   skip:
-    reason: "Test not supported for cisco-8102 as it doesnt support single hop BFD.
+    reason: "Test not supported for cisco as it doesnt support single hop BFD.
              and not supported for platforms other than Nvidia 4600c/4700/5600 and cisco-8102. Skipping the test"
     conditions_logical_operator: or
     conditions:
-      - "platform in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0']"
+      - "platform in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-8111_32eh_o-r0', 'x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
       - "platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0']"
       - "release in ['201811', '201911']"
 


### PR DESCRIPTION

### Description of PR
Extended the SingleHop BFD skip to other cisco platforms
Double commi PR# https://github.com/sonic-net/sonic-mgmt/pull/14862
Summary:
Fixes # (issue)

### Type of change


- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?

Extended the SingleHop BFD skip to other cisco platforms


#### How did you do it?

#### How did you verify/test it?
Ran sonic-mgmt to validate the change
bfd/test_bfd.py::test_bfd_basic[ipv4-dut_init_first] INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv4-dut_init_first] setup ====================
SKIPPED (Test not supported for cisco as it doesnt support single hop BFD. Skipping the test)INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv4-dut_init_first] teardown ====================

bfd/test_bfd.py::test_bfd_basic[ipv4-ptf_init_first] INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv4-ptf_init_first] setup ====================
SKIPPED (Test not supported for cisco as it doesnt support single hop BFD. Skipping the test)INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv4-ptf_init_first] teardown ====================

bfd/test_bfd.py::test_bfd_basic[ipv6-dut_init_first] INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv6-dut_init_first] setup ====================
SKIPPED (Test not supported for cisco as it doesnt support single hop BFD. Skipping the test)INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv6-dut_init_first] teardown ====================

bfd/test_bfd.py::test_bfd_basic[ipv6-ptf_init_first] INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv6-ptf_init_first] setup ====================
SKIPPED (Test not supported for cisco as it doesnt support single hop BFD. Skipping the test)INFO:SectionStartLogger:==================== bfd/test_bfd.py::test_bfd_basic[ipv6-ptf_init_first] teardown ====================
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
