### PR TITLE
Modify Small Partition Size to 300M from 100M

### DIFF
--- a/tests/syslog/test_logrotate.py
+++ b/tests/syslog/test_logrotate.py
@@ -15,7 +15,7 @@ pytestmark = [
 ]
 
 LOG_FOLDER = '/var/log'
-SMALL_VAR_LOG_PARTITION_SIZE = '100M'
+SMALL_VAR_LOG_PARTITION_SIZE = '300M'
 FAKE_IP = '10.20.30.40'
 FAKE_MAC = 'aa:bb:cc:dd:11:22'
 


### PR DESCRIPTION
### Description of PR
It's found in some scaled setup the OC testing for test_logrotate_small_size could fail on fallocate 512K. 
{"changed": true, "cmd": "sudo fallocate -l 512.0K /var/log/syslog", "delta": "0:00:00.014333", "end": "2024-10-28 21:15:46.973853", "failed": true, "msg": "non-zero return code", "rc": 1, "start": "2024-10-28 21:15:46.959520", "stderr": "fallocate: fallocate failed: No space left on device", "stderr_lines": ["fallocate: fallocate failed: No space left on device"], "stdout": "", "stdout_lines": []}

Our scaled setup could have 34K BGP routes and has more BGP neighbors. This test did config-reload after mounting new partition to /var/log. All new services restart and can fill the syslog and other logs and reach partition size. 

Added debug code to find after config reload the /var/log partition situation:

udev             16G     0   16G   0% /dev
tmpfs           3.2G   49M  3.1G   2% /run
root-overlay     32G  6.7G   25G  22% /
/dev/sda3        32G  6.7G   25G  22% /host
/dev/loop2       89M   87M     0 100% /var/log
tmpfs            16G   60K   16G   1% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           4.0M     0  4.0M   0% /sys/fs/cgroup

List all files under /var/log: /n total 4117
drwxr-xr-x 6 root root    1024 Oct 28 21:15 .
drwxr-xr-x 1 root root    4096 Oct 25 21:11 ..
-rw-r----- 1 root adm        0 Oct 28 21:15 auth.log
-rw-r----- 1 root adm    47075 Oct 28 21:15 auth.log.1
-rw-r----- 1 root adm        0 Oct 28 21:15 cron.log
drwxr-xr-x 2 root root    1024 Oct 28 21:15 frr
-rw-r----- 1 root adm        0 Oct 28 21:15 gnmi.log
-rw-r----- 1 root adm     1007 Oct 28 21:15 gnmi.log.1
drwx------ 2 root root   12288 Oct 28 21:10 lost+found
-rw-r--r-- 1 root root      64 Oct 28 21:15 nokia-watchdog.log
drwxrwxrwx 2 root root    1024 Oct 28 21:12 ntpsec
drwxr-xr-x 2 root root    1024 Oct 28 21:15 swss
-rw-r----- 1 root adm        0 Oct 28 21:15 syslog
-rw-r----- 1 root adm  3185638 Oct 28 21:15 syslog.1
-rw-r----- 1 root adm        0 Oct 28 21:15 teamd.log
-rw-r----- 1 root adm   955766 Oct 28 21:14 teamd.log.1
-rw-r----- 1 root adm        0 Oct 28 21:15 telemetry.log

Solution is to make this partition to 300M during the test. This could make the test pass in scaled setup. 

Summary:
Fixes # (issue)

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
test_logrotate_small_size test sometimes fails.
#### How did you do it?

#### How did you verify/test it?
Verified with the change. We never hit the failure for test_logrotate_small_size.
