### PR TITLE
[chassis]: Add all running_golden_config files for multi-asics based on num_asic

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -183,8 +183,8 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
     elif config_source == 'running_golden_config':
         golden_path = '/etc/sonic/running_golden_config.json'
         if sonic_host.is_multi_asic:
-            for asic in sonic_host.asics:
-                golden_path = f'{golden_path},/etc/sonic/running_golden_config{asic.asic_index}.json'  # noqa: E231
+            for asic in range(sonic_host.num_asics()):
+                golden_path = f'{golden_path},/etc/sonic/running_golden_config{asic}.json'  # noqa: E231
         cmd = f'config reload -y -l {golden_path} &>/dev/null'
         if config_force_option_supported(sonic_host):
             cmd = f'config reload -y -f -l {golden_path} &>/dev/null'


### PR DESCRIPTION
Signed-off-by: anamehra anamehra@cisco.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fixes config reload -y <running_golden_config> for chassis sup by using num_asics to populate config db file list




Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
During some tests, config is restored via config reload using runnin_golden config files.

config reload -y expects all n+1 config files be provided as input but sonic-mgmt script only includes the config files for present asics.

System had 10 asics but max asics could be 16. The command shows only 10+1(global) config db

Before fix:
```2024 Oct 19 09:53:32.038630 sfd-t2-sup INFO python[815457]: ansible-ansible.legacy.command Invoked with executable=/bin/bash _raw_params=config reload -y -f -l /etc/sonic/running_golden_config.json,/ee
tc/sonic/running_golden_config0.json,/etc/sonic/running_golden_config1.json,/etc/sonic/running_golden_config4.json,/etc/sonic/running_golden_config5.json,/etc/sonic/running_golden_config8.json,/etc/soo
nic/running_golden_config9.json,/etc/sonic/running_golden_config10.json,/etc/sonic/running_golden_config11.json,/etc/sonic/running_golden_config12.json,/etc/sonic/running_golden_config13.json &>/dev/nn
ull _uses_shell=True warn=False stdin_add_newline=True strip_empty_ends=True argv=None chdir=None creates=None removes=None stdin=None
```

#### How did you do it?
Use num_asics for the DUT host and populate the CLI args list with running_golden_config db file path for each possible asic, present or absent.

#### How did you verify/test it?
RUn sonic-mgmt tests suits

After fix:

Config reload on RP with max 16 asics, 10 resent:
```
2024 Oct 30 20:45:56.831628 sfd-t2-sup INFO python[3758349]: ansible-ansible.legacy.command Invoked with executable=/bin/bash _raw_params=config reload -y -f -l /etc/sonic/running_golden_config.json,//
etc/sonic/running_golden_config0.json,/etc/sonic/running_golden_config1.json,/etc/sonic/running_golden_config2.json,/etc/sonic/running_golden_config3.json,/etc/sonic/running_golden_config4.json,/etc/ss
onic/running_golden_config5.json,/etc/sonic/running_golden_config6.json,/etc/sonic/running_golden_config7.json,/etc/sonic/running_golden_config8.json,/etc/sonic/running_golden_config9.json,/etc/sonic//
running_golden_config10.json,/etc/sonic/running_golden_config11.json,/etc/sonic/running_golden_config12.json,/etc/sonic/running_golden_config13.json,/etc/sonic/running_golden_config14.json,/etc/sonic//
running_golden_config15.json &>/dev/null _uses_shell=True warn=False stdin_add_newline=True strip_empty_ends=True argv=None chdir=None creates=None removes=None stdin=None
2024 Oct 30 20:46:01.770294 sfd-t2-sup NOTICE CCmisApi: 'reload' executing with command: config reload -y -f -l /etc/sonic/running_golden_config.json,/etc/sonic/running_golden_config0.json,/etc/sonic//
running_golden_config1.json,/etc/sonic/running_golden_config2.json,/etc/sonic/running_golden_config3.json,/etc/sonic/running_golden_config4.json,/etc/sonic/running_golden_config5.json,/etc/sonic/runnii
ng_golden_config6.json,/etc/sonic/running_golden_config7.json,/etc/sonic/running_golden_config8.json,/etc/sonic/running_golden_config9.json,/etc/sonic/running_golden_config10.json,/etc/sonic/running_gg
olden_config11.json,/etc/sonic/running_golden_config12.json,/etc/sonic/running_golden_config13.json,/etc/sonic/running_golden_config14.json,/etc/sonic/running_golden_config15.json
```

Config reload on LC with 3 asics:
```
2024 Oct 30 20:45:53.282867 sfd-t2-lc0 INFO python[86920]: ansible-ansible.legacy.command Invoked with executable=/bin/bash _raw_params=config reload -y -f -l /etc/sonic/running_golden_confii
g.json,/etc/sonic/running_golden_config0.json,/etc/sonic/running_golden_config1.json,/etc/sonic/running_golden_config2.json &>/dev/null _uses_shell=True warn=False stdin_add_newline=True strr
ip_empty_ends=True argv=None chdir=None creates=None removes=None stdin=None
2024 Oct 30 20:45:54.919206 sfd-t2-lc0 NOTICE CCmisApi: 'reload' executing with command: config reload -y -f -l /etc/sonic/running_golden_config.json,/etc/sonic/running_golden_config0.json,//
etc/sonic/running_golden_config1.json,/etc/sonic/running_golden_config2.json
2024 Oct 30 20:45:54.919305 sfd-t2-lc0 NOTICE CCmisApi: 'reload' stopping services...
```

#### Any platform specific information?
Chassis Supervisor

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
