### PR TITLE
[Bugfix] Fix fixture not found issue in script `pfc_asym/test_pfc_asym.py`.

### DIFF
--- a/tests/pfc_asym/test_pfc_asym.py
+++ b/tests/pfc_asym/test_pfc_asym.py
@@ -1,4 +1,5 @@
 from tests.ptf_runner import ptf_runner
+from tests.common.fixtures.pfc_asym import setup    # noqa F401
 import pytest
 
 pytestmark = [
@@ -11,7 +12,7 @@ def prepare_syncdrpc(swapSyncd):
     pass
 
 
-def test_pfc_asym_off_tx_pfc(ptfhost, setup, pfc_storm_runner):
+def test_pfc_asym_off_tx_pfc(ptfhost, setup, pfc_storm_runner):     # noqa F811
     """
     @summary: Asymmetric PFC is disabled. Verify that DUT generates PFC frames only on lossless priorities when
                 asymmetric PFC is disabled
@@ -29,7 +30,7 @@ def test_pfc_asym_off_tx_pfc(ptfhost, setup, pfc_storm_runner):
                log_file="/tmp/pfc_asym.PfcAsymOffOnTxTest.log")
 
 
-def test_pfc_asym_off_rx_pause_frames(ptfhost, setup, pfc_storm_runner):
+def test_pfc_asym_off_rx_pause_frames(ptfhost, setup, pfc_storm_runner):        # noqa F811
     """
     @summary: Asymmetric PFC is disabled. Verify that while receiving PFC frames DUT drops packets only for lossless
                 priorities (RX and Tx queue buffers are full)
@@ -48,7 +49,7 @@ def test_pfc_asym_off_rx_pause_frames(ptfhost, setup, pfc_storm_runner):
                log_file="/tmp/pfc_asym.PfcAsymOffRxTest.log")
 
 
-def test_pfc_asym_on_tx_pfc(ptfhost, setup, enable_pfc_asym, pfc_storm_runner):
+def test_pfc_asym_on_tx_pfc(ptfhost, setup, enable_pfc_asym, pfc_storm_runner):     # noqa F811
     """
     @summary: Asymmetric PFC is enabled. Verify that DUT generates PFC frames only on lossless priorities when
                 asymmetric PFC is enabled
@@ -67,7 +68,7 @@ def test_pfc_asym_on_tx_pfc(ptfhost, setup, enable_pfc_asym, pfc_storm_runner):
                log_file="/tmp/pfc_asym.PfcAsymOffOnTxTest.log")
 
 
-def test_pfc_asym_on_handle_pfc_all_prio(ptfhost, setup, enable_pfc_asym, pfc_storm_runner):
+def test_pfc_asym_on_handle_pfc_all_prio(ptfhost, setup, enable_pfc_asym, pfc_storm_runner):        # noqa F811
     """
     @summary: Asymmetric PFC is enabled. Verify that while receiving PFC frames DUT handle PFC frames on all
                 priorities when asymetric mode is enabled


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
There is an error while running test case test_pfc_asym_off_rx_pause_frames, as fixture setup is defined in `tests.common.fixtures.pfc_asym`. In this PR, we import this fixture in this test script to fix this issue. 
```
 def test_pfc_asym_off_rx_pause_frames(ptfhost, setup, pfc_storm_runner):
       fixture 'setup' not found
```

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
There is an error while running test case test_pfc_asym_off_rx_pause_frames, as fixture setup is defined in `tests.common.fixtures.pfc_asym`. In this PR, we import this fixture in this test script to fix this issue. 
```
 def test_pfc_asym_off_rx_pause_frames(ptfhost, setup, pfc_storm_runner):
       fixture 'setup' not found
```

#### How did you do it?
In this PR, we import this fixture in this test script to fix this issue. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
