### PR TITLE
Add new topology marks for some subtype topologies. 

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -147,7 +147,7 @@ t0:
   - snmp/test_snmp_default_route.py
   - snmp/test_snmp_fdb.py
   - snmp/test_snmp_interfaces.py
-  - snmp/test_snmp_link_local.py
+  - snmp/test_snmp_link_local_ip.py
   - snmp/test_snmp_lldp.py
   - snmp/test_snmp_loopback.py
   - snmp/test_snmp_memory.py
@@ -429,7 +429,7 @@ multi-asic-t1-lag:
   - bgp/test_bgp_fact.py
   - bgp/test_bgp_update_timer.py
   - snmp/test_snmp_default_route.py
-  - snmp/test_snmp_link_local.py
+  - snmp/test_snmp_link_local_ip.py
   - snmp/test_snmp_loopback.py
   - snmp/test_snmp_pfc_counters.py
   - snmp/test_snmp_queue.py

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -147,7 +147,7 @@ t0:
   - snmp/test_snmp_default_route.py
   - snmp/test_snmp_fdb.py
   - snmp/test_snmp_interfaces.py
-  - snmp/test_snmp_link_local_ip.py
+  - snmp/test_snmp_link_local.py
   - snmp/test_snmp_lldp.py
   - snmp/test_snmp_loopback.py
   - snmp/test_snmp_memory.py

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -429,7 +429,7 @@ multi-asic-t1-lag:
   - bgp/test_bgp_fact.py
   - bgp/test_bgp_update_timer.py
   - snmp/test_snmp_default_route.py
-  - snmp/test_snmp_link_local_ip.py
+  - snmp/test_snmp_link_local.py
   - snmp/test_snmp_loopback.py
   - snmp/test_snmp_pfc_counters.py
   - snmp/test_snmp_queue.py

--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -25,7 +25,7 @@ from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 
 
 pytestmark = [
-    pytest.mark.topology('t1'),
+    pytest.mark.topology('t1', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -2,7 +2,7 @@ import pytest
 from tests.common.helpers.bgp import run_bgp_facts
 
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('any', 't0-sonic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/bgp/test_bgp_fact.py
+++ b/tests/bgp/test_bgp_fact.py
@@ -2,7 +2,7 @@ import pytest
 from tests.common.helpers.bgp import run_bgp_facts
 
 pytestmark = [
-    pytest.mark.topology('any', 't0-sonic'),
+    pytest.mark.topology('any', 't0-sonic', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -25,7 +25,7 @@ from tests.common.helpers.constants import DEFAULT_NAMESPACE
 
 
 pytestmark = [
-    pytest.mark.topology("any"),
+    pytest.mark.topology("any", "t1-multi-asic"),
 ]
 
 PEER_COUNT = 2

--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -12,7 +12,7 @@ except ImportError:
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer globally
-    pytest.mark.topology('any'),
+    pytest.mark.topology('any', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -19,7 +19,7 @@ from tests.common.helpers.dut_utils import get_disabled_container_list
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('any', 't1-multi-asic'),
     pytest.mark.disable_loganalyzer
 ]
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -21,7 +21,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyze
 from tests.dhcp_relay.dhcp_relay_utils import check_routes_to_dhcp_server, restart_dhcp_service
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0', 't0-2vlan'),
+    pytest.mark.topology('t0', 'm0', 't0-2vlans'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -21,7 +21,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyze
 from tests.dhcp_relay.dhcp_relay_utils import check_routes_to_dhcp_server, restart_dhcp_service
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0'),
+    pytest.mark.topology('t0', 'm0', 't0-2vlan'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -21,7 +21,7 @@ from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_s
 from tests.common.dualtor.dual_tor_common import active_active_ports                                        # noqa F401
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0', 'mx'),
+    pytest.mark.topology('t0', 'm0', 'mx', 't0-2vlan'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -21,7 +21,7 @@ from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_s
 from tests.common.dualtor.dual_tor_common import active_active_ports                                        # noqa F401
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0', 'mx', 't0-2vlan'),
+    pytest.mark.topology('t0', 'm0', 'mx', 't0-2vlans'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/http/test_http_copy.py
+++ b/tests/http/test_http_copy.py
@@ -5,7 +5,7 @@ from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology("any"),
+    pytest.mark.topology("any", "t1-multi-asic"),
     pytest.mark.device_type("vs"),
 ]
 

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -317,7 +317,7 @@ class TestShowInterfaces():
             if regex_int.match(line):
                 interfaces.append(regex_int.match(line).group(0))
 
-        assert(len(interfaces) > 0)
+        assert (len(interfaces) > 0)
 
         for item in interfaces:
             if mode == 'alias':
@@ -551,7 +551,7 @@ class TestShowQueue():
                 intfsChecked += 1
 
         # At least one interface should have been checked to have a valid result
-        assert(intfsChecked > 0)
+        assert (intfsChecked > 0)
 
     def test_show_queue_counters_interface(self, setup_config_mode, sample_intf):
         """

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -10,7 +10,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.sonic_db import redis_get_keys
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any', 't1-multi-asic')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/macsec/test_controlplane.py
+++ b/tests/macsec/test_controlplane.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.macsec_required,
-    pytest.mark.topology("t0", "t2"),
+    pytest.mark.topology("t0", "t2", "t0-sonic"),
 ]
 
 

--- a/tests/macsec/test_dataplane.py
+++ b/tests/macsec/test_dataplane.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.macsec_required,
-    pytest.mark.topology("t0", "t2"),
+    pytest.mark.topology("t0", "t2", "t0-sonic"),
 ]
 
 

--- a/tests/macsec/test_deployment.py
+++ b/tests/macsec/test_deployment.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.macsec_required,
-    pytest.mark.topology("t0", "t2"),
+    pytest.mark.topology("t0", "t2", "t0-sonic"),
 ]
 
 

--- a/tests/macsec/test_fault_handling.py
+++ b/tests/macsec/test_fault_handling.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.macsec_required,
-    pytest.mark.topology("t0", "t2"),
+    pytest.mark.topology("t0", "t2", "t0-sonic"),
 ]
 
 

--- a/tests/macsec/test_interop_protocol.py
+++ b/tests/macsec/test_interop_protocol.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.macsec_required,
-    pytest.mark.topology("t0", "t2"),
+    pytest.mark.topology("t0", "t2", "t0-sonic"),
 ]
 
 

--- a/tests/monit/test_monit_status.py
+++ b/tests/monit/test_monit_status.py
@@ -13,7 +13,7 @@ from tests.common.helpers.assertions import pytest_require
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('any', 't1-multi-asic'),
     pytest.mark.disable_loganalyzer
 ]
 

--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -15,7 +15,7 @@ import scapy.layers.l2
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1")
+    pytest.mark.topology("t0", "t1", "t0-sonic")
 ]
 
 

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -18,7 +18,7 @@ from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('t0'),
+    pytest.mark.topology('t0', "t0-sonic"),
     pytest.mark.skip_check_dut_health
 ]
 

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -23,7 +23,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('any', 't1-multi-asic'),
     pytest.mark.disable_loganalyzer
 ]
 

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -11,7 +11,7 @@ markers:
     pretest: tests are run before feature/regression test cases to prepare the DUT/environment.
     posttest: tests are run after feature/regression test cases to cleanup the DUT/environment and/or collect diagnostics.
     sanity_check: override the default sanity check settings
-    topology: specify which topology testcase can be executed on: (t0, t1, ptf, etc)
+    topology: specify which topology testcase can be executed on: (t0, t1, ptf, etc). For subtype topology marks, such as `t0-2vlans`, `t1-multi-asic`, plaese add them only when you confirm that the test script needs to run on this topology.
     platform: specify which platform testcase can be executed on: (physical, virtual, broadcom, mellanox, etc)
     supported_completeness_level: test supported levels of completeness (coverage) level (Debug, Basic, Confident, Thorough)
     skip_check_dut_health: skip default execution of check_dut_health_status fixture

--- a/tests/scp/test_scp_copy.py
+++ b/tests/scp/test_scp_copy.py
@@ -3,7 +3,7 @@ from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology("any"),
+    pytest.mark.topology("any", "t1-multi-asic"),
     pytest.mark.device_type("vs"),
 ]
 

--- a/tests/snmp/test_snmp_default_route.py
+++ b/tests/snmp/test_snmp_default_route.py
@@ -4,7 +4,7 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_link_local.py
+++ b/tests/snmp/test_snmp_link_local.py
@@ -3,7 +3,7 @@ from tests.common.helpers.snmp_helpers import get_snmp_facts
 from tests.common import config_reload
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_loopback.py
+++ b/tests/snmp/test_snmp_loopback.py
@@ -5,7 +5,7 @@ from tests.common.devices.eos import EosHost
 from tests.common.utilities import skip_release
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_pfc_counters.py
+++ b/tests/snmp/test_snmp_pfc_counters.py
@@ -2,7 +2,7 @@ import pytest
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('any', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_queue.py
+++ b/tests/snmp/test_snmp_queue.py
@@ -2,7 +2,7 @@ import pytest
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('any', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -10,7 +10,7 @@ MULTICAST_CTRS = 4
 BUFFER_QUEUES_REMOVED = 2
 
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('any', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -13,7 +13,7 @@ from tests.common.utilities import skip_release
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('any'),
+    pytest.mark.topology('any', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -18,7 +18,7 @@ from .utils import duthost_shell_with_unreachable_retry
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('any'),
+    pytest.mark.topology('any', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/tacacs/test_jit_user.py
+++ b/tests/tacacs/test_jit_user.py
@@ -6,7 +6,7 @@ from tests.common.utilities import check_output
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('any'),
+    pytest.mark.topology('any', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -8,7 +8,7 @@ import logging
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('any'),
+    pytest.mark.topology('any', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/tacacs/test_rw_user.py
+++ b/tests/tacacs/test_rw_user.py
@@ -5,7 +5,7 @@ from tests.common.utilities import check_output
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('any'),
+    pytest.mark.topology('any', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -4,7 +4,7 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
-    pytest.mark.topology('any'),
+    pytest.mark.topology('any', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/vlan/test_host_vlan.py
+++ b/tests/vlan/test_host_vlan.py
@@ -16,7 +16,7 @@ from tests.common.utilities import skip_release
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
-    pytest.mark.topology("t0", "m0", "mx", 't0-2vlan')
+    pytest.mark.topology("t0", "m0", "mx", 't0-2vlans')
 ]
 
 DUT_VLAN_INTF_MAC = "00:00:11:22:33:44"

--- a/tests/vlan/test_host_vlan.py
+++ b/tests/vlan/test_host_vlan.py
@@ -16,7 +16,7 @@ from tests.common.utilities import skip_release
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
-    pytest.mark.topology("t0", "m0", "mx")
+    pytest.mark.topology("t0", "m0", "mx", 't0-2vlan')
 ]
 
 DUT_VLAN_INTF_MAC = "00:00:11:22:33:44"

--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -15,7 +15,7 @@ from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa F
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't0-52', 'm0', 'mx')
+    pytest.mark.topology('t0', 't0-52', 'm0', 'mx', 't0-2vlan')
 ]
 
 

--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -15,7 +15,7 @@ from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa F
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't0-52', 'm0', 'mx', 't0-2vlan')
+    pytest.mark.topology('t0', 't0-52', 'm0', 'mx', 't0-2vlans')
 ]
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We currently have several subtype topologies for `t0` and `t1`, such as `t0-2vlans` and `t1-multi-asic`. At present, the scripts used for PR checkers are hard-coded in `pr_test_scripts.yaml`, and none of them are specifically marked by their topology. Moving forward, we plan to dynamically assign test scripts to the appropriate PR checkers, which will require clear topology-specific markings. In this PR, we introduce new topology marks to identify and distinguish these subtype topologies.

**Note: Please ensure that these subtype marks are added only when the test script needs to run on these specific topologies. Otherwise, do not add them.**

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
We currently have several subtype topologies for `t0` and `t1`, such as `t0-2vlans` and `t1-multi-asic`. At present, the scripts used for PR checkers are hard-coded in `pr_test_scripts.yaml`, and none of them are specifically marked by their topology. Moving forward, we plan to dynamically assign test scripts to the appropriate PR checkers, which will require clear topology-specific markings. In this PR, we introduce new topology marks to identify and distinguish these subtype topologies.

**Note: Please ensure that these subtype marks are added only when the test script needs to run on these specific topologies. Otherwise, do not add them.**

#### How did you do it?
 We introduce new topology marks to identify and distinguish these subtype topologies.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
