### PR TITLE
Increase the ready timeout for fast reboot test

### DIFF
--- a/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
+++ b/ansible/roles/test/tasks/common_tasks/reboot_sonic.yml
@@ -9,7 +9,7 @@
 
 - name: set default value for sonic ready timeout
   set_fact:
-    ready_timeout: 180
+    ready_timeout: 540
   when: ready_timeout is not defined
 
 - fail:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Increase the ready timeout from 180 to 540.
This is due to the flow was modified so that counter initialization happens approximately 5 minutes after the boot, which is introduced in PR - 
https://github.com/sonic-net/sonic-sairedis/pull/1362

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Due to PR https://github.com/sonic-net/sonic-sairedis/pull/1362, the ready timeout in continuous fast reboot test should be increased.
#### How did you do it?
Increase the ready timeout from 180 to 540.
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
