### PR TITLE
[ansible][minigraph] Fix minigraph template for devices which have autoneg enabled but the topo file does not contain autoneg interfaces

### DIFF
--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -53,7 +53,7 @@
   </LinkMetadataDeclaration>
 {% endif %}
 
-{% if msft_an_enabled is defined %}
+{% if msft_an_enabled is defined and vm_topo_config.get('autoneg_interfaces') is not none %}
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% for if_index in vm_topo_config['autoneg_interfaces']['intfs'] %}


### PR DESCRIPTION
… (#15134)
cherry-pick #15134 

This pull request updates the Jinja2 template minigraph_link_meta.j2 by modifying the generation of the section.

Key Changes:
* The condition has been changed from simply checking if msft_an_enabled is defined to also checking if vm_topo_config.get('autoneg_interfaces') is not None.
* This ensures that the section is only included if both msft_an_enabled is defined and the autoneg_interfaces attribute in vm_topo_config exists and is not None.

This ensures if some testbeds/devices have msft_an_enabled they do not end up treated as autoneg devices unless the topo file contains the AN interface list

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
