### PR TITLE
Ansible error formatting

### DIFF
--- a/tests/common/errors.py
+++ b/tests/common/errors.py
@@ -10,11 +10,25 @@ class UnsupportedAnsibleModule(Exception):
 
 
 def dump_ansible_results(results, stdout_callback='json'):
-    try:
-        cb = callback_loader.get(stdout_callback)
-        return cb._dump_results(results) if cb else results
-    except Exception:
-        return str(results)
+    simple_attrs = ""
+    stdout = "stdout =\n"
+    stderr = "stderr =\n"
+    for key in results:
+        if key in ['stdout', 'stderr', 'stdout_lines', 'stderr_lines']:
+            if '_lines' in key:
+                text = "\n".join(results[key])
+            else:
+                if str(key) + "_lines" in results:
+                    # Skip when _lines is present
+                    continue
+                text = str(results[key])
+            if "err" in key:
+                stderr += text
+            else:
+                stdout += text
+        else:
+            simple_attrs += "{} = {}\n".format(key, results[key])
+    return "{}\n\n{}\n\n{}".format(simple_attrs, stdout, stderr)
 
 
 class RunAnsibleModuleFail(AnsibleError):

--- a/tests/common/errors.py
+++ b/tests/common/errors.py
@@ -26,7 +26,7 @@ def dump_ansible_results(results):
                 stderr += text
         else:
             simple_attrs += "{} = {}\n".format(key, results[key])
-    return "{}\n\n{}\n\n{}".format(simple_attrs, stdout, stderr)
+    return "{}{}{}".format(simple_attrs, stdout, stderr)
 
 
 class RunAnsibleModuleFail(AnsibleError):

--- a/tests/common/errors.py
+++ b/tests/common/errors.py
@@ -2,30 +2,28 @@
 Customize exceptions
 """
 from ansible.errors import AnsibleError
-from ansible.plugins.loader import callback_loader
 
 
 class UnsupportedAnsibleModule(Exception):
     pass
 
 
-def dump_ansible_results(results, stdout_callback='json'):
+def dump_ansible_results(results):
+    """Dump ansible results in a clean format.
+    Prints simple attributes printed first, followed by the stdout and stderr."""
     simple_attrs = ""
     stdout = "stdout =\n"
     stderr = "stderr =\n"
     for key in results:
-        if key in ['stdout', 'stderr', 'stdout_lines', 'stderr_lines']:
-            if '_lines' in key:
-                text = "\n".join(results[key])
-            else:
-                if str(key) + "_lines" in results:
-                    # Skip when _lines is present
-                    continue
-                text = str(results[key])
-            if "err" in key:
-                stderr += text
-            else:
+        if key in ['stdout', 'stderr']:
+            # Use stdout_lines and stderr_lines instead
+            continue
+        if '_lines' in key:
+            text = "\n".join(results[key])
+            if key == 'stdout_lines':
                 stdout += text
+            else:
+                stderr += text
         else:
             simple_attrs += "{} = {}\n".format(key, results[key])
     return "{}\n\n{}\n\n{}".format(simple_attrs, stdout, stderr)

--- a/tests/common/errors.py
+++ b/tests/common/errors.py
@@ -2,6 +2,7 @@
 Customize exceptions
 """
 from ansible.errors import AnsibleError
+from ansible.plugins.loader import callback_loader
 
 
 class UnsupportedAnsibleModule(Exception):

--- a/tests/common/errors.py
+++ b/tests/common/errors.py
@@ -2,7 +2,6 @@
 Customize exceptions
 """
 from ansible.errors import AnsibleError
-from ansible.plugins.loader import callback_loader
 
 
 class UnsupportedAnsibleModule(Exception):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Revises ansible error output to be custom formatted such that it prints in the following order:
1. Random fields that don't involve readable text printing, such as the command used or how long the test ran.
2. stdout_lines formatted with proper newlines. 
3. stderr_lines also formatted. 

The output is sorted with the most interesting failure information at the bottom, namely the stderr. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

Inserted an artificial error on a Cisco-8000 series device, observed below output (trimmed out the tail of the cmd and invocation  fields):
```
E           tests.common.errors.RunAnsibleModuleFail: run module shell failed, Ansible Results =>
E           failed = True
E           changed = True
E           end = 2024-10-28 15:03:26.079813
E           cmd = /root/env-python3/bin/ptf --test-dir saitests/py3 sai_qos_tests.PFCtest ...
E           delta = 0:00:38.058404
E           rc = 1
E           invocation = {'module_args': {'creates': None, ...
E           start = 2024-10-28 15:02:48.021409
E           msg = non-zero return code
E           _ansible_no_log = None
E
E
E           stdout =
E           Using packet manipulation module: ptf.packet_scapy
E
E           ******************************************
E           ATTENTION: SOME TESTS DID NOT PASS!!!
E
E           The following tests failed:
E           PFCtest
E
E           ******************************************
E
E           stderr =
E           sai_qos_tests.PFCtest ... test dst_port_id: 4, src_port_id: 1, src_vlan: None
E           actual dst_port_id: 4
E           after send packets short of triggering PFC:
E               recv_counters [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 274295, 2756, 0, 0, 298189, 0, 0, 0]
E               recv_counters_base [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 239377, 2357, 0, 0, 149657, 0, 0, 0]
E               xmit_counters [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10403712, 151749, 0, 0, 1384, 0, 0, 0]
E               xmit_counters_base [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10338490, 150820, 0, 0, 1268, 0, 0, 0]
E
E           FAIL
E
E           ======================================================================
E           FAIL: sai_qos_tests.PFCtest
E           ----------------------------------------------------------------------
E           Traceback (most recent call last):
E             File "saitests/py3/sai_qos_tests.py", line 1812, in runTest
E               'ERROR TESTING - unexpectedly PFC counter increase, {}'.format(test_stage))
E             File "saitests/py3/sai_qos_tests.py", line 293, in qos_test_assert
E               assert condition, message
E           AssertionError: ERROR TESTING - unexpectedly PFC counter increase, after send packets short of triggering PFC
E
E           ----------------------------------------------------------------------
E           Ran 1 test in 37.176s
E
E           FAILED (failures=1)
```

#### Any platform specific information?

Will affect all platforms. 

#### Supported testbed topology if it's a new test case?

Will affect all topologies.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
