### PR TITLE
[sonic-mgmt][conditional_mark] Remove incorrect quotes around github issue url

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -155,7 +155,7 @@ bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot:
              or over topologies which doesn't support slb."
     conditions_logical_operator: or
     conditions:
-      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56'] and 'https://github.com/sonic-net/sonic-mgmt/issues/9201'"
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56'] and https://github.com/sonic-net/sonic-mgmt/issues/9201"
       - "'backend' in topo_name or 'mgmttor' in topo_name"
 
 bgp/test_bgp_speaker.py:
@@ -797,7 +797,7 @@ generic_config_updater/test_eth_interface.py::test_replace_fec:
              / generic_config_updater is not a supported feature for T2'
     conditions_logical_operator: "OR"
     conditions:
-      - "hwsku in ['Arista-7260CX3-D108C8', 'Arista-7260CX3-Q64', 'Mellanox-SN3800-D112C8'] and 'https://github.com/sonic-net/sonic-mgmt/issues/11237'"
+      - "hwsku in ['Arista-7260CX3-D108C8', 'Arista-7260CX3-Q64', 'Mellanox-SN3800-D112C8'] and https://github.com/sonic-net/sonic-mgmt/issues/11237"
       - "'t2' in topo_name"
 
 generic_config_updater/test_eth_interface.py::test_toggle_pfc_asym:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Remove incorrect quotes around github issue url in tests_mark_conditions.yaml file.
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/281

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
PR#https://github.com/sonic-net/sonic-mgmt/pull/14912 has introduced single quotes around github issue url and this is causing conditional mark evaluation to fail. Thus conditional mark config is not honored and couple of tests are getting scheduled even though they are supposed to be skipped. 

```
07:58:59 __init__.evaluate_condition              L0504 ERROR  | Failed to evaluate condition, raw_condition=hwsku in ['Arista-7260CX3-D108C8', 'Arista-7260CX3-Q64', 'Mellanox-SN3800-D112C8'] and 'https://github.com/sonic-net/sonic-mgmt/issues/11237', condition_str=hwsku in ['Arista-7260CX3-D108C8', 'Arista-7260CX3-Q64', 'Mellanox-SN3800-D112C8'] and 'True
Traceback (most recent call last):
  File "/data/sonic-mgmt/tests/common/plugins/conditional_mark/__init__.py", line 499, in evaluate_condition
    condition_result = bool(eval(condition_str, basic_facts))
  File "<string>", line 1
    hwsku in ['Arista-7260CX3-D108C8', 'Arista-7260CX3-Q64', 'Mellanox-SN3800-D112C8'] and 'True
                                                                                               ^
SyntaxError: EOL while scanning string literal
collected 2 items
```


#### How did you do it?
Removed those unnecessary single quotes around the url.

#### How did you verify/test it?
Ran `generic_config_updater/test_eth_interface.py::test_replace_fec` and it's getting skipped correctly on `Arista-7260CX3-D108C8` platform (currently it's getting scheduled and failing due to PR#14912).

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
