### PR TITLE
Use WRED red for DNX

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -472,12 +472,12 @@ def config_wred(host_ans, kmin, kmax, pmax, profile=None, asic_value=None):
 
     color = 'green'
 
-    # Broadcom ASIC only supports RED.
-    if asic_type == 'broadcom':
+    # Broadcom DNX ASIC only supports RED.
+    if "platform_asic" in host_ans.facts and host_ans.facts["platform_asic"] == "broadcom-dnx":
         color = 'red'
 
-    kmax_arg = '-{}max' % color[0]
-    kmin_arg = '-{}min' % color[0]
+    kmax_arg = '-{}max'.format(color[0])
+    kmin_arg = '-{}min'.format(color[0])
 
     for p in profiles:
         """ This is not the profile to configure """

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -484,8 +484,8 @@ def config_wred(host_ans, kmin, kmax, pmax, profile=None, asic_value=None):
         if profile is not None and profile != p:
             continue
 
-        kmin_old = int(profiles[p]['{}_min_threshold' % color])
-        kmax_old = int(profiles[p]['{}_max_threshold' % color])
+        kmin_old = int(profiles[p]['{}_min_threshold'.format(color)])
+        kmax_old = int(profiles[p]['{}_max_threshold'.format(color)])
 
         if kmin_old > kmax_old:
             return False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Braodcom DNX only supports WRED red.  So update test accordingly.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
