### PR TITLE
sonic-mgmt: fix info in testbed_vm_info.py err msg

### DIFF
--- a/ansible/library/testbed_vm_info.py
+++ b/ansible/library/testbed_vm_info.py
@@ -129,8 +129,7 @@ def main():
             else:
                 err_msg = "Cannot find the vm {} in VM inventory file {}, please make sure you have enough VMs" \
                           "for the topology you are using."
-                err_msg.format(vm_name, vm_facts.vm_file)
-                module.fail_json(msg=err_msg)
+                module.fail_json(msg=err_msg.format(vm_name, vm_facts.vm_file))
         module.exit_json(
             ansible_facts={'neighbor_eosvm_mgmt': vm_mgmt_ip, 'topoall': vm_facts.topoall})
     except (IOError, OSError):


### PR DESCRIPTION
### Description of PR
In ansible/library/testbed_vm_info.py, there is a format string passed to a method without the actual formatting applied, i.e. the '{}'s are printed out rather than the desired information they're supposed to represent. This change passes the error message to the method with the correct formatting applied.

Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To fix a mistake that was noticed in the printout of an error message.

#### How did you do it?
Pass the format string with the appropriate formatting applied to the applicable method, as opposed to the raw format string.

#### How did you verify/test it?
Tested on 202405 against the t0-isolated-d128u128s2, topology, which at the time of this writing is known to encounter the issue that will result in this error message being printed.

#### Any platform specific information?
Tested on Arista-7060X6-64PE-C256S2.