### PR TITLE
test_lldp_syncd.py: Provide enough ready time for flap, restart, and reboot testcases

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -222,7 +222,6 @@ def test_lldp_entry_table_after_flap(
                 interface
             ),
         )
-        time.sleep(3)  # Provide time for DB to be ready so that it can be queried below
 
         lldpctl_interfaces = lldpctl_output["lldp"]["interface"]
         assert_lldp_interfaces(

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -146,12 +146,14 @@ def verify_lldp_entry(db_instance, interface):
     else:
         return False
 
+
 def verify_lldp_keys(db_instance):
     lldp_entry_keys = get_lldp_entry_keys(db_instance)
     if lldp_entry_keys:
         return True
     else:
         return False
+
 
 def verify_lldp_table(duthost):
     output = duthost.shell("show lldp table")["stdout"]
@@ -220,7 +222,7 @@ def test_lldp_entry_table_after_flap(
                 interface
             ),
         )
-        time.sleep(3) # Provide time for DB to be ready so that it can be queried below
+        time.sleep(3)  # Provide time for DB to be ready so that it can be queried below
 
         lldpctl_interfaces = lldpctl_output["lldp"]["interface"]
         assert_lldp_interfaces(
@@ -308,7 +310,7 @@ def test_lldp_entry_table_after_reboot(
     # Verify DB keys because DB takes more time to be ready after LLDP is up
     result = wait_until(
             120, 2, 5, verify_lldp_keys, db_instance
-    ) 
+    )
     pytest_assert(result, "no entry keys found after cold reboot on DUT")
 
     lldpctl_interfaces = lldpctl_output["lldp"]["interface"]

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -6,7 +6,7 @@ import logging
 from tests.common.reboot import reboot, REBOOT_TYPE_COLD
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-
+import time
 
 logger = logging.getLogger(__name__)
 

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -108,18 +108,21 @@ def assert_lldp_entry_content(interface, entry_content, lldpctl_interface):
         == list(lldpctl_interface["chassis"].keys())[0],
         "lldp_rem_sys_name does not match for {}".format(interface),
     )
-    pytest_assert(
-        entry_content["lldp_rem_sys_desc"] == chassis_info["descr"],
-        "lldp_rem_sys_desc does not match for {}".format(interface),
-    )
-    pytest_assert(
-        entry_content["lldp_rem_port_desc"] == port_info.get("descr", ""),
-        "lldp_rem_port_desc does not match for {}".format(interface),
-    )
-    pytest_assert(
-        entry_content["lldp_rem_man_addr"] == chassis_info.get("mgmt-ip", ""),
-        "lldp_rem_man_addr does not match for {}".format(interface),
-    )
+    if 'descr' in chassis_info.keys():
+        pytest_assert(
+            entry_content["lldp_rem_sys_desc"] == chassis_info["descr"],
+            "lldp_rem_sys_desc does not match for {}".format(interface),
+        )
+    if 'descr' in port_info.keys():
+        pytest_assert(
+            entry_content["lldp_rem_port_desc"] == port_info.get("descr", ""),
+            "lldp_rem_port_desc does not match for {}".format(interface),
+        )
+    if 'mgmt-ip' in chassis_info.keys():
+        pytest_assert(
+            entry_content["lldp_rem_man_addr"] == chassis_info.get("mgmt-ip", ""),
+            "lldp_rem_man_addr does not match for {}".format(interface),
+        )
     pytest_assert(
         entry_content["lldp_rem_sys_cap_supported"] == "28 00",
         "lldp_rem_sys_cap_supported does not match for {}".format(interface),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Provide enough ready time for flap, restart, and reboot testcases.

For flap testcase, sometimes get_lldp_entry_content() will return empty entry content even though the testcase has just verified the entry content using the same function. It seems we need to provide enough time for the DB object to be ready again for query. Also increase wait_until() timeout from 60 seconds to 120 seconds.

For restart testcase, increase wait_until() timeout from 60 seconds to 120 seconds.

For reboot testcase, DB takes more time to be ready after DUT/LLDP is up, thus adding a verify DB keys assertion check after DUT rebooted before proceeding to the rest of the assertion checks.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fixing testcode.

#### How did you do it?
Explained above.

#### How did you verify/test it?
Tested on HW topo.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
