### PR TITLE
[202405] Support t1-32-lag topology in qos sai test

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -38,7 +38,7 @@ class QosBase:
     SUPPORTED_T0_TOPOS = ["t0", "t0-56-po2vlan", "t0-64", "t0-116", "t0-35", "dualtor-56", "dualtor-64", "dualtor-120",
                           "dualtor", "t0-120", "t0-80", "t0-backend", "t0-56-o8v48", "t0-8-lag", "t0-standalone-32",
                           "t0-standalone-64", "t0-standalone-128", "t0-standalone-256"]
-    SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-56-lag", "t1-backend", "t1-28-lag"]
+    SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-56-lag", "t1-backend", "t1-28-lag", "t1-32-lag"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
     SUPPORTED_ASIC_LIST = ["pac", "gr", "gr2", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "td3", "th3",
                            "j2c+", "jr2", "th5"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The PR is to backport https://github.com/sonic-net/sonic-mgmt/pull/13048 to 202405 branch.
Below `KeyError` issue will be fixed.
```
KeyError(0)
Traceback (most recent call last):
  File "/var/src/sonic-mgmt_vms7-t1-4700-5_663c03f52c964d8bf34904c3/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/var/src/sonic-mgmt_vms7-t1-4700-5_663c03f52c964d8bf34904c3/tests/qos/qos_sai_base.py", line 1222, in dutConfig
    testPorts = self.__buildTestPorts(request, testPortIds, testPortIps, src_port_ids, dst_port_ids,
  File "/var/src/sonic-mgmt_vms7-t1-4700-5_663c03f52c964d8bf34904c3/tests/qos/qos_sai_base.py", line 745, in __buildTestPorts
    src_dut_port_ids = testPortIds[get_src_dst_asic_and_duts['src_dut_index']]
KeyError: 0
ERROR    
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
This PR is to fix KeyError issue in qos sai test.

#### How did you do it?
Add the new topology into the supported topologies list.

#### How did you verify/test it?
The change is verified in nightly test in 202311 branch.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
