### PR TITLE
[GCU] [MA] Adding support in existing tests - kubernetes

### DIFF
--- a/tests/generic_config_updater/test_kubernetes_config.py
+++ b/tests/generic_config_updater/test_kubernetes_config.py
@@ -179,6 +179,10 @@ test_data_2 = [
 ]
 
 
+def add_namespace_indentation(multiline_string, spaces=4):
+    return multiline_string.replace('\n', '\n' + ' ' * spaces)
+
+
 @pytest.fixture(autouse=True)
 def setup_env(duthosts, rand_one_dut_hostname):
     """
@@ -265,6 +269,13 @@ def k8s_config_update(duthost, test_data):
     for num, (json_patch, target_config, target_table, expected_result) in enumerate(test_data):
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
+
+        if duthost.is_multi_asic:
+            json_namespace = '/localhost'
+            for patch in json_patch:
+                if 'path' in patch:
+                    patch['path'] = re.sub(r'^/', f'/{json_namespace}/', patch['path'])
+            target_config = [add_namespace_indentation(item) for item in target_config]
 
         try:
             output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR adds changes for adding Multi-ASIC support for generic config updater (GCU) in existing test_kubernetes suite.
Original ticket that got splitted: https://github.com/sonic-net/sonic-mgmt/pull/14070
This change has a dependency on common changes added via https://github.com/sonic-net/sonic-mgmt/pull/15182

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ X] 202405

### Approach
#### What is the motivation for this PR?
To add  support for Multi-ASIC testing in existing GCU suite generic_config_updater/test_kubernetes.py.
#### How did you do it?

#### How did you verify/test it?
Ran in vs-kvm-t0 testbed. Ran in t2 MA platform.
![image](https://github.com/user-attachments/assets/f6750649-9431-4854-9cab-57be0ef0c03f)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
