### PR TITLE
Add dummy ptf.testutils library to skip traffic test in KVM

### DIFF
--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -297,11 +297,16 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
                 logging.info("Skip tunnel traffic verify due to traffic test was skipped.")
                 return
             try:
-                port_index, rec_pkt = testutils.verify_packet_any_port(
+                result = testutils.verify_packet_any_port(
                     ptfadapter,
                     self.exp_pkt,
                     ports=self.listen_ports
                 )
+                if isinstance(result, tuple):
+                    port_index, rec_pkt = result
+                elif isinstance(result, bool):
+                    logging.info("Using dummy testutils to skip traffic test.")
+                    return
             except AssertionError as detail:
                 logging.debug("Error occurred in polling for tunnel traffic", exc_info=True)
                 if "Did not receive expected packet on any of ports" in str(detail):

--- a/tests/common/plugins/ptfadapter/dummy_testutils.py
+++ b/tests/common/plugins/ptfadapter/dummy_testutils.py
@@ -13,7 +13,7 @@ class DummyTestUtils:
     def __init__(self, *args, **kwargs):
         func_dict = {}
         for name, func in inspect.getmembers(testutils, inspect.isfunction):
-            if name.startswith("send") or name.startswith("verify"):
+            if name.startswith("verify"):
                 func_dict[name] = func
         self.func_dict = func_dict
 

--- a/tests/common/plugins/ptfadapter/dummy_testutils.py
+++ b/tests/common/plugins/ptfadapter/dummy_testutils.py
@@ -1,0 +1,28 @@
+import ptf.testutils as testutils
+import inspect
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def wrapped(*args, **kwargs):
+    return True
+
+
+class DummyTestUtils:
+    def __init__(self, *args, **kwargs):
+        func_dict = {}
+        for name, func in inspect.getmembers(testutils, inspect.isfunction):
+            if name.startswith("send") or name.startswith("verify"):
+                func_dict[name] = func
+        self.func_dict = func_dict
+
+    def __enter__(self, *args, **kwargs):
+        """ enter in 'with' block """
+        for name, func in self.func_dict.items():
+            setattr(testutils, name, wrapped)
+
+    def __exit__(self, *args, **kwargs):
+        """ exit from 'with' block """
+        for name, func in self.func_dict.items():
+            setattr(testutils, name, self.func_dict[name])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,7 @@ from tests.common.connections.console_host import ConsoleHost
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.helpers.inventory_utils import trim_inventory
 from tests.common.utilities import InterruptableThread
+from tests.common.plugins.ptfadapter.dummy_testutils import DummyTestUtils
 
 try:
     from tests.macsec import MacsecPluginT2, MacsecPluginT0
@@ -989,6 +990,18 @@ def pytest_runtest_makereport(item, call):
     # be "setup", "call", "teardown"
 
     setattr(item, "rep_" + rep.when, rep)
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_call(item):
+    if "skip_traffic_test" in item.keywords:
+        logger.info("Skip traffic test in conftest")
+        with DummyTestUtils():
+            logger.info("Set ptf.testutils to DummyTestUtils to skip traffic test")
+            yield
+            logger.info("Reset ptf.testutils")
+    else:
+        yield
 
 
 def collect_techsupport_on_dut(request, a_dut):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -995,7 +995,7 @@ def pytest_runtest_makereport(item, call):
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_call(item):
     if "skip_traffic_test" in item.keywords:
-        logger.info("Skip traffic test in conftest")
+        logger.info("Got skip_traffic_test marker, will skip traffic test")
         with DummyTestUtils():
             logger.info("Set ptf.testutils to DummyTestUtils to skip traffic test")
             yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -992,6 +992,9 @@ def pytest_runtest_makereport(item, call):
     setattr(item, "rep_" + rep.when, rep)
 
 
+# This function is a pytest hook implementation that is called in runtest call stage.
+# We are using this hook to set ptf.testutils to DummyTestUtils if the test is marked with "skip_traffic_test",
+# DummyTestUtils would always return True for all verify function in ptf.testutils.
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_call(item):
     if "skip_traffic_test" in item.keywords:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently we are using marker "skip_traffic_test" to decide whether to run traffic test or not. Then the marker would pass to a fixture called by each data plane testcase.
This approach is only applied in master branch, which cause a lot of code change in test scripts, and difficult to do cherry pick.
#### How did you do it?
Based on the marker "skip_traffic_test", use a testcase level pytest hook to get the marker, if it exists, then setattr to a function always return for all testutils function startwith "send" or "verify", and setattr back when test finished.
#### How did you verify/test it?
Verified in KVM test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
