### PR TITLE
test_lldp_syncd.py: increase timeout after reboot and allow `lldp_rem_sys_desc` to be empty value

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -109,7 +109,7 @@ def assert_lldp_entry_content(interface, entry_content, lldpctl_interface):
         "lldp_rem_sys_name does not match for {}".format(interface),
     )
     pytest_assert(
-        entry_content["lldp_rem_sys_desc"] == chassis_info["descr"],
+        entry_content["lldp_rem_sys_desc"] == chassis_info.get("descr", ""),
         "lldp_rem_sys_desc does not match for {}".format(interface),
     )
     pytest_assert(
@@ -208,7 +208,7 @@ def test_lldp_entry_table_after_flap(
         # Shutdown and startup the interface
         duthost.shell("sudo config interface shutdown {}".format(interface))
         duthost.shell("sudo config interface startup {}".format(interface))
-        result = wait_until(30, 2, 5, verify_lldp_entry, db_instance, interface)
+        result = wait_until(60, 2, 5, verify_lldp_entry, db_instance, interface)
         pytest_assert(
             result,
             "After interface {} flap, no LLDP_ENTRY_TABLE entry for it.".format(


### PR DESCRIPTION
### Description of PR
test_lldp_syncd.py does not account for the possibility that `lldp_rem_sys_desc` is empty as it does for other entries it verifies like `lldp_rem_man_addr`.

On t2(min), we also require a larger timeout in the wait_until after reboot.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Observed test fails due to empty `lldp_rem_sys_desc` value.  t2 results flaky due to short wait_until after reboot.

#### How did you do it?

#### How did you verify/test it?
Confirmed test passes on our fixed and chassis systems with these changes

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
