### PR TITLE
Fix test_check_show_lpmode case

### DIFF
--- a/tests/platform_tests/sfp/test_show_intf_xcvr.py
+++ b/tests/platform_tests/sfp/test_show_intf_xcvr.py
@@ -83,7 +83,19 @@ def test_check_show_lpmode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         return
     assert sfp_lpmode['rc'] == 0, "Run command '{}' failed".format(cmd_sfp_presence)
 
+    sfp_lpmode_data = sfp_lpmode["stdout_lines"]
+
+    # Check if the header is present
+    header = sfp_lpmode_data[0]
+    logging.info(f"The header is: {header}")
+    if header.replace(" ", "") != "Port        Low-power Mode".replace(" ", ""):
+        logging.error("Invalid output format: Header missing")
+        return False
+
+    # Check interface lpmode
+    sfp_lpmode_info = parse_output(sfp_lpmode_data[2:])
+    logging.info(f"The interface sfp lpmode info is: {sfp_lpmode_info}")
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
             assert validate_transceiver_lpmode(
-                sfp_lpmode['stdout']), "Interface mode incorrect in 'show interface transceiver lpmode'"
+                sfp_lpmode_info, intf), "Interface mode incorrect in 'show interface transceiver lpmode'"

--- a/tests/platform_tests/sfp/util.py
+++ b/tests/platform_tests/sfp/util.py
@@ -47,15 +47,14 @@ def get_dev_conn(duthost, conn_graph_facts, asic_index):
     return portmap, dev_conn
 
 
-def validate_transceiver_lpmode(output):
-    lines = output.strip().split('\n')
-    # Check if the header is present
-    if lines[0].replace(" ", "") != "Port        Low-power Mode".replace(" ", ""):
-        logging.error("Invalid output format: Header missing")
+def validate_transceiver_lpmode(sfp_lpmode, port):
+    lpmode = sfp_lpmode.get(port)
+    if lpmode is None:
+        logging.error(f"Interface {port} does not present in the show command")
         return False
-    for line in lines[2:]:
-        port, lpmode = line.strip().split()
-        if lpmode not in ["Off", "On"]:
-            logging.error("Invalid low-power mode {} for port {}".format(lpmode, port))
-            return False
+
+    if lpmode not in ["Off", "On"]:
+        logging.error("Invalid low-power mode {} for port {}".format(lpmode, port))
+        return False
+
     return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix test_check_show_lpmode case
Fixes # (issue)
1. Currently the `test_check_show_lpmode` case use `xcvr_skip_list` function to check lpmode for only supported interface, but the code passes all the output of `show interface transceiver lpmode` to `validate_transceiver_lpmode` function, then the function checks each interface lpmode. This is incorrect. Fix it.

For example, if the interface lpmode is like this "`['Ethernet0   N/A', 'Ethernet1  Off']`", Ethernet0 is RJ45 and no lpmode check is needed. Ethernet1 needs to check lpmode
- In the current logic, Ethernet0 does not check lpmode, which is correct.
- Ethernet1 needs to check lpmode, but the code passes all the output `(['Ethernet0 N/A', 'Ethernet1 Off'])` of the command to the function `validate_transceiver_lpmode`. It checks each item and finds that Ethernet0 lpmode is "`N/A`", then the case fails. This is incorrect

2. Move the "`check if header exists`" test from `validate_transceiver_lpmode` to `test_check_show_lpmode`. So the header only check one time.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
