### PR TITLE
[dualtor-aa] Fix arp flux of soc IPs

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -386,6 +386,10 @@ class VMTopology(object):
         if os.path.exists("/var/run/netns/%s" % self.netns):
             VMTopology.cmd("ip netns delete %s" % self.netns)
 
+    def enable_arp_filter_netns(self):
+        """ENable ARP filter in the netns."""
+        VMTopology.cmd("ip netns exec %s sysctl -w net.ipv4.conf.all.arp_filter=1" % self.netns)
+
     def add_mgmt_port_to_netns(self, mgmt_bridge, mgmt_ip, mgmt_gw, mgmt_ipv6_addr=None, mgmt_gw_v6=None):
         if VMTopology.intf_not_exists(MGMT_PORT_NAME, netns=self.netns):
             self.add_br_if_to_netns(
@@ -1862,6 +1866,9 @@ def main():
 
             if net.netns:
                 net.add_network_namespace()
+                # Let's enable arp_filter in the netns
+                # to prevent arp flux
+                net.enable_arp_filter_netns()
                 net.add_mgmt_port_to_netns(
                     mgmt_bridge, netns_mgmt_ip_addr, ptf_mgmt_ip_gw)
                 net.enable_netns_loopback()
@@ -2007,6 +2014,9 @@ def main():
 
             if net.netns:
                 net.add_network_namespace()
+                # Let's enable arp_filter in the netns
+                # to prevent arp flux
+                net.enable_arp_filter_netns()
                 net.add_mgmt_port_to_netns(
                     mgmt_bridge, netns_mgmt_ip_addr, ptf_mgmt_ip_gw)
                 net.enable_netns_loopback()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
If the test server is Ubuntu 22.04, SoC IP ARP flux is observed on the
DUTs for dualtor-aa testbed.
* `arping` the soc IP `192.168.0.3` on the DUT
```
# arping 192.168.0.3 -C 1
ARPING 192.168.0.3
60 bytes from 8a:0e:6b:72:5f:9e (192.168.0.3): index=0 time=3.771 msec
60 bytes from 5a:ef:b2:32:64:e4 (192.168.0.3): index=1 time=4.001 msec
60 bytes from ba:88:12:db:99:d7 (192.168.0.3): index=2 time=4.012 msec
60 bytes from b6:8c:cc:28:78:ff (192.168.0.3): index=3 time=4.020 msec
60 bytes from 4e:68:db:25:b0:b9 (192.168.0.3): index=4 time=4.027 msec
60 bytes from ba:38:ee:59:d7:72 (192.168.0.3): index=5 time=4.034 msec
60 bytes from 22:f7:ce:56:48:f1 (192.168.0.3): index=6 time=4.040 msec
60 bytes from 8a:0f:a2:16:a6:58 (192.168.0.3): index=7 time=4.047 msec
60 bytes from 76:f7:26:c7:53:d1 (192.168.0.3): index=8 time=4.055 msec
60 bytes from 8e:48:56:77:85:4a (192.168.0.3): index=9 time=4.062 msec
60 bytes from c6:38:7b:91:4f:fd (192.168.0.3): index=10 time=4.069 msec
60 bytes from 5e:91:6f:bb:a8:b9 (192.168.0.3): index=11 time=4.076 msec
60 bytes from be:bd:ee:a3:01:63 (192.168.0.3): index=12 time=4.082 msec
60 bytes from a2:2a:68:2a:8f:80 (192.168.0.3): index=13 time=4.089 msec
60 bytes from be:d1:9f:13:3f:04 (192.168.0.3): index=14 time=4.096 msec
60 bytes from fa:69:f8:9a:a4:b2 (192.168.0.3): index=15 time=4.103 msec
60 bytes from 8a:96:aa:de:e3:87 (192.168.0.3): index=16 time=4.110 msec
60 bytes from da:83:06:7f:0b:0d (192.168.0.3): index=17 time=4.117 msec
60 bytes from 26:1c:46:03:d5:b3 (192.168.0.3): index=18 time=4.125 msec
60 bytes from 4a:6c:02:2b:0b:1e (192.168.0.3): index=19 time=4.132 msec
60 bytes from 7e:54:cb:96:d8:cc (192.168.0.3): index=20 time=4.138 msec
60 bytes from 42:ab:a4:64:be:42 (192.168.0.3): index=21 time=4.145 msec
60 bytes from ce:4a:cd:d3:f2:34 (192.168.0.3): index=22 time=4.150 msec
60 bytes from a2:f9:f2:31:eb:bd (192.168.0.3): index=23 time=4.155 msec

--- 192.168.0.3 statistics ---
1 packets transmitted, 24 packets received,   0% unanswered (23 extra)
rtt min/avg/max/std-dev = 3.771/4.069/4.155/0.077 ms
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Let's enable `arp_filter` to prevent this.

#### How did you verify/test it?
With this PR:
```
# arping 192.168.0.3 -C 1
ARPING 192.168.0.3
60 bytes from a2:f9:f2:31:eb:bd (192.168.0.3): index=0 time=2.047 msec

--- 192.168.0.3 statistics ---
1 packets transmitted, 1 packets received,   0% unanswered (0 extra)
rtt min/avg/max/std-dev = 2.047/2.047/2.047/0.000 ms
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
