### PR TITLE
[Testgap] Verify BGP configuration for 8111 compute AI development

### DIFF
--- a/tests/bgp/test_bgp_config.py
+++ b/tests/bgp/test_bgp_config.py
@@ -1,0 +1,32 @@
+import logging
+
+from tests.common.helpers.assertions import pytest_assert
+
+
+logger = logging.getLogger(__name__)
+
+
+def test_bgp_config(
+    duthosts, enum_rand_one_per_hwsku_frontend_hostname
+):
+    """
+    @summary: This test case is to verify if "set ipv6 next-hop prefer-global"
+    in the output of "show runningconfiguration bgp" command
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    cmd = "show runningconfiguration bgp"
+
+    bgp_config_result = duthost.shell(cmd)
+    logger.info("output of command '{}': {}".format(cmd, bgp_config_result))
+    pytest_assert(
+        bgp_config_result["rc"] == 0,
+        "{} return value is not 0, output={}".format(
+            cmd, bgp_config_result
+        ),
+    )
+    pytest_assert(
+        "set ipv6 next-hop prefer-global" in bgp_config_result["stdout"],
+        "Did not find ipv6 next-hop in output={}".format(
+            bgp_config_result
+        ),
+    )

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -138,6 +138,12 @@ bgp/test_bgp_bbr.py:
       - "'t1' not in topo_type"
       - "platform in ['x86_64-8111_32eh_o-r0', 'x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
 
+bgp/test_bgp_config.py:
+  skip:
+    reason: "Only supported on Cisco-8000 compute ai platform."
+    conditions:
+      - "platform not in ['x86_64-8111_32eh_o-r0']"
+
 bgp/test_bgp_gr_helper.py:
   skip:
     reason: 'bgp graceful restarted is not a supported feature for T2'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
There are special configurations in BGP on Cisco 8111 computer AI development.
T0 and T1 are both applied.
This PR is to verify this. The test gap is https://github.com/sonic-net/sonic-mgmt/issues/13684

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
There are special configurations in BGP on Cisco 8111 computer AI development.

#### How did you do it?

#### How did you verify/test it?
Verify 8111 has the configuration
Test condition mark: verify non-8111 will NOT run the test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
