### PR TITLE
Ignore loganalyzer error for syncd _attribute_enum_values_capability

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -32,6 +32,9 @@ r, ".* sonic systemd.* kdump-tools.service - Kernel crash dump capture service.*
 r, ".* ERR swss#orchagent: :- getPort: Failed to get cached bridge port ID.*"
 r, ".* ERR syncd#syncd: .* SAI_API_PORT:brcm_sai_get_port_attribute:\d+ Error -2 processing  port attribute ID: 17.*"
 
+# Errors for config reload on broadcom platform on 202405
+r, ".* ERR syncd\d*#syncd.*_attribute_enum_values_capability.*count.*greater than capability-count 0.*"
+
 # Errors for config reload on broadcom platform on 202311
 r, ".* ERR swss#orchagent: :- queryHashNativeHashFieldListEnumCapabilities: Failed to get attribute.*"
 r, ".* ERR swss#orchagent: :- queryHashNativeHashFieldListAttrCapabilities: Failed to get attribute.*"


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Ignore loganalyzer error for syncd _attribute_enum_values_capability
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Errors to ignore are like:
ERR syncd#syncd: [none] SAI_API_HASH:sai_query_native_hash_attribute_enum_values_capability:2462 count 11 greater than capability-count 0 
ERR syncd#syncd: [none] SAI_API_SWITCH:sai_query_switch_attribute_enum_values_capability:22146 count 6 greater than capability-count 0

The error is normal as it is printed for querying the available count first before the actual query, where capability-count is always 0. 
The API call is from https://github.com/sonic-net/sonic-swss/blob/master/orchagent/switch/switch_capabilities.cpp#L316-L324

#### How did you do it?
Ignore the logs in log analyzer

#### How did you verify/test it?
Tested with "drop_packets/" which was failed the issue.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
