### PR TITLE
Update the method of checking lldp table and service in test_lldp_syncd

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -257,7 +257,7 @@ def test_lldp_entry_table_after_lldp_restart(
     pytest_assert(result, "no output for show lldp table after restarting lldp")
     result = duthost.shell("sudo systemctl status lldp")["stdout"]
     pytest_assert(
-        "active (running)" in result["stdout"],
+        "active (running)" in result,
         "LLDP service is not running",
     )
     lldpctl_interfaces = lldpctl_output["lldp"]["interface"]

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -148,9 +148,8 @@ def verify_lldp_entry(db_instance, interface):
 
 
 def verify_lldp_table(duthost):
-    # based on experience, eth0 shows up at last
     output = duthost.shell("show lldp table")["stdout"]
-    if "eth0" in output:
+    if "Total entries displayed" in output:
         return True
     else:
         return False
@@ -255,14 +254,19 @@ def test_lldp_entry_table_after_lldp_restart(
     result = wait_until(
         60, 2, 5, verify_lldp_table, duthost
     )  # Adjust based on LLDP service restart time
-    pytest_assert(result, "eth0 is still not in output of show lldp table")
+    pytest_assert(result, "no output for show lldp table after restarting lldp")
+    result = duthost.shell("sudo systemctl status lldp")
+    pytest_assert(
+        "active (running)" in result["stdout"],
+        "LLDP service is not running",
+    )
     lldpctl_interfaces = lldpctl_output["lldp"]["interface"]
     assert_lldp_interfaces(
         lldp_entry_keys, show_lldp_table_int_list, lldpctl_interfaces
     )
     for interface in lldp_entry_keys:
         entry_content = get_lldp_entry_content(db_instance, interface)
-
+        logger.debug("entry_content:{}".format(entry_content))
         if isinstance(lldpctl_interfaces, dict):
             lldpctl_interface = lldpctl_interfaces.get(interface)
         elif isinstance(lldpctl_interfaces, list):

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -255,7 +255,7 @@ def test_lldp_entry_table_after_lldp_restart(
         60, 2, 5, verify_lldp_table, duthost
     )  # Adjust based on LLDP service restart time
     pytest_assert(result, "no output for show lldp table after restarting lldp")
-    result = duthost.shell("sudo systemctl status lldp")
+    result = duthost.shell("sudo systemctl status lldp")["stdout"]
     pytest_assert(
         "active (running)" in result["stdout"],
         "LLDP service is not running",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix the issue: https://github.com/sonic-net/sonic-mgmt/issues/15089

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Using `eth0` to check lldp table validation is not reasonable, use the last line of `show lldp table`, which is `Total entries displayed` as a checker instead and also check the lldp service status after restarting lldp process.

#### How did you do it?
Update `verify_lldp_table` and check the output of `systemctl status lldp`
#### How did you verify/test it?
Run `lldp/test_lldp_syncd.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
