### PR TITLE
Skip RX_DRP check on Mellanox platform in test_drop_l3_ip_packet_non_dut_mac

### DIFF
--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -725,8 +725,11 @@ class TestIPPacket(object):
             return
         pytest_assert(rx_ok >= self.PKT_NUM_MIN,
                       "Received {} packets in rx, not in expected range".format(rx_ok))
-        pytest_assert(rx_drp >= self.PKT_NUM_MIN,
-                      "Dropped {} packets in rx, not in expected range".format(rx_drp))
+        asic_type = duthost.facts["asic_type"]
+        # Packet is dropped silently on Mellanox platform if the destination MAC address is not the router MAC
+        if asic_type not in ["mellanox"]:
+            pytest_assert(rx_drp >= self.PKT_NUM_MIN,
+                          "Dropped {} packets in rx, not in expected range".format(rx_drp))
         pytest_assert(tx_ok <= self.PKT_NUM_ZERO,
                       "Forwarded {} packets in tx, not in expected range".format(tx_ok))
         pytest_assert(max(tx_drp, tx_rif_err) <= self.PKT_NUM_ZERO,


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to skip `RX_DRP` counter check on Mellanox platform in `test_drop_l3_ip_packet_non_dut_mac`.
The packets are dropped silently on Mellanox devices.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to skip `RX_DRP` counter check on Mellanox platform in `test_drop_l3_ip_packet_non_dut_mac`.

#### How did you do it?
Check asic_type and skip check of `RX_DRP`.

#### How did you verify/test it?
The change is verified on a Mellanox testbed.
```
collected 1 item                                                                                                                                                                                      

ip/test_ip_packet.py::TestIPPacket::test_drop_l3_ip_packet_non_dut_mac[str2-msn2700-spy-2] PASSED                                                                                               [100%]

```
#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
