### PR TITLE
[Cisco 8800 test gap] Remove the skip mark for platform_tests/api/test_psu.py::TestPsuApi::test_power

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -363,7 +363,7 @@ platform_tests/api/test_psu.py::TestPsuApi::test_power:
   skip:
     reason: "Unsupported platform API"
     conditions:
-      - "asic_type in ['mellanox', 'cisco-8000'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - "asic_type in ['mellanox'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0']"
 
 platform_tests/api/test_psu.py::TestPsuApi::test_temperature:
   skip:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

test_power is skipped by https://github.com/sonic-net/sonic-mgmt/pull/5409
It was an unsupported function at that time.
Not it's supported, hence remove the skip mark.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Scan and review skipped test cases on Cisco 8800 chassis.
#### How did you do it?
Enable test_power.
#### How did you verify/test it?
run on physical testbeds.

platform_tests/api/test_psu.py::TestPsuApi::test_fans[***-sup-1] PASSED [ 88%]
platform_tests/api/test_psu.py::TestPsuApi::test_power[***-sup-1] PASSED [ 90%]
platform_tests/api/test_psu.py::TestPsuApi::test_temperature[***-sup-1] PASSED [ 92%]
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
