### PR TITLE
Add test to verify IPinIP packet targeting at vnet route is decapsulated for T1

### DIFF
--- a/tests/decap/test_subnet_decap.py
+++ b/tests/decap/test_subnet_decap.py
@@ -8,26 +8,25 @@ from collections import defaultdict
 import ptf.packet as packet
 import ptf.testutils as testutils
 from ptf.mask import Mask
+from tests.common.config_reload import config_reload
 from tests.common.dualtor.dual_tor_utils import rand_selected_interface     # noqa F401
 from tests.common.fixtures.ptfhost_utils import skip_traffic_test           # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py       # noqa F401
-from tests.common.config_reload import config_reload
+from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 
+ecmp_utils = Ecmp_Utils()
 logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('t0', 't1', 'dualtor')
 ]
 
-DECAP_IPINIP_SUBNET_CONFIG_TEMPLATE = "decap/template/decap_ipinip_subnet_config.j2"
-DECAP_IPINIP_SUBNET_CONFIG_JSON = "decap_ipinip_subnet_config.json"
-DECAP_IPINIP_SUBNET_DEL_TEMPLATE = "decap/template/decap_ipinip_subnet_delete.j2"
-DECAP_IPINIP_SUBNET_DEL_JSON = "decap_ipinip_subnet_delete.json"
-
 SUBNET_DECAP_SRC_IP_V4 = "20.20.20.0/24"
 SUBNET_DECAP_SRC_IP_V6 = "fc01::/120"
-OUTER_DST_IP_V4 = "192.168.0.200"
-OUTER_DST_IP_V6 = "fc02:1000::200"
+VLAN_SUBNET_OUTER_DST_IP_V4 = "192.168.0.200"
+VLAN_SUBNET_OUTER_DST_IP_V6 = "fc02:1000::200"
+VNET_ROUTE_IP_V4 = "40.40.40.0"
+VNET_ROUTE_IP_V6 = "fc04::"
 
 
 @pytest.fixture(scope='module')
@@ -48,36 +47,148 @@ def prepare_subnet_decap_config(rand_selected_dut):
 
 
 @pytest.fixture(scope='module')
-def prepare_vlan_subnet_test_port(rand_selected_dut, tbinfo):
-    mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
-    topo = tbinfo["topo"]["type"]
-    dut_port = list(mg_facts['minigraph_portchannels'].keys())[0]
-    if not dut_port:
-        pytest.skip('No portchannels found')
-    dut_eth_port = mg_facts["minigraph_portchannels"][dut_port]["members"][0]
-    ptf_src_port = mg_facts["minigraph_ptf_indices"][dut_eth_port]
+def prepare_vnet_vxlan_config(rand_selected_dut, tbinfo):
+    logger.info("Prepare vnet vxlan config")
+    minigraph_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
 
-    downstream_port_ids = []
-    upstream_port_ids = []
-    for interface, neighbor in list(mg_facts["minigraph_neighbors"].items()):
-        port_id = mg_facts["minigraph_ptf_indices"][interface]
-        if topo == "t0" and "Servers" in neighbor["name"]:
-            downstream_port_ids.append(port_id)
-        elif topo == "t0" and "T1" in neighbor["name"]:
-            upstream_port_ids.append(port_id)
+    # Should I keep the temporary files copied to DUT?
+    ecmp_utils.Constants['KEEP_TEMP_FILES'] = True
 
-    logger.info("ptf_src_port: {}, downstream_port_ids: {}, upstream_port_ids: {}"
-                .format(ptf_src_port, downstream_port_ids, upstream_port_ids))
-    return ptf_src_port, downstream_port_ids, upstream_port_ids
+    # Is debugging going on, or is it a production run? If it is a
+    # production run, use time-stamped file names for temp files.
+    ecmp_utils.Constants['DEBUG'] = True
+
+    # The host id in the ip addresses for DUT. It can be anything,
+    # but helps to keep as a single number that is easy to identify
+    # as DUT.
+    ecmp_utils.Constants['DUT_HOSTID'] = 10
+
+    data = {}
+    for af in ['v4', 'v6']:
+        if af == 'v4':
+            vni_base = 1000
+        elif af == 'v6':
+            vni_base = 2000
+
+        encap_type_data = {}
+        encap_type_data['selected_interfaces'] = ecmp_utils.select_required_interfaces(
+                rand_selected_dut,
+                number_of_required_interfaces=1,
+                minigraph_data=minigraph_facts,
+                af=af)
+        # To store the names of the tunnels, for every outer layer version.
+        tunnel_names = {}
+        # To track the vnets for every outer_layer_version.
+        vnet_af_map = {}
+        outer_layer_version = af
+
+        tunnel_names[outer_layer_version] = ecmp_utils.create_vxlan_tunnel(
+            rand_selected_dut,
+            minigraph_data=minigraph_facts,
+            af=outer_layer_version)
+
+        payload_version = af
+        encap_type = "{}_in_{}".format(payload_version, outer_layer_version)
+
+        vnet_af_map[outer_layer_version] = ecmp_utils.create_vnets(
+            rand_selected_dut,
+            tunnel_name=tunnel_names[outer_layer_version],
+            vnet_count=1,     # default scope can take only one vnet.
+            vnet_name_prefix="Vnet_" + encap_type,
+            scope="default",
+            vni_base=vni_base)
+        encap_type_data['vnet_vni_map'] = vnet_af_map[outer_layer_version]
+
+        encap_type_data['vnet_intf_map'] = ecmp_utils.setup_vnet_intf(
+            selected_interfaces=encap_type_data['selected_interfaces'],
+            vnet_list=list(encap_type_data['vnet_vni_map'].keys()),
+            minigraph_data=minigraph_facts)
+        encap_type_data['intf_to_ip_map'] = ecmp_utils.assign_intf_ip_address(
+            selected_interfaces=encap_type_data['selected_interfaces'],
+            af=payload_version)
+        encap_type_data['t2_ports'] = ecmp_utils.get_t2_ports(
+            rand_selected_dut,
+            minigraph_facts)
+        encap_type_data['neighbor_config'] = ecmp_utils.configure_vnet_neighbors(
+            rand_selected_dut,
+            encap_type_data['intf_to_ip_map'],
+            minigraph_data=minigraph_facts,
+            af=payload_version)
+        encap_type_data['dest_to_nh_map'] = ecmp_utils.create_vnet_routes(
+            rand_selected_dut, list(encap_type_data['vnet_vni_map'].keys()),
+            nhs_per_destination=1,
+            number_of_available_nexthops=10,
+            number_of_ecmp_nhs=10,
+            dest_af=payload_version,
+            dest_net_prefix=10,
+            nexthop_prefix=10,
+            nh_af=outer_layer_version)
+
+        data[af] = encap_type_data
+
+    yield data
+
+    for af in data:
+        encap_type_data = data[af]
+        outer_layer_version = af
+        payload_version = af
+
+        ecmp_utils.set_routes_in_dut(
+            rand_selected_dut,
+            encap_type_data['dest_to_nh_map'],
+            payload_version,
+            "DEL")
+
+        for intf in encap_type_data['selected_interfaces']:
+            redis_string = "INTERFACE"
+            if "PortChannel" in intf:
+                redis_string = "PORTCHANNEL_INTERFACE"
+            rand_selected_dut.shell("redis-cli -n 4 hdel \"{}|{}\""
+                                    "vnet_name".format(redis_string, intf))
+            rand_selected_dut.shell(
+                "for i in `redis-cli -n 4 --scan --pattern \"NEIGH|{}|*\" `; "
+                "do redis-cli -n 4 del $i ; done".format(intf))
+
+        # This script's setup code re-uses same vnets for v4inv4 and v6inv4.
+        # There will be same vnet in multiple encap types.
+        # So remove vnets *after* removing the routes first.
+        for vnet in list(data[encap_type]['vnet_vni_map'].keys()):
+            rand_selected_dut.shell("redis-cli -n 4 del \"VNET|{}\"".format(vnet))
+
+        time.sleep(5)
+        for tunnel in list(tunnel_names.values()):
+            rand_selected_dut.shell(
+                "redis-cli -n 4 del \"VXLAN_TUNNEL|{}\"".format(tunnel))
+
+        time.sleep(1)
 
 
 @pytest.fixture(scope='module')
-def prepare_negative_ip_port_map(prepare_vlan_subnet_test_port):
-    _, downstream_port_ids, _ = prepare_vlan_subnet_test_port
+def prepare_test_ports(rand_selected_dut, tbinfo):
+    mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
+    topo = tbinfo["topo"]["type"]
+
+    downstream_ptf_port_ids = []
+    upstream_ptf_port_ids = []
+    for interface, neighbor in list(mg_facts["minigraph_neighbors"].items()):
+        port_id = mg_facts["minigraph_ptf_indices"][interface]
+        if (topo == "t1" and "T2" in neighbor["name"]) or (topo == "t0" and "T1" in neighbor["name"]):
+            upstream_ptf_port_ids.append(port_id)
+        elif (topo == "t0" and "Servers" in neighbor["name"]) or (topo == "t1" and "T0" in neighbor["name"]):
+            downstream_ptf_port_ids.append(port_id)
+
+    logger.info("downstream_ptf_port_ids: {}, upstream_ptf_port_ids: {}"
+                .format(downstream_ptf_port_ids, upstream_ptf_port_ids))
+    return downstream_ptf_port_ids, upstream_ptf_port_ids
+
+
+@pytest.fixture(scope='module')
+def prepare_negative_ip_port_map(prepare_test_ports):
+    downstream_port_ids, _ = prepare_test_ports
     ptf_target_port = random.choice(downstream_port_ids)
     ip_to_port = {
-        OUTER_DST_IP_V4: ptf_target_port,
-        OUTER_DST_IP_V6: ptf_target_port
+        VLAN_SUBNET_OUTER_DST_IP_V4: ptf_target_port,
+        VLAN_SUBNET_OUTER_DST_IP_V6: ptf_target_port
     }
     return ptf_target_port, ip_to_port
 
@@ -127,7 +238,7 @@ def build_encapsulated_vlan_subnet_packet(ptfadapter, rand_selected_dut, ip_vers
     logger.info("eth_src: {}, eth_dst: {}".format(eth_src, eth_dst))
 
     if ip_version == "IPv4":
-        outer_dst_ipv4 = OUTER_DST_IP_V4
+        outer_dst_ipv4 = VLAN_SUBNET_OUTER_DST_IP_V4
         if stage == "positive":
             outer_src_ipv4 = "20.20.20.10"
         elif stage == "negative":
@@ -146,7 +257,7 @@ def build_encapsulated_vlan_subnet_packet(ptfadapter, rand_selected_dut, ip_vers
         )
 
     elif ip_version == "IPv6":
-        outer_dst_ipv6 = OUTER_DST_IP_V6
+        outer_dst_ipv6 = VLAN_SUBNET_OUTER_DST_IP_V6
         if stage == "positive":
             outer_src_ipv6 = "fc01::10"
         elif stage == "negative":
@@ -167,7 +278,7 @@ def build_encapsulated_vlan_subnet_packet(ptfadapter, rand_selected_dut, ip_vers
     return outer_packet
 
 
-def build_expected_vlan_subnet_packet(encapsulated_packet, ip_version, stage, decrease_ttl=False):
+def build_expected_packet(encapsulated_packet, ip_version, stage="positive", decrease_ttl=False):
     if stage == "positive":
         if ip_version == "IPv4":
             pkt = encapsulated_packet[packet.IP].payload[packet.IP].copy()
@@ -191,35 +302,92 @@ def build_expected_vlan_subnet_packet(encapsulated_packet, ip_version, stage, de
     return exp_pkt
 
 
-def verify_packet_with_expected(ptfadapter, stage, pkt, exp_pkt, send_port,
+def build_encapsulated_vnet_route_packet(ptfadapter, rand_selected_dut, ip_version):
+    eth_dst = rand_selected_dut.facts["router_mac"]
+    eth_src = ptfadapter.dataplane.get_mac(0, 0)
+    logger.info("eth_src: {}, eth_dst: {}".format(eth_src, eth_dst))
+
+    if ip_version == "IPv4":
+        inner_packet = testutils.simple_ip_packet(
+            ip_src="1.1.1.1",
+            ip_dst="2.2.2.2"
+        )[packet.IP]
+        outer_src_ipv4 = "20.20.20.10"
+        outer_dst_ipv4 = "40.40.40.10"
+        outer_packet = testutils.simple_vxlan_packet(
+            eth_dst=eth_dst,
+            eth_src=eth_src,
+            ip_src=outer_src_ipv4,
+            ip_dst=outer_dst_ipv4,
+            vxlan_vni=1000,
+            inner_frame=inner_packet
+        )
+
+    elif ip_version == "IPv6":
+        inner_packet = testutils.simple_tcpv6_packet(
+            ipv6_src="1::1",
+            ipv6_dst="2::2"
+        )[packet.IPv6]
+        outer_src_ipv6 = "fc01::10"
+        outer_dst_ipv6 = "fc04::10"
+        outer_packet = testutils.simple_vxlanv6_packet(
+            eth_dst=eth_dst,
+            eth_src=eth_src,
+            ipv6_src=outer_src_ipv6,
+            ipv6_dst=outer_dst_ipv6,
+            vxlan_vni=2000,
+            inner_frame=inner_packet
+        )
+
+    return outer_packet
+
+
+def verify_packet_with_expected(ptfadapter, pkt, exp_pkt, send_port,
                                 recv_ports=[], recv_port=None, timeout=10, skip_traffic_test=False):    # noqa F811
     if skip_traffic_test is True:
         logger.info("Skip traffic test")
         return
     ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, send_port, pkt)
-    if stage == "positive":
+    if len(recv_ports) > 0:
         testutils.verify_packet_any_port(ptfadapter, exp_pkt, recv_ports, timeout=10)
-    elif stage == "negative":
+    elif recv_port is not None:
         testutils.verify_packet(ptfadapter, exp_pkt, recv_port, timeout=10)
 
 
 @pytest.mark.parametrize("ip_version", ["IPv4", "IPv6"])
 @pytest.mark.parametrize("stage", ["positive", "negative"])
 def test_vlan_subnet_decap(request, rand_selected_dut, tbinfo, ptfhost, ptfadapter, ip_version, stage,
-                           prepare_subnet_decap_config, prepare_vlan_subnet_test_port,
+                           prepare_subnet_decap_config, prepare_test_ports,
                            prepare_negative_ip_port_map, setup_arp_responder, skip_traffic_test):     # noqa F811
-    ptf_src_port, _, upstream_port_ids = prepare_vlan_subnet_test_port
+    _, upstream_ptf_port_ids = prepare_test_ports
+    ptf_src_port = random.choice(upstream_ptf_port_ids)
 
     encapsulated_packet = build_encapsulated_vlan_subnet_packet(ptfadapter, rand_selected_dut, ip_version, stage)
-    exp_pkt = build_expected_vlan_subnet_packet(encapsulated_packet, ip_version, stage, decrease_ttl=True)
+    exp_pkt = build_expected_packet(encapsulated_packet, ip_version, stage=stage, decrease_ttl=True)
 
     if stage == "negative":
+        recv_ports = []
         ptf_target_port, _ = prepare_negative_ip_port_map
         request.getfixturevalue('setup_arp_responder')
     else:
+        recv_ports = upstream_ptf_port_ids
         ptf_target_port = None
 
-    verify_packet_with_expected(ptfadapter, stage, encapsulated_packet, exp_pkt,
-                                ptf_src_port, recv_ports=upstream_port_ids, recv_port=ptf_target_port,
+    verify_packet_with_expected(ptfadapter, encapsulated_packet, exp_pkt,
+                                ptf_src_port, recv_ports=recv_ports, recv_port=ptf_target_port,
                                 skip_traffic_test=skip_traffic_test)
+
+
+@pytest.mark.parametrize("ip_version", ["IPv4", "IPv6"])
+def test_vnet_route_decap(request, rand_selected_dut, tbinfo, ptfhost, ptfadapter, ip_version,
+                          prepare_subnet_decap_config, prepare_vnet_vxlan_config,
+                          prepare_test_ports, skip_traffic_test):     # noqa F811
+
+    _, upstream_ptf_port_ids = prepare_test_ports
+    ptf_src_port = random.choice(upstream_ptf_port_ids)
+    encapsulated_packet = build_encapsulated_vnet_route_packet(ptfadapter, rand_selected_dut, ip_version)
+    exp_pkt = build_expected_packet(encapsulated_packet, ip_version, decrease_ttl=True)
+    recv_ports = upstream_ptf_port_ids
+    verify_packet_with_expected(ptfadapter, encapsulated_packet, exp_pkt, ptf_src_port,
+                                recv_ports=recv_ports, skip_traffic_test=skip_traffic_test)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In Azure network, Netscan uses IP-decap to check for route blackholes, but servers do not support decapsulation, making it impossible to perform server-to-server checks. To address this, we developed the subnet decap feature to detect if the link between the server and T0 is functioning properly. Additionally, new test cases are required to ensure the functionality of subnet decap is working as expected.
Sever to T0 test was added in https://github.com/sonic-net/sonic-mgmt/pull/14720, we need to add server to T1 test
#### How did you do it?
Add test to verify IPinIP packet targeting at vnet route is decapsulated for T1
Ref test gap issue: https://github.com/sonic-net/sonic-mgmt/issues/13122
Ref test plan: https://github.com/sonic-net/sonic-mgmt/pull/12990
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
