### PR TITLE
Fix various pfcwd config_db check failure

### DIFF
--- a/tests/pfcwd/test_pfc_config.py
+++ b/tests/pfcwd/test_pfc_config.py
@@ -158,10 +158,14 @@ def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     Returns:
         None
     """
-    yield
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     logger.info("--- Stop Pfcwd --")
     duthost.command("pfcwd stop")
+
+    yield
+
+    logger.info("--- Start Pfcwd--")
+    duthost.command("pfcwd start_default")
 
 
 @pytest.mark.usefixtures('cfg_setup')
@@ -320,7 +324,7 @@ class TestDefaultPfcConfig(object):
             None
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        config_reload(duthost, config_source='minigraph')
+        config_reload(duthost, config_source='minigraph', safe_reload=True)
         # sleep 20 seconds to make sure configuration is loaded
         time.sleep(20)
         res = duthost.command('pfcwd show config')

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -29,7 +29,7 @@ def pfc_queue_idx():
     yield 3   # Hardcoded in the testcase as well.
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def degrade_pfcwd_detection(duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
     """
     A fixture to degrade PFC Watchdog detection logic.
@@ -73,7 +73,7 @@ def degrade_pfcwd_detection(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     duthost.file(path='/tmp/pfc_detect_mellanox.lua', state='absent')
 
 
-@pytest.fixture(scope='class', autouse=True)
+@pytest.fixture(scope='function', autouse=True)
 def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Fixture that stops PFC Watchdog before each test run
@@ -91,7 +91,7 @@ def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost.command("pfcwd start_default")
 
 
-@pytest.fixture(scope='class', autouse=True)
+@pytest.fixture(scope='function', autouse=True)
 def storm_test_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,     # noqa F811
                              enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
     """

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -85,6 +85,11 @@ def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     logger.info("--- Stop Pfcwd --")
     duthost.command("pfcwd stop")
 
+    yield
+
+    logger.info("--- Start Pfcwd --")
+    duthost.command("pfcwd start_default")
+
 
 @pytest.fixture(scope='class', autouse=True)
 def storm_test_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,     # noqa F811

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -29,7 +29,7 @@ def pfc_queue_idx():
     yield 3   # Hardcoded in the testcase as well.
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='module')
 def degrade_pfcwd_detection(duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
     """
     A fixture to degrade PFC Watchdog detection logic.
@@ -73,7 +73,7 @@ def degrade_pfcwd_detection(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     duthost.file(path='/tmp/pfc_detect_mellanox.lua', state='absent')
 
 
-@pytest.fixture(scope='function', autouse=True)
+@pytest.fixture(scope='class', autouse=True)
 def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Fixture that stops PFC Watchdog before each test run
@@ -91,7 +91,7 @@ def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost.command("pfcwd start_default")
 
 
-@pytest.fixture(scope='function', autouse=True)
+@pytest.fixture(scope='class', autouse=True)
 def storm_test_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,     # noqa F811
                              enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
     """

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -28,7 +28,7 @@ def pfc_queue_idx(pfcwd_timer_setup_restore):
     yield pfcwd_timer_setup_restore['storm_handle'].pfc_queue_idx
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='class')
 def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Fixture that stops PFC Watchdog before each test run
@@ -67,7 +67,7 @@ def ignore_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, log
     yield
 
 
-@pytest.fixture(scope='function', autouse=True)
+@pytest.fixture(scope='class', autouse=True)
 def pfcwd_timer_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,        # noqa F811
                               enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, stop_pfcwd):
     """

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -28,8 +28,8 @@ def pfc_queue_idx(pfcwd_timer_setup_restore):
     yield pfcwd_timer_setup_restore['storm_handle'].pfc_queue_idx
 
 
-@pytest.fixture(scope='class')
-def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+@pytest.fixture(scope='module')
+def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname, core_dump_and_config_check):
     """
     Fixture that stops PFC Watchdog before each test run
 
@@ -67,7 +67,7 @@ def ignore_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, log
     yield
 
 
-@pytest.fixture(scope='class', autouse=True)
+@pytest.fixture(scope='module', autouse=True)
 def pfcwd_timer_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,        # noqa F811
                               enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, stop_pfcwd):
     """

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -28,7 +28,7 @@ def pfc_queue_idx(pfcwd_timer_setup_restore):
     yield pfcwd_timer_setup_restore['storm_handle'].pfc_queue_idx
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope='class')
 def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Fixture that stops PFC Watchdog before each test run
@@ -39,6 +39,11 @@ def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     logger.info("--- Stop Pfcwd --")
     duthost.command("pfcwd stop")
+
+    yield
+
+    logger.info("--- Start Pfcwd --")
+    duthost.command("pfcwd start_default")
 
 
 @pytest.fixture(autouse=True)
@@ -64,7 +69,7 @@ def ignore_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, log
 
 @pytest.fixture(scope='class', autouse=True)
 def pfcwd_timer_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,        # noqa F811
-                              enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+                              enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, stop_pfcwd):
     """
     Fixture that inits the test vars, start PFCwd on ports and cleans up after the test run
 

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -28,7 +28,7 @@ def pfc_queue_idx(pfcwd_timer_setup_restore):
     yield pfcwd_timer_setup_restore['storm_handle'].pfc_queue_idx
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope='function')
 def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Fixture that stops PFC Watchdog before each test run
@@ -67,7 +67,7 @@ def ignore_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, log
     yield
 
 
-@pytest.fixture(scope='class', autouse=True)
+@pytest.fixture(scope='function', autouse=True)
 def pfcwd_timer_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,        # noqa F811
                               enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, stop_pfcwd):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 29826096, 29826079, 29808432


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Currently, for PFCWD, we are setting the config_db a certain way for our test case. However, after the tear down, we do not recover the ConfigDB setting to the original which leads to config_db_check issue


#### How did you do it?

This PR attempt to fix 
- test_pfcwd_all_port_storm
- test_pfcwd_timer_accuracy
- pfcwd/test_pfc_config

Since they're similar

#### How did you verify/test it?
I've verified on T2 chassis switch
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
