### PR TITLE
[macsec] pass tbinfo to get_extended_minigraph_facts

### DIFF
--- a/tests/macsec/__init__.py
+++ b/tests/macsec/__init__.py
@@ -51,7 +51,7 @@ class MacsecPlugin(object):
                                  ids=profiles,
                                  scope="module")
 
-    def get_ctrl_nbr_names(self, macsec_duthost, nbrhosts):
+    def get_ctrl_nbr_names(self, macsec_duthost, nbrhosts, tbinfo):
         return NotImplementedError()
 
     def downstream_neighbor(self,tbinfo, neighbor):
@@ -127,7 +127,7 @@ class MacsecPlugin(object):
             topo_name = tbinfo['topo']['name']
             pytest.skip("None of neighbors on topology {}".format(topo_name))
 
-        ctrl_nbr_names = self.get_ctrl_nbr_names(macsec_duthost, nbrhosts)
+        ctrl_nbr_names = self.get_ctrl_nbr_names(macsec_duthost, nbrhosts, tbinfo)
         logger.info("Controlled links {}".format(ctrl_nbr_names))
         nbrhosts = {name: nbrhosts[name] for name in ctrl_nbr_names}
         return self.find_links_from_nbr(macsec_duthost, tbinfo, nbrhosts)
@@ -227,7 +227,7 @@ class MacsecPluginT0(MacsecPlugin):
     def __init__(self):
          super(MacsecPluginT0, self).__init__()
 
-    def get_ctrl_nbr_names(self, macsec_duthost, nbrhosts):
+    def get_ctrl_nbr_names(self, macsec_duthost, nbrhosts, tbinfo):
         ctrl_nbr_names = natsort.natsorted(nbrhosts.keys())[:2]
         return ctrl_nbr_names
 
@@ -250,8 +250,8 @@ class MacsecPluginT2(MacsecPlugin):
     def __init__(self):
          super(MacsecPluginT2, self).__init__()
 
-    def get_ctrl_nbr_names(self, macsec_duthost, nbrhosts):
-        mg_facts = macsec_duthost.get_extended_minigraph_facts()
+    def get_ctrl_nbr_names(self, macsec_duthost, nbrhosts, tbinfo):
+        mg_facts = macsec_duthost.get_extended_minigraph_facts(tbinfo)
         ctrl_nbr_names = mg_facts['macsec_neighbors']
         return ctrl_nbr_names
 

--- a/tests/macsec/macsec_config_helper.py
+++ b/tests/macsec/macsec_config_helper.py
@@ -220,9 +220,9 @@ def setup_macsec_configuration(duthost, ctrl_links, profile_name, default_priori
 
     # 3. Wait for interface's macsec ready
     for dut_port, nbr in list(ctrl_links.items()):
-        wait_until(20, 3, 0,
-                   lambda: duthost.iface_macsec_ok(dut_port) and
-                   nbr["host"].iface_macsec_ok(nbr["port"]))
+        assert wait_until(20, 3, 0,
+                          lambda: duthost.iface_macsec_ok(dut_port) and
+                          nbr["host"].iface_macsec_ok(nbr["port"]))
 
     # Enabling macsec may cause link flap, which impacts LACP, BGP, etc
     # protocols. To hold some time for protocol recovery.


### PR DESCRIPTION
### Description of PR
macsec tests when run on T2 chassis fail with a runtime exception, due to tbinfo not being passed into a get_extended_minigraph_facts() call.
Also assert if the macsec links fail to be ok when bringing up the test case

Summary:
Fixes #15078

### Type of change

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
