### PR TITLE
Update the way of shutdown bgp service in qos sai test

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1371,8 +1371,6 @@ class QosSaiBase(QosBase):
         src_services = [
             {"docker": src_asic.get_docker_name("lldp"), "service": "lldp-syncd"},
             {"docker": src_asic.get_docker_name("lldp"), "service": "lldpd"},
-            {"docker": src_asic.get_docker_name("bgp"),  "service": "bgpd"},
-            {"docker": src_asic.get_docker_name("bgp"),  "service": "bgpmon"},
             {"docker": src_asic.get_docker_name("radv"), "service": "radvd"},
             {"docker": src_asic.get_docker_name("swss"), "service": "arp_update"}
         ]
@@ -1381,8 +1379,6 @@ class QosSaiBase(QosBase):
             dst_services = [
                 {"docker": dst_asic.get_docker_name("lldp"), "service": "lldp-syncd"},
                 {"docker": dst_asic.get_docker_name("lldp"), "service": "lldpd"},
-                {"docker": dst_asic.get_docker_name("bgp"), "service": "bgpd"},
-                {"docker": dst_asic.get_docker_name("bgp"), "service": "bgpmon"},
                 {"docker": dst_asic.get_docker_name("radv"), "service": "radvd"},
                 {"docker": dst_asic.get_docker_name("swss"), "service": "arp_update"}
             ]
@@ -1395,17 +1391,22 @@ class QosSaiBase(QosBase):
         disable_container_autorestart(src_dut, testcase="test_qos_sai", feature_list=feature_list)
         for service in src_services:
             updateDockerService(src_dut, action="stop", **service)
+        src_dut.shell("sudo config bgp shutdown all")
         if src_asic != dst_asic:
             disable_container_autorestart(dst_dut, testcase="test_qos_sai", feature_list=feature_list)
             for service in dst_services:
                 updateDockerService(dst_dut, action="stop", **service)
+            dst_dut.shell("sudo config bgp shutdown all")
+
         yield
 
         for service in src_services:
             updateDockerService(src_dut, action="start", **service)
+        src_dut.shell("sudo config bgp start all")
         if src_asic != dst_asic:
             for service in dst_services:
                 updateDockerService(dst_dut, action="start", **service)
+            dst_dut.shell("sudo config bgp start all")
 
         """ Start mux conatiner for dual ToR """
         if 'dualtor' in tbinfo['topo']['name']:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Update the way of shutdown bgp service in qos sai test 
In MSN2700 T0 setup, the original way of setting bgp down would be too slow 
And the bgp routes would be delay handled after several minutes, it would affect the qos buffer test result

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
In MSN2700 T0 setup, the original way of setting bgp down would be too slow 
And the bgp routes would be delay handled after several minutes, it would affect the qos buffer test result
#### How did you do it?
Use bgp shutdown/start to control bgp
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
