### PR TITLE
[drop_packets] Skip drop_packets on MGFX

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -5,11 +5,12 @@
 #Hence, it is not dropped by default in Cisco-8000. For dropping link local address, it should be done through security/DATA ACL
 drop_packets/test_configurable_drop_counters.py::test_dip_link_local:
   skip:
-    reason: "Cisco 8000 platform and some mlx platforms does not drop DIP link local packets"
+    reason: "MGFX topos doesn't support drop packets / Cisco 8000 platform and some mlx platforms does not drop DIP link local packets"
     conditions_logical_operator: or
     conditions:
       - "'Mellanox' in hwsku"
       - asic_type=='cisco-8000'
+      - "topo_type in ['m0', 'mx']"
 
 drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down:
   skip:
@@ -19,31 +20,38 @@ drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down:
 
 drop_packets/test_configurable_drop_counters.py::test_sip_link_local:
   skip:
-    reason: "Cisco 8000 platform and some MLX platforms does not drop SIP link local packets"
+    reason: "MGFX topos doesn't support drop packets / Cisco 8000 platform and some MLX platforms does not drop SIP link local packets"
     conditions_logical_operator: or
     conditions:
       - asic_type=="cisco-8000"
       - "'Mellanox' in hwsku"
+      - "topo_type in ['m0', 'mx']"
 #######################################
 #####     test_drop_counters.py   #####
 #######################################
 drop_packets/test_drop_counters.py::test_absent_ip_header:
   skip:
-    reason: "Test case not supported on Broadcom DNX platform"
+    reason: "Test case not supported on Broadcom DNX platform and MGFX topos"
+    conditions_logical_operator: or
     conditions:
       - "asic_subtype in ['broadcom-dnx']"
+      - "topo_type in ['m0', 'mx']"
 
 drop_packets/test_drop_counters.py::test_acl_egress_drop:
   skip:
-    reason: "Not supported on Broadcom platforms"
+    reason: "Not supported on Broadcom platforms and MGFX topos"
+    conditions_logical_operator: or
     conditions:
       - "asic_type in ['broadcom']"
+      - "topo_type in ['m0', 'mx']"
 
 drop_packets/test_drop_counters.py::test_dst_ip_absent:
   skip:
-    reason: "Test case not supported on Broadcom DNX platform and Cisco 8000 platform"
+    reason: "Test case not supported on Broadcom DNX platform and Cisco 8000 platform and MGFX topos"
+    conditions_logical_operator: or
     conditions:
       - "asic_subtype in ['broadcom-dnx'] or asic_type in ['cisco-8000']"
+      - "topo_type in ['m0', 'mx']"
 
 drop_packets/test_drop_counters.py::test_dst_ip_absent[vlan_members]:
   skip:
@@ -55,9 +63,11 @@ drop_packets/test_drop_counters.py::test_dst_ip_absent[vlan_members]:
 
 drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr:
   skip:
-    reason: "Cisco 8000 platform does not drop DIP loopback packets. Test also not supported on Broadcom DNX"
+    reason: "Cisco 8000 platform does not drop DIP loopback packets. Test also not supported on Broadcom DNX and MGFX topos"
+    conditions_logical_operator: or
     conditions:
       - "(asic_type=='cisco-8000') or (asic_subtype in ['broadcom-dnx'])"
+      - "topo_type in ['m0', 'mx']"
 
 drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[vlan_members]:
   skip:
@@ -69,23 +79,28 @@ drop_packets/test_drop_counters.py::test_dst_ip_is_loopback_addr[vlan_members]:
 
 drop_packets/test_drop_counters.py::test_dst_ip_link_local:
   skip:
-    reason: "Cisco 8000 broadcom DNX platforms and some MLX platforms do not drop DIP linklocal packets"
+    reason: "MGFX topos doesn't support drop packets / Cisco 8000 broadcom DNX platforms and some MLX platforms do not drop DIP linklocal packets"
     conditions_logical_operator: or
     conditions:
       - "(asic_type=='cisco-8000') or (asic_subtype in ['broadcom-dnx'])"
       - "'Mellanox' in hwsku"
+      - "topo_type in ['m0', 'mx']"
 
 drop_packets/test_drop_counters.py::test_equal_smac_dmac_drop:
   skip:
-    reason: "Drop not enabled on chassis since internal traffic uses same smac & dmac"
+    conditions_logical_operator: or
+    reason: "MGFX topos doesn't support drop packets / Drop not enabled on chassis since internal traffic uses same smac & dmac"
     conditions:
       - "asic_subtype in ['broadcom-dnx']"
+      - "topo_type in ['m0', 'mx']"
 
 drop_packets/test_drop_counters.py::test_ip_is_zero_addr:
   skip:
-    reason: "Cisco 8000 platform does not drop packets with 0.0.0.0 source or destination IP address"
+    conditions_logical_operator: or
+    reason: "MGFX topos doesn't support drop packets / Cisco 8000 platform does not drop packets with 0.0.0.0 source or destination IP address"
     conditions:
       - "asic_type=='cisco-8000'"
+      - "topo_type in ['m0', 'mx']"
 
 drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv4-dst]:
   skip:
@@ -128,9 +143,11 @@ drop_packets/test_drop_counters.py::test_ip_is_zero_addr[vlan_members-ipv6-src]:
 
 drop_packets/test_drop_counters.py::test_ip_pkt_with_expired_ttl:
   skip:
-    reason: "Not supported on Mellanox devices"
+    reason: "Not supported on Mellanox devices and MGFX topos"
+    conditions_logical_operator: or
     conditions:
       - "asic_type in ['mellanox']"
+      - "topo_type in ['m0', 'mx']"
 
 drop_packets/test_drop_counters.py::test_loopback_filter:
   # Test case is skipped, because SONiC does not have a control to adjust loop-back filter settings.
@@ -143,9 +160,11 @@ drop_packets/test_drop_counters.py::test_loopback_filter:
 
 drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link:
   skip:
-    reason: "VS platform do not support fanout configuration"
+    reason: "MGFX topos doesn't support drop packets / VS platform do not support fanout configuration"
+    conditions_logical_operator: or
     conditions:
       - "asic_type in ['vs']"
+      - "topo_type in ['m0', 'mx']"
 
 drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[vlan_members]:
   skip:
@@ -163,15 +182,19 @@ drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop[vlan_members
 
 drop_packets/test_drop_counters.py::test_src_ip_is_class_e:
   skip:
-    reason: "Cisco 8000 platform does not drop packets with source IP address in class E"
+    reason: "MGFX topos doesn't support drop packets / Cisco 8000 platform does not drop packets with source IP address in class E"
+    conditions_logical_operator: or
     conditions:
       - "asic_type=='cisco-8000'"
+      - "topo_type in ['m0', 'mx']"
 
 drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr:
   skip:
-    reason: "Test currently not supported on broadcom DNX platform"
+    conditions_logical_operator: or
+    reason: "MGFX topos doesn't support drop packets / Test currently not supported on broadcom DNX platform"
     conditions:
       - "asic_subtype in ['broadcom-dnx']"
+      - "topo_type in ['m0', 'mx']"
 
 drop_packets/test_drop_counters.py::test_src_ip_is_loopback_addr[vlan_members]:
   skip:
@@ -199,8 +222,9 @@ drop_packets/test_drop_counters.py::test_src_ip_is_multicast_addr[vlan_members-i
 
 drop_packets/test_drop_counters.py::test_src_ip_link_local:
   skip:
-    reason: "Cisco 8000 broadcom DNX platforms and some MLX platforms do not drop SIP linklocal packets"
+    reason: "MGFX topos doesn't support drop packets / Cisco 8000 broadcom DNX platforms and some MLX platforms do not drop SIP linklocal packets"
     conditions_logical_operator: or
     conditions:
       - "(asic_type=='cisco-8000') or (asic_subtype in ['broadcom-dnx'])"
       - "'Mellanox' in hwsku"
+      - "topo_type in ['m0', 'mx']"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
drop_packtes tests were skipped for MGFX by folder previously. Now it is broken by this change https://github.com/sonic-net/sonic-mgmt/pull/14395
Hence update condition mark

#### How did you do it?
Update condition mark

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
