### PR TITLE
Adjust fixture order in arp test unknown mac

### DIFF
--- a/tests/arp/test_unknown_mac.py
+++ b/tests/arp/test_unknown_mac.py
@@ -152,13 +152,14 @@ def unknownMacSetup(duthosts, rand_one_dut_hostname, tbinfo):
 
 
 @pytest.fixture
-def flushArpFdb(duthosts, rand_one_dut_hostname):
+def flushArpFdb(duthosts, rand_one_dut_hostname, dut_disable_arp_update):
     """
     Fixture to flush all ARP and FDB entries
 
     Args:
         duthosts(AnsibleHost) : multi dut instance
         rand_one_dut_hostname(string) : one of the dut instances from the multi dut
+        dut_disable_arp_update(fixture) : module scope fixture to disable arp update
     """
     duthost = duthosts[rand_one_dut_hostname]
     logger.info("Clear all ARP and FDB entries on the DUT")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix fixture order to eliminate flaky test 

#### How did you do it?
Make the fixture ```flushArpFdb``` depend on the fixture ```dut_disable_arp_update```, so that the fixture ```populateArp``` depends on ```flushArpFdb```, which in turn depends on ```dut_disable_arp_update```. This ensures that ARP updates are disabled and tables are cleared before populating the ARP entry.

#### How did you verify/test it?
Validate it in the internal setup: arp/test_unknown_mac.py
```
-------------------------------------------------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/arp/test_unknown_mac.xml ---------------------------------------------------------------

----------------------------------------------------------------------------------------- live log sessionfinish ------------------------------------------------------------------------------------------

09:59:36 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs

================================================================================ 3 passed, 2 warnings in 188.21s (0:03:08) ================================================================================
```

#### Any platform specific information?
str3-7060x6-64pe-1

#### Supported testbed topology if it's a new test case?
t0-standalone-32

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
