### PR TITLE
[202305] Fix test authorization failed on S6000 issue by split test case.

### DIFF
--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -184,7 +184,7 @@ def check_authorization_tacacs_only(
     )
 
 
-def test_authorization_tacacs_only(
+def test_authorization_tacacs_only_commands_1(
                                 duthosts,
                                 enum_rand_one_per_hwsku_hostname,
                                 setup_authorization_tacacs,
@@ -212,7 +212,25 @@ def test_authorization_tacacs_only(
         "find -type f -name testfile -print | xargs /bin/rm -f",
         "touch testfile",
         "rm -f testfi*",
-        "mkdir -p test",
+        "mkdir -p test"
+    ]
+
+    for subcommand in commands:
+        exit_code, stdout, stderr = ssh_run_command(remote_user_client, subcommand)
+        pytest_assert(exit_code == 0)
+
+
+def test_authorization_tacacs_only_commands_2(
+                                duthosts,
+                                enum_rand_one_per_hwsku_hostname,
+                                setup_authorization_tacacs,
+                                tacacs_creds,
+                                check_tacacs,
+                                remote_user_client,
+                                remote_rw_user_client):
+
+    # check commands used by scripts
+    commands = [
         "portstat -c",
         "show ip bgp summary",
         "show ipv6 bgp summary",
@@ -237,6 +255,16 @@ def test_authorization_tacacs_only(
     for subcommand in commands:
         exit_code, stdout, stderr = ssh_run_command(remote_user_client, subcommand)
         pytest_assert(exit_code == 0)
+
+
+def test_authorization_tacacs_only_rw_commands(
+                                duthosts,
+                                enum_rand_one_per_hwsku_hostname,
+                                setup_authorization_tacacs,
+                                tacacs_creds,
+                                check_tacacs,
+                                remote_user_client,
+                                remote_rw_user_client):
 
     rw_commands = [
         "sudo config interface",


### PR DESCRIPTION
 Fix test authorization failed on S6000 issue by split test case.

#### Why I did it
Test authorization failed on S6000 device.
This is because S6000 have slowly CPU which make command 2-3 times slowly than other platform.
Because test authorization test case run too many commands with a new SSH session, the ansible ssh session will timeout and break.

##### Work item tracking
- Microsoft ADO: 29720857

#### How I did it
Split test case to 3 small test cases.

#### How to verify it
Pass all test case.
Manually verify the test case can pass on S6000 platform.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Fix test authorization failed on S6000 issue by split test case.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

