### PR TITLE
[ansible][minigraph] add support for adding autonegotiation in minigraph templates and fanout EOS (#13990)

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -311,7 +311,7 @@ error handling: checks if attribute values are None type or string "None"
 
 
 def makeSonicLabLinks(data, outfile):
-    csv_columns = "StartDevice,StartPort,EndDevice,EndPort,BandWidth,VlanID,VlanMode,SlotId"
+    csv_columns = "StartDevice,StartPort,EndDevice,EndPort,BandWidth,VlanID,VlanMode,AutoNeg,SlotId"
     topology = data
     csv_file = outfile
 
@@ -331,6 +331,7 @@ def makeSonicLabLinks(data, outfile):
                     bandWidth = element.get("Bandwidth")
                     vlanID = element.get("VlanID")
                     vlanMode = element.get("VlanMode")
+                    AutoNeg = element.get("AutoNeg")
                     slotId = element.get("SlotId")
 
                     # catch empty values
@@ -346,10 +347,13 @@ def makeSonicLabLinks(data, outfile):
                         vlanMode = ""
                     if not slotId:
                         slotId = ""
+                    if not AutoNeg:
+                        AutoNeg = ""
 
                     row = startDevice + "," + startPort + "," + endDevice + "," + \
                         endPort + "," + str(bandWidth) + \
                         "," + str(vlanID) + "," + vlanMode + \
+                        "," + str(AutoNeg) + \
                         "," + str(slotId)
                     f.write(row + "\n")
     except IOError:

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -299,6 +299,7 @@ class LabGraph(object):
             band_width = link["BandWidth"]
             vlan_ID = link["VlanID"]
             vlan_mode = link["VlanMode"]
+            autoneg_mode = link.get("AutoNeg", "off")
 
             if start_device not in links:
                 links[start_device] = {}
@@ -313,11 +314,13 @@ class LabGraph(object):
                 "peerdevice": end_device,
                 "peerport": end_port,
                 "speed": band_width,
+                "autoneg": autoneg_mode,
             }
             links[end_device][end_port] = {
                 "peerdevice": start_device,
                 "peerport": start_port,
                 "speed": band_width,
+                "autoneg": autoneg_mode,
             }
 
             port_vlans[start_device][start_port] = {

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -328,6 +328,8 @@ class ParseTestbedTopoinfo():
 
         if 'DUT' in topo_definition['topology']:
             vm_topo_config['DUT'] = topo_definition['topology']['DUT']
+            if 'autoneg_interfaces' in vm_topo_config['DUT']:
+                vm_topo_config['autoneg_interfaces'] = topo_definition['topology']['DUT']['autoneg_interfaces']
         else:
             vm_topo_config['DUT'] = {}
 

--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -36,14 +36,20 @@ interface defaults
 {% for intf in device_port_vlans[inventory_hostname] %}
 interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
+# TODO: Add an additional var/check in fanout devices if autoneg is enabled with the below check
+{%     if device_conn[inventory_hostname][intf]['autoneg']|lower == "on" %}
+   speed auto {{ device_conn[inventory_hostname][intf]['speed'] }}full
+{%   else %}
    speed force {{ device_conn[inventory_hostname][intf]['speed'] }}full
+{%     endif %}
 {%   if device_port_vlans[inventory_hostname][intf]['mode'] == 'Trunk' %}
    switchport mode trunk
    switchport trunk allowed vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
 {%   else %}
    switchport mode dot1q-tunnel
    switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" %}
+# TODO: Add an additional var/check in fanout devices if autoneg is enabled with the below check
+{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" and device_conn[inventory_hostname][intf]['autoneg']|lower == "off" %}
    error-correction encoding reed-solomon
 {%     else %}
    no error-correction encoding

--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -39,8 +39,13 @@ vrf definition management
    switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
+{% if device_conn[inventory_hostname][intf]['autoneg']|lower == "on" %}
+   speed auto {{ device_conn[inventory_hostname][intf]['speed'] }}full
+   no error-correction encoding
+{%     else %}
    speed forced 100gfull
    error-correction encoding reed-solomon
+{%     endif %}
    no shutdown
 {%     elif device_conn[inventory_hostname][intf]['speed'] == "40000" %}
    interface {{ intf }}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -32,7 +32,12 @@
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% for if_index in vm_topo_config['autoneg_interfaces']['intfs'] %}
+
+{% if "mellanox" in device_info[inventory_hostname]['HwSku']|lower %}
+{% set autoneg_intf = "etp" ~ if_index %}
+{% else %}
 {% set autoneg_intf = "Ethernet" ~ if_index ~ "/1" %}
+{% endif %}
 {% if device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['autoneg']|lower == "on" %}
         <a:LinkMetadata>
             <a:Name i:nil="true"/>

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -27,3 +27,30 @@
     </Link>
   </LinkMetadataDeclaration>
 {% endif %}
+
+{% if msft_an_enabled is defined %}
+  <LinkMetadataDeclaration>
+    <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+{% for if_index in vm_topo_config['autoneg_interfaces']['intfs'] %}
+{% set autoneg_intf = "Ethernet" ~ if_index ~ "/1" %}
+{% if device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['autoneg']|lower == "on" %}
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+            <a:DeviceProperty>
+                 <a:Name>AutoNegotiation</a:Name>
+                 <a:Value>True</a:Value>
+            </a:DeviceProperty>
+            <a:DeviceProperty>
+                 <a:Name>FECDisabled</a:Name>
+                 <a:Reference i:nil="true"/>
+                 <a:Value>True</a:Value>
+            </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>{{ device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['peerdevice'] }}:{{ device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['peerport'] }};{{ inventory_hostname }}:{{ autoneg_intf }}</a:Key>
+        </a:LinkMetadata>
+{% endif %}
+{% endfor %}
+    </Link>
+  </LinkMetadataDeclaration>
+{% endif %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -28,7 +28,7 @@
   </LinkMetadataDeclaration>
 {% endif %}
 
-{% if msft_an_enabled is defined %}
+{% if msft_an_enabled is defined and vm_topo_config.get('autoneg_interfaces') is not none %}
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% for if_index in vm_topo_config['autoneg_interfaces']['intfs'] %}

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -136,6 +136,13 @@
             <a:Value>{{ switch_type }}</a:Value>
           </a:DeviceProperty>
 {% endif %}
+{% if msft_an_enabled is defined %}
+          <a:DeviceProperty>
+            <a:Name>AutoNegotiation</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>{{ msft_an_enabled }}</a:Value>
+          </a:DeviceProperty>
+{% endif %}
 {% if num_asics == 1 and switch_type is defined and switch_type == 'voq' %}
           <a:DeviceProperty>
             <a:Name>SwitchId</a:Name>

--- a/ansible/vars/topo_t0-116.yml
+++ b/ansible/vars/topo_t0-116.yml
@@ -134,6 +134,8 @@ topology:
         - 31
       vm_offset: 3
   DUT:
+    autoneg_interfaces:
+      intfs: [13, 14, 15, 16]
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:

--- a/ansible/vars/topo_t0.yml
+++ b/ansible/vars/topo_t0.yml
@@ -51,6 +51,8 @@ topology:
         - 31
       vm_offset: 3
   DUT:
+    autoneg_interfaces:
+      intfs: [7, 8, 9, 10]
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:


### PR DESCRIPTION
…

cherry-pick #13990 
cherry-pick #15134 
cherry-pick #15004 

These changes add a support for adding auto negotiation to specific testbed based on variables defined in ansible

Two things are required for autoneg support

1. autoneg_enabled : True must be enabled in inventory files
2. t0 topo file must have a port list for autoneg Example:
intfs : [1, 2, 3, 4, 5, 6, 7, 8]
With these changes the PR includes changes to pick the port numbering from topo file and apply minigraph parsing changes such that during deploy-mg or gen-mg the required ports have autoneg and deployment is clean with link up

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
