### PR TITLE
Add handling of VOQ_CHASSIS iBGP entries in test_bgp_queues.py

### DIFF
--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -59,9 +59,9 @@ def test_bgp_queues(duthosts, enum_frontend_dut_hostname, enum_asic_index, tbinf
     for k, v in list(bgp_facts['bgp_neighbors'].items()):
         # Only consider established bgp sessions
         if v['state'] == 'established':
-            # For "peer group" if it's internal it will be "INTERNAL_PEER_V4" or "INTERNAL_PEER_V6"
+            # For "peer group" if it's internal it will be "INTERNAL_PEER_V4", "INTERNAL_PEER_V6", "VOQ_CHASSIS_V4_PEER" or "VOQ_CHASSIS_V6_PEER"
             # If it's external it will be "RH_V4", "RH_V6", "AH_V4", "AH_V6", ...
-            if "INTERNAL" in v["peer group"] and duthost.get_facts().get('modular_chassis'):
+            if ("INTERNAL" in v["peer group"] or "VOQ_CHASSIS" in v["peer group"]) and duthost.get_facts().get('modular_chassis'):
                 # Skip iBGP neighbors since we only want to verify eBGP
                 continue
             assert (k in arp_dict.keys() or k in ndp_dict.keys())


### PR DESCRIPTION
https://github.com/sonic-net/sonic-mgmt/pull/14310 added skipping iBGP entries in `test_bgp_queues.py` but this doesn't work for VOQ chassis systems.
Added condition to also skip on VOQ chassis systems.

Summary:
Fixes #15213

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405