### PR TITLE
Fix posttest fetch slow issue

### DIFF
--- a/ansible/library/fetch_no_slurp.py
+++ b/ansible/library/fetch_no_slurp.py
@@ -1,0 +1,85 @@
+# This is a virtual module that is entirely implemented as an action plugin.
+# For actual implementation, please refer to ansible/plugins/action/fetch_no_slurp.py
+
+DOCUMENTATION = r'''
+module: fetch_no_slurp.py
+short_description: fetch file from remote controller to host without using ansible.builtin.slurp
+description:
+    - This module behaves like ansible.builtin.fetch but will not trigger ansible.builtin.slurp when become=True, which
+      will significantly increases our performance.
+    - For example: 1.4 GB file with original fetch when use with become=True will take 4 hours whereas this will take
+      1.5 minutes with become=True given the same parameters
+options:
+  src:
+    description:
+    - The file on the remote system to fetch.
+    - This I(must) be a file, not a directory.
+    - Recursive fetching may be supported in a later release.
+    required: yes
+  dest:
+    description:
+    - A directory to save the file into.
+    - For example, if the O(dest) directory is C(/backup) a O(src) file named C(/etc/profile) on host
+      C(host.example.com), would be saved into C(/backup/host.example.com/etc/profile).
+      The host name is based on the inventory name.
+    required: yes
+  fail_on_missing:
+    version_added: '1.1'
+    description:
+    - When set to V(true), the task will fail if the remote file cannot be read for any reason.
+    - Prior to Ansible 2.5, setting this would only fail if the source file was missing.
+    - The default was changed to V(true) in Ansible 2.5.
+    type: bool
+    default: yes
+  validate_checksum:
+    version_added: '1.4'
+    description:
+    - Verify that the source and destination checksums match after the files are fetched.
+    type: bool
+    default: yes
+  flat:
+    version_added: '1.2'
+    description:
+    - Allows you to override the default behavior of appending hostname/path/to/file to the destination.
+    - If O(dest) ends with '/', it will use the basename of the source file, similar to the copy module.
+    - This can be useful if working with a single host, or if retrieving files that are uniquely named per host.
+    - If using multiple hosts with the same filename, the file will be overwritten for each host.
+    type: bool
+    default: no
+extends_documentation_fragment:
+    - action_common_attributes
+    - action_common_attributes.files
+    - action_common_attributes.flow
+attributes:
+  action:
+    support: full
+  async:
+    support: none
+  bypass_host_loop:
+    support: none
+  check_mode:
+    support: full
+  diff_mode:
+    support: full
+  platform:
+    platforms: posix, windows
+  safe_file_operations:
+    support: none
+  vault:
+    support: none
+'''
+
+EXAMPLES = r'''
+- name: Store file from DUT to current folder
+  fetch_no_slurp:
+    src: /tmp/remote_file
+    dest: /tmp/local_folder
+    flat: True
+
+Which is equivalent to
+'''
+
+
+TEST_EXAMPLE = r'''
+duthost.fetch_no_slurp(src="/tmp/remove_file", dest="/tmp/local_folder", flat=True)
+'''

--- a/ansible/plugins/action/fetch_no_slurp.py
+++ b/ansible/plugins/action/fetch_no_slurp.py
@@ -1,0 +1,160 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+from ansible.errors import AnsibleError, AnsibleActionFail, AnsibleActionSkip
+from ansible.module_utils.common.text.converters import to_bytes, to_text
+from ansible.module_utils.six import string_types
+from ansible.module_utils.parsing.convert_bool import boolean
+from ansible.plugins.action import ActionBase
+from ansible.utils.display import Display
+from ansible.utils.hashing import checksum, md5, secure_hash
+from ansible.utils.path import makedirs_safe, is_subpath
+
+display = Display()
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+        ''' handler for fetch_no_slurp operations '''
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        try:
+            if self._play_context.check_mode:
+                raise AnsibleActionSkip('check mode not (yet) supported for this module')
+
+            source = self._task.args.get('src', None)
+            original_dest = dest = self._task.args.get('dest', None)
+            flat = boolean(self._task.args.get('flat'), strict=False)
+            fail_on_missing = boolean(self._task.args.get('fail_on_missing', True), strict=False)
+            validate_checksum = boolean(self._task.args.get('validate_checksum', True), strict=False)
+
+            msg = ''
+            # validate source and dest are strings FIXME: use basic.py and module specs
+            if not isinstance(source, string_types):
+                msg = "Invalid type supplied for source option, it must be a string"
+
+            if not isinstance(dest, string_types):
+                msg = "Invalid type supplied for dest option, it must be a string"
+
+            if source is None or dest is None:
+                msg = "src and dest are required"
+
+            if msg:
+                raise AnsibleActionFail(msg)
+
+            source = self._connection._shell.join_path(source)
+            source = self._remote_expand_user(source)
+
+            remote_stat = {}
+            remote_checksum = None
+
+            try:
+                remote_stat = self._execute_remote_stat(source, all_vars=task_vars, follow=True)
+            except AnsibleError as ae:
+                result['changed'] = False
+                result['file'] = source
+                if fail_on_missing:
+                    result['failed'] = True
+                    result['msg'] = to_text(ae)
+                else:
+                    result['msg'] = "%s, ignored" % to_text(ae, errors='surrogate_or_replace')
+
+                return result
+
+            remote_checksum = remote_stat.get('checksum')
+            if remote_stat.get('exists'):
+                if remote_stat.get('isdir'):
+                    result['failed'] = True
+                    result['changed'] = False
+                    result['msg'] = "remote file is a directory, fetch cannot work on directories"
+
+                    # Historically, these don't fail because you may want to transfer
+                    # a log file that possibly MAY exist but keep going to fetch other
+                    # log files. Today, this is better achieved by adding
+                    # ignore_errors or failed_when to the task.  Control the behaviour
+                    # via fail_when_missing
+                    if not fail_on_missing:
+                        result['msg'] += ", not transferring, ignored"
+                        del result['changed']
+                        del result['failed']
+
+                    return result
+
+            # calculate the destination name
+            if os.path.sep not in self._connection._shell.join_path('a', ''):
+                source = self._connection._shell._unquote(source)
+                source_local = source.replace('\\', '/')
+            else:
+                source_local = source
+
+            # ensure we only use file name, avoid relative paths
+            if not is_subpath(dest, original_dest):
+                # TODO: ? dest = os.path.expanduser(dest.replace(('../','')))
+                raise AnsibleActionFail("Detected directory traversal, expected to be" +
+                                        "contained in '%s' but got '%s'" % (original_dest, dest))
+
+            if flat:
+                if os.path.isdir(to_bytes(dest, errors='surrogate_or_strict')) and not dest.endswith(os.sep):
+                    raise AnsibleActionFail("dest is an existing directory, use a trailing slash if you want to" +
+                                            "fetch src into that directory")
+                if dest.endswith(os.sep):
+                    # if the path ends with "/", we'll use the source filename as the
+                    # destination filename
+                    base = os.path.basename(source_local)
+                    dest = os.path.join(dest, base)
+                if not dest.startswith("/"):
+                    # if dest does not start with "/", we'll assume a relative path
+                    dest = self._loader.path_dwim(dest)
+            else:
+                # files are saved in dest dir, with a subdir for each host, then the filename
+                if 'inventory_hostname' in task_vars:
+                    target_name = task_vars['inventory_hostname']
+                else:
+                    target_name = self._play_context.remote_addr
+                dest = "%s/%s/%s" % (self._loader.path_dwim(dest), target_name, source_local)
+
+            dest = os.path.normpath(dest)
+
+            # calculate checksum for the local file
+            local_checksum = checksum(dest)
+
+            if remote_checksum != local_checksum:
+                # create the containing directories, if needed
+                makedirs_safe(os.path.dirname(dest))
+
+                # fetch the file and check for changes
+                self._connection.fetch_file(source, dest)
+
+                new_checksum = secure_hash(dest)
+                # For backwards compatibility. We'll return None on FIPS enabled systems
+                try:
+                    new_md5 = md5(dest)
+                except ValueError:
+                    new_md5 = None
+
+                if validate_checksum and new_checksum != remote_checksum:
+                    result.update(dict(failed=True, md5sum=new_md5,
+                                       msg="checksum mismatch", file=source, dest=dest, remote_md5sum=None,
+                                       checksum=new_checksum, remote_checksum=remote_checksum))
+                else:
+                    result.update({'changed': True, 'md5sum': new_md5, 'dest': dest,
+                                   'remote_md5sum': None, 'checksum': new_checksum,
+                                   'remote_checksum': remote_checksum})
+            else:
+                # For backwards compatibility. We'll return None on FIPS enabled systems
+                try:
+                    local_md5 = md5(dest)
+                except ValueError:
+                    local_md5 = None
+                result.update(dict(changed=False, md5sum=local_md5, file=source, dest=dest, checksum=local_checksum))
+
+        finally:
+            self._remove_tmp_path(self._connection._shell.tmpdir)
+
+        return result

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -34,7 +34,7 @@ def test_collect_techsupport(request, duthosts, enum_dut_hostname):
     out = duthost.command("show techsupport --since {}".format(since), module_ignore_errors=True)
     if out['rc'] == 0:
         tar_file = out['stdout_lines'][-1]
-        duthost.fetch(src=tar_file, dest=TECHSUPPORT_SAVE_PATH, flat=True)
+        duthost.fetch_no_slurp(src=tar_file, dest=TECHSUPPORT_SAVE_PATH, flat=True)
 
     assert True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix post test fetch file issue for large dump file
Fixes # (issue) 29889214

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
There is a huge performance impact when using ansible fetch with `become=True`. This is also documented in the ansible module documentation (https://docs.ansible.com/ansible/latest/collections/ansible/builtin/fetch_module.html) where they suggested not to use `become=True`. 

However in our case we need to use `become=True` for fetch because we're trying to fetch from `/var/dump`

The same issue was also reported in https://github.com/ansible/ansible/issues/31194. 

#### How did you do it?
The solution is to create a fetch module without dependent on slurp. Doing this will improve 600 times the speed

#### How did you verify/test it?
Testing with 1.4GB file, in nightly and manual test we're expecting 4 hours to finish downloading this file using normal `fetch`
Using `fetch_no_slurp` this will take 1.5 minutes

Verified on different T0, T2 platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
