### PR TITLE
Skip check for Rx PFC count if multiple lossy TC bits are set

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -623,7 +623,7 @@ def verify_pause_frame_count_dut(rx_dut,
                 if len(prios) > 1 and is_cisco_device(tx_dut) and not test_traffic_pause:
                     pytest_assert(pfc_pause_rx_frames == 0,
                                   "PFC pause frames should not be counted in RX PFC counters for priority {}"
-                                  .format(prio))
+                                  .format(prios))
                 else:
                     pytest_assert(pfc_pause_rx_frames > 0,
                                   "PFC pause frames should be received and counted in RX PFC counters for priority {}"

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -586,8 +586,7 @@ def verify_in_flight_buffer_pkts(duthost,
                               format(dropped_packets))
 
 
-def verify_pause_frame_count_dut(duthost,
-                                 rx_dut,
+def verify_pause_frame_count_dut(rx_dut,
                                  tx_dut,
                                  test_traffic_pause,
                                  global_pause,
@@ -621,7 +620,7 @@ def verify_pause_frame_count_dut(duthost,
                 pytest_assert(pfc_pause_rx_frames == 0,
                               "PFC pause frames with no bit set in the class enable vector should be dropped")
             else:
-                if len(prios) > 1 and is_cisco_device(duthost) and not test_traffic_pause:
+                if len(prios) > 1 and is_cisco_device(tx_dut) and not test_traffic_pause:
                     pytest_assert(pfc_pause_rx_frames == 0,
                                   "PFC pause frames should not be counted in RX PFC counters for priority {}"
                                   .format(prio))

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -621,11 +621,7 @@ def verify_pause_frame_count_dut(duthost,
                 pytest_assert(pfc_pause_rx_frames == 0,
                               "PFC pause frames with no bit set in the class enable vector should be dropped")
             else:
-                if len(prios) == 1 and is_cisco_device(duthost) and not test_traffic_pause:
-                    pytest_assert(pfc_pause_rx_frames > 0,
-                                  "PFC pause frames should be received and counted in RX PFC counters for priority {}"
-                                  .format(prio))
-                elif len(prios) > 1 and is_cisco_device(duthost) and not test_traffic_pause:
+                if len(prios) > 1 and is_cisco_device(duthost) and not test_traffic_pause:
                     pytest_assert(pfc_pause_rx_frames == 0,
                                   "PFC pause frames should not be counted in RX PFC counters for priority {}"
                                   .format(prio))

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -12,6 +12,7 @@ from tests.common.snappi_tests.common_helpers import get_egress_queue_count, pfc
 from tests.common.snappi_tests.port import select_ports, select_tx_port
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics
 from tests.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.cisco_data import is_cisco_device
 
 logger = logging.getLogger(__name__)
 
@@ -585,7 +586,8 @@ def verify_in_flight_buffer_pkts(duthost,
                               format(dropped_packets))
 
 
-def verify_pause_frame_count_dut(rx_dut,
+def verify_pause_frame_count_dut(duthost,
+                                 rx_dut,
                                  tx_dut,
                                  test_traffic_pause,
                                  global_pause,
@@ -619,9 +621,18 @@ def verify_pause_frame_count_dut(rx_dut,
                 pytest_assert(pfc_pause_rx_frames == 0,
                               "PFC pause frames with no bit set in the class enable vector should be dropped")
             else:
-                pytest_assert(pfc_pause_rx_frames > 0,
-                              "PFC pause frames should be received and counted in RX PFC counters for priority {}"
-                              .format(prio))
+                if len(prios) == 1 and is_cisco_device(duthost) and not test_traffic_pause:
+                    pytest_assert(pfc_pause_rx_frames > 0,
+                                  "PFC pause frames should be received and counted in RX PFC counters for priority {}"
+                                  .format(prio))
+                elif len(prios) > 1 and is_cisco_device(duthost) and not test_traffic_pause:
+                    pytest_assert(pfc_pause_rx_frames == 0,
+                                  "PFC pause frames should not be counted in RX PFC counters for priority {}"
+                                  .format(prio))
+                else:
+                    pytest_assert(pfc_pause_rx_frames > 0,
+                                  "PFC pause frames should be received and counted in RX PFC counters for priority {}"
+                                  .format(prio))
 
     for peer_port, prios in dut_port_config[0].items():  # PFC pause frames sent by DUT's ingress port to TGEN
         for prio in prios:

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -19,7 +19,6 @@ from tests.common.snappi_tests.traffic_generation import setup_base_traffic_conf
     verify_rx_frame_count_dut
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.read_pcap import validate_pfc_frame
-from tests.common.cisco_data import is_cisco_device
 
 
 logger = logging.getLogger(__name__)

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -19,6 +19,7 @@ from tests.common.snappi_tests.traffic_generation import setup_base_traffic_conf
     verify_rx_frame_count_dut
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.read_pcap import validate_pfc_frame
+from tests.common.cisco_data import is_cisco_device
 
 
 logger = logging.getLogger(__name__)
@@ -270,7 +271,8 @@ def run_pfc_test(api,
     # Verify PFC pause frame count on the DUT
     # rx_dut is Ingress DUT receiving traffic.
     # tx_dut is Egress DUT sending traffic to IXIA and also receiving PFCs.
-    verify_pause_frame_count_dut(rx_dut=rx_dut,
+    verify_pause_frame_count_dut(duthost,
+                                 rx_dut=rx_dut,
                                  tx_dut=tx_dut,
                                  test_traffic_pause=test_traffic_pause,
                                  global_pause=global_pause,

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -271,8 +271,7 @@ def run_pfc_test(api,
     # Verify PFC pause frame count on the DUT
     # rx_dut is Ingress DUT receiving traffic.
     # tx_dut is Egress DUT sending traffic to IXIA and also receiving PFCs.
-    verify_pause_frame_count_dut(duthost,
-                                 rx_dut=rx_dut,
+    verify_pause_frame_count_dut(rx_dut=rx_dut,
                                  tx_dut=tx_dut,
                                  test_traffic_pause=test_traffic_pause,
                                  global_pause=global_pause,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Skip check for Rx PFC counter if multiple lossy TC bits are set. This is a cisco-8000 specific check. 
Rx counter is incremented only if a single lossy TC bit is set.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Ran snappi tests for lossy/lossless to confirm:
```
=============================================== short test summary info ================================================
PASSED snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[aaa14-ixia-m64|0]
PASSED snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[aaa14-ixia-m64|1]
PASSED snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[aaa14-ixia-m64|2]
PASSED snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[aaa14-ixia-m64|5]
PASSED snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[aaa14-ixia-m64|6]
PASSED snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_multi_lossy_prio
PASSED snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot[cold]
PASSED snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_multi_lossy_prio_reboot[cold]
SKIPPED [2] common/helpers/assertions.py:16: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [2] common/helpers/assertions.py:16: Reboot type fast is not supported on cisco-8000 switches
================================ 8 passed, 4 skipped, 12 warnings in 2715.22s (0:45:15) ================================


============================================== short test summary info ===============================================
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[aaa14-ixia-m64|3]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[aaa14-ixia-m64|4]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_counter_check[aaa14-ixia-m64|3]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_counter_check[aaa14-ixia-m64|4]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[cold]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio_reboot[cold]
SKIPPED [2] common/helpers/assertions.py:16: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [2] common/helpers/assertions.py:16: Reboot type fast is not supported on cisco-8000 switches
=============================== 7 passed, 4 skipped, 11 warnings in 2275.18s (0:37:55) =============================== 

```


#### Any platform specific information?
Applicable for all cisco-8000 platforms.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
