### PR TITLE
Fix asic identification

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -32,7 +32,7 @@ PROCESS_TO_CONTAINER_MAP = {
     "orchagent": "swss",
     "syncd": "syncd"
 }
-
+UNKNOWN_ASIC = "unknown"
 
 class SonicHost(AnsibleHostBase):
     """
@@ -1754,27 +1754,31 @@ Totals               6450                 6449
         cmd = "/usr/bin/redis-cli {}".format(redis_cmd)
         return self.command(cmd, verbose=False)
 
+    def _try_get_brcm_asic_name(self, output):
+        search_sets = {
+            "td2": {"b85", "BCM5685"},
+            "td3": {"b87", "BCM5687"},
+            "th":  {"b96", "BCM5696"},
+            "th2": {"b97", "BCM5697"},
+            "th3": {"b98", "BCM5698"},
+        }
+        for asic in search_sets.keys():
+            for search_term in search_sets[asic]:
+                if search_term in output:
+                    return asic
+        return UNKNOWN_ASIC
+
     def get_asic_name(self):
-        asic = "unknown"
+        asic = UNKNOWN_ASIC
         output = self.shell("lspci", module_ignore_errors=True)["stdout"]
-        if ("Broadcom Limited Device b960" in output or
-                "Broadcom Limited Broadcom BCM56960" in output):
-            asic = "th"
-        elif "Device b971" in output:
-            asic = "th2"
-        elif ("Broadcom Limited Device b850" in output or
-                "Broadcom Limited Broadcom BCM56850" in output or
-                "Broadcom Inc. and subsidiaries Broadcom BCM56850" in output):
-            asic = "td2"
-        elif ("Broadcom Limited Device b870" in output or
-                "Broadcom Inc. and subsidiaries Device b870" in output):
-            asic = "td3"
-        elif "Broadcom Limited Device b980" in output:
-            asic = "th3"
+        if "Broadcom" in output:
+            asic = self._try_get_brcm_asic_name(output)
         elif "Cisco Systems Inc Device a001" in output:
             asic = "gb"
         elif "Mellanox Technologies" in output:
             asic = "spc"
+
+        logger.info("asic: {}".format(asic))
 
         return asic
 

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1761,6 +1761,8 @@ Totals               6450                 6449
             "th":  {"b96", "BCM5696"},
             "th2": {"b97", "BCM5697"},
             "th3": {"b98", "BCM5698"},
+            "th4": {"b99", "BCM5699"},
+            "th5": {"f90", "BCM7890"},
         }
         for asic in search_sets.keys():
             for search_term in search_sets[asic]:

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -34,6 +34,7 @@ PROCESS_TO_CONTAINER_MAP = {
 }
 UNKNOWN_ASIC = "unknown"
 
+
 class SonicHost(AnsibleHostBase):
     """
     A remote host running SONiC.


### PR DESCRIPTION
### Description of PR
ASIC identification is (mostly) done by matching entire lines from the output of the lspci command. This is prone to failure over time, if the output lines change for whatever reason. A more robust approach is to match only those tokens which can
be considered reliable in identifying and distinguishing the ASICs, as opposed to matching whole lines of output. This change implements the token-based approach.

Additionally, this PR introduces the token matching for the TH4 and TH5 asics.

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
`test_everflow_per_interface.py` was failing due to misidentified asic (i.e. asic was "unknown"), causing the test to execute a different code path than intended.

#### How did you do it?
Updated the matching logic to compare on the pertinent information returned from the lspci command, rather than entire portions of the returned lines.

#### How did you verify/test it?
Ran the `test_everflow_per_interface.py` against TH2, TH4, and TH5-based Arista DUTs and confirmed that the tests passed.