### PR TITLE
enable fanout for 202405

### DIFF
--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -63,4 +63,5 @@
       include_tasks:
         sonic/fanout_sonic_202311.yml
       when: dry_run is not defined and incremental is not defined
-  when: "'2023' in fanout_sonic_version['build_version']"
+  # use 202311 fanout playbook for 202405 for now. If new requirements come up, we can create a new playbook for 202405
+  when: "'2023' in fanout_sonic_version['build_version'] or '202405' in fanout_sonic_version['build_version']"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable sonic fanout support for 202405 image
Currently, reuse 202311 fanout configuration for now as no new changes. If new changes required, we can create a separate 202405 fanout template.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Enable fanout support for 202405 image

#### How did you do it?

#### How did you verify/test it?
Tested on 7060x6 platform, it deployed fanout successfully.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
