### PR TITLE
[202305]Add same speed ports into one portchannel for test_fdb (#15163)

### DIFF
--- a/tests/common/helpers/portchannel_to_vlan.py
+++ b/tests/common/helpers/portchannel_to_vlan.py
@@ -5,6 +5,7 @@ import ipaddress
 import time
 import sys
 from netaddr import valid_ipv4
+import logging
 
 from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses    # noqa F401
@@ -97,18 +98,16 @@ def setup_dut_lag(duthost, dut_ports, vlan, src_vlan_id):
 
     lag_port_list = []
     port_list_idx = 0
-    port_list = list(dut_ports[ATTR_PORT_BEHIND_LAG].values())
     # Add ports to port channel
-    for port_list_idx in range(0, len(dut_ports[ATTR_PORT_BEHIND_LAG])):
-        port_name = port_list[port_list_idx]
+    for port_id, port_name in dut_ports[ATTR_PORT_BEHIND_LAG].items():
+        logging.info("add member for port id {} port name {}".format(port_id, port_name))
         duthost.del_member_from_vlan(src_vlan_id, port_name)
         duthost.shell("config portchannel member add {} {}".format(DUT_LAG_NAME, port_name))
         lag_port_list.append(port_name)
         port_list_idx += 1
-    port_list = list(dut_ports[ATTR_PORT_NO_TEST].values())
     # Remove ports from vlan
-    for port_list_idx in range(0, len(dut_ports[ATTR_PORT_NO_TEST])):
-        port_name = port_list[port_list_idx]
+    for port_id, port_name in dut_ports[ATTR_PORT_NO_TEST].items():
+        logging.info("delete member from vlan for port id {} port name {}".format(port_id, port_name))
         duthost.del_member_from_vlan(src_vlan_id, port_name)
 
     duthost.shell("config vlan add {}".format(vlan["id"]))
@@ -191,12 +190,23 @@ def setup_dut_ptf(ptfhost, duthost, tbinfo, vlan_intfs_dict):
     for port_name, _ in list(src_vlan_members.items()):
         port_id = port_index_map[port_name]
         if len(dut_ports[ATTR_PORT_BEHIND_LAG]) < number_of_lag_member:
-            dut_ports[ATTR_PORT_BEHIND_LAG][port_id] = port_name
-        elif len(dut_ports[ATTR_PORT_TEST]) < number_of_test_ports:
+            if len(dut_ports[ATTR_PORT_BEHIND_LAG]) == 0:
+                dut_ports[ATTR_PORT_BEHIND_LAG][port_id] = port_name
+                continue
+            # Get the speed of the current port
+            port_speed = cfg_facts["PORT"][port_name]['speed']
+            # Only choose same speed for the ports in a same lag
+            first_port_name = list(dut_ports[ATTR_PORT_BEHIND_LAG].values())[0]
+            first_port_speed = cfg_facts["PORT"][first_port_name]['speed']
+            # Only add same speed ports into portchannel, otherwise adding member will fail
+            if len(dut_ports[ATTR_PORT_BEHIND_LAG]) > 0 and port_speed == first_port_speed:
+                dut_ports[ATTR_PORT_BEHIND_LAG][port_id] = port_name
+                continue
+        if len(dut_ports[ATTR_PORT_TEST]) < number_of_test_ports:
             dut_ports[ATTR_PORT_TEST][port_id] = port_name
         else:
             dut_ports[ATTR_PORT_NO_TEST][port_id] = port_name
-
+    logging.info("dut_ports:{}".format(dut_ports))
     ptf_ports = {
         ATTR_PORT_BEHIND_LAG: {},
     }


### PR DESCRIPTION
What is the motivation for this PR?
test_fdb failed on t0-118, Ethernet0 and Etherent10 has different speed, Etherent0 becomes 100G, not 50G. It will have "Error: Port speed of Ethernet10 is different than the other members of the portchannel PortChannel1" if add those 2 ports into one portchannel.

How did you do it?
Update setup_dut_ptf function to pick up same speed ports. Improve setup_dut_lag function to loop dut_ports[ATTR_PORT_BEHIND_LAG] items, no need to create a new list to get its port name. dut_ports[ATTR_PORT_BEHIND_LAG] looks like this:
port_behind_lag': {0: 'Ethernet0', 1: 'Ethernet4'}

How did you verify/test it?
run fdb/test_fdb.py.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Cherry pick https://github.com/sonic-net/sonic-mgmt/pull/15163

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
