### PR TITLE
Porting PR:15099 to 202405: Move the common code from testcases to the fixtures.

### DIFF
--- a/tests/common/snappi_tests/qos_fixtures.py
+++ b/tests/common/snappi_tests/qos_fixtures.py
@@ -3,7 +3,7 @@ import time
 import json
 from tests.common.snappi_tests.common_helpers import \
         stop_pfcwd, disable_packet_aging, enable_packet_aging
-from tests.common.utilities import get_running_config
+from tests.override_config_table.utilities import get_running_config
 
 """
 RDMA test cases may require variety of fixtures. This

--- a/tests/common/snappi_tests/qos_fixtures.py
+++ b/tests/common/snappi_tests/qos_fixtures.py
@@ -1,4 +1,9 @@
 import pytest
+import time
+import json
+from tests.common.snappi_tests.common_helpers import \
+        stop_pfcwd, disable_packet_aging, enable_packet_aging
+from tests.common.utilities import get_running_config
 
 """
 RDMA test cases may require variety of fixtures. This
@@ -106,3 +111,59 @@ def lossy_prio_list(all_prio_list, lossless_prio_list):
     """
     result = [x for x in all_prio_list if x not in lossless_prio_list]
     return result
+
+
+# Introducing these functions, since the existing pfcwd-start function
+# uses start-default. The start-default starts pfcwd only if the config
+# is enabled by default. Since we need a definite way to start pfcwd,
+# the following functions are introduced.
+def get_pfcwd_config(duthost):
+    config = get_running_config(duthost)
+    if "PFC_WD" in config.keys():
+        return config['PFC_WD']
+    else:
+        all_configs = []
+        output = duthost.shell("ip netns | awk '{print $1}'")['stdout']
+        all_asic_list = output.split("\n")
+        all_asic_list.append(None)
+        for space in all_asic_list:
+            config = get_running_config(duthost, space)
+            if "PFC_WD" in config.keys():
+                all_configs.append(config['PFC_WD'])
+            else:
+                all_configs.append({})
+        return all_configs
+
+
+def reapply_pfcwd(duthost, pfcwd_config):
+    timestamp = time.time()
+    file_prefix = f"{timestamp}_pfcwd"
+    if type(pfcwd_config) is dict:
+        duthost.copy(content=json.dumps({"PFC_WD": pfcwd_config}, indent=4), dest=file_prefix)
+        duthost.shell(f"config load {file_prefix} -y")
+    elif type(pfcwd_config) is list:
+        output = duthost.shell("ip netns | awk '{print $1}'")['stdout']
+        all_asic_list = output.split("\n")
+        all_asic_list.append(None)
+
+        all_files = []
+        for index, config in enumerate(pfcwd_config):
+            filename = "{}_{}.json".format(file_prefix, all_asic_list[index])
+            duthost.copy(content=json.dumps({"PFC_WD": config}, indent=4), dest=filename)
+            all_files.append(filename)
+        duthost.shell("config load {} -y".format(",".join(all_files)))
+    else:
+        raise RuntimeError(f"Script problem: Got an unsupported type of pfcwd_config:{pfcwd_config}")
+
+
+@pytest.fixture(autouse=False)
+def disable_pfcwd(duthosts):
+    pfcwd_value = {}
+    for duthost in duthosts:
+        pfcwd_value[duthost.hostname] = get_pfcwd_config(duthost)
+        stop_pfcwd(duthost)
+        disable_packet_aging(duthost)
+    yield
+    for duthost in duthosts:
+        reapply_pfcwd(duthost, pfcwd_value[duthost.hostname])
+        enable_packet_aging(duthost)

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -19,6 +19,8 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.snappi_tests.variables import dut_ip_start, snappi_ip_start, prefix_length, \
     dut_ipv6_start, snappi_ipv6_start, v6_prefix_length, pfcQueueGroupSize, \
     pfcQueueValueDict          # noqa: F401
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -552,7 +554,8 @@ def cvg_api(snappi_api_serv_ip,
 
 def snappi_dut_base_config(duthost_list,
                            snappi_ports,
-                           snappi_api):
+                           snappi_api,
+                           setup=True):
     """
     Generate snappi API config and port config information for the testbed
     Args:
@@ -613,18 +616,33 @@ def snappi_dut_base_config(duthost_list,
 
     port_config_list = []
 
+    return (setup_dut_ports(
+        setup=setup,
+        duthost_list=duthost_list,
+        config=config,
+        port_config_list=port_config_list,
+        snappi_ports=new_snappi_ports))
+
+
+def setup_dut_ports(
+        setup,
+        duthost_list,
+        config,
+        port_config_list,
+        snappi_ports):
+
     for index, duthost in enumerate(duthost_list):
         config_result = __vlan_intf_config(config=config,
                                            port_config_list=port_config_list,
                                            duthost=duthost,
-                                           snappi_ports=new_snappi_ports)
+                                           snappi_ports=snappi_ports)
         pytest_assert(config_result is True, 'Fail to configure Vlan interfaces')
 
     for index, duthost in enumerate(duthost_list):
         config_result = __portchannel_intf_config(config=config,
                                                   port_config_list=port_config_list,
                                                   duthost=duthost,
-                                                  snappi_ports=new_snappi_ports)
+                                                  snappi_ports=snappi_ports)
         pytest_assert(config_result is True, 'Fail to configure portchannel interfaces')
 
     if is_snappi_multidut(duthost_list):
@@ -633,17 +651,18 @@ def snappi_dut_base_config(duthost_list,
                                                     config=config,
                                                     port_config_list=port_config_list,
                                                     duthost=duthost,
-                                                    snappi_ports=new_snappi_ports)
+                                                    snappi_ports=snappi_ports,
+                                                    setup=setup)
             pytest_assert(config_result is True, 'Fail to configure multidut L3 interfaces')
     else:
         for index, duthost in enumerate(duthost_list):
             config_result = __l3_intf_config(config=config,
                                              port_config_list=port_config_list,
                                              duthost=duthost,
-                                             snappi_ports=new_snappi_ports)
+                                             snappi_ports=snappi_ports)
             pytest_assert(config_result is True, 'Fail to configure L3 interfaces')
 
-    return config, port_config_list, new_snappi_ports
+    return config, port_config_list, snappi_ports
 
 
 @pytest.fixture(scope="function")
@@ -772,7 +791,7 @@ def __intf_config(config, port_config_list, duthost, snappi_ports):
     return True
 
 
-def __intf_config_multidut(config, port_config_list, duthost, snappi_ports):
+def __intf_config_multidut(config, port_config_list, duthost, snappi_ports, setup=True):
     """
     Configures interfaces of the DUT
     Args:
@@ -780,6 +799,7 @@ def __intf_config_multidut(config, port_config_list, duthost, snappi_ports):
         port_config_list (list): list of Snappi port configuration information
         duthost (object): device under test
         snappi_ports (list): list of Snappi port information
+        setup: Setting up or teardown? True or False
     Returns:
         True if we successfully configure the interfaces or False
     """
@@ -797,17 +817,25 @@ def __intf_config_multidut(config, port_config_list, duthost, snappi_ports):
                                                                             port['peer_port'],
                                                                             dutIp,
                                                                             prefix_length))
+        if setup:
+            cmd = "add"
+        else:
+            cmd = "remove"
         if port['asic_value'] is None:
-            duthost.command('sudo config interface ip add {} {}/{} \n' .format(
+            duthost.command('sudo config interface ip {} {} {}/{} \n' .format(
+                                                                                cmd,
                                                                                 port['peer_port'],
                                                                                 dutIp,
                                                                                 prefix_length))
         else:
-            duthost.command('sudo config interface -n {} ip add {} {}/{} \n' .format(
+            duthost.command('sudo config interface -n {} ip {} {} {}/{} \n' .format(
                                                                                     port['asic_value'],
+                                                                                    cmd,
                                                                                     port['peer_port'],
                                                                                     dutIp,
                                                                                     prefix_length))
+        if setup is False:
+            continue
         port['intf_config_changed'] = True
         device = config.devices.device(name='Device Port {}'.format(port_id))[-1]
         ethernet = device.ethernets.add()

--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -1,6 +1,17 @@
+import logging
+import pytest
 from tests.common.broadcom_data import is_broadcom_device
 from tests.common.helpers.assertions import pytest_require
 from tests.common.cisco_data import is_cisco_device
+from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+from tests.common.config_reload import config_reload
+from tests.common.reboot import reboot
+from tests.common.helpers.parallel import parallel_run
+from tests.common.utilities import wait_until
+from tests.common.snappi_tests.snappi_fixtures import get_snappi_ports_for_rdma, \
+    snappi_dut_base_config
+
+logger = logging.getLogger(__name__)
 
 
 def skip_warm_reboot(duthost, reboot_type):
@@ -21,8 +32,10 @@ def skip_warm_reboot(duthost, reboot_type):
         reboot_case_supported = False
     elif is_broadcom_device(duthost) and asic_type in SKIP_LIST and "warm" in reboot_type:
         reboot_case_supported = False
-    pytest_require(reboot_case_supported, "Reboot type {} is not supported on {} switches".
-                   format(reboot_type, duthost.facts['asic_type']))
+    msg = "Reboot type {} is {} supported on {} switches".format(
+            reboot_type, "" if reboot_case_supported else "not", duthost.facts['asic_type'])
+    logger.info(msg)
+    pytest_require(reboot_case_supported, msg)
 
 
 def skip_ecn_tests(duthost):
@@ -55,3 +68,80 @@ def skip_pfcwd_test(duthost, trigger_pfcwd):
     """
     pytest_require(trigger_pfcwd is True or is_broadcom_device(duthost) is False,
                    'Skip trigger_pfcwd=False test cases for Broadcom devices')
+
+
+@pytest.fixture(autouse=True, params=MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
+def multidut_port_info(request):
+    yield request.param
+
+
+@pytest.fixture(autouse=True)
+def setup_ports_and_dut(
+        duthosts,
+        snappi_api,
+        get_snappi_ports,
+        multidut_port_info,
+        number_of_tx_rx_ports):
+    for testbed_subtype, rdma_ports in multidut_port_info.items():
+        tx_port_count, rx_port_count = number_of_tx_rx_ports
+        if len(get_snappi_ports) < tx_port_count + rx_port_count:
+            pytest.skip(
+                "Need Minimum of 2 ports defined in ansible/files/*links.csv"
+                " file, got:{}".format(len(get_snappi_ports)))
+
+        if len(rdma_ports['tx_ports']) < tx_port_count:
+            pytest.skip(
+                "MULTIDUT_PORT_INFO doesn't have the required Tx ports defined for "
+                "testbed {}, subtype {} in variables.py".format(
+                    MULTIDUT_TESTBED, testbed_subtype))
+
+        if len(rdma_ports['rx_ports']) < rx_port_count:
+            pytest.skip(
+                "MULTIDUT_PORT_INFO doesn't have the required Rx ports defined for "
+                "testbed {}, subtype {} in variables.py".format(
+                    MULTIDUT_TESTBED, testbed_subtype))
+        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+        snappi_ports = get_snappi_ports_for_rdma(
+            get_snappi_ports,
+            rdma_ports,
+            tx_port_count,
+            rx_port_count,
+            MULTIDUT_TESTBED)
+        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(
+            duthosts, snappi_ports, snappi_api, setup=True)
+
+    if len(port_config_list) < 2:
+        pytest.skip("This test requires at least 2 ports")
+    yield (testbed_config, port_config_list, snappi_ports)
+
+    snappi_dut_base_config(duthosts, snappi_ports, snappi_api, setup=False)
+
+
+@pytest.fixture(params=['warm', 'cold', 'fast'])
+def reboot_duts(setup_ports_and_dut, localhost, request):
+    reboot_type = request.param
+    _, _, snappi_ports = setup_ports_and_dut
+    skip_warm_reboot(snappi_ports[0]['duthost'], reboot_type)
+    skip_warm_reboot(snappi_ports[1]['duthost'], reboot_type)
+
+    def save_config_and_reboot(node, results=None):
+        logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, node.hostname))
+        node.shell("mkdir /etc/sonic/orig_configs; mv /etc/sonic/config_db* /etc/sonic/orig_configs/")
+        node.shell("sudo config save -y")
+        reboot(node, localhost, reboot_type=reboot_type, safe_reboot=True)
+        logger.info("Wait until the system is stable")
+        wait_until(180, 20, 0, node.critical_services_fully_started)
+
+    # Convert the list of duthosts into a list of tuples as required for parallel func.
+    args = set((snappi_ports[0]['duthost'], snappi_ports[1]['duthost']))
+    parallel_run(save_config_and_reboot, {}, {}, list(args), timeout=900)
+
+    yield
+
+    def revert_config_and_reload(node, results=None):
+        node.shell("mv /etc/sonic/orig_configs/* /etc/sonic/ ; rmdir /etc/sonic/orig_configs; ")
+        config_reload(node, safe_reload=True)
+
+    # parallel_run(revert_config_and_reload, {}, {}, list(args), timeout=900)
+    for duthost in args:
+        revert_config_and_reload(node=duthost)

--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -6,7 +6,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts  # noqa F401
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector,\
     get_lossless_buffer_size, get_pg_dropped_packets,\
-    stop_pfcwd, disable_packet_aging, sec_to_nanosec,\
+    disable_packet_aging, enable_packet_aging, sec_to_nanosec,\
     get_pfc_frame_count, packet_capture, config_capture_pkt,\
     traffic_flow_mode, calc_pfc_pause_flow_rate      # noqa F401
 from tests.common.snappi_tests.port import select_ports, select_tx_port  # noqa F401
@@ -90,10 +90,6 @@ def run_pfc_test(api,
     dut_asics_to_be_configured.add((ingress_duthost, tx_port['asic_value']))
 
     pytest_assert(testbed_config is not None, 'Fail to get L2/3 testbed config')
-
-    for duthost, asic in dut_asics_to_be_configured:
-        stop_pfcwd(duthost, asic)
-        disable_packet_aging(duthost)
 
     global DATA_FLOW_DURATION_SEC
     global data_flow_delay_sec
@@ -290,7 +286,7 @@ def run_pfc_test(api,
         verify_in_flight_buffer_pkts(duthost=egress_duthost,
                                      flow_metrics=in_flight_flow_metrics,
                                      snappi_extra_params=snappi_extra_params,
-                                     asic_value=rx_port['asic_value'])
+                                     asic_value=tx_port['asic_value'])
     else:
         # Verify zero pause frames are counted when the PFC class enable vector is not set
         verify_unset_cev_pause_frame_count(duthost=duthost,

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -6,32 +6,36 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     snappi_api, snappi_dut_base_config, get_snappi_ports_for_rdma, cleanup_config, get_snappi_ports_multi_dut, \
     snappi_testbed_config, get_snappi_ports_single_dut, \
     get_snappi_ports, is_snappi_multidut                                        # noqa: F401
+from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut, reboot_duts  # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
-    lossy_prio_list                         # noqa F401
-from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+    lossy_prio_list, disable_pfcwd          # noqa F401
 from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_pfc_test
-from tests.common.reboot import reboot
-from tests.common.utilities import wait_until
 import logging
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.snappi_tests.files.helper import skip_warm_reboot
+
+
 logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
+@pytest.fixture(autouse=True)
+def number_of_tx_rx_ports():
+    yield (1, 1)
+
+
 def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: F811
                                         conn_graph_facts,               # noqa: F811
-                                        fanout_graph_facts_multidut,             # noqa: F811
+                                        fanout_graph_facts_multidut,    # noqa: F811
                                         duthosts,
                                         enum_dut_lossless_prio,
-                                        prio_dscp_map,                   # noqa: F811
-                                        lossless_prio_list,              # noqa: F811
-                                        all_prio_list,                   # noqa: F811
-                                        get_snappi_ports,                 # noqa: F811
-                                        tbinfo,                           # noqa: F811
-                                        multidut_port_info):
+                                        prio_dscp_map,                  # noqa: F811
+                                        lossless_prio_list,             # noqa: F811
+                                        all_prio_list,                  # noqa: F811
+                                        get_snappi_ports,               # noqa: F811
+                                        tbinfo,                         # noqa: F811
+                                        disable_pfcwd,                  # noqa: F811
+                                        setup_ports_and_dut):           # noqa: F811
 
     """
     Test if PFC can pause a single lossless priority in multidut setup
@@ -51,33 +55,8 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
     Returns:
         N/A
     """
-    snappi_port_list = get_snappi_ports
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
 
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
-
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
     _, lossless_prio = enum_dut_lossless_prio.split('|')
     lossless_prio = int(lossless_prio)
@@ -103,20 +82,18 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=True,
                  snappi_extra_params=snappi_extra_params)
-    cleanup_config(duthosts, snappi_ports)
 
 
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
-def test_pfc_pause_multi_lossless_prio(snappi_api,                  # noqa: F811
-                                       conn_graph_facts,            # noqa: F811
-                                       fanout_graph_facts_multidut,          # noqa: F811
+def test_pfc_pause_multi_lossless_prio(snappi_api,                   # noqa: F811
+                                       conn_graph_facts,             # noqa: F811
+                                       fanout_graph_facts_multidut,  # noqa: F811
                                        duthosts,
                                        prio_dscp_map,                # noqa: F811
                                        lossy_prio_list,              # noqa: F811
-                                       lossless_prio_list,       # noqa: F811
-                                       get_snappi_ports,            # noqa: F811
-                                       tbinfo,          # noqa: F811
-                                       multidut_port_info):    # noqa: F811
+                                       lossless_prio_list,           # noqa: F811
+                                       get_snappi_ports,             # noqa: F811
+                                       tbinfo,
+                                       setup_ports_and_dut):         # noqa: F811
 
     """
     Test if PFC can pause multiple lossless priorities in multidut setup
@@ -134,31 +111,7 @@ def test_pfc_pause_multi_lossless_prio(snappi_api,                  # noqa: F811
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
-
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
     pause_prio_list = lossless_prio_list
     test_prio_list = lossless_prio_list
@@ -180,25 +133,23 @@ def test_pfc_pause_multi_lossless_prio(snappi_api,                  # noqa: F811
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=True,
                  snappi_extra_params=snappi_extra_params)
-    cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
-@pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
-def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # noqa: F811
-                                               conn_graph_facts,            # noqa: F811
-                                               fanout_graph_facts_multidut,          # noqa: F811
+def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                   # noqa: F811
+                                               conn_graph_facts,             # noqa: F811
+                                               fanout_graph_facts_multidut,  # noqa: F811
                                                duthosts,
                                                localhost,
-                                               enum_dut_lossless_prio,    # noqa: F811
                                                prio_dscp_map,            # noqa: F811
                                                lossless_prio_list,         # noqa: F811
                                                all_prio_list,        # noqa: F811
-                                               reboot_type,
                                                get_snappi_ports,         # noqa: F811
                                                tbinfo,              # noqa: F811
-                                               multidut_port_info):
+                                               enum_dut_lossless_prio,    # noqa: F811
+                                               setup_ports_and_dut,          # noqa: F811
+                                               disable_pfcwd,                # noqa: F811
+                                               reboot_duts):                 # noqa: F811
     """
     Test if PFC can pause a single lossless priority even after various types of reboot in multidut setup
 
@@ -208,43 +159,15 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
         fanout_graph_facts_multidut (pytest fixture): fanout graph
         duthosts (pytest fixture): list of DUTs
         localhost (pytest fixture): localhost handle
+        enum_dut_lossless_prio (str): lossless priority to test, e.g., 's6100-1|3'
         all_prio_list (pytest fixture): list of all the priorities
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
-        lossless_prio_list (pytest fixture): list of all the lossless priorities
-        reboot_type (str): reboot type to be issued on the DUT
         tbinfo (pytest fixture): fixture provides information about testbed
         get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
-
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
-
-    skip_warm_reboot(snappi_ports[0]['duthost'], reboot_type)
-    skip_warm_reboot(snappi_ports[1]['duthost'], reboot_type)
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
     _, lossless_prio = enum_dut_lossless_prio.split('|')
     lossless_prio = int(lossless_prio)
@@ -257,12 +180,6 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
-    for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
-        logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-        reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
-        logger.info("Wait until the system is stable")
-        wait_until(180, 20, 0, duthost.critical_services_fully_started)
-
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
                  port_config_list=port_config_list,
@@ -276,24 +193,21 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
                  test_traffic_pause=True,
                  snappi_extra_params=snappi_extra_params)
 
-    cleanup_config(duthosts, snappi_ports)
-
 
 @pytest.mark.disable_loganalyzer
-@pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
-def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noqa: F811
-                                              conn_graph_facts,            # noqa: F811
-                                              fanout_graph_facts_multidut,          # noqa: F811
+def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                   # noqa: F811
+                                              conn_graph_facts,             # noqa: F811
+                                              fanout_graph_facts_multidut,  # noqa: F811
                                               duthosts,
                                               localhost,
-                                              prio_dscp_map,                 # noqa: F811
-                                              lossy_prio_list,               # noqa: F811
-                                              lossless_prio_list,             # noqa: F811
-                                              reboot_type,
-                                              get_snappi_ports,         # noqa: F811
-                                              tbinfo,         # noqa: F811
-                                              multidut_port_info):
+                                              prio_dscp_map,                # noqa: F811
+                                              lossy_prio_list,              # noqa: F811
+                                              lossless_prio_list,           # noqa: F811
+                                              get_snappi_ports,             # noqa: F811
+                                              tbinfo,                       # noqa: F811
+                                              setup_ports_and_dut,          # noqa: F811
+                                              disable_pfcwd,                # noqa: F811
+                                              reboot_duts):                 # noqa: F811
     """
     Test if PFC can pause multiple lossless priorities even after various types of reboot in multidut setup
 
@@ -306,39 +220,13 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noq
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
         lossless_prio_list (pytest fixture): list of all the lossless priorities
         lossy_prio_list (pytest fixture): list of all the lossy priorities
-        reboot_type (str): reboot type to be issued on the DUT
         tbinfo (pytest fixture): fixture provides information about testbed
         get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
-    skip_warm_reboot(snappi_ports[0]['duthost'], reboot_type)
-    skip_warm_reboot(snappi_ports[1]['duthost'], reboot_type)
     pause_prio_list = lossless_prio_list
     test_prio_list = lossless_prio_list
     bg_prio_list = lossy_prio_list
@@ -346,12 +234,6 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noq
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
-
-    for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
-        logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-        reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
-        logger.info("Wait until the system is stable")
-        wait_until(180, 20, 0, duthost.critical_services_fully_started)
 
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
@@ -365,5 +247,3 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                  # noq
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=True,
                  snappi_extra_params=snappi_extra_params)
-
-    cleanup_config(duthosts, snappi_ports)

--- a/tests/snappi_tests/test_multidut_snappi.py
+++ b/tests/snappi_tests/test_multidut_snappi.py
@@ -2,15 +2,15 @@ import time
 import pytest
 import random
 import logging
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut      # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, snappi_api, \
     snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config, \
     get_snappi_ports_multi_dut       # noqa: F401
-from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.common.snappi_tests.port import select_ports
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list  # noqa: F401
-from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp
+from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut  # noqa: F401
 logger = logging.getLogger(__name__)
 SNAPPI_POLL_DELAY_SEC = 2
 
@@ -90,17 +90,21 @@ def __gen_all_to_all_traffic(testbed_config,
     return testbed_config
 
 
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
+@pytest.fixture(autouse=True)
+def number_of_tx_rx_ports():
+    yield (1, 1)
+
+
 def test_snappi(request,
                 duthosts,
-                snappi_api,                         # noqa: F811
-                conn_graph_facts,                  # noqa: F811
-                fanout_graph_facts_multidut,               # noqa: F811
-                lossless_prio_list,    # noqa: F811
-                get_snappi_ports,      # noqa: F811
-                tbinfo,      # noqa: F811
-                multidut_port_info,
-                prio_dscp_map,                                                  # noqa: F811
+                snappi_api,                   # noqa: F811
+                conn_graph_facts,             # noqa: F811
+                fanout_graph_facts_multidut,  # noqa: F811
+                lossless_prio_list,           # noqa: F811
+                get_snappi_ports,             # noqa: F811
+                tbinfo,
+                prio_dscp_map,                # noqa: F811
+                setup_ports_and_dut           # noqa: F811
                 ):
 
     """
@@ -117,33 +121,10 @@ def test_snappi(request,
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
-
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                 tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
     lossless_prio = random.sample(lossless_prio_list, 1)
     lossless_prio = int(lossless_prio[0])
-
-    pytest_require(len(port_config_list) >= 2, "This test requires at least 2 ports")
 
     config = __gen_all_to_all_traffic(testbed_config=testbed_config,
                                       port_config_list=port_config_list,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Snappi reboot testcases don't save the config before rebooting the DUT. This causes the DUT to loose all the config, and the test fails with "ARP is not resolved" errors.

This PR addresses this issue by saving the config before any reboot. Also this PR moves the code that is reused in multiple tests to a common code.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
