### PR TITLE
Add a new case to check if 'ip nht resolve-via-default' config exists

### DIFF
--- a/tests/bgp/test_bgpmon.py
+++ b/tests/bgp/test_bgpmon.py
@@ -109,6 +109,17 @@ def build_syn_pkt(local_addr, peer_addr):
     return exp_packet
 
 
+def test_resolve_via_default_exist(duthost):
+    """
+    Test to verify if 'ip nht resolve-via-default' and 'ipv6 nht resolve-via-default' are present in global FRR config.
+    """
+    frr_global_config = duthost.shell("vtysh -c 'show running-config'")['stdout']
+    pytest_assert("ip nht resolve-via-default" in frr_global_config,
+                  "ip nht resolve-via-default not present in global FRR config")
+    pytest_assert("ipv6 nht resolve-via-default" in frr_global_config,
+                  "ipv6 nht resolve-via-default not present in global FRR config")
+
+
 def test_bgpmon(dut_with_default_route, localhost, enum_rand_one_frontend_asic_index,
                 common_setup_teardown, set_timeout_for_bgpmon, ptfadapter, ptfhost):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
There has been an issue that missing exit in the FRR template that caused nht config is missed in the FRR config when vrf is configurated. After fixing the issue in https://github.com/sonic-net/sonic-buildimage/pull/19587, add a new case to verify the 'ip nht resolve-via-default' should be present in FRR config whether vrf is configurated.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
