### PR TITLE
Multi-asic fixes for `lldp/test_lldp_syncd.py`

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -16,6 +16,7 @@ pytestmark = [
     pytest.mark.topology("any"),
 ]
 
+
 @pytest.fixture(scope="function")
 def ignore_expected_loganalyzer_exceptions(duthosts, loganalyzer):
     """Ignore expected failures logs during test execution."""
@@ -27,6 +28,7 @@ def ignore_expected_loganalyzer_exceptions(duthosts, loganalyzer):
                     r".*ERR.* 'routeCheck' status failed.*",
                 ]
             )
+
 
 @pytest.fixture(autouse="True")
 def db_instance(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
@@ -46,12 +48,14 @@ def get_lldp_entry_keys(dbs):
         lldp_entries.extend([key.split(":")[1] for key in items])
     return lldp_entries
 
+
 # Helper function to get LLDP_ENTRY_TABLE content
 def get_lldp_entry_content(dbs, interface):
     lldp_content = {}
     for db in dbs:
         lldp_content.update(db.hget_all("LLDP_ENTRY_TABLE:{}".format(interface)))
     return lldp_content
+
 
 # Helper function to get lldptcl output
 def get_lldpctl_facts_output(duthost, enum_frontend_asic_index):

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -16,25 +16,42 @@ pytestmark = [
     pytest.mark.topology("any"),
 ]
 
+@pytest.fixture(scope="function")
+def ignore_expected_loganalyzer_exceptions(duthosts, loganalyzer):
+    """Ignore expected failures logs during test execution."""
+    if loganalyzer:
+        for duthost in duthosts:
+            loganalyzer[duthost.hostname].ignore_regex.extend(
+                [
+                    # Interface flaps in test_lldp_entry_table_after_flap can cause routeCheck to fail momentarily
+                    r".*ERR.* 'routeCheck' status failed.*",
+                ]
+            )
 
 @pytest.fixture(autouse="True")
 def db_instance(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    appl_db = SonicDbCli(duthost, APPL_DB)
+    appl_db = []
+    for asic in duthost.asics:
+        appl_db.append(SonicDbCli(asic, APPL_DB))
     # Cleanup code here
     return appl_db
 
 
 # Helper function to get the LLDP_ENTRY_TABLE keys
-def get_lldp_entry_keys(db):
-    items = db.get_keys("LLDP_ENTRY_TABLE*")
-    return [key.split(":")[1] for key in items]
-
+def get_lldp_entry_keys(dbs):
+    lldp_entries = []
+    for db in dbs:
+        items = db.get_keys("LLDP_ENTRY_TABLE*")
+        lldp_entries.extend([key.split(":")[1] for key in items])
+    return lldp_entries
 
 # Helper function to get LLDP_ENTRY_TABLE content
-def get_lldp_entry_content(db, interface):
-    return db.hget_all("LLDP_ENTRY_TABLE:{}".format(interface))
-
+def get_lldp_entry_content(dbs, interface):
+    lldp_content = {}
+    for db in dbs:
+        lldp_content.update(db.hget_all("LLDP_ENTRY_TABLE:{}".format(interface)))
+    return lldp_content
 
 # Helper function to get lldptcl output
 def get_lldpctl_facts_output(duthost, enum_frontend_asic_index):
@@ -46,8 +63,18 @@ def get_lldpctl_facts_output(duthost, enum_frontend_asic_index):
 
 
 def get_lldpctl_output(duthost):
-    result = duthost.shell("docker exec lldp /usr/sbin/lldpctl -f json")["stdout"]
-    return json.loads(result)
+    if duthost.is_multi_asic:
+        resultDict = {}
+        for asic in duthost.asics:
+            result = duthost.shell("docker exec lldp{} /usr/sbin/lldpctl -f json".format(asic.asic_index))["stdout"]
+            if not resultDict:
+                resultDict = json.loads(result)
+            else:
+                resultDict['lldp']['interface'].extend(json.loads(result)['lldp']['interface'])
+    else:
+        result = duthost.shell("docker exec lldp /usr/sbin/lldpctl -f json")["stdout"]
+        resultDict = json.loads(result)
+    return resultDict
 
 
 # Helper function to get show lldp table output
@@ -193,7 +220,7 @@ def test_lldp_entry_table_content(
 
 # Test case 3: Verify LLDP_ENTRY_TABLE after interface flap
 def test_lldp_entry_table_after_flap(
-    duthosts, enum_rand_one_per_hwsku_frontend_hostname, db_instance
+    duthosts, enum_rand_one_per_hwsku_frontend_hostname, db_instance, ignore_expected_loganalyzer_exceptions
 ):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     # Fetch interfaces from LLDP_ENTRY_TABLE
@@ -203,11 +230,15 @@ def test_lldp_entry_table_after_flap(
 
     for interface in lldp_entry_keys:
         if interface == "eth0":
-            pytest.skip("Skipping test for eth0 interface")
+            # Skip test for 'eth0' interface
+            continue
         # Shutdown and startup the interface
-        duthost.shell("sudo config interface shutdown {}".format(interface))
-        duthost.shell("sudo config interface startup {}".format(interface))
-        result = wait_until(60, 2, 5, verify_lldp_entry, db_instance, interface)
+        asicStr = ""
+        if duthost.is_multi_asic:
+            asicStr = "-n {}".format(duthost.get_port_asic_instance(interface).get_asic_namespace())
+        duthost.shell("sudo config interface {} shutdown {}".format(asicStr, interface))
+        duthost.shell("sudo config interface {} startup {}".format(asicStr, interface))
+        result = wait_until(60, 2, 10, verify_lldp_entry, db_instance, interface)
         pytest_assert(
             result,
             "After interface {} flap, no LLDP_ENTRY_TABLE entry for it.".format(
@@ -250,16 +281,18 @@ def test_lldp_entry_table_after_lldp_restart(
     lldpctl_output = get_lldpctl_output(duthost)
 
     # Restart the LLDP service
-    duthost.shell("sudo systemctl restart lldp")
+    for asic in duthost.asics:
+        duthost.shell("sudo systemctl restart {}".format(asic.get_service_name('lldp')))
     result = wait_until(
         60, 2, 5, verify_lldp_table, duthost
     )  # Adjust based on LLDP service restart time
     pytest_assert(result, "no output for show lldp table after restarting lldp")
-    result = duthost.shell("sudo systemctl status lldp")["stdout"]
-    pytest_assert(
-        "active (running)" in result,
-        "LLDP service is not running",
-    )
+    for asic in duthost.asics:
+        result = duthost.shell("sudo systemctl status {}".format(asic.get_service_name('lldp')))["stdout"]
+        pytest_assert(
+            "active (running)" in result,
+            "LLDP service is not running",
+        )
     lldpctl_interfaces = lldpctl_output["lldp"]["interface"]
     assert_lldp_interfaces(
         lldp_entry_keys, show_lldp_table_int_list, lldpctl_interfaces
@@ -296,6 +329,7 @@ def test_lldp_entry_table_after_reboot(
         reboot_helper=None,
         reboot_kwargs=None,
         safe_reboot=True,
+        check_intf_up_ports=True
     )
     lldpctl_interfaces = lldpctl_output["lldp"]["interface"]
     assert_lldp_interfaces(


### PR DESCRIPTION
### Description of PR
Various multi-asic fixes in `lldp/test_lldp_syncd.py`
* Fix helper functions `db_instance`, `get_lldp_entry_keys`, `get_lldp_entry_content`, `get_lldpctl_output` to query both namespaces

test_lldp_entry_table_after_flap
* Ignore routeCheck log errors as this test flaps ports and churns routes `ignore_expected_loganalyzer_exceptions`
* Don't skip the test if it finds `eth0` port, just continue
* Add namespace to `config interface` commands
* Increase delay from 5s to 10s as `verify_lldp_entry` was seeing the stale `LLDP_ENTRY` from before link flap and returning True

test_lldp_entry_table_after_lldp_restart
* Query the per-namespace `lldp` docker when available

test_lldp_entry_table_after_reboot
* wait until `check_intf_up_ports=True` when rebooting, otherwise the `LLDP_ENTRY` may flap when the ports come up

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/15256

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
