### PR TITLE
Integrate test_cacl_application_dualtor test

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -196,7 +196,7 @@ cacl/test_cacl_application.py::test_cacl_application_dualtor:
     reason: "test_cacl_application_dualtor is only supported on dualtor topology / Skip test_cacl_application temporarily due to known issue"
     conditions_logical_operator: or
     conditions:
-      - "topo_name not in ['dualtor', 'dualtor-56', 'dualtor-64', 'dualtor-120']"
+      - "topo_name not in ['dualtor', 'dualtor-56', 'dualtor-64', 'dualtor-64-breakout', 'dualtor-120']"
       - "https://github.com/sonic-net/sonic-mgmt/issues/13805"
 
 cacl/test_cacl_application.py::test_cacl_application_nondualtor:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add dualtor-64-breakout topology to support case test_cacl_application_dualtor

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Case test_cacl_application_dualtor shall run on topology dualtor-64-breakout
#### How did you do it?
Update the skip condition
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
