### PR TITLE
fix sample_golden_config_db.j2 portchannel undefined

### DIFF
--- a/tests/golden_config_infra/templates/sample_golden_config_db.j2
+++ b/tests/golden_config_infra/templates/sample_golden_config_db.j2
@@ -1,7 +1,9 @@
 {% set portchannels= [] %}
-{% for pc, value in PORTCHANNEL.items() %}
-    {% set _ = portchannels.append(pc) %}
-{% endfor %}
+{% if PORTCHANNEL is defined %}
+    {% for pc, value in PORTCHANNEL.items() %}
+        {% set _ = portchannels.append(pc) %}
+    {% endfor %}
+{% endif %}
 
 {
     "NEW_FEATURE": {


### PR DESCRIPTION
Add portchannel check to sample_golden_config_db.j2 to resolve errors for topos (specifically mx) that do not have portchannels for `golden_config_infra/test_config_reload_with_rendered_golden_config.py` when running `sonic-cfggen -d -t /tmp/golden_config_db.j2 > /etc/sonic/golden_config_db.json`

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #15310

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

Fix #15310

#### How did you do it?

Added portchannel check in sample_golden_config_db.j2  jinja file

#### How did you verify/test it?

Ran and tested on mx topos with no portchannels defined

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
