### PR TITLE
adding 8122 platforms to watchdog.yml file

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -162,3 +162,15 @@ x86_64-8111_32eh_o-r0:
     valid_timeout: 10
     greater_timeout: 6553
     too_big_timeout: 6554
+
+x86_64-8122_64ehf_o-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554
+
+x86_64-8122_64eh_o-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554


### PR DESCRIPTION
What is the motivation for this PR?
Adding Cisco 8122 platforms to platform_tests/api/watchdog.yml file. This is needed for testcase platform_tests/api/test_watchdog.py

**How did you do it?**
Added the details for 8122 platforms to watchdog.yml file

**Type of change** 
-Test modification

**Back port request** 
-202405

**How did you verify/test it?**
Made sure that testcase platform_tests/api/test_watchdog.py passes on 8122 platforms after adding them to watchdog.yml file