### PR TITLE
feat: add mac entry count to sanity

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -109,6 +109,9 @@ def filter_check_items(tbinfo, check_items):
     if 'dualtor' not in tbinfo['topo']['name'] and 'check_mux_simulator' in filtered_check_items:
         filtered_check_items.remove('check_mux_simulator')
 
+    if 't2' not in tbinfo['topo']['name'] and 'check_mac_entry_count' in filtered_check_items:
+        filtered_check_items.remove('check_mac_entry_count')
+
     return filtered_check_items
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add MAC entry count check to sanity check for T2 topo.

Summary:
Fixes # (issue) Microsoft ADO 29825466

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
During our T2 Nightly run, we found that there will be a chance that the port channel connection between 2 ASICs is up but MAC address was not being learnt. Therefore, we need to have sanity check to make sure all the MAC addresses have been learned by the T2 supervisor, otherwise issue like this will affect the test result and can impact production env.

#### How did you do it?
Adding `check_mac_entry_count()` function to sanity check for T2 topo supervisor only. This check will take ~17 seconds to finish.

#### How did you verify/test it?
Run the updated code on T2 and can confirm it's checking the MAC entry count properly. Besides, I can also confirm that this check will be skipped on non-T2 devices.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T2

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
