### PR TITLE
Snmp fixes - test_snmp_default_route and test_snmp_queue_counters

### DIFF
--- a/tests/snmp/test_snmp_default_route.py
+++ b/tests/snmp/test_snmp_default_route.py
@@ -31,7 +31,7 @@ def test_snmp_default_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     for line in dut_result['stdout_lines']:
         if 'via' in line:
             ip, interface = line.split('via')
-            ip = ip.strip("*, ")
+            ip = ip.strip("*, ,recursive")
             interface = interface.strip("*, ")
             if interface != "eth0" and 'Ethernet-BP' not in interface:
                 dut_result_nexthops.append(ip)

--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -66,7 +66,7 @@ def get_asic_interface(inter_facts):
 
 def test_snmp_queue_counters(duthosts,
                              enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-                             creds_all_duts, teardown):
+                             creds_all_duts):
     """
     Test SNMP queue counters
       - Set "create_only_config_db_buffers" to true in config db, to create
@@ -163,12 +163,11 @@ def test_snmp_queue_counters(duthosts,
                              (queue_counters_cnt_pre - multicast_expected_diff)))
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(autouse=True, scope="module")
 def teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Teardown procedure for all test function
-    :param duthosts: List of DUT hosts
-    :param enum_rand_one_per_hwsku_frontend_hostname: hostname of a randomly selected DUT
+    param duthosts: duthosts object
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     yield


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes test issue introduced as part of #[3537](https://github.com/sonic-net/sonic-utilities/pull/3537) for _test_snmp_default_route_ test, and
- General fix for _test_snmp_queue_counters_ test teardown.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

- After PR #[3537](https://github.com/sonic-net/sonic-utilities/pull/3537) introduction, CLI command output for '_show ip route 0.0.0.0/0_' has been changed and a new word '_recursive_' gets added. Hence sonic-mgmt needs to be modified to support this new change. For example,  "_* 11.0.0.145 recursive via iBGP_"
- During teardown of '_test_snmp_queue_counters_' test, sometimes we see the following error while recopying the _config_db_ json file for the duthost.
```
E           tests.common.errors.RunAnsibleModuleFail: run module copy failed, Ansible Results =>
E           {"changed": false, "failed": true, "msg": "Source /etc/sonic/orig_config_db1.json not found"}

complex_args = {'dest': '/etc/sonic/config_db1.json', 'remote_src': True, 'src': '/etc/sonic/orig_config_db1.json'}
filename   = '/data/tests/snmp/test_snmp_queue_counters.py'
function_name = 'teardown'
```

#### How did you do it?

- Handle '_recursive_' word as well while parsing for ip-address in _test_snmp_default_route_ test case.
- Make sure the duthost is same during test call and teardown in _test_snmp_queue_counters_ test case.

#### How did you verify/test it?

- Ran all the above-mentioned test cases on a T2 chassis and made sure tests passed with expected behavior.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/user-attachments/assets/ef967e04-4af7-428d-95d3-c4afc1a3082f)
