### PR TITLE
Handle p bit properly in bfd_responder

### DIFF
--- a/ansible/roles/test/files/helpers/bfd_responder.py
+++ b/ansible/roles/test/files/helpers/bfd_responder.py
@@ -14,7 +14,8 @@ scapy2.conf.use_pcap = True
 
 IPv4 = '4'
 IPv6 = '6'
-
+BFD_FLAG_P_BIT = 5
+BFD_FLAG_F_BIT = 4
 
 def get_if(iff, cmd):
     s = socket.socket()
@@ -92,7 +93,7 @@ class BFDResponder(object):
             return
         session = self.sessions[ip_dst]
         if bfd_state == 3:
-            #Respond with F bit if P bit is set
+            # Respond with F bit if P bit is set
             if (bfd_flags & (1 << BFD_FLAG_P_BIT)):
                 session["pkt"].payload.payload.payload.load.flags = (1 << BFD_FLAG_F_BIT)
             interface.send(session["pkt"])

--- a/ansible/roles/test/files/helpers/bfd_responder.py
+++ b/ansible/roles/test/files/helpers/bfd_responder.py
@@ -17,6 +17,7 @@ IPv6 = '6'
 BFD_FLAG_P_BIT = 5
 BFD_FLAG_F_BIT = 4
 
+
 def get_if(iff, cmd):
     s = socket.socket()
     ifreq = ioctl(s, cmd, struct.pack("16s16x", iff))

--- a/ansible/roles/test/files/helpers/bfd_responder.py
+++ b/ansible/roles/test/files/helpers/bfd_responder.py
@@ -86,13 +86,17 @@ class BFDResponder(object):
 
     def action(self, interface):
         data = interface.recv()
-        mac_src, mac_dst, ip_src, ip_dst,  bfd_remote_disc, bfd_state = self.extract_bfd_info(
+        mac_src, mac_dst, ip_src, ip_dst,  bfd_remote_disc, bfd_state, bfd_flags = self.extract_bfd_info(
             data)
         if ip_dst not in self.sessions:
             return
         session = self.sessions[ip_dst]
         if bfd_state == 3:
+            #Respond with F bit if P bit is set
+            if (bfd_flags & (1 << BFD_FLAG_P_BIT)):
+                session["pkt"].payload.payload.payload.load.flags = (1 << BFD_FLAG_F_BIT)
             interface.send(session["pkt"])
+            session["pkt"].payload.payload.payload.load.flags = 0
             return
 
         if bfd_state == 2:
@@ -101,6 +105,7 @@ class BFDResponder(object):
         bfd_pkt_init = self.craft_bfd_packet(
             session, data, mac_src, mac_dst, ip_src, ip_dst, bfd_remote_disc, 2)
         bfd_pkt_init.payload.payload.chksum = None
+        bfd_pkt_init.payload.payload.payload.load.flags = 0
         interface.send(bfd_pkt_init)
         bfd_pkt_init.payload.payload.payload.load.sta = 3
         bfd_pkt_init.payload.payload.chksum = None
@@ -120,10 +125,11 @@ class BFDResponder(object):
         bfdpkt = BFD(ether.payload.payload.payload.load)
         bfd_remote_disc = bfdpkt.my_discriminator
         bfd_state = bfdpkt.sta
+        bfd_flags = bfdpkt.flags
         if ip_priority != self.bfd_default_ip_priority:
             raise RuntimeError("Received BFD packet with incorrect priority value: {}".format(ip_priority))
         logging.debug('BFD packet info: sip {}, dip {}, priority {}'.format(ip_src, ip_dst, ip_priority))
-        return mac_src, mac_dst, ip_src, ip_dst, bfd_remote_disc, bfd_state
+        return mac_src, mac_dst, ip_src, ip_dst, bfd_remote_disc, bfd_state, bfd_flags
 
     def craft_bfd_packet(self, session, data, mac_src, mac_dst, ip_src, ip_dst, bfd_remote_disc, bfd_state):
         ethpart = scapy2.Ether(data)


### PR DESCRIPTION
### Description of PR
Summary:
On cisco platform, ipv4/ipv6 multihop tests are failing because BFD injected packets are not using correct queue (should be UC7 instead of UC0). The reason is because once BFD session is up, BFD responder always sends packets with P bit set. When DUT receives these packets, it punts them to control plane which injects packets with F bit set in response.
Why these packets with F bit don't go out of UC7 is a known issue which is already fixed in cisco sdk.
However, even without the sdk fix, there should gone be constant exchange of packets with P/F bits when session is UP.
BFD responder currently uses first packet it receives from DUT as template and always uses flags from that packet for subsequent packets (which has P bit set). The fix is in BFD responder to respond with F bit set if a packet with P bit is received, otherwise do not set any flags for other packets.

### Type of change

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ x] 202311
- [x ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation