### PR TITLE
[202405] Update platform sfp tests to skip dom check for sfp with flat memory

### DIFF
--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -5,6 +5,7 @@ This script contains re-usable functions for checking status of transceivers.
 """
 import logging
 import re
+from copy import deepcopy
 
 
 def parse_transceiver_info(output_lines):
@@ -95,7 +96,7 @@ def check_transceiver_details(dut, asic_index, interfaces, xcvr_skip_list):
                     "Expected field %s is not found in %s while checking %s" % (field, port_xcvr_info["stdout"], intf)
 
 
-def check_transceiver_dom_sensor_basic(dut, asic_index, interfaces, xcvr_skip_list):
+def check_transceiver_dom_sensor_basic(dut, asic_index, interfaces, xcvr_skip_list, port_list_with_flat_memory):
     """
     @summary: Check whether all the specified interface are in TRANSCEIVER_DOM_SENSOR redis DB.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
@@ -108,11 +109,11 @@ def check_transceiver_dom_sensor_basic(dut, asic_index, interfaces, xcvr_skip_li
     xcvr_dom_sensor = dut.command(docker_cmd)
     parsed_xcvr_dom_sensor = parse_transceiver_dom_sensor(xcvr_dom_sensor["stdout_lines"])
     for intf in interfaces:
-        if intf not in xcvr_skip_list[dut.hostname]:
+        if intf not in xcvr_skip_list[dut.hostname] + port_list_with_flat_memory[dut.hostname]:
             assert intf in parsed_xcvr_dom_sensor, "TRANSCEIVER_DOM_SENSOR of %s is not found in DB" % intf
 
 
-def check_transceiver_dom_sensor_details(dut, asic_index, interfaces, xcvr_skip_list):
+def check_transceiver_dom_sensor_details(dut, asic_index, interfaces, xcvr_skip_list, port_list_with_flat_memory):
     """
     @summary: Check the detailed TRANSCEIVER_DOM_SENSOR content of all the specified interfaces.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
@@ -123,7 +124,7 @@ def check_transceiver_dom_sensor_details(dut, asic_index, interfaces, xcvr_skip_
     expected_fields = ["temperature", "voltage", "rx1power", "rx2power", "rx3power", "rx4power", "tx1bias",
                        "tx2bias", "tx3bias", "tx4bias", "tx1power", "tx2power", "tx3power", "tx4power"]
     for intf in interfaces:
-        if intf not in xcvr_skip_list[dut.hostname]:
+        if intf not in xcvr_skip_list[dut.hostname] + port_list_with_flat_memory[dut.hostname]:
             cmd = 'redis-cli -n 6 hgetall "TRANSCEIVER_DOM_SENSOR|%s"' % intf
             docker_cmd = asichost.get_docker_cmd(cmd, "database")
             port_xcvr_dom_sensor = dut.command(docker_cmd)
@@ -133,7 +134,7 @@ def check_transceiver_dom_sensor_details(dut, asic_index, interfaces, xcvr_skip_
                     field, port_xcvr_dom_sensor["stdout"], intf)
 
 
-def check_transceiver_status(dut, asic_index, interfaces, xcvr_skip_list):
+def check_transceiver_status(dut, asic_index, interfaces, xcvr_skip_list, port_list_with_flat_memory):
     """
     @summary: Check transceiver information of all the specified interfaces in redis DB.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
@@ -141,5 +142,248 @@ def check_transceiver_status(dut, asic_index, interfaces, xcvr_skip_list):
     """
     check_transceiver_basic(dut, asic_index, interfaces, xcvr_skip_list)
     check_transceiver_details(dut, asic_index, interfaces, xcvr_skip_list)
-    check_transceiver_dom_sensor_basic(dut, asic_index, interfaces, xcvr_skip_list)
-    check_transceiver_dom_sensor_details(dut, asic_index, interfaces, xcvr_skip_list)
+    check_transceiver_dom_sensor_basic(dut, asic_index, interfaces, xcvr_skip_list, port_list_with_flat_memory)
+    check_transceiver_dom_sensor_details(dut, asic_index, interfaces, xcvr_skip_list, port_list_with_flat_memory)
+
+
+def get_sfp_eeprom_map_per_port(eeprom_infos):
+    sfp_eeprom_map_per_port = {}
+    sfp_eeprom_list = eeprom_infos.split("\n")
+    regex_port_name = r"^(?P<key>Ethernet\d+):(?P<value>.*)"
+    line_start_num_list_per_port = []
+    for index, line in enumerate(sfp_eeprom_list):
+        res_port_name = re.search(regex_port_name, line)
+        if res_port_name:
+            port_name = res_port_name.groupdict()["key"].strip()
+            line_start_num_list_per_port.append([port_name, index])
+    logging.info(f"line_start_num_list_per_port :{line_start_num_list_per_port}")
+
+    for index in range(len(line_start_num_list_per_port)):
+        if index == len(line_start_num_list_per_port) - 1:
+            line_start_num_for_current_port = line_start_num_list_per_port[index][1]
+            line_end_num_for_current_port = len(sfp_eeprom_list) - 1
+        else:
+            line_start_num_for_current_port = line_start_num_list_per_port[index][1]
+            line_end_num_for_current_port = line_start_num_list_per_port[index + 1][1] - 1
+        sfp_eeprom_map_per_port[line_start_num_list_per_port[index][0]] = deepcopy(
+            sfp_eeprom_list[line_start_num_for_current_port:line_end_num_for_current_port+1])
+
+    logging.info(f"sfp_eeprom_map_per_port :{sfp_eeprom_map_per_port}")
+
+    return sfp_eeprom_map_per_port
+
+
+def get_ports_with_flat_memory(dut):
+    ports_with_flat_memory = []
+    cmd_show_eeprom = "sudo sfputil show eeprom -d"
+
+    eeprom_infos = dut.command(cmd_show_eeprom, module_ignore_errors=True)['stdout']
+    sfp_eerpom_map_per_port = get_sfp_eeprom_map_per_port(eeprom_infos)
+    for port_name, sfp_eeprom in sfp_eerpom_map_per_port.items():
+        if "DOM values not supported for flat memory module" in " ".join(sfp_eeprom):
+            ports_with_flat_memory.append(port_name)
+    logging.info(f"Ports with flat memory: {ports_with_flat_memory}")
+    return ports_with_flat_memory
+
+
+def parse_one_sfp_eeprom_info(sfp_eeprom_info):
+    """
+    Parse the one sfp eeprom info, return top_key, sfp_eeprom_info_dict
+    e.g
+    sfp_info:
+    Ethernet0: SFP EEPROM detected
+        Application Advertisement: N/A
+        Connector: No separable connector
+        Encoding: 64B/66B
+        Extended Identifier: Power Class 3 Module (2.5W max.),
+                             No CLEI code present in Page 02h, CDR present in TX, CDR present in RX
+        Extended RateSelect Compliance: Unknown
+        Identifier: QSFP28 or later
+        Length Cable Assembly(m): 3.0
+        Nominal Bit Rate(100Mbs): 255
+        Specification compliance:
+                10/40G Ethernet Compliance Code: Extended
+                Extended Specification Compliance: 100G AOC (Active Optical Cable) or 25GAUI C2M AOC
+                Fibre Channel Link Length: Unknown
+                Fibre Channel Speed: Unknown
+                Fibre Channel Transmission Media: Unknown
+                Fibre Channel Transmitter Technology: Unknown
+                Gigabit Ethernet Compliant Codes: Unknown
+                SAS/SATA Compliance Codes: Unknown
+                SONET Compliance Codes: Unknown
+        Vendor Date Code(YYYY-MM-DD Lot): 2019-01-17
+        Vendor Name: Mellanox
+        Vendor OUI: 00-02-c9
+        Vendor PN: MFA1A00-C003
+        Vendor Rev: B2
+        Vendor SN: MT1903FT05965
+        ChannelMonitorValues:
+                RX1Power: 0.927dBm
+                RX2Power: 0.938dBm
+                RX3Power: 0.912dBm
+                RX4Power: 0.95dBm
+                TX1Bias: 6.75mA
+                TX1Power: 1.071dBm
+                TX2Bias: 6.75mA
+                TX2Power: 1.04dBm
+                TX3Bias: 6.75mA
+                TX3Power: 1.039dBm
+                TX4Bias: 6.75mA
+                TX4Power: 1.031dBm
+        ChannelThresholdValues:
+                RxPowerHighAlarm  : 5.4dBm
+                RxPowerHighWarning: 2.4dBm
+                RxPowerLowAlarm   : -13.307dBm
+                RxPowerLowWarning : -10.301dBm
+                TxBiasHighAlarm   : 8.5mA
+                TxBiasHighWarning : 8.0mA
+                TxBiasLowAlarm    : 5.492mA
+                TxBiasLowWarning  : 6.0mA
+        ModuleMonitorValues:
+                Temperature: 43.105C
+                Vcc: 3.235Volts
+        ModuleThresholdValues:
+                TempHighAlarm  : 80.0C
+                TempHighWarning: 70.0C
+                TempLowAlarm   : -10.0C
+                TempLowWarning : 0.0C
+                VccHighAlarm   : 3.5Volts
+                VccHighWarning : 3.465Volts
+                VccLowAlarm    : 3.1Volts
+                VccLowWarning  : 3.135Volts
+    top_key, sfp_eeprom_info_dict:
+    Ethernet0,
+    {
+        'Ethernet0': 'SFP EEPROM detected',
+        'Application Advertisement': 'N/A',
+        'Connector': 'No separable connector',
+        'Encoding': '64B/66B',
+        'Extended Identifier': 'Power Class 3 Module (2.5W max.),
+                               No CLEI code present in Page 02h, CDR present in TX, CDR present in RX',
+        'Extended RateSelect Compliance': 'Unknown',
+        'Identifier': 'QSFP28 or later',
+        'Length Cable Assembly(m)': '3.0',
+        'Nominal Bit Rate(100Mbs)': '255',
+        'Specification compliance': {
+            '10/40G Ethernet Compliance Code': 'Extended',
+            'Extended Specification Compliance': '100G AOC (Active Optical Cable) or 25GAUI C2M AOC',
+            'Fibre Channel Link Length': 'Unknown',
+            'Fibre Channel Speed': 'Unknown',
+            'Fibre Channel Transmission Media': 'Unknown',
+            'Fibre Channel Transmitter Technology': 'Unknown',
+            'Gigabit Ethernet Compliant Codes': 'Unknown',
+            'SAS/SATA Compliance Codes': 'Unknown',
+            'SONET Compliance Codes': 'Unknown'
+        },
+        'Vendor Date Code(YYYY-MM-DD Lot)': '2019-01-17',
+        'Vendor Name': 'Mellanox',
+        'Vendor OUI': '00-02-c9',
+        'Vendor PN': 'MFA1A00-C003',
+        'Vendor Rev': 'B2',
+        'Vendor SN': 'MT1903FT05965',
+        'ChannelMonitorValues': {
+            'RX1Power': '0.927dBm',
+            'RX2Power': '0.938dBm',
+            'RX3Power': '0.912dBm',
+            'RX4Power': '0.95dBm',
+            'TX1Bias': '6.75mA',
+            'TX1Power': '1.071dBm',
+            'TX2Bias': '6.75mA',
+            'TX2Power': '1.04dBm',
+            'TX3Bias': '6.75mA',
+            'TX3Power': '1.039dBm',
+            'TX4Bias': '6.75mA',
+            'TX4Power': '1.031dBm'
+        },
+        'ChannelThresholdValues': {
+            'RxPowerHighAlarm': '5.4dBm',
+            'RxPowerHighWarning': '2.4dBm',
+            'RxPowerLowAlarm': '-13.307dBm',
+            'RxPowerLowWarning': '-10.301dBm',
+            'TxBiasHighAlarm': '8.5mA',
+            'TxBiasHighWarning': '8.0mA',
+            'TxBiasLowAlarm': '5.492mA',
+            'TxBiasLowWarning': '6.0mA'
+        },
+        'ModuleMonitorValues': {
+            'Temperature': '43.105C',
+            'Vcc': '3.235Volts'
+        },
+        'ModuleThresholdValues': {
+            'TempHighAlarm': '80.0C',
+            'TempHighWarning': '70.0C',
+            'TempLowAlarm': '-10.0C',
+            'TempLowWarning': '0.0C',
+            'VccHighAlarm': '3.5Volts',
+            'VccHighWarning': '3.465Volts',
+            'VccLowAlarm': '3.1Volts',
+            'VccLowWarning': '3.135Volts'
+        }
+    }
+    """
+    pattern_top_layer_key_value = r"^(?P<key>Ethernet\d+):(?P<value>.*)"
+    pattern_second_layer_key_value = r"(^\s{8}|\t{1})(?P<key>[a-zA-Z0-9][a-zA-Z0-9\s\/\(\)-]+):(?P<value>.*)"
+    pattern_third_layer_key_value = r"(^\s{16}|\t{2})(?P<key>[a-zA-Z0-9][a-zA-Z0-9\s\/]+):(?P<value>.*)"
+
+    one_sfp_eeprom_info_dict = {}
+    second_layer_dict = {}
+    previous_key = ""
+    top_key = ""
+    for line in sfp_eeprom_info:
+        res1 = re.match(pattern_top_layer_key_value, line)
+        if res1:
+            top_key = res1.groupdict()["key"].strip()
+            one_sfp_eeprom_info_dict[top_key] = res1.groupdict()[
+                "value"].strip()
+            continue
+        res2 = re.match(pattern_second_layer_key_value, line)
+        if res2:
+            if second_layer_dict and previous_key:
+                one_sfp_eeprom_info_dict[previous_key] = second_layer_dict
+                second_layer_dict = {}
+            one_sfp_eeprom_info_dict[res2.groupdict()["key"].strip()] = res2.groupdict()[
+                "value"].strip()
+            previous_key = res2.groupdict()["key"].strip()
+        else:
+            res3 = re.match(pattern_third_layer_key_value, line)
+            if res3:
+                second_layer_dict[res3.groupdict()["key"].strip()] = res3.groupdict()[
+                    "value"].strip()
+    if second_layer_dict and previous_key:
+        one_sfp_eeprom_info_dict[previous_key] = second_layer_dict
+
+    return top_key, one_sfp_eeprom_info_dict
+
+
+def parse_sfp_eeprom_infos(eeprom_infos):
+    """
+    This method is to parses sfp eeprom infos, and return sfp_eeprom_info_dict
+    """
+    sfp_eerpom_map_per_port = get_sfp_eeprom_map_per_port(eeprom_infos)
+    sfp_eeprom_info_dict = {}
+    for port_name, eeprom_info in sfp_eerpom_map_per_port.items():
+        _, eeprom_info = parse_one_sfp_eeprom_info(eeprom_info)
+        sfp_eeprom_info_dict[port_name] = eeprom_info
+    return sfp_eeprom_info_dict
+
+
+def is_passive_cable(sfp_eeprom_info):
+    # The implementation of the function refers to the function of is_xcvr_optical
+    if "Specification compliance" in sfp_eeprom_info:
+        spec_compliance = sfp_eeprom_info["Specification compliance"]
+
+        if "passive" in spec_compliance or "Passive" in spec_compliance:
+            # for QSFP-DD  OSFP-8X, and QSFP+C, it has the key "Specification compliance"
+            return True
+        elif isinstance(spec_compliance, dict):
+            if "SFP+CableTechnology" in spec_compliance and "Passive" in spec_compliance.get("SFP+CableTechnology", ""):
+                # For SFP/SFP+/SFP28, it has the key  "SFP+CableTechnolog"
+                return True
+            else:
+                if "10/40G Ethernet Compliance Code" in spec_compliance and\
+                        "CR" in spec_compliance.get("10/40G Ethernet Compliance Code", " "):
+                    return True
+                if "Extended Specification Compliance" in spec_compliance and\
+                        "CR" in spec_compliance.get("Extended Specification Compliance", " "):
+                    return True
+    return False

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -15,6 +15,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.plugins.sanity_check.recover import neighbor_vm_restore
 from .args.counterpoll_cpu_usage_args import add_counterpoll_cpu_usage_args
 from .mellanox.mellanox_thermal_control_test_helper import suspend_hw_tc_service, resume_hw_tc_service
+from tests.common.platform.transceiver_utils import get_ports_with_flat_memory
 
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(
@@ -787,3 +788,12 @@ def dpu_npu_port_list(duthosts):
                     dpu_npu_port_list[dut.hostname].append(port_key.split("|")[-1])
     logging.info(f"dpu npu port list: {dpu_npu_port_list}")
     return dpu_npu_port_list
+
+
+@pytest.fixture(scope="module")
+def port_list_with_flat_memory(duthosts):
+    ports_with_flat_memory = {}
+    for dut in duthosts:
+        ports_with_flat_memory.update({dut.hostname: get_ports_with_flat_memory(dut)})
+    logging.info(f"port list with flat memory: {ports_with_flat_memory}")
+    return ports_with_flat_memory

--- a/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
@@ -2,7 +2,8 @@ import pytest
 import allure
 
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts  # noqa F401
-from .util import parse_sfp_eeprom_infos, check_sfp_eeprom_info, is_support_dom, get_pci_cr0_path, get_pciconf0_path
+from .util import check_sfp_eeprom_info, is_support_dom, get_pci_cr0_path, get_pciconf0_path
+from tests.common.platform.transceiver_utils import parse_sfp_eeprom_infos
 
 pytestmark = [
     pytest.mark.asic('mellanox', 'nvidia-bluefield'),
@@ -54,10 +55,11 @@ def sfp_test_intfs_to_dom_map(duthosts, rand_one_dut_hostname, conn_graph_facts,
 
 
 @pytest.mark.parametrize("show_eeprom_cmd", SHOW_EEPOMR_CMDS)
-def test_check_sfp_eeprom_with_option_dom(duthosts, rand_one_dut_hostname, show_eeprom_cmd, sfp_test_intfs_to_dom_map):
+def test_check_sfp_eeprom_with_option_dom(duthosts, rand_one_dut_hostname, show_eeprom_cmd, sfp_test_intfs_to_dom_map,
+                                          port_list_with_flat_memory):
     """This test case is to check result of  transceiver eeprom with option -d is correct or not for every interface .
     It will do below checks for every available interface
-        1. Check if all expected keys exist in the the result
+        1. Check if all expected keys exist in the result
         2. When cable support dom, check the corresponding keys related to monitor exist,
            and the the corresponding value has correct format
     """
@@ -76,5 +78,6 @@ def test_check_sfp_eeprom_with_option_dom(duthosts, rand_one_dut_hostname, show_
                     if sfp_info_dict[intf] == "SFP EEPROM Not detected":
                         allure.step("{}: SFP EEPROM Not detected".format(intf))
                         continue
+                    is_flat_memory = True if intf in port_list_with_flat_memory[duthost.hostname] else False
                     check_sfp_eeprom_info(
-                        duthost, sfp_info_dict[intf], inft_support_dom, show_eeprom_cmd)
+                        duthost, sfp_info_dict[intf], inft_support_dom, show_eeprom_cmd, is_flat_memory)

--- a/tests/platform_tests/mellanox/util.py
+++ b/tests/platform_tests/mellanox/util.py
@@ -2,190 +2,8 @@ import re
 import logging
 import ast
 
-pattern_top_layer_key_value = r"^(?P<key>Ethernet\d+):(?P<value>.*)"
-pattern_second_layer_key_value = r"(^\s{8}|\t{1})(?P<key>[a-zA-Z0-9][a-zA-Z0-9\s\/\(\)-]+):(?P<value>.*)"
-pattern_third_layer_key_value = r"(^\s{16}|\t{2})(?P<key>[a-zA-Z0-9][a-zA-Z0-9\s\/]+):(?P<value>.*)"
 
-pattern_digit_unit = r"^(?P<digit>-[0-9\.]+|[0-9.]+)(?P<unit>dBm|mA|C|c|Volts)"
-
-
-def parse_one_sfp_eeprom_info(sfp_eeprom_info):
-    """
-    Parse the one sfp eeprom info, return top_key, sfp_eeprom_info_dict
-    e.g
-    sfp_info:
-    Ethernet0: SFP EEPROM detected
-        Application Advertisement: N/A
-        Connector: No separable connector
-        Encoding: 64B/66B
-        Extended Identifier: Power Class 3 Module (2.5W max.),
-                             No CLEI code present in Page 02h, CDR present in TX, CDR present in RX
-        Extended RateSelect Compliance: Unknown
-        Identifier: QSFP28 or later
-        Length Cable Assembly(m): 3.0
-        Nominal Bit Rate(100Mbs): 255
-        Specification compliance:
-                10/40G Ethernet Compliance Code: Extended
-                Extended Specification Compliance: 100G AOC (Active Optical Cable) or 25GAUI C2M AOC
-                Fibre Channel Link Length: Unknown
-                Fibre Channel Speed: Unknown
-                Fibre Channel Transmission Media: Unknown
-                Fibre Channel Transmitter Technology: Unknown
-                Gigabit Ethernet Compliant Codes: Unknown
-                SAS/SATA Compliance Codes: Unknown
-                SONET Compliance Codes: Unknown
-        Vendor Date Code(YYYY-MM-DD Lot): 2019-01-17
-        Vendor Name: Mellanox
-        Vendor OUI: 00-02-c9
-        Vendor PN: MFA1A00-C003
-        Vendor Rev: B2
-        Vendor SN: MT1903FT05965
-        ChannelMonitorValues:
-                RX1Power: 0.927dBm
-                RX2Power: 0.938dBm
-                RX3Power: 0.912dBm
-                RX4Power: 0.95dBm
-                TX1Bias: 6.75mA
-                TX1Power: 1.071dBm
-                TX2Bias: 6.75mA
-                TX2Power: 1.04dBm
-                TX3Bias: 6.75mA
-                TX3Power: 1.039dBm
-                TX4Bias: 6.75mA
-                TX4Power: 1.031dBm
-        ChannelThresholdValues:
-                RxPowerHighAlarm  : 5.4dBm
-                RxPowerHighWarning: 2.4dBm
-                RxPowerLowAlarm   : -13.307dBm
-                RxPowerLowWarning : -10.301dBm
-                TxBiasHighAlarm   : 8.5mA
-                TxBiasHighWarning : 8.0mA
-                TxBiasLowAlarm    : 5.492mA
-                TxBiasLowWarning  : 6.0mA
-        ModuleMonitorValues:
-                Temperature: 43.105C
-                Vcc: 3.235Volts
-        ModuleThresholdValues:
-                TempHighAlarm  : 80.0C
-                TempHighWarning: 70.0C
-                TempLowAlarm   : -10.0C
-                TempLowWarning : 0.0C
-                VccHighAlarm   : 3.5Volts
-                VccHighWarning : 3.465Volts
-                VccLowAlarm    : 3.1Volts
-                VccLowWarning  : 3.135Volts
-    top_key, sfp_eeprom_info_dict:
-    Ethernet0,
-    {
-        'Ethernet0': 'SFP EEPROM detected',
-        'Application Advertisement': 'N/A',
-        'Connector': 'No separable connector',
-        'Encoding': '64B/66B',
-        'Extended Identifier': 'Power Class 3 Module (2.5W max.),
-                               No CLEI code present in Page 02h, CDR present in TX, CDR present in RX',
-        'Extended RateSelect Compliance': 'Unknown',
-        'Identifier': 'QSFP28 or later',
-        'Length Cable Assembly(m)': '3.0',
-        'Nominal Bit Rate(100Mbs)': '255',
-        'Specification compliance': {
-            '10/40G Ethernet Compliance Code': 'Extended',
-            'Extended Specification Compliance': '100G AOC (Active Optical Cable) or 25GAUI C2M AOC',
-            'Fibre Channel Link Length': 'Unknown',
-            'Fibre Channel Speed': 'Unknown',
-            'Fibre Channel Transmission Media': 'Unknown',
-            'Fibre Channel Transmitter Technology': 'Unknown',
-            'Gigabit Ethernet Compliant Codes': 'Unknown',
-            'SAS/SATA Compliance Codes': 'Unknown',
-            'SONET Compliance Codes': 'Unknown'
-        },
-        'Vendor Date Code(YYYY-MM-DD Lot)': '2019-01-17',
-        'Vendor Name': 'Mellanox',
-        'Vendor OUI': '00-02-c9',
-        'Vendor PN': 'MFA1A00-C003',
-        'Vendor Rev': 'B2',
-        'Vendor SN': 'MT1903FT05965',
-        'ChannelMonitorValues': {
-            'RX1Power': '0.927dBm',
-            'RX2Power': '0.938dBm',
-            'RX3Power': '0.912dBm',
-            'RX4Power': '0.95dBm',
-            'TX1Bias': '6.75mA',
-            'TX1Power': '1.071dBm',
-            'TX2Bias': '6.75mA',
-            'TX2Power': '1.04dBm',
-            'TX3Bias': '6.75mA',
-            'TX3Power': '1.039dBm',
-            'TX4Bias': '6.75mA',
-            'TX4Power': '1.031dBm'
-        },
-        'ChannelThresholdValues': {
-            'RxPowerHighAlarm': '5.4dBm',
-            'RxPowerHighWarning': '2.4dBm',
-            'RxPowerLowAlarm': '-13.307dBm',
-            'RxPowerLowWarning': '-10.301dBm',
-            'TxBiasHighAlarm': '8.5mA',
-            'TxBiasHighWarning': '8.0mA',
-            'TxBiasLowAlarm': '5.492mA',
-            'TxBiasLowWarning': '6.0mA'
-        },
-        'ModuleMonitorValues': {
-            'Temperature': '43.105C',
-            'Vcc': '3.235Volts'
-        },
-        'ModuleThresholdValues': {
-            'TempHighAlarm': '80.0C',
-            'TempHighWarning': '70.0C',
-            'TempLowAlarm': '-10.0C',
-            'TempLowWarning': '0.0C',
-            'VccHighAlarm': '3.5Volts',
-            'VccHighWarning': '3.465Volts',
-            'VccLowAlarm': '3.1Volts',
-            'VccLowWarning': '3.135Volts'
-        }
-    }
-    """
-    one_sfp_eeprom_info_dict = {}
-    second_layer_dict = {}
-    previous_key = ""
-    top_key = ""
-    for line in sfp_eeprom_info.split("\n"):
-        res1 = re.match(pattern_top_layer_key_value, line)
-        if res1:
-            top_key = res1.groupdict()["key"].strip()
-            one_sfp_eeprom_info_dict[top_key] = res1.groupdict()[
-                "value"].strip()
-            continue
-        res2 = re.match(pattern_second_layer_key_value, line)
-        if res2:
-            if second_layer_dict and previous_key:
-                one_sfp_eeprom_info_dict[previous_key] = second_layer_dict
-                second_layer_dict = {}
-            one_sfp_eeprom_info_dict[res2.groupdict()["key"].strip()] = res2.groupdict()[
-                "value"].strip()
-            previous_key = res2.groupdict()["key"].strip()
-        else:
-            res3 = re.match(pattern_third_layer_key_value, line)
-            if res3:
-                second_layer_dict[res3.groupdict()["key"].strip()] = res3.groupdict()[
-                    "value"].strip()
-    if second_layer_dict and previous_key:
-        one_sfp_eeprom_info_dict[previous_key] = second_layer_dict
-
-    return top_key, one_sfp_eeprom_info_dict
-
-
-def parse_sfp_eeprom_infos(eeprom_infos):
-    """
-    This method is to pares sfp eeprom infos, and return sfp_eeprom_info_dict
-    """
-    sfp_eeprom_info_dict = {}
-    for sfp_info in eeprom_infos.split("\n\n"):
-        intf, eeprom_info = parse_one_sfp_eeprom_info(sfp_info)
-        sfp_eeprom_info_dict[intf] = eeprom_info
-    return sfp_eeprom_info_dict
-
-
-def check_sfp_eeprom_info(duthost, sfp_eeprom_info, is_support_dom, show_eeprom_cmd):
+def check_sfp_eeprom_info(duthost, sfp_eeprom_info, is_support_dom, show_eeprom_cmd, is_flat_memory):
     """
     This method is check sfp info is correct or not.
     1. Check if all expected keys exist in the sfp_eeprom_info
@@ -220,6 +38,12 @@ def check_sfp_eeprom_info(duthost, sfp_eeprom_info, is_support_dom, show_eeprom_
                                          "ModuleThresholdValues"}
         expected_keys = (expected_keys | {
                          "MonitorData", "ThresholdData"}) - excluded_keys
+
+    if is_flat_memory and show_eeprom_cmd == "sudo sfputil show eeprom -d":
+        logging.info("SKip dom parameters check due to port with flat memory")
+        excluded_keys = excluded_keys | {"ChannelMonitorValues", "ChannelThresholdValues", "ModuleMonitorValues",
+                                         "ModuleThresholdValues", "MonitorData", "ThresholdData"}
+        expected_keys = expected_keys - excluded_keys
 
     for key in expected_keys:
         assert key in sfp_eeprom_info, "key {} doesn't exist in {}".format(

--- a/tests/platform_tests/test_xcvr_info_in_db.py
+++ b/tests/platform_tests/test_xcvr_info_in_db.py
@@ -16,7 +16,7 @@ pytestmark = [
 
 
 def test_xcvr_info_in_db(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                         enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list):   # noqa F811
+                         enum_frontend_asic_index, conn_graph_facts, xcvr_skip_list, port_list_with_flat_memory):   # noqa F811
     """
     @summary: This test case is to verify that xcvrd works as expected by checking transceiver information in DB
     """
@@ -35,4 +35,4 @@ def test_xcvr_info_in_db(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
             enum_frontend_asic_index, all_interfaces))
 
     check_transceiver_status(
-        duthost, enum_frontend_asic_index, all_interfaces, xcvr_skip_list)
+        duthost, enum_frontend_asic_index, all_interfaces, xcvr_skip_list, port_list_with_flat_memory)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

1. Sfp eeprom with option dom is not working on Xcvrs with flat memory. There is a relevant PR:https://github.com/sonic-net/sonic-utilities/pull/3385. Therefore, skip dom check for sfp with flat memory.  Also, fix sonic mgmt issue: https://github.com/sonic-net/sonic-mgmt/issues/12981
2. Skip test ports with flat memory for test_get_transceiver_bulk_status

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix issue： https://github.com/sonic-net/sonic-mgmt/issues/12981

#### How did you do it?
Skip dom checker for sfp with flat memory

#### How did you verify/test it?
run test_xcvr_info_in_db and test_check_sfp_eeprom_with_option_dom 

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
