### PR TITLE
[Fix] Fixing reboot check, IP cleanup and Execution time for multidut PFC cases

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -577,6 +577,14 @@ def rand_one_dut_lossless_prio(request):
     return lossless_prio_list[0]
 
 
+@pytest.fixture(scope="module")
+def rand_one_dut_lossy_prio(request):
+    lossless_prio_list = generate_priority_lists(request, 'lossy')
+    if len(lossless_prio_list) > 1:
+        lossless_prio_list = random.sample(lossless_prio_list, 1)
+    return lossless_prio_list[0]
+
+
 @pytest.fixture(scope="module", autouse=True)
 def reset_critical_services_list(duthosts):
     """

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -27,7 +27,7 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
                                         conn_graph_facts,               # noqa: F811
                                         fanout_graph_facts_multidut,             # noqa: F811
                                         duthosts,
-                                        enum_dut_lossless_prio,
+                                        rand_one_dut_lossless_prio,
                                         prio_dscp_map,                   # noqa: F811
                                         lossless_prio_list,              # noqa: F811
                                         all_prio_list,                   # noqa: F811
@@ -43,7 +43,7 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
         conn_graph_facts (pytest fixture): connection graph
         fanout_graph_facts_multidut (pytest fixture): fanout graph
         duthosts (pytest fixture): list of DUTs
-        enum_dut_lossless_prio (str): lossless priority to test, e.g., 's6100-1|3'
+        rand_one_dut_lossless_prio (str): lossless priority to test, e.g., 's6100-1|3'
         all_prio_list (pytest fixture): list of all the priorities
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
         lossless_prio_list (pytest fixture): list of all the lossless priorities
@@ -82,7 +82,7 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
                                                                                 snappi_ports,
                                                                                 snappi_api)
 
-    _, lossless_prio = enum_dut_lossless_prio.split('|')
+    _, lossless_prio = rand_one_dut_lossless_prio.split('|')
     lossless_prio = int(lossless_prio)
     pause_prio_list = [lossless_prio]
     test_prio_list = [lossless_prio]
@@ -197,7 +197,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
                                                fanout_graph_facts_multidut,          # noqa: F811
                                                duthosts,
                                                localhost,
-                                               enum_dut_lossless_prio,    # noqa: F811
+                                               rand_one_dut_lossless_prio,    # noqa: F811
                                                prio_dscp_map,            # noqa: F811
                                                lossless_prio_list,         # noqa: F811
                                                all_prio_list,        # noqa: F811
@@ -254,7 +254,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
     skip_warm_reboot(snappi_ports[0]['duthost'], reboot_type)
     skip_warm_reboot(snappi_ports[1]['duthost'], reboot_type)
 
-    _, lossless_prio = enum_dut_lossless_prio.split('|')
+    _, lossless_prio = rand_one_dut_lossless_prio.split('|')
     lossless_prio = int(lossless_prio)
     pause_prio_list = [lossless_prio]
     test_prio_list = [lossless_prio]

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -4,9 +4,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_grap
     fanout_graph_facts_multidut     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_dut_base_config, is_snappi_multidut, \
-    get_snappi_ports_for_rdma, cleanup_config, get_snappi_ports_multi_dut, \
-    snappi_testbed_config, get_snappi_ports_single_dut, \
-    get_snappi_ports, is_snappi_multidut                                        # noqa: F401
+    get_snappi_ports_for_rdma, cleanup_config, get_snappi_ports                              # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list                         # noqa F401
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED  # noqa F401

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -3,15 +3,17 @@ from tests.common.helpers.assertions import pytest_require, pytest_assert       
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
     fanout_graph_facts_multidut     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-    snappi_api, snappi_dut_base_config, get_snappi_ports_for_rdma, cleanup_config, get_snappi_ports_multi_dut, \
+    snappi_api, snappi_dut_base_config, is_snappi_multidut, \
+    get_snappi_ports_for_rdma, cleanup_config, get_snappi_ports_multi_dut, \
     snappi_testbed_config, get_snappi_ports_single_dut, \
     get_snappi_ports, is_snappi_multidut                                        # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list                         # noqa F401
-from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
-from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_pfc_test
-from tests.common.reboot import reboot
-from tests.common.utilities import wait_until
+from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED  # noqa F401
+from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_pfc_test  # noqa F401
+from tests.common.reboot import reboot  # noqa F401
+from tests.common.utilities import wait_until # noqa F401
+from tests.common.platform.processes_utils import wait_critical_processes # noqa F401
 import logging
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import skip_warm_reboot
@@ -74,7 +76,7 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
             snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
                                                      tx_port_count, rx_port_count, MULTIDUT_TESTBED)
         else:
-            snappi_ports = get_snappi_ports
+            snappi_ports = snappi_port_list
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)
@@ -90,20 +92,21 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
-
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=True,
-                 snappi_extra_params=snappi_extra_params)
-    cleanup_config(duthosts, snappi_ports)
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts_multidut,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=True,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
@@ -138,6 +141,8 @@ def test_pfc_pause_multi_lossless_prio(snappi_api,                  # noqa: F811
         tx_port_count = 1
         rx_port_count = 1
         snappi_port_list = get_snappi_ports
+        pytest_assert(MULTIDUT_TESTBED == tbinfo['conf-name'],
+                      "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
         pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
@@ -151,11 +156,8 @@ def test_pfc_pause_multi_lossless_prio(snappi_api,                  # noqa: F811
                       testbed {}, subtype {} in variables.py'.
                       format(MULTIDUT_TESTBED, testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
+        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)
@@ -167,20 +169,20 @@ def test_pfc_pause_multi_lossless_prio(snappi_api,                  # noqa: F811
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
-
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=True,
-                 snappi_extra_params=snappi_extra_params)
-    cleanup_config(duthosts, snappi_ports)
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts_multidut,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=True,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
@@ -221,6 +223,8 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
         tx_port_count = 1
         rx_port_count = 1
         snappi_port_list = get_snappi_ports
+        pytest_assert(MULTIDUT_TESTBED == tbinfo['conf-name'],
+                      "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
         pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
@@ -234,11 +238,8 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
                       testbed {}, subtype {} in variables.py'.
                       format(MULTIDUT_TESTBED, testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
+        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)
@@ -256,27 +257,29 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+    try:
+        for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
+            logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
+            reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
+            logger.info("Wait until the system is stable")
+            wait_critical_processes(duthost)
+            pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
+                          "Not all critical services are fully started")
 
-    for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
-        logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-        reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
-        logger.info("Wait until the system is stable")
-        wait_until(180, 20, 0, duthost.critical_services_fully_started)
-
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=True,
-                 snappi_extra_params=snappi_extra_params)
-
-    cleanup_config(duthosts, snappi_ports)
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts_multidut,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=True,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
@@ -316,6 +319,8 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noq
         tx_port_count = 1
         rx_port_count = 1
         snappi_port_list = get_snappi_ports
+        pytest_assert(MULTIDUT_TESTBED == tbinfo['conf-name'],
+                      "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
         pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
@@ -329,11 +334,8 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noq
                       testbed {}, subtype {} in variables.py'.
                       format(MULTIDUT_TESTBED, testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
+        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)
@@ -346,24 +348,26 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noq
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+    try:
+        for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
+            logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
+            reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
+            logger.info("Wait until the system is stable")
+            wait_critical_processes(duthost)
+            pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
+                          "Not all critical services are fully started")
 
-    for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
-        logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-        reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
-        logger.info("Wait until the system is stable")
-        wait_until(180, 20, 0, duthost.critical_services_fully_started)
-
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=True,
-                 snappi_extra_params=snappi_extra_params)
-
-    cleanup_config(duthosts, snappi_ports)
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts_multidut,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=True,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -265,7 +265,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
     try:
-        for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
+        for duthost in set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]):
             logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
             reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
             logger.info("Wait until the system is stable")
@@ -359,7 +359,7 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noq
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
     try:
-        for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
+        for duthost in set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]):
             logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
             reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
             logger.info("Wait until the system is stable")

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -58,7 +58,8 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
         tx_port_count = 1
         rx_port_count = 1
         snappi_port_list = get_snappi_ports
-
+        pytest_assert(MULTIDUT_TESTBED == tbinfo['conf-name'],
+                      "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
         pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
@@ -76,7 +77,7 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
             snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
                                                      tx_port_count, rx_port_count, MULTIDUT_TESTBED)
         else:
-            snappi_ports = snappi_port_list
+            snappi_ports = get_snappi_ports
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)
@@ -156,8 +157,11 @@ def test_pfc_pause_multi_lossless_prio(snappi_api,                  # noqa: F811
                       testbed {}, subtype {} in variables.py'.
                       format(MULTIDUT_TESTBED, testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        if is_snappi_multidut(duthosts):
+            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        else:
+            snappi_ports = get_snappi_ports
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)
@@ -238,8 +242,11 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
                       testbed {}, subtype {} in variables.py'.
                       format(MULTIDUT_TESTBED, testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        if is_snappi_multidut(duthosts):
+            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        else:
+            snappi_ports = get_snappi_ports
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)
@@ -334,8 +341,11 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noq
                       testbed {}, subtype {} in variables.py'.
                       format(MULTIDUT_TESTBED, testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        if is_snappi_multidut(duthosts):
+            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        else:
+            snappi_ports = get_snappi_ports
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -1,24 +1,24 @@
 import pytest
 from tests.common.helpers.assertions import pytest_require, pytest_assert                   # noqa: F401
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
-    fanout_graph_facts_multidut     # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut, \
+    fanout_graph_facts   # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_dut_base_config, get_snappi_ports_for_rdma, cleanup_config, \
-    get_snappi_ports_single_dut, snappi_testbed_config, \
-    get_snappi_ports_multi_dut, is_snappi_multidut, \
-    get_snappi_ports                                         # noqa: F401
+    get_snappi_ports, is_snappi_multidut, \
+    get_snappi_ports_single_dut, get_snappi_ports_multi_dut  # noqa F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list                         # noqa F401
-from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED   # noqa F401
 from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_pfc_test
-from tests.common.reboot import reboot
-from tests.common.utilities import wait_until
+from tests.common.reboot import reboot   # noqa F401
+from tests.common.utilities import wait_until   # noqa F401
+from tests.common.platform.processes_utils import wait_critical_processes   # noqa F401
 import logging
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import skip_warm_reboot
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [pytest.mark.topology('multidut-tgen')]
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
@@ -55,6 +55,8 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
         tx_port_count = 1
         rx_port_count = 1
         snappi_port_list = get_snappi_ports
+        pytest_assert(MULTIDUT_TESTBED == tbinfo['conf-name'],
+                      "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
         pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
@@ -68,11 +70,8 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
                       testbed {}, subtype {} in variables.py'.
                       format(MULTIDUT_TESTBED, testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
+        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)
@@ -86,26 +85,27 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
-
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=False,
-                 snappi_extra_params=snappi_extra_params)
-    cleanup_config(duthosts, snappi_ports)
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts_multidut,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=False,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
                                     conn_graph_facts,       # noqa: F811
-                                    fanout_graph_facts_multidut,     # noqa: F811
+                                    fanout_graph_facts,     # noqa: F811
                                     duthosts,
                                     prio_dscp_map,                   # noqa: F811
                                     lossy_prio_list,              # noqa: F811
@@ -133,6 +133,8 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
         tx_port_count = 1
         rx_port_count = 1
         snappi_port_list = get_snappi_ports
+        pytest_assert(MULTIDUT_TESTBED == tbinfo['conf-name'],
+                      "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
         pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
@@ -146,11 +148,8 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
                       testbed {}, subtype {} in variables.py'.
                       format(MULTIDUT_TESTBED, testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
+        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)
@@ -161,20 +160,21 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
-
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=False,
-                 snappi_extra_params=snappi_extra_params)
-    cleanup_config(duthosts, snappi_ports)
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=False,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
@@ -216,6 +216,8 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
         tx_port_count = 1
         rx_port_count = 1
         snappi_port_list = get_snappi_ports
+        pytest_assert(MULTIDUT_TESTBED == tbinfo['conf-name'],
+                      "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
         pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
@@ -229,11 +231,8 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
                       testbed {}, subtype {} in variables.py'.
                       format(MULTIDUT_TESTBED, testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
+        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)
@@ -247,29 +246,32 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
     test_prio_list = [lossy_prio]
     bg_prio_list = [p for p in all_prio_list]
     bg_prio_list.remove(lossy_prio)
+    try:
+        for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
+            logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
+            reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
+            logger.info("Wait until the system is stable")
+            wait_critical_processes(duthost)
+            pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
+                          "Not all critical services are fully started")
 
-    for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
-        logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-        reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
-        logger.info("Wait until the system is stable")
-        wait_until(180, 20, 0, duthost.critical_services_fully_started)
+        snappi_extra_params = SnappiTestParams()
+        snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
-    snappi_extra_params = SnappiTestParams()
-    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
-
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=False,
-                 snappi_extra_params=snappi_extra_params)
-    cleanup_config(duthosts, snappi_ports)
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts_multidut,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=False,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
@@ -277,7 +279,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
                                            conn_graph_facts,    # noqa: F811
-                                           fanout_graph_facts_multidut,  # noqa: F811
+                                           fanout_graph_facts,  # noqa: F811
                                            duthosts,
                                            localhost,
                                            prio_dscp_map,       # noqa: F811
@@ -310,6 +312,8 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
         tx_port_count = 1
         rx_port_count = 1
         snappi_port_list = get_snappi_ports
+        pytest_assert(MULTIDUT_TESTBED == tbinfo['conf-name'],
+                      "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
         pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
@@ -323,11 +327,8 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
                       testbed {}, subtype {} in variables.py'.
                       format(MULTIDUT_TESTBED, testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
+        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)
@@ -337,26 +338,29 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
     pause_prio_list = lossy_prio_list
     test_prio_list = lossy_prio_list
     bg_prio_list = lossless_prio_list
+    try:
+        for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
+            logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
+            reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
+            logger.info("Wait until the system is stable")
+            wait_critical_processes(duthost)
+            pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
+                          "Not all critical services are fully started")
 
-    for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
-        logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-        reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
-        logger.info("Wait until the system is stable")
-        wait_until(180, 20, 0, duthost.critical_services_fully_started)
+        snappi_extra_params = SnappiTestParams()
+        snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
-    snappi_extra_params = SnappiTestParams()
-    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
-
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=False,
-                 snappi_extra_params=snappi_extra_params)
-    cleanup_config(duthosts, snappi_ports)
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts_multidut,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=False,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -26,7 +26,7 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
                                      conn_graph_facts,          # noqa: F811
                                      fanout_graph_facts_multidut,        # noqa: F811
                                      duthosts,
-                                     enum_dut_lossy_prio,
+                                     rand_one_dut_lossy_prio,
                                      prio_dscp_map,                   # noqa: F811
                                      lossy_prio_list,              # noqa: F811
                                      all_prio_list,                   # noqa: F811
@@ -41,7 +41,7 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
         conn_graph_facts (pytest fixture): connection graph
         fanout_graph_facts_multidut (pytest fixture): fanout graph
         duthosts (pytest fixture): list of DUTs
-        enum_dut_lossy_prio (str): name of lossy priority to test, e.g., 's6100-1|2'
+        rand_one_dut_lossy_prio (str): name of lossy priority to test, e.g., 's6100-1|2'
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
         lossy_prio_list (pytest fixture): list of all the lossy priorities
         all_prio_list (pytest fixture): list of all the priorities
@@ -79,7 +79,7 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
                                                                                 snappi_ports,
                                                                                 snappi_api)
 
-    _, lossy_prio = enum_dut_lossy_prio.split('|')
+    _, lossy_prio = rand_one_dut_lossy_prio.split('|')
     lossy_prio = int(lossy_prio)
     pause_prio_list = [lossy_prio]
     test_prio_list = [lossy_prio]
@@ -191,7 +191,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
                                             fanout_graph_facts_multidut,     # noqa: F811
                                             duthosts,
                                             localhost,
-                                            enum_dut_lossy_prio,
+                                            rand_one_dut_lossy_prio,
                                             prio_dscp_map,                   # noqa: F811
                                             lossy_prio_list,              # noqa: F811
                                             all_prio_list,                   # noqa: F811
@@ -208,7 +208,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
         fanout_graph_facts (pytest fixture): fanout graph
         duthosts (pytest fixture): list of DUTs
         localhost (pytest fixture): localhost handle
-        enum_dut_lossy_prio (str): name of lossy priority to test, e.g., 's6100-1|2'
+        rand_one_dut_lossy_prio (str): name of lossy priority to test, e.g., 's6100-1|2'
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
         lossy_prio_list (pytest fixture): list of all the lossy priorities
         all_prio_list (pytest fixture): list of all the priorities
@@ -249,7 +249,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
     skip_warm_reboot(snappi_ports[0]['duthost'], reboot_type)
     skip_warm_reboot(snappi_ports[1]['duthost'], reboot_type)
 
-    _, lossy_prio = enum_dut_lossy_prio.split('|')
+    _, lossy_prio = rand_one_dut_lossy_prio.split('|')
     lossy_prio = int(lossy_prio)
     pause_prio_list = [lossy_prio]
     test_prio_list = [lossy_prio]

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -70,8 +70,11 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
                       testbed {}, subtype {} in variables.py'.
                       format(MULTIDUT_TESTBED, testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        if is_snappi_multidut(duthosts):
+            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        else:
+            snappi_ports = get_snappi_ports
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)
@@ -148,8 +151,11 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
                       testbed {}, subtype {} in variables.py'.
                       format(MULTIDUT_TESTBED, testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        if is_snappi_multidut(duthosts):
+            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        else:
+            snappi_ports = get_snappi_ports
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)
@@ -231,8 +237,11 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
                       testbed {}, subtype {} in variables.py'.
                       format(MULTIDUT_TESTBED, testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        if is_snappi_multidut(duthosts):
+            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        else:
+            snappi_ports = get_snappi_ports
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)
@@ -327,8 +336,11 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
                       testbed {}, subtype {} in variables.py'.
                       format(MULTIDUT_TESTBED, testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        if is_snappi_multidut(duthosts):
+            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        else:
+            snappi_ports = get_snappi_ports
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
                                                                                 snappi_ports,
                                                                                 snappi_api)

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -256,7 +256,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
     bg_prio_list = [p for p in all_prio_list]
     bg_prio_list.remove(lossy_prio)
     try:
-        for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
+        for duthost in set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]):
             logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
             reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
             logger.info("Wait until the system is stable")
@@ -351,7 +351,7 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
     test_prio_list = lossy_prio_list
     bg_prio_list = lossless_prio_list
     try:
-        for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
+        for duthost in set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]):
             logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
             reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
             logger.info("Wait until the system is stable")

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -4,8 +4,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_grap
     fanout_graph_facts   # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_dut_base_config, get_snappi_ports_for_rdma, cleanup_config, \
-    get_snappi_ports, is_snappi_multidut, \
-    get_snappi_ports_single_dut, get_snappi_ports_multi_dut  # noqa F401
+    get_snappi_ports, is_snappi_multidut    # noqa F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list                         # noqa F401
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED   # noqa F401


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fixing reboot check and IP cleanup for multidut PFC cases
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Previously the ip cleanup was not working as expected and safe-reboot argument was not present,
#### How did you do it?
Added try finally block for IP cleanup and safe_reboot=True option and instead of enum_dut_lossy added rand_one_dut_lossy_prio fixture which reduces the execution time of the script
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

### Output
PASSED                                                                                                                                                   [ 91%]
---------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------
03:34:11 __init__.pytest_runtest_teardown         L0049 INFO   | collect memory after test test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info0-cold]
03:34:11 __init__.pytest_runtest_teardown         L0072 INFO   | After test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 28.1}}}, 'after_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 27.3}}}}

snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info0-fast] 
------------------------------------------------------------------------ live log setup ------------------------------------------------------------------------
03:34:11 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
03:34:11 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
03:34:11 __init__.loganalyzer                     L0051 INFO   | Log analyzer is disabled
03:34:11 __init__.memory_utilization              L0091 INFO   | Hostname: sonic-s6100-dut1, Hwsku: Arista-7060CX-32S-C32, Platform: x86_64-arista_7060_cx32s
03:34:11 __init__.store_fixture_values            L0017 INFO   | store memory_utilization test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info0-fast]
03:34:11 __init__.pytest_runtest_setup            L0024 INFO   | collect memory before test test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info0-fast]
03:34:12 __init__.pytest_runtest_setup            L0044 INFO   | Before test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 27.3}}}, 'after_test': {'sonic-s6100-dut1': {}}}
------------------------------------------------------------------------ live log call -------------------------------------------------------------------------
03:34:12 test_multidut_pfc_pause_lossless_with_sn L0337 INFO   | Running test for testbed subtype: single-dut-single-asic
03:34:12 snappi_fixtures.__intf_config_multidut   L0796 INFO   | Configuring Dut: sonic-s6100-dut1 with port Ethernet0 with IP 20.1.1.1/24
03:34:14 snappi_fixtures.__intf_config_multidut   L0796 INFO   | Configuring Dut: sonic-s6100-dut1 with port Ethernet4 with IP 20.1.2.1/24
03:34:17 test_multidut_pfc_pause_lossless_with_sn L0348 INFO   | Snappi Ports : [{'ip': '10.36.78.53', 'card_id': '6', 'port_id': 0, 'peer_port': 'Ethernet0', 'peer_device': 'sonic-s6100-dut1', 'speed': '100000', 'intf_config_changed': True, 'location': '10.36.78.53;6;1', 'api_server_ip': '10.36.78.59', 'asic_type': 'broadcom', 'duthost': <MultiAsicSonicHost sonic-s6100-dut1>, 'snappi_speed_type': 'speed_100_gbps', 'asic_value': None}, {'ip': '10.36.78.53', 'card_id': '6', 'port_id': 1, 'peer_port': 'Ethernet4', 'peer_device': 'sonic-s6100-dut1', 'speed': '100000', 'intf_config_changed': True, 'location': '10.36.78.53;6;2', 'api_server_ip': '10.36.78.59', 'asic_type': 'broadcom', 'duthost': <MultiAsicSonicHost sonic-s6100-dut1>, 'snappi_speed_type': 'speed_100_gbps', 'asic_value': None}]
03:34:17 test_multidut_pfc_pause_lossless_with_sn L0354 INFO   | Issuing a fast reboot on the dut sonic-s6100-dut1
03:34:17 reboot.reboot                            L0264 INFO   | Reboot sonic-s6100-dut1: wait[120], timeout[180]
03:34:17 reboot.reboot                            L0266 INFO   | DUT sonic-s6100-dut1 create a file /dev/shm/test_reboot before rebooting
03:34:18 reboot.wait_for_shutdown                 L0161 INFO   | waiting for ssh to drop on sonic-s6100-dut1
03:34:18 reboot.execute_reboot_command            L0201 INFO   | rebooting sonic-s6100-dut1 with command "fast-reboot"
03:35:15 reboot.wait_for_startup                  L0182 INFO   | waiting for ssh to startup on sonic-s6100-dut1
03:35:32 reboot.wait_for_startup                  L0193 INFO   | ssh has started up on sonic-s6100-dut1
03:35:32 reboot.reboot                            L0281 INFO   | waiting for switch sonic-s6100-dut1 to initialize
03:39:00 processes_utils.wait_critical_processes  L0076 INFO   | Wait until all critical processes are healthy in 300 sec
03:39:00 processes_utils._all_critical_processes_ L0045 INFO   | Check critical processes status
03:39:10 reboot.reboot                            L0311 INFO   | fast reboot finished on sonic-s6100-dut1
03:39:11 reboot.reboot                            L0314 INFO   | DUT sonic-s6100-dut1 up since 2024-10-23 02:12:37.030000
03:39:11 test_multidut_pfc_pause_lossless_with_sn L0356 INFO   | Wait until the system is stable
03:39:11 processes_utils.wait_critical_processes  L0076 INFO   | Wait until all critical processes are healthy in 300 sec
03:39:11 processes_utils._all_critical_processes_ L0045 INFO   | Check critical processes status
03:39:20 test_multidut_pfc_pause_lossless_with_sn L0354 INFO   | Issuing a fast reboot on the dut sonic-s6100-dut1
03:39:20 reboot.reboot                            L0264 INFO   | Reboot sonic-s6100-dut1: wait[120], timeout[180]
03:39:20 reboot.reboot                            L0266 INFO   | DUT sonic-s6100-dut1 create a file /dev/shm/test_reboot before rebooting
03:39:21 reboot.wait_for_shutdown                 L0161 INFO   | waiting for ssh to drop on sonic-s6100-dut1
03:39:21 reboot.execute_reboot_command            L0201 INFO   | rebooting sonic-s6100-dut1 with command "fast-reboot"
03:40:17 reboot.wait_for_startup                  L0182 INFO   | waiting for ssh to startup on sonic-s6100-dut1
03:40:34 reboot.wait_for_startup                  L0193 INFO   | ssh has started up on sonic-s6100-dut1
03:40:34 reboot.reboot                            L0281 INFO   | waiting for switch sonic-s6100-dut1 to initialize
03:44:02 processes_utils.wait_critical_processes  L0076 INFO   | Wait until all critical processes are healthy in 300 sec
03:44:02 processes_utils._all_critical_processes_ L0045 INFO   | Check critical processes status
03:44:12 reboot.reboot                            L0311 INFO   | fast reboot finished on sonic-s6100-dut1
03:44:13 reboot.reboot                            L0314 INFO   | DUT sonic-s6100-dut1 up since 2024-10-23 02:17:37.570000
03:44:13 test_multidut_pfc_pause_lossless_with_sn L0356 INFO   | Wait until the system is stable
03:44:13 processes_utils.wait_critical_processes  L0076 INFO   | Wait until all critical processes are healthy in 300 sec
03:44:13 processes_utils._all_critical_processes_ L0045 INFO   | Check critical processes status
03:44:32 snappi_api.info                          L1242 INFO   | Config validation 0.022s
03:44:33 snappi_api.info                          L1242 INFO   | Ports configuration 0.244s
03:44:34 snappi_api.info                          L1242 INFO   | Captures configuration 0.159s
03:44:40 snappi_api.info                          L1242 INFO   | Location hosts ready [10.36.78.53] 2.082s
03:44:40 snappi_api.info                          L1242 INFO   | Speed change not require due to redundant Layer1 config
03:44:40 snappi_api.info                          L1242 INFO   | Aggregation mode speed change 0.013s
03:44:42 snappi_api.info                          L1242 INFO   | Location preemption [10.36.78.53;6;2] 0.087s
03:45:03 snappi_api.info                          L1242 INFO   | Location connect [Port 1] 20.785s
03:45:03 snappi_api.info                          L1242 INFO   | Location state check [Port 1] 0.229s
03:45:03 snappi_api.info                          L1242 INFO   | Location configuration 29.758s
03:45:11 snappi_api.info                          L1242 INFO   | Layer1 configuration 7.547s
03:45:11 snappi_api.info                          L1242 INFO   | Lag Configuration 0.070s
03:45:12 snappi_api.info                          L1242 INFO   | Convert device config : 0.446s
03:45:12 snappi_api.info                          L1242 INFO   | Create IxNetwork device config : 0.000s
03:45:12 snappi_api.info                          L1242 INFO   | Push IxNetwork device config : 0.179s
03:45:12 snappi_api.info                          L1242 INFO   | Devices configuration 0.701s
03:45:18 snappi_api.info                          L1242 INFO   | Flows configuration 5.866s
03:45:25 snappi_api.info                          L1242 INFO   | Start interfaces 6.855s
03:45:25 snappi_api.info                          L1242 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
03:45:25 traffic_generation.run_traffic           L0321 INFO   | Wait for Arp to Resolve ...
03:45:30 traffic_generation.run_traffic           L0342 INFO   | Starting transmit on all flows ...
03:45:33 snappi_api.info                          L1242 INFO   | Flows generate/apply 1.852s
03:45:45 snappi_api.info                          L1242 INFO   | Flows clear statistics 12.401s
03:45:45 snappi_api.info                          L1242 INFO   | Captures start 0.000s
03:45:49 snappi_api.info                          L1242 INFO   | Flows start 3.557s
03:45:49 traffic_generation.run_traffic           L0349 INFO   | Polling DUT for traffic statistics for 67 seconds ...
03:47:27 traffic_generation.run_traffic           L0368 INFO   | Polling TGEN for in-flight traffic statistics...
03:47:28 traffic_generation.run_traffic           L0373 INFO   | In-flight traffic statistics for flows: ['Test Flow Prio 3', 'Test Flow Prio 4', 'Background Flow Prio 1', 'Background Flow Prio 5', 'Background Flow Prio 6', 'Background Flow Prio 2', 'Background Flow Prio 0']
03:47:28 traffic_generation.run_traffic           L0374 INFO   | In-flight TX frames: [729, 729, 67887931, 67887931, 67887931, 67887931, 67887931]
03:47:28 traffic_generation.run_traffic           L0375 INFO   | In-flight RX frames: [0, 0, 67887931, 67887931, 67887931, 67887931, 67887931]
03:48:33 traffic_generation.run_traffic           L0376 INFO   | DUT polling complete
03:48:33 traffic_generation.run_traffic           L0387 INFO   | Checking if all flows have stopped. Attempt #1
03:48:34 traffic_generation.run_traffic           L0394 INFO   | All test and background traffic flows stopped
03:48:36 traffic_generation.run_traffic           L0417 INFO   | Dumping per-flow statistics
03:48:38 traffic_generation.run_traffic           L0419 INFO   | Stopping transmit on all remaining flows
03:48:44 snappi_api.info                          L1242 INFO   | Flows stop 6.372s
03:48:57 snappi_fixtures.cleanup_config           L0952 INFO   | Removing Configuration on Dut: sonic-s6100-dut1 with port Ethernet0 with ip :20.1.1.1/24
03:48:59 snappi_fixtures.cleanup_config           L0952 INFO   | Removing Configuration on Dut: sonic-s6100-dut1 with port Ethernet4 with ip :20.1.2.1/24
PASSED                                                                                                                                                   [100%]
---------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------
03:49:01 __init__.pytest_runtest_teardown         L0049 INFO   | collect memory after test test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info0-fast]
03:49:02 __init__.pytest_runtest_teardown         L0072 INFO   | After test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 27.3}}}, 'after_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 28.0}}}}
03:49:02 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture snappi_api teardown starts --------------------
03:49:31 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture snappi_api teardown ends --------------------
03:49:31 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture start_pfcwd_after_test teardown starts --------------------
03:49:32 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture start_pfcwd_after_test teardown ends --------------------
03:49:32 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossy_prio teardown starts --------------------
03:49:32 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossy_prio teardown ends --------------------
03:49:32 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossless_prio teardown starts --------------------
03:49:32 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossless_prio teardown ends --------------------
03:49:32 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture enable_packet_aging_after_test teardown starts --------------------
03:49:32 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture enable_packet_aging_after_test teardown ends --------------------
03:49:35 conftest.core_dump_and_config_check      L2203 INFO   | Dumping Disk and Memory Space informataion after test on sonic-s6100-dut1
03:49:36 conftest.core_dump_and_config_check      L2207 INFO   | Collecting core dumps after test on sonic-s6100-dut1
03:49:36 conftest.core_dump_and_config_check      L2224 INFO   | Collecting running config after test on sonic-s6100-dut1
03:49:38 conftest.core_dump_and_config_check      L2381 INFO   | Executing config reload of config_db_bgp.json
03:50:08 conftest.core_dump_and_config_check      L2383 INFO   | Core dump and config check passed for test_multidut_pfc_pause_lossless_with_snappi.py


======================================================================= warnings summary =======================================================================
../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.loganalyzer
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.sanity_check
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.test_completeness
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

../../../../usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:471
  /usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:471: CryptographyDeprecationWarning: Blowfish has been deprecated
    cipher=algorithms.Blowfish,

../../../../usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:485
  /usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:485: CryptographyDeprecationWarning: CAST5 has been deprecated
    cipher=algorithms.CAST5,

snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py: 17 warnings
  /usr/local/lib/python3.8/dist-packages/pytest_ansible/module_dispatcher/v213.py:100: UserWarning: provided hosts list is empty, only localhost is available
    warnings.warn("provided hosts list is empty, only localhost is available")

snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[sonic-s6100-dut1|3-multidut_port_info0]
snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[sonic-s6100-dut1|3-multidut_port_info0]
  /usr/local/lib/python3.8/dist-packages/ixnetwork_restpy/testplatform/sessions/sessions.py:59: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    elif LooseVersion(build_number) < LooseVersion('8.52'):

snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py: 11 warnings
  /usr/lib/python3/dist-packages/urllib3/connectionpool.py:999: InsecureRequestWarning: Unverified HTTPS request is being made to host '10.36.78.59'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------
03:50:08 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
========================================================= 12 passed, 37 warnings in 8129.33s (2:15:29) =========================================================
INFO:root:Can not get Allure report URL. Please check logs