### PR TITLE
Stabilize pfcwd warm-reboot test on Mellanox platform

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -35,7 +35,7 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="module")
-def two_queues(request):
+def two_queues(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
     """
     Enable/Disable sending traffic to queues [4, 3]
     By default send to queue 4
@@ -48,6 +48,14 @@ def two_queues(request):
     Returns:
         two_queues: False/True
     """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    dut_asic_type = duthost.facts["asic_type"].lower()
+    # On Mellanox devices, if the leaf-fanout is running EOS, then only one queue is supported
+    if dut_asic_type == "mellanox":
+        for fanouthost in list(fanouthosts.values()):
+            fanout_os = fanouthost.get_fanout_os()
+            if fanout_os == 'eos':
+                return False
     return request.config.getoption('--two-queues')
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
`test_pfcwd_wb` is flaky on Mellanox platform because PFCWD is not triggered as expected. The error is as below.
```
tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 0
expected_match: 0
expected_missing_match: 1

Expected Messages that are missing:
.* detected PFC storm .*
```
The failure is because the `pfc_gen.py` script running on leaf-fanout can't generate continuous PFC pause to trigger PFCWD on DUT. 
For each lossless queue, a separated `pfc_gen.py` will be running on leaf-fanout. If `two_queues` is true, then there will be two processes running for each port in test. Due to job schedule, it's not guaranteed that all processes can generate continuous PFC pause to trigger PFCWD.
To workaround the issue, the PR set `two_queues` to `False` for Mellanox platform if leaf-fanout is running `EOS`.  

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to stabilize `test_pfcwd_wb` by limiting queue number to 1 on Mellanox platform if leaf-fanout is running `EOS`.

#### How did you do it?
Update fixture `two_queues`.

#### How did you verify/test it?
The change is verified on a Mellanox-SN2700 testbed. Test can pass after the change.
```
collected 3 items                                                                                                                                                                                     

pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[no_storm-str2-msn2700-spy-1] 
PASSED                                                                                                                                                                                          [ 33%]
pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[storm-str2-msn2700-spy-1] 
PASSED                                                                                                                                                                                          [ 66%] 
```
#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
