### PR TITLE
Fixing test_multidut_snappi.

### DIFF
--- a/tests/snappi_tests/test_multidut_snappi.py
+++ b/tests/snappi_tests/test_multidut_snappi.py
@@ -5,10 +5,11 @@ import logging
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut      # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, snappi_api, \
-    snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config      # noqa: F401
+    snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config, \
+    get_snappi_ports_multi_dut       # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.common.snappi_tests.port import select_ports
-from tests.common.snappi_tests.qos_fixtures import prio_dscp_map  # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list  # noqa: F401
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 logger = logging.getLogger(__name__)
 SNAPPI_POLL_DELAY_SEC = 2
@@ -25,7 +26,7 @@ def __gen_all_to_all_traffic(testbed_config,
                              prio_dscp_map              # noqa: F811
                              ):
 
-    rate_percent = 100 / (len(port_config_list) - 1)
+    rate_percent = 50 / (len(port_config_list) - 1)
     duration_sec = 2
     pkt_size = 1024
 
@@ -135,7 +136,7 @@ def test_snappi(request,
                                                                                 snappi_api)
 
     lossless_prio = random.sample(lossless_prio_list, 1)
-    lossless_prio = int(lossless_prio)
+    lossless_prio = int(lossless_prio[0])
 
     pytest_require(len(port_config_list) >= 2, "This test requires at least 2 ports")
 

--- a/tests/snappi_tests/test_multidut_snappi.py
+++ b/tests/snappi_tests/test_multidut_snappi.py
@@ -19,6 +19,7 @@ pytestmark = [pytest.mark.topology('multidut-tgen')]
 
 @pytest.mark.disable_loganalyzer
 def __gen_all_to_all_traffic(testbed_config,
+                             duthosts,
                              port_config_list,
                              conn_data,
                              fanout_data,
@@ -26,7 +27,11 @@ def __gen_all_to_all_traffic(testbed_config,
                              prio_dscp_map              # noqa: F811
                              ):
 
-    rate_percent = 50 / (len(port_config_list) - 1)
+    line_rate = 100
+    if duthosts[0].facts['asic_type'] == "cisco-8000":
+        line_rate = 50
+    rate_percent = line_rate / (len(port_config_list) - 1)
+
     duration_sec = 2
     pkt_size = 1024
 
@@ -145,7 +150,8 @@ def test_snappi(request,
                                       conn_data=conn_graph_facts,
                                       fanout_data=fanout_graph_facts_multidut,
                                       priority=int(lossless_prio),
-                                      prio_dscp_map=prio_dscp_map)
+                                      prio_dscp_map=prio_dscp_map,
+                                      duthosts=duthosts)
 
     pkt_size = config.flows[0].size.fixed
     rate_percent = config.flows[0].rate.percentage


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Minor fixes to test_multidut_snappi.py to make it pass in cisco-8000.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
There are minor issues in test_multidut_snappi.py that had caused it to fail in cisco-8000. This PR aims to fix these issues.

#### How did you verify the change
```
=========================================================================================================================== PASSES ===========================================================================================================================
 
______________________________________________________________________________________________________________ test_snappi[multidut_port_info0] 
______________________________________________________________________________________________________________
----------------------------------------------------------------------------- generated xml file: /run_logs/ixia/fixed_variables/2024-10-17-22-38-56/tr_2024-10-17-22-38-56.xml --------------------------------------
---------------------------------------- INFO:root:Can not get Allure report URL. Please check logs ---------------------
---------------------------------------------------------------------------------------------- live log sessionfinish ------
------------------------------------------------------------------------------------------------------------- 22:47:39 __init__.pytest_terminal_summary         
L0067 INFO   | Can not get Allure report URL. Please check logs 
================================================================================================================== short test summary info ==========================================================================================
========================= PASSED snappi_tests/test_multidut_snappi.py::test_snappi[multidut_port_info0] ==========================================================================================
=============== 1 passed, 4 warnings in 521.32s (0:08:41) ========================================================================================================== sonic@ixia-sonic-mgmt-whitebox:/data/tests$  
```