### PR TITLE
Disable loganalzyer for test_lldp_entry_table_after_reboot

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -124,8 +124,17 @@ def assert_lldp_entry_content(interface, entry_content, lldpctl_interface):
         entry_content["lldp_rem_sys_cap_supported"] == "28 00",
         "lldp_rem_sys_cap_supported does not match for {}".format(interface),
     )
+    if interface == "eth0":
+        expected_sys_cap_enable_result = (
+            entry_content["lldp_rem_sys_cap_enabled"] == "28 00"
+            or entry_content["lldp_rem_sys_cap_enabled"] == "20 00",
+        )
+    else:
+        expected_sys_cap_enable_result = (
+            entry_content["lldp_rem_sys_cap_enabled"] == "28 00"
+        )
     pytest_assert(
-        entry_content["lldp_rem_sys_cap_enabled"] == "28 00",
+        expected_sys_cap_enable_result,
         "lldp_rem_sys_cap_enabled does not match for {}".format(interface),
     )
 
@@ -265,6 +274,7 @@ def test_lldp_entry_table_after_lldp_restart(
 
 
 # Test case 5: Verify LLDP_ENTRY_TABLE after reboot
+@pytest.mark.disable_loganalyzer
 def test_lldp_entry_table_after_reboot(
     localhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, db_instance
 ):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- In test_lldp_entry_table_after_reboot case, it will reboot DUT, syslog will lost after reboot, start mark will not be found when try to do log analysis, and there will be some ERROR or WARNING syslog during bootup, LogAnalyzer needs to be disabled for this case.
- For some DUTs, eth0 connects to some switches which `lldp_rem_sys_cap_enabled` is `20 00` instead of `28 00`, need to consider both scenarios.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix the failure of test_lldp_entry_table_after_reboot and the failure due to `Failed: lldp_rem_sys_cap_enabled does not match for eth0`

#### How did you do it?
add `@pytest.mark.disable_loganalyzer `for `test_lldp_entry_table_after_reboot `
Consider `20 00` as valid value for eth0's `lldp_rem_sys_cap_enabled`

#### How did you verify/test it?
Run `lldp/test_lldp_syncd.py`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
