### PR TITLE
[202405] Xfail fdb/test_fdb_mac_learning.py::TestFdbMacLearning::testARPComplete on Broadcom platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -683,6 +683,13 @@ fdb/test_fdb_mac_expire.py:
     conditions:
       - "topo_type not in ['t0', 'm0', 'mx']"
 
+fdb/test_fdb_mac_learning.py::TestFdbMacLearning::testARPComplete:
+  xfail:
+    reason: "Testcase failed on Broadcom platforms with teardown syslog error"
+    conditions:
+      - "asic_type in ['broadcom']"
+      - "https://github.com/aristanetworks/sonic-qual.msft/issues/267"
+
 #######################################
 #####            fib              #####
 #######################################


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Xfail fdb/test_fdb_mac_learning.py::TestFdbMacLearning::testARPComplete on Broadcom platforms due to known issue 
https://github.com/aristanetworks/sonic-qual.msft/issues/267

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
