### PR TITLE
fix: handle EOFError for cache reading

### DIFF
--- a/tests/common/devices/duthosts.py
+++ b/tests/common/devices/duthosts.py
@@ -72,18 +72,29 @@ class DutHosts(object):
             self.__initialize_nodes()
 
     def __initialize_nodes_for_parallel(self):
-        self._nodes_for_parallel_initial_checks = self._Nodes([
-            MultiAsicSonicHost(
-                self.ansible_adhoc,
-                hostname,
-                self,
-                self.tbinfo['topo']['type'],
-            ) for hostname in self.tbinfo["duts"]
-        ])
+        if self.is_parallel_leader:
+            self._nodes_for_parallel_initial_checks = self._Nodes([
+                MultiAsicSonicHost(
+                    self.ansible_adhoc,
+                    hostname,
+                    self,
+                    self.tbinfo['topo']['type'],
+                ) for hostname in self.tbinfo["duts"]
+            ])
 
-        self._nodes_for_parallel_tests = self._Nodes([
-            node for node in self._nodes_for_parallel_initial_checks if node.hostname == self.target_hostname
-        ])
+            self._nodes_for_parallel_tests = self._Nodes([
+                node for node in self._nodes_for_parallel_initial_checks if node.hostname == self.target_hostname
+            ])
+        else:
+            self._nodes_for_parallel_initial_checks = None
+            self._nodes_for_parallel_tests = self._Nodes([
+                MultiAsicSonicHost(
+                    self.ansible_adhoc,
+                    self.target_hostname,
+                    self,
+                    self.tbinfo['topo']['type'],
+                )
+            ])
 
         self._nodes_for_parallel = (
             self._nodes_for_parallel_initial_checks if self.is_parallel_leader else self._nodes_for_parallel_tests


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When parallel run is enabled, multiple processes may try to read/write the same cache file, so there will be a small chance that the file is being written by process 1 while process 2 is reading it, which will cause EOFError in process 2. In this case, we will retry reading the file in process 2. If we still get EOFError after some retry attempts, we will return NOTEXIST to overwrite the file.

In the meantime, we should also optimize how we initialize the DUT hosts when parallel run is enabled to reduce the chance of having such cache read issue. 

Summary:
Fixes # (issue) Microsoft ADO 30031372

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To prevent EOFError when reading cache file when parallel run is enabled.

#### How did you do it?
Add retry mechanism and optimize how DUT hosts are initialized when parallel is enabled.

#### How did you verify/test it?
I ran the updated code and can confirm parallel run is still working as expected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
