### PR TITLE
Extend test fail timeout for weak hardware support.

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -542,7 +542,7 @@ def consumes_memory_and_checks_container_restart(duthost, container):
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=marker_prefix)
     loganalyzer.expect_regex = container.get_restart_expected_logre()
     with loganalyzer:
-        timeout_monit_fail = 180  # fails happens after 10 cycles of 1 second
+        timeout_monit_fail = 360  # fails happens after timeout wait
         container.start_consume_memory()
         container.wait_monit_mem_failed(timeout_monit_fail)
         logger.info("Container %s should now be restarting", container.name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue):Microsoft ADO 29793270

### Type of change
Extend test fail timeout for weak hardware support (S6000)

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Some weak hardware(S6000) needs to be support, which is slow and break test due to timeout.

#### How did you do it?
Extend failure timeout.

#### How did you verify/test it?
It won't extend test time, just declare failure timeout is changed.

#### Any platform specific information?
S6000

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
