### PR TITLE
Wait for the interface to come up before verifying the FEC mode after configuration

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -203,17 +203,3 @@ def get_dpu_npu_ports_from_hwsku(duthost):
             dpu_npu_port_list.append(intf)
     logging.info(f"DPU NPU ports in hwsku.json are {dpu_npu_port_list}")
     return dpu_npu_port_list
-
-
-def check_interface_running_status(duthost, interface):
-    """
-    @summary: Check if the oper status of the specified interface is up.
-    @param duthost: The AnsibleHost object of DUT. For interacting with DUT.
-    @param interface: The interface that needs to be checked.
-    @return: True if the oper status is up, False otherwise.
-    """
-    logging.info("Checking oper status for interface {interface}")
-    output = duthost.command("show interface status {}".format(interface))
-    intf_status = output["stdout_lines"][2].split()
-
-    return intf_status[7] == "up"

--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -203,3 +203,17 @@ def get_dpu_npu_ports_from_hwsku(duthost):
             dpu_npu_port_list.append(intf)
     logging.info(f"DPU NPU ports in hwsku.json are {dpu_npu_port_list}")
     return dpu_npu_port_list
+
+
+def check_interface_running_status(duthost, interface):
+    """
+    @summary: Check if the oper status of the specified interface is up.
+    @param duthost: The AnsibleHost object of DUT. For interacting with DUT.
+    @param interface: The interface that needs to be checked.
+    @return: True if the oper status is up, False otherwise.
+    """
+    logging.info("Checking oper status for interface {interface}")
+    output = duthost.command("show interface status {}".format(interface))
+    intf_status = output["stdout_lines"][2].split()
+
+    return intf_status[7] == "up"

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -2,7 +2,6 @@ import logging
 import pytest
 
 from tests.common.utilities import skip_release, wait_until
-from tests.common.platform.interface_utils import check_interface_running_status
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
@@ -81,7 +80,7 @@ def test_config_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
         config_status = duthost.command("sudo config interface fec {} rs"
                                         .format(intf['interface']))
         if config_status:
-            wait_until(12, 1, 0, check_interface_running_status, duthost, intf["interface"])
+            wait_until(30, 2, 0, duthost.is_interface_status_up, intf["interface"])
             # Verify the FEC operational mode is restored
             logging.info("Get output of '{} {}'".format("show interfaces fec status", intf['interface']))
             fec_status = duthost.show_and_parse("show interfaces fec status {}".format(intf['interface']))

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -1,7 +1,8 @@
 import logging
 import pytest
 
-from tests.common.utilities import skip_release
+from tests.common.utilities import skip_release, wait_until
+from tests.common.platform.interface_utils import check_interface_running_status
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
@@ -80,7 +81,7 @@ def test_config_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
         config_status = duthost.command("sudo config interface fec {} rs"
                                         .format(intf['interface']))
         if config_status:
-            duthost.command("sleep 7")
+            wait_until(12, 1, 0, check_interface_running_status, duthost, intf["interface"])
             # Verify the FEC operational mode is restored
             logging.info("Get output of '{} {}'".format("show interfaces fec status", intf['interface']))
             fec_status = duthost.show_and_parse("show interfaces fec status {}".format(intf['interface']))

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -80,7 +80,7 @@ def test_config_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
         config_status = duthost.command("sudo config interface fec {} rs"
                                         .format(intf['interface']))
         if config_status:
-            duthost.command("sleep 2")
+            duthost.command("sleep 7")
             # Verify the FEC operational mode is restored
             logging.info("Get output of '{} {}'".format("show interfaces fec status", intf['interface']))
             fec_status = duthost.show_and_parse("show interfaces fec status {}".format(intf['interface']))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

This pull request waits for the interface to come up before verifying the FEC mode after configuration. The link flaps to apply the FEC configuration, and the time required varies across different platforms and speeds.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified on the Mellanox 4700 and Cisco 8101 platforms where the issue is reproduced.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
