### PR TITLE
[MGFX] Fix transceiver checker function for MGFX DUT

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -36,6 +36,9 @@ LOGS_ON_TMPFS_PLATFORMS = [
     "armhf-nokia_ixs7215_52x-r0"
 ]
 
+MGFX_HWSKU = ["Arista-720DT-G48S4", "Nokia-7215", "Nokia-M0-7215", "Celestica-E1031-T48S4"]
+MGFX_XCVR_INTF = ['Ethernet48', 'Ethernet49', 'Ethernet50', 'Ethernet51']
+
 TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
 
 FMT = "%b %d %H:%M:%S.%f"
@@ -294,6 +297,8 @@ def check_interfaces_and_transceivers(duthost, request):
     xcvr_info = duthost.command("redis-cli -n 6 keys TRANSCEIVER_INFO*")
     parsed_xcvr_info = parse_transceiver_info(xcvr_info["stdout_lines"])
     interfaces = conn_graph_facts["device_conn"][duthost.hostname]
+    if duthost.facts['hwsku'] in MGFX_HWSKU:
+        interfaces = MGFX_XCVR_INTF
     for intf in interfaces:
         if intf not in parsed_xcvr_info:
             raise RebootHealthError(

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -25,9 +25,6 @@ Helper script for fanout switch operations
 logger = logging.getLogger(__name__)
 
 
-MGFX_HWSKU = ["Arista-720DT-G48S4", "Nokia-7215", "Nokia-M0-7215", "Celestica-E1031-T48S4"]
-MGFX_XCVR_INTF = ['Ethernet48', 'Ethernet49', 'Ethernet50', 'Ethernet51']
-
 LOGS_ON_TMPFS_PLATFORMS = [
     "x86_64-arista_7050_qx32",
     "x86_64-arista_7050_qx32s",
@@ -38,6 +35,9 @@ LOGS_ON_TMPFS_PLATFORMS = [
     "x86_64-dell_s6100_c2538-r0",
     "armhf-nokia_ixs7215_52x-r0"
 ]
+
+MGFX_HWSKU = ["Arista-720DT-G48S4", "Nokia-7215", "Nokia-M0-7215", "Celestica-E1031-T48S4"]
+MGFX_XCVR_INTF = ['Ethernet48', 'Ethernet49', 'Ethernet50', 'Ethernet51']
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
 

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -25,6 +25,9 @@ Helper script for fanout switch operations
 logger = logging.getLogger(__name__)
 
 
+MGFX_HWSKU = ["Arista-720DT-G48S4", "Nokia-7215", "Nokia-M0-7215", "Celestica-E1031-T48S4"]
+MGFX_XCVR_INTF = ['Ethernet48', 'Ethernet49', 'Ethernet50', 'Ethernet51']
+
 LOGS_ON_TMPFS_PLATFORMS = [
     "x86_64-arista_7050_qx32",
     "x86_64-arista_7050_qx32s",
@@ -35,9 +38,6 @@ LOGS_ON_TMPFS_PLATFORMS = [
     "x86_64-dell_s6100_c2538-r0",
     "armhf-nokia_ixs7215_52x-r0"
 ]
-
-MGFX_HWSKU = ["Arista-720DT-G48S4", "Nokia-7215", "Nokia-M0-7215", "Celestica-E1031-T48S4"]
-MGFX_XCVR_INTF = ['Ethernet48', 'Ethernet49', 'Ethernet50', 'Ethernet51']
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix transceiver checker function for MGFX DUT

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fix transceiver checker function for MGFX DUT.

#### How did you do it?
For MGFX platform, only Ethernet48 ~ Ethernet51 are transceiver interfaces. Restrict the checking on those 4 ports.

#### How did you verify/test it?
Verified by upgrade-path test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
