### PR TITLE
Address test gap in test_mgmt_ipv6

### DIFF
--- a/tests/common/helpers/syslog_helpers.py
+++ b/tests/common/helpers/syslog_helpers.py
@@ -23,6 +23,10 @@ def check_default_route(rand_selected_dut):
     if result == 0:
         neigh_ip = duthost.shell(
             "ip route show default table default | cut -d ' ' -f 3", module_ignore_errors=True)['stdout']
+
+        # We ping here to make sure that the neigh_ip is not stale before checking for reachability
+        duthost.shell("ping -c 1 {}".format(neigh_ip), module_ignore_errors=True)
+
         result = duthost.shell(
             "ip -4 neigh show {} | grep REACHABLE".format(neigh_ip), module_ignore_errors=True)['rc']
         if result == 0:
@@ -31,6 +35,10 @@ def check_default_route(rand_selected_dut):
     if result == 0:
         neigh_ip = duthost.shell(
             "ip -6 route show default table default | cut -d ' ' -f 3", module_ignore_errors=True)['stdout']
+
+        # We ping here to make sure that the neigh_ip is not stale before checking for reachability
+        duthost.shell("ping -c 1 {}".format(neigh_ip), module_ignore_errors=True)
+
         result = duthost.shell(
             "ip -6 neigh show {} | grep REACHABLE".format(neigh_ip), module_ignore_errors=True)['rc']
         if result == 0:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fixing test gap on test_mgmt_ipv6
Fixes # (issue) 28836766

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?


Currently test_mgmt_ipv6 is having the following skipped tests:

SKIPPED [2] ip/test_mgmt_ipv6_only.py:122: DUT has no default route, skiped
SKIPPED [1] ip/test_mgmt_ipv6_only.py:192: Skipping test as no Ethernet0 frontpanel port on supervisor

"DUT has no default route, skiped" was because the ipv6 default gateway becomes stale from not using it. 
- Solution: adding a ping and check if it's still reachable after `ping`

"Skipping test as no Ethernet0 frontpanel port on supervisor" was because the test is meant to be for supervisor:
- Solution: only use the enumerate of frontend nodes. This is to avoid in the future someone else need to investigate why this one is skipped. We should only call the fixture we want to test.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
