### PR TITLE
[New testcase] PO & PO Member flap status sync across all DBs scenario

### DIFF
--- a/tests/common/helpers/voq_lag.py
+++ b/tests/common/helpers/voq_lag.py
@@ -230,6 +230,8 @@ def verify_lag_member_in_asic_db(asics, lag_id, expected=0):
             if asicdb.hget_key_value(lag_member, "SAI_LAG_MEMBER_ATTR_LAG_ID") == lag_oid:
                 count += 1
 
+        logging.info("Found {} members of LAG in {} asic {} ASIC_DB"
+                     .format(count, asic.sonichost.hostname, asic.asic_index))
         pytest_assert(count == expected, "Found {} LAG members in {} asic{} ASIC_DB, expected {}"
                                          .format(count, asic.sonichost.hostname, asic.asic_index, expected))
 

--- a/tests/common/helpers/voq_lag.py
+++ b/tests/common/helpers/voq_lag.py
@@ -11,14 +11,13 @@ TMP_PC = 'PortChannel999'
 
 def get_lag_ids_from_chassis_db(duthosts):
     """
-    Get lag_ids from CHASSIS_DB
-    cmd = 'redis-dump -H 10.0.5.16 -p 6380 -d 12 -y -k "*SYSTEM_LAG_TABLE*PortChannel0016"'
-      Args:
-          duthosts: The duthost fixture.
+    Get all LAG IDs from CHASSIS_DB
 
-      Returns:
-          lag_ids<list>: lag id
+    Args:
+        duthosts: duthosts to probe
 
+    Returns:
+        lag_ids: List of LAG ids in CHASSIS_DB
     """
     lag_ids = list()
     for sup in duthosts.supervisor_nodes:
@@ -27,29 +26,30 @@ def get_lag_ids_from_chassis_db(duthosts):
         for lag in lag_list:
             lag_ids.append(voqdb.hget_key_value(lag, "lag_id"))
 
-    logging.info("LAG id's preset in CHASSIS_DB are {}".format(lag_ids))
+    logging.info("LAG IDs present in CHASSIS_DB are {}".format(lag_ids))
     return lag_ids
 
 
-def get_lag_id_from_chassis_db(duthosts):
+def get_lag_id_from_chassis_db(duthosts, pc=TMP_PC):
     """
-    Get LAG id for a lag form CHASSIS_DB
+    Get LAG ID for a LAG from CHASSIS_DB
+
     Args:
-        duthosts: The duthost fixture.
+        duthosts: duthosts to probe
 
     Returns:
-        lag_ids <int>: lag id
+        lag_id: LAG ID of LAG
     """
     for sup in duthosts.supervisor_nodes:
         voqdb = VoqDbCli(sup)
         lag_list = voqdb.get_lag_list()
         for lag in lag_list:
-            if TMP_PC in lag:
+            if pc in lag:
                 lag_id = voqdb.hget_key_value(lag, "lag_id")
-                logging.info("LAG id for lag {} is {}".format(TMP_PC, lag_id))
+                logging.info("LAG ID for LAG {} is {}".format(pc, lag_id))
                 return lag_id
 
-        pytest.fail("LAG id for lag {} is not preset in CHASSIS_DB".format(TMP_PC))
+        pytest.fail("LAG ID for LAG {} is not present in CHASSIS_DB".format(pc))
 
 
 def verify_lag_interface(duthost, asic, portchannel, expected=True):

--- a/tests/common/helpers/voq_lag.py
+++ b/tests/common/helpers/voq_lag.py
@@ -2,7 +2,6 @@ import pytest
 import logging
 import re
 
-from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.sonic_db import AsicDbCli, AppDbCli, VoqDbCli
 

--- a/tests/common/helpers/voq_lag.py
+++ b/tests/common/helpers/voq_lag.py
@@ -159,8 +159,10 @@ def verify_lag_id_in_asic_dbs(asics, lag_id, expected=True):
                 exists = True
                 break
 
-        lag_id_exists_msg = "LAG ID {} exists in {} asic{} ASIC_DB".format(lag_id, asic.sonichost.hostname, asic.asic_index)
-        lag_id_missing_msg = "LAG ID {} doesn't exist in {} asic{} ASIC_DB".format(lag_id, asic.sonichost.hostname, asic.asic_index)
+        lag_id_exists_msg = "LAG ID {} exists in {} asic{} ASIC_DB"\
+                            .format(lag_id, asic.sonichost.hostname, asic.asic_index)
+        lag_id_missing_msg = "LAG ID {} doesn't exist in {} asic{} ASIC_DB"\
+                             .format(lag_id, asic.sonichost.hostname, asic.asic_index)
         lag_msg = lag_id_exists_msg if exists else lag_id_missing_msg
         if exists == expected:
             logging.info(lag_msg)
@@ -291,7 +293,10 @@ def verify_lag_member_status_in_asic_db(asics, lag_id, exp_disabled=0):
                 if status == "true":
                     disabled += 1
 
-        logging.info("Found {} members of LAG in {} asic {} ASIC_DB, {} are disabled".format(count, asic.sonichost.hostname, asic.asic_index, disabled))
-        pytest_assert(count != 0, "No members matching LAG exist in {} asic {} ASIC_DB".format(asic.sonichost.hostname, asic.asic_index))
-        pytest_assert(disabled == exp_disabled, "Found {} disabled members of LAG in {} asic {} ASIC_DB, expected {}"
-                                                .format(disabled, asic.sonichost.hostname, asic.asic_index, exp_disabled))
+        logging.info("Found {} members of LAG in {} asic {} ASIC_DB, {} are disabled"
+                     .format(count, asic.sonichost.hostname, asic.asic_index, disabled))
+        pytest_assert(count != 0, "No members matching LAG exist in {} asic {} ASIC_DB"
+                                  .format(asic.sonichost.hostname, asic.asic_index))
+        pytest_assert(disabled == exp_disabled,
+                      "Found {} disabled members of LAG in {} asic {} ASIC_DB, expected {}"
+                      .format(disabled, asic.sonichost.hostname, asic.asic_index, exp_disabled))

--- a/tests/pc/test_po_voq.py
+++ b/tests/pc/test_po_voq.py
@@ -1,6 +1,8 @@
 import pytest
+import random
 import tests.common.helpers.voq_lag as voq_lag
 from tests.common.helpers.voq_helpers import verify_no_routes_from_nexthop
+from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 import logging
@@ -170,3 +172,65 @@ def test_voq_po_down_via_cli_update(duthosts, enum_rand_one_per_hwsku_frontend_h
         duthost.shell("config interface {} startup {}".format(asic.cli_ns_option, voq_lag.TMP_PC))
         pytest_assert(wait_until(30, 5, 0, lambda: duthost.check_intf_link_state(voq_lag.TMP_PC)),
                       "{} is not enabled".format(voq_lag.TMP_PC))
+
+
+@pytest.mark.parametrize("flap_method", ["local", "remote"])
+def test_voq_po_member_down_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup_teardown, fanouthosts, flap_method):
+    """
+    Test to verify when a LAG member goes down on an ASIC, it is synced across all DBs
+
+    All DBs = local app db, chassis app db, local & remote asic db
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    remote_duthosts = [dut_host for dut_host in duthosts.frontend_nodes if dut_host != duthost]
+    asic, portchannel_ip, portchannel_members = setup_teardown
+    tmp_lag_id = voq_lag.get_lag_id_from_chassis_db(duthosts)
+
+    # Make sure LAG is up across all DBs (all PC members are up across all DBs)
+    for portchannel_member in portchannel_members:
+        voq_lag.verify_lag_member_status_in_app_db(asic, portchannel_member, enabled=True)
+        voq_lag.verify_lag_member_status_in_chassis_db(duthosts, portchannel_member, enabled=True)
+    # For checking LAG member status in ASIC_DB,
+    # we check how many members are disabled in a LAG since we can't identify individual members
+    voq_lag.verify_lag_member_status_in_asic_db(duthost.asics, tmp_lag_id, exp_disabled=0)
+    for remote_duthost in remote_duthosts:
+        voq_lag.verify_lag_member_status_in_asic_db(remote_duthost.asics, tmp_lag_id, exp_disabled=0)
+
+    # Choose a random LAG member to bring down, check that LAG member down is synced across all DBs
+    down_pc_member = random.choice(portchannel_members)
+    fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, duthost.hostname, down_pc_member)
+    up_pc_members = [pc_member for pc_member in portchannel_members if pc_member != down_pc_member]
+    try:
+        if flap_method == "local":
+            logging.info("Disabling {} via CLI".format(down_pc_member))
+            duthost.shell("config interface {} shutdown {}".format(asic.cli_ns_option, down_pc_member))
+        else:
+            logging.info("Disabling {} via fanout to simulate external flapping".format(down_pc_member))
+            logging.info("Disabling {} on {}".format(fanout_port, fanout.hostname))
+            fanout.shell("config interface shutdown {}".format(fanout_port))
+
+        pytest_assert(wait_until(30, 5, 0, lambda: not duthost.check_intf_link_state(down_pc_member)),
+                      "{} is not disabled".format(down_pc_member))
+
+        # Verify other LAG members are still up
+        for up_pc_member in up_pc_members:
+            voq_lag.verify_lag_member_status_in_app_db(asic, up_pc_member, enabled=True)
+            voq_lag.verify_lag_member_status_in_chassis_db(duthosts, up_pc_member, enabled=True)
+
+        voq_lag.verify_lag_member_status_in_app_db(asic, down_pc_member, enabled=False)
+        voq_lag.verify_lag_member_status_in_chassis_db(duthosts, down_pc_member, enabled=False)
+        voq_lag.verify_lag_member_status_in_asic_db(duthost.asics, tmp_lag_id, exp_disabled=1)
+        for remote_duthost in remote_duthosts:
+            voq_lag.verify_lag_member_status_in_asic_db(remote_duthost.asics, tmp_lag_id, exp_disabled=1)
+    finally:
+        # Bring LAG member back up
+        if flap_method == "local":
+            logging.info("Enabling {} via CLI".format(down_pc_member))
+            duthost.shell("config interface {} startup {}".format(asic.cli_ns_option, down_pc_member))
+        else:
+            logging.info("Enabling {} via fanout".format(down_pc_member))
+            logging.info("Enabling {} on {}".format(fanout_port, fanout.hostname))
+            fanout.shell("config interface startup {}".format(fanout_port))
+
+        pytest_assert(wait_until(30, 5, 0, lambda: duthost.check_intf_link_state(down_pc_member)),
+                      "{} is not enabled".format(down_pc_member))

--- a/tests/pc/test_po_voq.py
+++ b/tests/pc/test_po_voq.py
@@ -239,7 +239,7 @@ def test_voq_po_member_down_update(duthosts, enum_rand_one_per_hwsku_frontend_ho
         else:
             logging.info("Disabling {} via fanout to simulate external flapping".format(down_pc_member))
             logging.info("Disabling {} on {}".format(fanout_port, fanout.hostname))
-            fanout.shell("config interface shutdown {}".format(fanout_port))
+            fanout.shutdown(fanout_port)
 
         pytest_assert(wait_until(30, 5, 0, lambda: not duthost.check_intf_link_state(down_pc_member)),
                       "{} is not disabled".format(down_pc_member))
@@ -262,7 +262,7 @@ def test_voq_po_member_down_update(duthosts, enum_rand_one_per_hwsku_frontend_ho
         else:
             logging.info("Enabling {} via fanout".format(down_pc_member))
             logging.info("Enabling {} on {}".format(fanout_port, fanout.hostname))
-            fanout.shell("config interface startup {}".format(fanout_port))
+            fanout.no_shutdown(fanout_port)
 
         pytest_assert(wait_until(30, 5, 0, lambda: duthost.check_intf_link_state(down_pc_member)),
                       "{} is not enabled".format(down_pc_member))

--- a/tests/pc/test_po_voq.py
+++ b/tests/pc/test_po_voq.py
@@ -89,7 +89,7 @@ def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     yield asic, portchannel_ip, portchannel_members
 
     # Move members and IP from new temporary LAG back to original lag, delete old LAG
-    logging.info("Moving LAG members {} and IP {} back to LAG {} from temporary LAG {}"
+    logging.info("Moving LAG members {} and IP {} from temporary LAG {} back to LAG {}"
                  .format(portchannel_members, portchannel_ip, portchannel, voq_lag.TMP_PC))
     asic.config_ip_intf(voq_lag.TMP_PC, portchannel_ip, "remove")
     for portchannel_member in portchannel_members:

--- a/tests/pc/test_po_voq.py
+++ b/tests/pc/test_po_voq.py
@@ -206,7 +206,8 @@ def test_voq_po_down_via_cli_update(duthosts, enum_rand_one_per_hwsku_frontend_h
 
 
 @pytest.mark.parametrize("flap_method", ["local", "remote"])
-def test_voq_po_member_down_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup_teardown, fanouthosts, flap_method):
+def test_voq_po_member_down_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                   setup_teardown, fanouthosts, flap_method):
     """
     Test to verify when a LAG member goes down on an ASIC, it is synced across all DBs
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #14984 and cleanup similar tests in file

I suggest looking at individual commits to have an easier time navigating changes

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Test gap for DB states across local & remote linecards updating for PO member state changes
#### How did you do it?
Added 2 testcases, one where PO went down, one where individual member went down
#### How did you verify/test it?
Tested on T2 testbed
#### Any platform specific information?
T2 VoQ only
#### Supported testbed topology if it's a new test case?
T2 VoQ only
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
