### PR TITLE
Update dst_path for switch_sai_thrift library

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -337,7 +337,7 @@ def test_update_saithrift_ptf(request, ptfhost):
     SRC_PATH = PY_PATH + "saithrift-0.9-py3.11.egg/switch_sai_thrift"
     DST_PATH = PY_PATH + "switch_sai_thrift"
     if ptfhost.stat(path=SRC_PATH)['stat']['exists'] and not ptfhost.stat(path=DST_PATH)['stat']['exists']:
-        ptfhost.copy(src=SRC_PATH, dest=DST_PATH, remote_src=True)
+        ptfhost.copy(src=SRC_PATH, dest=PY_PATH, remote_src=True)
     logging.info("Python saithrift package installed successfully")
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix an issue in PR https://github.com/sonic-net/sonic-mgmt/pull/14886
The dst_path should be `/usr/lib/python3/dist-packages/`, not `/usr/lib/python3/dist-packages/switch_sai_thrift`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to fix an issue in PR https://github.com/sonic-net/sonic-mgmt/pull/14886

#### How did you do it?
Fix the dest_path.

#### How did you verify/test it?
The change is verified by running `qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit`.
```
collected 20 items                                                                                                                                                                                    

qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1] 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
20:17:15 ptf_runner.get_dut_type                  L0045 WARNING| DUT type file doesn't exist.
 ^H20:19:43 ptf_runner.get_dut_type                  L0045 WARNING| DUT type file doesn't exist.
-------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------
20:20:23 ptf_runner.get_dut_type                  L0045 WARNING| DUT type file doesn't exist.
PASSED                                                                                                                                                                                          [  5%]
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2] 
-------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------
20:22:35 ptf_runner.get_dut_type                  L0045 WARNING| DUT type file doesn't exist.
 ^HPASSED                                                                                                                                                                                          [ 10%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
