### PR TITLE
Enable test_reload_config for 202405 release

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -994,7 +994,7 @@ platform_tests/test_reload_config.py::test_reload_configuration_checks:
     conditions:
       - "asic_type in ['barefoot'] and hwsku in ['newport']"
       - "https://github.com/sonic-net/sonic-buildimage/issues/19879 and asic_type in ['vs']"
-      - "asic_type in ['cisco-8000'] and release in ['202205', '202211', '202305', '202405']"
+      - "asic_type in ['cisco-8000'] and release in ['202205', '202211', '202305']"
 
 #######################################
 ######  test_secure_upgrade.py  #######


### PR DESCRIPTION
As part of testgap task, confirmed and verified test_reload_config.py::test_reload_configuration_checks is working on Cisco8000 device with 202405 release.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
As part of testgap task, confirmed and verified test_reload_config.py::test_reload_configuration_checks is working on Cisco8000 device with 202405 release.
Fixes #13494 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
verified on cisco t2-8800 device
platform_tests/test_reload_config.py::test_reload_configuration[----] PASSED                                                                                                                                              [ 16%]
platform_tests/test_reload_config.py::test_reload_configuration_checks[----] PASSED                                                                                                                                       [ 33%]
platform_tests/test_reload_config.py::test_reload_configuration[----] PASSED                                                                                                                                              [ 50%]
platform_tests/test_reload_config.py::test_reload_configuration_checks[----] PASSED                                                                                                                                       [ 66%]
platform_tests/test_reload_config.py::test_reload_configuration[----] PASSED                                                                                                                                              [ 83%]
platform_tests/test_reload_config.py::test_reload_configuration_checks[----] PASSED                                                                                                                                       [100%]
6 passed, 1 warning in 5447.90s (1:30:47)
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
