### PR TITLE
[202405] Fix intermittent issue on reboot in test_lldp_syncd

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -90,6 +90,13 @@ def get_show_lldp_table_output(duthost):
     return interface_list
 
 
+def check_lldp_table_keys(duthost, db_instance):
+    # Check if LLDP_ENTRY_TABLE keys match show lldp table output
+    lldp_entry_keys = get_lldp_entry_keys(db_instance)
+    show_lldp_table_int_list = get_show_lldp_table_output(duthost)
+    return sorted(lldp_entry_keys) == sorted(show_lldp_table_int_list)
+
+
 def assert_lldp_interfaces(
     lldp_entry_keys, show_lldp_table_int_list, lldpctl_interface
 ):
@@ -322,6 +329,12 @@ def test_lldp_entry_table_after_reboot(
     localhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, db_instance
 ):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+
+    # Verify LLDP_ENTRY_TABLE keys match show lldp table output at the start of test
+    keys_match = wait_until(30, 5, 0, check_lldp_table_keys, duthost, db_instance)
+    if not keys_match:
+        assert keys_match, "LLDP_ENTRY_TABLE keys do not match 'show lldp table' output"
+
     # reboot
     logging.info("Run cold reboot on DUT")
     reboot(


### PR DESCRIPTION
### Description of PR
At the start of `test_lldp_syncd.py::test_lldp_entry_table_after_reboot` the test polls and checks that LLDP_ENTRY_TABLE keys match show lldp table output.

The `eth0` port is added last so sometimes the entry keys will have it but the lldp table output will not.  From debugging, this is the case since the end of the previous test (I put a check on the keys vs lldp table output and observed the missing `eth0` at the end of `test_lldp_syncd.py::test_lldp_entry_table_after_lldp_restart`).  From our test results, this issue hits both fixed and modular, but appears to be more easily reproduced on fixed systems.

Added a wait_until at the start of `test_lldp_entry_table_after_reboot` to wait until the LLDP_ENTRY_TABLE keys match show lldp table output before the tests starts to reboot.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Observed another intermittent issue in `test_lldp_syncd` in addition to the issues fixed by https://github.com/sonic-net/sonic-mgmt/pull/15258.

#### How did you do it?

#### How did you verify/test it?
Verified the test on one of our fixed system by running test 50 times with this change and PR#15258 to ensure all the intermittent fails are gone. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
