### PR TITLE
Run mux simulator script per testbed

### DIFF
--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -42,7 +42,7 @@
   - name: Copy the mux simulator to test server
     copy:
       src: mux_simulator.py
-      dest: "{{ abs_root_path }}"
+      dest: "{{ abs_root_path }}/mux_simulator_{{ mux_simulator_port }}.py"
       mode: 0755
 
   - name: Generate mux-simulator systemd service file

--- a/ansible/roles/vm_set/templates/mux-simulator.service.j2
+++ b/ansible/roles/vm_set/templates/mux-simulator.service.j2
@@ -3,4 +3,4 @@ Description=mux simulator
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/env {{python_command}} {{ abs_root_path }}/mux_simulator.py {{ mux_simulator_port }} {{ vm_set_name }} -v
+ExecStart=/usr/bin/env {{python_command}} {{ abs_root_path }}/mux_simulator_{{ mux_simulator_port }}.py {{ mux_simulator_port }} {{ vm_set_name }} -v


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
As `mux_simulator` script differs between branches, let's copy `mux_simulator` per testbed.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Use the port number as suffix.

#### How did you verify/test it?
Run on dualtor testbeds that share the same host server, ensure `mux_simulator`s run with each owne script file.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
