### PR TITLE
Move the lossy skip condition above the code checking for the lossy key.

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1610,6 +1610,12 @@ class TestQosSai(QosSaiBase):
             else:
                 qosConfig = dutQosConfig["param"]
 
+        if dutTestParams["basicParams"].get("platform_asic", None) \
+                == "cisco-8000":
+            if not get_src_dst_asic_and_duts['single_asic_test']:
+                if pgProfile == "wm_pg_shared_lossy":
+                    pytest.skip("The lossy test is not valid for multiAsic configuration.")
+
         if "wm_pg_shared_lossless" in pgProfile:
             pktsNumFillShared = qosConfig[pgProfile]["pkts_num_trig_pfc"]
         elif "wm_pg_shared_lossy" in pgProfile:
@@ -1619,12 +1625,6 @@ class TestQosSai(QosSaiBase):
                     "cisco-8000 Q100 platform.")
             pktsNumFillShared = int(
                 qosConfig[pgProfile]["pkts_num_trig_egr_drp"]) - 1
-
-        if dutTestParams["basicParams"].get("platform_asic", None) \
-                == "cisco-8000":
-            if not get_src_dst_asic_and_duts['single_asic_test']:
-                if pgProfile == "wm_pg_shared_lossy":
-                    pytest.skip("The lossy test is not valid for multiAsic configuration.")
 
         self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The skip for non-single-asic variant for the test:qos/test_qos_sai.py::ttestQosSaiPgSharedWatermark[wm_pg_shared_lossy] was added by https://github.com/sonic-net/sonic-mgmt/pull/14892 in the wrong location. We need to move this skip before it checks for the wm_pg_shared_lossy key.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
The keyerror addressed in the PR:https://github.com/sonic-net/sonic-mgmt/pull/14892 is still occuring, since the skip was added after the Key checking code. This PR moves it up above the Keychecking code.

#### How did you do it?
Moved the skip block above.

#### How did you verify/test it?
Ran it on my TB:
