### PR TITLE
Update when customMsg is logged

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -969,7 +969,8 @@ def pytest_runtest_makereport(item, call):
     if call.when == 'setup':
         item.user_properties.append(('start', str(datetime.fromtimestamp(call.start))))
     elif call.when == 'teardown':
-        log_custom_msg(item)
+        if item.nodeid == item.session.items[-1].nodeid:
+            log_custom_msg(item)
         item.user_properties.append(('end', str(datetime.fromtimestamp(call.stop))))
 
     # Filter out unnecessary logs captured on "stdout" and "stderr"


### PR DESCRIPTION
Existing log_custom_msg was called for every test cases' teardown. Update this to reduce number of customMsg per test session and only register to very last test

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Existing log_custom_msg was called for every test cases' teardown. Update this to reduce number of customMsg per test session and only register to very last test

How to use: 
import DUT_CHECK_NAMESPACE from tests.common.helpers.constants
from tests.common.helpers.custom_msg_utils import add_custom_msg

add_custom_msg(request, f"{DUT_CHECK_NAMESPACE}.{customMsgNameYouWant}", {customMsgValueYouWantToStore})

Every cache value under DUT_CHECK_NAMESPACE will be stored in a dictionary and uploaded to Data Explorer

Investigation:
pytest_sessionfinish is the very last function to be called after all test cases are done. But due to pytest's reporting mechanism, it will generate report ***before*** pytest_sessionfinish. Therefore, any changes to item.user_properties will not be reflected to results.xml, where we parse and transform into json to upload to Data Explorer. 

As a second-best solution, log_custom_msg will be called from pytest_runtest_makereport, where this hook will check if it's the last test case, and the call is during teardown of the test case.

log_custom_msg was tested against the following edge case scenarios as well.
- pre/post sanity check exceptions
- test skipped due to conditional_mark

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
run tests to cover edge cases, verify it only logs customMsg once per test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
