### PR TITLE
[202305] [cherry-pick] Fix reload_config failed on M0 device because PFCWD feature does not exist #14138

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -61,6 +61,12 @@ def config_force_option_supported(duthost):
     return False
 
 
+def pfcwd_feature_enabled(duthost):
+    device_metadata = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']['DEVICE_METADATA']
+    pfc_status = device_metadata['localhost']["default_pfcwd_status"]
+    return pfc_status == 'enable'
+
+
 @ignore_loganalyzer
 def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True,
                   safe_reload=False, wait_before_force_reload=0,
@@ -146,8 +152,9 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
         pytest_assert(wait_until(wait + 300, 20, 0, sonic_host.critical_services_fully_started),
                       "All critical services should be fully started!")
         wait_critical_processes(sonic_host)
-        if config_source == 'minigraph':
-            pytest_assert(wait_until(300, 20, 0, chk_for_pfc_wd, sonic_host),
+        # PFCWD feature does not enable on some topology, for example M0
+        if config_source == 'minigraph' and pfcwd_feature_enabled(sonic_host):
+            pytest_assert(wait_until(wait + 300, 20, 0, chk_for_pfc_wd, sonic_host),
                           "PFC_WD is missing in CONFIG-DB")
 
         if check_intf_up_ports:


### PR DESCRIPTION
Fix reload_config failed on M0 device because PFCWD feature does not exist

#### Why I did it
test case test_fallback_to_local_authorization_with_config_reload failed on M0 device when reload config.
It's because PFCWD feature does not exist on M0.

##### Work item tracking
- Microsoft ADO: 28794363

#### How I did it
Ignore check when PFCWD feature not enable on device.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Fix reload_config failed on M0 device because PFCWD feature does not exist

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

