### PR TITLE
sonic-mgmt/IXIA test to verify the PFC frame sent by DUT has a valid src_mac address in T2

### DIFF
--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -17,7 +17,7 @@ from tests.common.snappi_tests.traffic_generation import setup_base_traffic_conf
     verify_in_flight_buffer_pkts, verify_unset_cev_pause_frame_count, verify_tx_frame_count_dut, \
     verify_rx_frame_count_dut
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.common.snappi_tests.read_pcap import validate_pfc_frame
+from tests.common.snappi_tests.read_pcap import validate_pfc_frame, validate_pfc_frame_cisco
 
 
 logger = logging.getLogger(__name__)
@@ -309,6 +309,184 @@ def run_pfc_test(api,
         # and only test traffic flows are generated
         verify_rx_frame_count_dut(duthost=duthost,
                                   snappi_extra_params=snappi_extra_params)
+
+def run_valid_pfc_frame_test(api,
+                             testbed_config,
+                             port_config_list,
+                             conn_data,
+                             fanout_data,
+                             global_pause,
+                             pause_prio_list,
+                             test_prio_list,
+                             bg_prio_list,
+                             prio_dscp_map,
+                             test_traffic_pause,
+                             snappi_extra_params=None):
+    """
+    Run a multidut valid PFC test
+    Args:
+        api (obj): snappi session
+        testbed_config (obj): testbed L1/L2/L3 configuration
+        port_config_list (list): list of port configuration
+        conn_data (dict): the dictionary returned by conn_graph_fact.
+        fanout_data (dict): the dictionary returned by fanout_graph_fact.
+        duthost (Ansible host instance): device under test
+        dut_port (str): DUT port to test
+        global_pause (bool): if pause frame is IEEE 802.3X pause
+        pause_prio_list (list): priorities to pause for pause frames
+        test_prio_list (list): priorities of test flows
+        bg_prio_list (list): priorities of background flows
+        prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
+        test_traffic_pause (bool): if test flows are expected to be paused
+        snappi_extra_params (SnappiTestParams obj): additional parameters for Snappi traffic
+    Returns:
+        N/A
+    """
+
+    if snappi_extra_params is None:
+        snappi_extra_params = SnappiTestParams()
+
+    # Traffic flow:
+    # tx_port (TGEN) --- ingress DUT --- egress DUT --- rx_port (TGEN)
+
+    # initialize the (duthost, port) set.
+    dut_asics_to_be_configured = set()
+
+    rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
+    egress_duthost = rx_port['duthost']
+    dut_asics_to_be_configured.add((egress_duthost, rx_port['asic_value']))
+
+    tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
+    ingress_duthost = tx_port['duthost']
+    dut_asics_to_be_configured.add((ingress_duthost, tx_port['asic_value']))
+
+    pytest_assert(testbed_config is not None, 'Fail to get L2/3 testbed config')
+
+    DATA_FLOW_DURATION_SEC = 5
+    data_flow_delay_sec = 1
+
+    # Port id of Rx port for traffic config
+    port_id = 0
+
+    # Rate percent must be an integer
+    test_flow_rate_percent = int(TEST_FLOW_AGGR_RATE_PERCENT / len(test_prio_list))
+
+    # Generate base traffic config
+    snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,
+                                                                     port_config_list=port_config_list,
+                                                                     port_id=port_id)
+
+    speed_str = testbed_config.layer1[0].speed
+    speed_gbps = int(float(speed_str.split('_')[1]))
+
+    if snappi_extra_params.poll_device_runtime:
+        # If the switch needs to be polled as traffic is running for stats,
+        # then the test runtime needs to be increased for the polling delay
+        DATA_FLOW_DURATION_SEC += ANSIBLE_POLL_DELAY_SEC
+        data_flow_delay_sec = ANSIBLE_POLL_DELAY_SEC
+
+    if snappi_extra_params.packet_capture_type != packet_capture.NO_CAPTURE:
+        # Setup capture config
+        if snappi_extra_params.is_snappi_ingress_port_cap:
+            # packet capture is required on the ingress snappi port
+            snappi_extra_params.packet_capture_ports = [snappi_extra_params.base_flow_config["rx_port_name"]]
+        else:
+            # packet capture will be on the egress snappi port
+            snappi_extra_params.packet_capture_ports = [snappi_extra_params.base_flow_config["tx_port_name"]]
+
+        snappi_extra_params.packet_capture_file = snappi_extra_params.packet_capture_type.value
+
+        config_capture_pkt(testbed_config=testbed_config,
+                           port_names=snappi_extra_params.packet_capture_ports,
+                           capture_type=snappi_extra_params.packet_capture_type,
+                           capture_name=snappi_extra_params.packet_capture_file)
+        logger.info("Packet capture file: {}.pcapng".format(snappi_extra_params.packet_capture_file))
+
+    # Set default traffic flow configs if not set
+    if snappi_extra_params.traffic_flow_config.data_flow_config is None:
+        snappi_extra_params.traffic_flow_config.data_flow_config = {
+            "flow_name": TEST_FLOW_NAME,
+            "flow_dur_sec": DATA_FLOW_DURATION_SEC,
+            "flow_rate_percent": test_flow_rate_percent,
+            "flow_rate_pps": None,
+            "flow_rate_bps": None,
+            "flow_pkt_size": data_flow_pkt_size,
+            "flow_pkt_count": None,
+            "flow_delay_sec": data_flow_delay_sec,
+            "flow_traffic_type": traffic_flow_mode.FIXED_DURATION
+        }
+
+    if snappi_extra_params.traffic_flow_config.pause_flow_config is None:
+        snappi_extra_params.traffic_flow_config.pause_flow_config = {
+            "flow_name": PAUSE_FLOW_NAME,
+            "flow_dur_sec": None,
+            "flow_rate_percent": None,
+            "flow_rate_pps": calc_pfc_pause_flow_rate(speed_gbps),
+            "flow_rate_bps": None,
+            "flow_pkt_size": 64,
+            "flow_pkt_count": None,
+            "flow_delay_sec": 0,
+            "flow_traffic_type": traffic_flow_mode.CONTINUOUS
+        }
+
+    if snappi_extra_params.packet_capture_type == packet_capture.PFC_CAPTURE:
+        # PFC pause frame capture is requested
+        validate_pfc_frame = True
+    else:
+        # PFC pause frame capture is not requested
+        validate_pfc_frame = False
+
+    # Generate test flow config
+    generate_test_flows(testbed_config=testbed_config,
+                        test_flow_prio_list=test_prio_list,
+                        prio_dscp_map=prio_dscp_map,
+                        snappi_extra_params=snappi_extra_params)
+
+    # Generate pause storm config
+    generate_pause_flows(testbed_config=testbed_config,
+                         pause_prio_list=pause_prio_list,
+                         global_pause=global_pause,
+                         snappi_extra_params=snappi_extra_params)
+
+    flows = testbed_config.flows
+
+    all_flow_names = [flow.name for flow in flows]
+    data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
+
+    # Clear PFC counters before traffic run
+    duthost = egress_duthost
+    duthost.command("sonic-clear pfccounters")
+    time.sleep(1)
+
+    """ Run traffic """
+    tgen_flow_stats, _, _ = run_traffic(duthost=duthost,
+                                        api=api,
+                                        config=testbed_config,
+                                        data_flow_names=data_flow_names,
+                                        all_flow_names=all_flow_names,
+                                        exp_dur_sec=DATA_FLOW_DURATION_SEC +
+                                        data_flow_delay_sec,
+                                        snappi_extra_params=snappi_extra_params)
+
+    # Reset pfc delay parameter
+    pfc = testbed_config.layer1[0].flow_control.ieee_802_1qbb
+    pfc.pfc_delay = 0
+
+    # Verify PFC pause frames
+    if validate_pfc_frame:
+        peer_mac_addr = snappi_extra_params.base_flow_config["tx_port_config"].gateway_mac
+        is_valid_pfc_frame, error_msg = validate_pfc_frame_cisco(
+                        snappi_extra_params.packet_capture_file + ".pcapng",
+                        peer_mac_addr=peer_mac_addr)
+        pytest_assert(is_valid_pfc_frame, error_msg)
+        return
+
+    # Verify basic test flows metrics from ixia
+    verify_basic_test_flow(flow_metrics=tgen_flow_stats,
+                           speed_gbps=speed_gbps,
+                           tolerance=TOLERANCE_THRESHOLD,
+                           test_flow_pause=test_traffic_pause,
+                           snappi_extra_params=snappi_extra_params)
 
 
 def run_tx_drop_counter(

--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -310,6 +310,7 @@ def run_pfc_test(api,
         verify_rx_frame_count_dut(duthost=duthost,
                                   snappi_extra_params=snappi_extra_params)
 
+
 def run_valid_pfc_frame_test(api,
                              testbed_config,
                              port_config_list,

--- a/tests/snappi_tests/multidut/pfc/test_multidut_valid_src_mac_pfc_frame.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_valid_src_mac_pfc_frame.py
@@ -7,8 +7,8 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     snappi_testbed_config, get_snappi_ports_single_dut, \
     get_snappi_ports, is_snappi_multidut                                        # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
-    lossy_prio_list                         # noqa F401
-from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+    lossy_prio_list, disable_pfcwd                         # noqa F401
+from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut  # noqa: F401
 from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_valid_pfc_frame_test
 import logging
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
@@ -18,7 +18,11 @@ logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
+@pytest.fixture(autouse=True)
+def number_of_tx_rx_ports():
+    yield (1, 1)
+
+
 def test_valid_pfc_frame_src_mac(snappi_api,                     # noqa: F811
                                  conn_graph_facts,               # noqa: F811
                                  fanout_graph_facts_multidut,             # noqa: F811
@@ -29,10 +33,12 @@ def test_valid_pfc_frame_src_mac(snappi_api,                     # noqa: F811
                                  all_prio_list,                   # noqa: F811
                                  get_snappi_ports,                 # noqa: F811
                                  tbinfo,                           # noqa: F811
-                                 multidut_port_info):
+                                 disable_pfcwd,                      # noqa: F811
+                                 setup_ports_and_dut               # noqa: F811
+                                 ):
 
     """
-    Test if PFC can pause a single lossless priority in multidut setup
+    Test the PFC frame captured has a valid src address
 
     Args:
         snappi_api (pytest fixture): SNAPPI session
@@ -49,32 +55,8 @@ def test_valid_pfc_frame_src_mac(snappi_api,                     # noqa: F811
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
 
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
-
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = snappi_port_list
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
     _, lossless_prio = enum_dut_lossless_prio.split('|')
     lossless_prio = int(lossless_prio)

--- a/tests/snappi_tests/multidut/pfc/test_multidut_valid_src_mac_pfc_frame.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_valid_src_mac_pfc_frame.py
@@ -1,0 +1,105 @@
+import pytest
+from tests.common.helpers.assertions import pytest_require, pytest_assert                   # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
+    fanout_graph_facts_multidut     # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
+    snappi_api, snappi_dut_base_config, get_snappi_ports_for_rdma, cleanup_config, get_snappi_ports_multi_dut, \
+    snappi_testbed_config, get_snappi_ports_single_dut, \
+    get_snappi_ports, is_snappi_multidut                                        # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
+    lossy_prio_list                         # noqa F401
+from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_valid_pfc_frame_test
+import logging
+from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.common.snappi_tests.common_helpers import packet_capture
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+
+
+@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
+def test_valid_pfc_frame_src_mac(snappi_api,                     # noqa: F811
+                                 conn_graph_facts,               # noqa: F811
+                                 fanout_graph_facts_multidut,             # noqa: F811
+                                 duthosts,
+                                 enum_dut_lossless_prio,
+                                 prio_dscp_map,                   # noqa: F811
+                                 lossless_prio_list,              # noqa: F811
+                                 all_prio_list,                   # noqa: F811
+                                 get_snappi_ports,                 # noqa: F811
+                                 tbinfo,                           # noqa: F811
+                                 multidut_port_info):
+
+    """
+    Test if PFC can pause a single lossless priority in multidut setup
+
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts_multidut (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        enum_dut_lossless_prio (str): lossless priority to test, e.g., 's6100-1|3'
+        all_prio_list (pytest fixture): list of all the priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        lossless_prio_list (pytest fixture): list of all the lossless priorities
+        tbinfo (pytest fixture): fixture provides information about testbed
+        get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
+
+    Returns:
+        N/A
+    """
+    for testbed_subtype, rdma_ports in multidut_port_info.items():
+        tx_port_count = 1
+        rx_port_count = 1
+        snappi_port_list = get_snappi_ports
+
+        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+
+        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
+                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
+                      testbed {}, subtype {} in variables.py'.
+                      format(MULTIDUT_TESTBED, testbed_subtype))
+
+        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
+                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
+                      testbed {}, subtype {} in variables.py'.
+                      format(MULTIDUT_TESTBED, testbed_subtype))
+        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+        if is_snappi_multidut(duthosts):
+            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        else:
+            snappi_ports = snappi_port_list
+        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
+                                                                                snappi_ports,
+                                                                                snappi_api)
+
+    _, lossless_prio = enum_dut_lossless_prio.split('|')
+    lossless_prio = int(lossless_prio)
+    pause_prio_list = [lossless_prio]
+    test_prio_list = [lossless_prio]
+    bg_prio_list = [p for p in all_prio_list]
+    bg_prio_list.remove(lossless_prio)
+
+    logger.info("Snappi Ports : {}".format(snappi_ports))
+
+    snappi_extra_params = SnappiTestParams()
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+    snappi_extra_params.packet_capture_type = packet_capture.PFC_CAPTURE
+    snappi_extra_params.is_snappi_ingress_port_cap = False
+
+    run_valid_pfc_frame_test(api=snappi_api,
+                             testbed_config=testbed_config,
+                             port_config_list=port_config_list,
+                             conn_data=conn_graph_facts,
+                             fanout_data=fanout_graph_facts_multidut,
+                             global_pause=False,
+                             pause_prio_list=pause_prio_list,
+                             test_prio_list=test_prio_list,
+                             bg_prio_list=bg_prio_list,
+                             prio_dscp_map=prio_dscp_map,
+                             test_traffic_pause=True,
+                             snappi_extra_params=snappi_extra_params)
+    cleanup_config(duthosts, snappi_ports)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

Add a IXIA testcase to capture the PFC frame sent by DUT and verify the src_mac is a valid address.

#### How did you do it?

- Injected lossless traffic and PAUSE flows from the IXIA
- The resulting congestion caused the DUT to send XOFF frames
- Capture the XOFF frame on IXIA port and read and verify the validity of XOFF frame
- Compare the src_mac in XOFF frame against the peer DUT port mac address

#### How did you verify/test it?

Ran on T2 Ixia setup

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
