### PR TITLE
Increase time interval to retrieve snmp facts

### DIFF
--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -8,8 +8,8 @@ from tests.common.devices.eos import EosHost
 
 logger = logging.getLogger(__name__)
 
-DEF_WAIT_TIMEOUT = 300
-DEF_CHECK_INTERVAL = 10
+DEF_WAIT_TIMEOUT = 500
+DEF_CHECK_INTERVAL = 20
 
 global_snmp_facts = {}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR
Resolve flaky test when running ```tests/snmp/test_snmp_phy_entity.py```, it couldn't retrieve transceiver dom sensor info for all ports in time when running multiple test modules all at once.

#### How did you do it?
Increase default wait timeout from 300s to 500s, increase default check interval from 10s to 20s.

#### How did you verify/test it?
Validate it in the internal setup 
```
=========================== short test summary info ============================
SKIPPED [1] snmp/test_snmp_phy_entity.py:370: Not supported on non supervisor node
SKIPPED [1] platform_tests/thermal_control_test_helper.py:123: No mocker defined for this platform x86_64-arista_7060x6_64pe
SKIPPED [1] snmp/test_snmp_phy_entity.py:644: At least 2 PSUs required for rest of the testing in this case
============= 4 passed, 3 skipped, 1 warning in 330.68s (0:05:30) ==============
```

#### Any platform specific information?
str3-7060x6-64pe-1
#### Supported testbed topology if it's a new test case?
t0-standalone-32
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
