### PR TITLE
Replace redis-cli with sonic-db-cli for the test cases could be run for image with or without ENABLE_MULTIDB=y

### DIFF
--- a/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
+++ b/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
@@ -92,7 +92,7 @@ def get_pg_lossless_profiles(duthost):
     Args:
     duthost: DUT host object
     """
-    pg_lossless_profiles_str = duthost.shell("redis-cli -n 0 KEYS *BUFFER_PROFILE_TABLE:pg_lossless*")["stdout_lines"]
+    pg_lossless_profiles_str = duthost.shell("sonic-db-cli APPL_DB KEYS *BUFFER_PROFILE_TABLE:pg_lossless*")["stdout_lines"]
     pg_lossless_profiles_lst = []
 
     for pg_lossless_profile_str in pg_lossless_profiles_str:

--- a/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
+++ b/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
@@ -92,7 +92,9 @@ def get_pg_lossless_profiles(duthost):
     Args:
     duthost: DUT host object
     """
-    pg_lossless_profiles_str = duthost.shell("sonic-db-cli APPL_DB KEYS *BUFFER_PROFILE_TABLE:pg_lossless*")["stdout_lines"]
+    pg_lossless_profiles_str = duthost.shell(
+        "sonic-db-cli APPL_DB KEYS *BUFFER_PROFILE_TABLE:pg_lossless*"
+    )["stdout_lines"]
     pg_lossless_profiles_lst = []
 
     for pg_lossless_profile_str in pg_lossless_profiles_str:

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -210,7 +210,7 @@ def select_interface_for_mellnaox_device(setup, duthost):
     ERR swss#orchagent: :- processPriorityGroup: Failed to set port:Ethernet0 pg:3 buffer profile attribute, status:-4
     """
     selected_interface = ''
-    interface_cable_length_list = duthost.shell('redis-cli -n 4 hgetall "CABLE_LENGTH|AZURE" ')['stdout_lines']
+    interface_cable_length_list = duthost.shell('sonic-db-cli CONFIG_DB hgetall "CABLE_LENGTH|AZURE" ')['stdout_lines']
     support_cable_length_list = ["40m", "5m"]
     for intf in setup['physical_interfaces']:
         if intf in interface_cable_length_list:

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -317,7 +317,7 @@ class TestShowInterfaces():
             if regex_int.match(line):
                 interfaces.append(regex_int.match(line).group(0))
 
-        assert(len(interfaces) > 0)
+        assert (len(interfaces) > 0)
 
         for item in interfaces:
             if mode == 'alias':
@@ -551,7 +551,7 @@ class TestShowQueue():
                 intfsChecked += 1
 
         # At least one interface should have been checked to have a valid result
-        assert(intfsChecked > 0)
+        assert (intfsChecked > 0)
 
     def test_show_queue_counters_interface(self, setup_config_mode, sample_intf):
         """


### PR DESCRIPTION
### Description of PR
Modify /tests/iface_namingmode/test_iface_namingmode.py and /tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py 
Replace redis-cli with sonic-db-cli for the test cases could be run for image with or without ENABLE_MULTIDB=y


Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
sonic-mgmt tests for multi DB
#### How did you do it?
Replace redis-cli with sonic-db-cli 
#### How did you verify/test it?

For test_iface_namingmode.py, run
./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c iface_namingmode/test_iface_namingmode.py -f vtestbed.yaml -i ../ansible/veos_vtb -e "--neighbor_type=sonic"
in image with or without ENABLE_MULTIDB=y, results are both
38 passed, 22 skipped, 1 warning

For test_mmu_dynamic_threshold_config_update.py, run
./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c generic_config_updater/test_mmu_dynamic_threshold_config_update.py -f vtestbed.yaml -i ../ansible/veos_vtb -e "--neighbor_type=sonic"
in image with or without ENABLE_MULTIDB=y, results are both
generic_config_updater/test_mmu_dynamic_threshold_config_update.py::test_dynamic_th_config_updates[replace] PASSED [100%]
instead of SKIPPED