### PR TITLE
Fix skip condition for test_pfc_asym_off_rx_pause_frames

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1255,9 +1255,7 @@ pfc_asym/test_pfc_asym.py:
 
 pfc_asym/test_pfc_asym.py::test_pfc_asym_off_rx_pause_frames:
    skip:
-     reason: "skipped for Barefoot platform"
-     conditions:
-        - "asic_type in ['barefoot']"
+     reason: "skipped for all platforms"
 
 #######################################
 #####         pfcwd               #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix skip condition for test_pfc_asym_off_rx_pause_frames
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
test_pfc_asym_off_rx_pause_frames was skipped on all platforms. However, after the new match rule of conditional marks, the longest matching entry is picked up, making test_pfc_asym_off_rx_pause_frames not skipped on certain platforms. 

#### How did you do it?
test_pfc_asym_off_rx_pause_frames should be skipped on all platforms to be equivalent to the skip condition before the new match rule.

#### How did you verify/test it?
Check that test_pfc_asym_off_rx_pause_frames is skipped
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
