### PR TITLE
Fix mock dualtor tunnel decap term creation failure

### DIFF
--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -378,7 +378,8 @@ def apply_tunnel_table_to_dut(cleanup_mocked_configs, rand_selected_dut, mock_pe
                 'ecn_mode': 'copy_from_outer',
                 'encap_ecn_mode': 'standard',
                 'ttl_mode': 'pipe',
-                'tunnel_type': 'IPINIP'
+                'tunnel_type': 'IPINIP',
+                'src_ip': str(mock_peer_switch_loopback_ip.ip)
             }
         }
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix the t0 mock dualtor test failure due to orchagent exit during tunnel/decap term creation:
```
2024 Oct 24 02:12:57.407935 str2-7050cx3-acs-02 ERR syncd#syncd: [none] SAI_API_TUNNEL:brcm_sai_tnl_mp_create_tunnel_term_table_entry:5183 Multiple IP Tunnel Terminators with same dst ip are not supported
2024 Oct 24 02:12:57.408057 str2-7050cx3-acs-02 ERR syncd#syncd: :- sendApiResponse: api SAI_COMMON_API_CREATE failed in syncd mode: SAI_STATUS_NOT_SUPPORTED
2024 Oct 24 02:12:57.408169 str2-7050cx3-acs-02 ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_VR_ID: oid:0x3000000000023
2024 Oct 24 02:12:57.408225 str2-7050cx3-acs-02 ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE: SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2MP
2024 Oct 24 02:12:57.408586 str2-7050cx3-acs-02 ERR swss#orchagent: :- create: create status: SAI_STATUS_NOT_SUPPORTED
2024 Oct 24 02:12:57.408765 str2-7050cx3-acs-02 ERR swss#orchagent: :- addDecapTunnelTermEntry: Failed to create tunnel decap term entry 10.1.0.32/32.
2024 Oct 24 02:12:57.408896 str2-7050cx3-acs-02 ERR swss#orchagent: :- handleSaiCreateStatus: Encountered failure in create operation, exiting orchagent, SAI API: SAI_API_TUNNEL, status: SAI_STATUS_NOT_SUPPORTED
2024 Oct 24 02:12:57.408982 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- notifySyncd: sending syncd: SYNCD_INVOKE_DUMP
2024 Oct 24 02:12:57.409050 str2-7050cx3-acs-02 ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TUNNEL_TYPE: SAI_TUNNEL_TYPE_IPINIP
2024 Oct 24 02:12:57.409121 str2-7050cx3-acs-02 ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_ACTION_TUNNEL_ID: oid:0x2a0000000006f0
2024 Oct 24 02:12:57.409251 str2-7050cx3-acs-02 ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP: 10.1.0.32
2024 Oct 24 02:12:57.410383 str2-7050cx3-acs-02 NOTICE syncd#syncd: :- processNotifySyncd: Invoking SAI failure dump
2024 Oct 24 02:12:57.437513 str2-7050cx3-acs-02 NOTICE swss#orchagent: :- sai_redis_notify_syncd: invoked DUMP succeeded
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
The decap term creation failure is due to that the decap term of the mocking tunnel `MuxTunnel0:10.1.0.32` is a duplicate of `IPINIP_TUNNEL:10.1.0.32`:
* `IPINIP_TUNNEL:10.1.0.32`
```
127.0.0.1:6379> hgetall "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.1.0.32"
1) "term_type"
2) "P2MP"
```
* `MuxTunnel0:10.1.0.32`
```
127.0.0.1:6379> hgetall "TUNNEL_DECAP_TERM_TABLE:MuxTunnel0:10.1.0.32"
1) "term_type"
2) "P2MP"
```

The root cause is that, the mux tunnel config applied by the mocking utility miss the source IP field; `MuxTunnel0:10.1.0.32` should have `term_type` as `P2P` and source IP specified as the peer ToR:
```
127.0.0.1:6379> hgetall "TUNNEL_DECAP_TERM_TABLE:MuxTunnel0:10.1.0.32"
1) "src_ip"
2) "10.1.0.33"
3) "term_type"
4) "P2P"
```

#### How did you verify/test it?
```
dualtor/test_orch_stress.py::test_change_mux_state PASSED                                                                                                                                                                                                              [100%]

================================================================================================================== 1 passed, 1 warning in 653.13s (0:10:53) ==================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
