### PR TITLE
Add topo t1-isolated-d224u8

### DIFF
--- a/ansible/vars/topo_t1-isolated-d224u8.yaml
+++ b/ansible/vars/topo_t1-isolated-d224u8.yaml
@@ -1,0 +1,5356 @@
+topology:
+  VMs:
+    ARISTA01T0:
+      vlans:
+        - 0
+      vm_offset: 0
+    ARISTA02T0:
+      vlans:
+        - 1
+      vm_offset: 1
+    ARISTA03T0:
+      vlans:
+        - 2
+      vm_offset: 2
+    ARISTA04T0:
+      vlans:
+        - 3
+      vm_offset: 3
+    ARISTA05T0:
+      vlans:
+        - 4
+      vm_offset: 4
+    ARISTA06T0:
+      vlans:
+        - 5
+      vm_offset: 5
+    ARISTA07T0:
+      vlans:
+        - 6
+      vm_offset: 6
+    ARISTA08T0:
+      vlans:
+        - 7
+      vm_offset: 7
+    ARISTA09T0:
+      vlans:
+        - 8
+      vm_offset: 8
+    ARISTA10T0:
+      vlans:
+        - 9
+      vm_offset: 9
+    ARISTA11T0:
+      vlans:
+        - 10
+      vm_offset: 10
+    ARISTA12T0:
+      vlans:
+        - 11
+      vm_offset: 11
+    ARISTA13T0:
+      vlans:
+        - 12
+      vm_offset: 12
+    ARISTA14T0:
+      vlans:
+        - 13
+      vm_offset: 13
+    ARISTA15T0:
+      vlans:
+        - 14
+      vm_offset: 14
+    ARISTA16T0:
+      vlans:
+        - 15
+      vm_offset: 15
+    ARISTA17T0:
+      vlans:
+        - 16
+      vm_offset: 16
+    ARISTA18T0:
+      vlans:
+        - 17
+      vm_offset: 17
+    ARISTA19T0:
+      vlans:
+        - 18
+      vm_offset: 18
+    ARISTA20T0:
+      vlans:
+        - 19
+      vm_offset: 19
+    ARISTA21T0:
+      vlans:
+        - 20
+      vm_offset: 20
+    ARISTA22T0:
+      vlans:
+        - 21
+      vm_offset: 21
+    ARISTA23T0:
+      vlans:
+        - 22
+      vm_offset: 22
+    ARISTA24T0:
+      vlans:
+        - 23
+      vm_offset: 23
+    ARISTA25T0:
+      vlans:
+        - 24
+      vm_offset: 24
+    ARISTA26T0:
+      vlans:
+        - 25
+      vm_offset: 25
+    ARISTA27T0:
+      vlans:
+        - 26
+      vm_offset: 26
+    ARISTA28T0:
+      vlans:
+        - 27
+      vm_offset: 27
+    ARISTA29T0:
+      vlans:
+        - 28
+      vm_offset: 28
+    ARISTA30T0:
+      vlans:
+        - 29
+      vm_offset: 29
+    ARISTA31T0:
+      vlans:
+        - 30
+      vm_offset: 30
+    ARISTA32T0:
+      vlans:
+        - 31
+      vm_offset: 31
+    ARISTA33T0:
+      vlans:
+        - 32
+      vm_offset: 32
+    ARISTA34T0:
+      vlans:
+        - 33
+      vm_offset: 33
+    ARISTA35T0:
+      vlans:
+        - 34
+      vm_offset: 34
+    ARISTA36T0:
+      vlans:
+        - 35
+      vm_offset: 35
+    ARISTA37T0:
+      vlans:
+        - 36
+      vm_offset: 36
+    ARISTA38T0:
+      vlans:
+        - 37
+      vm_offset: 37
+    ARISTA39T0:
+      vlans:
+        - 38
+      vm_offset: 38
+    ARISTA40T0:
+      vlans:
+        - 39
+      vm_offset: 39
+    ARISTA41T0:
+      vlans:
+        - 40
+      vm_offset: 40
+    ARISTA42T0:
+      vlans:
+        - 41
+      vm_offset: 41
+    ARISTA43T0:
+      vlans:
+        - 42
+      vm_offset: 42
+    ARISTA44T0:
+      vlans:
+        - 43
+      vm_offset: 43
+    ARISTA45T0:
+      vlans:
+        - 44
+      vm_offset: 44
+    ARISTA46T0:
+      vlans:
+        - 45
+      vm_offset: 45
+    ARISTA47T0:
+      vlans:
+        - 46
+      vm_offset: 46
+    ARISTA48T0:
+      vlans:
+        - 47
+      vm_offset: 47
+    ARISTA49T2:
+      vlans:
+        - 48
+      vm_offset: 48
+    ARISTA50T2:
+      vlans:
+        - 49
+      vm_offset: 49
+    ARISTA51T0:
+      vlans:
+        - 56
+      vm_offset: 50
+    ARISTA52T0:
+      vlans:
+        - 57
+      vm_offset: 51
+    ARISTA53T0:
+      vlans:
+        - 58
+      vm_offset: 52
+    ARISTA54T0:
+      vlans:
+        - 59
+      vm_offset: 53
+    ARISTA55T0:
+      vlans:
+        - 60
+      vm_offset: 54
+    ARISTA56T0:
+      vlans:
+        - 61
+      vm_offset: 55
+    ARISTA57T0:
+      vlans:
+        - 62
+      vm_offset: 56
+    ARISTA58T0:
+      vlans:
+        - 63
+      vm_offset: 57
+    ARISTA59T2:
+      vlans:
+        - 64
+      vm_offset: 58
+    ARISTA60T2:
+      vlans:
+        - 65
+      vm_offset: 59
+    ARISTA61T0:
+      vlans:
+        - 72
+      vm_offset: 60
+    ARISTA62T0:
+      vlans:
+        - 73
+      vm_offset: 61
+    ARISTA63T0:
+      vlans:
+        - 74
+      vm_offset: 62
+    ARISTA64T0:
+      vlans:
+        - 75
+      vm_offset: 63
+    ARISTA65T0:
+      vlans:
+        - 76
+      vm_offset: 64
+    ARISTA66T0:
+      vlans:
+        - 77
+      vm_offset: 65
+    ARISTA67T0:
+      vlans:
+        - 78
+      vm_offset: 66
+    ARISTA68T0:
+      vlans:
+        - 79
+      vm_offset: 67
+    ARISTA69T0:
+      vlans:
+        - 80
+      vm_offset: 68
+    ARISTA70T0:
+      vlans:
+        - 81
+      vm_offset: 69
+    ARISTA71T0:
+      vlans:
+        - 82
+      vm_offset: 70
+    ARISTA72T0:
+      vlans:
+        - 83
+      vm_offset: 71
+    ARISTA73T0:
+      vlans:
+        - 84
+      vm_offset: 72
+    ARISTA74T0:
+      vlans:
+        - 85
+      vm_offset: 73
+    ARISTA75T0:
+      vlans:
+        - 86
+      vm_offset: 74
+    ARISTA76T0:
+      vlans:
+        - 87
+      vm_offset: 75
+    ARISTA77T0:
+      vlans:
+        - 88
+      vm_offset: 76
+    ARISTA78T0:
+      vlans:
+        - 89
+      vm_offset: 77
+    ARISTA79T0:
+      vlans:
+        - 90
+      vm_offset: 78
+    ARISTA80T0:
+      vlans:
+        - 91
+      vm_offset: 79
+    ARISTA81T0:
+      vlans:
+        - 92
+      vm_offset: 80
+    ARISTA82T0:
+      vlans:
+        - 93
+      vm_offset: 81
+    ARISTA83T0:
+      vlans:
+        - 94
+      vm_offset: 82
+    ARISTA84T0:
+      vlans:
+        - 95
+      vm_offset: 83
+    ARISTA85T0:
+      vlans:
+        - 96
+      vm_offset: 84
+    ARISTA86T0:
+      vlans:
+        - 97
+      vm_offset: 85
+    ARISTA87T0:
+      vlans:
+        - 98
+      vm_offset: 86
+    ARISTA88T0:
+      vlans:
+        - 99
+      vm_offset: 87
+    ARISTA89T0:
+      vlans:
+        - 100
+      vm_offset: 88
+    ARISTA90T0:
+      vlans:
+        - 101
+      vm_offset: 89
+    ARISTA91T0:
+      vlans:
+        - 102
+      vm_offset: 90
+    ARISTA92T0:
+      vlans:
+        - 103
+      vm_offset: 91
+    ARISTA93T0:
+      vlans:
+        - 104
+      vm_offset: 92
+    ARISTA94T0:
+      vlans:
+        - 105
+      vm_offset: 93
+    ARISTA95T0:
+      vlans:
+        - 106
+      vm_offset: 94
+    ARISTA96T0:
+      vlans:
+        - 107
+      vm_offset: 95
+    ARISTA97T0:
+      vlans:
+        - 108
+      vm_offset: 96
+    ARISTA98T0:
+      vlans:
+        - 109
+      vm_offset: 97
+    ARISTA99T0:
+      vlans:
+        - 110
+      vm_offset: 98
+    ARISTA100T0:
+      vlans:
+        - 111
+      vm_offset: 99
+    ARISTA101T0:
+      vlans:
+        - 112
+      vm_offset: 100
+    ARISTA102T0:
+      vlans:
+        - 113
+      vm_offset: 101
+    ARISTA103T0:
+      vlans:
+        - 114
+      vm_offset: 102
+    ARISTA104T0:
+      vlans:
+        - 115
+      vm_offset: 103
+    ARISTA105T0:
+      vlans:
+        - 116
+      vm_offset: 104
+    ARISTA106T0:
+      vlans:
+        - 117
+      vm_offset: 105
+    ARISTA107T0:
+      vlans:
+        - 118
+      vm_offset: 106
+    ARISTA108T0:
+      vlans:
+        - 119
+      vm_offset: 107
+    ARISTA109T0:
+      vlans:
+        - 120
+      vm_offset: 108
+    ARISTA110T0:
+      vlans:
+        - 121
+      vm_offset: 109
+    ARISTA111T0:
+      vlans:
+        - 122
+      vm_offset: 110
+    ARISTA112T0:
+      vlans:
+        - 123
+      vm_offset: 111
+    ARISTA113T0:
+      vlans:
+        - 124
+      vm_offset: 112
+    ARISTA114T0:
+      vlans:
+        - 125
+      vm_offset: 113
+    ARISTA115T0:
+      vlans:
+        - 126
+      vm_offset: 114
+    ARISTA116T0:
+      vlans:
+        - 127
+      vm_offset: 115
+    ARISTA117T0:
+      vlans:
+        - 128
+      vm_offset: 116
+    ARISTA118T0:
+      vlans:
+        - 129
+      vm_offset: 117
+    ARISTA119T0:
+      vlans:
+        - 130
+      vm_offset: 118
+    ARISTA120T0:
+      vlans:
+        - 131
+      vm_offset: 119
+    ARISTA121T0:
+      vlans:
+        - 132
+      vm_offset: 120
+    ARISTA122T0:
+      vlans:
+        - 133
+      vm_offset: 121
+    ARISTA123T0:
+      vlans:
+        - 134
+      vm_offset: 122
+    ARISTA124T0:
+      vlans:
+        - 135
+      vm_offset: 123
+    ARISTA125T0:
+      vlans:
+        - 136
+      vm_offset: 124
+    ARISTA126T0:
+      vlans:
+        - 137
+      vm_offset: 125
+    ARISTA127T0:
+      vlans:
+        - 138
+      vm_offset: 126
+    ARISTA128T0:
+      vlans:
+        - 139
+      vm_offset: 127
+    ARISTA129T0:
+      vlans:
+        - 140
+      vm_offset: 128
+    ARISTA130T0:
+      vlans:
+        - 141
+      vm_offset: 129
+    ARISTA131T0:
+      vlans:
+        - 142
+      vm_offset: 130
+    ARISTA132T0:
+      vlans:
+        - 143
+      vm_offset: 131
+    ARISTA133T0:
+      vlans:
+        - 144
+      vm_offset: 132
+    ARISTA134T0:
+      vlans:
+        - 145
+      vm_offset: 133
+    ARISTA135T0:
+      vlans:
+        - 146
+      vm_offset: 134
+    ARISTA136T0:
+      vlans:
+        - 147
+      vm_offset: 135
+    ARISTA137T0:
+      vlans:
+        - 148
+      vm_offset: 136
+    ARISTA138T0:
+      vlans:
+        - 149
+      vm_offset: 137
+    ARISTA139T0:
+      vlans:
+        - 150
+      vm_offset: 138
+    ARISTA140T0:
+      vlans:
+        - 151
+      vm_offset: 139
+    ARISTA141T0:
+      vlans:
+        - 152
+      vm_offset: 140
+    ARISTA142T0:
+      vlans:
+        - 153
+      vm_offset: 141
+    ARISTA143T0:
+      vlans:
+        - 154
+      vm_offset: 142
+    ARISTA144T0:
+      vlans:
+        - 155
+      vm_offset: 143
+    ARISTA145T0:
+      vlans:
+        - 156
+      vm_offset: 144
+    ARISTA146T0:
+      vlans:
+        - 157
+      vm_offset: 145
+    ARISTA147T0:
+      vlans:
+        - 158
+      vm_offset: 146
+    ARISTA148T0:
+      vlans:
+        - 159
+      vm_offset: 147
+    ARISTA149T0:
+      vlans:
+        - 160
+      vm_offset: 148
+    ARISTA150T0:
+      vlans:
+        - 161
+      vm_offset: 149
+    ARISTA151T0:
+      vlans:
+        - 162
+      vm_offset: 150
+    ARISTA152T0:
+      vlans:
+        - 163
+      vm_offset: 151
+    ARISTA153T0:
+      vlans:
+        - 164
+      vm_offset: 152
+    ARISTA154T0:
+      vlans:
+        - 165
+      vm_offset: 153
+    ARISTA155T0:
+      vlans:
+        - 166
+      vm_offset: 154
+    ARISTA156T0:
+      vlans:
+        - 167
+      vm_offset: 155
+    ARISTA157T0:
+      vlans:
+        - 168
+      vm_offset: 156
+    ARISTA158T0:
+      vlans:
+        - 169
+      vm_offset: 157
+    ARISTA159T0:
+      vlans:
+        - 170
+      vm_offset: 158
+    ARISTA160T0:
+      vlans:
+        - 171
+      vm_offset: 159
+    ARISTA161T0:
+      vlans:
+        - 172
+      vm_offset: 160
+    ARISTA162T0:
+      vlans:
+        - 173
+      vm_offset: 161
+    ARISTA163T0:
+      vlans:
+        - 174
+      vm_offset: 162
+    ARISTA164T0:
+      vlans:
+        - 175
+      vm_offset: 163
+    ARISTA165T2:
+      vlans:
+        - 176
+      vm_offset: 164
+    ARISTA166T2:
+      vlans:
+        - 177
+      vm_offset: 165
+    ARISTA167T0:
+      vlans:
+        - 184
+      vm_offset: 166
+    ARISTA168T0:
+      vlans:
+        - 185
+      vm_offset: 167
+    ARISTA169T0:
+      vlans:
+        - 186
+      vm_offset: 168
+    ARISTA170T0:
+      vlans:
+        - 187
+      vm_offset: 169
+    ARISTA171T0:
+      vlans:
+        - 188
+      vm_offset: 170
+    ARISTA172T0:
+      vlans:
+        - 189
+      vm_offset: 171
+    ARISTA173T0:
+      vlans:
+        - 190
+      vm_offset: 172
+    ARISTA174T0:
+      vlans:
+        - 191
+      vm_offset: 173
+    ARISTA175T2:
+      vlans:
+        - 192
+      vm_offset: 174
+    ARISTA176T2:
+      vlans:
+        - 193
+      vm_offset: 175
+    ARISTA177T0:
+      vlans:
+        - 200
+      vm_offset: 176
+    ARISTA178T0:
+      vlans:
+        - 201
+      vm_offset: 177
+    ARISTA179T0:
+      vlans:
+        - 202
+      vm_offset: 178
+    ARISTA180T0:
+      vlans:
+        - 203
+      vm_offset: 179
+    ARISTA181T0:
+      vlans:
+        - 204
+      vm_offset: 180
+    ARISTA182T0:
+      vlans:
+        - 205
+      vm_offset: 181
+    ARISTA183T0:
+      vlans:
+        - 206
+      vm_offset: 182
+    ARISTA184T0:
+      vlans:
+        - 207
+      vm_offset: 183
+    ARISTA185T0:
+      vlans:
+        - 208
+      vm_offset: 184
+    ARISTA186T0:
+      vlans:
+        - 209
+      vm_offset: 185
+    ARISTA187T0:
+      vlans:
+        - 210
+      vm_offset: 186
+    ARISTA188T0:
+      vlans:
+        - 211
+      vm_offset: 187
+    ARISTA189T0:
+      vlans:
+        - 212
+      vm_offset: 188
+    ARISTA190T0:
+      vlans:
+        - 213
+      vm_offset: 189
+    ARISTA191T0:
+      vlans:
+        - 214
+      vm_offset: 190
+    ARISTA192T0:
+      vlans:
+        - 215
+      vm_offset: 191
+    ARISTA193T0:
+      vlans:
+        - 216
+      vm_offset: 192
+    ARISTA194T0:
+      vlans:
+        - 217
+      vm_offset: 193
+    ARISTA195T0:
+      vlans:
+        - 218
+      vm_offset: 194
+    ARISTA196T0:
+      vlans:
+        - 219
+      vm_offset: 195
+    ARISTA197T0:
+      vlans:
+        - 220
+      vm_offset: 196
+    ARISTA198T0:
+      vlans:
+        - 221
+      vm_offset: 197
+    ARISTA199T0:
+      vlans:
+        - 222
+      vm_offset: 198
+    ARISTA200T0:
+      vlans:
+        - 223
+      vm_offset: 199
+    ARISTA201T0:
+      vlans:
+        - 224
+      vm_offset: 200
+    ARISTA202T0:
+      vlans:
+        - 225
+      vm_offset: 201
+    ARISTA203T0:
+      vlans:
+        - 226
+      vm_offset: 202
+    ARISTA204T0:
+      vlans:
+        - 227
+      vm_offset: 203
+    ARISTA205T0:
+      vlans:
+        - 228
+      vm_offset: 204
+    ARISTA206T0:
+      vlans:
+        - 229
+      vm_offset: 205
+    ARISTA207T0:
+      vlans:
+        - 230
+      vm_offset: 206
+    ARISTA208T0:
+      vlans:
+        - 231
+      vm_offset: 207
+    ARISTA209T0:
+      vlans:
+        - 232
+      vm_offset: 208
+    ARISTA210T0:
+      vlans:
+        - 233
+      vm_offset: 209
+    ARISTA211T0:
+      vlans:
+        - 234
+      vm_offset: 210
+    ARISTA212T0:
+      vlans:
+        - 235
+      vm_offset: 211
+    ARISTA213T0:
+      vlans:
+        - 236
+      vm_offset: 212
+    ARISTA214T0:
+      vlans:
+        - 237
+      vm_offset: 213
+    ARISTA215T0:
+      vlans:
+        - 238
+      vm_offset: 214
+    ARISTA216T0:
+      vlans:
+        - 239
+      vm_offset: 215
+    ARISTA217T0:
+      vlans:
+        - 240
+      vm_offset: 216
+    ARISTA218T0:
+      vlans:
+        - 241
+      vm_offset: 217
+    ARISTA219T0:
+      vlans:
+        - 242
+      vm_offset: 218
+    ARISTA220T0:
+      vlans:
+        - 243
+      vm_offset: 219
+    ARISTA221T0:
+      vlans:
+        - 244
+      vm_offset: 220
+    ARISTA222T0:
+      vlans:
+        - 245
+      vm_offset: 221
+    ARISTA223T0:
+      vlans:
+        - 246
+      vm_offset: 222
+    ARISTA224T0:
+      vlans:
+        - 247
+      vm_offset: 223
+    ARISTA225T0:
+      vlans:
+        - 248
+      vm_offset: 224
+    ARISTA226T0:
+      vlans:
+        - 249
+      vm_offset: 225
+    ARISTA227T0:
+      vlans:
+        - 250
+      vm_offset: 226
+    ARISTA228T0:
+      vlans:
+        - 251
+      vm_offset: 227
+    ARISTA229T0:
+      vlans:
+        - 252
+      vm_offset: 228
+    ARISTA230T0:
+      vlans:
+        - 253
+      vm_offset: 229
+    ARISTA231T0:
+      vlans:
+        - 254
+      vm_offset: 230
+    ARISTA232T0:
+      vlans:
+        - 255
+      vm_offset: 231
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: LeafRouter
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
+  spine:
+    swrole: spine
+  tor:
+    swrole: tor
+
+configuration:
+  ARISTA01T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.0
+          - fc00::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        ipv4: 10.0.0.1/31
+        ipv6: fc00::2/126
+    bp_interfaces:
+      ipv4: 10.10.246.2/24
+      ipv6: fc0a::2/64
+  ARISTA02T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.2
+          - fc00::5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.2/32
+        ipv6: 2064:100::2/128
+      Ethernet1:
+        ipv4: 10.0.0.3/31
+        ipv6: fc00::6/126
+    bp_interfaces:
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::3/64
+  ARISTA03T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.4
+          - fc00::9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.3/32
+        ipv6: 2064:100::3/128
+      Ethernet1:
+        ipv4: 10.0.0.5/31
+        ipv6: fc00::a/126
+    bp_interfaces:
+      ipv4: 10.10.246.4/24
+      ipv6: fc0a::4/64
+  ARISTA04T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.6
+          - fc00::d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.4/32
+        ipv6: 2064:100::4/128
+      Ethernet1:
+        ipv4: 10.0.0.7/31
+        ipv6: fc00::e/126
+    bp_interfaces:
+      ipv4: 10.10.246.5/24
+      ipv6: fc0a::5/64
+  ARISTA05T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.8
+          - fc00::11
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.5/32
+        ipv6: 2064:100::5/128
+      Ethernet1:
+        ipv4: 10.0.0.9/31
+        ipv6: fc00::12/126
+    bp_interfaces:
+      ipv4: 10.10.246.6/24
+      ipv6: fc0a::6/64
+  ARISTA06T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.10
+          - fc00::15
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.6/32
+        ipv6: 2064:100::6/128
+      Ethernet1:
+        ipv4: 10.0.0.11/31
+        ipv6: fc00::16/126
+    bp_interfaces:
+      ipv4: 10.10.246.7/24
+      ipv6: fc0a::7/64
+  ARISTA07T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.12
+          - fc00::19
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.7/32
+        ipv6: 2064:100::7/128
+      Ethernet1:
+        ipv4: 10.0.0.13/31
+        ipv6: fc00::1a/126
+    bp_interfaces:
+      ipv4: 10.10.246.8/24
+      ipv6: fc0a::8/64
+  ARISTA08T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.14
+          - fc00::1d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.8/32
+        ipv6: 2064:100::8/128
+      Ethernet1:
+        ipv4: 10.0.0.15/31
+        ipv6: fc00::1e/126
+    bp_interfaces:
+      ipv4: 10.10.246.9/24
+      ipv6: fc0a::9/64
+  ARISTA09T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.16
+          - fc00::21
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.9/32
+        ipv6: 2064:100::9/128
+      Ethernet1:
+        ipv4: 10.0.0.17/31
+        ipv6: fc00::22/126
+    bp_interfaces:
+      ipv4: 10.10.246.10/24
+      ipv6: fc0a::a/64
+  ARISTA10T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.18
+          - fc00::25
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.10/32
+        ipv6: 2064:100::a/128
+      Ethernet1:
+        ipv4: 10.0.0.19/31
+        ipv6: fc00::26/126
+    bp_interfaces:
+      ipv4: 10.10.246.11/24
+      ipv6: fc0a::b/64
+  ARISTA11T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.20
+          - fc00::29
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.11/32
+        ipv6: 2064:100::b/128
+      Ethernet1:
+        ipv4: 10.0.0.21/31
+        ipv6: fc00::2a/126
+    bp_interfaces:
+      ipv4: 10.10.246.12/24
+      ipv6: fc0a::c/64
+  ARISTA12T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.22
+          - fc00::2d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.12/32
+        ipv6: 2064:100::c/128
+      Ethernet1:
+        ipv4: 10.0.0.23/31
+        ipv6: fc00::2e/126
+    bp_interfaces:
+      ipv4: 10.10.246.13/24
+      ipv6: fc0a::d/64
+  ARISTA13T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.24
+          - fc00::31
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.13/32
+        ipv6: 2064:100::d/128
+      Ethernet1:
+        ipv4: 10.0.0.25/31
+        ipv6: fc00::32/126
+    bp_interfaces:
+      ipv4: 10.10.246.14/24
+      ipv6: fc0a::e/64
+  ARISTA14T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.26
+          - fc00::35
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.14/32
+        ipv6: 2064:100::e/128
+      Ethernet1:
+        ipv4: 10.0.0.27/31
+        ipv6: fc00::36/126
+    bp_interfaces:
+      ipv4: 10.10.246.15/24
+      ipv6: fc0a::f/64
+  ARISTA15T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.28
+          - fc00::39
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.15/32
+        ipv6: 2064:100::f/128
+      Ethernet1:
+        ipv4: 10.0.0.29/31
+        ipv6: fc00::3a/126
+    bp_interfaces:
+      ipv4: 10.10.246.16/24
+      ipv6: fc0a::10/64
+  ARISTA16T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.30
+          - fc00::3d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.16/32
+        ipv6: 2064:100::10/128
+      Ethernet1:
+        ipv4: 10.0.0.31/31
+        ipv6: fc00::3e/126
+    bp_interfaces:
+      ipv4: 10.10.246.17/24
+      ipv6: fc0a::11/64
+  ARISTA17T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.32
+          - fc00::41
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.17/32
+        ipv6: 2064:100::11/128
+      Ethernet1:
+        ipv4: 10.0.0.33/31
+        ipv6: fc00::42/126
+    bp_interfaces:
+      ipv4: 10.10.246.18/24
+      ipv6: fc0a::12/64
+  ARISTA18T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.34
+          - fc00::45
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.18/32
+        ipv6: 2064:100::12/128
+      Ethernet1:
+        ipv4: 10.0.0.35/31
+        ipv6: fc00::46/126
+    bp_interfaces:
+      ipv4: 10.10.246.19/24
+      ipv6: fc0a::13/64
+  ARISTA19T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.36
+          - fc00::49
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.19/32
+        ipv6: 2064:100::13/128
+      Ethernet1:
+        ipv4: 10.0.0.37/31
+        ipv6: fc00::4a/126
+    bp_interfaces:
+      ipv4: 10.10.246.20/24
+      ipv6: fc0a::14/64
+  ARISTA20T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.38
+          - fc00::4d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.20/32
+        ipv6: 2064:100::14/128
+      Ethernet1:
+        ipv4: 10.0.0.39/31
+        ipv6: fc00::4e/126
+    bp_interfaces:
+      ipv4: 10.10.246.21/24
+      ipv6: fc0a::15/64
+  ARISTA21T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.40
+          - fc00::51
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.21/32
+        ipv6: 2064:100::15/128
+      Ethernet1:
+        ipv4: 10.0.0.41/31
+        ipv6: fc00::52/126
+    bp_interfaces:
+      ipv4: 10.10.246.22/24
+      ipv6: fc0a::16/64
+  ARISTA22T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.42
+          - fc00::55
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.22/32
+        ipv6: 2064:100::16/128
+      Ethernet1:
+        ipv4: 10.0.0.43/31
+        ipv6: fc00::56/126
+    bp_interfaces:
+      ipv4: 10.10.246.23/24
+      ipv6: fc0a::17/64
+  ARISTA23T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.44
+          - fc00::59
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.23/32
+        ipv6: 2064:100::17/128
+      Ethernet1:
+        ipv4: 10.0.0.45/31
+        ipv6: fc00::5a/126
+    bp_interfaces:
+      ipv4: 10.10.246.24/24
+      ipv6: fc0a::18/64
+  ARISTA24T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.46
+          - fc00::5d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.24/32
+        ipv6: 2064:100::18/128
+      Ethernet1:
+        ipv4: 10.0.0.47/31
+        ipv6: fc00::5e/126
+    bp_interfaces:
+      ipv4: 10.10.246.25/24
+      ipv6: fc0a::19/64
+  ARISTA25T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.48
+          - fc00::61
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.25/32
+        ipv6: 2064:100::19/128
+      Ethernet1:
+        ipv4: 10.0.0.49/31
+        ipv6: fc00::62/126
+    bp_interfaces:
+      ipv4: 10.10.246.26/24
+      ipv6: fc0a::1a/64
+  ARISTA26T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.50
+          - fc00::65
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.26/32
+        ipv6: 2064:100::1a/128
+      Ethernet1:
+        ipv4: 10.0.0.51/31
+        ipv6: fc00::66/126
+    bp_interfaces:
+      ipv4: 10.10.246.27/24
+      ipv6: fc0a::1b/64
+  ARISTA27T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.52
+          - fc00::69
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.27/32
+        ipv6: 2064:100::1b/128
+      Ethernet1:
+        ipv4: 10.0.0.53/31
+        ipv6: fc00::6a/126
+    bp_interfaces:
+      ipv4: 10.10.246.28/24
+      ipv6: fc0a::1c/64
+  ARISTA28T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.54
+          - fc00::6d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.28/32
+        ipv6: 2064:100::1c/128
+      Ethernet1:
+        ipv4: 10.0.0.55/31
+        ipv6: fc00::6e/126
+    bp_interfaces:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::1d/64
+  ARISTA29T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.56
+          - fc00::71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+    bp_interfaces:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::1e/64
+  ARISTA30T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.58
+          - fc00::75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+    bp_interfaces:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::1f/64
+  ARISTA31T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.60
+          - fc00::79
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+    bp_interfaces:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::20/64
+  ARISTA32T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.62
+          - fc00::7d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+    bp_interfaces:
+      ipv4: 10.10.246.33/24
+      ipv6: fc0a::21/64
+  ARISTA33T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.64
+          - fc00::81
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.33/32
+        ipv6: 2064:100::21/128
+      Ethernet1:
+        ipv4: 10.0.0.65/31
+        ipv6: fc00::82/126
+    bp_interfaces:
+      ipv4: 10.10.246.34/24
+      ipv6: fc0a::22/64
+  ARISTA34T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.66
+          - fc00::85
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.34/32
+        ipv6: 2064:100::22/128
+      Ethernet1:
+        ipv4: 10.0.0.67/31
+        ipv6: fc00::86/126
+    bp_interfaces:
+      ipv4: 10.10.246.35/24
+      ipv6: fc0a::23/64
+  ARISTA35T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.68
+          - fc00::89
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.35/32
+        ipv6: 2064:100::23/128
+      Ethernet1:
+        ipv4: 10.0.0.69/31
+        ipv6: fc00::8a/126
+    bp_interfaces:
+      ipv4: 10.10.246.36/24
+      ipv6: fc0a::24/64
+  ARISTA36T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.70
+          - fc00::8d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.36/32
+        ipv6: 2064:100::24/128
+      Ethernet1:
+        ipv4: 10.0.0.71/31
+        ipv6: fc00::8e/126
+    bp_interfaces:
+      ipv4: 10.10.246.37/24
+      ipv6: fc0a::25/64
+  ARISTA37T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.72
+          - fc00::91
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.37/32
+        ipv6: 2064:100::25/128
+      Ethernet1:
+        ipv4: 10.0.0.73/31
+        ipv6: fc00::92/126
+    bp_interfaces:
+      ipv4: 10.10.246.38/24
+      ipv6: fc0a::26/64
+  ARISTA38T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.74
+          - fc00::95
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.38/32
+        ipv6: 2064:100::26/128
+      Ethernet1:
+        ipv4: 10.0.0.75/31
+        ipv6: fc00::96/126
+    bp_interfaces:
+      ipv4: 10.10.246.39/24
+      ipv6: fc0a::27/64
+  ARISTA39T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.76
+          - fc00::99
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.39/32
+        ipv6: 2064:100::27/128
+      Ethernet1:
+        ipv4: 10.0.0.77/31
+        ipv6: fc00::9a/126
+    bp_interfaces:
+      ipv4: 10.10.246.40/24
+      ipv6: fc0a::28/64
+  ARISTA40T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.78
+          - fc00::9d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.40/32
+        ipv6: 2064:100::28/128
+      Ethernet1:
+        ipv4: 10.0.0.79/31
+        ipv6: fc00::9e/126
+    bp_interfaces:
+      ipv4: 10.10.246.41/24
+      ipv6: fc0a::29/64
+  ARISTA41T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.80
+          - fc00::a1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.41/32
+        ipv6: 2064:100::29/128
+      Ethernet1:
+        ipv4: 10.0.0.81/31
+        ipv6: fc00::a2/126
+    bp_interfaces:
+      ipv4: 10.10.246.42/24
+      ipv6: fc0a::2a/64
+  ARISTA42T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.82
+          - fc00::a5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.42/32
+        ipv6: 2064:100::2a/128
+      Ethernet1:
+        ipv4: 10.0.0.83/31
+        ipv6: fc00::a6/126
+    bp_interfaces:
+      ipv4: 10.10.246.43/24
+      ipv6: fc0a::2b/64
+  ARISTA43T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.84
+          - fc00::a9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.43/32
+        ipv6: 2064:100::2b/128
+      Ethernet1:
+        ipv4: 10.0.0.85/31
+        ipv6: fc00::aa/126
+    bp_interfaces:
+      ipv4: 10.10.246.44/24
+      ipv6: fc0a::2c/64
+  ARISTA44T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.86
+          - fc00::ad
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.44/32
+        ipv6: 2064:100::2c/128
+      Ethernet1:
+        ipv4: 10.0.0.87/31
+        ipv6: fc00::ae/126
+    bp_interfaces:
+      ipv4: 10.10.246.45/24
+      ipv6: fc0a::2d/64
+  ARISTA45T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.88
+          - fc00::b1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.45/32
+        ipv6: 2064:100::2d/128
+      Ethernet1:
+        ipv4: 10.0.0.89/31
+        ipv6: fc00::b2/126
+    bp_interfaces:
+      ipv4: 10.10.246.46/24
+      ipv6: fc0a::2e/64
+  ARISTA46T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.90
+          - fc00::b5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.46/32
+        ipv6: 2064:100::2e/128
+      Ethernet1:
+        ipv4: 10.0.0.91/31
+        ipv6: fc00::b6/126
+    bp_interfaces:
+      ipv4: 10.10.246.47/24
+      ipv6: fc0a::2f/64
+  ARISTA47T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.92
+          - fc00::b9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.47/32
+        ipv6: 2064:100::2f/128
+      Ethernet1:
+        ipv4: 10.0.0.93/31
+        ipv6: fc00::ba/126
+    bp_interfaces:
+      ipv4: 10.10.246.48/24
+      ipv6: fc0a::30/64
+  ARISTA48T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.94
+          - fc00::bd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.48/32
+        ipv6: 2064:100::30/128
+      Ethernet1:
+        ipv4: 10.0.0.95/31
+        ipv6: fc00::be/126
+    bp_interfaces:
+      ipv4: 10.10.246.49/24
+      ipv6: fc0a::31/64
+  ARISTA49T2:
+    properties:
+    - common
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.96
+          - fc00::c1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.49/32
+        ipv6: 2064:100::31/128
+      Ethernet1:
+        ipv4: 10.0.0.97/31
+        ipv6: fc00::c2/126
+    bp_interfaces:
+      ipv4: 10.10.246.50/24
+      ipv6: fc0a::32/64
+  ARISTA50T2:
+    properties:
+    - common
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.98
+          - fc00::c5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.50/32
+        ipv6: 2064:100::32/128
+      Ethernet1:
+        ipv4: 10.0.0.99/31
+        ipv6: fc00::c6/126
+    bp_interfaces:
+      ipv4: 10.10.246.51/24
+      ipv6: fc0a::33/64
+  ARISTA51T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.112
+          - fc00::e1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.57/32
+        ipv6: 2064:100::39/128
+      Ethernet1:
+        ipv4: 10.0.0.113/31
+        ipv6: fc00::e2/126
+    bp_interfaces:
+      ipv4: 10.10.246.52/24
+      ipv6: fc0a::34/64
+  ARISTA52T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.114
+          - fc00::e5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.58/32
+        ipv6: 2064:100::3a/128
+      Ethernet1:
+        ipv4: 10.0.0.115/31
+        ipv6: fc00::e6/126
+    bp_interfaces:
+      ipv4: 10.10.246.53/24
+      ipv6: fc0a::35/64
+  ARISTA53T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.116
+          - fc00::e9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.59/32
+        ipv6: 2064:100::3b/128
+      Ethernet1:
+        ipv4: 10.0.0.117/31
+        ipv6: fc00::ea/126
+    bp_interfaces:
+      ipv4: 10.10.246.54/24
+      ipv6: fc0a::36/64
+  ARISTA54T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.118
+          - fc00::ed
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.60/32
+        ipv6: 2064:100::3c/128
+      Ethernet1:
+        ipv4: 10.0.0.119/31
+        ipv6: fc00::ee/126
+    bp_interfaces:
+      ipv4: 10.10.246.55/24
+      ipv6: fc0a::37/64
+  ARISTA55T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.120
+          - fc00::f1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.61/32
+        ipv6: 2064:100::3d/128
+      Ethernet1:
+        ipv4: 10.0.0.121/31
+        ipv6: fc00::f2/126
+    bp_interfaces:
+      ipv4: 10.10.246.56/24
+      ipv6: fc0a::38/64
+  ARISTA56T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.122
+          - fc00::f5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.62/32
+        ipv6: 2064:100::3e/128
+      Ethernet1:
+        ipv4: 10.0.0.123/31
+        ipv6: fc00::f6/126
+    bp_interfaces:
+      ipv4: 10.10.246.57/24
+      ipv6: fc0a::39/64
+  ARISTA57T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.124
+          - fc00::f9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.63/32
+        ipv6: 2064:100::3f/128
+      Ethernet1:
+        ipv4: 10.0.0.125/31
+        ipv6: fc00::fa/126
+    bp_interfaces:
+      ipv4: 10.10.246.58/24
+      ipv6: fc0a::3a/64
+  ARISTA58T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.126
+          - fc00::fd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.64/32
+        ipv6: 2064:100::40/128
+      Ethernet1:
+        ipv4: 10.0.0.127/31
+        ipv6: fc00::fe/126
+    bp_interfaces:
+      ipv4: 10.10.246.59/24
+      ipv6: fc0a::3b/64
+  ARISTA59T2:
+    properties:
+    - common
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.128
+          - fc00::101
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.65/32
+        ipv6: 2064:100::41/128
+      Ethernet1:
+        ipv4: 10.0.0.129/31
+        ipv6: fc00::102/126
+    bp_interfaces:
+      ipv4: 10.10.246.60/24
+      ipv6: fc0a::3c/64
+  ARISTA60T2:
+    properties:
+    - common
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.130
+          - fc00::105
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.66/32
+        ipv6: 2064:100::42/128
+      Ethernet1:
+        ipv4: 10.0.0.131/31
+        ipv6: fc00::106/126
+    bp_interfaces:
+      ipv4: 10.10.246.61/24
+      ipv6: fc0a::3d/64
+  ARISTA61T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.144
+          - fc00::121
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.73/32
+        ipv6: 2064:100::49/128
+      Ethernet1:
+        ipv4: 10.0.0.145/31
+        ipv6: fc00::122/126
+    bp_interfaces:
+      ipv4: 10.10.246.62/24
+      ipv6: fc0a::3e/64
+  ARISTA62T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.146
+          - fc00::125
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.74/32
+        ipv6: 2064:100::4a/128
+      Ethernet1:
+        ipv4: 10.0.0.147/31
+        ipv6: fc00::126/126
+    bp_interfaces:
+      ipv4: 10.10.246.63/24
+      ipv6: fc0a::3f/64
+  ARISTA63T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.148
+          - fc00::129
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.75/32
+        ipv6: 2064:100::4b/128
+      Ethernet1:
+        ipv4: 10.0.0.149/31
+        ipv6: fc00::12a/126
+    bp_interfaces:
+      ipv4: 10.10.246.64/24
+      ipv6: fc0a::40/64
+  ARISTA64T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.150
+          - fc00::12d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.76/32
+        ipv6: 2064:100::4c/128
+      Ethernet1:
+        ipv4: 10.0.0.151/31
+        ipv6: fc00::12e/126
+    bp_interfaces:
+      ipv4: 10.10.246.65/24
+      ipv6: fc0a::41/64
+  ARISTA65T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.152
+          - fc00::131
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.77/32
+        ipv6: 2064:100::4d/128
+      Ethernet1:
+        ipv4: 10.0.0.153/31
+        ipv6: fc00::132/126
+    bp_interfaces:
+      ipv4: 10.10.246.66/24
+      ipv6: fc0a::42/64
+  ARISTA66T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.154
+          - fc00::135
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.78/32
+        ipv6: 2064:100::4e/128
+      Ethernet1:
+        ipv4: 10.0.0.155/31
+        ipv6: fc00::136/126
+    bp_interfaces:
+      ipv4: 10.10.246.67/24
+      ipv6: fc0a::43/64
+  ARISTA67T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.156
+          - fc00::139
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.79/32
+        ipv6: 2064:100::4f/128
+      Ethernet1:
+        ipv4: 10.0.0.157/31
+        ipv6: fc00::13a/126
+    bp_interfaces:
+      ipv4: 10.10.246.68/24
+      ipv6: fc0a::44/64
+  ARISTA68T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.158
+          - fc00::13d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.80/32
+        ipv6: 2064:100::50/128
+      Ethernet1:
+        ipv4: 10.0.0.159/31
+        ipv6: fc00::13e/126
+    bp_interfaces:
+      ipv4: 10.10.246.69/24
+      ipv6: fc0a::45/64
+  ARISTA69T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.160
+          - fc00::141
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.81/32
+        ipv6: 2064:100::51/128
+      Ethernet1:
+        ipv4: 10.0.0.161/31
+        ipv6: fc00::142/126
+    bp_interfaces:
+      ipv4: 10.10.246.70/24
+      ipv6: fc0a::46/64
+  ARISTA70T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.162
+          - fc00::145
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.82/32
+        ipv6: 2064:100::52/128
+      Ethernet1:
+        ipv4: 10.0.0.163/31
+        ipv6: fc00::146/126
+    bp_interfaces:
+      ipv4: 10.10.246.71/24
+      ipv6: fc0a::47/64
+  ARISTA71T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.164
+          - fc00::149
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.83/32
+        ipv6: 2064:100::53/128
+      Ethernet1:
+        ipv4: 10.0.0.165/31
+        ipv6: fc00::14a/126
+    bp_interfaces:
+      ipv4: 10.10.246.72/24
+      ipv6: fc0a::48/64
+  ARISTA72T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.166
+          - fc00::14d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.84/32
+        ipv6: 2064:100::54/128
+      Ethernet1:
+        ipv4: 10.0.0.167/31
+        ipv6: fc00::14e/126
+    bp_interfaces:
+      ipv4: 10.10.246.73/24
+      ipv6: fc0a::49/64
+  ARISTA73T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.168
+          - fc00::151
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.85/32
+        ipv6: 2064:100::55/128
+      Ethernet1:
+        ipv4: 10.0.0.169/31
+        ipv6: fc00::152/126
+    bp_interfaces:
+      ipv4: 10.10.246.74/24
+      ipv6: fc0a::4a/64
+  ARISTA74T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.170
+          - fc00::155
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.86/32
+        ipv6: 2064:100::56/128
+      Ethernet1:
+        ipv4: 10.0.0.171/31
+        ipv6: fc00::156/126
+    bp_interfaces:
+      ipv4: 10.10.246.75/24
+      ipv6: fc0a::4b/64
+  ARISTA75T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.172
+          - fc00::159
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.87/32
+        ipv6: 2064:100::57/128
+      Ethernet1:
+        ipv4: 10.0.0.173/31
+        ipv6: fc00::15a/126
+    bp_interfaces:
+      ipv4: 10.10.246.76/24
+      ipv6: fc0a::4c/64
+  ARISTA76T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.174
+          - fc00::15d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.88/32
+        ipv6: 2064:100::58/128
+      Ethernet1:
+        ipv4: 10.0.0.175/31
+        ipv6: fc00::15e/126
+    bp_interfaces:
+      ipv4: 10.10.246.77/24
+      ipv6: fc0a::4d/64
+  ARISTA77T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.176
+          - fc00::161
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.89/32
+        ipv6: 2064:100::59/128
+      Ethernet1:
+        ipv4: 10.0.0.177/31
+        ipv6: fc00::162/126
+    bp_interfaces:
+      ipv4: 10.10.246.78/24
+      ipv6: fc0a::4e/64
+  ARISTA78T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.178
+          - fc00::165
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.90/32
+        ipv6: 2064:100::5a/128
+      Ethernet1:
+        ipv4: 10.0.0.179/31
+        ipv6: fc00::166/126
+    bp_interfaces:
+      ipv4: 10.10.246.79/24
+      ipv6: fc0a::4f/64
+  ARISTA79T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.180
+          - fc00::169
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.91/32
+        ipv6: 2064:100::5b/128
+      Ethernet1:
+        ipv4: 10.0.0.181/31
+        ipv6: fc00::16a/126
+    bp_interfaces:
+      ipv4: 10.10.246.80/24
+      ipv6: fc0a::50/64
+  ARISTA80T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.182
+          - fc00::16d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.92/32
+        ipv6: 2064:100::5c/128
+      Ethernet1:
+        ipv4: 10.0.0.183/31
+        ipv6: fc00::16e/126
+    bp_interfaces:
+      ipv4: 10.10.246.81/24
+      ipv6: fc0a::51/64
+  ARISTA81T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.184
+          - fc00::171
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.93/32
+        ipv6: 2064:100::5d/128
+      Ethernet1:
+        ipv4: 10.0.0.185/31
+        ipv6: fc00::172/126
+    bp_interfaces:
+      ipv4: 10.10.246.82/24
+      ipv6: fc0a::52/64
+  ARISTA82T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.186
+          - fc00::175
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.94/32
+        ipv6: 2064:100::5e/128
+      Ethernet1:
+        ipv4: 10.0.0.187/31
+        ipv6: fc00::176/126
+    bp_interfaces:
+      ipv4: 10.10.246.83/24
+      ipv6: fc0a::53/64
+  ARISTA83T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.188
+          - fc00::179
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.95/32
+        ipv6: 2064:100::5f/128
+      Ethernet1:
+        ipv4: 10.0.0.189/31
+        ipv6: fc00::17a/126
+    bp_interfaces:
+      ipv4: 10.10.246.84/24
+      ipv6: fc0a::54/64
+  ARISTA84T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.190
+          - fc00::17d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.96/32
+        ipv6: 2064:100::60/128
+      Ethernet1:
+        ipv4: 10.0.0.191/31
+        ipv6: fc00::17e/126
+    bp_interfaces:
+      ipv4: 10.10.246.85/24
+      ipv6: fc0a::55/64
+  ARISTA85T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.192
+          - fc00::181
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.97/32
+        ipv6: 2064:100::61/128
+      Ethernet1:
+        ipv4: 10.0.0.193/31
+        ipv6: fc00::182/126
+    bp_interfaces:
+      ipv4: 10.10.246.86/24
+      ipv6: fc0a::56/64
+  ARISTA86T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.194
+          - fc00::185
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.98/32
+        ipv6: 2064:100::62/128
+      Ethernet1:
+        ipv4: 10.0.0.195/31
+        ipv6: fc00::186/126
+    bp_interfaces:
+      ipv4: 10.10.246.87/24
+      ipv6: fc0a::57/64
+  ARISTA87T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.196
+          - fc00::189
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.99/32
+        ipv6: 2064:100::63/128
+      Ethernet1:
+        ipv4: 10.0.0.197/31
+        ipv6: fc00::18a/126
+    bp_interfaces:
+      ipv4: 10.10.246.88/24
+      ipv6: fc0a::58/64
+  ARISTA88T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.198
+          - fc00::18d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.100/32
+        ipv6: 2064:100::64/128
+      Ethernet1:
+        ipv4: 10.0.0.199/31
+        ipv6: fc00::18e/126
+    bp_interfaces:
+      ipv4: 10.10.246.89/24
+      ipv6: fc0a::59/64
+  ARISTA89T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.200
+          - fc00::191
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.101/32
+        ipv6: 2064:100::65/128
+      Ethernet1:
+        ipv4: 10.0.0.201/31
+        ipv6: fc00::192/126
+    bp_interfaces:
+      ipv4: 10.10.246.90/24
+      ipv6: fc0a::5a/64
+  ARISTA90T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.202
+          - fc00::195
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.102/32
+        ipv6: 2064:100::66/128
+      Ethernet1:
+        ipv4: 10.0.0.203/31
+        ipv6: fc00::196/126
+    bp_interfaces:
+      ipv4: 10.10.246.91/24
+      ipv6: fc0a::5b/64
+  ARISTA91T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.204
+          - fc00::199
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.103/32
+        ipv6: 2064:100::67/128
+      Ethernet1:
+        ipv4: 10.0.0.205/31
+        ipv6: fc00::19a/126
+    bp_interfaces:
+      ipv4: 10.10.246.92/24
+      ipv6: fc0a::5c/64
+  ARISTA92T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.206
+          - fc00::19d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.104/32
+        ipv6: 2064:100::68/128
+      Ethernet1:
+        ipv4: 10.0.0.207/31
+        ipv6: fc00::19e/126
+    bp_interfaces:
+      ipv4: 10.10.246.93/24
+      ipv6: fc0a::5d/64
+  ARISTA93T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.208
+          - fc00::1a1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.105/32
+        ipv6: 2064:100::69/128
+      Ethernet1:
+        ipv4: 10.0.0.209/31
+        ipv6: fc00::1a2/126
+    bp_interfaces:
+      ipv4: 10.10.246.94/24
+      ipv6: fc0a::5e/64
+  ARISTA94T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.210
+          - fc00::1a5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.106/32
+        ipv6: 2064:100::6a/128
+      Ethernet1:
+        ipv4: 10.0.0.211/31
+        ipv6: fc00::1a6/126
+    bp_interfaces:
+      ipv4: 10.10.246.95/24
+      ipv6: fc0a::5f/64
+  ARISTA95T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.212
+          - fc00::1a9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.107/32
+        ipv6: 2064:100::6b/128
+      Ethernet1:
+        ipv4: 10.0.0.213/31
+        ipv6: fc00::1aa/126
+    bp_interfaces:
+      ipv4: 10.10.246.96/24
+      ipv6: fc0a::60/64
+  ARISTA96T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.214
+          - fc00::1ad
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.108/32
+        ipv6: 2064:100::6c/128
+      Ethernet1:
+        ipv4: 10.0.0.215/31
+        ipv6: fc00::1ae/126
+    bp_interfaces:
+      ipv4: 10.10.246.97/24
+      ipv6: fc0a::61/64
+  ARISTA97T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.216
+          - fc00::1b1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.109/32
+        ipv6: 2064:100::6d/128
+      Ethernet1:
+        ipv4: 10.0.0.217/31
+        ipv6: fc00::1b2/126
+    bp_interfaces:
+      ipv4: 10.10.246.98/24
+      ipv6: fc0a::62/64
+  ARISTA98T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.218
+          - fc00::1b5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.110/32
+        ipv6: 2064:100::6e/128
+      Ethernet1:
+        ipv4: 10.0.0.219/31
+        ipv6: fc00::1b6/126
+    bp_interfaces:
+      ipv4: 10.10.246.99/24
+      ipv6: fc0a::63/64
+  ARISTA99T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.220
+          - fc00::1b9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.111/32
+        ipv6: 2064:100::6f/128
+      Ethernet1:
+        ipv4: 10.0.0.221/31
+        ipv6: fc00::1ba/126
+    bp_interfaces:
+      ipv4: 10.10.246.100/24
+      ipv6: fc0a::64/64
+  ARISTA100T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.222
+          - fc00::1bd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.112/32
+        ipv6: 2064:100::70/128
+      Ethernet1:
+        ipv4: 10.0.0.223/31
+        ipv6: fc00::1be/126
+    bp_interfaces:
+      ipv4: 10.10.246.101/24
+      ipv6: fc0a::65/64
+  ARISTA101T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.224
+          - fc00::1c1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.113/32
+        ipv6: 2064:100::71/128
+      Ethernet1:
+        ipv4: 10.0.0.225/31
+        ipv6: fc00::1c2/126
+    bp_interfaces:
+      ipv4: 10.10.246.102/24
+      ipv6: fc0a::66/64
+  ARISTA102T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.226
+          - fc00::1c5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.114/32
+        ipv6: 2064:100::72/128
+      Ethernet1:
+        ipv4: 10.0.0.227/31
+        ipv6: fc00::1c6/126
+    bp_interfaces:
+      ipv4: 10.10.246.103/24
+      ipv6: fc0a::67/64
+  ARISTA103T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.228
+          - fc00::1c9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.115/32
+        ipv6: 2064:100::73/128
+      Ethernet1:
+        ipv4: 10.0.0.229/31
+        ipv6: fc00::1ca/126
+    bp_interfaces:
+      ipv4: 10.10.246.104/24
+      ipv6: fc0a::68/64
+  ARISTA104T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.230
+          - fc00::1cd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.116/32
+        ipv6: 2064:100::74/128
+      Ethernet1:
+        ipv4: 10.0.0.231/31
+        ipv6: fc00::1ce/126
+    bp_interfaces:
+      ipv4: 10.10.246.105/24
+      ipv6: fc0a::69/64
+  ARISTA105T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.232
+          - fc00::1d1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.117/32
+        ipv6: 2064:100::75/128
+      Ethernet1:
+        ipv4: 10.0.0.233/31
+        ipv6: fc00::1d2/126
+    bp_interfaces:
+      ipv4: 10.10.246.106/24
+      ipv6: fc0a::6a/64
+  ARISTA106T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.234
+          - fc00::1d5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.118/32
+        ipv6: 2064:100::76/128
+      Ethernet1:
+        ipv4: 10.0.0.235/31
+        ipv6: fc00::1d6/126
+    bp_interfaces:
+      ipv4: 10.10.246.107/24
+      ipv6: fc0a::6b/64
+  ARISTA107T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.236
+          - fc00::1d9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.119/32
+        ipv6: 2064:100::77/128
+      Ethernet1:
+        ipv4: 10.0.0.237/31
+        ipv6: fc00::1da/126
+    bp_interfaces:
+      ipv4: 10.10.246.108/24
+      ipv6: fc0a::6c/64
+  ARISTA108T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.238
+          - fc00::1dd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.120/32
+        ipv6: 2064:100::78/128
+      Ethernet1:
+        ipv4: 10.0.0.239/31
+        ipv6: fc00::1de/126
+    bp_interfaces:
+      ipv4: 10.10.246.109/24
+      ipv6: fc0a::6d/64
+  ARISTA109T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.240
+          - fc00::1e1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.121/32
+        ipv6: 2064:100::79/128
+      Ethernet1:
+        ipv4: 10.0.0.241/31
+        ipv6: fc00::1e2/126
+    bp_interfaces:
+      ipv4: 10.10.246.110/24
+      ipv6: fc0a::6e/64
+  ARISTA110T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.242
+          - fc00::1e5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.122/32
+        ipv6: 2064:100::7a/128
+      Ethernet1:
+        ipv4: 10.0.0.243/31
+        ipv6: fc00::1e6/126
+    bp_interfaces:
+      ipv4: 10.10.246.111/24
+      ipv6: fc0a::6f/64
+  ARISTA111T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.244
+          - fc00::1e9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.123/32
+        ipv6: 2064:100::7b/128
+      Ethernet1:
+        ipv4: 10.0.0.245/31
+        ipv6: fc00::1ea/126
+    bp_interfaces:
+      ipv4: 10.10.246.112/24
+      ipv6: fc0a::70/64
+  ARISTA112T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.246
+          - fc00::1ed
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.124/32
+        ipv6: 2064:100::7c/128
+      Ethernet1:
+        ipv4: 10.0.0.247/31
+        ipv6: fc00::1ee/126
+    bp_interfaces:
+      ipv4: 10.10.246.113/24
+      ipv6: fc0a::71/64
+  ARISTA113T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.248
+          - fc00::1f1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.125/32
+        ipv6: 2064:100::7d/128
+      Ethernet1:
+        ipv4: 10.0.0.249/31
+        ipv6: fc00::1f2/126
+    bp_interfaces:
+      ipv4: 10.10.246.114/24
+      ipv6: fc0a::72/64
+  ARISTA114T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.250
+          - fc00::1f5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.126/32
+        ipv6: 2064:100::7e/128
+      Ethernet1:
+        ipv4: 10.0.0.251/31
+        ipv6: fc00::1f6/126
+    bp_interfaces:
+      ipv4: 10.10.246.115/24
+      ipv6: fc0a::73/64
+  ARISTA115T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.252
+          - fc00::1f9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.127/32
+        ipv6: 2064:100::7f/128
+      Ethernet1:
+        ipv4: 10.0.0.253/31
+        ipv6: fc00::1fa/126
+    bp_interfaces:
+      ipv4: 10.10.246.116/24
+      ipv6: fc0a::74/64
+  ARISTA116T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.0.254
+          - fc00::1fd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.128/32
+        ipv6: 2064:100::80/128
+      Ethernet1:
+        ipv4: 10.0.0.255/31
+        ipv6: fc00::1fe/126
+    bp_interfaces:
+      ipv4: 10.10.246.117/24
+      ipv6: fc0a::75/64
+  ARISTA117T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.0
+          - fc00::201
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.129/32
+        ipv6: 2064:100::81/128
+      Ethernet1:
+        ipv4: 10.0.1.1/31
+        ipv6: fc00::202/126
+    bp_interfaces:
+      ipv4: 10.10.246.118/24
+      ipv6: fc0a::76/64
+  ARISTA118T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.2
+          - fc00::205
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.130/32
+        ipv6: 2064:100::82/128
+      Ethernet1:
+        ipv4: 10.0.1.3/31
+        ipv6: fc00::206/126
+    bp_interfaces:
+      ipv4: 10.10.246.119/24
+      ipv6: fc0a::77/64
+  ARISTA119T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.4
+          - fc00::209
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.131/32
+        ipv6: 2064:100::83/128
+      Ethernet1:
+        ipv4: 10.0.1.5/31
+        ipv6: fc00::20a/126
+    bp_interfaces:
+      ipv4: 10.10.246.120/24
+      ipv6: fc0a::78/64
+  ARISTA120T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.6
+          - fc00::20d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.132/32
+        ipv6: 2064:100::84/128
+      Ethernet1:
+        ipv4: 10.0.1.7/31
+        ipv6: fc00::20e/126
+    bp_interfaces:
+      ipv4: 10.10.246.121/24
+      ipv6: fc0a::79/64
+  ARISTA121T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.8
+          - fc00::211
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.133/32
+        ipv6: 2064:100::85/128
+      Ethernet1:
+        ipv4: 10.0.1.9/31
+        ipv6: fc00::212/126
+    bp_interfaces:
+      ipv4: 10.10.246.122/24
+      ipv6: fc0a::7a/64
+  ARISTA122T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.10
+          - fc00::215
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.134/32
+        ipv6: 2064:100::86/128
+      Ethernet1:
+        ipv4: 10.0.1.11/31
+        ipv6: fc00::216/126
+    bp_interfaces:
+      ipv4: 10.10.246.123/24
+      ipv6: fc0a::7b/64
+  ARISTA123T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.12
+          - fc00::219
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.135/32
+        ipv6: 2064:100::87/128
+      Ethernet1:
+        ipv4: 10.0.1.13/31
+        ipv6: fc00::21a/126
+    bp_interfaces:
+      ipv4: 10.10.246.124/24
+      ipv6: fc0a::7c/64
+  ARISTA124T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.14
+          - fc00::21d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.136/32
+        ipv6: 2064:100::88/128
+      Ethernet1:
+        ipv4: 10.0.1.15/31
+        ipv6: fc00::21e/126
+    bp_interfaces:
+      ipv4: 10.10.246.125/24
+      ipv6: fc0a::7d/64
+  ARISTA125T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.16
+          - fc00::221
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.137/32
+        ipv6: 2064:100::89/128
+      Ethernet1:
+        ipv4: 10.0.1.17/31
+        ipv6: fc00::222/126
+    bp_interfaces:
+      ipv4: 10.10.246.126/24
+      ipv6: fc0a::7e/64
+  ARISTA126T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.18
+          - fc00::225
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.138/32
+        ipv6: 2064:100::8a/128
+      Ethernet1:
+        ipv4: 10.0.1.19/31
+        ipv6: fc00::226/126
+    bp_interfaces:
+      ipv4: 10.10.246.127/24
+      ipv6: fc0a::7f/64
+  ARISTA127T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.20
+          - fc00::229
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.139/32
+        ipv6: 2064:100::8b/128
+      Ethernet1:
+        ipv4: 10.0.1.21/31
+        ipv6: fc00::22a/126
+    bp_interfaces:
+      ipv4: 10.10.246.128/24
+      ipv6: fc0a::80/64
+  ARISTA128T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.22
+          - fc00::22d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.140/32
+        ipv6: 2064:100::8c/128
+      Ethernet1:
+        ipv4: 10.0.1.23/31
+        ipv6: fc00::22e/126
+    bp_interfaces:
+      ipv4: 10.10.246.129/24
+      ipv6: fc0a::81/64
+  ARISTA129T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.24
+          - fc00::231
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.141/32
+        ipv6: 2064:100::8d/128
+      Ethernet1:
+        ipv4: 10.0.1.25/31
+        ipv6: fc00::232/126
+    bp_interfaces:
+      ipv4: 10.10.246.130/24
+      ipv6: fc0a::82/64
+  ARISTA130T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.26
+          - fc00::235
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.142/32
+        ipv6: 2064:100::8e/128
+      Ethernet1:
+        ipv4: 10.0.1.27/31
+        ipv6: fc00::236/126
+    bp_interfaces:
+      ipv4: 10.10.246.131/24
+      ipv6: fc0a::83/64
+  ARISTA131T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.28
+          - fc00::239
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.143/32
+        ipv6: 2064:100::8f/128
+      Ethernet1:
+        ipv4: 10.0.1.29/31
+        ipv6: fc00::23a/126
+    bp_interfaces:
+      ipv4: 10.10.246.132/24
+      ipv6: fc0a::84/64
+  ARISTA132T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.30
+          - fc00::23d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.144/32
+        ipv6: 2064:100::90/128
+      Ethernet1:
+        ipv4: 10.0.1.31/31
+        ipv6: fc00::23e/126
+    bp_interfaces:
+      ipv4: 10.10.246.133/24
+      ipv6: fc0a::85/64
+  ARISTA133T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.32
+          - fc00::241
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.145/32
+        ipv6: 2064:100::91/128
+      Ethernet1:
+        ipv4: 10.0.1.33/31
+        ipv6: fc00::242/126
+    bp_interfaces:
+      ipv4: 10.10.246.134/24
+      ipv6: fc0a::86/64
+  ARISTA134T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.34
+          - fc00::245
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.146/32
+        ipv6: 2064:100::92/128
+      Ethernet1:
+        ipv4: 10.0.1.35/31
+        ipv6: fc00::246/126
+    bp_interfaces:
+      ipv4: 10.10.246.135/24
+      ipv6: fc0a::87/64
+  ARISTA135T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.36
+          - fc00::249
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.147/32
+        ipv6: 2064:100::93/128
+      Ethernet1:
+        ipv4: 10.0.1.37/31
+        ipv6: fc00::24a/126
+    bp_interfaces:
+      ipv4: 10.10.246.136/24
+      ipv6: fc0a::88/64
+  ARISTA136T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.38
+          - fc00::24d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.148/32
+        ipv6: 2064:100::94/128
+      Ethernet1:
+        ipv4: 10.0.1.39/31
+        ipv6: fc00::24e/126
+    bp_interfaces:
+      ipv4: 10.10.246.137/24
+      ipv6: fc0a::89/64
+  ARISTA137T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.40
+          - fc00::251
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.149/32
+        ipv6: 2064:100::95/128
+      Ethernet1:
+        ipv4: 10.0.1.41/31
+        ipv6: fc00::252/126
+    bp_interfaces:
+      ipv4: 10.10.246.138/24
+      ipv6: fc0a::8a/64
+  ARISTA138T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.42
+          - fc00::255
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.150/32
+        ipv6: 2064:100::96/128
+      Ethernet1:
+        ipv4: 10.0.1.43/31
+        ipv6: fc00::256/126
+    bp_interfaces:
+      ipv4: 10.10.246.139/24
+      ipv6: fc0a::8b/64
+  ARISTA139T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.44
+          - fc00::259
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.151/32
+        ipv6: 2064:100::97/128
+      Ethernet1:
+        ipv4: 10.0.1.45/31
+        ipv6: fc00::25a/126
+    bp_interfaces:
+      ipv4: 10.10.246.140/24
+      ipv6: fc0a::8c/64
+  ARISTA140T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.46
+          - fc00::25d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.152/32
+        ipv6: 2064:100::98/128
+      Ethernet1:
+        ipv4: 10.0.1.47/31
+        ipv6: fc00::25e/126
+    bp_interfaces:
+      ipv4: 10.10.246.141/24
+      ipv6: fc0a::8d/64
+  ARISTA141T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.48
+          - fc00::261
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.153/32
+        ipv6: 2064:100::99/128
+      Ethernet1:
+        ipv4: 10.0.1.49/31
+        ipv6: fc00::262/126
+    bp_interfaces:
+      ipv4: 10.10.246.142/24
+      ipv6: fc0a::8e/64
+  ARISTA142T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.50
+          - fc00::265
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.154/32
+        ipv6: 2064:100::9a/128
+      Ethernet1:
+        ipv4: 10.0.1.51/31
+        ipv6: fc00::266/126
+    bp_interfaces:
+      ipv4: 10.10.246.143/24
+      ipv6: fc0a::8f/64
+  ARISTA143T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.52
+          - fc00::269
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.155/32
+        ipv6: 2064:100::9b/128
+      Ethernet1:
+        ipv4: 10.0.1.53/31
+        ipv6: fc00::26a/126
+    bp_interfaces:
+      ipv4: 10.10.246.144/24
+      ipv6: fc0a::90/64
+  ARISTA144T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.54
+          - fc00::26d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.156/32
+        ipv6: 2064:100::9c/128
+      Ethernet1:
+        ipv4: 10.0.1.55/31
+        ipv6: fc00::26e/126
+    bp_interfaces:
+      ipv4: 10.10.246.145/24
+      ipv6: fc0a::91/64
+  ARISTA145T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.56
+          - fc00::271
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.157/32
+        ipv6: 2064:100::9d/128
+      Ethernet1:
+        ipv4: 10.0.1.57/31
+        ipv6: fc00::272/126
+    bp_interfaces:
+      ipv4: 10.10.246.146/24
+      ipv6: fc0a::92/64
+  ARISTA146T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.58
+          - fc00::275
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.158/32
+        ipv6: 2064:100::9e/128
+      Ethernet1:
+        ipv4: 10.0.1.59/31
+        ipv6: fc00::276/126
+    bp_interfaces:
+      ipv4: 10.10.246.147/24
+      ipv6: fc0a::93/64
+  ARISTA147T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.60
+          - fc00::279
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.159/32
+        ipv6: 2064:100::9f/128
+      Ethernet1:
+        ipv4: 10.0.1.61/31
+        ipv6: fc00::27a/126
+    bp_interfaces:
+      ipv4: 10.10.246.148/24
+      ipv6: fc0a::94/64
+  ARISTA148T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.62
+          - fc00::27d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.160/32
+        ipv6: 2064:100::a0/128
+      Ethernet1:
+        ipv4: 10.0.1.63/31
+        ipv6: fc00::27e/126
+    bp_interfaces:
+      ipv4: 10.10.246.149/24
+      ipv6: fc0a::95/64
+  ARISTA149T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.64
+          - fc00::281
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.161/32
+        ipv6: 2064:100::a1/128
+      Ethernet1:
+        ipv4: 10.0.1.65/31
+        ipv6: fc00::282/126
+    bp_interfaces:
+      ipv4: 10.10.246.150/24
+      ipv6: fc0a::96/64
+  ARISTA150T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.66
+          - fc00::285
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.162/32
+        ipv6: 2064:100::a2/128
+      Ethernet1:
+        ipv4: 10.0.1.67/31
+        ipv6: fc00::286/126
+    bp_interfaces:
+      ipv4: 10.10.246.151/24
+      ipv6: fc0a::97/64
+  ARISTA151T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.68
+          - fc00::289
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.163/32
+        ipv6: 2064:100::a3/128
+      Ethernet1:
+        ipv4: 10.0.1.69/31
+        ipv6: fc00::28a/126
+    bp_interfaces:
+      ipv4: 10.10.246.152/24
+      ipv6: fc0a::98/64
+  ARISTA152T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.70
+          - fc00::28d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.164/32
+        ipv6: 2064:100::a4/128
+      Ethernet1:
+        ipv4: 10.0.1.71/31
+        ipv6: fc00::28e/126
+    bp_interfaces:
+      ipv4: 10.10.246.153/24
+      ipv6: fc0a::99/64
+  ARISTA153T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.72
+          - fc00::291
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.165/32
+        ipv6: 2064:100::a5/128
+      Ethernet1:
+        ipv4: 10.0.1.73/31
+        ipv6: fc00::292/126
+    bp_interfaces:
+      ipv4: 10.10.246.154/24
+      ipv6: fc0a::9a/64
+  ARISTA154T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.74
+          - fc00::295
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.166/32
+        ipv6: 2064:100::a6/128
+      Ethernet1:
+        ipv4: 10.0.1.75/31
+        ipv6: fc00::296/126
+    bp_interfaces:
+      ipv4: 10.10.246.155/24
+      ipv6: fc0a::9b/64
+  ARISTA155T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.76
+          - fc00::299
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.167/32
+        ipv6: 2064:100::a7/128
+      Ethernet1:
+        ipv4: 10.0.1.77/31
+        ipv6: fc00::29a/126
+    bp_interfaces:
+      ipv4: 10.10.246.156/24
+      ipv6: fc0a::9c/64
+  ARISTA156T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.78
+          - fc00::29d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.168/32
+        ipv6: 2064:100::a8/128
+      Ethernet1:
+        ipv4: 10.0.1.79/31
+        ipv6: fc00::29e/126
+    bp_interfaces:
+      ipv4: 10.10.246.157/24
+      ipv6: fc0a::9d/64
+  ARISTA157T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.80
+          - fc00::2a1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.169/32
+        ipv6: 2064:100::a9/128
+      Ethernet1:
+        ipv4: 10.0.1.81/31
+        ipv6: fc00::2a2/126
+    bp_interfaces:
+      ipv4: 10.10.246.158/24
+      ipv6: fc0a::9e/64
+  ARISTA158T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.82
+          - fc00::2a5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.170/32
+        ipv6: 2064:100::aa/128
+      Ethernet1:
+        ipv4: 10.0.1.83/31
+        ipv6: fc00::2a6/126
+    bp_interfaces:
+      ipv4: 10.10.246.159/24
+      ipv6: fc0a::9f/64
+  ARISTA159T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.84
+          - fc00::2a9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.171/32
+        ipv6: 2064:100::ab/128
+      Ethernet1:
+        ipv4: 10.0.1.85/31
+        ipv6: fc00::2aa/126
+    bp_interfaces:
+      ipv4: 10.10.246.160/24
+      ipv6: fc0a::a0/64
+  ARISTA160T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.86
+          - fc00::2ad
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.172/32
+        ipv6: 2064:100::ac/128
+      Ethernet1:
+        ipv4: 10.0.1.87/31
+        ipv6: fc00::2ae/126
+    bp_interfaces:
+      ipv4: 10.10.246.161/24
+      ipv6: fc0a::a1/64
+  ARISTA161T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.88
+          - fc00::2b1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.173/32
+        ipv6: 2064:100::ad/128
+      Ethernet1:
+        ipv4: 10.0.1.89/31
+        ipv6: fc00::2b2/126
+    bp_interfaces:
+      ipv4: 10.10.246.162/24
+      ipv6: fc0a::a2/64
+  ARISTA162T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.90
+          - fc00::2b5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.174/32
+        ipv6: 2064:100::ae/128
+      Ethernet1:
+        ipv4: 10.0.1.91/31
+        ipv6: fc00::2b6/126
+    bp_interfaces:
+      ipv4: 10.10.246.163/24
+      ipv6: fc0a::a3/64
+  ARISTA163T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.92
+          - fc00::2b9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.175/32
+        ipv6: 2064:100::af/128
+      Ethernet1:
+        ipv4: 10.0.1.93/31
+        ipv6: fc00::2ba/126
+    bp_interfaces:
+      ipv4: 10.10.246.164/24
+      ipv6: fc0a::a4/64
+  ARISTA164T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.94
+          - fc00::2bd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.176/32
+        ipv6: 2064:100::b0/128
+      Ethernet1:
+        ipv4: 10.0.1.95/31
+        ipv6: fc00::2be/126
+    bp_interfaces:
+      ipv4: 10.10.246.165/24
+      ipv6: fc0a::a5/64
+  ARISTA165T2:
+    properties:
+    - common
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.1.96
+          - fc00::2c1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.177/32
+        ipv6: 2064:100::b1/128
+      Ethernet1:
+        ipv4: 10.0.1.97/31
+        ipv6: fc00::2c2/126
+    bp_interfaces:
+      ipv4: 10.10.246.166/24
+      ipv6: fc0a::a6/64
+  ARISTA166T2:
+    properties:
+    - common
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.1.98
+          - fc00::2c5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.178/32
+        ipv6: 2064:100::b2/128
+      Ethernet1:
+        ipv4: 10.0.1.99/31
+        ipv6: fc00::2c6/126
+    bp_interfaces:
+      ipv4: 10.10.246.167/24
+      ipv6: fc0a::a7/64
+  ARISTA167T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.112
+          - fc00::2e1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.185/32
+        ipv6: 2064:100::b9/128
+      Ethernet1:
+        ipv4: 10.0.1.113/31
+        ipv6: fc00::2e2/126
+    bp_interfaces:
+      ipv4: 10.10.246.168/24
+      ipv6: fc0a::a8/64
+  ARISTA168T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.114
+          - fc00::2e5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.186/32
+        ipv6: 2064:100::ba/128
+      Ethernet1:
+        ipv4: 10.0.1.115/31
+        ipv6: fc00::2e6/126
+    bp_interfaces:
+      ipv4: 10.10.246.169/24
+      ipv6: fc0a::a9/64
+  ARISTA169T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.116
+          - fc00::2e9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.187/32
+        ipv6: 2064:100::bb/128
+      Ethernet1:
+        ipv4: 10.0.1.117/31
+        ipv6: fc00::2ea/126
+    bp_interfaces:
+      ipv4: 10.10.246.170/24
+      ipv6: fc0a::aa/64
+  ARISTA170T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.118
+          - fc00::2ed
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.188/32
+        ipv6: 2064:100::bc/128
+      Ethernet1:
+        ipv4: 10.0.1.119/31
+        ipv6: fc00::2ee/126
+    bp_interfaces:
+      ipv4: 10.10.246.171/24
+      ipv6: fc0a::ab/64
+  ARISTA171T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.120
+          - fc00::2f1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.189/32
+        ipv6: 2064:100::bd/128
+      Ethernet1:
+        ipv4: 10.0.1.121/31
+        ipv6: fc00::2f2/126
+    bp_interfaces:
+      ipv4: 10.10.246.172/24
+      ipv6: fc0a::ac/64
+  ARISTA172T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.122
+          - fc00::2f5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.190/32
+        ipv6: 2064:100::be/128
+      Ethernet1:
+        ipv4: 10.0.1.123/31
+        ipv6: fc00::2f6/126
+    bp_interfaces:
+      ipv4: 10.10.246.173/24
+      ipv6: fc0a::ad/64
+  ARISTA173T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.124
+          - fc00::2f9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.191/32
+        ipv6: 2064:100::bf/128
+      Ethernet1:
+        ipv4: 10.0.1.125/31
+        ipv6: fc00::2fa/126
+    bp_interfaces:
+      ipv4: 10.10.246.174/24
+      ipv6: fc0a::ae/64
+  ARISTA174T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.126
+          - fc00::2fd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.192/32
+        ipv6: 2064:100::c0/128
+      Ethernet1:
+        ipv4: 10.0.1.127/31
+        ipv6: fc00::2fe/126
+    bp_interfaces:
+      ipv4: 10.10.246.175/24
+      ipv6: fc0a::af/64
+  ARISTA175T2:
+    properties:
+    - common
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.1.128
+          - fc00::301
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.193/32
+        ipv6: 2064:100::c1/128
+      Ethernet1:
+        ipv4: 10.0.1.129/31
+        ipv6: fc00::302/126
+    bp_interfaces:
+      ipv4: 10.10.246.176/24
+      ipv6: fc0a::b0/64
+  ARISTA176T2:
+    properties:
+    - common
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.1.130
+          - fc00::305
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.194/32
+        ipv6: 2064:100::c2/128
+      Ethernet1:
+        ipv4: 10.0.1.131/31
+        ipv6: fc00::306/126
+    bp_interfaces:
+      ipv4: 10.10.246.177/24
+      ipv6: fc0a::b1/64
+  ARISTA177T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.144
+          - fc00::321
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.201/32
+        ipv6: 2064:100::c9/128
+      Ethernet1:
+        ipv4: 10.0.1.145/31
+        ipv6: fc00::322/126
+    bp_interfaces:
+      ipv4: 10.10.246.178/24
+      ipv6: fc0a::b2/64
+  ARISTA178T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.146
+          - fc00::325
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.202/32
+        ipv6: 2064:100::ca/128
+      Ethernet1:
+        ipv4: 10.0.1.147/31
+        ipv6: fc00::326/126
+    bp_interfaces:
+      ipv4: 10.10.246.179/24
+      ipv6: fc0a::b3/64
+  ARISTA179T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.148
+          - fc00::329
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.203/32
+        ipv6: 2064:100::cb/128
+      Ethernet1:
+        ipv4: 10.0.1.149/31
+        ipv6: fc00::32a/126
+    bp_interfaces:
+      ipv4: 10.10.246.180/24
+      ipv6: fc0a::b4/64
+  ARISTA180T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.150
+          - fc00::32d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.204/32
+        ipv6: 2064:100::cc/128
+      Ethernet1:
+        ipv4: 10.0.1.151/31
+        ipv6: fc00::32e/126
+    bp_interfaces:
+      ipv4: 10.10.246.181/24
+      ipv6: fc0a::b5/64
+  ARISTA181T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.152
+          - fc00::331
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.205/32
+        ipv6: 2064:100::cd/128
+      Ethernet1:
+        ipv4: 10.0.1.153/31
+        ipv6: fc00::332/126
+    bp_interfaces:
+      ipv4: 10.10.246.182/24
+      ipv6: fc0a::b6/64
+  ARISTA182T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.154
+          - fc00::335
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.206/32
+        ipv6: 2064:100::ce/128
+      Ethernet1:
+        ipv4: 10.0.1.155/31
+        ipv6: fc00::336/126
+    bp_interfaces:
+      ipv4: 10.10.246.183/24
+      ipv6: fc0a::b7/64
+  ARISTA183T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.156
+          - fc00::339
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.207/32
+        ipv6: 2064:100::cf/128
+      Ethernet1:
+        ipv4: 10.0.1.157/31
+        ipv6: fc00::33a/126
+    bp_interfaces:
+      ipv4: 10.10.246.184/24
+      ipv6: fc0a::b8/64
+  ARISTA184T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.158
+          - fc00::33d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.208/32
+        ipv6: 2064:100::d0/128
+      Ethernet1:
+        ipv4: 10.0.1.159/31
+        ipv6: fc00::33e/126
+    bp_interfaces:
+      ipv4: 10.10.246.185/24
+      ipv6: fc0a::b9/64
+  ARISTA185T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.160
+          - fc00::341
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.209/32
+        ipv6: 2064:100::d1/128
+      Ethernet1:
+        ipv4: 10.0.1.161/31
+        ipv6: fc00::342/126
+    bp_interfaces:
+      ipv4: 10.10.246.186/24
+      ipv6: fc0a::ba/64
+  ARISTA186T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.162
+          - fc00::345
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.210/32
+        ipv6: 2064:100::d2/128
+      Ethernet1:
+        ipv4: 10.0.1.163/31
+        ipv6: fc00::346/126
+    bp_interfaces:
+      ipv4: 10.10.246.187/24
+      ipv6: fc0a::bb/64
+  ARISTA187T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.164
+          - fc00::349
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.211/32
+        ipv6: 2064:100::d3/128
+      Ethernet1:
+        ipv4: 10.0.1.165/31
+        ipv6: fc00::34a/126
+    bp_interfaces:
+      ipv4: 10.10.246.188/24
+      ipv6: fc0a::bc/64
+  ARISTA188T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.166
+          - fc00::34d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.212/32
+        ipv6: 2064:100::d4/128
+      Ethernet1:
+        ipv4: 10.0.1.167/31
+        ipv6: fc00::34e/126
+    bp_interfaces:
+      ipv4: 10.10.246.189/24
+      ipv6: fc0a::bd/64
+  ARISTA189T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.168
+          - fc00::351
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.213/32
+        ipv6: 2064:100::d5/128
+      Ethernet1:
+        ipv4: 10.0.1.169/31
+        ipv6: fc00::352/126
+    bp_interfaces:
+      ipv4: 10.10.246.190/24
+      ipv6: fc0a::be/64
+  ARISTA190T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.170
+          - fc00::355
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.214/32
+        ipv6: 2064:100::d6/128
+      Ethernet1:
+        ipv4: 10.0.1.171/31
+        ipv6: fc00::356/126
+    bp_interfaces:
+      ipv4: 10.10.246.191/24
+      ipv6: fc0a::bf/64
+  ARISTA191T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.172
+          - fc00::359
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.215/32
+        ipv6: 2064:100::d7/128
+      Ethernet1:
+        ipv4: 10.0.1.173/31
+        ipv6: fc00::35a/126
+    bp_interfaces:
+      ipv4: 10.10.246.192/24
+      ipv6: fc0a::c0/64
+  ARISTA192T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.174
+          - fc00::35d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.216/32
+        ipv6: 2064:100::d8/128
+      Ethernet1:
+        ipv4: 10.0.1.175/31
+        ipv6: fc00::35e/126
+    bp_interfaces:
+      ipv4: 10.10.246.193/24
+      ipv6: fc0a::c1/64
+  ARISTA193T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.176
+          - fc00::361
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.217/32
+        ipv6: 2064:100::d9/128
+      Ethernet1:
+        ipv4: 10.0.1.177/31
+        ipv6: fc00::362/126
+    bp_interfaces:
+      ipv4: 10.10.246.194/24
+      ipv6: fc0a::c2/64
+  ARISTA194T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.178
+          - fc00::365
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.218/32
+        ipv6: 2064:100::da/128
+      Ethernet1:
+        ipv4: 10.0.1.179/31
+        ipv6: fc00::366/126
+    bp_interfaces:
+      ipv4: 10.10.246.195/24
+      ipv6: fc0a::c3/64
+  ARISTA195T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.180
+          - fc00::369
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.219/32
+        ipv6: 2064:100::db/128
+      Ethernet1:
+        ipv4: 10.0.1.181/31
+        ipv6: fc00::36a/126
+    bp_interfaces:
+      ipv4: 10.10.246.196/24
+      ipv6: fc0a::c4/64
+  ARISTA196T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.182
+          - fc00::36d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.220/32
+        ipv6: 2064:100::dc/128
+      Ethernet1:
+        ipv4: 10.0.1.183/31
+        ipv6: fc00::36e/126
+    bp_interfaces:
+      ipv4: 10.10.246.197/24
+      ipv6: fc0a::c5/64
+  ARISTA197T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.184
+          - fc00::371
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.221/32
+        ipv6: 2064:100::dd/128
+      Ethernet1:
+        ipv4: 10.0.1.185/31
+        ipv6: fc00::372/126
+    bp_interfaces:
+      ipv4: 10.10.246.198/24
+      ipv6: fc0a::c6/64
+  ARISTA198T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.186
+          - fc00::375
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.222/32
+        ipv6: 2064:100::de/128
+      Ethernet1:
+        ipv4: 10.0.1.187/31
+        ipv6: fc00::376/126
+    bp_interfaces:
+      ipv4: 10.10.246.199/24
+      ipv6: fc0a::c7/64
+  ARISTA199T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.188
+          - fc00::379
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.223/32
+        ipv6: 2064:100::df/128
+      Ethernet1:
+        ipv4: 10.0.1.189/31
+        ipv6: fc00::37a/126
+    bp_interfaces:
+      ipv4: 10.10.246.200/24
+      ipv6: fc0a::c8/64
+  ARISTA200T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.190
+          - fc00::37d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.224/32
+        ipv6: 2064:100::e0/128
+      Ethernet1:
+        ipv4: 10.0.1.191/31
+        ipv6: fc00::37e/126
+    bp_interfaces:
+      ipv4: 10.10.246.201/24
+      ipv6: fc0a::c9/64
+  ARISTA201T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.192
+          - fc00::381
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.225/32
+        ipv6: 2064:100::e1/128
+      Ethernet1:
+        ipv4: 10.0.1.193/31
+        ipv6: fc00::382/126
+    bp_interfaces:
+      ipv4: 10.10.246.202/24
+      ipv6: fc0a::ca/64
+  ARISTA202T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.194
+          - fc00::385
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.226/32
+        ipv6: 2064:100::e2/128
+      Ethernet1:
+        ipv4: 10.0.1.195/31
+        ipv6: fc00::386/126
+    bp_interfaces:
+      ipv4: 10.10.246.203/24
+      ipv6: fc0a::cb/64
+  ARISTA203T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.196
+          - fc00::389
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.227/32
+        ipv6: 2064:100::e3/128
+      Ethernet1:
+        ipv4: 10.0.1.197/31
+        ipv6: fc00::38a/126
+    bp_interfaces:
+      ipv4: 10.10.246.204/24
+      ipv6: fc0a::cc/64
+  ARISTA204T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.198
+          - fc00::38d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.228/32
+        ipv6: 2064:100::e4/128
+      Ethernet1:
+        ipv4: 10.0.1.199/31
+        ipv6: fc00::38e/126
+    bp_interfaces:
+      ipv4: 10.10.246.205/24
+      ipv6: fc0a::cd/64
+  ARISTA205T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.200
+          - fc00::391
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.229/32
+        ipv6: 2064:100::e5/128
+      Ethernet1:
+        ipv4: 10.0.1.201/31
+        ipv6: fc00::392/126
+    bp_interfaces:
+      ipv4: 10.10.246.206/24
+      ipv6: fc0a::ce/64
+  ARISTA206T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.202
+          - fc00::395
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.230/32
+        ipv6: 2064:100::e6/128
+      Ethernet1:
+        ipv4: 10.0.1.203/31
+        ipv6: fc00::396/126
+    bp_interfaces:
+      ipv4: 10.10.246.207/24
+      ipv6: fc0a::cf/64
+  ARISTA207T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.204
+          - fc00::399
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.231/32
+        ipv6: 2064:100::e7/128
+      Ethernet1:
+        ipv4: 10.0.1.205/31
+        ipv6: fc00::39a/126
+    bp_interfaces:
+      ipv4: 10.10.246.208/24
+      ipv6: fc0a::d0/64
+  ARISTA208T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.206
+          - fc00::39d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.232/32
+        ipv6: 2064:100::e8/128
+      Ethernet1:
+        ipv4: 10.0.1.207/31
+        ipv6: fc00::39e/126
+    bp_interfaces:
+      ipv4: 10.10.246.209/24
+      ipv6: fc0a::d1/64
+  ARISTA209T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.208
+          - fc00::3a1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.233/32
+        ipv6: 2064:100::e9/128
+      Ethernet1:
+        ipv4: 10.0.1.209/31
+        ipv6: fc00::3a2/126
+    bp_interfaces:
+      ipv4: 10.10.246.210/24
+      ipv6: fc0a::d2/64
+  ARISTA210T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.210
+          - fc00::3a5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.234/32
+        ipv6: 2064:100::ea/128
+      Ethernet1:
+        ipv4: 10.0.1.211/31
+        ipv6: fc00::3a6/126
+    bp_interfaces:
+      ipv4: 10.10.246.211/24
+      ipv6: fc0a::d3/64
+  ARISTA211T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.212
+          - fc00::3a9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.235/32
+        ipv6: 2064:100::eb/128
+      Ethernet1:
+        ipv4: 10.0.1.213/31
+        ipv6: fc00::3aa/126
+    bp_interfaces:
+      ipv4: 10.10.246.212/24
+      ipv6: fc0a::d4/64
+  ARISTA212T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.214
+          - fc00::3ad
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.236/32
+        ipv6: 2064:100::ec/128
+      Ethernet1:
+        ipv4: 10.0.1.215/31
+        ipv6: fc00::3ae/126
+    bp_interfaces:
+      ipv4: 10.10.246.213/24
+      ipv6: fc0a::d5/64
+  ARISTA213T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.216
+          - fc00::3b1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.237/32
+        ipv6: 2064:100::ed/128
+      Ethernet1:
+        ipv4: 10.0.1.217/31
+        ipv6: fc00::3b2/126
+    bp_interfaces:
+      ipv4: 10.10.246.214/24
+      ipv6: fc0a::d6/64
+  ARISTA214T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.218
+          - fc00::3b5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.238/32
+        ipv6: 2064:100::ee/128
+      Ethernet1:
+        ipv4: 10.0.1.219/31
+        ipv6: fc00::3b6/126
+    bp_interfaces:
+      ipv4: 10.10.246.215/24
+      ipv6: fc0a::d7/64
+  ARISTA215T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.220
+          - fc00::3b9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.239/32
+        ipv6: 2064:100::ef/128
+      Ethernet1:
+        ipv4: 10.0.1.221/31
+        ipv6: fc00::3ba/126
+    bp_interfaces:
+      ipv4: 10.10.246.216/24
+      ipv6: fc0a::d8/64
+  ARISTA216T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.222
+          - fc00::3bd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.240/32
+        ipv6: 2064:100::f0/128
+      Ethernet1:
+        ipv4: 10.0.1.223/31
+        ipv6: fc00::3be/126
+    bp_interfaces:
+      ipv4: 10.10.246.217/24
+      ipv6: fc0a::d9/64
+  ARISTA217T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.224
+          - fc00::3c1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.241/32
+        ipv6: 2064:100::f1/128
+      Ethernet1:
+        ipv4: 10.0.1.225/31
+        ipv6: fc00::3c2/126
+    bp_interfaces:
+      ipv4: 10.10.246.218/24
+      ipv6: fc0a::da/64
+  ARISTA218T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.226
+          - fc00::3c5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.242/32
+        ipv6: 2064:100::f2/128
+      Ethernet1:
+        ipv4: 10.0.1.227/31
+        ipv6: fc00::3c6/126
+    bp_interfaces:
+      ipv4: 10.10.246.219/24
+      ipv6: fc0a::db/64
+  ARISTA219T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.228
+          - fc00::3c9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.243/32
+        ipv6: 2064:100::f3/128
+      Ethernet1:
+        ipv4: 10.0.1.229/31
+        ipv6: fc00::3ca/126
+    bp_interfaces:
+      ipv4: 10.10.246.220/24
+      ipv6: fc0a::dc/64
+  ARISTA220T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.230
+          - fc00::3cd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.244/32
+        ipv6: 2064:100::f4/128
+      Ethernet1:
+        ipv4: 10.0.1.231/31
+        ipv6: fc00::3ce/126
+    bp_interfaces:
+      ipv4: 10.10.246.221/24
+      ipv6: fc0a::dd/64
+  ARISTA221T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.232
+          - fc00::3d1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.245/32
+        ipv6: 2064:100::f5/128
+      Ethernet1:
+        ipv4: 10.0.1.233/31
+        ipv6: fc00::3d2/126
+    bp_interfaces:
+      ipv4: 10.10.246.222/24
+      ipv6: fc0a::de/64
+  ARISTA222T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.234
+          - fc00::3d5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.246/32
+        ipv6: 2064:100::f6/128
+      Ethernet1:
+        ipv4: 10.0.1.235/31
+        ipv6: fc00::3d6/126
+    bp_interfaces:
+      ipv4: 10.10.246.223/24
+      ipv6: fc0a::df/64
+  ARISTA223T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.236
+          - fc00::3d9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.247/32
+        ipv6: 2064:100::f7/128
+      Ethernet1:
+        ipv4: 10.0.1.237/31
+        ipv6: fc00::3da/126
+    bp_interfaces:
+      ipv4: 10.10.246.224/24
+      ipv6: fc0a::e0/64
+  ARISTA224T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.238
+          - fc00::3dd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.248/32
+        ipv6: 2064:100::f8/128
+      Ethernet1:
+        ipv4: 10.0.1.239/31
+        ipv6: fc00::3de/126
+    bp_interfaces:
+      ipv4: 10.10.246.225/24
+      ipv6: fc0a::e1/64
+  ARISTA225T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.240
+          - fc00::3e1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.249/32
+        ipv6: 2064:100::f9/128
+      Ethernet1:
+        ipv4: 10.0.1.241/31
+        ipv6: fc00::3e2/126
+    bp_interfaces:
+      ipv4: 10.10.246.226/24
+      ipv6: fc0a::e2/64
+  ARISTA226T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.242
+          - fc00::3e5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.250/32
+        ipv6: 2064:100::fa/128
+      Ethernet1:
+        ipv4: 10.0.1.243/31
+        ipv6: fc00::3e6/126
+    bp_interfaces:
+      ipv4: 10.10.246.227/24
+      ipv6: fc0a::e3/64
+  ARISTA227T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.244
+          - fc00::3e9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.251/32
+        ipv6: 2064:100::fb/128
+      Ethernet1:
+        ipv4: 10.0.1.245/31
+        ipv6: fc00::3ea/126
+    bp_interfaces:
+      ipv4: 10.10.246.228/24
+      ipv6: fc0a::e4/64
+  ARISTA228T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.246
+          - fc00::3ed
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.252/32
+        ipv6: 2064:100::fc/128
+      Ethernet1:
+        ipv4: 10.0.1.247/31
+        ipv6: fc00::3ee/126
+    bp_interfaces:
+      ipv4: 10.10.246.229/24
+      ipv6: fc0a::e5/64
+  ARISTA229T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.248
+          - fc00::3f1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.253/32
+        ipv6: 2064:100::fd/128
+      Ethernet1:
+        ipv4: 10.0.1.249/31
+        ipv6: fc00::3f2/126
+    bp_interfaces:
+      ipv4: 10.10.246.230/24
+      ipv6: fc0a::e6/64
+  ARISTA230T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.250
+          - fc00::3f5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.254/32
+        ipv6: 2064:100::fe/128
+      Ethernet1:
+        ipv4: 10.0.1.251/31
+        ipv6: fc00::3f6/126
+    bp_interfaces:
+      ipv4: 10.10.246.231/24
+      ipv6: fc0a::e7/64
+  ARISTA231T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.252
+          - fc00::3f9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.255/32
+        ipv6: 2064:100::ff/128
+      Ethernet1:
+        ipv4: 10.0.1.253/31
+        ipv6: fc00::3fa/126
+    bp_interfaces:
+      ipv4: 10.10.246.232/24
+      ipv6: fc0a::e8/64
+  ARISTA232T0:
+    properties:
+    - common
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+          - 10.0.1.254
+          - fc00::3fd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.1.0/32
+        ipv6: 2064:100::100/128
+      Ethernet1:
+        ipv4: 10.0.1.255/31
+        ipv6: fc00::3fe/126
+    bp_interfaces:
+      ipv4: 10.10.246.233/24
+      ipv6: fc0a::e9/64

--- a/ansible/veos
+++ b/ansible/veos
@@ -21,6 +21,7 @@ all:
           - t1-64-lag
           - t1-64-lag-clet
           - t1-backend
+          - t1-isolated-d224u8
           - t0
           - t0-16
           - t0-56

--- a/docs/testbed/README.testbed.Overview.md
+++ b/docs/testbed/README.testbed.Overview.md
@@ -143,10 +143,10 @@ Like the T0 type topology, the T1 type topology also has variations:
 
 #### Variation t1-isolated-d224u8
 
-* The DUT has 64 ports (even ports are disabled).
+* The DUT has 232 ports.
 * Requires 232 VMs.
-* 4 of the ports are connected to 8 VMs simulating upstream T2 neighbors. No port-channel is configured for the links between DUT and T2 neighbors.
-* 28 of the ports are connected to 224 VMs simulating downstream T0 neighbors. No port-channel is configured for the links between DUT and T0 neighbors.
+* 8 of the ports are connected to 8 VMs simulating upstream T2 neighbors. No port-channel is configured for the links between DUT and T2 neighbors.
+* 224 of the ports are connected to 224 VMs simulating downstream T0 neighbors. No port-channel is configured for the links between DUT and T0 neighbors.
 
 ### T2 type topology
 

--- a/docs/testbed/README.testbed.Overview.md
+++ b/docs/testbed/README.testbed.Overview.md
@@ -146,7 +146,7 @@ Like the T0 type topology, the T1 type topology also has variations:
 * The DUT has 64 ports (even ports are disabled).
 * Requires 232 VMs.
 * 4 of the ports are connected to 8 VMs simulating upstream T2 neighbors. No port-channel is configured for the links between DUT and T2 neighbors.
-* 28 of the ports are connected to 224 VMs simulating upstream T0 neighbors. No port-channel is configured for the links between DUT and T0 neighbors.
+* 28 of the ports are connected to 224 VMs simulating downstream T0 neighbors. No port-channel is configured for the links between DUT and T0 neighbors.
 
 ### T2 type topology
 

--- a/docs/testbed/README.testbed.Overview.md
+++ b/docs/testbed/README.testbed.Overview.md
@@ -141,6 +141,13 @@ Like the T0 type topology, the T1 type topology also has variations:
 * 16 of the ports are connected to 8 VMs simulating upstream T2 neighbors. Each VM has 2 links connected. The connection to each upstream T2 is configured as a port-channel with 2 links.
 * 16 of the ports are connected to another 16 VMs simulating downstream T0 neighbors. No port-channel is configured for the links between DUT and T0 neighbors.
 
+#### Variation t1-isolated-d224u8
+
+* The DUT has 64 ports (even ports are disabled).
+* Requires 232 VMs.
+* 4 of the ports are connected to 8 VMs simulating upstream T2 neighbors. No port-channel is configured for the links between DUT and T2 neighbors.
+* 28 of the ports are connected to 224 VMs simulating upstream T0 neighbors. No port-channel is configured for the links between DUT and T0 neighbors.
+
 ### T2 type topology
 
 The T2 type topology is to simulate a SONiC DUT running as a T2 device. For a T2 device, in most case it is a chassis with multiple line cards and a supervisor card. For this type of topology, a set of DUT ports on some line cards are connected to VMs simulating upstream T3 neighbors. Another set of DUT ports on some line cards are connected to VMs simulating downstream T1 neighbors.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add a new T1 topology with 224 VMs simulating downstream T0 neighbors and 8 VMs simulating upstream T2 neighbors. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Create a new topo named t1-isolated-d224u8.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
t1-isolated-d224u8

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
