### PR TITLE
[ansible][minigraph] Enhance template for adding autonegotiation in Mellanox and add Arista 7260 template changes

### DIFF
--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -39,8 +39,13 @@ vrf definition management
    switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
+{% if device_conn[inventory_hostname][intf]['autoneg']|lower == "on" %}
+   speed auto {{ device_conn[inventory_hostname][intf]['speed'] }}full
+   no error-correction encoding
+{%     else %}
    speed forced 100gfull
    error-correction encoding reed-solomon
+{%     endif %}
    no shutdown
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "40000" %}
    interface {{ intf }}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -57,7 +57,12 @@
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% for if_index in vm_topo_config['autoneg_interfaces']['intfs'] %}
+
+{% if "mellanox" in device_info[inventory_hostname]['HwSku']|lower %}
+{% set autoneg_intf = "etp" ~ if_index %}
+{% else %}
 {% set autoneg_intf = "Ethernet" ~ if_index ~ "/1" %}
+{% endif %}
 {% if device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['autoneg']|lower == "on" %}
         <a:LinkMetadata>
             <a:Name i:nil="true"/>


### PR DESCRIPTION
…

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

This pull request introduces modifications to the `arista_7260cx3_deploy.j2` and `minigraph_link_meta.j2` templates in the sonic-mgmt repository. The changes primarily focus on handling speed and auto-negotiation configurations for devices.


- Autoneg/Forced speed setting is applied directly as 100gfull with Reed-Solomon error correction encoding.

- Adjusted the interface naming convention for devices, now consistently using the EthernetX/1 format.
Removed vendor-specific logic (Mellanox handling) to unify the approach for generating auto-negotiation metadata across devices.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
