### PR TITLE
Fix conflicted skipping condition for test_pfc_asym

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1259,12 +1259,6 @@ pfc_asym/test_pfc_asym.py:
     conditions:
       - "asic_type not in ['barefoot']"
 
-pfc_asym/test_pfc_asym.py::test_pfc_asym_off_rx_pause_frames:
-   skip:
-     reason: "skipped for Barefoot platform"
-     conditions:
-        - "asic_type in ['barefoot']"
-
 #######################################
 #####         pfcwd               #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes conflicted skipping condition for `test_pfc_asym`.
Before this change, there are two skipping conditions.
```
#######################################
#####         pfc_asym            #####
#######################################
pfc_asym/test_pfc_asym.py:
  skip:
    reason: 'pfc_asym test skip except for on Barefoot platforms'
    conditions:
      - "asic_type not in ['barefoot']"

pfc_asym/test_pfc_asym.py::test_pfc_asym_off_rx_pause_frames:
   skip:
     reason: "skipped for Barefoot platform"
     conditions:
        - "asic_type in ['barefoot']"
```
This PR reomoved the second one as it has been covered by the first one.
 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to fix conflicted skipping condition for `test_pfc_asym`.

#### How did you do it?
Remove the unused condition.

#### How did you verify/test it?
Verified by syntax check.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
