### PR TITLE
[dhcp_relay][dualtor] Add test case for DHCP drop on standby tor

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -167,7 +167,7 @@ def verify_acl_drop_on_standby_tor(rand_unselected_dut, dut_dhcp_relay_data, tes
             client_interface_name = dhcp_relay["client_iface"]["name"]
             # Get acl mark per interface
             output = (rand_unselected_dut
-                      .shell("ebtables -L INPUT | grep '\-i {} \-j mark \-\-mark\-set' | awk '{{print $6}}'"
+                      .shell(r"ebtables -L INPUT | grep '\-i {} \-j mark \-\-mark\-set' | awk '{{print $6}}'"
                              .format(client_interface_name)))
             pytest_assert(output["rc"] == 0 and len(output["stdout_lines"]) == 1,
                           "Failed get DHCP acl mark for {}, err: {}".format(client_interface_name, output["stderr"]))

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -501,7 +501,8 @@ def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_route
 
 def test_dhcp_relay_random_sport(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
                                  setup_standby_ports_on_rand_unselected_tor,				 # noqa F811
-                                 toggle_all_simulator_ports_to_rand_selected_tor_m):    # noqa F811
+                                 toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa F811
+                                 verify_acl_drop_on_standby_tor):    # noqa F811
     """Test DHCP relay functionality on T0 topology with random source port (sport)
        If the client is SNAT'd, the source port could be changed to a non-standard port (i.e., not 68).
        Verify that DHCP relay works with random high sport.

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -150,9 +150,47 @@ def start_dhcp_monitor_debug_counter(duthost):
         assert False, "Failed to start dhcpmon in debug counter mode\n"
 
 
+def get_acl_count_by_mark(rand_unselected_dut, mark):
+    output = rand_unselected_dut.shell("iptables -nvL DHCP | grep 'DROP' | grep '{}' | awk '{{print $1}}'"
+                                        .format(mark))
+    pytest_assert(output["rc"] == 0 and len(output["stdout_lines"]) == 1,
+                    "Failed get DHCP acl count for {}, err: {}".format(mark, output["stderr"]))
+    return int(output["stdout"].strip())
+
+
+@pytest.fixture(scope="function")
+def verify_acl_drop_on_standby_tor(rand_unselected_dut, dut_dhcp_relay_data, testing_config):
+    testing_mode, _ = testing_config
+    if testing_mode == DUAL_TOR_MODE:
+        # Clear DHCP acl counter
+        rand_unselected_dut.shell("iptables -Z")
+        pre_client_dhcp_acl_counts = {}
+        for dhcp_relay in dut_dhcp_relay_data:
+            client_interface_name = dhcp_relay["client_iface"]["name"]
+            # Get acl mark per interface
+            output = (rand_unselected_dut
+                      .shell("ebtables -L INPUT | grep '\-i {} \-j mark \-\-mark\-set' | awk '{{print $6}}'"
+                             .format(client_interface_name)))
+            pytest_assert(output["rc"] == 0 and len(output["stdout_lines"]) == 1,
+                        "Failed get DHCP acl mark for {}, err: {}".format(client_interface_name, output["stderr"]))
+            mark = output["stdout"].strip()
+            pre_client_dhcp_acl_counts[client_interface_name] = {"mark": mark}
+            # Get acl count by acl mark
+            pre_client_dhcp_acl_counts[client_interface_name]["count"] = get_acl_count_by_mark(rand_unselected_dut, mark)
+
+    yield
+
+    if testing_mode == DUAL_TOR_MODE:
+        for client_interface_name, item in pre_client_dhcp_acl_counts.items():
+            after_count = get_acl_count_by_mark(rand_unselected_dut, item["mark"])
+            pytest_assert(after_count == item["count"] + 2, "Drop count of {} {} is unexpected, pre: {}, after: {}"
+                          .format(client_interface_name, item["mark"], item["count"], after_count))
+
+
 def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
                             setup_standby_ports_on_rand_unselected_tor,												# noqa F811
-                            rand_unselected_dut, toggle_all_simulator_ports_to_rand_selected_tor_m):     # noqa F811
+                            rand_unselected_dut, toggle_all_simulator_ports_to_rand_selected_tor_m,
+                            verify_acl_drop_on_standby_tor):     # noqa F811
     """Test DHCP relay functionality on T0 topology.
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
     """
@@ -241,7 +279,7 @@ def test_dhcp_relay_with_source_port_ip_in_relay_enabled(ptfhost, dut_dhcp_relay
                                                          validate_dut_routes_exist, testing_config,
                                                          setup_standby_ports_on_rand_unselected_tor,												# noqa F811
                                                          rand_unselected_dut, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
-                                                         enable_source_port_ip_in_relay):
+                                                         enable_source_port_ip_in_relay, verify_acl_drop_on_standby_tor):
     """Test DHCP relay functionality on T0 topology.
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
     """
@@ -429,7 +467,8 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
 
 def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
                                 setup_standby_ports_on_rand_unselected_tor,				 # noqa F811
-                                toggle_all_simulator_ports_to_rand_selected_tor_m):     # noqa F811
+                                toggle_all_simulator_ports_to_rand_selected_tor_m,
+                                verify_acl_drop_on_standby_tor):     # noqa F811
     """Test DHCP relay functionality on T0 topology with unicast mac
        Instead of using broadcast MAC, use unicast MAC of DUT and verify that DHCP relay functionality is entact.
     """
@@ -464,7 +503,8 @@ def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_route
 
 def test_dhcp_relay_random_sport(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
                                  setup_standby_ports_on_rand_unselected_tor,				 # noqa F811
-                                 toggle_all_simulator_ports_to_rand_selected_tor_m):    # noqa F811
+                                 toggle_all_simulator_ports_to_rand_selected_tor_m,
+                                 verify_acl_drop_on_standby_tor):    # noqa F811
     """Test DHCP relay functionality on T0 topology with random source port (sport)
        If the client is SNAT'd, the source port could be changed to a non-standard port (i.e., not 68).
        Verify that DHCP relay works with random high sport.

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -162,8 +162,6 @@ def get_acl_count_by_mark(rand_unselected_dut, mark):
 def verify_acl_drop_on_standby_tor(rand_unselected_dut, dut_dhcp_relay_data, testing_config, tbinfo):
     testing_mode, _ = testing_config
     if testing_mode == DUAL_TOR_MODE and "dualtor-aa" not in tbinfo["topo"]["name"]:
-        # Clear DHCP acl counter
-        rand_unselected_dut.shell("iptables -Z")
         pre_client_dhcp_acl_counts = {}
         for dhcp_relay in dut_dhcp_relay_data:
             client_interface_name = dhcp_relay["client_iface"]["name"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Add test to verify DHCP packets are dropped by standby tor https://github.com/sonic-net/sonic-mgmt/issues/5627

#### How did you do it?
Verify packet drop count by cacl

#### How did you verify/test it?
Run test on dualtor / t0 topos, all passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
