### PR TITLE
Disable proxy for POST requests to PTF

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -288,7 +288,7 @@ def update_routes(action, ptfip, port, route):
     url = 'http://%s:%d' % (ptfip, port)
     data = {'commands': msg}
     logging.info('Post url={}, data={}'.format(url, data))
-    r = requests.post(url, data=data)
+    r = requests.post(url, data=data, proxies={"http": None, "https": None})
     assert r.status_code == 200
 
 

--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -271,7 +271,7 @@ def update_routes(action, ptfip, port, route):
         return
     url = 'http://%s:%d' % (ptfip, port)
     data = {'commands': msg}
-    r = requests.post(url, data=data)
+    r = requests.post(url, data=data, proxies={"http": None, "https": None})
     assert r.status_code == 200
 
 

--- a/tests/bgp/test_bgp_sentinel.py
+++ b/tests/bgp/test_bgp_sentinel.py
@@ -321,7 +321,7 @@ def change_route(operation, ptfip, neighbor, route, nexthop, port, community):
     url = "http://%s:%d" % (ptfip, port)
     data = {"command": "neighbor %s %s route %s next-hop %s local-preference 10000 community [%s]"
             % (neighbor, operation, route, nexthop, community)}
-    r = requests.post(url, data=data)
+    r = requests.post(url, data=data, proxies={"http": None, "https": None})
     assert r.status_code == 200
 
 

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -58,7 +58,7 @@ def withdraw_route(ptfip, neighbor, route, nexthop, port):
 def change_route(operation, ptfip, neighbor, route, nexthop, port):
     url = "http://%s:%d" % (ptfip, port)
     data = {"command": "neighbor %s %s route %s next-hop %s" % (neighbor, operation, route, nexthop)}
-    r = requests.post(url, data=data)
+    r = requests.post(url, data=data, proxies={"http": None, "https": None})
     assert r.status_code == 200
 
 

--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -341,7 +341,7 @@ def install_route_from_exabgp(operation, ptfip, route_list, port):
     data = {"command": command}
     logger.info("url: {}".format(url))
     logger.info("command: {}".format(data))
-    r = requests.post(url, data=data, timeout=90)
+    r = requests.post(url, data=data, timeout=90, proxies={"http": None, "https": None})
     assert r.status_code == 200
 
 

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -143,7 +143,7 @@ class BGPNeighbor(object):
         msg = msg.format(self.peer_ip)
         logging.debug("teardown session: %s", msg)
         url = "http://%s:%d" % (self.ptfip, self.port)
-        resp = requests.post(url, data={"commands": msg})
+        resp = requests.post(url, data={"commands": msg}, proxies={"http": None, "https": None})
         logging.debug("teardown session return: %s" % resp)
         assert resp.status_code == 200
 
@@ -162,7 +162,7 @@ class BGPNeighbor(object):
         msg = msg.format(**route)
         logging.debug("announce route: %s", msg)
         url = "http://%s:%d" % (self.ptfip, self.port)
-        resp = requests.post(url, data={"commands": msg})
+        resp = requests.post(url, data={"commands": msg}, proxies={"http": None, "https": None})
         logging.debug("announce return: %s", resp)
         assert resp.status_code == 200
 
@@ -174,6 +174,6 @@ class BGPNeighbor(object):
         msg = msg.format(**route)
         logging.debug("withdraw route: %s", msg)
         url = "http://%s:%d" % (self.ptfip, self.port)
-        resp = requests.post(url, data={"commands": msg})
+        resp = requests.post(url, data={"commands": msg}, proxies={"http": None, "https": None})
         logging.debug("withdraw return: %s", resp)
         assert resp.status_code == 200

--- a/tests/route/test_route_bgp_ecmp.py
+++ b/tests/route/test_route_bgp_ecmp.py
@@ -34,7 +34,7 @@ def change_route(operation, ptfip, route, nexthop, port, aspath):
     url = "http://%s:%d" % (ptfip, port)
     data = {
         "command": "%s route %s next-hop %s as-path [ %s ]" % (operation, route, nexthop, aspath)}
-    r = requests.post(url, data=data, timeout=30)
+    r = requests.post(url, data=data, timeout=30, proxies={"http": None, "https": None})
     if r.status_code != 200:
         raise Exception(
             "Change routes failed: url={}, data={}, r.status_code={}, r.reason={}, r.headers={}, r.text={}".format(

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -77,7 +77,7 @@ def change_route(operation, ptfip, route, nexthop, port, aspath):
     url = "http://%s:%d" % (ptfip, port)
     data = {
         "command": "%s route %s next-hop %s as-path [ %s ]" % (operation, route, nexthop, aspath)}
-    r = requests.post(url, data=data)
+    r = requests.post(url, data=data, proxies={"http": None, "https": None})
     assert r.status_code == 200
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  Ensures no proxy is used when sending HTTP POST requests to PTF in bgp tests even if proxy variables are set in the environment.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Tests that make HTTP POST requests to PTFIP:exabgpPort for bgp updates were failing when proxy variables were set in the environment (gateway timeout 504). Workaround had been to unset these variables before starting the tests. This PR fixes the test scripts such that they don't use the env proxy when making such HTTP requests.

#### How did you do it?
Explicitly set the proxies to `None` when making post requests to ignore the corresponding environment variables.

Precedent for this change exists: https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/library/announce_routes.py#L163

#### How did you verify/test it?
Following tests passed with the change despite the presence of proxy variables in the sonic-mgmt container environment (tested on DUT Cisco 8101):

- test_bgp_update_timer.py
- test_bgp_sentinel.py
- test_bgp_bbr.py
- test_bgp_speaker.py
- test_route_flap.py
- test_bgp_dual_asn.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
