### PR TITLE
[dualtor][mux_simulator] Fix mux simulator stuck

### DIFF
--- a/ansible/roles/vm_set/files/mux_simulator.py
+++ b/ansible/roles/vm_set/files/mux_simulator.py
@@ -8,6 +8,7 @@ import random
 import re
 import shlex
 import subprocess
+import socket
 import sys
 import threading
 import traceback
@@ -966,4 +967,5 @@ if __name__ == '__main__':
     app.logger.info('Starting server on port {}'.format(sys.argv[1]))
     create_muxes(arg_vm_set)
     app.logger.info('####################### STARTING HTTP SERVER #######################')
-    app.run(host='0.0.0.0', port=http_port, threaded=False)
+    socket.setdefaulttimeout(60)
+    app.run(host='0.0.0.0', port=http_port, threaded=True)

--- a/ansible/roles/vm_set/files/mux_simulator.py
+++ b/ansible/roles/vm_set/files/mux_simulator.py
@@ -968,4 +968,4 @@ if __name__ == '__main__':
     create_muxes(arg_vm_set)
     app.logger.info('####################### STARTING HTTP SERVER #######################')
     socket.setdefaulttimeout(60)
-    app.run(host='0.0.0.0', port=http_port, threaded=True)
+    app.run(host='0.0.0.0', port=http_port, threaded=True)          # nosemgrep


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Active-standby Dualtor is failing to talk to `mux_simulator`:
```
# curl -v http://10.64.246.154:8082/mux/vms24-7/24
*   Trying 10.64.246.154:8082...
```
* on the test server, TCP syn drops are reported increasing:
```
# netstat -s | grep -i listen
    1531500 times the listen queue of a socket overflowed
    1531501 SYNs to LISTEN sockets dropped
```
* mux simulator sync queue is overflowing:
```
# ss -lnt
State                     Recv-Q                     Send-Q                                          Local Address:Port                                         Peer Address:Port
LISTEN                    129                          128                                                   0.0.0.0:8082                                              0.0.0.0:*
```
* It appeared that `mux_simulator` is stuck in the `recvfrom`:
```
# strace -p 21315
strace: Process 21315 attached
recvfrom(6,
```
* and there is no existing TCP connection on the test server/DUT for fd 6.

`mux_simulator` is blocking reading from an already closed TCP connection, so subsequent HTTP requests cannot be handled properly, which resulted in the TCP sync queue overflow.

#### How did you do it?
1. Enable `mux_simulator` to work in threaded mode.
2. Set socket timeout to 60s, if a worker thread stucks in the `recvfrom` like this, this will ensure the work thread exits after 60s, so no resource leak.

#### How did you verify/test it?
Run `mux_simulator` with the change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
