### PR TITLE
[sub_port_interfaces] Exclude ptf_ports from all_up_ports correctly

### DIFF
--- a/tests/sub_port_interfaces/conftest.py
+++ b/tests/sub_port_interfaces/conftest.py
@@ -523,7 +523,11 @@ def apply_balancing_config(duthost, ptfhost, ptfadapter, define_sub_ports_config
         all_up_ports = set()
         for port in list(mg_facts['minigraph_ports'].keys()):
             all_up_ports.add("eth" + str(mg_facts['minigraph_ptf_indices'][port]))
-        src_ports = tuple(all_up_ports.difference(ptf_ports))
+
+        if isinstance(ptf_ports, dict):  # port_type: port_in_lag
+            src_ports = tuple(all_up_ports.difference(set(ptf_ports.values())))
+        else:
+            src_ports = tuple(all_up_ports.difference(ptf_ports))
 
     network = '1.1.1.0/24'
     network = ipaddress.ip_network(network)


### PR DESCRIPTION
Exclude ptf_ports from all_up_ports correctly

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In t1 topology, sometimes, there would be a failure:
test_balancing_sub_ports[port_in_lag]
log:
E Failed: Expected packet not available:

The src_ports should be the result of all_up_ports exclude ptf_ports
but src_ports is dictionary type when port type is port_in_lag, then it will failed to exclude.

Note:
(Pdb) p ptf_ports
OrderedDict([('bond1', 'eth1'), ('bond2', 'eth2')])
(Pdb) p all_up_ports
{'eth28', 'eth19', 'eth16', 'eth31', 'eth23', 'eth24', 'eth29', 'eth21', 'eth18', 'eth1', 'eth20', 'eth22', 'eth9', 'eth3', 'eth12', 'eth7', 'eth30', 'eth6', 'eth5', 'eth4', 'eth8', 'eth11', 'eth15', 'eth13', 'eth2', 'eth17', 'eth14', 'eth10'}

(Pdb) p src_ports
('eth28', 'eth7', 'eth10', 'eth19', 'eth30', 'eth16', 'eth6', 'eth5', 'eth4', 'eth31', 'eth23', 'eth8', 'eth24', 'eth29', 'eth21', 'eth18', '**eth1**', 'eth11', 'eth20', 'eth15', 'eth22', 'eth13', '**eth2**', 'eth9', 'eth17', 'eth14', 'eth3', 'eth12')   

**the src_ports still include eth1, eth2.  NG.**

This update will exclude eth1, eth2 from all_up_ports correctly
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
t1 topology
test_balancing_sub_ports[port_in_lag]   for several times

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
