### PR TITLE
Add snappi tests to PR test skip yml

### DIFF
--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -216,6 +216,7 @@ tgen:
   - snappi_tests/bgp/test_bgp_rib_in_convergence.py
   - snappi_tests/bgp/test_bgp_scalability.py
   - snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
+  - snappi_tests/ecn/test_ecn_marking_cisco8000.py
   - snappi_tests/ecn/test_red_accuracy_with_snappi.py
   - snappi_tests/multidut/bgp/test_bgp_outbound_downlink_port_flap.py
   - snappi_tests/multidut/bgp/test_bgp_outbound_downlink_process_crash.py
@@ -239,6 +240,7 @@ tgen:
   - snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
   - snappi_tests/multidut/pfcwd/test_multidut_pfcwd_burst_storm_with_snappi.py
   - snappi_tests/multidut/pfcwd/test_multidut_pfcwd_m2o_with_snappi.py
+  - snappi_tests/multidut/pfcwd/test_multidut_pfcwd_runtime_traffic_with_snappi.py
   - snappi_tests/lacp/test_add_remove_link_from_dut.py
   - snappi_tests/lacp/test_add_remove_link_physically.py
   - snappi_tests/lacp/test_lacp_timers_effect.py
@@ -255,6 +257,7 @@ tgen:
   - snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py
   - snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py
   - snappi_tests/qos/test_ipip_packet_reorder_with_snappi.py
+  - snappi_tests/test_multidut_snappi.py
 
 snappi:
   # Snappi test only support on physical snappi testbed


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
Meanwhile, we are using .azure-pipelines/testscripts_analyse/ to static test scripts have been added or not, if a test script need to skip in KVM test, need to add it to .azure-pipelines/pr_test_skip_scripts.yaml and we would mark it as checked/covered.
Based on that, snappi test could not run on KVM platform, so need to add these tests to .azure-pipelines/pr_test_skip_scripts.yaml
#### How did you do it?
Add snappi test scripts to .azure-pipelines/pr_test_skip_scripts.yaml
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
