### PR TITLE
Fix platform_tests/test_advanced_reboot.py test_warm_reboot_mac_jump for mac jump detection

### DIFF
--- a/tests/common/platform/reboot_timing_constants.py
+++ b/tests/common/platform/reboot_timing_constants.py
@@ -56,9 +56,9 @@ OTHER_PATTERNS = {
         "SYNCD_CREATE_SWITCH|End": re.compile(
             r'.*syncd#syncd.*performWarmRestartSingleSwitch: Warm boot: create switch VID.*'),
         "FDB_EVENT_OTHER_MAC_EXPIRY|Start": re.compile(
-            r".* INFO syncd#syncd.*SAI_API_FDB.*fdbEvent: (delete \(0\)|0) for mac (?!00-06-07-08-09-0A).*"),
+            r".*syncd#syncd.*SAI_API_FDB.*fdbEvent: (delete \(0\)|0) for mac (?!00-06-07-08-09-0A).*"),
         "FDB_EVENT_SCAPY_MAC_EXPIRY|Start": re.compile(
-            r".* INFO syncd#syncd.*SAI_API_FDB.*fdbEvent: (delete \(0\)|0) for mac 00-06-07-08-09-0A.*")
+            r".*syncd#syncd.*SAI_API_FDB.*fdbEvent: (delete \(0\)|0) for mac 00-06-07-08-09-0A.*")
     },
     "MLNX": {
         "SYNCD_CREATE_SWITCH|Start": re.compile(

--- a/tests/common/platform/templates/expect_boot_messages
+++ b/tests/common/platform/templates/expect_boot_messages
@@ -19,7 +19,7 @@ r, ".* NOTICE syncd#syncd.*performWarmRestart: switches defined in warm restart.
 r, ".* NOTICE syncd#syncd.*performWarmRestartSingleSwitch: Warm boot: create switch VID.*"
 r, ".* NOTICE bgp#fpmsyncd.*main: Warm-Restart timer started.*.*"
 r, ".* NOTICE bgp#fpmsyncd.*main: Warm-Restart reconciliation processed..*"
-r, ".* INFO syncd#syncd.*SAI_API_FDB:_brcm_sai_fdb_event_cb.*fdbEvent: (delete \(0\)|0) for mac.*"
+r, ".* syncd#syncd.*SAI_API_FDB:_brcm_sai_fdb_event_cb.*fdbEvent: (delete \(0\)|0) for mac.*"
 r, ".* NOTICE swss#orchagent.*setAgingFDB: Set switch.*fdb_aging_time 0 sec"
 r, ".* NOTICE swss#orchagent.*do.*Task: Set switch attribute fdb_aging_time to 600"
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  Update the regex to detect mac jump because the log level for the message changed
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The log level for fdbEvent messsage to detect mac jump is changed to NOTICE, so the regex used by the test has to be updated.  

#### How did you do it?
Change the regex for detecting mac jump

#### How did you verify/test it?
Check the test can pass after the change
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
