### PR TITLE
[macsec]: test macsec counters over rekey, and clear command

### DIFF
--- a/tests/macsec/macsec_config_helper.py
+++ b/tests/macsec/macsec_config_helper.py
@@ -47,13 +47,14 @@ def set_macsec_profile(host, port, profile_name, priority, cipher_suite,
         "primary_cak": primary_cak,
         "primary_ckn": primary_ckn,
         "policy": policy,
-        "send_sci": send_sci,
+        "send_sci" if send_sci else "no_send_sci": "",
         "rekey_period": rekey_period,
     }
-    cmd = "sonic-db-cli {} CONFIG_DB HMSET 'MACSEC_PROFILE|{}' ".format(
-        getns_prefix(host, port), profile_name)
+    opts = ""
     for k, v in list(macsec_profile.items()):
-        cmd += " '{}' '{}' ".format(k, v)
+        opts += " --{} {}".format(k, v)
+    cmd = "config macsec {} profile add {} {}".format(
+        getns_prefix(host, port), profile_name, opts)
     host.command(cmd)
     if send_sci == "false":
         # The MAC address of SONiC host is locally administrated
@@ -77,10 +78,10 @@ def delete_macsec_profile(host, port, profile_name):
     if host.is_multi_asic and port is None:
         for ns in host.get_asic_namespace_list():
             CMD_PREFIX = "-n {}".format(ns) if ns is not None else " "
-            cmd = "sonic-db-cli {} CONFIG_DB DEL 'MACSEC_PROFILE|{}'".format(CMD_PREFIX, profile_name)
+            cmd = "config macsec {} profile del {}".format(CMD_PREFIX, profile_name)
             host.command(cmd)
     else:
-        cmd = ("sonic-db-cli {} CONFIG_DB DEL 'MACSEC_PROFILE|{}'"
+        cmd = ("config macsec {} profile del {}"
                .format(getns_prefix(host, port), profile_name))
         host.command(cmd)
 
@@ -100,7 +101,7 @@ def enable_macsec_port(host, port, profile_name):
         host.command("sudo config portchannel {} member del {} {}".format(getns_prefix(host, port), pc["name"], port))
         time.sleep(2)
 
-    cmd = "sonic-db-cli {} CONFIG_DB HSET 'PORT|{}' 'macsec' '{}'".format(getns_prefix(host, port), port, profile_name)
+    cmd = "config macsec {} port add {} {}".format(getns_prefix(host, port), port, profile_name)
     host.command(cmd)
 
     if dnx_platform and pc:
@@ -125,7 +126,7 @@ def disable_macsec_port(host, port):
         host.command("sudo config portchannel {} member del {} {}".format(getns_prefix(host, port), pc["name"], port))
         time.sleep(2)
 
-    cmd = "sonic-db-cli {} CONFIG_DB HDEL 'PORT|{}' 'macsec'".format(getns_prefix(host, port), port)
+    cmd = "config macsec {} port del {}".format(getns_prefix(host, port), port)
     host.command(cmd)
 
     if dnx_platform and pc:

--- a/tests/macsec/macsec_config_helper.py
+++ b/tests/macsec/macsec_config_helper.py
@@ -220,9 +220,9 @@ def setup_macsec_configuration(duthost, ctrl_links, profile_name, default_priori
 
     # 3. Wait for interface's macsec ready
     for dut_port, nbr in list(ctrl_links.items()):
-        assert wait_until(20, 3, 0,
-                          lambda: duthost.iface_macsec_ok(dut_port) and
-                          nbr["host"].iface_macsec_ok(nbr["port"]))
+        wait_until(20, 3, 0,
+                   lambda: duthost.iface_macsec_ok(dut_port) and
+                   nbr["host"].iface_macsec_ok(nbr["port"]))
 
     # Enabling macsec may cause link flap, which impacts LACP, BGP, etc
     # protocols. To hold some time for protocol recovery.

--- a/tests/macsec/test_dataplane.py
+++ b/tests/macsec/test_dataplane.py
@@ -135,8 +135,12 @@ class TestDataPlane():
 
         # multiple of rekey period to wait, to ensure a rekey has happened
         REKEY_PERIOD_WAIT_SCALE = 1.5
-        PKT_NUM = 5 if not rekey_period else int(rekey_period * REKEY_PERIOD_WAIT_SCALE)
         PKT_OCTET = 1024
+        if not rekey_period or duthost.facts["asic_type"] == "vs":
+            # If no rekeys, or vsonic, only send 5 packets
+            PKT_NUM = 5
+        else:
+            PKT_NUM = int(rekey_period * REKEY_PERIOD_WAIT_SCALE)
 
         # Counters which only go up
         MONOTONIC_COUNTERS = {
@@ -195,7 +199,7 @@ class TestDataPlane():
         # Sum up end counter
         egress_end_counters, ingress_end_counters = get_counters(duthost, up_ports)
 
-        if duthost.facts["asic_type"] == "vs" and not rekey_period:
+        if duthost.facts["asic_type"] == "vs":
             # vsonic only has xpn counter
             i = 'SAI_MACSEC_SA_ATTR_CURRENT_XPN'
             assert egress_end_counters[i] - egress_start_counters[i] >= PKT_NUM


### PR DESCRIPTION
* test macsec counters over rekey
* use show command for counters
* test sonic-clear macsec

Summary:
Fixes #13347

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x ] 202405

### Approach
#### What is the motivation for this PR?

Fix test gap by adding sonic-clear macsec tests and testing over rekeys

#### How did you verify/test it?
Ran on macsec t2 chassis, using profiles with rekeys and without
https://elastictest.org/scheduler/testplan/6720229a42c9736d8d478924

