### PR TITLE
Fix mismatch between show lldp table and the content of lldp entry table

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -46,6 +46,7 @@ def get_lldp_entry_keys(dbs):
     for db in dbs:
         items = db.get_keys("LLDP_ENTRY_TABLE*")
         lldp_entries.extend([key.split(":")[1] for key in items])
+    logger.debug("lldp entry keys: {}".format(lldp_entries))
     return lldp_entries
 
 
@@ -54,6 +55,7 @@ def get_lldp_entry_content(dbs, interface):
     lldp_content = {}
     for db in dbs:
         lldp_content.update(db.hget_all("LLDP_ENTRY_TABLE:{}".format(interface)))
+    logger.debug("lldp entry content: {}".format(lldp_content))
     return lldp_content
 
 
@@ -288,7 +290,7 @@ def test_lldp_entry_table_after_lldp_restart(
     for asic in duthost.asics:
         duthost.shell("sudo systemctl restart {}".format(asic.get_service_name('lldp')))
     result = wait_until(
-        60, 2, 5, verify_lldp_table, duthost
+        60, 2, 20, verify_lldp_table, duthost
     )  # Adjust based on LLDP service restart time
     pytest_assert(result, "no output for show lldp table after restarting lldp")
     for asic in duthost.asics:
@@ -321,7 +323,6 @@ def test_lldp_entry_table_after_reboot(
 ):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     lldp_entry_keys = get_lldp_entry_keys(db_instance)
-    show_lldp_table_int_list = get_show_lldp_table_output(duthost)
     lldpctl_output = get_lldpctl_output(duthost)
 
     # reboot
@@ -336,6 +337,7 @@ def test_lldp_entry_table_after_reboot(
         check_intf_up_ports=True
     )
     lldpctl_interfaces = lldpctl_output["lldp"]["interface"]
+    show_lldp_table_int_list = get_show_lldp_table_output(duthost)
     assert_lldp_interfaces(
         lldp_entry_keys, show_lldp_table_int_list, lldpctl_interfaces
     )

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -322,9 +322,6 @@ def test_lldp_entry_table_after_reboot(
     localhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, db_instance
 ):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    lldp_entry_keys = get_lldp_entry_keys(db_instance)
-    lldpctl_output = get_lldpctl_output(duthost)
-
     # reboot
     logging.info("Run cold reboot on DUT")
     reboot(
@@ -336,8 +333,10 @@ def test_lldp_entry_table_after_reboot(
         safe_reboot=True,
         check_intf_up_ports=True
     )
-    lldpctl_interfaces = lldpctl_output["lldp"]["interface"]
+    lldp_entry_keys = get_lldp_entry_keys(db_instance)
+    lldpctl_output = get_lldpctl_output(duthost)
     show_lldp_table_int_list = get_show_lldp_table_output(duthost)
+    lldpctl_interfaces = lldpctl_output["lldp"]["interface"]
     assert_lldp_interfaces(
         lldp_entry_keys, show_lldp_table_int_list, lldpctl_interfaces
     )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix failure of "`Failed: LLDP_ENTRY_TABLE keys do not match` 'show lldp table' output" in `lldp.test_lldp_syncd.test_lldp_entry_table_after_reboot`
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
In `lldp.test_lldp_syncd.test_lldp_entry_table_after_reboot`, case always failed due to "`Failed: LLDP_ENTRY_TABLE keys do not match` 'show lldp table' output" 
#### How did you do it?
It is caused by the systemcl restart lldp in previous case `lldp.test_lldp_syncd.test_lldp_entry_table_after_lldp_restart`.
Eth0 didn't come up after lldp restart.
Check the content of lldp table after reboot not before reboot.
#### How did you verify/test it?
run lldp/test_lldp_syncd.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
