### PR TITLE
Update qos parameters for hwsku Mellanox-4700-V64 and topology dualtor-aa-64-breakout

### DIFF
--- a/tests/qos/files/qos_params.spc3.yaml
+++ b/tests/qos/files/qos_params.spc3.yaml
@@ -99,3 +99,36 @@ qos_params:
                     pkts_num_trig_pfc: 176064
                     pkts_num_trig_ingr_drp: 177916
                     pkts_num_margin: 4
+        topo-dualtor-aa-64-breakout:
+            200000_40m:
+                pkts_num_leak_out: 0
+                pcbb_xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 164884
+                    pkts_num_trig_ingr_drp: 165595
+                    pkts_num_margin: 4
+                pcbb_xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 164884
+                    pkts_num_trig_ingr_drp: 165595
+                    pkts_num_margin: 4
+                pcbb_xoff_3:
+                    outer_dscp: 2
+                    dscp: 3
+                    ecn: 1
+                    pg: 2
+                    pkts_num_trig_pfc: 164884
+                    pkts_num_trig_ingr_drp: 165595
+                    pkts_num_margin: 4
+                pcbb_xoff_4:
+                    outer_dscp: 6
+                    dscp: 4
+                    ecn: 1
+                    pg: 6
+                    pkts_num_trig_pfc: 164884
+                    pkts_num_trig_ingr_drp: 165595
+                    pkts_num_margin: 4


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Update qos parameters for hwsku Mellanox-4700-V64 and topology dualtor-aa-64-breakout
It could make sure case test_tunnel_qos_remap#test_xoff_for_pcbb could PASS at hwsku Mellanox-4700-V64 and topology dualtor-aa-64-breakout

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Make case test_tunnel_qos_remap#test_xoff_for_pcbb could PASS at hwsku Mellanox-4700-V64 and topology dualtor-aa-64-breakout
#### How did you do it?
Add qos parameters
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?
MSN4700 hwsku Mellanox-4700-V64 and topology dualtor-aa-64-breakout
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
