### PR TITLE
Add check to see if bgp sessions are up before proceeding with the tests

### DIFF
--- a/tests/bgp/test_seq_idf_isolation.py
+++ b/tests/bgp/test_seq_idf_isolation.py
@@ -108,6 +108,7 @@ def test_idf_isolated_no_export(rand_one_downlink_duthost,
     nbrs = dut_nbrs(duthost, nbrhosts)
     orig_v4_routes = parse_routes_on_neighbors(duthost, nbrs, 4)
     orig_v6_routes = parse_routes_on_neighbors(duthost, nbrs, 6)
+    up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
     try:
         # Issue command to isolate with no export community on DUT
         duthost.shell("sudo idf_isolation isolated_no_export")
@@ -117,6 +118,11 @@ def test_idf_isolated_no_export(rand_one_downlink_duthost,
         exp_community = ["no-export", traffic_shift_community]
         cur_v4_routes = {}
         cur_v6_routes = {}
+        # verify sessions are established
+        pytest_assert(
+            wait_until(300, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+            "All BGP sessions are not up. No point in continuing the test"
+        )
         # Verify that all routes advertised to neighbor at the start of the test
         if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v4_routes, cur_v4_routes, 4, exp_community):
@@ -134,6 +140,11 @@ def test_idf_isolated_no_export(rand_one_downlink_duthost,
                       "DUT is not in unisolated state")
         cur_v4_routes = {}
         cur_v6_routes = {}
+        # verify sessions are established
+        pytest_assert(
+            wait_until(300, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+            "All BGP sessions are not up. No point in continuing the test"
+        )
         # Verify that all routes seen at the start of the test are re-advertised to neighbors
         if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):
@@ -161,12 +172,18 @@ def test_idf_isolated_withdraw_all(duthosts, rand_one_downlink_duthost,
     nbrs = dut_nbrs(duthost, nbrhosts)
     orig_v4_routes = parse_routes_on_neighbors(duthost, nbrs, 4)
     orig_v6_routes = parse_routes_on_neighbors(duthost, nbrs, 6)
+    up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
     try:
         # Issue command to isolate by withdrawing all routes
         duthost.shell("sudo idf_isolation isolated_withdraw_all")
         # Verify DUT is in isolated-withdraw-all state.
         pytest_assert(IDF_ISOLATED_WITHDRAW_ALL == get_idf_isolation_state(duthost),
                       "DUT is not in isolated_withdraw_all state")
+        # verify sessions are established
+        pytest_assert(
+            wait_until(300, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+            "All BGP sessions are not up. No point in continuing the test"
+        )
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(duthosts, duthost, nbrs,
                                                                           traffic_shift_community),
                       "Failed to verify only loopback route in isolated_withdraw_all state")
@@ -177,6 +194,11 @@ def test_idf_isolated_withdraw_all(duthosts, rand_one_downlink_duthost,
                       "DUT is not in unisolated state")
         cur_v4_routes = {}
         cur_v6_routes = {}
+        # verify sessions are established
+        pytest_assert(
+            wait_until(300, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+            "All BGP sessions are not up. No point in continuing the test"
+        )
         # Verify that all routes advertised to neighbor at the start of the test
         if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):
@@ -206,6 +228,7 @@ def test_idf_isolation_no_export_with_config_reload(rand_one_downlink_duthost,
     nbrs = dut_nbrs(duthost, nbrhosts)
     orig_v4_routes = parse_routes_on_neighbors(duthost, nbrs, 4)
     orig_v6_routes = parse_routes_on_neighbors(duthost, nbrs, 6)
+    up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
     try:
         # Issue command to isolate with no export community on DUT
         duthost.shell("sudo idf_isolation isolated_no_export")
@@ -218,6 +241,11 @@ def test_idf_isolation_no_export_with_config_reload(rand_one_downlink_duthost,
         exp_community = ["no-export", traffic_shift_community]
         cur_v4_routes = {}
         cur_v6_routes = {}
+        # verify sessions are established
+        pytest_assert(
+            wait_until(300, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+            "All BGP sessions are not up. No point in continuing the test"
+        )
         # Verify that all routes advertised to neighbor at the start of the test
         if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v4_routes, cur_v4_routes, 4, exp_community):
@@ -241,6 +269,11 @@ def test_idf_isolation_no_export_with_config_reload(rand_one_downlink_duthost,
                       "DUT is not isolated_no_export state")
         cur_v4_routes = {}
         cur_v6_routes = {}
+        # verify sessions are established
+        pytest_assert(
+            wait_until(300, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+            "All BGP sessions are not up. No point in continuing the test"
+        )
         # Verify that all routes seen at the start of the test are re-advertised to neighbors
         if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):
@@ -272,6 +305,7 @@ def test_idf_isolation_withdraw_all_with_config_reload(duthosts, rand_one_downli
         # Get all routes on neighbors before doing TSA
         orig_v4_routes = parse_routes_on_neighbors(duthost, nbrs, 4)
         orig_v6_routes = parse_routes_on_neighbors(duthost, nbrs, 6)
+        up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
 
         # Issue command to isolate with no export community on DUT
         duthost.shell("sudo idf_isolation isolated_withdraw_all")
@@ -281,6 +315,11 @@ def test_idf_isolation_withdraw_all_with_config_reload(duthosts, rand_one_downli
         # Verify DUT is in isolated-withdraw-all state.
         pytest_assert(IDF_ISOLATED_WITHDRAW_ALL == get_idf_isolation_state(duthost),
                       "DUT is not isolated_no_export state")
+        # verify sessions are established
+        pytest_assert(
+            wait_until(300, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+            "All BGP sessions are not up. No point in continuing the test"
+        )
         pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(duthosts, duthost, nbrs,
                                                                           traffic_shift_community),
                       "Failed to verify only loopback route in isolated_withdraw_all state")
@@ -296,6 +335,11 @@ def test_idf_isolation_withdraw_all_with_config_reload(duthosts, rand_one_downli
         # Wait until all routes are announced to neighbors
         cur_v4_routes = {}
         cur_v6_routes = {}
+        # verify sessions are established
+        pytest_assert(
+            wait_until(300, 10, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+            "All BGP sessions are not up. No point in continuing the test"
+        )
         # Verify that all routes advertised to neighbor at the start of the test
         if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):


### PR DESCRIPTION
### Description of PR
Test currently doesn't check if the bgp sessions are all up before proceeding with the tests. Adding a check to make sure they are and then proceed with the tests. With this change we are seeing all the tests pass for chassis

Summary:
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Test currently doesn't check if the bgp sessions are all up before proceeding with the tests. Adding a check to make sure they are and then proceed with the tests. With this change we are seeing all the tests pass for chassis

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
Validated on Cisco chassis

============================= test session starts ==============================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.5.0
ansible: 2.13.13
rootdir: /data/tests
configfile: pytest.ini
plugins: metadata-3.1.1, forked-1.6.0, html-4.1.1, repeat-0.9.3, xdist-1.28.0, allure-pytest-2.8.22, ansible-4.0.0
collected 4 items

bgp/test_seq_idf_isolation.py::test_idf_isolated_no_export PASSED        [ 25%]
bgp/test_seq_idf_isolation.py::test_idf_isolated_withdraw_all PASSED     [ 50%]
bgp/test_seq_idf_isolation.py::test_idf_isolation_no_export_with_config_reload PASSED [ 75%]
bgp/test_seq_idf_isolation.py::test_idf_isolation_withdraw_all_with_config_reload PASSED [100%]