### PR TITLE
[ECMP hash] Tests for Vxlan and Nvgre packets using different packet fields

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -1075,7 +1075,8 @@ class VxlanHashTest(HashTest):
                             format(ip_src, ip_dst, src_port, rcvd_port, exp_src_mac, actual_src_mac))
         return (rcvd_port, rcvd_pkt)
 
-    def check_ip_route(self, hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip, outer_src_ipv6, outer_dst_ipv6):
+    def check_ip_route(self, hash_key, src_port, dst_port_lists, outer_src_ip,
+                       outer_dst_ip, outer_src_ipv6, outer_dst_ipv6):
         if self.ipver == 'ipv4-ipv4' or self.ipver == 'ipv4-ipv6':
             (matched_port, received) = self.check_ipv4_route(
                 hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip)
@@ -1116,7 +1117,8 @@ class VxlanHashTest(HashTest):
             logging.info('Checking hash key {}, src_port={}, exp_ports={}, outer_src_ip={}, outer_dst_ip={}'
                          .format(hash_key, src_port, exp_port_lists, outer_src_ip, outer_dst_ip))
             (matched_index, _) = self.check_ip_route(hash_key,
-                                                     src_port, exp_port_lists, outer_src_ip, outer_dst_ip, outer_src_ipv6, outer_dst_ipv6)
+                                                     src_port, exp_port_lists, outer_src_ip, outer_dst_ip,
+                                                     outer_src_ipv6, outer_dst_ipv6)
             hit_count_map[matched_index] = hit_count_map.get(
                 matched_index, 0) + 1
         logging.info("hash_key={}, hit count map: {}".format(
@@ -1237,7 +1239,7 @@ class NvgreHashTest(HashTest):
                 "tcp_dport": dport}
             inner_pkt = simple_tcpv6_packet(**pkt_opts)
 
-        tni = random.randint(1,254) + 20000
+        tni = random.randint(1, 254) + 20000
         pkt_opts = {
             'eth_dst': router_mac,
             'ip_src': outer_src_ip,
@@ -1392,7 +1394,8 @@ class NvgreHashTest(HashTest):
                             format(ip_src, ip_dst, src_port, rcvd_port, exp_src_mac, actual_src_mac))
         return (rcvd_port, rcvd_pkt)
 
-    def check_ip_route(self, hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip,outer_src_ipv6,outer_dst_ipv6):
+    def check_ip_route(self, hash_key, src_port, dst_port_lists, outer_src_ip,
+                       outer_dst_ip, outer_src_ipv6, outer_dst_ipv6):
         if self.ipver == 'ipv4-ipv4' or self.ipver == 'ipv4-ipv6':
             (matched_port, received) = self.check_ipv4_route(
                 hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip, self.ipver)
@@ -1433,7 +1436,8 @@ class NvgreHashTest(HashTest):
             logging.info('Checking hash key {}, src_port={}, exp_ports={}, outer_src_ip={}, outer_dst_ip={}'
                          .format(hash_key, src_port, exp_port_lists, outer_src_ip, outer_dst_ip))
             (matched_index, _) = self.check_ip_route(hash_key,
-                                                     src_port, exp_port_lists, outer_src_ip, outer_dst_ip, outer_src_ipv6, outer_dst_ipv6)
+                                                     src_port, exp_port_lists, outer_src_ip, outer_dst_ip,
+                                                     outer_src_ipv6, outer_dst_ipv6)
             hit_count_map[matched_index] = hit_count_map.get(
                 matched_index, 0) + 1
         logging.info("hash_key={}, hit count map: {}".format(

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -26,6 +26,9 @@ from ptf.testutils import simple_tcpv6_packet
 from ptf.testutils import send_packet
 from ptf.testutils import verify_packet_any_port
 from ptf.testutils import simple_ipv4ip_packet
+from ptf.testutils import simple_vxlan_packet
+from ptf.testutils import simple_vxlanv6_packet
+from ptf.testutils import simple_nvgre_packet
 
 import fib
 import lpm
@@ -108,6 +111,7 @@ class HashTest(BaseTest):
         # set the base mac here to make it persistent across calls of check_ip_route
         self.base_mac = self.dataplane.get_mac(
             *random.choice(list(self.dataplane.ports.keys())))
+        self.vxlan_dest_port = int(self.test_params.get('vxlan_dest_port', 0))
 
     def _get_nexthops(self, src_port, dst_ip):
         active_dut_indexes = [0]
@@ -841,6 +845,618 @@ class IPinIPHashTest(HashTest):
         @summary: Send IPinIP packet for each range of both IPv4 and IPv6 spaces and
         expect the packet to be received from one of the expected ports
         """
+        logging.info("List of hash_keys: {}".format(self.hash_keys))
+        for hash_key in self.hash_keys:
+            logging.info("hash test hash_key: {}".format(hash_key))
+            self.check_hash(hash_key)
+
+class VxlanHashTest(HashTest):
+    '''
+    This test is to verify the hash key for VxLAN packet.
+    The src_ip, dst_ip, src_port and dst_port of inner frame are expected to be hash keys
+    for IPinIP packet.
+    '''
+
+    def check_ipv4_route(self, hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip):
+        '''
+        @summary: Check IPv4 route works.
+        @param hash_key: hash key to build packet with.
+        @param src_port: index of port to use for sending packet to switch
+        @param dst_port_lists: list of ports on which to expect packet to come back from the switch
+        @param outer_src_ip: source ip at the outer layer
+        @param outer_dst_ip: destination ip at the outer layer
+        '''
+        ip_src = self.src_ip_interval.get_random_ip(
+        ) if hash_key == 'src-ip' else self.src_ip_interval.get_first_ip()
+        ip_dst = self.dst_ip_interval.get_random_ip(
+        ) if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
+        sport = random.randint(0, 65535) if hash_key == 'src-port' else 1234
+        dport = random.randint(0, 65535) if hash_key == 'dst-port' else 80
+        outer_sport = random.randint(0,65536) if hash_key == 'outer-src-port' else 1234
+
+        src_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
+            if hash_key == 'src-mac' else self.base_mac
+        dst_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
+            if hash_key == 'dst-mac' else self.base_mac
+
+        router_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']
+
+        vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
+        ip_proto = self._get_ip_proto() if hash_key == 'ip-proto' else None
+
+        if self.ipver == "ipv4-ipv4":
+            pkt_opts = {
+                "eth_src": src_mac,
+                "eth_dst": dst_mac,
+                "ip_dst": ip_dst,
+                "ip_src": ip_src,
+                "ip_ttl": 64,
+                "tcp_sport": sport,
+                "tcp_dport": dport}
+
+            inner_pkt = simple_tcp_packet(**pkt_opts)
+        else:
+            pkt_opts = {
+                "eth_src": src_mac,
+                "eth_dst": dst_mac,
+                "ipv6_dst": ip_dst,
+                "ipv6_src": ip_src,
+                "ipv6_hlim": 64,
+                "tcp_sport": sport,
+                "tcp_dport": dport}
+            inner_pkt = simple_tcpv6_packet(**pkt_opts)
+        pkt_opts = {
+            'eth_dst': router_mac,
+            'ip_src': outer_src_ip,
+            'ip_dst': outer_dst_ip,
+            'ip_ttl': 64,
+            'udp_sport': outer_sport,
+            'udp_dport': self.vxlan_dest_port,
+            'with_udp_chksum': False,
+            'vxlan_vni': 2000,
+            'inner_frame': inner_pkt}
+        vxlan_pkt = simple_vxlan_packet(**pkt_opts)
+
+        exp_pkt = vxlan_pkt.copy()
+        exp_pkt['IP'].ttl -= 1
+
+        masked_exp_pkt = Mask(exp_pkt)
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+        # mask the chksum also if masking the ttl
+        if self.ignore_ttl:
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
+
+        send_packet(self, src_port, vxlan_pkt)
+        logging.info('Sent Outer Ether(src={}, dst={})/IP(src={}, dst={})VxLAN(sport={}, dport={})/Inner Ether(src={}, dst={}), IP(src={}, '
+                     'dst={} )/TCP(sport={}, dport={} on port {})'
+                     .format(vxlan_pkt.src,
+                             vxlan_pkt.dst,
+                             vxlan_pkt['IP'].src,
+                             vxlan_pkt['IP'].dst,
+                             outer_sport,
+                             self.vxlan_dest_port,
+                             inner_pkt.src,
+                             inner_pkt.dst,
+                             ip_src,
+                             ip_dst,
+                             sport,
+                             dport,
+                             src_port))
+        logging.info(vxlan_pkt.show())
+
+        dst_ports = list(itertools.chain(*dst_port_lists))
+        rcvd_port_index, rcvd_pkt = verify_packet_any_port(
+            self, masked_exp_pkt, dst_ports)
+        rcvd_port = dst_ports[rcvd_port_index]
+        exp_src_mac = None
+        if len(self.ptf_test_port_map[str(rcvd_port)]["target_src_mac"]) > 1:
+            # active-active dualtor, the packet could be received from either ToR, so use the received
+            # port to find the corresponding ToR
+            for dut_index, port_list in enumerate(dst_port_lists):
+                if rcvd_port in port_list:
+                    exp_src_mac = self.ptf_test_port_map[str(
+                        rcvd_port)]["target_src_mac"][dut_index]
+        else:
+            exp_src_mac = self.ptf_test_port_map[str(
+                rcvd_port)]["target_src_mac"][0]
+        actual_src_mac = scapy.Ether(rcvd_pkt).src
+        if exp_src_mac != actual_src_mac:
+            raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
+                            "but the src mac doesn't match, expected {}, got {}".
+                            format(ip_src, ip_dst, src_port, rcvd_port, exp_src_mac, actual_src_mac))
+        return (rcvd_port, rcvd_pkt)
+
+    def check_ipv6_route(self, hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip):
+        '''
+        @summary: Check IPv6 route works.
+        @param hash_key: hash key to build packet with.
+        @param in_port: index of port to use for sending packet to switch
+        @param dst_port_lists: list of ports on which to expect packet to come back from the switch
+        @param outer_src_ip: source ip at the outer layer
+        @param outer_dst_ip: destination ip at the outer layer
+        '''
+        ip_src = self.src_ip_interval.get_random_ip(
+        ) if hash_key == 'src-ip' else self.src_ip_interval.get_first_ip()
+        ip_dst = self.dst_ip_interval.get_random_ip(
+        ) if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
+
+        sport = random.randint(0, 65535) if hash_key == 'src-port' else 1234
+        dport = random.randint(0, 65535) if hash_key == 'dst-port' else 80
+
+        src_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
+            if hash_key == 'src-mac' else self.base_mac
+        dst_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
+            if hash_key == 'dst-mac' else self.base_mac
+        router_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']
+
+        vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
+        ip_proto = self._get_ip_proto(
+            ipv6=True) if hash_key == "ip-proto" else None
+        outer_sport = random.randint(0,65536) if hash_key == 'outer-src-port' else 1234
+
+        inner_pkt_len = random.randrange(
+            100, 1024) if hash_key == 'inner_length' else 100
+
+        if self.ipver == 'ipv6-ipv6':
+            pkt_opts = {
+                "eth_src": src_mac,
+                "eth_dst": dst_mac,
+                "ipv6_dst": ip_dst,
+                "ipv6_src": ip_src,
+                "ipv6_hlim": 64,
+                "tcp_sport": sport,
+                "tcp_dport": dport}
+            inner_pkt = simple_tcpv6_packet(**pkt_opts)
+        else:
+            pkt_opts = {
+                "eth_src": src_mac,
+                "eth_dst": dst_mac,
+                "ip_dst": ip_dst,
+                "ip_src": ip_src,
+                "ip_ttl": 64,
+                "tcp_sport": sport,
+                "tcp_dport": dport}
+            inner_pkt = simple_tcp_packet(**pkt_opts)
+
+        pkt_opts = {
+            'eth_dst': router_mac,
+            'ipv6_src': outer_src_ip,
+            'ipv6_dst': outer_dst_ip,
+            'ipv6_hlim': 64,
+            'udp_sport': outer_sport,
+            'udp_dport': self.vxlan_dest_port,
+            'with_udp_chksum': False,
+            'vxlan_vni': 2000,
+            'inner_frame': inner_pkt}
+        vxlan_pkt = simple_vxlanv6_packet(**pkt_opts)
+
+        exp_pkt = vxlan_pkt.copy()
+        exp_pkt['IPv6'].hlim -= 1
+
+        masked_exp_pkt = Mask(exp_pkt)
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+
+        send_packet(self, src_port, vxlan_pkt)
+        logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={})VxLAN(sport={}, dport={})/Inner Ether(src={}, dst={}), Inner IPv6(src={}, '
+                     'dst={})/TCP(sport={}, dport={} on port {})'
+                     .format(vxlan_pkt.src,
+                             vxlan_pkt.dst,
+                             vxlan_pkt['IPv6'].src,
+                             vxlan_pkt['IPv6'].dst,
+                             outer_sport,
+                             self.vxlan_dest_port,
+                             inner_pkt.src,
+                             inner_pkt.dst,
+                             ip_src,
+                             ip_dst,
+                             sport,
+                             dport,
+                             src_port))
+
+        dst_ports = list(itertools.chain(*dst_port_lists))
+        rcvd_port_index, rcvd_pkt = verify_packet_any_port(
+            self, masked_exp_pkt, dst_ports)
+        rcvd_port = dst_ports[rcvd_port_index]
+
+        exp_src_mac = None
+        if len(self.ptf_test_port_map[str(rcvd_port)]["target_src_mac"]) > 1:
+            # active-active dualtor, the packet could be received from either ToR, so use the received
+            # port to find the corresponding ToR
+            for dut_index, port_list in enumerate(dst_port_lists):
+                if rcvd_port in port_list:
+                    exp_src_mac = self.ptf_test_port_map[str(
+                        rcvd_port)]["target_src_mac"][dut_index]
+        else:
+            exp_src_mac = self.ptf_test_port_map[str(
+                rcvd_port)]["target_src_mac"][0]
+
+        actual_src_mac = scapy.Ether(rcvd_pkt).src
+        if exp_src_mac != actual_src_mac:
+            raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
+                            "but the src mac doesn't match, expected {}, got {}".
+                            format(ip_src, ip_dst, src_port, rcvd_port, exp_src_mac, actual_src_mac))
+        return (rcvd_port, rcvd_pkt)
+
+    def check_ip_route(self, hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip, outer_src_ipv6, outer_dst_ipv6):
+        if self.ipver == 'ipv4-ipv4' or self.ipver == 'ipv4-ipv6':
+            (matched_port, received) = self.check_ipv4_route(
+                hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip)
+        else:
+            (matched_port, received) = self.check_ipv6_route(
+                hash_key, src_port, dst_port_lists, outer_src_ipv6, outer_dst_ipv6)
+
+        assert received
+
+        logging.info("Received packet at " + str(matched_port))
+        time.sleep(0.02)
+
+        return (matched_port, received)
+
+    def check_hash(self, hash_key):
+        # Use dummy IPv4 address for outer_src_ip and outer_dst_ip
+        # We don't care the actually value as long as the outer_dst_ip is routed by default routed
+        # The outer_src_ip and outer_dst_ip are fixed
+        outer_src_ip = '80.1.0.31'
+        outer_dst_ip = '80.1.0.32'
+        outer_src_ipv6 = '80::31'
+        outer_dst_ipv6 = '80::32'
+        src_port, exp_port_lists, next_hops = self.get_src_and_exp_ports(
+            outer_dst_ip)
+        if self.switch_type == "chassis-packet":
+            exp_port_lists = self.check_same_asic(src_port, exp_port_lists)
+
+        logging.info("outer_src_ip={}, outer_dst_ip={}, src_port={}, exp_port_lists={}".format(
+            outer_src_ip, outer_dst_ip, src_port, exp_port_lists))
+        for exp_port_list in exp_port_lists:
+            if len(exp_port_list) <= 1:
+                logging.warning("{} has only {} nexthop".format(
+                    outer_dst_ip, exp_port_list))
+                assert False
+
+        hit_count_map = {}
+        for _ in range(0, self.balancing_test_times*len(list(itertools.chain(*exp_port_lists)))):
+            logging.info('Checking hash key {}, src_port={}, exp_ports={}, outer_src_ip={}, outer_dst_ip={}'
+                         .format(hash_key, src_port, exp_port_lists, outer_src_ip, outer_dst_ip))
+            (matched_index, _) = self.check_ip_route(hash_key,
+                                                     src_port, exp_port_lists, outer_src_ip, outer_dst_ip, outer_src_ipv6, outer_dst_ipv6)
+            hit_count_map[matched_index] = hit_count_map.get(
+                matched_index, 0) + 1
+        logging.info("hash_key={}, hit count map: {}".format(
+            hash_key, hit_count_map))
+
+        for next_hop in next_hops:
+            self.check_balancing(next_hop.get_next_hop(), hit_count_map, src_port)
+
+    def runTest(self):
+        """
+        @summary: Send IPinIP packet for each range of both IPv4 and IPv6 spaces and
+        expect the packet to be received from one of the expected ports
+        """
+        logging.info("List of hash_keys: {}".format(self.hash_keys))
+        for hash_key in self.hash_keys:
+            logging.info("hash test hash_key: {}".format(hash_key))
+            self.check_hash(hash_key)
+
+class NvgreHashTest(HashTest):
+    '''
+    This test is to verify the hash key for NvGRE packet.
+    The src_ip, dst_ip, src_port and dst_port of inner frame are expected to be hash keys
+    for NvGRE packet.
+    '''
+
+    def simple_nvgrev6_packet(self, pktlen=300,
+                              eth_dst='00:01:02:03:04:05',
+                              eth_src='00:06:07:08:09:0a',
+                              dl_vlan_enable=False,
+                              vlan_vid=0,
+                              vlan_pcp=0,
+                              dl_vlan_cfi=0,
+                              ipv6_src='1::2',
+                              ipv6_dst='3::4',
+                              ipv6_fl=0,
+                              ipv6_tc=0,
+                              ipv6_ecn=None,
+                              ipv6_dscp=None,
+                              ipv6_hlim=64,
+                              nvgre_version=0,
+                              nvgre_tni=None,
+                              nvgre_flowid=0,
+                              inner_frame=None
+                              ):
+        '''
+        @summary: Helper function to construct an IPv6 NVGRE packet
+        '''
+        if scapy.NVGRE is None:
+            logging.error(
+                "A NVGRE packet was requested but NVGRE is not supported by your Scapy. "
+                "See README for more information")
+            return None
+
+        nvgre_hdr = scapy.NVGRE(vsid=nvgre_tni, flowid=nvgre_flowid)
+
+        if (dl_vlan_enable):
+            pkt = scapy.Ether(dst=eth_dst, src=eth_src) / \
+                scapy.Dot1Q(prio=vlan_pcp, id=dl_vlan_cfi, vlan=vlan_vid) / \
+                scapy.IPv6(src=ipv6_src, dst=ipv6_dst, fl=ipv6_fl, tc=ipv6_tc, hlim=ipv6_hlim, nh=47) / \
+                nvgre_hdr
+        else:
+            pkt = scapy.Ether(dst=eth_dst, src=eth_src) / \
+                scapy.IPv6(src=ipv6_src, dst=ipv6_dst, fl=ipv6_fl, tc=ipv6_tc, hlim=ipv6_hlim, nh=47) / \
+                nvgre_hdr
+
+        if inner_frame:
+            pkt = pkt / inner_frame
+        else:
+            pkt = pkt / scapy.IP()
+            pkt = pkt/("D" * (pktlen - len(pkt)))
+
+        return pkt
+
+    def check_ipv4_route(self, hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip, ipver):
+        '''
+        @summary: Check IPv4 route works.
+        @param hash_key: hash key to build packet with.
+        @param src_port: index of port to use for sending packet to switch
+        @param dst_port_lists: list of ports on which to expect packet to come back from the switch
+        @param outer_src_ip: source ip at the outer layer
+        @param outer_dst_ip: destination ip at the outer layer
+        '''
+        ip_src = self.src_ip_interval.get_random_ip(
+        ) if hash_key == 'src-ip' else self.src_ip_interval.get_first_ip()
+        ip_dst = self.dst_ip_interval.get_random_ip(
+        ) if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
+        sport = random.randint(0, 65535) if hash_key == 'src-port' else 1234
+        dport = random.randint(0, 65535) if hash_key == 'dst-port' else 80
+
+        src_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
+            if hash_key == 'src-mac' else self.base_mac
+        dst_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
+            if hash_key == 'dst-mac' else self.base_mac
+
+        router_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']
+
+        vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
+        ip_proto = self._get_ip_proto() if hash_key == 'ip-proto' else None
+
+        if self.ipver == 'ipv4-ipv4':
+            pkt_opts = {
+                "eth_src": src_mac,
+                "eth_dst": dst_mac,
+                "ip_dst": ip_dst,
+                "ip_src": ip_src,
+                "ip_ttl": 64,
+                "tcp_sport": sport,
+                "tcp_dport": dport}
+            inner_pkt = simple_tcp_packet(**pkt_opts)
+        else:
+            pkt_opts = {
+                "eth_src": src_mac,
+                "eth_dst": dst_mac,
+                "ipv6_dst": ip_dst,
+                "ipv6_src": ip_src,
+                "ipv6_hlim": 64,
+                "tcp_sport": sport,
+                "tcp_dport": dport}
+            inner_pkt = simple_tcpv6_packet(**pkt_opts)
+
+        tni = random.randint(1,254) + 20000
+        pkt_opts = {
+            'eth_dst': router_mac,
+            'ip_src': outer_src_ip,
+            'ip_dst': outer_dst_ip,
+            'ip_ttl': 64,
+            'nvgre_tni': tni,
+            'inner_frame': inner_pkt}
+        nvgre_pkt = simple_nvgre_packet(**pkt_opts)
+
+        exp_pkt = nvgre_pkt.copy()
+        exp_pkt['IP'].ttl -= 1
+
+        masked_exp_pkt = Mask(exp_pkt)
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+
+        send_packet(self, src_port, nvgre_pkt)
+        logging.info('Sent Outer Ether(src={}, dst={})/IP(src={}, dst={}, nvgre_tni={})/Inner Ether(src={}, dst={}), IP(src={}, '
+                     'dst={} )/TCP(sport={}, dport={} on port {})'
+                     .format(nvgre_pkt.src,
+                             nvgre_pkt.dst,
+                             nvgre_pkt['IP'].src,
+                             nvgre_pkt['IP'].dst,
+                             tni,
+                             inner_pkt.src,
+                             inner_pkt.dst,
+                             ip_src,
+                             ip_dst,
+                             sport,
+                             dport,
+                             src_port))
+
+        dst_ports = list(itertools.chain(*dst_port_lists))
+        rcvd_port_index, rcvd_pkt = verify_packet_any_port(
+            self, masked_exp_pkt, dst_ports)
+        rcvd_port = dst_ports[rcvd_port_index]
+        exp_src_mac = None
+        if len(self.ptf_test_port_map[str(rcvd_port)]["target_src_mac"]) > 1:
+            # active-active dualtor, the packet could be received from either ToR, so use the received
+            # port to find the corresponding ToR
+            for dut_index, port_list in enumerate(dst_port_lists):
+                if rcvd_port in port_list:
+                    exp_src_mac = self.ptf_test_port_map[str(
+                        rcvd_port)]["target_src_mac"][dut_index]
+        else:
+            exp_src_mac = self.ptf_test_port_map[str(
+                rcvd_port)]["target_src_mac"][0]
+        actual_src_mac = scapy.Ether(rcvd_pkt).src
+        if exp_src_mac != actual_src_mac:
+            raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
+                            "but the src mac doesn't match, expected {}, got {}".
+                            format(ip_src, ip_dst, src_port, rcvd_port, exp_src_mac, actual_src_mac))
+        return (rcvd_port, rcvd_pkt)
+
+    def check_ipv6_route(self, hash_key, src_port, dst_port_lists, outer_src_ipv6, outer_dst_ipv6, ipver):
+        '''
+        @summary: Check IPv6 route works.
+        @param hash_key: hash key to build packet with.
+        @param in_port: index of port to use for sending packet to switch
+        @param dst_port_lists: list of ports on which to expect packet to come back from the switch
+        @param outer_src_ip: source ip at the outer layer
+        @param outer_dst_ip: destination ip at the outer layer
+        '''
+        ip_src = self.src_ip_interval.get_random_ip(
+        ) if hash_key == 'src-ip' else self.src_ip_interval.get_first_ip()
+        ip_dst = self.dst_ip_interval.get_random_ip(
+        ) if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
+
+        sport = random.randint(0, 65535) if hash_key == 'src-port' else 1234
+        dport = random.randint(0, 65535) if hash_key == 'dst-port' else 80
+
+        src_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
+            if hash_key == 'src-mac' else self.base_mac
+        dst_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
+            if hash_key == 'dst-mac' else self.base_mac
+        router_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']
+
+        vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
+        ip_proto = self._get_ip_proto(
+            ipv6=True) if hash_key == "ip-proto" else None
+
+        if self.ipver == 'ipv6-ipv6':
+            pkt_opts = {
+                "eth_src": src_mac,
+                "eth_dst": dst_mac,
+                "ipv6_dst": ip_dst,
+                "ipv6_src": ip_src,
+                "ipv6_hlim": 64,
+                "tcp_sport": sport,
+                "tcp_dport": dport}
+            inner_pkt = simple_tcpv6_packet(**pkt_opts)
+        else:
+            pkt_opts = {
+                "eth_src": src_mac,
+                "eth_dst": dst_mac,
+                "ip_dst": ip_dst,
+                "ip_src": ip_src,
+                "ip_ttl": 64,
+                "tcp_sport": sport,
+                "tcp_dport": dport}
+            inner_pkt = simple_tcp_packet(**pkt_opts)
+
+        tni = random.randint(1,254) + 20000
+        pkt_opts = {
+            'eth_dst': router_mac,
+            'ipv6_src': outer_src_ipv6,
+            'ipv6_dst': outer_dst_ipv6,
+            'ipv6_hlim': 64,
+            'nvgre_tni': tni,
+            'inner_frame': inner_pkt}
+        nvgre_pkt = self.simple_nvgrev6_packet(**pkt_opts)
+
+        exp_pkt = nvgre_pkt.copy()
+
+        masked_exp_pkt = Mask(exp_pkt)
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
+
+        send_packet(self, src_port, nvgre_pkt)
+        logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={}, proto={})/IPv6(src={}, '
+                     'dst={})/TCP(sport={}, dport={} on port {})'
+                     .format(nvgre_pkt.src,
+                             nvgre_pkt.dst,
+                             nvgre_pkt['IPv6'].src,
+                             nvgre_pkt['IPv6'].dst,
+                             nvgre_pkt['IPv6'].proto,
+                             ip_src,
+                             ip_dst,
+                             sport,
+                             dport,
+                             src_port))
+
+        dst_ports = list(itertools.chain(*dst_port_lists))
+        rcvd_port_index, rcvd_pkt = verify_packet_any_port(
+            self, masked_exp_pkt, dst_ports)
+        rcvd_port = dst_ports[rcvd_port_index]
+
+        exp_src_mac = None
+        if len(self.ptf_test_port_map[str(rcvd_port)]["target_src_mac"]) > 1:
+            # active-active dualtor, the packet could be received from either ToR, so use the received
+            # port to find the corresponding ToR
+            for dut_index, port_list in enumerate(dst_port_lists):
+                if rcvd_port in port_list:
+                    exp_src_mac = self.ptf_test_port_map[str(
+                        rcvd_port)]["target_src_mac"][dut_index]
+        else:
+            exp_src_mac = self.ptf_test_port_map[str(
+                rcvd_port)]["target_src_mac"][0]
+
+        actual_src_mac = scapy.Ether(rcvd_pkt).src
+        if exp_src_mac != actual_src_mac:
+            raise Exception("Pkt sent from {} to {} on port {} was rcvd pkt on {} which is one of the expected ports, "
+                            "but the src mac doesn't match, expected {}, got {}".
+                            format(ip_src, ip_dst, src_port, rcvd_port, exp_src_mac, actual_src_mac))
+        return (rcvd_port, rcvd_pkt)
+
+    def check_ip_route(self, hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip,outer_src_ipv6,outer_dst_ipv6):
+        if self.ipver == 'ipv4-ipv4' or self.ipver == 'ipv4-ipv6':
+            (matched_port, received) = self.check_ipv4_route(
+                hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip, self.ipver)
+        else:
+            (matched_port, received) = self.check_ipv6_route(
+                hash_key, src_port, dst_port_lists, outer_src_ipv6, outer_dst_ipv6, self.ipver)
+
+        assert received
+
+        logging.info("Received packet at " + str(matched_port))
+        time.sleep(0.02)
+
+        return (matched_port, received)
+
+    def check_hash(self, hash_key):
+        # Use dummy IPv4 address for outer_src_ip and outer_dst_ip
+        # We don't care the actually value as long as the outer_dst_ip is routed by default routed
+        # The outer_src_ip and outer_dst_ip are fixed
+        outer_src_ip = '80.1.0.31'
+        outer_dst_ip = '80.1.0.32'
+        outer_src_ipv6 = '80::31'
+        outer_dst_ipv6 = '80::32'
+        src_port, exp_port_lists, next_hops = self.get_src_and_exp_ports(
+            outer_dst_ip)
+        if self.switch_type == "chassis-packet":
+            exp_port_lists = self.check_same_asic(src_port, exp_port_lists)
+
+        logging.info("outer_src_ip={}, outer_dst_ip={}, src_port={}, exp_port_lists={}".format(
+            outer_src_ip, outer_dst_ip, src_port, exp_port_lists))
+        for exp_port_list in exp_port_lists:
+            if len(exp_port_list) <= 1:
+                logging.warning("{} has only {} nexthop".format(
+                    outer_dst_ip, exp_port_list))
+                assert False
+
+        hit_count_map = {}
+        for _ in range(0, self.balancing_test_times*len(list(itertools.chain(*exp_port_lists)))):
+            logging.info('Checking hash key {}, src_port={}, exp_ports={}, outer_src_ip={}, outer_dst_ip={}'
+                         .format(hash_key, src_port, exp_port_lists, outer_src_ip, outer_dst_ip))
+            (matched_index, _) = self.check_ip_route(hash_key,
+                                                     src_port, exp_port_lists, outer_src_ip, outer_dst_ip, outer_src_ipv6, outer_dst_ipv6)
+            hit_count_map[matched_index] = hit_count_map.get(
+                matched_index, 0) + 1
+        logging.info("hash_key={}, hit count map: {}".format(
+            hash_key, hit_count_map))
+
+        for next_hop in next_hops:
+            self.check_balancing(next_hop.get_next_hop(), hit_count_map, src_port)
+
+    def runTest(self):
+        """
+        @summary: Send NvGRE packet for each range of both IPv4 and IPv6 spaces and
+        expect the packet to be received from one of the expected ports
+        """
+        logging.info("List of hash_keys: {}".format(self.hash_keys))
         for hash_key in self.hash_keys:
             logging.info("hash test hash_key: {}".format(hash_key))
             self.check_hash(hash_key)

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -850,6 +850,7 @@ class IPinIPHashTest(HashTest):
             logging.info("hash test hash_key: {}".format(hash_key))
             self.check_hash(hash_key)
 
+
 class VxlanHashTest(HashTest):
     '''
     This test is to verify the hash key for VxLAN packet.
@@ -872,7 +873,7 @@ class VxlanHashTest(HashTest):
         ) if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
         sport = random.randint(0, 65535) if hash_key == 'src-port' else 1234
         dport = random.randint(0, 65535) if hash_key == 'dst-port' else 80
-        outer_sport = random.randint(0,65536) if hash_key == 'outer-src-port' else 1234
+        outer_sport = random.randint(0, 65536) if hash_key == 'outer-src-port' else 1234
 
         src_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
             if hash_key == 'src-mac' else self.base_mac
@@ -880,9 +881,6 @@ class VxlanHashTest(HashTest):
             if hash_key == 'dst-mac' else self.base_mac
 
         router_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']
-
-        vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
-        ip_proto = self._get_ip_proto() if hash_key == 'ip-proto' else None
 
         if self.ipver == "ipv4-ipv4":
             pkt_opts = {
@@ -930,7 +928,8 @@ class VxlanHashTest(HashTest):
             masked_exp_pkt.set_do_not_care_scapy(scapy.TCP, "chksum")
 
         send_packet(self, src_port, vxlan_pkt)
-        logging.info('Sent Outer Ether(src={}, dst={})/IP(src={}, dst={})VxLAN(sport={}, dport={})/Inner Ether(src={}, dst={}), IP(src={}, '
+        logging.info('Sent Outer Ether(src={}, dst={})/IP(src={}, dst={})VxLAN(sport={}, '
+                     'dport={})/Inner Ether(src={}, dst={}), IP(src={}, '
                      'dst={} )/TCP(sport={}, dport={} on port {})'
                      .format(vxlan_pkt.src,
                              vxlan_pkt.dst,
@@ -992,13 +991,7 @@ class VxlanHashTest(HashTest):
             if hash_key == 'dst-mac' else self.base_mac
         router_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']
 
-        vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
-        ip_proto = self._get_ip_proto(
-            ipv6=True) if hash_key == "ip-proto" else None
-        outer_sport = random.randint(0,65536) if hash_key == 'outer-src-port' else 1234
-
-        inner_pkt_len = random.randrange(
-            100, 1024) if hash_key == 'inner_length' else 100
+        outer_sport = random.randint(0, 65536) if hash_key == 'outer-src-port' else 1234
 
         if self.ipver == 'ipv6-ipv6':
             pkt_opts = {
@@ -1041,7 +1034,8 @@ class VxlanHashTest(HashTest):
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
 
         send_packet(self, src_port, vxlan_pkt)
-        logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={})VxLAN(sport={}, dport={})/Inner Ether(src={}, dst={}), Inner IPv6(src={}, '
+        logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={})VxLAN(sport={}, dport={})'
+                     '/Inner Ether(src={}, dst={}), Inner IPv6(src={}, '
                      'dst={})/TCP(sport={}, dport={} on port {})'
                      .format(vxlan_pkt.src,
                              vxlan_pkt.dst,
@@ -1261,7 +1255,8 @@ class NvgreHashTest(HashTest):
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
 
         send_packet(self, src_port, nvgre_pkt)
-        logging.info('Sent Outer Ether(src={}, dst={})/IP(src={}, dst={}, nvgre_tni={})/Inner Ether(src={}, dst={}), IP(src={}, '
+        logging.info('Sent Outer Ether(src={}, dst={})/IP(src={}, dst={}, nvgre_tni={})'
+                     '/Inner Ether(src={}, dst={}), IP(src={}, '
                      'dst={} )/TCP(sport={}, dport={} on port {})'
                      .format(nvgre_pkt.src,
                              nvgre_pkt.dst,
@@ -1321,10 +1316,6 @@ class NvgreHashTest(HashTest):
             if hash_key == 'dst-mac' else self.base_mac
         router_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']
 
-        vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
-        ip_proto = self._get_ip_proto(
-            ipv6=True) if hash_key == "ip-proto" else None
-
         if self.ipver == 'ipv6-ipv6':
             pkt_opts = {
                 "eth_src": src_mac,
@@ -1346,7 +1337,7 @@ class NvgreHashTest(HashTest):
                 "tcp_dport": dport}
             inner_pkt = simple_tcp_packet(**pkt_opts)
 
-        tni = random.randint(1,254) + 20000
+        tni = random.randint(1, 254) + 20000
         pkt_opts = {
             'eth_dst': router_mac,
             'ipv6_src': outer_src_ipv6,

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -1137,6 +1137,7 @@ class VxlanHashTest(HashTest):
             logging.info("hash test hash_key: {}".format(hash_key))
             self.check_hash(hash_key)
 
+
 class NvgreHashTest(HashTest):
     '''
     This test is to verify the hash key for NvGRE packet.
@@ -1214,9 +1215,6 @@ class NvgreHashTest(HashTest):
             if hash_key == 'dst-mac' else self.base_mac
 
         router_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']
-
-        vlan_id = random.choice(self.vlan_ids) if hash_key == 'vlan-id' else 0
-        ip_proto = self._get_ip_proto() if hash_key == 'ip-proto' else None
 
         if self.ipver == 'ipv4-ipv4':
             pkt_opts = {

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -779,6 +779,18 @@ fib/test_fib.py::test_ipinip_hash:
     conditions:
       - "asic_type in ['mellanox']"
 
+fib/test_fib.py::test_vxlan_hash:
+  skip:
+    reason: 'Vxlan hash test is not fully supported on VS platform'
+    conditions:
+      - "asic_type in ['vs']"
+
+fib/test_fib.py::test_nvgre_hash:
+  skip:
+    reason: 'Nvgre hash test is not fully supported on VS platform'
+    conditions:
+      - "asic_type in ['vs']"
+
 #######################################
 #####   generic_config_updater    #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -779,15 +779,15 @@ fib/test_fib.py::test_ipinip_hash:
     conditions:
       - "asic_type in ['mellanox']"
 
-fib/test_fib.py::test_vxlan_hash:
-  skip:
-    reason: 'Vxlan hash test is not fully supported on VS platform'
-    conditions:
-      - "asic_type in ['vs']"
-
 fib/test_fib.py::test_nvgre_hash:
   skip:
     reason: 'Nvgre hash test is not fully supported on VS platform'
+    conditions:
+      - "asic_type in ['vs']"
+
+fib/test_fib.py::test_vxlan_hash:
+  skip:
+    reason: 'Vxlan hash test is not fully supported on VS platform'
     conditions:
       - "asic_type in ['vs']"
 

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -458,7 +458,7 @@ def vxlan_ipver(request):
 def test_vxlan_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files_per_function,  # noqa F811
                      hash_keys, ptfhost, vxlan_ipver, tbinfo, mux_server_url,             # noqa F811
                      ignore_ttl, single_fib_for_duts, duts_running_config_facts,    # noqa F811
-                     duts_minigraph_facts):
+                     duts_minigraph_facts):                                         # noqa F811
     # Query the default VxLAN UDP port from switch's APPL_DB
     vxlan_dport_check = duthost.shell('redis-cli -n 0 hget "SWITCH_TABLE:switch" "vxlan_port"')
     if 'stdout' in vxlan_dport_check and vxlan_dport_check['stdout'].isdigit():
@@ -505,7 +505,7 @@ def nvgre_ipver(request):
 def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files_per_function,  # noqa F811
                      hash_keys, ptfhost, nvgre_ipver, tbinfo, mux_server_url,             # noqa F811
                      ignore_ttl, single_fib_for_duts, duts_running_config_facts,    # noqa F811
-                     duts_minigraph_facts):
+                     duts_minigraph_facts):                                         # noqa F811
 
     # For NVGRE, default hash key is inner 5-tuple.
     # Due to current limitation, NVGRE hash keys are updated for different vendors.

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -451,6 +451,7 @@ def test_ipinip_hash_negative(add_default_route_to_dut, duthosts, fib_info_files
                socket_recv_size=16384,
                is_python3=True)
 
+
 @pytest.fixture(params=["ipv4-ipv4", "ipv4-ipv6", "ipv6-ipv6", "ipv6-ipv4"])
 def vxlan_ipver(request):
     return request.param
@@ -486,7 +487,7 @@ def test_vxlan_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files_
                        "hash_keys": hash_keys,
                        "src_ip_range": ",".join(src_ip_range),
                        "dst_ip_range": ",".join(dst_ip_range),
-                       "vxlan_dest_port" : vxlan_dest_port,
+                       "vxlan_dest_port": vxlan_dest_port,
                        "vlan_ids": VLANIDS,
                        "ignore_ttl": ignore_ttl,
                        "single_fib_for_duts": single_fib_for_duts,
@@ -496,6 +497,7 @@ def test_vxlan_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files_
                qlen=PTF_QLEN,
                socket_recv_size=16384,
                is_python3=True)
+
 
 @pytest.fixture(params=["ipv4-ipv4", "ipv4-ipv6", "ipv6-ipv6", "ipv6-ipv4"])
 def nvgre_ipver(request):
@@ -508,13 +510,13 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files_
     # For NVGRE, default hash key is inner 5-tuple.
     # Due to current limitation, NVGRE hash keys are updated for different vendors.
     # Hash-key will be updated once we get the full support.
-    hash_keys = ['src-ip','dst-ip','src-port','dst-port','src-mac','dst-mac']
+    hash_keys = ['src-ip', 'dst-ip', 'src-port', 'dst-port', 'src-mac', 'dst-mac']
     if duthost.facts['asic_type'] in ["cisco-8000"]:
         logging.info("Cisco: hash-key is src-mac, dst-mac")
-        hash_keys = ['src-mac','dst-mac']
+        hash_keys = ['src-mac', 'dst-mac']
     if duthost.facts['asic_type'] in ["mellanox"]:
         logging.info("Mellanox: hash-key is src-ip, dst-ip")
-        hash_keys = ['src-ip','dst-ip']
+        hash_keys = ['src-ip', 'dst-ip']
 
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     log_file = "/tmp/hash_test.NvgreHashTest.{}.{}.log".format(

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -450,3 +450,98 @@ def test_ipinip_hash_negative(add_default_route_to_dut, duthosts, fib_info_files
                qlen=PTF_QLEN,
                socket_recv_size=16384,
                is_python3=True)
+
+@pytest.fixture(params=["ipv4-ipv4", "ipv4-ipv6", "ipv6-ipv6", "ipv6-ipv4"])
+def vxlan_ipver(request):
+    return request.param
+def test_vxlan_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files_per_function,  # noqa F811
+                     hash_keys, ptfhost, vxlan_ipver, tbinfo, mux_server_url,             # noqa F811
+                     ignore_ttl, single_fib_for_duts, duts_running_config_facts,    # noqa F811
+                     duts_minigraph_facts):
+    # Query the default VxLAN UDP port from switch's APPL_DB
+    vxlan_dport_check = duthost.shell('redis-cli -n 0 hget "SWITCH_TABLE:switch" "vxlan_port"')
+    if 'stdout' in vxlan_dport_check and vxlan_dport_check['stdout'].isdigit():
+        vxlan_dest_port = int(vxlan_dport_check['stdout'])
+    else:
+        vxlan_dest_port = 4789
+    # For VxLAN, outer L4 Source port provides entropy
+    hash_keys = ['outer-src-port']
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+    log_file = "/tmp/hash_test.VxlanHashTest.{}.{}.log".format(
+        vxlan_ipver, timestamp)
+    logging.info("PTF log file: %s" % log_file)
+    if vxlan_ipver == "ipv4-ipv4" or vxlan_ipver == "ipv6-ipv4":
+        src_ip_range = SRC_IP_RANGE
+        dst_ip_range = DST_IP_RANGE
+    else:
+        src_ip_range = SRC_IPV6_RANGE
+        dst_ip_range = DST_IPV6_RANGE
+    ptf_runner(ptfhost,
+               "ptftests",
+               "hash_test.VxlanHashTest",
+               platform_dir="ptftests",
+               params={"fib_info_files": fib_info_files_per_function[:3],   # Test at most 3 DUTs
+                       "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url,
+                                                              duts_running_config_facts, duts_minigraph_facts),
+                       "hash_keys": hash_keys,
+                       "src_ip_range": ",".join(src_ip_range),
+                       "dst_ip_range": ",".join(dst_ip_range),
+                       "vxlan_dest_port" : vxlan_dest_port,
+                       "vlan_ids": VLANIDS,
+                       "ignore_ttl": ignore_ttl,
+                       "single_fib_for_duts": single_fib_for_duts,
+                       "ipver": vxlan_ipver
+                       },
+               log_file=log_file,
+               qlen=PTF_QLEN,
+               socket_recv_size=16384,
+               is_python3=True)
+
+@pytest.fixture(params=["ipv4-ipv4", "ipv4-ipv6", "ipv6-ipv6", "ipv6-ipv4"])
+def nvgre_ipver(request):
+    return request.param
+def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files_per_function,  # noqa F811
+                     hash_keys, ptfhost, nvgre_ipver, tbinfo, mux_server_url,             # noqa F811
+                     ignore_ttl, single_fib_for_duts, duts_running_config_facts,    # noqa F811
+                     duts_minigraph_facts):
+
+    # For NVGRE, default hash key is inner 5-tuple.
+    # Due to current limitation, NVGRE hash keys are updated for different vendors.
+    # Hash-key will be updated once we get the full support.
+    hash_keys = ['src-ip','dst-ip','src-port','dst-port','src-mac','dst-mac']
+    if duthost.facts['asic_type'] in ["cisco-8000"]:
+        logging.info("Cisco: hash-key is src-mac, dst-mac")
+        hash_keys = ['src-mac','dst-mac']
+    if duthost.facts['asic_type'] in ["mellanox"]:
+        logging.info("Mellanox: hash-key is src-ip, dst-ip")
+        hash_keys = ['src-ip','dst-ip']
+
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+    log_file = "/tmp/hash_test.NvgreHashTest.{}.{}.log".format(
+        nvgre_ipver, timestamp)
+    logging.info("PTF log file: %s" % log_file)
+    if nvgre_ipver == "ipv4-ipv4" or nvgre_ipver == "ipv6-ipv4":
+        src_ip_range = SRC_IP_RANGE
+        dst_ip_range = DST_IP_RANGE
+    else:
+        src_ip_range = SRC_IPV6_RANGE
+        dst_ip_range = DST_IPV6_RANGE
+    ptf_runner(ptfhost,
+               "ptftests",
+               "hash_test.NvgreHashTest",
+               platform_dir="ptftests",
+               params={"fib_info_files": fib_info_files_per_function[:3],   # Test at most 3 DUTs
+                       "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url,
+                                                              duts_running_config_facts, duts_minigraph_facts),
+                       "hash_keys": hash_keys,
+                       "src_ip_range": ",".join(src_ip_range),
+                       "dst_ip_range": ",".join(dst_ip_range),
+                       "vlan_ids": VLANIDS,
+                       "ignore_ttl": ignore_ttl,
+                       "single_fib_for_duts": single_fib_for_duts,
+                       "ipver": nvgre_ipver
+                       },
+               log_file=log_file,
+               qlen=PTF_QLEN,
+               socket_recv_size=16384,
+               is_python3=True)


### PR DESCRIPTION
### Description of PR
Add ECMP test case to validate hash_keys for Vxlan and NVGRE packet types.

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/8166

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Approach
#### What is the motivation for this PR?
To verify ECMP balancing based on different packet fields for Vxlan and Nvgre.

#### How did you verify/test it?
Validated the tests on Mellanox, Cisco and Broadcom SKUs.

#### Supported testbed topology if it's a new test case?
All
