### PR TITLE
skip vxlan_decap testcase on cisco 8122 platform - New

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2059,6 +2059,12 @@ vxlan/test_vxlan_crm.py::Test_VxLAN_Crm::test_crm_512_nexthop_groups[v6_in_v6]:
       - "(is_multi_asic == True) or (platform not in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn4280-r0'])"
       - "asic_gen == 'spc1'"
 
+vxlan/test_vxlan_decap.py:
+  skip:
+    reason: "vxlan support not available for cisco-8122 platforms"
+    conditions:
+      - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
+
 vxlan/test_vxlan_ecmp.py:
   skip:
     reason: "VxLAN ECMP test is not yet supported on multi-ASIC platform. Also this test can only run on some platforms."


### PR DESCRIPTION
**What is the motivation for this PR?**
Skipping test_vxlan_decap testcase as vxlan support is not available for cisco 8122 platforms.

**How did you do it?**
Added a skip condition for test vxlan/test_vxlan_decap.py for cisco 8122 platforms in file tests/common/plugins/conditional_mark/tests_mark_conditions.yaml

**Type of change** 
-Test modification

**Back port request** 
-202311
-202405


**How did you verify/test it?**
Ran vxlan/test_vxlan_decap.py for Cisco 8122 platform. Made sure it was skipped with 'vxlan support not available for cisco-8122 platform'