### PR TITLE
add topo t0-isolated-d128u128s2

### DIFF
--- a/ansible/vars/topo_t0-isolated-d128u128s2.yml
+++ b/ansible/vars/topo_t0-isolated-d128u128s2.yml
@@ -1,0 +1,3545 @@
+topology:
+  host_interfaces:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
+    - 15
+    - 16
+    - 17
+    - 18
+    - 19
+    - 20
+    - 21
+    - 22
+    - 23
+    - 24
+    - 25
+    - 26
+    - 27
+    - 28
+    - 29
+    - 30
+    - 31
+    - 96
+    - 97
+    - 98
+    - 99
+    - 100
+    - 101
+    - 102
+    - 103
+    - 104
+    - 105
+    - 106
+    - 107
+    - 108
+    - 109
+    - 110
+    - 111
+    - 112
+    - 113
+    - 114
+    - 115
+    - 116
+    - 117
+    - 118
+    - 119
+    - 120
+    - 121
+    - 122
+    - 123
+    - 124
+    - 125
+    - 126
+    - 127
+    - 128
+    - 129
+    - 130
+    - 131
+    - 132
+    - 133
+    - 134
+    - 135
+    - 136
+    - 137
+    - 138
+    - 139
+    - 140
+    - 141
+    - 142
+    - 143
+    - 144
+    - 145
+    - 146
+    - 147
+    - 148
+    - 149
+    - 150
+    - 151
+    - 152
+    - 153
+    - 154
+    - 155
+    - 156
+    - 157
+    - 158
+    - 159
+    - 224
+    - 225
+    - 226
+    - 227
+    - 228
+    - 229
+    - 230
+    - 231
+    - 232
+    - 233
+    - 234
+    - 235
+    - 236
+    - 237
+    - 238
+    - 239
+    - 240
+    - 241
+    - 242
+    - 243
+    - 244
+    - 245
+    - 246
+    - 247
+    - 248
+    - 249
+    - 250
+    - 251
+    - 252
+    - 253
+    - 254
+    - 255
+  VMs:
+    ARISTA01T1:
+      vlans:
+        - 32
+      vm_offset: 0
+    ARISTA02T1:
+      vlans:
+        - 33
+      vm_offset: 1
+    ARISTA03T1:
+      vlans:
+        - 34
+      vm_offset: 2
+    ARISTA04T1:
+      vlans:
+        - 35
+      vm_offset: 3
+    ARISTA05T1:
+      vlans:
+        - 36
+      vm_offset: 4
+    ARISTA06T1:
+      vlans:
+        - 37
+      vm_offset: 5
+    ARISTA07T1:
+      vlans:
+        - 38
+      vm_offset: 6
+    ARISTA08T1:
+      vlans:
+        - 39
+      vm_offset: 7
+    ARISTA09T1:
+      vlans:
+        - 40
+      vm_offset: 8
+    ARISTA10T1:
+      vlans:
+        - 41
+      vm_offset: 9
+    ARISTA11T1:
+      vlans:
+        - 42
+      vm_offset: 10
+    ARISTA12T1:
+      vlans:
+        - 43
+      vm_offset: 11
+    ARISTA13T1:
+      vlans:
+        - 44
+      vm_offset: 12
+    ARISTA14T1:
+      vlans:
+        - 45
+      vm_offset: 13
+    ARISTA15T1:
+      vlans:
+        - 46
+      vm_offset: 14
+    ARISTA16T1:
+      vlans:
+        - 47
+      vm_offset: 15
+    ARISTA17T1:
+      vlans:
+        - 48
+      vm_offset: 16
+    ARISTA18T1:
+      vlans:
+        - 49
+      vm_offset: 17
+    ARISTA19T1:
+      vlans:
+        - 50
+      vm_offset: 18
+    ARISTA20T1:
+      vlans:
+        - 51
+      vm_offset: 19
+    ARISTA21T1:
+      vlans:
+        - 52
+      vm_offset: 20
+    ARISTA22T1:
+      vlans:
+        - 53
+      vm_offset: 21
+    ARISTA23T1:
+      vlans:
+        - 54
+      vm_offset: 22
+    ARISTA24T1:
+      vlans:
+        - 55
+      vm_offset: 23
+    ARISTA25T1:
+      vlans:
+        - 56
+      vm_offset: 24
+    ARISTA26T1:
+      vlans:
+        - 57
+      vm_offset: 25
+    ARISTA27T1:
+      vlans:
+        - 58
+      vm_offset: 26
+    ARISTA28T1:
+      vlans:
+        - 59
+      vm_offset: 27
+    ARISTA29T1:
+      vlans:
+        - 60
+      vm_offset: 28
+    ARISTA30T1:
+      vlans:
+        - 61
+      vm_offset: 29
+    ARISTA31T1:
+      vlans:
+        - 62
+      vm_offset: 30
+    ARISTA32T1:
+      vlans:
+        - 63
+      vm_offset: 31
+    ARISTA33T1:
+      vlans:
+        - 64
+      vm_offset: 32
+    ARISTA34T1:
+      vlans:
+        - 65
+      vm_offset: 33
+    ARISTA35T1:
+      vlans:
+        - 66
+      vm_offset: 34
+    ARISTA36T1:
+      vlans:
+        - 67
+      vm_offset: 35
+    ARISTA37T1:
+      vlans:
+        - 68
+      vm_offset: 36
+    ARISTA38T1:
+      vlans:
+        - 69
+      vm_offset: 37
+    ARISTA39T1:
+      vlans:
+        - 70
+      vm_offset: 38
+    ARISTA40T1:
+      vlans:
+        - 71
+      vm_offset: 39
+    ARISTA41T1:
+      vlans:
+        - 72
+      vm_offset: 40
+    ARISTA42T1:
+      vlans:
+        - 73
+      vm_offset: 41
+    ARISTA43T1:
+      vlans:
+        - 74
+      vm_offset: 42
+    ARISTA44T1:
+      vlans:
+        - 75
+      vm_offset: 43
+    ARISTA45T1:
+      vlans:
+        - 76
+      vm_offset: 44
+    ARISTA46T1:
+      vlans:
+        - 77
+      vm_offset: 45
+    ARISTA47T1:
+      vlans:
+        - 78
+      vm_offset: 46
+    ARISTA48T1:
+      vlans:
+        - 79
+      vm_offset: 47
+    ARISTA49T1:
+      vlans:
+        - 80
+      vm_offset: 48
+    ARISTA50T1:
+      vlans:
+        - 81
+      vm_offset: 49
+    ARISTA51T1:
+      vlans:
+        - 82
+      vm_offset: 50
+    ARISTA52T1:
+      vlans:
+        - 83
+      vm_offset: 51
+    ARISTA53T1:
+      vlans:
+        - 84
+      vm_offset: 52
+    ARISTA54T1:
+      vlans:
+        - 85
+      vm_offset: 53
+    ARISTA55T1:
+      vlans:
+        - 86
+      vm_offset: 54
+    ARISTA56T1:
+      vlans:
+        - 87
+      vm_offset: 55
+    ARISTA57T1:
+      vlans:
+        - 88
+      vm_offset: 56
+    ARISTA58T1:
+      vlans:
+        - 89
+      vm_offset: 57
+    ARISTA59T1:
+      vlans:
+        - 90
+      vm_offset: 58
+    ARISTA60T1:
+      vlans:
+        - 91
+      vm_offset: 59
+    ARISTA61T1:
+      vlans:
+        - 92
+      vm_offset: 60
+    ARISTA62T1:
+      vlans:
+        - 93
+      vm_offset: 61
+    ARISTA63T1:
+      vlans:
+        - 94
+      vm_offset: 62
+    ARISTA64T1:
+      vlans:
+        - 95
+      vm_offset: 63
+    ARISTA65T1:
+      vlans:
+        - 160
+      vm_offset: 64
+    ARISTA66T1:
+      vlans:
+        - 161
+      vm_offset: 65
+    ARISTA67T1:
+      vlans:
+        - 162
+      vm_offset: 66
+    ARISTA68T1:
+      vlans:
+        - 163
+      vm_offset: 67
+    ARISTA69T1:
+      vlans:
+        - 164
+      vm_offset: 68
+    ARISTA70T1:
+      vlans:
+        - 165
+      vm_offset: 69
+    ARISTA71T1:
+      vlans:
+        - 166
+      vm_offset: 70
+    ARISTA72T1:
+      vlans:
+        - 167
+      vm_offset: 71
+    ARISTA73T1:
+      vlans:
+        - 168
+      vm_offset: 72
+    ARISTA74T1:
+      vlans:
+        - 169
+      vm_offset: 73
+    ARISTA75T1:
+      vlans:
+        - 170
+      vm_offset: 74
+    ARISTA76T1:
+      vlans:
+        - 171
+      vm_offset: 75
+    ARISTA77T1:
+      vlans:
+        - 172
+      vm_offset: 76
+    ARISTA78T1:
+      vlans:
+        - 173
+      vm_offset: 77
+    ARISTA79T1:
+      vlans:
+        - 174
+      vm_offset: 78
+    ARISTA80T1:
+      vlans:
+        - 175
+      vm_offset: 79
+    ARISTA81T1:
+      vlans:
+        - 176
+      vm_offset: 80
+    ARISTA82T1:
+      vlans:
+        - 177
+      vm_offset: 81
+    ARISTA83T1:
+      vlans:
+        - 178
+      vm_offset: 82
+    ARISTA84T1:
+      vlans:
+        - 179
+      vm_offset: 83
+    ARISTA85T1:
+      vlans:
+        - 180
+      vm_offset: 84
+    ARISTA86T1:
+      vlans:
+        - 181
+      vm_offset: 85
+    ARISTA87T1:
+      vlans:
+        - 182
+      vm_offset: 86
+    ARISTA88T1:
+      vlans:
+        - 183
+      vm_offset: 87
+    ARISTA89T1:
+      vlans:
+        - 184
+      vm_offset: 88
+    ARISTA90T1:
+      vlans:
+        - 185
+      vm_offset: 89
+    ARISTA91T1:
+      vlans:
+        - 186
+      vm_offset: 90
+    ARISTA92T1:
+      vlans:
+        - 187
+      vm_offset: 91
+    ARISTA93T1:
+      vlans:
+        - 188
+      vm_offset: 92
+    ARISTA94T1:
+      vlans:
+        - 189
+      vm_offset: 93
+    ARISTA95T1:
+      vlans:
+        - 190
+      vm_offset: 94
+    ARISTA96T1:
+      vlans:
+        - 191
+      vm_offset: 95
+    ARISTA97T1:
+      vlans:
+        - 192
+      vm_offset: 96
+    ARISTA98T1:
+      vlans:
+        - 193
+      vm_offset: 97
+    ARISTA99T1:
+      vlans:
+        - 194
+      vm_offset: 98
+    ARISTA100T1:
+      vlans:
+        - 195
+      vm_offset: 99
+    ARISTA101T1:
+      vlans:
+        - 196
+      vm_offset: 100
+    ARISTA102T1:
+      vlans:
+        - 197
+      vm_offset: 101
+    ARISTA103T1:
+      vlans:
+        - 198
+      vm_offset: 102
+    ARISTA104T1:
+      vlans:
+        - 199
+      vm_offset: 103
+    ARISTA105T1:
+      vlans:
+        - 200
+      vm_offset: 104
+    ARISTA106T1:
+      vlans:
+        - 201
+      vm_offset: 105
+    ARISTA107T1:
+      vlans:
+        - 202
+      vm_offset: 106
+    ARISTA108T1:
+      vlans:
+        - 203
+      vm_offset: 107
+    ARISTA109T1:
+      vlans:
+        - 204
+      vm_offset: 108
+    ARISTA110T1:
+      vlans:
+        - 205
+      vm_offset: 109
+    ARISTA111T1:
+      vlans:
+        - 206
+      vm_offset: 110
+    ARISTA112T1:
+      vlans:
+        - 207
+      vm_offset: 111
+    ARISTA113T1:
+      vlans:
+        - 208
+      vm_offset: 112
+    ARISTA114T1:
+      vlans:
+        - 209
+      vm_offset: 113
+    ARISTA115T1:
+      vlans:
+        - 210
+      vm_offset: 114
+    ARISTA116T1:
+      vlans:
+        - 211
+      vm_offset: 115
+    ARISTA117T1:
+      vlans:
+        - 212
+      vm_offset: 116
+    ARISTA118T1:
+      vlans:
+        - 213
+      vm_offset: 117
+    ARISTA119T1:
+      vlans:
+        - 214
+      vm_offset: 118
+    ARISTA120T1:
+      vlans:
+        - 215
+      vm_offset: 119
+    ARISTA121T1:
+      vlans:
+        - 216
+      vm_offset: 120
+    ARISTA122T1:
+      vlans:
+        - 217
+      vm_offset: 121
+    ARISTA123T1:
+      vlans:
+        - 218
+      vm_offset: 122
+    ARISTA124T1:
+      vlans:
+        - 219
+      vm_offset: 123
+    ARISTA125T1:
+      vlans:
+        - 220
+      vm_offset: 124
+    ARISTA126T1:
+      vlans:
+        - 221
+      vm_offset: 125
+    ARISTA127T1:
+      vlans:
+        - 222
+      vm_offset: 126
+    ARISTA128T1:
+      vlans:
+        - 223
+      vm_offset: 127
+    ARISTA129T1:
+      vlans:
+        - 256
+      vm_offset: 128
+    ARISTA130T1:
+      vlans:
+        - 257
+      vm_offset: 129
+  DUT:
+    vlan_configs:
+      default_vlan_config: one_vlan_a
+      one_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257]
+          prefix: 192.168.0.1/21
+          prefix_v6: fc02:1000::1/64
+          tag: 1000
+      two_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
+          prefix: 192.168.0.1/22
+          prefix_v6: fc02:400::1/64
+          tag: 1000
+        Vlan1100:
+          id: 1100
+          intfs: [128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255]
+          prefix: 192.168.4.1/22
+          prefix_v6: fc02:401::1/64
+          tag: 1100
+      four_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
+          prefix: 192.168.0.1/24
+          prefix_v6: fc02:400::1/64
+          tag: 1000
+        Vlan1100:
+          id: 1100
+          intfs: [64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
+          prefix: 192.168.1.1/24
+          prefix_v6: fc02:401::1/64
+          tag: 1100
+        Vlan1200:
+          id: 1200
+          intfs: [128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191]
+          prefix: 192.168.2.1/24
+          prefix_v6: fc02:402::1/64
+          tag: 1200
+        Vlan1300:
+          id: 1300
+          intfs: [192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255]
+          prefix: 192.168.3.1/24
+          prefix_v6: fc02:403::1/64
+          tag: 1300
+      hexa_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+          prefix: 192.168.0.1/24
+          prefix_v6: fc02:400::1/64
+          tag: 1000
+        Vlan1100:
+          id: 1100
+          intfs: [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+          prefix: 192.168.1.1/24
+          prefix_v6: fc02:401::1/64
+          tag: 1100
+        Vlan1200:
+          id: 1200
+          intfs: [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47]
+          prefix: 192.168.2.1/24
+          prefix_v6: fc02:402::1/64
+          tag: 1200
+        Vlan1300:
+          id: 1300
+          intfs: [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
+          prefix: 192.168.3.1/24
+          prefix_v6: fc02:403::1/64
+          tag: 1300
+        Vlan1400:
+          id: 1400
+          intfs: [64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79]
+          prefix: 192.168.4.1/24
+          prefix_v6: fc02:404::1/64
+          tag: 1400
+        Vlan1500:
+          id: 1500
+          intfs: [80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95]
+          prefix: 192.168.5.1/24
+          prefix_v6: fc02:405::1/64
+          tag: 1500
+        Vlan1600:
+          id: 1600
+          intfs: [96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111]
+          prefix: 192.168.6.1/24
+          prefix_v6: fc02:406::1/64
+          tag: 1600
+        Vlan1700:
+          id: 1700
+          intfs: [112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
+          prefix: 192.168.7.1/24
+          prefix_v6: fc02:407::1/64
+          tag: 1700
+        Vlan1800:
+          id: 1800
+          intfs: [128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143]
+          prefix: 192.168.8.1/24
+          prefix_v6: fc02:408::1/64
+          tag: 1800
+        Vlan1900:
+          id: 1900
+          intfs: [144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159]
+          prefix: 192.168.9.1/24
+          prefix_v6: fc02:409::1/64
+          tag: 1900
+        Vlan2000:
+          id: 2000
+          intfs: [160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175]
+          prefix: 192.168.10.1/24
+          prefix_v6: fc02:410::1/64
+          tag: 2000
+        Vlan2100:
+          id: 2100
+          intfs: [176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191]
+          prefix: 192.168.11.1/24
+          prefix_v6: fc02:411::1/64
+          tag: 2100
+        Vlan2200:
+          id: 2200
+          intfs: [192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207]
+          prefix: 192.168.12.1/24
+          prefix_v6: fc02:412::1/64
+          tag: 2200
+        Vlan2300:
+          id: 2300
+          intfs: [208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223]
+          prefix: 192.168.13.1/24
+          prefix_v6: fc02:413::1/64
+          tag: 2300
+        Vlan2400:
+          id: 2400
+          intfs: [224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239]
+          prefix: 192.168.14.1/24
+          prefix_v6: fc02:414::1/64
+          tag: 2400
+        Vlan2500:
+          id: 2500
+          intfs: [240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255]
+          prefix: 192.168.15.1/24
+          prefix_v6: fc02:415::1/64
+          tag: 2500
+
+configuration_properties:
+  common:
+    dut_asn: 64601
+    dut_type: ToRRouter
+    swrole: leaf
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
+    spine_asn: 65534
+    leaf_asn_start: 64802
+    tor_asn_start: 64601
+    failure_rate: 0
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+
+configuration:
+    ARISTA01T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.64
+            - fc00::81
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.33/32
+           ipv6: 2064:100::21/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.65/31
+           ipv6: fc00::82/126
+       bp_interfaces:
+         ipv4: 10.10.246.2/24
+         ipv6: fc0a::2/64
+    ARISTA02T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.66
+            - fc00::85
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.34/32
+           ipv6: 2064:100::22/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.67/31
+           ipv6: fc00::86/126
+       bp_interfaces:
+         ipv4: 10.10.246.3/24
+         ipv6: fc0a::3/64
+    ARISTA03T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.68
+            - fc00::89
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.35/32
+           ipv6: 2064:100::23/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.69/31
+           ipv6: fc00::8a/126
+       bp_interfaces:
+         ipv4: 10.10.246.4/24
+         ipv6: fc0a::4/64
+    ARISTA04T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.70
+            - fc00::8d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.36/32
+           ipv6: 2064:100::24/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.71/31
+           ipv6: fc00::8e/126
+       bp_interfaces:
+         ipv4: 10.10.246.5/24
+         ipv6: fc0a::5/64
+    ARISTA05T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.72
+            - fc00::91
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.37/32
+           ipv6: 2064:100::25/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.73/31
+           ipv6: fc00::92/126
+       bp_interfaces:
+         ipv4: 10.10.246.6/24
+         ipv6: fc0a::6/64
+    ARISTA06T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.74
+            - fc00::95
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.38/32
+           ipv6: 2064:100::26/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.75/31
+           ipv6: fc00::96/126
+       bp_interfaces:
+         ipv4: 10.10.246.7/24
+         ipv6: fc0a::7/64
+    ARISTA07T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.76
+            - fc00::99
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.39/32
+           ipv6: 2064:100::27/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.77/31
+           ipv6: fc00::9a/126
+       bp_interfaces:
+         ipv4: 10.10.246.8/24
+         ipv6: fc0a::8/64
+    ARISTA08T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.78
+            - fc00::9d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.40/32
+           ipv6: 2064:100::28/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.79/31
+           ipv6: fc00::9e/126
+       bp_interfaces:
+         ipv4: 10.10.246.9/24
+         ipv6: fc0a::9/64
+    ARISTA09T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.80
+            - fc00::a1
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.41/32
+           ipv6: 2064:100::29/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.81/31
+           ipv6: fc00::a2/126
+       bp_interfaces:
+         ipv4: 10.10.246.10/24
+         ipv6: fc0a::a/64
+    ARISTA10T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.82
+            - fc00::a5
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.42/32
+           ipv6: 2064:100::2a/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.83/31
+           ipv6: fc00::a6/126
+       bp_interfaces:
+         ipv4: 10.10.246.11/24
+         ipv6: fc0a::b/64
+    ARISTA11T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.84
+            - fc00::a9
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.43/32
+           ipv6: 2064:100::2b/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.85/31
+           ipv6: fc00::aa/126
+       bp_interfaces:
+         ipv4: 10.10.246.12/24
+         ipv6: fc0a::c/64
+    ARISTA12T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.86
+            - fc00::ad
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.44/32
+           ipv6: 2064:100::2c/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.87/31
+           ipv6: fc00::ae/126
+       bp_interfaces:
+         ipv4: 10.10.246.13/24
+         ipv6: fc0a::d/64
+    ARISTA13T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.88
+            - fc00::b1
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.45/32
+           ipv6: 2064:100::2d/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.89/31
+           ipv6: fc00::b2/126
+       bp_interfaces:
+         ipv4: 10.10.246.14/24
+         ipv6: fc0a::e/64
+    ARISTA14T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.90
+            - fc00::b5
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.46/32
+           ipv6: 2064:100::2e/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.91/31
+           ipv6: fc00::b6/126
+       bp_interfaces:
+         ipv4: 10.10.246.15/24
+         ipv6: fc0a::f/64
+    ARISTA15T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.92
+            - fc00::b9
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.47/32
+           ipv6: 2064:100::2f/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.93/31
+           ipv6: fc00::ba/126
+       bp_interfaces:
+         ipv4: 10.10.246.16/24
+         ipv6: fc0a::10/64
+    ARISTA16T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.94
+            - fc00::bd
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.48/32
+           ipv6: 2064:100::30/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.95/31
+           ipv6: fc00::be/126
+       bp_interfaces:
+         ipv4: 10.10.246.17/24
+         ipv6: fc0a::11/64
+    ARISTA17T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.96
+            - fc00::c1
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.49/32
+           ipv6: 2064:100::31/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.97/31
+           ipv6: fc00::c2/126
+       bp_interfaces:
+         ipv4: 10.10.246.18/24
+         ipv6: fc0a::12/64
+    ARISTA18T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.98
+            - fc00::c5
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.50/32
+           ipv6: 2064:100::32/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.99/31
+           ipv6: fc00::c6/126
+       bp_interfaces:
+         ipv4: 10.10.246.19/24
+         ipv6: fc0a::13/64
+    ARISTA19T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.100
+            - fc00::c9
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.51/32
+           ipv6: 2064:100::33/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.101/31
+           ipv6: fc00::ca/126
+       bp_interfaces:
+         ipv4: 10.10.246.20/24
+         ipv6: fc0a::14/64
+    ARISTA20T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.102
+            - fc00::cd
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.52/32
+           ipv6: 2064:100::34/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.103/31
+           ipv6: fc00::ce/126
+       bp_interfaces:
+         ipv4: 10.10.246.21/24
+         ipv6: fc0a::15/64
+    ARISTA21T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.104
+            - fc00::d1
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.53/32
+           ipv6: 2064:100::35/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.105/31
+           ipv6: fc00::d2/126
+       bp_interfaces:
+         ipv4: 10.10.246.22/24
+         ipv6: fc0a::16/64
+    ARISTA22T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.106
+            - fc00::d5
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.54/32
+           ipv6: 2064:100::36/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.107/31
+           ipv6: fc00::d6/126
+       bp_interfaces:
+         ipv4: 10.10.246.23/24
+         ipv6: fc0a::17/64
+    ARISTA23T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.108
+            - fc00::d9
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.55/32
+           ipv6: 2064:100::37/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.109/31
+           ipv6: fc00::da/126
+       bp_interfaces:
+         ipv4: 10.10.246.24/24
+         ipv6: fc0a::18/64
+    ARISTA24T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.110
+            - fc00::dd
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.56/32
+           ipv6: 2064:100::38/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.111/31
+           ipv6: fc00::de/126
+       bp_interfaces:
+         ipv4: 10.10.246.25/24
+         ipv6: fc0a::19/64
+    ARISTA25T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.112
+            - fc00::e1
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.57/32
+           ipv6: 2064:100::39/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.113/31
+           ipv6: fc00::e2/126
+       bp_interfaces:
+         ipv4: 10.10.246.26/24
+         ipv6: fc0a::1a/64
+    ARISTA26T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.114
+            - fc00::e5
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.58/32
+           ipv6: 2064:100::3a/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.115/31
+           ipv6: fc00::e6/126
+       bp_interfaces:
+         ipv4: 10.10.246.27/24
+         ipv6: fc0a::1b/64
+    ARISTA27T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.116
+            - fc00::e9
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.59/32
+           ipv6: 2064:100::3b/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.117/31
+           ipv6: fc00::ea/126
+       bp_interfaces:
+         ipv4: 10.10.246.28/24
+         ipv6: fc0a::1c/64
+    ARISTA28T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.118
+            - fc00::ed
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.60/32
+           ipv6: 2064:100::3c/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.119/31
+           ipv6: fc00::ee/126
+       bp_interfaces:
+         ipv4: 10.10.246.29/24
+         ipv6: fc0a::1d/64
+    ARISTA29T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.120
+            - fc00::f1
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.61/32
+           ipv6: 2064:100::3d/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.121/31
+           ipv6: fc00::f2/126
+       bp_interfaces:
+         ipv4: 10.10.246.30/24
+         ipv6: fc0a::1e/64
+    ARISTA30T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.122
+            - fc00::f5
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.62/32
+           ipv6: 2064:100::3e/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.123/31
+           ipv6: fc00::f6/126
+       bp_interfaces:
+         ipv4: 10.10.246.31/24
+         ipv6: fc0a::1f/64
+    ARISTA31T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.124
+            - fc00::f9
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.63/32
+           ipv6: 2064:100::3f/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.125/31
+           ipv6: fc00::fa/126
+       bp_interfaces:
+         ipv4: 10.10.246.32/24
+         ipv6: fc0a::20/64
+    ARISTA32T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.126
+            - fc00::fd
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.64/32
+           ipv6: 2064:100::40/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.127/31
+           ipv6: fc00::fe/126
+       bp_interfaces:
+         ipv4: 10.10.246.33/24
+         ipv6: fc0a::21/64
+    ARISTA33T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.128
+            - fc00::101
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.65/32
+           ipv6: 2064:100::41/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.129/31
+           ipv6: fc00::102/126
+       bp_interfaces:
+         ipv4: 10.10.246.34/24
+         ipv6: fc0a::22/64
+    ARISTA34T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.130
+            - fc00::105
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.66/32
+           ipv6: 2064:100::42/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.131/31
+           ipv6: fc00::106/126
+       bp_interfaces:
+         ipv4: 10.10.246.35/24
+         ipv6: fc0a::23/64
+    ARISTA35T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.132
+            - fc00::109
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.67/32
+           ipv6: 2064:100::43/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.133/31
+           ipv6: fc00::10a/126
+       bp_interfaces:
+         ipv4: 10.10.246.36/24
+         ipv6: fc0a::24/64
+    ARISTA36T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.134
+            - fc00::10d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.68/32
+           ipv6: 2064:100::44/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.135/31
+           ipv6: fc00::10e/126
+       bp_interfaces:
+         ipv4: 10.10.246.37/24
+         ipv6: fc0a::25/64
+    ARISTA37T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.136
+            - fc00::111
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.69/32
+           ipv6: 2064:100::45/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.137/31
+           ipv6: fc00::112/126
+       bp_interfaces:
+         ipv4: 10.10.246.38/24
+         ipv6: fc0a::26/64
+    ARISTA38T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.138
+            - fc00::115
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.70/32
+           ipv6: 2064:100::46/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.139/31
+           ipv6: fc00::116/126
+       bp_interfaces:
+         ipv4: 10.10.246.39/24
+         ipv6: fc0a::27/64
+    ARISTA39T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.140
+            - fc00::119
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.71/32
+           ipv6: 2064:100::47/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.141/31
+           ipv6: fc00::11a/126
+       bp_interfaces:
+         ipv4: 10.10.246.40/24
+         ipv6: fc0a::28/64
+    ARISTA40T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.142
+            - fc00::11d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.72/32
+           ipv6: 2064:100::48/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.143/31
+           ipv6: fc00::11e/126
+       bp_interfaces:
+         ipv4: 10.10.246.41/24
+         ipv6: fc0a::29/64
+    ARISTA41T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.144
+            - fc00::121
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.73/32
+           ipv6: 2064:100::49/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.145/31
+           ipv6: fc00::122/126
+       bp_interfaces:
+         ipv4: 10.10.246.42/24
+         ipv6: fc0a::2a/64
+    ARISTA42T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.146
+            - fc00::125
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.74/32
+           ipv6: 2064:100::4a/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.147/31
+           ipv6: fc00::126/126
+       bp_interfaces:
+         ipv4: 10.10.246.43/24
+         ipv6: fc0a::2b/64
+    ARISTA43T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.148
+            - fc00::129
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.75/32
+           ipv6: 2064:100::4b/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.149/31
+           ipv6: fc00::12a/126
+       bp_interfaces:
+         ipv4: 10.10.246.44/24
+         ipv6: fc0a::2c/64
+    ARISTA44T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.150
+            - fc00::12d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.76/32
+           ipv6: 2064:100::4c/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.151/31
+           ipv6: fc00::12e/126
+       bp_interfaces:
+         ipv4: 10.10.246.45/24
+         ipv6: fc0a::2d/64
+    ARISTA45T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.152
+            - fc00::131
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.77/32
+           ipv6: 2064:100::4d/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.153/31
+           ipv6: fc00::132/126
+       bp_interfaces:
+         ipv4: 10.10.246.46/24
+         ipv6: fc0a::2e/64
+    ARISTA46T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.154
+            - fc00::135
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.78/32
+           ipv6: 2064:100::4e/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.155/31
+           ipv6: fc00::136/126
+       bp_interfaces:
+         ipv4: 10.10.246.47/24
+         ipv6: fc0a::2f/64
+    ARISTA47T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.156
+            - fc00::139
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.79/32
+           ipv6: 2064:100::4f/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.157/31
+           ipv6: fc00::13a/126
+       bp_interfaces:
+         ipv4: 10.10.246.48/24
+         ipv6: fc0a::30/64
+    ARISTA48T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.158
+            - fc00::13d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.80/32
+           ipv6: 2064:100::50/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.159/31
+           ipv6: fc00::13e/126
+       bp_interfaces:
+         ipv4: 10.10.246.49/24
+         ipv6: fc0a::31/64
+    ARISTA49T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.160
+            - fc00::141
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.81/32
+           ipv6: 2064:100::51/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.161/31
+           ipv6: fc00::142/126
+       bp_interfaces:
+         ipv4: 10.10.246.50/24
+         ipv6: fc0a::32/64
+    ARISTA50T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.162
+            - fc00::145
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.82/32
+           ipv6: 2064:100::52/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.163/31
+           ipv6: fc00::146/126
+       bp_interfaces:
+         ipv4: 10.10.246.51/24
+         ipv6: fc0a::33/64
+    ARISTA51T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.164
+            - fc00::149
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.83/32
+           ipv6: 2064:100::53/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.165/31
+           ipv6: fc00::14a/126
+       bp_interfaces:
+         ipv4: 10.10.246.52/24
+         ipv6: fc0a::34/64
+    ARISTA52T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.166
+            - fc00::14d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.84/32
+           ipv6: 2064:100::54/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.167/31
+           ipv6: fc00::14e/126
+       bp_interfaces:
+         ipv4: 10.10.246.53/24
+         ipv6: fc0a::35/64
+    ARISTA53T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.168
+            - fc00::151
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.85/32
+           ipv6: 2064:100::55/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.169/31
+           ipv6: fc00::152/126
+       bp_interfaces:
+         ipv4: 10.10.246.54/24
+         ipv6: fc0a::36/64
+    ARISTA54T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.170
+            - fc00::155
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.86/32
+           ipv6: 2064:100::56/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.171/31
+           ipv6: fc00::156/126
+       bp_interfaces:
+         ipv4: 10.10.246.55/24
+         ipv6: fc0a::37/64
+    ARISTA55T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.172
+            - fc00::159
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.87/32
+           ipv6: 2064:100::57/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.173/31
+           ipv6: fc00::15a/126
+       bp_interfaces:
+         ipv4: 10.10.246.56/24
+         ipv6: fc0a::38/64
+    ARISTA56T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.174
+            - fc00::15d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.88/32
+           ipv6: 2064:100::58/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.175/31
+           ipv6: fc00::15e/126
+       bp_interfaces:
+         ipv4: 10.10.246.57/24
+         ipv6: fc0a::39/64
+    ARISTA57T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.176
+            - fc00::161
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.89/32
+           ipv6: 2064:100::59/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.177/31
+           ipv6: fc00::162/126
+       bp_interfaces:
+         ipv4: 10.10.246.58/24
+         ipv6: fc0a::3a/64
+    ARISTA58T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.178
+            - fc00::165
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.90/32
+           ipv6: 2064:100::5a/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.179/31
+           ipv6: fc00::166/126
+       bp_interfaces:
+         ipv4: 10.10.246.59/24
+         ipv6: fc0a::3b/64
+    ARISTA59T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.180
+            - fc00::169
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.91/32
+           ipv6: 2064:100::5b/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.181/31
+           ipv6: fc00::16a/126
+       bp_interfaces:
+         ipv4: 10.10.246.60/24
+         ipv6: fc0a::3c/64
+    ARISTA60T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.182
+            - fc00::16d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.92/32
+           ipv6: 2064:100::5c/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.183/31
+           ipv6: fc00::16e/126
+       bp_interfaces:
+         ipv4: 10.10.246.61/24
+         ipv6: fc0a::3d/64
+    ARISTA61T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.184
+            - fc00::171
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.93/32
+           ipv6: 2064:100::5d/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.185/31
+           ipv6: fc00::172/126
+       bp_interfaces:
+         ipv4: 10.10.246.62/24
+         ipv6: fc0a::3e/64
+    ARISTA62T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.186
+            - fc00::175
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.94/32
+           ipv6: 2064:100::5e/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.187/31
+           ipv6: fc00::176/126
+       bp_interfaces:
+         ipv4: 10.10.246.63/24
+         ipv6: fc0a::3f/64
+    ARISTA63T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.188
+            - fc00::179
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.95/32
+           ipv6: 2064:100::5f/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.189/31
+           ipv6: fc00::17a/126
+       bp_interfaces:
+         ipv4: 10.10.246.64/24
+         ipv6: fc0a::40/64
+    ARISTA64T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.0.190
+            - fc00::17d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.96/32
+           ipv6: 2064:100::60/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.0.191/31
+           ipv6: fc00::17e/126
+       bp_interfaces:
+         ipv4: 10.10.246.65/24
+         ipv6: fc0a::41/64
+    ARISTA65T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.64
+            - fc00::281
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.161/32
+           ipv6: 2064:100::a1/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.65/31
+           ipv6: fc00::282/126
+       bp_interfaces:
+         ipv4: 10.10.246.66/24
+         ipv6: fc0a::42/64
+    ARISTA66T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.66
+            - fc00::285
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.162/32
+           ipv6: 2064:100::a2/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.67/31
+           ipv6: fc00::286/126
+       bp_interfaces:
+         ipv4: 10.10.246.67/24
+         ipv6: fc0a::43/64
+    ARISTA67T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.68
+            - fc00::289
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.163/32
+           ipv6: 2064:100::a3/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.69/31
+           ipv6: fc00::28a/126
+       bp_interfaces:
+         ipv4: 10.10.246.68/24
+         ipv6: fc0a::44/64
+    ARISTA68T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.70
+            - fc00::28d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.164/32
+           ipv6: 2064:100::a4/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.71/31
+           ipv6: fc00::28e/126
+       bp_interfaces:
+         ipv4: 10.10.246.69/24
+         ipv6: fc0a::45/64
+    ARISTA69T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.72
+            - fc00::291
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.165/32
+           ipv6: 2064:100::a5/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.73/31
+           ipv6: fc00::292/126
+       bp_interfaces:
+         ipv4: 10.10.246.70/24
+         ipv6: fc0a::46/64
+    ARISTA70T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.74
+            - fc00::295
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.166/32
+           ipv6: 2064:100::a6/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.75/31
+           ipv6: fc00::296/126
+       bp_interfaces:
+         ipv4: 10.10.246.71/24
+         ipv6: fc0a::47/64
+    ARISTA71T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.76
+            - fc00::299
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.167/32
+           ipv6: 2064:100::a7/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.77/31
+           ipv6: fc00::29a/126
+       bp_interfaces:
+         ipv4: 10.10.246.72/24
+         ipv6: fc0a::48/64
+    ARISTA72T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.78
+            - fc00::29d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.168/32
+           ipv6: 2064:100::a8/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.79/31
+           ipv6: fc00::29e/126
+       bp_interfaces:
+         ipv4: 10.10.246.73/24
+         ipv6: fc0a::49/64
+    ARISTA73T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.80
+            - fc00::2a1
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.169/32
+           ipv6: 2064:100::a9/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.81/31
+           ipv6: fc00::2a2/126
+       bp_interfaces:
+         ipv4: 10.10.246.74/24
+         ipv6: fc0a::4a/64
+    ARISTA74T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.82
+            - fc00::2a5
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.170/32
+           ipv6: 2064:100::aa/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.83/31
+           ipv6: fc00::2a6/126
+       bp_interfaces:
+         ipv4: 10.10.246.75/24
+         ipv6: fc0a::4b/64
+    ARISTA75T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.84
+            - fc00::2a9
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.171/32
+           ipv6: 2064:100::ab/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.85/31
+           ipv6: fc00::2aa/126
+       bp_interfaces:
+         ipv4: 10.10.246.76/24
+         ipv6: fc0a::4c/64
+    ARISTA76T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.86
+            - fc00::2ad
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.172/32
+           ipv6: 2064:100::ac/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.87/31
+           ipv6: fc00::2ae/126
+       bp_interfaces:
+         ipv4: 10.10.246.77/24
+         ipv6: fc0a::4d/64
+    ARISTA77T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.88
+            - fc00::2b1
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.173/32
+           ipv6: 2064:100::ad/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.89/31
+           ipv6: fc00::2b2/126
+       bp_interfaces:
+         ipv4: 10.10.246.78/24
+         ipv6: fc0a::4e/64
+    ARISTA78T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.90
+            - fc00::2b5
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.174/32
+           ipv6: 2064:100::ae/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.91/31
+           ipv6: fc00::2b6/126
+       bp_interfaces:
+         ipv4: 10.10.246.79/24
+         ipv6: fc0a::4f/64
+    ARISTA79T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.92
+            - fc00::2b9
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.175/32
+           ipv6: 2064:100::af/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.93/31
+           ipv6: fc00::2ba/126
+       bp_interfaces:
+         ipv4: 10.10.246.80/24
+         ipv6: fc0a::50/64
+    ARISTA80T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.94
+            - fc00::2bd
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.176/32
+           ipv6: 2064:100::b0/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.95/31
+           ipv6: fc00::2be/126
+       bp_interfaces:
+         ipv4: 10.10.246.81/24
+         ipv6: fc0a::51/64
+    ARISTA81T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.96
+            - fc00::2c1
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.177/32
+           ipv6: 2064:100::b1/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.97/31
+           ipv6: fc00::2c2/126
+       bp_interfaces:
+         ipv4: 10.10.246.82/24
+         ipv6: fc0a::52/64
+    ARISTA82T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.98
+            - fc00::2c5
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.178/32
+           ipv6: 2064:100::b2/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.99/31
+           ipv6: fc00::2c6/126
+       bp_interfaces:
+         ipv4: 10.10.246.83/24
+         ipv6: fc0a::53/64
+    ARISTA83T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.100
+            - fc00::2c9
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.179/32
+           ipv6: 2064:100::b3/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.101/31
+           ipv6: fc00::2ca/126
+       bp_interfaces:
+         ipv4: 10.10.246.84/24
+         ipv6: fc0a::54/64
+    ARISTA84T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.102
+            - fc00::2cd
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.180/32
+           ipv6: 2064:100::b4/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.103/31
+           ipv6: fc00::2ce/126
+       bp_interfaces:
+         ipv4: 10.10.246.85/24
+         ipv6: fc0a::55/64
+    ARISTA85T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.104
+            - fc00::2d1
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.181/32
+           ipv6: 2064:100::b5/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.105/31
+           ipv6: fc00::2d2/126
+       bp_interfaces:
+         ipv4: 10.10.246.86/24
+         ipv6: fc0a::56/64
+    ARISTA86T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.106
+            - fc00::2d5
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.182/32
+           ipv6: 2064:100::b6/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.107/31
+           ipv6: fc00::2d6/126
+       bp_interfaces:
+         ipv4: 10.10.246.87/24
+         ipv6: fc0a::57/64
+    ARISTA87T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.108
+            - fc00::2d9
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.183/32
+           ipv6: 2064:100::b7/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.109/31
+           ipv6: fc00::2da/126
+       bp_interfaces:
+         ipv4: 10.10.246.88/24
+         ipv6: fc0a::58/64
+    ARISTA88T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.110
+            - fc00::2dd
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.184/32
+           ipv6: 2064:100::b8/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.111/31
+           ipv6: fc00::2de/126
+       bp_interfaces:
+         ipv4: 10.10.246.89/24
+         ipv6: fc0a::59/64
+    ARISTA89T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.112
+            - fc00::2e1
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.185/32
+           ipv6: 2064:100::b9/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.113/31
+           ipv6: fc00::2e2/126
+       bp_interfaces:
+         ipv4: 10.10.246.90/24
+         ipv6: fc0a::5a/64
+    ARISTA90T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.114
+            - fc00::2e5
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.186/32
+           ipv6: 2064:100::ba/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.115/31
+           ipv6: fc00::2e6/126
+       bp_interfaces:
+         ipv4: 10.10.246.91/24
+         ipv6: fc0a::5b/64
+    ARISTA91T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.116
+            - fc00::2e9
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.187/32
+           ipv6: 2064:100::bb/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.117/31
+           ipv6: fc00::2ea/126
+       bp_interfaces:
+         ipv4: 10.10.246.92/24
+         ipv6: fc0a::5c/64
+    ARISTA92T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.118
+            - fc00::2ed
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.188/32
+           ipv6: 2064:100::bc/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.119/31
+           ipv6: fc00::2ee/126
+       bp_interfaces:
+         ipv4: 10.10.246.93/24
+         ipv6: fc0a::5d/64
+    ARISTA93T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.120
+            - fc00::2f1
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.189/32
+           ipv6: 2064:100::bd/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.121/31
+           ipv6: fc00::2f2/126
+       bp_interfaces:
+         ipv4: 10.10.246.94/24
+         ipv6: fc0a::5e/64
+    ARISTA94T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.122
+            - fc00::2f5
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.190/32
+           ipv6: 2064:100::be/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.123/31
+           ipv6: fc00::2f6/126
+       bp_interfaces:
+         ipv4: 10.10.246.95/24
+         ipv6: fc0a::5f/64
+    ARISTA95T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.124
+            - fc00::2f9
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.191/32
+           ipv6: 2064:100::bf/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.125/31
+           ipv6: fc00::2fa/126
+       bp_interfaces:
+         ipv4: 10.10.246.96/24
+         ipv6: fc0a::60/64
+    ARISTA96T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.126
+            - fc00::2fd
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.192/32
+           ipv6: 2064:100::c0/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.127/31
+           ipv6: fc00::2fe/126
+       bp_interfaces:
+         ipv4: 10.10.246.97/24
+         ipv6: fc0a::61/64
+    ARISTA97T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.128
+            - fc00::301
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.193/32
+           ipv6: 2064:100::c1/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.129/31
+           ipv6: fc00::302/126
+       bp_interfaces:
+         ipv4: 10.10.246.98/24
+         ipv6: fc0a::62/64
+    ARISTA98T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.130
+            - fc00::305
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.194/32
+           ipv6: 2064:100::c2/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.131/31
+           ipv6: fc00::306/126
+       bp_interfaces:
+         ipv4: 10.10.246.99/24
+         ipv6: fc0a::63/64
+    ARISTA99T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.132
+            - fc00::309
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.195/32
+           ipv6: 2064:100::c3/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.133/31
+           ipv6: fc00::30a/126
+       bp_interfaces:
+         ipv4: 10.10.246.100/24
+         ipv6: fc0a::64/64
+    ARISTA100T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.134
+            - fc00::30d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.196/32
+           ipv6: 2064:100::c4/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.135/31
+           ipv6: fc00::30e/126
+       bp_interfaces:
+         ipv4: 10.10.246.101/24
+         ipv6: fc0a::65/64
+    ARISTA101T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.136
+            - fc00::311
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.197/32
+           ipv6: 2064:100::c5/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.137/31
+           ipv6: fc00::312/126
+       bp_interfaces:
+         ipv4: 10.10.246.102/24
+         ipv6: fc0a::66/64
+    ARISTA102T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.138
+            - fc00::315
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.198/32
+           ipv6: 2064:100::c6/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.139/31
+           ipv6: fc00::316/126
+       bp_interfaces:
+         ipv4: 10.10.246.103/24
+         ipv6: fc0a::67/64
+    ARISTA103T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.140
+            - fc00::319
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.199/32
+           ipv6: 2064:100::c7/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.141/31
+           ipv6: fc00::31a/126
+       bp_interfaces:
+         ipv4: 10.10.246.104/24
+         ipv6: fc0a::68/64
+    ARISTA104T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.142
+            - fc00::31d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.200/32
+           ipv6: 2064:100::c8/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.143/31
+           ipv6: fc00::31e/126
+       bp_interfaces:
+         ipv4: 10.10.246.105/24
+         ipv6: fc0a::69/64
+    ARISTA105T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.144
+            - fc00::321
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.201/32
+           ipv6: 2064:100::c9/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.145/31
+           ipv6: fc00::322/126
+       bp_interfaces:
+         ipv4: 10.10.246.106/24
+         ipv6: fc0a::6a/64
+    ARISTA106T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.146
+            - fc00::325
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.202/32
+           ipv6: 2064:100::ca/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.147/31
+           ipv6: fc00::326/126
+       bp_interfaces:
+         ipv4: 10.10.246.107/24
+         ipv6: fc0a::6b/64
+    ARISTA107T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.148
+            - fc00::329
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.203/32
+           ipv6: 2064:100::cb/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.149/31
+           ipv6: fc00::32a/126
+       bp_interfaces:
+         ipv4: 10.10.246.108/24
+         ipv6: fc0a::6c/64
+    ARISTA108T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.150
+            - fc00::32d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.204/32
+           ipv6: 2064:100::cc/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.151/31
+           ipv6: fc00::32e/126
+       bp_interfaces:
+         ipv4: 10.10.246.109/24
+         ipv6: fc0a::6d/64
+    ARISTA109T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.152
+            - fc00::331
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.205/32
+           ipv6: 2064:100::cd/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.153/31
+           ipv6: fc00::332/126
+       bp_interfaces:
+         ipv4: 10.10.246.110/24
+         ipv6: fc0a::6e/64
+    ARISTA110T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.154
+            - fc00::335
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.206/32
+           ipv6: 2064:100::ce/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.155/31
+           ipv6: fc00::336/126
+       bp_interfaces:
+         ipv4: 10.10.246.111/24
+         ipv6: fc0a::6f/64
+    ARISTA111T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.156
+            - fc00::339
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.207/32
+           ipv6: 2064:100::cf/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.157/31
+           ipv6: fc00::33a/126
+       bp_interfaces:
+         ipv4: 10.10.246.112/24
+         ipv6: fc0a::70/64
+    ARISTA112T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.158
+            - fc00::33d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.208/32
+           ipv6: 2064:100::d0/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.159/31
+           ipv6: fc00::33e/126
+       bp_interfaces:
+         ipv4: 10.10.246.113/24
+         ipv6: fc0a::71/64
+    ARISTA113T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.160
+            - fc00::341
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.209/32
+           ipv6: 2064:100::d1/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.161/31
+           ipv6: fc00::342/126
+       bp_interfaces:
+         ipv4: 10.10.246.114/24
+         ipv6: fc0a::72/64
+    ARISTA114T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.162
+            - fc00::345
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.210/32
+           ipv6: 2064:100::d2/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.163/31
+           ipv6: fc00::346/126
+       bp_interfaces:
+         ipv4: 10.10.246.115/24
+         ipv6: fc0a::73/64
+    ARISTA115T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.164
+            - fc00::349
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.211/32
+           ipv6: 2064:100::d3/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.165/31
+           ipv6: fc00::34a/126
+       bp_interfaces:
+         ipv4: 10.10.246.116/24
+         ipv6: fc0a::74/64
+    ARISTA116T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.166
+            - fc00::34d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.212/32
+           ipv6: 2064:100::d4/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.167/31
+           ipv6: fc00::34e/126
+       bp_interfaces:
+         ipv4: 10.10.246.117/24
+         ipv6: fc0a::75/64
+    ARISTA117T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.168
+            - fc00::351
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.213/32
+           ipv6: 2064:100::d5/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.169/31
+           ipv6: fc00::352/126
+       bp_interfaces:
+         ipv4: 10.10.246.118/24
+         ipv6: fc0a::76/64
+    ARISTA118T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.170
+            - fc00::355
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.214/32
+           ipv6: 2064:100::d6/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.171/31
+           ipv6: fc00::356/126
+       bp_interfaces:
+         ipv4: 10.10.246.119/24
+         ipv6: fc0a::77/64
+    ARISTA119T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.172
+            - fc00::359
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.215/32
+           ipv6: 2064:100::d7/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.173/31
+           ipv6: fc00::35a/126
+       bp_interfaces:
+         ipv4: 10.10.246.120/24
+         ipv6: fc0a::78/64
+    ARISTA120T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.174
+            - fc00::35d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.216/32
+           ipv6: 2064:100::d8/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.175/31
+           ipv6: fc00::35e/126
+       bp_interfaces:
+         ipv4: 10.10.246.121/24
+         ipv6: fc0a::79/64
+    ARISTA121T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.176
+            - fc00::361
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.217/32
+           ipv6: 2064:100::d9/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.177/31
+           ipv6: fc00::362/126
+       bp_interfaces:
+         ipv4: 10.10.246.122/24
+         ipv6: fc0a::7a/64
+    ARISTA122T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.178
+            - fc00::365
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.218/32
+           ipv6: 2064:100::da/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.179/31
+           ipv6: fc00::366/126
+       bp_interfaces:
+         ipv4: 10.10.246.123/24
+         ipv6: fc0a::7b/64
+    ARISTA123T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.180
+            - fc00::369
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.219/32
+           ipv6: 2064:100::db/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.181/31
+           ipv6: fc00::36a/126
+       bp_interfaces:
+         ipv4: 10.10.246.124/24
+         ipv6: fc0a::7c/64
+    ARISTA124T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.182
+            - fc00::36d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.220/32
+           ipv6: 2064:100::dc/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.183/31
+           ipv6: fc00::36e/126
+       bp_interfaces:
+         ipv4: 10.10.246.125/24
+         ipv6: fc0a::7d/64
+    ARISTA125T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.184
+            - fc00::371
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.221/32
+           ipv6: 2064:100::dd/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.185/31
+           ipv6: fc00::372/126
+       bp_interfaces:
+         ipv4: 10.10.246.126/24
+         ipv6: fc0a::7e/64
+    ARISTA126T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.186
+            - fc00::375
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.222/32
+           ipv6: 2064:100::de/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.187/31
+           ipv6: fc00::376/126
+       bp_interfaces:
+         ipv4: 10.10.246.127/24
+         ipv6: fc0a::7f/64
+    ARISTA127T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.188
+            - fc00::379
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.223/32
+           ipv6: 2064:100::df/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.189/31
+           ipv6: fc00::37a/126
+       bp_interfaces:
+         ipv4: 10.10.246.128/24
+         ipv6: fc0a::80/64
+    ARISTA128T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.1.190
+            - fc00::37d
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.0.224/32
+           ipv6: 2064:100::e0/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.1.191/31
+           ipv6: fc00::37e/126
+       bp_interfaces:
+         ipv4: 10.10.246.129/24
+         ipv6: fc0a::81/64
+    ARISTA129T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.2.0
+            - fc00::401
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.1.1/32
+           ipv6: 2064:100::101/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.2.1/31
+           ipv6: fc00::402/126
+       bp_interfaces:
+         ipv4: 10.10.246.130/24
+         ipv6: fc0a::82/64
+    ARISTA130T1:
+      properties:
+      - common
+      bgp:
+        asn: 64802
+        peers:
+          64601:
+            - 10.0.2.2
+            - fc00::405
+       interfaces:
+         Loopback0:
+           ipv4: 100.1.1.2/32
+           ipv6: 2064:100::102/128
+         Ethernet1:
+           lacp: 1
+         Port-Channel1:
+           ipv4: 10.0.2.3/31
+           ipv6: fc00::406/126
+       bp_interfaces:
+         ipv4: 10.10.246.131/24
+         ipv6: fc0a::83/64

--- a/ansible/vars/topo_t0-isolated-d128u128s2.yml
+++ b/ansible/vars/topo_t0-isolated-d128u128s2.yml
@@ -641,11 +641,11 @@ topology:
       vlans:
         - 223
       vm_offset: 127
-    ARISTA01PT1:
+    ARISTA01PT0:
       vlans:
         - 256
       vm_offset: 128
-    ARISTA02PT1:
+    ARISTA02PT0:
       vlans:
         - 257
       vm_offset: 129
@@ -811,7 +811,7 @@ configuration_properties:
     failure_rate: 0
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
-    
+
 configuration:
   ARISTA01T1:
     properties:
@@ -3245,11 +3245,11 @@ configuration:
     bp_interfaces:
       ipv4: 10.10.246.129/24
       ipv6: fc0a::81/64
-  ARISTA01PT1:
+  ARISTA01PT0:
     properties:
     - common
     bgp:
-      asn: 64802
+      asn: 64601
       peers:
         64601:
           - 10.0.2.0
@@ -3264,11 +3264,11 @@ configuration:
     bp_interfaces:
       ipv4: 10.10.246.130/24
       ipv6: fc0a::82/64
-  ARISTA02PT1:
+  ARISTA02PT0:
     properties:
     - common
     bgp:
-      asn: 64802
+      asn: 64601
       peers:
         64601:
           - 10.0.2.2

--- a/ansible/vars/topo_t0-isolated-d128u128s2.yml
+++ b/ansible/vars/topo_t0-isolated-d128u128s2.yml
@@ -641,11 +641,11 @@ topology:
       vlans:
         - 223
       vm_offset: 127
-    ARISTA129T1:
+    ARISTA01PT1:
       vlans:
         - 256
       vm_offset: 128
-    ARISTA130T1:
+    ARISTA02PT1:
       vlans:
         - 257
       vm_offset: 129
@@ -655,142 +655,142 @@ topology:
       one_vlan_a:
         Vlan1000:
           id: 1000
-          intfs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257]
+          intfs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255]
           prefix: 192.168.0.1/21
           prefix_v6: fc02:1000::1/64
           tag: 1000
       two_vlan_a:
         Vlan1000:
           id: 1000
-          intfs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
+          intfs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
           prefix: 192.168.0.1/22
           prefix_v6: fc02:400::1/64
           tag: 1000
         Vlan1100:
           id: 1100
-          intfs: [128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255]
+          intfs: [128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255]
           prefix: 192.168.4.1/22
           prefix_v6: fc02:401::1/64
           tag: 1100
       four_vlan_a:
         Vlan1000:
           id: 1000
-          intfs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
+          intfs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
           prefix: 192.168.0.1/24
           prefix_v6: fc02:400::1/64
           tag: 1000
         Vlan1100:
           id: 1100
-          intfs: [64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
+          intfs: [96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
           prefix: 192.168.1.1/24
           prefix_v6: fc02:401::1/64
           tag: 1100
         Vlan1200:
           id: 1200
-          intfs: [128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191]
+          intfs: [128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159]
           prefix: 192.168.2.1/24
           prefix_v6: fc02:402::1/64
           tag: 1200
         Vlan1300:
           id: 1300
-          intfs: [192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255]
+          intfs: [224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255]
           prefix: 192.168.3.1/24
           prefix_v6: fc02:403::1/64
           tag: 1300
       hexa_vlan_a:
         Vlan1000:
           id: 1000
-          intfs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+          intfs: [0, 1, 2, 3, 4, 5, 6, 7]
           prefix: 192.168.0.1/24
           prefix_v6: fc02:400::1/64
           tag: 1000
         Vlan1100:
           id: 1100
-          intfs: [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+          intfs: [8, 9, 10, 11, 12, 13, 14, 15]
           prefix: 192.168.1.1/24
           prefix_v6: fc02:401::1/64
           tag: 1100
         Vlan1200:
           id: 1200
-          intfs: [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47]
+          intfs: [16, 17, 18, 19, 20, 21, 22, 23]
           prefix: 192.168.2.1/24
           prefix_v6: fc02:402::1/64
           tag: 1200
         Vlan1300:
           id: 1300
-          intfs: [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
+          intfs: [24, 25, 26, 27, 28, 29, 30, 31]
           prefix: 192.168.3.1/24
           prefix_v6: fc02:403::1/64
           tag: 1300
         Vlan1400:
           id: 1400
-          intfs: [64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79]
+          intfs: [96, 97, 98, 99, 100, 101, 102, 103]
           prefix: 192.168.4.1/24
           prefix_v6: fc02:404::1/64
           tag: 1400
         Vlan1500:
           id: 1500
-          intfs: [80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95]
+          intfs: [104, 105, 106, 107, 108, 109, 110, 111]
           prefix: 192.168.5.1/24
           prefix_v6: fc02:405::1/64
           tag: 1500
         Vlan1600:
           id: 1600
-          intfs: [96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111]
+          intfs: [112, 113, 114, 115, 116, 117, 118, 119]
           prefix: 192.168.6.1/24
           prefix_v6: fc02:406::1/64
           tag: 1600
         Vlan1700:
           id: 1700
-          intfs: [112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127]
+          intfs: [120, 121, 122, 123, 124, 125, 126, 127]
           prefix: 192.168.7.1/24
           prefix_v6: fc02:407::1/64
           tag: 1700
         Vlan1800:
           id: 1800
-          intfs: [128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143]
+          intfs: [128, 129, 130, 131, 132, 133, 134, 135]
           prefix: 192.168.8.1/24
           prefix_v6: fc02:408::1/64
           tag: 1800
         Vlan1900:
           id: 1900
-          intfs: [144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159]
+          intfs: [136, 137, 138, 139, 140, 141, 142, 143]
           prefix: 192.168.9.1/24
           prefix_v6: fc02:409::1/64
           tag: 1900
         Vlan2000:
           id: 2000
-          intfs: [160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175]
+          intfs: [144, 145, 146, 147, 148, 149, 150, 151]
           prefix: 192.168.10.1/24
           prefix_v6: fc02:410::1/64
           tag: 2000
         Vlan2100:
           id: 2100
-          intfs: [176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191]
+          intfs: [152, 153, 154, 155, 156, 157, 158, 159]
           prefix: 192.168.11.1/24
           prefix_v6: fc02:411::1/64
           tag: 2100
         Vlan2200:
           id: 2200
-          intfs: [192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207]
+          intfs: [224, 225, 226, 227, 228, 229, 230, 231]
           prefix: 192.168.12.1/24
           prefix_v6: fc02:412::1/64
           tag: 2200
         Vlan2300:
           id: 2300
-          intfs: [208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223]
+          intfs: [232, 233, 234, 235, 236, 237, 238, 239]
           prefix: 192.168.13.1/24
           prefix_v6: fc02:413::1/64
           tag: 2300
         Vlan2400:
           id: 2400
-          intfs: [224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239]
+          intfs: [240, 241, 242, 243, 244, 245, 246, 247]
           prefix: 192.168.14.1/24
           prefix_v6: fc02:414::1/64
           tag: 2400
         Vlan2500:
           id: 2500
-          intfs: [240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255]
+          intfs: [248, 249, 250, 251, 252, 253, 254, 255]
           prefix: 192.168.15.1/24
           prefix_v6: fc02:415::1/64
           tag: 2500
@@ -827,8 +827,6 @@ configuration:
            ipv4: 100.1.0.33/32
            ipv6: 2064:100::21/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.65/31
            ipv6: fc00::82/126
        bp_interfaces:
@@ -848,8 +846,6 @@ configuration:
            ipv4: 100.1.0.34/32
            ipv6: 2064:100::22/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.67/31
            ipv6: fc00::86/126
        bp_interfaces:
@@ -869,8 +865,6 @@ configuration:
            ipv4: 100.1.0.35/32
            ipv6: 2064:100::23/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.69/31
            ipv6: fc00::8a/126
        bp_interfaces:
@@ -890,8 +884,6 @@ configuration:
            ipv4: 100.1.0.36/32
            ipv6: 2064:100::24/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.71/31
            ipv6: fc00::8e/126
        bp_interfaces:
@@ -911,8 +903,6 @@ configuration:
            ipv4: 100.1.0.37/32
            ipv6: 2064:100::25/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.73/31
            ipv6: fc00::92/126
        bp_interfaces:
@@ -932,8 +922,6 @@ configuration:
            ipv4: 100.1.0.38/32
            ipv6: 2064:100::26/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.75/31
            ipv6: fc00::96/126
        bp_interfaces:
@@ -953,8 +941,6 @@ configuration:
            ipv4: 100.1.0.39/32
            ipv6: 2064:100::27/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.77/31
            ipv6: fc00::9a/126
        bp_interfaces:
@@ -974,8 +960,6 @@ configuration:
            ipv4: 100.1.0.40/32
            ipv6: 2064:100::28/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.79/31
            ipv6: fc00::9e/126
        bp_interfaces:
@@ -995,8 +979,6 @@ configuration:
            ipv4: 100.1.0.41/32
            ipv6: 2064:100::29/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.81/31
            ipv6: fc00::a2/126
        bp_interfaces:
@@ -1016,8 +998,6 @@ configuration:
            ipv4: 100.1.0.42/32
            ipv6: 2064:100::2a/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.83/31
            ipv6: fc00::a6/126
        bp_interfaces:
@@ -1037,8 +1017,6 @@ configuration:
            ipv4: 100.1.0.43/32
            ipv6: 2064:100::2b/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.85/31
            ipv6: fc00::aa/126
        bp_interfaces:
@@ -1058,8 +1036,6 @@ configuration:
            ipv4: 100.1.0.44/32
            ipv6: 2064:100::2c/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.87/31
            ipv6: fc00::ae/126
        bp_interfaces:
@@ -1079,8 +1055,6 @@ configuration:
            ipv4: 100.1.0.45/32
            ipv6: 2064:100::2d/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.89/31
            ipv6: fc00::b2/126
        bp_interfaces:
@@ -1100,8 +1074,6 @@ configuration:
            ipv4: 100.1.0.46/32
            ipv6: 2064:100::2e/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.91/31
            ipv6: fc00::b6/126
        bp_interfaces:
@@ -1121,8 +1093,6 @@ configuration:
            ipv4: 100.1.0.47/32
            ipv6: 2064:100::2f/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.93/31
            ipv6: fc00::ba/126
        bp_interfaces:
@@ -1142,8 +1112,6 @@ configuration:
            ipv4: 100.1.0.48/32
            ipv6: 2064:100::30/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.95/31
            ipv6: fc00::be/126
        bp_interfaces:
@@ -1163,8 +1131,6 @@ configuration:
            ipv4: 100.1.0.49/32
            ipv6: 2064:100::31/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.97/31
            ipv6: fc00::c2/126
        bp_interfaces:
@@ -1184,8 +1150,6 @@ configuration:
            ipv4: 100.1.0.50/32
            ipv6: 2064:100::32/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.99/31
            ipv6: fc00::c6/126
        bp_interfaces:
@@ -1205,8 +1169,6 @@ configuration:
            ipv4: 100.1.0.51/32
            ipv6: 2064:100::33/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.101/31
            ipv6: fc00::ca/126
        bp_interfaces:
@@ -1226,8 +1188,6 @@ configuration:
            ipv4: 100.1.0.52/32
            ipv6: 2064:100::34/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.103/31
            ipv6: fc00::ce/126
        bp_interfaces:
@@ -1247,8 +1207,6 @@ configuration:
            ipv4: 100.1.0.53/32
            ipv6: 2064:100::35/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.105/31
            ipv6: fc00::d2/126
        bp_interfaces:
@@ -1268,8 +1226,6 @@ configuration:
            ipv4: 100.1.0.54/32
            ipv6: 2064:100::36/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.107/31
            ipv6: fc00::d6/126
        bp_interfaces:
@@ -1289,8 +1245,6 @@ configuration:
            ipv4: 100.1.0.55/32
            ipv6: 2064:100::37/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.109/31
            ipv6: fc00::da/126
        bp_interfaces:
@@ -1310,8 +1264,6 @@ configuration:
            ipv4: 100.1.0.56/32
            ipv6: 2064:100::38/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.111/31
            ipv6: fc00::de/126
        bp_interfaces:
@@ -1331,8 +1283,6 @@ configuration:
            ipv4: 100.1.0.57/32
            ipv6: 2064:100::39/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.113/31
            ipv6: fc00::e2/126
        bp_interfaces:
@@ -1352,8 +1302,6 @@ configuration:
            ipv4: 100.1.0.58/32
            ipv6: 2064:100::3a/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.115/31
            ipv6: fc00::e6/126
        bp_interfaces:
@@ -1373,8 +1321,6 @@ configuration:
            ipv4: 100.1.0.59/32
            ipv6: 2064:100::3b/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.117/31
            ipv6: fc00::ea/126
        bp_interfaces:
@@ -1394,8 +1340,6 @@ configuration:
            ipv4: 100.1.0.60/32
            ipv6: 2064:100::3c/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.119/31
            ipv6: fc00::ee/126
        bp_interfaces:
@@ -1415,8 +1359,6 @@ configuration:
            ipv4: 100.1.0.61/32
            ipv6: 2064:100::3d/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.121/31
            ipv6: fc00::f2/126
        bp_interfaces:
@@ -1436,8 +1378,6 @@ configuration:
            ipv4: 100.1.0.62/32
            ipv6: 2064:100::3e/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.123/31
            ipv6: fc00::f6/126
        bp_interfaces:
@@ -1457,8 +1397,6 @@ configuration:
            ipv4: 100.1.0.63/32
            ipv6: 2064:100::3f/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.125/31
            ipv6: fc00::fa/126
        bp_interfaces:
@@ -1478,8 +1416,6 @@ configuration:
            ipv4: 100.1.0.64/32
            ipv6: 2064:100::40/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.127/31
            ipv6: fc00::fe/126
        bp_interfaces:
@@ -1499,8 +1435,6 @@ configuration:
            ipv4: 100.1.0.65/32
            ipv6: 2064:100::41/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.129/31
            ipv6: fc00::102/126
        bp_interfaces:
@@ -1520,8 +1454,6 @@ configuration:
            ipv4: 100.1.0.66/32
            ipv6: 2064:100::42/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.131/31
            ipv6: fc00::106/126
        bp_interfaces:
@@ -1541,8 +1473,6 @@ configuration:
            ipv4: 100.1.0.67/32
            ipv6: 2064:100::43/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.133/31
            ipv6: fc00::10a/126
        bp_interfaces:
@@ -1562,8 +1492,6 @@ configuration:
            ipv4: 100.1.0.68/32
            ipv6: 2064:100::44/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.135/31
            ipv6: fc00::10e/126
        bp_interfaces:
@@ -1583,8 +1511,6 @@ configuration:
            ipv4: 100.1.0.69/32
            ipv6: 2064:100::45/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.137/31
            ipv6: fc00::112/126
        bp_interfaces:
@@ -1604,8 +1530,6 @@ configuration:
            ipv4: 100.1.0.70/32
            ipv6: 2064:100::46/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.139/31
            ipv6: fc00::116/126
        bp_interfaces:
@@ -1625,8 +1549,6 @@ configuration:
            ipv4: 100.1.0.71/32
            ipv6: 2064:100::47/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.141/31
            ipv6: fc00::11a/126
        bp_interfaces:
@@ -1646,8 +1568,6 @@ configuration:
            ipv4: 100.1.0.72/32
            ipv6: 2064:100::48/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.143/31
            ipv6: fc00::11e/126
        bp_interfaces:
@@ -1667,8 +1587,6 @@ configuration:
            ipv4: 100.1.0.73/32
            ipv6: 2064:100::49/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.145/31
            ipv6: fc00::122/126
        bp_interfaces:
@@ -1688,8 +1606,6 @@ configuration:
            ipv4: 100.1.0.74/32
            ipv6: 2064:100::4a/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.147/31
            ipv6: fc00::126/126
        bp_interfaces:
@@ -1709,8 +1625,6 @@ configuration:
            ipv4: 100.1.0.75/32
            ipv6: 2064:100::4b/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.149/31
            ipv6: fc00::12a/126
        bp_interfaces:
@@ -1730,8 +1644,6 @@ configuration:
            ipv4: 100.1.0.76/32
            ipv6: 2064:100::4c/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.151/31
            ipv6: fc00::12e/126
        bp_interfaces:
@@ -1751,8 +1663,6 @@ configuration:
            ipv4: 100.1.0.77/32
            ipv6: 2064:100::4d/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.153/31
            ipv6: fc00::132/126
        bp_interfaces:
@@ -1772,8 +1682,6 @@ configuration:
            ipv4: 100.1.0.78/32
            ipv6: 2064:100::4e/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.155/31
            ipv6: fc00::136/126
        bp_interfaces:
@@ -1793,8 +1701,6 @@ configuration:
            ipv4: 100.1.0.79/32
            ipv6: 2064:100::4f/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.157/31
            ipv6: fc00::13a/126
        bp_interfaces:
@@ -1814,8 +1720,6 @@ configuration:
            ipv4: 100.1.0.80/32
            ipv6: 2064:100::50/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.159/31
            ipv6: fc00::13e/126
        bp_interfaces:
@@ -1835,8 +1739,6 @@ configuration:
            ipv4: 100.1.0.81/32
            ipv6: 2064:100::51/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.161/31
            ipv6: fc00::142/126
        bp_interfaces:
@@ -1856,8 +1758,6 @@ configuration:
            ipv4: 100.1.0.82/32
            ipv6: 2064:100::52/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.163/31
            ipv6: fc00::146/126
        bp_interfaces:
@@ -1877,8 +1777,6 @@ configuration:
            ipv4: 100.1.0.83/32
            ipv6: 2064:100::53/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.165/31
            ipv6: fc00::14a/126
        bp_interfaces:
@@ -1898,8 +1796,6 @@ configuration:
            ipv4: 100.1.0.84/32
            ipv6: 2064:100::54/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.167/31
            ipv6: fc00::14e/126
        bp_interfaces:
@@ -1919,8 +1815,6 @@ configuration:
            ipv4: 100.1.0.85/32
            ipv6: 2064:100::55/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.169/31
            ipv6: fc00::152/126
        bp_interfaces:
@@ -1940,8 +1834,6 @@ configuration:
            ipv4: 100.1.0.86/32
            ipv6: 2064:100::56/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.171/31
            ipv6: fc00::156/126
        bp_interfaces:
@@ -1961,8 +1853,6 @@ configuration:
            ipv4: 100.1.0.87/32
            ipv6: 2064:100::57/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.173/31
            ipv6: fc00::15a/126
        bp_interfaces:
@@ -1982,8 +1872,6 @@ configuration:
            ipv4: 100.1.0.88/32
            ipv6: 2064:100::58/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.175/31
            ipv6: fc00::15e/126
        bp_interfaces:
@@ -2003,8 +1891,6 @@ configuration:
            ipv4: 100.1.0.89/32
            ipv6: 2064:100::59/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.177/31
            ipv6: fc00::162/126
        bp_interfaces:
@@ -2024,8 +1910,6 @@ configuration:
            ipv4: 100.1.0.90/32
            ipv6: 2064:100::5a/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.179/31
            ipv6: fc00::166/126
        bp_interfaces:
@@ -2045,8 +1929,6 @@ configuration:
            ipv4: 100.1.0.91/32
            ipv6: 2064:100::5b/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.181/31
            ipv6: fc00::16a/126
        bp_interfaces:
@@ -2066,8 +1948,6 @@ configuration:
            ipv4: 100.1.0.92/32
            ipv6: 2064:100::5c/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.183/31
            ipv6: fc00::16e/126
        bp_interfaces:
@@ -2087,8 +1967,6 @@ configuration:
            ipv4: 100.1.0.93/32
            ipv6: 2064:100::5d/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.185/31
            ipv6: fc00::172/126
        bp_interfaces:
@@ -2108,8 +1986,6 @@ configuration:
            ipv4: 100.1.0.94/32
            ipv6: 2064:100::5e/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.187/31
            ipv6: fc00::176/126
        bp_interfaces:
@@ -2129,8 +2005,6 @@ configuration:
            ipv4: 100.1.0.95/32
            ipv6: 2064:100::5f/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.189/31
            ipv6: fc00::17a/126
        bp_interfaces:
@@ -2150,8 +2024,6 @@ configuration:
            ipv4: 100.1.0.96/32
            ipv6: 2064:100::60/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.0.191/31
            ipv6: fc00::17e/126
        bp_interfaces:
@@ -2171,8 +2043,6 @@ configuration:
            ipv4: 100.1.0.161/32
            ipv6: 2064:100::a1/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.65/31
            ipv6: fc00::282/126
        bp_interfaces:
@@ -2192,8 +2062,6 @@ configuration:
            ipv4: 100.1.0.162/32
            ipv6: 2064:100::a2/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.67/31
            ipv6: fc00::286/126
        bp_interfaces:
@@ -2213,8 +2081,6 @@ configuration:
            ipv4: 100.1.0.163/32
            ipv6: 2064:100::a3/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.69/31
            ipv6: fc00::28a/126
        bp_interfaces:
@@ -2234,8 +2100,6 @@ configuration:
            ipv4: 100.1.0.164/32
            ipv6: 2064:100::a4/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.71/31
            ipv6: fc00::28e/126
        bp_interfaces:
@@ -2255,8 +2119,6 @@ configuration:
            ipv4: 100.1.0.165/32
            ipv6: 2064:100::a5/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.73/31
            ipv6: fc00::292/126
        bp_interfaces:
@@ -2276,8 +2138,6 @@ configuration:
            ipv4: 100.1.0.166/32
            ipv6: 2064:100::a6/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.75/31
            ipv6: fc00::296/126
        bp_interfaces:
@@ -2297,8 +2157,6 @@ configuration:
            ipv4: 100.1.0.167/32
            ipv6: 2064:100::a7/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.77/31
            ipv6: fc00::29a/126
        bp_interfaces:
@@ -2318,8 +2176,6 @@ configuration:
            ipv4: 100.1.0.168/32
            ipv6: 2064:100::a8/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.79/31
            ipv6: fc00::29e/126
        bp_interfaces:
@@ -2339,8 +2195,6 @@ configuration:
            ipv4: 100.1.0.169/32
            ipv6: 2064:100::a9/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.81/31
            ipv6: fc00::2a2/126
        bp_interfaces:
@@ -2360,8 +2214,6 @@ configuration:
            ipv4: 100.1.0.170/32
            ipv6: 2064:100::aa/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.83/31
            ipv6: fc00::2a6/126
        bp_interfaces:
@@ -2381,8 +2233,6 @@ configuration:
            ipv4: 100.1.0.171/32
            ipv6: 2064:100::ab/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.85/31
            ipv6: fc00::2aa/126
        bp_interfaces:
@@ -2402,8 +2252,6 @@ configuration:
            ipv4: 100.1.0.172/32
            ipv6: 2064:100::ac/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.87/31
            ipv6: fc00::2ae/126
        bp_interfaces:
@@ -2423,8 +2271,6 @@ configuration:
            ipv4: 100.1.0.173/32
            ipv6: 2064:100::ad/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.89/31
            ipv6: fc00::2b2/126
        bp_interfaces:
@@ -2444,8 +2290,6 @@ configuration:
            ipv4: 100.1.0.174/32
            ipv6: 2064:100::ae/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.91/31
            ipv6: fc00::2b6/126
        bp_interfaces:
@@ -2465,8 +2309,6 @@ configuration:
            ipv4: 100.1.0.175/32
            ipv6: 2064:100::af/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.93/31
            ipv6: fc00::2ba/126
        bp_interfaces:
@@ -2486,8 +2328,6 @@ configuration:
            ipv4: 100.1.0.176/32
            ipv6: 2064:100::b0/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.95/31
            ipv6: fc00::2be/126
        bp_interfaces:
@@ -2507,8 +2347,6 @@ configuration:
            ipv4: 100.1.0.177/32
            ipv6: 2064:100::b1/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.97/31
            ipv6: fc00::2c2/126
        bp_interfaces:
@@ -2528,8 +2366,6 @@ configuration:
            ipv4: 100.1.0.178/32
            ipv6: 2064:100::b2/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.99/31
            ipv6: fc00::2c6/126
        bp_interfaces:
@@ -2549,8 +2385,6 @@ configuration:
            ipv4: 100.1.0.179/32
            ipv6: 2064:100::b3/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.101/31
            ipv6: fc00::2ca/126
        bp_interfaces:
@@ -2570,8 +2404,6 @@ configuration:
            ipv4: 100.1.0.180/32
            ipv6: 2064:100::b4/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.103/31
            ipv6: fc00::2ce/126
        bp_interfaces:
@@ -2591,8 +2423,6 @@ configuration:
            ipv4: 100.1.0.181/32
            ipv6: 2064:100::b5/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.105/31
            ipv6: fc00::2d2/126
        bp_interfaces:
@@ -2612,8 +2442,6 @@ configuration:
            ipv4: 100.1.0.182/32
            ipv6: 2064:100::b6/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.107/31
            ipv6: fc00::2d6/126
        bp_interfaces:
@@ -2633,8 +2461,6 @@ configuration:
            ipv4: 100.1.0.183/32
            ipv6: 2064:100::b7/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.109/31
            ipv6: fc00::2da/126
        bp_interfaces:
@@ -2654,8 +2480,6 @@ configuration:
            ipv4: 100.1.0.184/32
            ipv6: 2064:100::b8/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.111/31
            ipv6: fc00::2de/126
        bp_interfaces:
@@ -2675,8 +2499,6 @@ configuration:
            ipv4: 100.1.0.185/32
            ipv6: 2064:100::b9/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.113/31
            ipv6: fc00::2e2/126
        bp_interfaces:
@@ -2696,8 +2518,6 @@ configuration:
            ipv4: 100.1.0.186/32
            ipv6: 2064:100::ba/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.115/31
            ipv6: fc00::2e6/126
        bp_interfaces:
@@ -2717,8 +2537,6 @@ configuration:
            ipv4: 100.1.0.187/32
            ipv6: 2064:100::bb/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.117/31
            ipv6: fc00::2ea/126
        bp_interfaces:
@@ -2738,8 +2556,6 @@ configuration:
            ipv4: 100.1.0.188/32
            ipv6: 2064:100::bc/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.119/31
            ipv6: fc00::2ee/126
        bp_interfaces:
@@ -2759,8 +2575,6 @@ configuration:
            ipv4: 100.1.0.189/32
            ipv6: 2064:100::bd/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.121/31
            ipv6: fc00::2f2/126
        bp_interfaces:
@@ -2780,8 +2594,6 @@ configuration:
            ipv4: 100.1.0.190/32
            ipv6: 2064:100::be/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.123/31
            ipv6: fc00::2f6/126
        bp_interfaces:
@@ -2801,8 +2613,6 @@ configuration:
            ipv4: 100.1.0.191/32
            ipv6: 2064:100::bf/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.125/31
            ipv6: fc00::2fa/126
        bp_interfaces:
@@ -2822,8 +2632,6 @@ configuration:
            ipv4: 100.1.0.192/32
            ipv6: 2064:100::c0/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.127/31
            ipv6: fc00::2fe/126
        bp_interfaces:
@@ -2843,8 +2651,6 @@ configuration:
            ipv4: 100.1.0.193/32
            ipv6: 2064:100::c1/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.129/31
            ipv6: fc00::302/126
        bp_interfaces:
@@ -2864,8 +2670,6 @@ configuration:
            ipv4: 100.1.0.194/32
            ipv6: 2064:100::c2/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.131/31
            ipv6: fc00::306/126
        bp_interfaces:
@@ -2885,8 +2689,6 @@ configuration:
            ipv4: 100.1.0.195/32
            ipv6: 2064:100::c3/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.133/31
            ipv6: fc00::30a/126
        bp_interfaces:
@@ -2906,8 +2708,6 @@ configuration:
            ipv4: 100.1.0.196/32
            ipv6: 2064:100::c4/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.135/31
            ipv6: fc00::30e/126
        bp_interfaces:
@@ -2927,8 +2727,6 @@ configuration:
            ipv4: 100.1.0.197/32
            ipv6: 2064:100::c5/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.137/31
            ipv6: fc00::312/126
        bp_interfaces:
@@ -2948,8 +2746,6 @@ configuration:
            ipv4: 100.1.0.198/32
            ipv6: 2064:100::c6/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.139/31
            ipv6: fc00::316/126
        bp_interfaces:
@@ -2969,8 +2765,6 @@ configuration:
            ipv4: 100.1.0.199/32
            ipv6: 2064:100::c7/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.141/31
            ipv6: fc00::31a/126
        bp_interfaces:
@@ -2990,8 +2784,6 @@ configuration:
            ipv4: 100.1.0.200/32
            ipv6: 2064:100::c8/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.143/31
            ipv6: fc00::31e/126
        bp_interfaces:
@@ -3011,8 +2803,6 @@ configuration:
            ipv4: 100.1.0.201/32
            ipv6: 2064:100::c9/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.145/31
            ipv6: fc00::322/126
        bp_interfaces:
@@ -3032,8 +2822,6 @@ configuration:
            ipv4: 100.1.0.202/32
            ipv6: 2064:100::ca/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.147/31
            ipv6: fc00::326/126
        bp_interfaces:
@@ -3053,8 +2841,6 @@ configuration:
            ipv4: 100.1.0.203/32
            ipv6: 2064:100::cb/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.149/31
            ipv6: fc00::32a/126
        bp_interfaces:
@@ -3074,8 +2860,6 @@ configuration:
            ipv4: 100.1.0.204/32
            ipv6: 2064:100::cc/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.151/31
            ipv6: fc00::32e/126
        bp_interfaces:
@@ -3095,8 +2879,6 @@ configuration:
            ipv4: 100.1.0.205/32
            ipv6: 2064:100::cd/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.153/31
            ipv6: fc00::332/126
        bp_interfaces:
@@ -3116,8 +2898,6 @@ configuration:
            ipv4: 100.1.0.206/32
            ipv6: 2064:100::ce/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.155/31
            ipv6: fc00::336/126
        bp_interfaces:
@@ -3137,8 +2917,6 @@ configuration:
            ipv4: 100.1.0.207/32
            ipv6: 2064:100::cf/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.157/31
            ipv6: fc00::33a/126
        bp_interfaces:
@@ -3158,8 +2936,6 @@ configuration:
            ipv4: 100.1.0.208/32
            ipv6: 2064:100::d0/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.159/31
            ipv6: fc00::33e/126
        bp_interfaces:
@@ -3179,8 +2955,6 @@ configuration:
            ipv4: 100.1.0.209/32
            ipv6: 2064:100::d1/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.161/31
            ipv6: fc00::342/126
        bp_interfaces:
@@ -3200,8 +2974,6 @@ configuration:
            ipv4: 100.1.0.210/32
            ipv6: 2064:100::d2/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.163/31
            ipv6: fc00::346/126
        bp_interfaces:
@@ -3221,8 +2993,6 @@ configuration:
            ipv4: 100.1.0.211/32
            ipv6: 2064:100::d3/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.165/31
            ipv6: fc00::34a/126
        bp_interfaces:
@@ -3242,8 +3012,6 @@ configuration:
            ipv4: 100.1.0.212/32
            ipv6: 2064:100::d4/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.167/31
            ipv6: fc00::34e/126
        bp_interfaces:
@@ -3263,8 +3031,6 @@ configuration:
            ipv4: 100.1.0.213/32
            ipv6: 2064:100::d5/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.169/31
            ipv6: fc00::352/126
        bp_interfaces:
@@ -3284,8 +3050,6 @@ configuration:
            ipv4: 100.1.0.214/32
            ipv6: 2064:100::d6/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.171/31
            ipv6: fc00::356/126
        bp_interfaces:
@@ -3305,8 +3069,6 @@ configuration:
            ipv4: 100.1.0.215/32
            ipv6: 2064:100::d7/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.173/31
            ipv6: fc00::35a/126
        bp_interfaces:
@@ -3326,8 +3088,6 @@ configuration:
            ipv4: 100.1.0.216/32
            ipv6: 2064:100::d8/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.175/31
            ipv6: fc00::35e/126
        bp_interfaces:
@@ -3347,8 +3107,6 @@ configuration:
            ipv4: 100.1.0.217/32
            ipv6: 2064:100::d9/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.177/31
            ipv6: fc00::362/126
        bp_interfaces:
@@ -3368,8 +3126,6 @@ configuration:
            ipv4: 100.1.0.218/32
            ipv6: 2064:100::da/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.179/31
            ipv6: fc00::366/126
        bp_interfaces:
@@ -3389,8 +3145,6 @@ configuration:
            ipv4: 100.1.0.219/32
            ipv6: 2064:100::db/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.181/31
            ipv6: fc00::36a/126
        bp_interfaces:
@@ -3410,8 +3164,6 @@ configuration:
            ipv4: 100.1.0.220/32
            ipv6: 2064:100::dc/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.183/31
            ipv6: fc00::36e/126
        bp_interfaces:
@@ -3431,8 +3183,6 @@ configuration:
            ipv4: 100.1.0.221/32
            ipv6: 2064:100::dd/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.185/31
            ipv6: fc00::372/126
        bp_interfaces:
@@ -3452,8 +3202,6 @@ configuration:
            ipv4: 100.1.0.222/32
            ipv6: 2064:100::de/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.187/31
            ipv6: fc00::376/126
        bp_interfaces:
@@ -3473,8 +3221,6 @@ configuration:
            ipv4: 100.1.0.223/32
            ipv6: 2064:100::df/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.189/31
            ipv6: fc00::37a/126
        bp_interfaces:
@@ -3494,14 +3240,12 @@ configuration:
            ipv4: 100.1.0.224/32
            ipv6: 2064:100::e0/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.1.191/31
            ipv6: fc00::37e/126
        bp_interfaces:
          ipv4: 10.10.246.129/24
          ipv6: fc0a::81/64
-    ARISTA129T1:
+    ARISTA01PT1:
       properties:
       - common
       bgp:
@@ -3515,14 +3259,12 @@ configuration:
            ipv4: 100.1.1.1/32
            ipv6: 2064:100::101/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.2.1/31
            ipv6: fc00::402/126
        bp_interfaces:
          ipv4: 10.10.246.130/24
          ipv6: fc0a::82/64
-    ARISTA130T1:
+    ARISTA02PT1:
       properties:
       - common
       bgp:
@@ -3536,8 +3278,6 @@ configuration:
            ipv4: 100.1.1.2/32
            ipv6: 2064:100::102/128
          Ethernet1:
-           lacp: 1
-         Port-Channel1:
            ipv4: 10.0.2.3/31
            ipv6: fc00::406/126
        bp_interfaces:

--- a/ansible/vars/topo_t0-isolated-d128u128s2.yml
+++ b/ansible/vars/topo_t0-isolated-d128u128s2.yml
@@ -811,2475 +811,2475 @@ configuration_properties:
     failure_rate: 0
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
-
+    
 configuration:
-    ARISTA01T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.64
-            - fc00::81
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.33/32
-           ipv6: 2064:100::21/128
-         Ethernet1:
-           ipv4: 10.0.0.65/31
-           ipv6: fc00::82/126
-       bp_interfaces:
-         ipv4: 10.10.246.2/24
-         ipv6: fc0a::2/64
-    ARISTA02T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.66
-            - fc00::85
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.34/32
-           ipv6: 2064:100::22/128
-         Ethernet1:
-           ipv4: 10.0.0.67/31
-           ipv6: fc00::86/126
-       bp_interfaces:
-         ipv4: 10.10.246.3/24
-         ipv6: fc0a::3/64
-    ARISTA03T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.68
-            - fc00::89
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.35/32
-           ipv6: 2064:100::23/128
-         Ethernet1:
-           ipv4: 10.0.0.69/31
-           ipv6: fc00::8a/126
-       bp_interfaces:
-         ipv4: 10.10.246.4/24
-         ipv6: fc0a::4/64
-    ARISTA04T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.70
-            - fc00::8d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.36/32
-           ipv6: 2064:100::24/128
-         Ethernet1:
-           ipv4: 10.0.0.71/31
-           ipv6: fc00::8e/126
-       bp_interfaces:
-         ipv4: 10.10.246.5/24
-         ipv6: fc0a::5/64
-    ARISTA05T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.72
-            - fc00::91
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.37/32
-           ipv6: 2064:100::25/128
-         Ethernet1:
-           ipv4: 10.0.0.73/31
-           ipv6: fc00::92/126
-       bp_interfaces:
-         ipv4: 10.10.246.6/24
-         ipv6: fc0a::6/64
-    ARISTA06T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.74
-            - fc00::95
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.38/32
-           ipv6: 2064:100::26/128
-         Ethernet1:
-           ipv4: 10.0.0.75/31
-           ipv6: fc00::96/126
-       bp_interfaces:
-         ipv4: 10.10.246.7/24
-         ipv6: fc0a::7/64
-    ARISTA07T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.76
-            - fc00::99
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.39/32
-           ipv6: 2064:100::27/128
-         Ethernet1:
-           ipv4: 10.0.0.77/31
-           ipv6: fc00::9a/126
-       bp_interfaces:
-         ipv4: 10.10.246.8/24
-         ipv6: fc0a::8/64
-    ARISTA08T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.78
-            - fc00::9d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.40/32
-           ipv6: 2064:100::28/128
-         Ethernet1:
-           ipv4: 10.0.0.79/31
-           ipv6: fc00::9e/126
-       bp_interfaces:
-         ipv4: 10.10.246.9/24
-         ipv6: fc0a::9/64
-    ARISTA09T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.80
-            - fc00::a1
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.41/32
-           ipv6: 2064:100::29/128
-         Ethernet1:
-           ipv4: 10.0.0.81/31
-           ipv6: fc00::a2/126
-       bp_interfaces:
-         ipv4: 10.10.246.10/24
-         ipv6: fc0a::a/64
-    ARISTA10T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.82
-            - fc00::a5
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.42/32
-           ipv6: 2064:100::2a/128
-         Ethernet1:
-           ipv4: 10.0.0.83/31
-           ipv6: fc00::a6/126
-       bp_interfaces:
-         ipv4: 10.10.246.11/24
-         ipv6: fc0a::b/64
-    ARISTA11T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.84
-            - fc00::a9
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.43/32
-           ipv6: 2064:100::2b/128
-         Ethernet1:
-           ipv4: 10.0.0.85/31
-           ipv6: fc00::aa/126
-       bp_interfaces:
-         ipv4: 10.10.246.12/24
-         ipv6: fc0a::c/64
-    ARISTA12T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.86
-            - fc00::ad
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.44/32
-           ipv6: 2064:100::2c/128
-         Ethernet1:
-           ipv4: 10.0.0.87/31
-           ipv6: fc00::ae/126
-       bp_interfaces:
-         ipv4: 10.10.246.13/24
-         ipv6: fc0a::d/64
-    ARISTA13T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.88
-            - fc00::b1
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.45/32
-           ipv6: 2064:100::2d/128
-         Ethernet1:
-           ipv4: 10.0.0.89/31
-           ipv6: fc00::b2/126
-       bp_interfaces:
-         ipv4: 10.10.246.14/24
-         ipv6: fc0a::e/64
-    ARISTA14T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.90
-            - fc00::b5
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.46/32
-           ipv6: 2064:100::2e/128
-         Ethernet1:
-           ipv4: 10.0.0.91/31
-           ipv6: fc00::b6/126
-       bp_interfaces:
-         ipv4: 10.10.246.15/24
-         ipv6: fc0a::f/64
-    ARISTA15T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.92
-            - fc00::b9
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.47/32
-           ipv6: 2064:100::2f/128
-         Ethernet1:
-           ipv4: 10.0.0.93/31
-           ipv6: fc00::ba/126
-       bp_interfaces:
-         ipv4: 10.10.246.16/24
-         ipv6: fc0a::10/64
-    ARISTA16T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.94
-            - fc00::bd
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.48/32
-           ipv6: 2064:100::30/128
-         Ethernet1:
-           ipv4: 10.0.0.95/31
-           ipv6: fc00::be/126
-       bp_interfaces:
-         ipv4: 10.10.246.17/24
-         ipv6: fc0a::11/64
-    ARISTA17T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.96
-            - fc00::c1
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.49/32
-           ipv6: 2064:100::31/128
-         Ethernet1:
-           ipv4: 10.0.0.97/31
-           ipv6: fc00::c2/126
-       bp_interfaces:
-         ipv4: 10.10.246.18/24
-         ipv6: fc0a::12/64
-    ARISTA18T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.98
-            - fc00::c5
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.50/32
-           ipv6: 2064:100::32/128
-         Ethernet1:
-           ipv4: 10.0.0.99/31
-           ipv6: fc00::c6/126
-       bp_interfaces:
-         ipv4: 10.10.246.19/24
-         ipv6: fc0a::13/64
-    ARISTA19T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.100
-            - fc00::c9
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.51/32
-           ipv6: 2064:100::33/128
-         Ethernet1:
-           ipv4: 10.0.0.101/31
-           ipv6: fc00::ca/126
-       bp_interfaces:
-         ipv4: 10.10.246.20/24
-         ipv6: fc0a::14/64
-    ARISTA20T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.102
-            - fc00::cd
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.52/32
-           ipv6: 2064:100::34/128
-         Ethernet1:
-           ipv4: 10.0.0.103/31
-           ipv6: fc00::ce/126
-       bp_interfaces:
-         ipv4: 10.10.246.21/24
-         ipv6: fc0a::15/64
-    ARISTA21T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.104
-            - fc00::d1
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.53/32
-           ipv6: 2064:100::35/128
-         Ethernet1:
-           ipv4: 10.0.0.105/31
-           ipv6: fc00::d2/126
-       bp_interfaces:
-         ipv4: 10.10.246.22/24
-         ipv6: fc0a::16/64
-    ARISTA22T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.106
-            - fc00::d5
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.54/32
-           ipv6: 2064:100::36/128
-         Ethernet1:
-           ipv4: 10.0.0.107/31
-           ipv6: fc00::d6/126
-       bp_interfaces:
-         ipv4: 10.10.246.23/24
-         ipv6: fc0a::17/64
-    ARISTA23T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.108
-            - fc00::d9
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.55/32
-           ipv6: 2064:100::37/128
-         Ethernet1:
-           ipv4: 10.0.0.109/31
-           ipv6: fc00::da/126
-       bp_interfaces:
-         ipv4: 10.10.246.24/24
-         ipv6: fc0a::18/64
-    ARISTA24T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.110
-            - fc00::dd
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.56/32
-           ipv6: 2064:100::38/128
-         Ethernet1:
-           ipv4: 10.0.0.111/31
-           ipv6: fc00::de/126
-       bp_interfaces:
-         ipv4: 10.10.246.25/24
-         ipv6: fc0a::19/64
-    ARISTA25T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.112
-            - fc00::e1
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.57/32
-           ipv6: 2064:100::39/128
-         Ethernet1:
-           ipv4: 10.0.0.113/31
-           ipv6: fc00::e2/126
-       bp_interfaces:
-         ipv4: 10.10.246.26/24
-         ipv6: fc0a::1a/64
-    ARISTA26T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.114
-            - fc00::e5
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.58/32
-           ipv6: 2064:100::3a/128
-         Ethernet1:
-           ipv4: 10.0.0.115/31
-           ipv6: fc00::e6/126
-       bp_interfaces:
-         ipv4: 10.10.246.27/24
-         ipv6: fc0a::1b/64
-    ARISTA27T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.116
-            - fc00::e9
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.59/32
-           ipv6: 2064:100::3b/128
-         Ethernet1:
-           ipv4: 10.0.0.117/31
-           ipv6: fc00::ea/126
-       bp_interfaces:
-         ipv4: 10.10.246.28/24
-         ipv6: fc0a::1c/64
-    ARISTA28T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.118
-            - fc00::ed
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.60/32
-           ipv6: 2064:100::3c/128
-         Ethernet1:
-           ipv4: 10.0.0.119/31
-           ipv6: fc00::ee/126
-       bp_interfaces:
-         ipv4: 10.10.246.29/24
-         ipv6: fc0a::1d/64
-    ARISTA29T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.120
-            - fc00::f1
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.61/32
-           ipv6: 2064:100::3d/128
-         Ethernet1:
-           ipv4: 10.0.0.121/31
-           ipv6: fc00::f2/126
-       bp_interfaces:
-         ipv4: 10.10.246.30/24
-         ipv6: fc0a::1e/64
-    ARISTA30T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.122
-            - fc00::f5
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.62/32
-           ipv6: 2064:100::3e/128
-         Ethernet1:
-           ipv4: 10.0.0.123/31
-           ipv6: fc00::f6/126
-       bp_interfaces:
-         ipv4: 10.10.246.31/24
-         ipv6: fc0a::1f/64
-    ARISTA31T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.124
-            - fc00::f9
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.63/32
-           ipv6: 2064:100::3f/128
-         Ethernet1:
-           ipv4: 10.0.0.125/31
-           ipv6: fc00::fa/126
-       bp_interfaces:
-         ipv4: 10.10.246.32/24
-         ipv6: fc0a::20/64
-    ARISTA32T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.126
-            - fc00::fd
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.64/32
-           ipv6: 2064:100::40/128
-         Ethernet1:
-           ipv4: 10.0.0.127/31
-           ipv6: fc00::fe/126
-       bp_interfaces:
-         ipv4: 10.10.246.33/24
-         ipv6: fc0a::21/64
-    ARISTA33T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.128
-            - fc00::101
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.65/32
-           ipv6: 2064:100::41/128
-         Ethernet1:
-           ipv4: 10.0.0.129/31
-           ipv6: fc00::102/126
-       bp_interfaces:
-         ipv4: 10.10.246.34/24
-         ipv6: fc0a::22/64
-    ARISTA34T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.130
-            - fc00::105
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.66/32
-           ipv6: 2064:100::42/128
-         Ethernet1:
-           ipv4: 10.0.0.131/31
-           ipv6: fc00::106/126
-       bp_interfaces:
-         ipv4: 10.10.246.35/24
-         ipv6: fc0a::23/64
-    ARISTA35T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.132
-            - fc00::109
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.67/32
-           ipv6: 2064:100::43/128
-         Ethernet1:
-           ipv4: 10.0.0.133/31
-           ipv6: fc00::10a/126
-       bp_interfaces:
-         ipv4: 10.10.246.36/24
-         ipv6: fc0a::24/64
-    ARISTA36T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.134
-            - fc00::10d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.68/32
-           ipv6: 2064:100::44/128
-         Ethernet1:
-           ipv4: 10.0.0.135/31
-           ipv6: fc00::10e/126
-       bp_interfaces:
-         ipv4: 10.10.246.37/24
-         ipv6: fc0a::25/64
-    ARISTA37T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.136
-            - fc00::111
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.69/32
-           ipv6: 2064:100::45/128
-         Ethernet1:
-           ipv4: 10.0.0.137/31
-           ipv6: fc00::112/126
-       bp_interfaces:
-         ipv4: 10.10.246.38/24
-         ipv6: fc0a::26/64
-    ARISTA38T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.138
-            - fc00::115
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.70/32
-           ipv6: 2064:100::46/128
-         Ethernet1:
-           ipv4: 10.0.0.139/31
-           ipv6: fc00::116/126
-       bp_interfaces:
-         ipv4: 10.10.246.39/24
-         ipv6: fc0a::27/64
-    ARISTA39T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.140
-            - fc00::119
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.71/32
-           ipv6: 2064:100::47/128
-         Ethernet1:
-           ipv4: 10.0.0.141/31
-           ipv6: fc00::11a/126
-       bp_interfaces:
-         ipv4: 10.10.246.40/24
-         ipv6: fc0a::28/64
-    ARISTA40T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.142
-            - fc00::11d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.72/32
-           ipv6: 2064:100::48/128
-         Ethernet1:
-           ipv4: 10.0.0.143/31
-           ipv6: fc00::11e/126
-       bp_interfaces:
-         ipv4: 10.10.246.41/24
-         ipv6: fc0a::29/64
-    ARISTA41T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.144
-            - fc00::121
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.73/32
-           ipv6: 2064:100::49/128
-         Ethernet1:
-           ipv4: 10.0.0.145/31
-           ipv6: fc00::122/126
-       bp_interfaces:
-         ipv4: 10.10.246.42/24
-         ipv6: fc0a::2a/64
-    ARISTA42T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.146
-            - fc00::125
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.74/32
-           ipv6: 2064:100::4a/128
-         Ethernet1:
-           ipv4: 10.0.0.147/31
-           ipv6: fc00::126/126
-       bp_interfaces:
-         ipv4: 10.10.246.43/24
-         ipv6: fc0a::2b/64
-    ARISTA43T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.148
-            - fc00::129
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.75/32
-           ipv6: 2064:100::4b/128
-         Ethernet1:
-           ipv4: 10.0.0.149/31
-           ipv6: fc00::12a/126
-       bp_interfaces:
-         ipv4: 10.10.246.44/24
-         ipv6: fc0a::2c/64
-    ARISTA44T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.150
-            - fc00::12d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.76/32
-           ipv6: 2064:100::4c/128
-         Ethernet1:
-           ipv4: 10.0.0.151/31
-           ipv6: fc00::12e/126
-       bp_interfaces:
-         ipv4: 10.10.246.45/24
-         ipv6: fc0a::2d/64
-    ARISTA45T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.152
-            - fc00::131
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.77/32
-           ipv6: 2064:100::4d/128
-         Ethernet1:
-           ipv4: 10.0.0.153/31
-           ipv6: fc00::132/126
-       bp_interfaces:
-         ipv4: 10.10.246.46/24
-         ipv6: fc0a::2e/64
-    ARISTA46T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.154
-            - fc00::135
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.78/32
-           ipv6: 2064:100::4e/128
-         Ethernet1:
-           ipv4: 10.0.0.155/31
-           ipv6: fc00::136/126
-       bp_interfaces:
-         ipv4: 10.10.246.47/24
-         ipv6: fc0a::2f/64
-    ARISTA47T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.156
-            - fc00::139
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.79/32
-           ipv6: 2064:100::4f/128
-         Ethernet1:
-           ipv4: 10.0.0.157/31
-           ipv6: fc00::13a/126
-       bp_interfaces:
-         ipv4: 10.10.246.48/24
-         ipv6: fc0a::30/64
-    ARISTA48T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.158
-            - fc00::13d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.80/32
-           ipv6: 2064:100::50/128
-         Ethernet1:
-           ipv4: 10.0.0.159/31
-           ipv6: fc00::13e/126
-       bp_interfaces:
-         ipv4: 10.10.246.49/24
-         ipv6: fc0a::31/64
-    ARISTA49T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.160
-            - fc00::141
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.81/32
-           ipv6: 2064:100::51/128
-         Ethernet1:
-           ipv4: 10.0.0.161/31
-           ipv6: fc00::142/126
-       bp_interfaces:
-         ipv4: 10.10.246.50/24
-         ipv6: fc0a::32/64
-    ARISTA50T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.162
-            - fc00::145
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.82/32
-           ipv6: 2064:100::52/128
-         Ethernet1:
-           ipv4: 10.0.0.163/31
-           ipv6: fc00::146/126
-       bp_interfaces:
-         ipv4: 10.10.246.51/24
-         ipv6: fc0a::33/64
-    ARISTA51T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.164
-            - fc00::149
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.83/32
-           ipv6: 2064:100::53/128
-         Ethernet1:
-           ipv4: 10.0.0.165/31
-           ipv6: fc00::14a/126
-       bp_interfaces:
-         ipv4: 10.10.246.52/24
-         ipv6: fc0a::34/64
-    ARISTA52T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.166
-            - fc00::14d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.84/32
-           ipv6: 2064:100::54/128
-         Ethernet1:
-           ipv4: 10.0.0.167/31
-           ipv6: fc00::14e/126
-       bp_interfaces:
-         ipv4: 10.10.246.53/24
-         ipv6: fc0a::35/64
-    ARISTA53T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.168
-            - fc00::151
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.85/32
-           ipv6: 2064:100::55/128
-         Ethernet1:
-           ipv4: 10.0.0.169/31
-           ipv6: fc00::152/126
-       bp_interfaces:
-         ipv4: 10.10.246.54/24
-         ipv6: fc0a::36/64
-    ARISTA54T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.170
-            - fc00::155
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.86/32
-           ipv6: 2064:100::56/128
-         Ethernet1:
-           ipv4: 10.0.0.171/31
-           ipv6: fc00::156/126
-       bp_interfaces:
-         ipv4: 10.10.246.55/24
-         ipv6: fc0a::37/64
-    ARISTA55T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.172
-            - fc00::159
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.87/32
-           ipv6: 2064:100::57/128
-         Ethernet1:
-           ipv4: 10.0.0.173/31
-           ipv6: fc00::15a/126
-       bp_interfaces:
-         ipv4: 10.10.246.56/24
-         ipv6: fc0a::38/64
-    ARISTA56T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.174
-            - fc00::15d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.88/32
-           ipv6: 2064:100::58/128
-         Ethernet1:
-           ipv4: 10.0.0.175/31
-           ipv6: fc00::15e/126
-       bp_interfaces:
-         ipv4: 10.10.246.57/24
-         ipv6: fc0a::39/64
-    ARISTA57T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.176
-            - fc00::161
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.89/32
-           ipv6: 2064:100::59/128
-         Ethernet1:
-           ipv4: 10.0.0.177/31
-           ipv6: fc00::162/126
-       bp_interfaces:
-         ipv4: 10.10.246.58/24
-         ipv6: fc0a::3a/64
-    ARISTA58T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.178
-            - fc00::165
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.90/32
-           ipv6: 2064:100::5a/128
-         Ethernet1:
-           ipv4: 10.0.0.179/31
-           ipv6: fc00::166/126
-       bp_interfaces:
-         ipv4: 10.10.246.59/24
-         ipv6: fc0a::3b/64
-    ARISTA59T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.180
-            - fc00::169
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.91/32
-           ipv6: 2064:100::5b/128
-         Ethernet1:
-           ipv4: 10.0.0.181/31
-           ipv6: fc00::16a/126
-       bp_interfaces:
-         ipv4: 10.10.246.60/24
-         ipv6: fc0a::3c/64
-    ARISTA60T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.182
-            - fc00::16d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.92/32
-           ipv6: 2064:100::5c/128
-         Ethernet1:
-           ipv4: 10.0.0.183/31
-           ipv6: fc00::16e/126
-       bp_interfaces:
-         ipv4: 10.10.246.61/24
-         ipv6: fc0a::3d/64
-    ARISTA61T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.184
-            - fc00::171
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.93/32
-           ipv6: 2064:100::5d/128
-         Ethernet1:
-           ipv4: 10.0.0.185/31
-           ipv6: fc00::172/126
-       bp_interfaces:
-         ipv4: 10.10.246.62/24
-         ipv6: fc0a::3e/64
-    ARISTA62T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.186
-            - fc00::175
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.94/32
-           ipv6: 2064:100::5e/128
-         Ethernet1:
-           ipv4: 10.0.0.187/31
-           ipv6: fc00::176/126
-       bp_interfaces:
-         ipv4: 10.10.246.63/24
-         ipv6: fc0a::3f/64
-    ARISTA63T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.188
-            - fc00::179
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.95/32
-           ipv6: 2064:100::5f/128
-         Ethernet1:
-           ipv4: 10.0.0.189/31
-           ipv6: fc00::17a/126
-       bp_interfaces:
-         ipv4: 10.10.246.64/24
-         ipv6: fc0a::40/64
-    ARISTA64T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.0.190
-            - fc00::17d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.96/32
-           ipv6: 2064:100::60/128
-         Ethernet1:
-           ipv4: 10.0.0.191/31
-           ipv6: fc00::17e/126
-       bp_interfaces:
-         ipv4: 10.10.246.65/24
-         ipv6: fc0a::41/64
-    ARISTA65T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.64
-            - fc00::281
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.161/32
-           ipv6: 2064:100::a1/128
-         Ethernet1:
-           ipv4: 10.0.1.65/31
-           ipv6: fc00::282/126
-       bp_interfaces:
-         ipv4: 10.10.246.66/24
-         ipv6: fc0a::42/64
-    ARISTA66T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.66
-            - fc00::285
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.162/32
-           ipv6: 2064:100::a2/128
-         Ethernet1:
-           ipv4: 10.0.1.67/31
-           ipv6: fc00::286/126
-       bp_interfaces:
-         ipv4: 10.10.246.67/24
-         ipv6: fc0a::43/64
-    ARISTA67T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.68
-            - fc00::289
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.163/32
-           ipv6: 2064:100::a3/128
-         Ethernet1:
-           ipv4: 10.0.1.69/31
-           ipv6: fc00::28a/126
-       bp_interfaces:
-         ipv4: 10.10.246.68/24
-         ipv6: fc0a::44/64
-    ARISTA68T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.70
-            - fc00::28d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.164/32
-           ipv6: 2064:100::a4/128
-         Ethernet1:
-           ipv4: 10.0.1.71/31
-           ipv6: fc00::28e/126
-       bp_interfaces:
-         ipv4: 10.10.246.69/24
-         ipv6: fc0a::45/64
-    ARISTA69T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.72
-            - fc00::291
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.165/32
-           ipv6: 2064:100::a5/128
-         Ethernet1:
-           ipv4: 10.0.1.73/31
-           ipv6: fc00::292/126
-       bp_interfaces:
-         ipv4: 10.10.246.70/24
-         ipv6: fc0a::46/64
-    ARISTA70T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.74
-            - fc00::295
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.166/32
-           ipv6: 2064:100::a6/128
-         Ethernet1:
-           ipv4: 10.0.1.75/31
-           ipv6: fc00::296/126
-       bp_interfaces:
-         ipv4: 10.10.246.71/24
-         ipv6: fc0a::47/64
-    ARISTA71T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.76
-            - fc00::299
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.167/32
-           ipv6: 2064:100::a7/128
-         Ethernet1:
-           ipv4: 10.0.1.77/31
-           ipv6: fc00::29a/126
-       bp_interfaces:
-         ipv4: 10.10.246.72/24
-         ipv6: fc0a::48/64
-    ARISTA72T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.78
-            - fc00::29d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.168/32
-           ipv6: 2064:100::a8/128
-         Ethernet1:
-           ipv4: 10.0.1.79/31
-           ipv6: fc00::29e/126
-       bp_interfaces:
-         ipv4: 10.10.246.73/24
-         ipv6: fc0a::49/64
-    ARISTA73T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.80
-            - fc00::2a1
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.169/32
-           ipv6: 2064:100::a9/128
-         Ethernet1:
-           ipv4: 10.0.1.81/31
-           ipv6: fc00::2a2/126
-       bp_interfaces:
-         ipv4: 10.10.246.74/24
-         ipv6: fc0a::4a/64
-    ARISTA74T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.82
-            - fc00::2a5
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.170/32
-           ipv6: 2064:100::aa/128
-         Ethernet1:
-           ipv4: 10.0.1.83/31
-           ipv6: fc00::2a6/126
-       bp_interfaces:
-         ipv4: 10.10.246.75/24
-         ipv6: fc0a::4b/64
-    ARISTA75T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.84
-            - fc00::2a9
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.171/32
-           ipv6: 2064:100::ab/128
-         Ethernet1:
-           ipv4: 10.0.1.85/31
-           ipv6: fc00::2aa/126
-       bp_interfaces:
-         ipv4: 10.10.246.76/24
-         ipv6: fc0a::4c/64
-    ARISTA76T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.86
-            - fc00::2ad
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.172/32
-           ipv6: 2064:100::ac/128
-         Ethernet1:
-           ipv4: 10.0.1.87/31
-           ipv6: fc00::2ae/126
-       bp_interfaces:
-         ipv4: 10.10.246.77/24
-         ipv6: fc0a::4d/64
-    ARISTA77T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.88
-            - fc00::2b1
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.173/32
-           ipv6: 2064:100::ad/128
-         Ethernet1:
-           ipv4: 10.0.1.89/31
-           ipv6: fc00::2b2/126
-       bp_interfaces:
-         ipv4: 10.10.246.78/24
-         ipv6: fc0a::4e/64
-    ARISTA78T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.90
-            - fc00::2b5
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.174/32
-           ipv6: 2064:100::ae/128
-         Ethernet1:
-           ipv4: 10.0.1.91/31
-           ipv6: fc00::2b6/126
-       bp_interfaces:
-         ipv4: 10.10.246.79/24
-         ipv6: fc0a::4f/64
-    ARISTA79T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.92
-            - fc00::2b9
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.175/32
-           ipv6: 2064:100::af/128
-         Ethernet1:
-           ipv4: 10.0.1.93/31
-           ipv6: fc00::2ba/126
-       bp_interfaces:
-         ipv4: 10.10.246.80/24
-         ipv6: fc0a::50/64
-    ARISTA80T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.94
-            - fc00::2bd
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.176/32
-           ipv6: 2064:100::b0/128
-         Ethernet1:
-           ipv4: 10.0.1.95/31
-           ipv6: fc00::2be/126
-       bp_interfaces:
-         ipv4: 10.10.246.81/24
-         ipv6: fc0a::51/64
-    ARISTA81T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.96
-            - fc00::2c1
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.177/32
-           ipv6: 2064:100::b1/128
-         Ethernet1:
-           ipv4: 10.0.1.97/31
-           ipv6: fc00::2c2/126
-       bp_interfaces:
-         ipv4: 10.10.246.82/24
-         ipv6: fc0a::52/64
-    ARISTA82T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.98
-            - fc00::2c5
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.178/32
-           ipv6: 2064:100::b2/128
-         Ethernet1:
-           ipv4: 10.0.1.99/31
-           ipv6: fc00::2c6/126
-       bp_interfaces:
-         ipv4: 10.10.246.83/24
-         ipv6: fc0a::53/64
-    ARISTA83T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.100
-            - fc00::2c9
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.179/32
-           ipv6: 2064:100::b3/128
-         Ethernet1:
-           ipv4: 10.0.1.101/31
-           ipv6: fc00::2ca/126
-       bp_interfaces:
-         ipv4: 10.10.246.84/24
-         ipv6: fc0a::54/64
-    ARISTA84T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.102
-            - fc00::2cd
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.180/32
-           ipv6: 2064:100::b4/128
-         Ethernet1:
-           ipv4: 10.0.1.103/31
-           ipv6: fc00::2ce/126
-       bp_interfaces:
-         ipv4: 10.10.246.85/24
-         ipv6: fc0a::55/64
-    ARISTA85T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.104
-            - fc00::2d1
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.181/32
-           ipv6: 2064:100::b5/128
-         Ethernet1:
-           ipv4: 10.0.1.105/31
-           ipv6: fc00::2d2/126
-       bp_interfaces:
-         ipv4: 10.10.246.86/24
-         ipv6: fc0a::56/64
-    ARISTA86T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.106
-            - fc00::2d5
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.182/32
-           ipv6: 2064:100::b6/128
-         Ethernet1:
-           ipv4: 10.0.1.107/31
-           ipv6: fc00::2d6/126
-       bp_interfaces:
-         ipv4: 10.10.246.87/24
-         ipv6: fc0a::57/64
-    ARISTA87T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.108
-            - fc00::2d9
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.183/32
-           ipv6: 2064:100::b7/128
-         Ethernet1:
-           ipv4: 10.0.1.109/31
-           ipv6: fc00::2da/126
-       bp_interfaces:
-         ipv4: 10.10.246.88/24
-         ipv6: fc0a::58/64
-    ARISTA88T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.110
-            - fc00::2dd
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.184/32
-           ipv6: 2064:100::b8/128
-         Ethernet1:
-           ipv4: 10.0.1.111/31
-           ipv6: fc00::2de/126
-       bp_interfaces:
-         ipv4: 10.10.246.89/24
-         ipv6: fc0a::59/64
-    ARISTA89T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.112
-            - fc00::2e1
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.185/32
-           ipv6: 2064:100::b9/128
-         Ethernet1:
-           ipv4: 10.0.1.113/31
-           ipv6: fc00::2e2/126
-       bp_interfaces:
-         ipv4: 10.10.246.90/24
-         ipv6: fc0a::5a/64
-    ARISTA90T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.114
-            - fc00::2e5
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.186/32
-           ipv6: 2064:100::ba/128
-         Ethernet1:
-           ipv4: 10.0.1.115/31
-           ipv6: fc00::2e6/126
-       bp_interfaces:
-         ipv4: 10.10.246.91/24
-         ipv6: fc0a::5b/64
-    ARISTA91T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.116
-            - fc00::2e9
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.187/32
-           ipv6: 2064:100::bb/128
-         Ethernet1:
-           ipv4: 10.0.1.117/31
-           ipv6: fc00::2ea/126
-       bp_interfaces:
-         ipv4: 10.10.246.92/24
-         ipv6: fc0a::5c/64
-    ARISTA92T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.118
-            - fc00::2ed
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.188/32
-           ipv6: 2064:100::bc/128
-         Ethernet1:
-           ipv4: 10.0.1.119/31
-           ipv6: fc00::2ee/126
-       bp_interfaces:
-         ipv4: 10.10.246.93/24
-         ipv6: fc0a::5d/64
-    ARISTA93T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.120
-            - fc00::2f1
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.189/32
-           ipv6: 2064:100::bd/128
-         Ethernet1:
-           ipv4: 10.0.1.121/31
-           ipv6: fc00::2f2/126
-       bp_interfaces:
-         ipv4: 10.10.246.94/24
-         ipv6: fc0a::5e/64
-    ARISTA94T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.122
-            - fc00::2f5
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.190/32
-           ipv6: 2064:100::be/128
-         Ethernet1:
-           ipv4: 10.0.1.123/31
-           ipv6: fc00::2f6/126
-       bp_interfaces:
-         ipv4: 10.10.246.95/24
-         ipv6: fc0a::5f/64
-    ARISTA95T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.124
-            - fc00::2f9
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.191/32
-           ipv6: 2064:100::bf/128
-         Ethernet1:
-           ipv4: 10.0.1.125/31
-           ipv6: fc00::2fa/126
-       bp_interfaces:
-         ipv4: 10.10.246.96/24
-         ipv6: fc0a::60/64
-    ARISTA96T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.126
-            - fc00::2fd
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.192/32
-           ipv6: 2064:100::c0/128
-         Ethernet1:
-           ipv4: 10.0.1.127/31
-           ipv6: fc00::2fe/126
-       bp_interfaces:
-         ipv4: 10.10.246.97/24
-         ipv6: fc0a::61/64
-    ARISTA97T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.128
-            - fc00::301
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.193/32
-           ipv6: 2064:100::c1/128
-         Ethernet1:
-           ipv4: 10.0.1.129/31
-           ipv6: fc00::302/126
-       bp_interfaces:
-         ipv4: 10.10.246.98/24
-         ipv6: fc0a::62/64
-    ARISTA98T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.130
-            - fc00::305
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.194/32
-           ipv6: 2064:100::c2/128
-         Ethernet1:
-           ipv4: 10.0.1.131/31
-           ipv6: fc00::306/126
-       bp_interfaces:
-         ipv4: 10.10.246.99/24
-         ipv6: fc0a::63/64
-    ARISTA99T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.132
-            - fc00::309
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.195/32
-           ipv6: 2064:100::c3/128
-         Ethernet1:
-           ipv4: 10.0.1.133/31
-           ipv6: fc00::30a/126
-       bp_interfaces:
-         ipv4: 10.10.246.100/24
-         ipv6: fc0a::64/64
-    ARISTA100T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.134
-            - fc00::30d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.196/32
-           ipv6: 2064:100::c4/128
-         Ethernet1:
-           ipv4: 10.0.1.135/31
-           ipv6: fc00::30e/126
-       bp_interfaces:
-         ipv4: 10.10.246.101/24
-         ipv6: fc0a::65/64
-    ARISTA101T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.136
-            - fc00::311
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.197/32
-           ipv6: 2064:100::c5/128
-         Ethernet1:
-           ipv4: 10.0.1.137/31
-           ipv6: fc00::312/126
-       bp_interfaces:
-         ipv4: 10.10.246.102/24
-         ipv6: fc0a::66/64
-    ARISTA102T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.138
-            - fc00::315
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.198/32
-           ipv6: 2064:100::c6/128
-         Ethernet1:
-           ipv4: 10.0.1.139/31
-           ipv6: fc00::316/126
-       bp_interfaces:
-         ipv4: 10.10.246.103/24
-         ipv6: fc0a::67/64
-    ARISTA103T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.140
-            - fc00::319
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.199/32
-           ipv6: 2064:100::c7/128
-         Ethernet1:
-           ipv4: 10.0.1.141/31
-           ipv6: fc00::31a/126
-       bp_interfaces:
-         ipv4: 10.10.246.104/24
-         ipv6: fc0a::68/64
-    ARISTA104T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.142
-            - fc00::31d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.200/32
-           ipv6: 2064:100::c8/128
-         Ethernet1:
-           ipv4: 10.0.1.143/31
-           ipv6: fc00::31e/126
-       bp_interfaces:
-         ipv4: 10.10.246.105/24
-         ipv6: fc0a::69/64
-    ARISTA105T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.144
-            - fc00::321
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.201/32
-           ipv6: 2064:100::c9/128
-         Ethernet1:
-           ipv4: 10.0.1.145/31
-           ipv6: fc00::322/126
-       bp_interfaces:
-         ipv4: 10.10.246.106/24
-         ipv6: fc0a::6a/64
-    ARISTA106T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.146
-            - fc00::325
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.202/32
-           ipv6: 2064:100::ca/128
-         Ethernet1:
-           ipv4: 10.0.1.147/31
-           ipv6: fc00::326/126
-       bp_interfaces:
-         ipv4: 10.10.246.107/24
-         ipv6: fc0a::6b/64
-    ARISTA107T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.148
-            - fc00::329
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.203/32
-           ipv6: 2064:100::cb/128
-         Ethernet1:
-           ipv4: 10.0.1.149/31
-           ipv6: fc00::32a/126
-       bp_interfaces:
-         ipv4: 10.10.246.108/24
-         ipv6: fc0a::6c/64
-    ARISTA108T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.150
-            - fc00::32d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.204/32
-           ipv6: 2064:100::cc/128
-         Ethernet1:
-           ipv4: 10.0.1.151/31
-           ipv6: fc00::32e/126
-       bp_interfaces:
-         ipv4: 10.10.246.109/24
-         ipv6: fc0a::6d/64
-    ARISTA109T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.152
-            - fc00::331
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.205/32
-           ipv6: 2064:100::cd/128
-         Ethernet1:
-           ipv4: 10.0.1.153/31
-           ipv6: fc00::332/126
-       bp_interfaces:
-         ipv4: 10.10.246.110/24
-         ipv6: fc0a::6e/64
-    ARISTA110T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.154
-            - fc00::335
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.206/32
-           ipv6: 2064:100::ce/128
-         Ethernet1:
-           ipv4: 10.0.1.155/31
-           ipv6: fc00::336/126
-       bp_interfaces:
-         ipv4: 10.10.246.111/24
-         ipv6: fc0a::6f/64
-    ARISTA111T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.156
-            - fc00::339
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.207/32
-           ipv6: 2064:100::cf/128
-         Ethernet1:
-           ipv4: 10.0.1.157/31
-           ipv6: fc00::33a/126
-       bp_interfaces:
-         ipv4: 10.10.246.112/24
-         ipv6: fc0a::70/64
-    ARISTA112T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.158
-            - fc00::33d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.208/32
-           ipv6: 2064:100::d0/128
-         Ethernet1:
-           ipv4: 10.0.1.159/31
-           ipv6: fc00::33e/126
-       bp_interfaces:
-         ipv4: 10.10.246.113/24
-         ipv6: fc0a::71/64
-    ARISTA113T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.160
-            - fc00::341
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.209/32
-           ipv6: 2064:100::d1/128
-         Ethernet1:
-           ipv4: 10.0.1.161/31
-           ipv6: fc00::342/126
-       bp_interfaces:
-         ipv4: 10.10.246.114/24
-         ipv6: fc0a::72/64
-    ARISTA114T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.162
-            - fc00::345
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.210/32
-           ipv6: 2064:100::d2/128
-         Ethernet1:
-           ipv4: 10.0.1.163/31
-           ipv6: fc00::346/126
-       bp_interfaces:
-         ipv4: 10.10.246.115/24
-         ipv6: fc0a::73/64
-    ARISTA115T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.164
-            - fc00::349
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.211/32
-           ipv6: 2064:100::d3/128
-         Ethernet1:
-           ipv4: 10.0.1.165/31
-           ipv6: fc00::34a/126
-       bp_interfaces:
-         ipv4: 10.10.246.116/24
-         ipv6: fc0a::74/64
-    ARISTA116T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.166
-            - fc00::34d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.212/32
-           ipv6: 2064:100::d4/128
-         Ethernet1:
-           ipv4: 10.0.1.167/31
-           ipv6: fc00::34e/126
-       bp_interfaces:
-         ipv4: 10.10.246.117/24
-         ipv6: fc0a::75/64
-    ARISTA117T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.168
-            - fc00::351
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.213/32
-           ipv6: 2064:100::d5/128
-         Ethernet1:
-           ipv4: 10.0.1.169/31
-           ipv6: fc00::352/126
-       bp_interfaces:
-         ipv4: 10.10.246.118/24
-         ipv6: fc0a::76/64
-    ARISTA118T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.170
-            - fc00::355
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.214/32
-           ipv6: 2064:100::d6/128
-         Ethernet1:
-           ipv4: 10.0.1.171/31
-           ipv6: fc00::356/126
-       bp_interfaces:
-         ipv4: 10.10.246.119/24
-         ipv6: fc0a::77/64
-    ARISTA119T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.172
-            - fc00::359
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.215/32
-           ipv6: 2064:100::d7/128
-         Ethernet1:
-           ipv4: 10.0.1.173/31
-           ipv6: fc00::35a/126
-       bp_interfaces:
-         ipv4: 10.10.246.120/24
-         ipv6: fc0a::78/64
-    ARISTA120T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.174
-            - fc00::35d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.216/32
-           ipv6: 2064:100::d8/128
-         Ethernet1:
-           ipv4: 10.0.1.175/31
-           ipv6: fc00::35e/126
-       bp_interfaces:
-         ipv4: 10.10.246.121/24
-         ipv6: fc0a::79/64
-    ARISTA121T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.176
-            - fc00::361
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.217/32
-           ipv6: 2064:100::d9/128
-         Ethernet1:
-           ipv4: 10.0.1.177/31
-           ipv6: fc00::362/126
-       bp_interfaces:
-         ipv4: 10.10.246.122/24
-         ipv6: fc0a::7a/64
-    ARISTA122T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.178
-            - fc00::365
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.218/32
-           ipv6: 2064:100::da/128
-         Ethernet1:
-           ipv4: 10.0.1.179/31
-           ipv6: fc00::366/126
-       bp_interfaces:
-         ipv4: 10.10.246.123/24
-         ipv6: fc0a::7b/64
-    ARISTA123T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.180
-            - fc00::369
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.219/32
-           ipv6: 2064:100::db/128
-         Ethernet1:
-           ipv4: 10.0.1.181/31
-           ipv6: fc00::36a/126
-       bp_interfaces:
-         ipv4: 10.10.246.124/24
-         ipv6: fc0a::7c/64
-    ARISTA124T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.182
-            - fc00::36d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.220/32
-           ipv6: 2064:100::dc/128
-         Ethernet1:
-           ipv4: 10.0.1.183/31
-           ipv6: fc00::36e/126
-       bp_interfaces:
-         ipv4: 10.10.246.125/24
-         ipv6: fc0a::7d/64
-    ARISTA125T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.184
-            - fc00::371
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.221/32
-           ipv6: 2064:100::dd/128
-         Ethernet1:
-           ipv4: 10.0.1.185/31
-           ipv6: fc00::372/126
-       bp_interfaces:
-         ipv4: 10.10.246.126/24
-         ipv6: fc0a::7e/64
-    ARISTA126T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.186
-            - fc00::375
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.222/32
-           ipv6: 2064:100::de/128
-         Ethernet1:
-           ipv4: 10.0.1.187/31
-           ipv6: fc00::376/126
-       bp_interfaces:
-         ipv4: 10.10.246.127/24
-         ipv6: fc0a::7f/64
-    ARISTA127T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.188
-            - fc00::379
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.223/32
-           ipv6: 2064:100::df/128
-         Ethernet1:
-           ipv4: 10.0.1.189/31
-           ipv6: fc00::37a/126
-       bp_interfaces:
-         ipv4: 10.10.246.128/24
-         ipv6: fc0a::80/64
-    ARISTA128T1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.1.190
-            - fc00::37d
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.0.224/32
-           ipv6: 2064:100::e0/128
-         Ethernet1:
-           ipv4: 10.0.1.191/31
-           ipv6: fc00::37e/126
-       bp_interfaces:
-         ipv4: 10.10.246.129/24
-         ipv6: fc0a::81/64
-    ARISTA01PT1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.2.0
-            - fc00::401
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.1.1/32
-           ipv6: 2064:100::101/128
-         Ethernet1:
-           ipv4: 10.0.2.1/31
-           ipv6: fc00::402/126
-       bp_interfaces:
-         ipv4: 10.10.246.130/24
-         ipv6: fc0a::82/64
-    ARISTA02PT1:
-      properties:
-      - common
-      bgp:
-        asn: 64802
-        peers:
-          64601:
-            - 10.0.2.2
-            - fc00::405
-       interfaces:
-         Loopback0:
-           ipv4: 100.1.1.2/32
-           ipv6: 2064:100::102/128
-         Ethernet1:
-           ipv4: 10.0.2.3/31
-           ipv6: fc00::406/126
-       bp_interfaces:
-         ipv4: 10.10.246.131/24
-         ipv6: fc0a::83/64
+  ARISTA01T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.64
+          - fc00::81
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.33/32
+        ipv6: 2064:100::21/128
+      Ethernet1:
+        ipv4: 10.0.0.65/31
+        ipv6: fc00::82/126
+    bp_interfaces:
+      ipv4: 10.10.246.2/24
+      ipv6: fc0a::2/64
+  ARISTA02T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.66
+          - fc00::85
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.34/32
+        ipv6: 2064:100::22/128
+      Ethernet1:
+        ipv4: 10.0.0.67/31
+        ipv6: fc00::86/126
+    bp_interfaces:
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::3/64
+  ARISTA03T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.68
+          - fc00::89
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.35/32
+        ipv6: 2064:100::23/128
+      Ethernet1:
+        ipv4: 10.0.0.69/31
+        ipv6: fc00::8a/126
+    bp_interfaces:
+      ipv4: 10.10.246.4/24
+      ipv6: fc0a::4/64
+  ARISTA04T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.70
+          - fc00::8d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.36/32
+        ipv6: 2064:100::24/128
+      Ethernet1:
+        ipv4: 10.0.0.71/31
+        ipv6: fc00::8e/126
+    bp_interfaces:
+      ipv4: 10.10.246.5/24
+      ipv6: fc0a::5/64
+  ARISTA05T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.72
+          - fc00::91
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.37/32
+        ipv6: 2064:100::25/128
+      Ethernet1:
+        ipv4: 10.0.0.73/31
+        ipv6: fc00::92/126
+    bp_interfaces:
+      ipv4: 10.10.246.6/24
+      ipv6: fc0a::6/64
+  ARISTA06T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.74
+          - fc00::95
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.38/32
+        ipv6: 2064:100::26/128
+      Ethernet1:
+        ipv4: 10.0.0.75/31
+        ipv6: fc00::96/126
+    bp_interfaces:
+      ipv4: 10.10.246.7/24
+      ipv6: fc0a::7/64
+  ARISTA07T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.76
+          - fc00::99
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.39/32
+        ipv6: 2064:100::27/128
+      Ethernet1:
+        ipv4: 10.0.0.77/31
+        ipv6: fc00::9a/126
+    bp_interfaces:
+      ipv4: 10.10.246.8/24
+      ipv6: fc0a::8/64
+  ARISTA08T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.78
+          - fc00::9d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.40/32
+        ipv6: 2064:100::28/128
+      Ethernet1:
+        ipv4: 10.0.0.79/31
+        ipv6: fc00::9e/126
+    bp_interfaces:
+      ipv4: 10.10.246.9/24
+      ipv6: fc0a::9/64
+  ARISTA09T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.80
+          - fc00::a1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.41/32
+        ipv6: 2064:100::29/128
+      Ethernet1:
+        ipv4: 10.0.0.81/31
+        ipv6: fc00::a2/126
+    bp_interfaces:
+      ipv4: 10.10.246.10/24
+      ipv6: fc0a::a/64
+  ARISTA10T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.82
+          - fc00::a5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.42/32
+        ipv6: 2064:100::2a/128
+      Ethernet1:
+        ipv4: 10.0.0.83/31
+        ipv6: fc00::a6/126
+    bp_interfaces:
+      ipv4: 10.10.246.11/24
+      ipv6: fc0a::b/64
+  ARISTA11T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.84
+          - fc00::a9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.43/32
+        ipv6: 2064:100::2b/128
+      Ethernet1:
+        ipv4: 10.0.0.85/31
+        ipv6: fc00::aa/126
+    bp_interfaces:
+      ipv4: 10.10.246.12/24
+      ipv6: fc0a::c/64
+  ARISTA12T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.86
+          - fc00::ad
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.44/32
+        ipv6: 2064:100::2c/128
+      Ethernet1:
+        ipv4: 10.0.0.87/31
+        ipv6: fc00::ae/126
+    bp_interfaces:
+      ipv4: 10.10.246.13/24
+      ipv6: fc0a::d/64
+  ARISTA13T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.88
+          - fc00::b1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.45/32
+        ipv6: 2064:100::2d/128
+      Ethernet1:
+        ipv4: 10.0.0.89/31
+        ipv6: fc00::b2/126
+    bp_interfaces:
+      ipv4: 10.10.246.14/24
+      ipv6: fc0a::e/64
+  ARISTA14T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.90
+          - fc00::b5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.46/32
+        ipv6: 2064:100::2e/128
+      Ethernet1:
+        ipv4: 10.0.0.91/31
+        ipv6: fc00::b6/126
+    bp_interfaces:
+      ipv4: 10.10.246.15/24
+      ipv6: fc0a::f/64
+  ARISTA15T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.92
+          - fc00::b9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.47/32
+        ipv6: 2064:100::2f/128
+      Ethernet1:
+        ipv4: 10.0.0.93/31
+        ipv6: fc00::ba/126
+    bp_interfaces:
+      ipv4: 10.10.246.16/24
+      ipv6: fc0a::10/64
+  ARISTA16T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.94
+          - fc00::bd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.48/32
+        ipv6: 2064:100::30/128
+      Ethernet1:
+        ipv4: 10.0.0.95/31
+        ipv6: fc00::be/126
+    bp_interfaces:
+      ipv4: 10.10.246.17/24
+      ipv6: fc0a::11/64
+  ARISTA17T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.96
+          - fc00::c1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.49/32
+        ipv6: 2064:100::31/128
+      Ethernet1:
+        ipv4: 10.0.0.97/31
+        ipv6: fc00::c2/126
+    bp_interfaces:
+      ipv4: 10.10.246.18/24
+      ipv6: fc0a::12/64
+  ARISTA18T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.98
+          - fc00::c5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.50/32
+        ipv6: 2064:100::32/128
+      Ethernet1:
+        ipv4: 10.0.0.99/31
+        ipv6: fc00::c6/126
+    bp_interfaces:
+      ipv4: 10.10.246.19/24
+      ipv6: fc0a::13/64
+  ARISTA19T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.100
+          - fc00::c9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.51/32
+        ipv6: 2064:100::33/128
+      Ethernet1:
+        ipv4: 10.0.0.101/31
+        ipv6: fc00::ca/126
+    bp_interfaces:
+      ipv4: 10.10.246.20/24
+      ipv6: fc0a::14/64
+  ARISTA20T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.102
+          - fc00::cd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.52/32
+        ipv6: 2064:100::34/128
+      Ethernet1:
+        ipv4: 10.0.0.103/31
+        ipv6: fc00::ce/126
+    bp_interfaces:
+      ipv4: 10.10.246.21/24
+      ipv6: fc0a::15/64
+  ARISTA21T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.104
+          - fc00::d1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.53/32
+        ipv6: 2064:100::35/128
+      Ethernet1:
+        ipv4: 10.0.0.105/31
+        ipv6: fc00::d2/126
+    bp_interfaces:
+      ipv4: 10.10.246.22/24
+      ipv6: fc0a::16/64
+  ARISTA22T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.106
+          - fc00::d5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.54/32
+        ipv6: 2064:100::36/128
+      Ethernet1:
+        ipv4: 10.0.0.107/31
+        ipv6: fc00::d6/126
+    bp_interfaces:
+      ipv4: 10.10.246.23/24
+      ipv6: fc0a::17/64
+  ARISTA23T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.108
+          - fc00::d9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.55/32
+        ipv6: 2064:100::37/128
+      Ethernet1:
+        ipv4: 10.0.0.109/31
+        ipv6: fc00::da/126
+    bp_interfaces:
+      ipv4: 10.10.246.24/24
+      ipv6: fc0a::18/64
+  ARISTA24T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.110
+          - fc00::dd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.56/32
+        ipv6: 2064:100::38/128
+      Ethernet1:
+        ipv4: 10.0.0.111/31
+        ipv6: fc00::de/126
+    bp_interfaces:
+      ipv4: 10.10.246.25/24
+      ipv6: fc0a::19/64
+  ARISTA25T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.112
+          - fc00::e1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.57/32
+        ipv6: 2064:100::39/128
+      Ethernet1:
+        ipv4: 10.0.0.113/31
+        ipv6: fc00::e2/126
+    bp_interfaces:
+      ipv4: 10.10.246.26/24
+      ipv6: fc0a::1a/64
+  ARISTA26T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.114
+          - fc00::e5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.58/32
+        ipv6: 2064:100::3a/128
+      Ethernet1:
+        ipv4: 10.0.0.115/31
+        ipv6: fc00::e6/126
+    bp_interfaces:
+      ipv4: 10.10.246.27/24
+      ipv6: fc0a::1b/64
+  ARISTA27T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.116
+          - fc00::e9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.59/32
+        ipv6: 2064:100::3b/128
+      Ethernet1:
+        ipv4: 10.0.0.117/31
+        ipv6: fc00::ea/126
+    bp_interfaces:
+      ipv4: 10.10.246.28/24
+      ipv6: fc0a::1c/64
+  ARISTA28T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.118
+          - fc00::ed
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.60/32
+        ipv6: 2064:100::3c/128
+      Ethernet1:
+        ipv4: 10.0.0.119/31
+        ipv6: fc00::ee/126
+    bp_interfaces:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::1d/64
+  ARISTA29T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.120
+          - fc00::f1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.61/32
+        ipv6: 2064:100::3d/128
+      Ethernet1:
+        ipv4: 10.0.0.121/31
+        ipv6: fc00::f2/126
+    bp_interfaces:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::1e/64
+  ARISTA30T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.122
+          - fc00::f5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.62/32
+        ipv6: 2064:100::3e/128
+      Ethernet1:
+        ipv4: 10.0.0.123/31
+        ipv6: fc00::f6/126
+    bp_interfaces:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::1f/64
+  ARISTA31T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.124
+          - fc00::f9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.63/32
+        ipv6: 2064:100::3f/128
+      Ethernet1:
+        ipv4: 10.0.0.125/31
+        ipv6: fc00::fa/126
+    bp_interfaces:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::20/64
+  ARISTA32T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.126
+          - fc00::fd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.64/32
+        ipv6: 2064:100::40/128
+      Ethernet1:
+        ipv4: 10.0.0.127/31
+        ipv6: fc00::fe/126
+    bp_interfaces:
+      ipv4: 10.10.246.33/24
+      ipv6: fc0a::21/64
+  ARISTA33T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.128
+          - fc00::101
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.65/32
+        ipv6: 2064:100::41/128
+      Ethernet1:
+        ipv4: 10.0.0.129/31
+        ipv6: fc00::102/126
+    bp_interfaces:
+      ipv4: 10.10.246.34/24
+      ipv6: fc0a::22/64
+  ARISTA34T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.130
+          - fc00::105
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.66/32
+        ipv6: 2064:100::42/128
+      Ethernet1:
+        ipv4: 10.0.0.131/31
+        ipv6: fc00::106/126
+    bp_interfaces:
+      ipv4: 10.10.246.35/24
+      ipv6: fc0a::23/64
+  ARISTA35T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.132
+          - fc00::109
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.67/32
+        ipv6: 2064:100::43/128
+      Ethernet1:
+        ipv4: 10.0.0.133/31
+        ipv6: fc00::10a/126
+    bp_interfaces:
+      ipv4: 10.10.246.36/24
+      ipv6: fc0a::24/64
+  ARISTA36T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.134
+          - fc00::10d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.68/32
+        ipv6: 2064:100::44/128
+      Ethernet1:
+        ipv4: 10.0.0.135/31
+        ipv6: fc00::10e/126
+    bp_interfaces:
+      ipv4: 10.10.246.37/24
+      ipv6: fc0a::25/64
+  ARISTA37T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.136
+          - fc00::111
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.69/32
+        ipv6: 2064:100::45/128
+      Ethernet1:
+        ipv4: 10.0.0.137/31
+        ipv6: fc00::112/126
+    bp_interfaces:
+      ipv4: 10.10.246.38/24
+      ipv6: fc0a::26/64
+  ARISTA38T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.138
+          - fc00::115
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.70/32
+        ipv6: 2064:100::46/128
+      Ethernet1:
+        ipv4: 10.0.0.139/31
+        ipv6: fc00::116/126
+    bp_interfaces:
+      ipv4: 10.10.246.39/24
+      ipv6: fc0a::27/64
+  ARISTA39T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.140
+          - fc00::119
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.71/32
+        ipv6: 2064:100::47/128
+      Ethernet1:
+        ipv4: 10.0.0.141/31
+        ipv6: fc00::11a/126
+    bp_interfaces:
+      ipv4: 10.10.246.40/24
+      ipv6: fc0a::28/64
+  ARISTA40T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.142
+          - fc00::11d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.72/32
+        ipv6: 2064:100::48/128
+      Ethernet1:
+        ipv4: 10.0.0.143/31
+        ipv6: fc00::11e/126
+    bp_interfaces:
+      ipv4: 10.10.246.41/24
+      ipv6: fc0a::29/64
+  ARISTA41T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.144
+          - fc00::121
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.73/32
+        ipv6: 2064:100::49/128
+      Ethernet1:
+        ipv4: 10.0.0.145/31
+        ipv6: fc00::122/126
+    bp_interfaces:
+      ipv4: 10.10.246.42/24
+      ipv6: fc0a::2a/64
+  ARISTA42T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.146
+          - fc00::125
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.74/32
+        ipv6: 2064:100::4a/128
+      Ethernet1:
+        ipv4: 10.0.0.147/31
+        ipv6: fc00::126/126
+    bp_interfaces:
+      ipv4: 10.10.246.43/24
+      ipv6: fc0a::2b/64
+  ARISTA43T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.148
+          - fc00::129
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.75/32
+        ipv6: 2064:100::4b/128
+      Ethernet1:
+        ipv4: 10.0.0.149/31
+        ipv6: fc00::12a/126
+    bp_interfaces:
+      ipv4: 10.10.246.44/24
+      ipv6: fc0a::2c/64
+  ARISTA44T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.150
+          - fc00::12d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.76/32
+        ipv6: 2064:100::4c/128
+      Ethernet1:
+        ipv4: 10.0.0.151/31
+        ipv6: fc00::12e/126
+    bp_interfaces:
+      ipv4: 10.10.246.45/24
+      ipv6: fc0a::2d/64
+  ARISTA45T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.152
+          - fc00::131
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.77/32
+        ipv6: 2064:100::4d/128
+      Ethernet1:
+        ipv4: 10.0.0.153/31
+        ipv6: fc00::132/126
+    bp_interfaces:
+      ipv4: 10.10.246.46/24
+      ipv6: fc0a::2e/64
+  ARISTA46T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.154
+          - fc00::135
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.78/32
+        ipv6: 2064:100::4e/128
+      Ethernet1:
+        ipv4: 10.0.0.155/31
+        ipv6: fc00::136/126
+    bp_interfaces:
+      ipv4: 10.10.246.47/24
+      ipv6: fc0a::2f/64
+  ARISTA47T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.156
+          - fc00::139
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.79/32
+        ipv6: 2064:100::4f/128
+      Ethernet1:
+        ipv4: 10.0.0.157/31
+        ipv6: fc00::13a/126
+    bp_interfaces:
+      ipv4: 10.10.246.48/24
+      ipv6: fc0a::30/64
+  ARISTA48T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.158
+          - fc00::13d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.80/32
+        ipv6: 2064:100::50/128
+      Ethernet1:
+        ipv4: 10.0.0.159/31
+        ipv6: fc00::13e/126
+    bp_interfaces:
+      ipv4: 10.10.246.49/24
+      ipv6: fc0a::31/64
+  ARISTA49T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.160
+          - fc00::141
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.81/32
+        ipv6: 2064:100::51/128
+      Ethernet1:
+        ipv4: 10.0.0.161/31
+        ipv6: fc00::142/126
+    bp_interfaces:
+      ipv4: 10.10.246.50/24
+      ipv6: fc0a::32/64
+  ARISTA50T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.162
+          - fc00::145
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.82/32
+        ipv6: 2064:100::52/128
+      Ethernet1:
+        ipv4: 10.0.0.163/31
+        ipv6: fc00::146/126
+    bp_interfaces:
+      ipv4: 10.10.246.51/24
+      ipv6: fc0a::33/64
+  ARISTA51T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.164
+          - fc00::149
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.83/32
+        ipv6: 2064:100::53/128
+      Ethernet1:
+        ipv4: 10.0.0.165/31
+        ipv6: fc00::14a/126
+    bp_interfaces:
+      ipv4: 10.10.246.52/24
+      ipv6: fc0a::34/64
+  ARISTA52T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.166
+          - fc00::14d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.84/32
+        ipv6: 2064:100::54/128
+      Ethernet1:
+        ipv4: 10.0.0.167/31
+        ipv6: fc00::14e/126
+    bp_interfaces:
+      ipv4: 10.10.246.53/24
+      ipv6: fc0a::35/64
+  ARISTA53T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.168
+          - fc00::151
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.85/32
+        ipv6: 2064:100::55/128
+      Ethernet1:
+        ipv4: 10.0.0.169/31
+        ipv6: fc00::152/126
+    bp_interfaces:
+      ipv4: 10.10.246.54/24
+      ipv6: fc0a::36/64
+  ARISTA54T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.170
+          - fc00::155
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.86/32
+        ipv6: 2064:100::56/128
+      Ethernet1:
+        ipv4: 10.0.0.171/31
+        ipv6: fc00::156/126
+    bp_interfaces:
+      ipv4: 10.10.246.55/24
+      ipv6: fc0a::37/64
+  ARISTA55T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.172
+          - fc00::159
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.87/32
+        ipv6: 2064:100::57/128
+      Ethernet1:
+        ipv4: 10.0.0.173/31
+        ipv6: fc00::15a/126
+    bp_interfaces:
+      ipv4: 10.10.246.56/24
+      ipv6: fc0a::38/64
+  ARISTA56T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.174
+          - fc00::15d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.88/32
+        ipv6: 2064:100::58/128
+      Ethernet1:
+        ipv4: 10.0.0.175/31
+        ipv6: fc00::15e/126
+    bp_interfaces:
+      ipv4: 10.10.246.57/24
+      ipv6: fc0a::39/64
+  ARISTA57T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.176
+          - fc00::161
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.89/32
+        ipv6: 2064:100::59/128
+      Ethernet1:
+        ipv4: 10.0.0.177/31
+        ipv6: fc00::162/126
+    bp_interfaces:
+      ipv4: 10.10.246.58/24
+      ipv6: fc0a::3a/64
+  ARISTA58T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.178
+          - fc00::165
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.90/32
+        ipv6: 2064:100::5a/128
+      Ethernet1:
+        ipv4: 10.0.0.179/31
+        ipv6: fc00::166/126
+    bp_interfaces:
+      ipv4: 10.10.246.59/24
+      ipv6: fc0a::3b/64
+  ARISTA59T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.180
+          - fc00::169
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.91/32
+        ipv6: 2064:100::5b/128
+      Ethernet1:
+        ipv4: 10.0.0.181/31
+        ipv6: fc00::16a/126
+    bp_interfaces:
+      ipv4: 10.10.246.60/24
+      ipv6: fc0a::3c/64
+  ARISTA60T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.182
+          - fc00::16d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.92/32
+        ipv6: 2064:100::5c/128
+      Ethernet1:
+        ipv4: 10.0.0.183/31
+        ipv6: fc00::16e/126
+    bp_interfaces:
+      ipv4: 10.10.246.61/24
+      ipv6: fc0a::3d/64
+  ARISTA61T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.184
+          - fc00::171
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.93/32
+        ipv6: 2064:100::5d/128
+      Ethernet1:
+        ipv4: 10.0.0.185/31
+        ipv6: fc00::172/126
+    bp_interfaces:
+      ipv4: 10.10.246.62/24
+      ipv6: fc0a::3e/64
+  ARISTA62T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.186
+          - fc00::175
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.94/32
+        ipv6: 2064:100::5e/128
+      Ethernet1:
+        ipv4: 10.0.0.187/31
+        ipv6: fc00::176/126
+    bp_interfaces:
+      ipv4: 10.10.246.63/24
+      ipv6: fc0a::3f/64
+  ARISTA63T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.188
+          - fc00::179
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.95/32
+        ipv6: 2064:100::5f/128
+      Ethernet1:
+        ipv4: 10.0.0.189/31
+        ipv6: fc00::17a/126
+    bp_interfaces:
+      ipv4: 10.10.246.64/24
+      ipv6: fc0a::40/64
+  ARISTA64T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.0.190
+          - fc00::17d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.96/32
+        ipv6: 2064:100::60/128
+      Ethernet1:
+        ipv4: 10.0.0.191/31
+        ipv6: fc00::17e/126
+    bp_interfaces:
+      ipv4: 10.10.246.65/24
+      ipv6: fc0a::41/64
+  ARISTA65T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.64
+          - fc00::281
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.161/32
+        ipv6: 2064:100::a1/128
+      Ethernet1:
+        ipv4: 10.0.1.65/31
+        ipv6: fc00::282/126
+    bp_interfaces:
+      ipv4: 10.10.246.66/24
+      ipv6: fc0a::42/64
+  ARISTA66T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.66
+          - fc00::285
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.162/32
+        ipv6: 2064:100::a2/128
+      Ethernet1:
+        ipv4: 10.0.1.67/31
+        ipv6: fc00::286/126
+    bp_interfaces:
+      ipv4: 10.10.246.67/24
+      ipv6: fc0a::43/64
+  ARISTA67T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.68
+          - fc00::289
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.163/32
+        ipv6: 2064:100::a3/128
+      Ethernet1:
+        ipv4: 10.0.1.69/31
+        ipv6: fc00::28a/126
+    bp_interfaces:
+      ipv4: 10.10.246.68/24
+      ipv6: fc0a::44/64
+  ARISTA68T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.70
+          - fc00::28d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.164/32
+        ipv6: 2064:100::a4/128
+      Ethernet1:
+        ipv4: 10.0.1.71/31
+        ipv6: fc00::28e/126
+    bp_interfaces:
+      ipv4: 10.10.246.69/24
+      ipv6: fc0a::45/64
+  ARISTA69T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.72
+          - fc00::291
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.165/32
+        ipv6: 2064:100::a5/128
+      Ethernet1:
+        ipv4: 10.0.1.73/31
+        ipv6: fc00::292/126
+    bp_interfaces:
+      ipv4: 10.10.246.70/24
+      ipv6: fc0a::46/64
+  ARISTA70T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.74
+          - fc00::295
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.166/32
+        ipv6: 2064:100::a6/128
+      Ethernet1:
+        ipv4: 10.0.1.75/31
+        ipv6: fc00::296/126
+    bp_interfaces:
+      ipv4: 10.10.246.71/24
+      ipv6: fc0a::47/64
+  ARISTA71T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.76
+          - fc00::299
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.167/32
+        ipv6: 2064:100::a7/128
+      Ethernet1:
+        ipv4: 10.0.1.77/31
+        ipv6: fc00::29a/126
+    bp_interfaces:
+      ipv4: 10.10.246.72/24
+      ipv6: fc0a::48/64
+  ARISTA72T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.78
+          - fc00::29d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.168/32
+        ipv6: 2064:100::a8/128
+      Ethernet1:
+        ipv4: 10.0.1.79/31
+        ipv6: fc00::29e/126
+    bp_interfaces:
+      ipv4: 10.10.246.73/24
+      ipv6: fc0a::49/64
+  ARISTA73T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.80
+          - fc00::2a1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.169/32
+        ipv6: 2064:100::a9/128
+      Ethernet1:
+        ipv4: 10.0.1.81/31
+        ipv6: fc00::2a2/126
+    bp_interfaces:
+      ipv4: 10.10.246.74/24
+      ipv6: fc0a::4a/64
+  ARISTA74T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.82
+          - fc00::2a5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.170/32
+        ipv6: 2064:100::aa/128
+      Ethernet1:
+        ipv4: 10.0.1.83/31
+        ipv6: fc00::2a6/126
+    bp_interfaces:
+      ipv4: 10.10.246.75/24
+      ipv6: fc0a::4b/64
+  ARISTA75T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.84
+          - fc00::2a9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.171/32
+        ipv6: 2064:100::ab/128
+      Ethernet1:
+        ipv4: 10.0.1.85/31
+        ipv6: fc00::2aa/126
+    bp_interfaces:
+      ipv4: 10.10.246.76/24
+      ipv6: fc0a::4c/64
+  ARISTA76T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.86
+          - fc00::2ad
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.172/32
+        ipv6: 2064:100::ac/128
+      Ethernet1:
+        ipv4: 10.0.1.87/31
+        ipv6: fc00::2ae/126
+    bp_interfaces:
+      ipv4: 10.10.246.77/24
+      ipv6: fc0a::4d/64
+  ARISTA77T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.88
+          - fc00::2b1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.173/32
+        ipv6: 2064:100::ad/128
+      Ethernet1:
+        ipv4: 10.0.1.89/31
+        ipv6: fc00::2b2/126
+    bp_interfaces:
+      ipv4: 10.10.246.78/24
+      ipv6: fc0a::4e/64
+  ARISTA78T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.90
+          - fc00::2b5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.174/32
+        ipv6: 2064:100::ae/128
+      Ethernet1:
+        ipv4: 10.0.1.91/31
+        ipv6: fc00::2b6/126
+    bp_interfaces:
+      ipv4: 10.10.246.79/24
+      ipv6: fc0a::4f/64
+  ARISTA79T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.92
+          - fc00::2b9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.175/32
+        ipv6: 2064:100::af/128
+      Ethernet1:
+        ipv4: 10.0.1.93/31
+        ipv6: fc00::2ba/126
+    bp_interfaces:
+      ipv4: 10.10.246.80/24
+      ipv6: fc0a::50/64
+  ARISTA80T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.94
+          - fc00::2bd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.176/32
+        ipv6: 2064:100::b0/128
+      Ethernet1:
+        ipv4: 10.0.1.95/31
+        ipv6: fc00::2be/126
+    bp_interfaces:
+      ipv4: 10.10.246.81/24
+      ipv6: fc0a::51/64
+  ARISTA81T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.96
+          - fc00::2c1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.177/32
+        ipv6: 2064:100::b1/128
+      Ethernet1:
+        ipv4: 10.0.1.97/31
+        ipv6: fc00::2c2/126
+    bp_interfaces:
+      ipv4: 10.10.246.82/24
+      ipv6: fc0a::52/64
+  ARISTA82T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.98
+          - fc00::2c5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.178/32
+        ipv6: 2064:100::b2/128
+      Ethernet1:
+        ipv4: 10.0.1.99/31
+        ipv6: fc00::2c6/126
+    bp_interfaces:
+      ipv4: 10.10.246.83/24
+      ipv6: fc0a::53/64
+  ARISTA83T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.100
+          - fc00::2c9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.179/32
+        ipv6: 2064:100::b3/128
+      Ethernet1:
+        ipv4: 10.0.1.101/31
+        ipv6: fc00::2ca/126
+    bp_interfaces:
+      ipv4: 10.10.246.84/24
+      ipv6: fc0a::54/64
+  ARISTA84T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.102
+          - fc00::2cd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.180/32
+        ipv6: 2064:100::b4/128
+      Ethernet1:
+        ipv4: 10.0.1.103/31
+        ipv6: fc00::2ce/126
+    bp_interfaces:
+      ipv4: 10.10.246.85/24
+      ipv6: fc0a::55/64
+  ARISTA85T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.104
+          - fc00::2d1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.181/32
+        ipv6: 2064:100::b5/128
+      Ethernet1:
+        ipv4: 10.0.1.105/31
+        ipv6: fc00::2d2/126
+    bp_interfaces:
+      ipv4: 10.10.246.86/24
+      ipv6: fc0a::56/64
+  ARISTA86T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.106
+          - fc00::2d5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.182/32
+        ipv6: 2064:100::b6/128
+      Ethernet1:
+        ipv4: 10.0.1.107/31
+        ipv6: fc00::2d6/126
+    bp_interfaces:
+      ipv4: 10.10.246.87/24
+      ipv6: fc0a::57/64
+  ARISTA87T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.108
+          - fc00::2d9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.183/32
+        ipv6: 2064:100::b7/128
+      Ethernet1:
+        ipv4: 10.0.1.109/31
+        ipv6: fc00::2da/126
+    bp_interfaces:
+      ipv4: 10.10.246.88/24
+      ipv6: fc0a::58/64
+  ARISTA88T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.110
+          - fc00::2dd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.184/32
+        ipv6: 2064:100::b8/128
+      Ethernet1:
+        ipv4: 10.0.1.111/31
+        ipv6: fc00::2de/126
+    bp_interfaces:
+      ipv4: 10.10.246.89/24
+      ipv6: fc0a::59/64
+  ARISTA89T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.112
+          - fc00::2e1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.185/32
+        ipv6: 2064:100::b9/128
+      Ethernet1:
+        ipv4: 10.0.1.113/31
+        ipv6: fc00::2e2/126
+    bp_interfaces:
+      ipv4: 10.10.246.90/24
+      ipv6: fc0a::5a/64
+  ARISTA90T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.114
+          - fc00::2e5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.186/32
+        ipv6: 2064:100::ba/128
+      Ethernet1:
+        ipv4: 10.0.1.115/31
+        ipv6: fc00::2e6/126
+    bp_interfaces:
+      ipv4: 10.10.246.91/24
+      ipv6: fc0a::5b/64
+  ARISTA91T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.116
+          - fc00::2e9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.187/32
+        ipv6: 2064:100::bb/128
+      Ethernet1:
+        ipv4: 10.0.1.117/31
+        ipv6: fc00::2ea/126
+    bp_interfaces:
+      ipv4: 10.10.246.92/24
+      ipv6: fc0a::5c/64
+  ARISTA92T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.118
+          - fc00::2ed
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.188/32
+        ipv6: 2064:100::bc/128
+      Ethernet1:
+        ipv4: 10.0.1.119/31
+        ipv6: fc00::2ee/126
+    bp_interfaces:
+      ipv4: 10.10.246.93/24
+      ipv6: fc0a::5d/64
+  ARISTA93T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.120
+          - fc00::2f1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.189/32
+        ipv6: 2064:100::bd/128
+      Ethernet1:
+        ipv4: 10.0.1.121/31
+        ipv6: fc00::2f2/126
+    bp_interfaces:
+      ipv4: 10.10.246.94/24
+      ipv6: fc0a::5e/64
+  ARISTA94T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.122
+          - fc00::2f5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.190/32
+        ipv6: 2064:100::be/128
+      Ethernet1:
+        ipv4: 10.0.1.123/31
+        ipv6: fc00::2f6/126
+    bp_interfaces:
+      ipv4: 10.10.246.95/24
+      ipv6: fc0a::5f/64
+  ARISTA95T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.124
+          - fc00::2f9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.191/32
+        ipv6: 2064:100::bf/128
+      Ethernet1:
+        ipv4: 10.0.1.125/31
+        ipv6: fc00::2fa/126
+    bp_interfaces:
+      ipv4: 10.10.246.96/24
+      ipv6: fc0a::60/64
+  ARISTA96T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.126
+          - fc00::2fd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.192/32
+        ipv6: 2064:100::c0/128
+      Ethernet1:
+        ipv4: 10.0.1.127/31
+        ipv6: fc00::2fe/126
+    bp_interfaces:
+      ipv4: 10.10.246.97/24
+      ipv6: fc0a::61/64
+  ARISTA97T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.128
+          - fc00::301
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.193/32
+        ipv6: 2064:100::c1/128
+      Ethernet1:
+        ipv4: 10.0.1.129/31
+        ipv6: fc00::302/126
+    bp_interfaces:
+      ipv4: 10.10.246.98/24
+      ipv6: fc0a::62/64
+  ARISTA98T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.130
+          - fc00::305
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.194/32
+        ipv6: 2064:100::c2/128
+      Ethernet1:
+        ipv4: 10.0.1.131/31
+        ipv6: fc00::306/126
+    bp_interfaces:
+      ipv4: 10.10.246.99/24
+      ipv6: fc0a::63/64
+  ARISTA99T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.132
+          - fc00::309
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.195/32
+        ipv6: 2064:100::c3/128
+      Ethernet1:
+        ipv4: 10.0.1.133/31
+        ipv6: fc00::30a/126
+    bp_interfaces:
+      ipv4: 10.10.246.100/24
+      ipv6: fc0a::64/64
+  ARISTA100T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.134
+          - fc00::30d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.196/32
+        ipv6: 2064:100::c4/128
+      Ethernet1:
+        ipv4: 10.0.1.135/31
+        ipv6: fc00::30e/126
+    bp_interfaces:
+      ipv4: 10.10.246.101/24
+      ipv6: fc0a::65/64
+  ARISTA101T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.136
+          - fc00::311
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.197/32
+        ipv6: 2064:100::c5/128
+      Ethernet1:
+        ipv4: 10.0.1.137/31
+        ipv6: fc00::312/126
+    bp_interfaces:
+      ipv4: 10.10.246.102/24
+      ipv6: fc0a::66/64
+  ARISTA102T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.138
+          - fc00::315
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.198/32
+        ipv6: 2064:100::c6/128
+      Ethernet1:
+        ipv4: 10.0.1.139/31
+        ipv6: fc00::316/126
+    bp_interfaces:
+      ipv4: 10.10.246.103/24
+      ipv6: fc0a::67/64
+  ARISTA103T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.140
+          - fc00::319
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.199/32
+        ipv6: 2064:100::c7/128
+      Ethernet1:
+        ipv4: 10.0.1.141/31
+        ipv6: fc00::31a/126
+    bp_interfaces:
+      ipv4: 10.10.246.104/24
+      ipv6: fc0a::68/64
+  ARISTA104T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.142
+          - fc00::31d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.200/32
+        ipv6: 2064:100::c8/128
+      Ethernet1:
+        ipv4: 10.0.1.143/31
+        ipv6: fc00::31e/126
+    bp_interfaces:
+      ipv4: 10.10.246.105/24
+      ipv6: fc0a::69/64
+  ARISTA105T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.144
+          - fc00::321
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.201/32
+        ipv6: 2064:100::c9/128
+      Ethernet1:
+        ipv4: 10.0.1.145/31
+        ipv6: fc00::322/126
+    bp_interfaces:
+      ipv4: 10.10.246.106/24
+      ipv6: fc0a::6a/64
+  ARISTA106T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.146
+          - fc00::325
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.202/32
+        ipv6: 2064:100::ca/128
+      Ethernet1:
+        ipv4: 10.0.1.147/31
+        ipv6: fc00::326/126
+    bp_interfaces:
+      ipv4: 10.10.246.107/24
+      ipv6: fc0a::6b/64
+  ARISTA107T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.148
+          - fc00::329
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.203/32
+        ipv6: 2064:100::cb/128
+      Ethernet1:
+        ipv4: 10.0.1.149/31
+        ipv6: fc00::32a/126
+    bp_interfaces:
+      ipv4: 10.10.246.108/24
+      ipv6: fc0a::6c/64
+  ARISTA108T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.150
+          - fc00::32d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.204/32
+        ipv6: 2064:100::cc/128
+      Ethernet1:
+        ipv4: 10.0.1.151/31
+        ipv6: fc00::32e/126
+    bp_interfaces:
+      ipv4: 10.10.246.109/24
+      ipv6: fc0a::6d/64
+  ARISTA109T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.152
+          - fc00::331
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.205/32
+        ipv6: 2064:100::cd/128
+      Ethernet1:
+        ipv4: 10.0.1.153/31
+        ipv6: fc00::332/126
+    bp_interfaces:
+      ipv4: 10.10.246.110/24
+      ipv6: fc0a::6e/64
+  ARISTA110T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.154
+          - fc00::335
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.206/32
+        ipv6: 2064:100::ce/128
+      Ethernet1:
+        ipv4: 10.0.1.155/31
+        ipv6: fc00::336/126
+    bp_interfaces:
+      ipv4: 10.10.246.111/24
+      ipv6: fc0a::6f/64
+  ARISTA111T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.156
+          - fc00::339
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.207/32
+        ipv6: 2064:100::cf/128
+      Ethernet1:
+        ipv4: 10.0.1.157/31
+        ipv6: fc00::33a/126
+    bp_interfaces:
+      ipv4: 10.10.246.112/24
+      ipv6: fc0a::70/64
+  ARISTA112T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.158
+          - fc00::33d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.208/32
+        ipv6: 2064:100::d0/128
+      Ethernet1:
+        ipv4: 10.0.1.159/31
+        ipv6: fc00::33e/126
+    bp_interfaces:
+      ipv4: 10.10.246.113/24
+      ipv6: fc0a::71/64
+  ARISTA113T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.160
+          - fc00::341
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.209/32
+        ipv6: 2064:100::d1/128
+      Ethernet1:
+        ipv4: 10.0.1.161/31
+        ipv6: fc00::342/126
+    bp_interfaces:
+      ipv4: 10.10.246.114/24
+      ipv6: fc0a::72/64
+  ARISTA114T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.162
+          - fc00::345
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.210/32
+        ipv6: 2064:100::d2/128
+      Ethernet1:
+        ipv4: 10.0.1.163/31
+        ipv6: fc00::346/126
+    bp_interfaces:
+      ipv4: 10.10.246.115/24
+      ipv6: fc0a::73/64
+  ARISTA115T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.164
+          - fc00::349
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.211/32
+        ipv6: 2064:100::d3/128
+      Ethernet1:
+        ipv4: 10.0.1.165/31
+        ipv6: fc00::34a/126
+    bp_interfaces:
+      ipv4: 10.10.246.116/24
+      ipv6: fc0a::74/64
+  ARISTA116T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.166
+          - fc00::34d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.212/32
+        ipv6: 2064:100::d4/128
+      Ethernet1:
+        ipv4: 10.0.1.167/31
+        ipv6: fc00::34e/126
+    bp_interfaces:
+      ipv4: 10.10.246.117/24
+      ipv6: fc0a::75/64
+  ARISTA117T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.168
+          - fc00::351
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.213/32
+        ipv6: 2064:100::d5/128
+      Ethernet1:
+        ipv4: 10.0.1.169/31
+        ipv6: fc00::352/126
+    bp_interfaces:
+      ipv4: 10.10.246.118/24
+      ipv6: fc0a::76/64
+  ARISTA118T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.170
+          - fc00::355
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.214/32
+        ipv6: 2064:100::d6/128
+      Ethernet1:
+        ipv4: 10.0.1.171/31
+        ipv6: fc00::356/126
+    bp_interfaces:
+      ipv4: 10.10.246.119/24
+      ipv6: fc0a::77/64
+  ARISTA119T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.172
+          - fc00::359
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.215/32
+        ipv6: 2064:100::d7/128
+      Ethernet1:
+        ipv4: 10.0.1.173/31
+        ipv6: fc00::35a/126
+    bp_interfaces:
+      ipv4: 10.10.246.120/24
+      ipv6: fc0a::78/64
+  ARISTA120T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.174
+          - fc00::35d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.216/32
+        ipv6: 2064:100::d8/128
+      Ethernet1:
+        ipv4: 10.0.1.175/31
+        ipv6: fc00::35e/126
+    bp_interfaces:
+      ipv4: 10.10.246.121/24
+      ipv6: fc0a::79/64
+  ARISTA121T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.176
+          - fc00::361
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.217/32
+        ipv6: 2064:100::d9/128
+      Ethernet1:
+        ipv4: 10.0.1.177/31
+        ipv6: fc00::362/126
+    bp_interfaces:
+      ipv4: 10.10.246.122/24
+      ipv6: fc0a::7a/64
+  ARISTA122T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.178
+          - fc00::365
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.218/32
+        ipv6: 2064:100::da/128
+      Ethernet1:
+        ipv4: 10.0.1.179/31
+        ipv6: fc00::366/126
+    bp_interfaces:
+      ipv4: 10.10.246.123/24
+      ipv6: fc0a::7b/64
+  ARISTA123T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.180
+          - fc00::369
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.219/32
+        ipv6: 2064:100::db/128
+      Ethernet1:
+        ipv4: 10.0.1.181/31
+        ipv6: fc00::36a/126
+    bp_interfaces:
+      ipv4: 10.10.246.124/24
+      ipv6: fc0a::7c/64
+  ARISTA124T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.182
+          - fc00::36d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.220/32
+        ipv6: 2064:100::dc/128
+      Ethernet1:
+        ipv4: 10.0.1.183/31
+        ipv6: fc00::36e/126
+    bp_interfaces:
+      ipv4: 10.10.246.125/24
+      ipv6: fc0a::7d/64
+  ARISTA125T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.184
+          - fc00::371
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.221/32
+        ipv6: 2064:100::dd/128
+      Ethernet1:
+        ipv4: 10.0.1.185/31
+        ipv6: fc00::372/126
+    bp_interfaces:
+      ipv4: 10.10.246.126/24
+      ipv6: fc0a::7e/64
+  ARISTA126T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.186
+          - fc00::375
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.222/32
+        ipv6: 2064:100::de/128
+      Ethernet1:
+        ipv4: 10.0.1.187/31
+        ipv6: fc00::376/126
+    bp_interfaces:
+      ipv4: 10.10.246.127/24
+      ipv6: fc0a::7f/64
+  ARISTA127T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.188
+          - fc00::379
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.223/32
+        ipv6: 2064:100::df/128
+      Ethernet1:
+        ipv4: 10.0.1.189/31
+        ipv6: fc00::37a/126
+    bp_interfaces:
+      ipv4: 10.10.246.128/24
+      ipv6: fc0a::80/64
+  ARISTA128T1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.1.190
+          - fc00::37d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.224/32
+        ipv6: 2064:100::e0/128
+      Ethernet1:
+        ipv4: 10.0.1.191/31
+        ipv6: fc00::37e/126
+    bp_interfaces:
+      ipv4: 10.10.246.129/24
+      ipv6: fc0a::81/64
+  ARISTA01PT1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.2.0
+          - fc00::401
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.1.1/32
+        ipv6: 2064:100::101/128
+      Ethernet1:
+        ipv4: 10.0.2.1/31
+        ipv6: fc00::402/126
+    bp_interfaces:
+      ipv4: 10.10.246.130/24
+      ipv6: fc0a::82/64
+  ARISTA02PT1:
+    properties:
+    - common
+    bgp:
+      asn: 64802
+      peers:
+        64601:
+          - 10.0.2.2
+          - fc00::405
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.1.2/32
+        ipv6: 2064:100::102/128
+      Ethernet1:
+        ipv4: 10.0.2.3/31
+        ipv6: fc00::406/126
+    bp_interfaces:
+      ipv4: 10.10.246.131/24
+      ipv6: fc0a::83/64

--- a/ansible/veos
+++ b/ansible/veos
@@ -37,6 +37,7 @@ all:
           - t0-standalone-64
           - t0-standalone-128
           - t0-standalone-256
+          - t0-isolated-d128u128s2
           - dualtor
           - dualtor-56
           - cable-test

--- a/docs/testbed/README.testbed.Overview.md
+++ b/docs/testbed/README.testbed.Overview.md
@@ -83,6 +83,7 @@ The T0 type topology has different variations. The differences are just the numb
 * t0-standalone-64
 * t0-standalone-128
 * t0-standalone-256
+* t0-isolated-*
 
 Below are details of some of the T0 variations:
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
add a new t0 topo with 128 downstream and 128 upstream ports and 2 service ports.
For bp_interfaces IP, used continuous IP from .2 to .131 to avoid going over /24 range.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
