### PR TITLE
Skipping test_static_route on Cisco 8122

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1639,11 +1639,12 @@ route/test_route_perf.py:
 
 route/test_static_route.py:
   skip:
-    reason: "Test not supported for 201911 images or older. Does not apply to standalone topos."
+    reason: "Test not supported for 201911 images or older. Does not apply to standalone topos. Not supported on cisco-8122 platform"
     conditions_logical_operator: OR
     conditions:
       - "release in ['201811', '201911']"
       - "'standalone' in topo_name"
+      - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
 
 route/test_static_route.py::test_static_route_ecmp_ipv6:
   # This test case may fail due to a known issue https://github.com/sonic-net/sonic-buildimage/issues/4930.


### PR DESCRIPTION
**What is the motivation for this PR?**
All 3 tests in test_static_route are failing on 8122.
Tests are failing because “show flowcnt-route stats“ does not show the 1 test pkt that the test has sent.
“show flowcnt-route stats“ does not show the test pkt because counter config itself failed.
Counter config failed because FLOW_COUNTER_CAPABILITY was enabled recently on ASIC/SDK side for 8122 but 'enable_forwarding_route_counter' is not enabled on SONiC/asic_cfg.json on 8122.
'enable_forwarding_route_counter' is not enabled on SONiC/asic_cfg.json on 8122 because of scale limits (cannot scale more than 50k with the current LPM profile).

As the feature is not enabled for this platform, need to skip this testcase

**How did you do it?**
Added a skip condition for test_static_route for 8122 platform 

**Type of change** 
-Test modification

**Back port request** 
-202311
-202405

**How did you verify/test it?**
Ran test_static_router.py on 8122 and verified it was skipped.
```
--------------------- generated xml file: /run_logs/ananshar/route/test_static_route_2024-10-21-03-14-31.xml ---------------------
INFO:root:Can not get Allure report URL. Please check logs

----------------------------------------------------- live log sessionfinish -----------------------------------------------------
03:14:52 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
==================================================== short test summary info =====================================================
SKIPPED [2] route/test_static_route.py: Test not supported for 201911 images or older. Does not apply to standalone topos. Not supported on cisco-8122 platform
SKIPPED [1] route/test_static_route.py:350: Test not supported for 201911 images or older. Does not apply to standalone topos. Not supported on cisco-8122 platform
SKIPPED [1] route/test_static_route.py:371: Test not supported for 201911 images or older. Does not apply to standalone topos. Not supported on cisco-8122 platform
================================================= 4 skipped, 1 warning in 20.15s =================================================
sonic@sonic-ucs-m6-24:/data/tests$ 
```