### PR TITLE
Remove skip_traffic_test fixture in acl tests

### DIFF
--- a/tests/acl/custom_acl_table/test_custom_acl_table.py
+++ b/tests/acl/custom_acl_table/test_custom_acl_table.py
@@ -262,6 +262,7 @@ def test_custom_acl(rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter,
     6. Verify the counter of expected rule increases as expected
     """
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
+    asic_type = rand_selected_dut.facts['asic_type']
     if "dualtor" in tbinfo["topo"]["name"]:
         mg_facts_unselected_dut = rand_unselected_dut.get_extended_minigraph_facts(tbinfo)
         vlan_name = list(mg_facts['minigraph_vlans'].keys())[0]
@@ -289,6 +290,9 @@ def test_custom_acl(rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter,
         clear_acl_counter(rand_selected_dut)
         if "dualtor-aa" in tbinfo["topo"]["name"]:
             clear_acl_counter(rand_unselected_dut)
+        if asic_type == 'vs':
+            logger.info("Skip ACL verification on VS platform")
+            continue
         ptfadapter.dataplane.flush()
         testutils.send(ptfadapter, pkt=pkt, port_id=src_port_indice)
         testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=dst_port_indices, timeout=5)

--- a/tests/acl/null_route/test_null_route_helper.py
+++ b/tests/acl/null_route/test_null_route_helper.py
@@ -9,7 +9,7 @@ import json
 from ptf.mask import Mask
 import ptf.packet as scapy
 
-from tests.common.fixtures.ptfhost_utils import remove_ip_addresses, skip_traffic_test  # noqa F401
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses  # noqa F401
 import ptf.testutils as testutils
 from tests.common.helpers.assertions import pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
@@ -229,12 +229,10 @@ def generate_packet(src_ip, dst_ip, dst_mac):
     return pkt, exp_pkt
 
 
-def send_and_verify_packet(ptfadapter, pkt, exp_pkt, tx_port, rx_port, expected_action, skip_traffic_test):     # noqa F811
+def send_and_verify_packet(ptfadapter, pkt, exp_pkt, tx_port, rx_port, expected_action):     # noqa F811
     """
     Send packet with ptfadapter and verify if packet is forwarded or dropped as expected.
     """
-    if skip_traffic_test:
-        return
     ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, pkt=pkt, port_id=tx_port)
     if expected_action == FORWARD:
@@ -244,7 +242,7 @@ def send_and_verify_packet(ptfadapter, pkt, exp_pkt, tx_port, rx_port, expected_
 
 
 def test_null_route_helper(rand_selected_dut, tbinfo, ptfadapter,
-                           apply_pre_defined_rules, setup_ptf, skip_traffic_test):  # noqa F811
+                           apply_pre_defined_rules, setup_ptf):  # noqa F811
     """
     Test case to verify script null_route_helper.
     Some packets are generated as defined in TEST_DATA and sent to DUT,
@@ -280,4 +278,4 @@ def test_null_route_helper(rand_selected_dut, tbinfo, ptfadapter,
             time.sleep(1)
 
         send_and_verify_packet(ptfadapter, pkt, exp_pkt, random.choice(ptf_interfaces),
-                               rx_port, expected_result, skip_traffic_test)
+                               rx_port, expected_result)

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -19,7 +19,6 @@ from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.config_reload import config_reload
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py, run_garp_service, change_mac_addresses   # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa F401
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr # noqa F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.utilities import wait_until, get_upstream_neigh_type, get_downstream_neigh_type, check_msg_in_syslog
@@ -634,7 +633,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         """
         pass
 
-    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):   # noqa F811
+    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):     # noqa F811
         """Perform actions after rules have been applied.
 
         Args:
@@ -664,7 +663,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
 
     @pytest.fixture(scope="class", autouse=True)
     def acl_rules(self, duthosts, localhost, setup, acl_table, populate_vlan_arp_entries, tbinfo,
-                  ip_version, conn_graph_facts):   # noqa F811
+                  ip_version, conn_graph_facts):        # noqa F811
         """Setup/teardown ACL rules for the current set of tests.
 
         Args:
@@ -704,7 +703,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
                        duthost, LOG_EXPECT_ACL_RULE_REMOVE_RE)
 
     def set_up_acl_rules_single_dut(self, acl_table,
-                                    conn_graph_facts, dut_to_analyzer_map, duthost, # noqa F811
+                                    conn_graph_facts, dut_to_analyzer_map, duthost,     # noqa F811
                                     ip_version, localhost,
                                     populate_vlan_arp_entries, tbinfo):
         logger.info("{}: ACL rule application started".format(duthost.hostname))
@@ -967,57 +966,57 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
 
         return exp_pkt
 
-    def test_ingress_unmatched_blocked(self, setup, direction, ptfadapter, ip_version, stage, skip_traffic_test):   # noqa F811
+    def test_ingress_unmatched_blocked(self, setup, direction, ptfadapter, ip_version, stage):
         """Verify that unmatched packets are dropped for ingress."""
         if stage == "egress":
             pytest.skip("Only run for ingress")
 
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version)
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
 
-    def test_egress_unmatched_forwarded(self, setup, direction, ptfadapter, ip_version, stage, skip_traffic_test):  # noqa F811
+    def test_egress_unmatched_forwarded(self, setup, direction, ptfadapter, ip_version, stage):
         """Verify that default egress rule allow all traffics"""
         if stage == "ingress":
             pytest.skip("Only run for egress")
 
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version)
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
 
     def test_source_ip_match_forwarded(self, setup, direction, ptfadapter,
-                                       counters_sanity_check, ip_version, skip_traffic_test):   # noqa F811
+                                       counters_sanity_check, ip_version):
         """Verify that we can match and forward a packet on source IP."""
         src_ip = "20.0.0.2" if ip_version == "ipv4" else "60c0:a800::6"
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(1)
 
     def test_rules_priority_forwarded(self, setup, direction, ptfadapter,
-                                      counters_sanity_check, ip_version, skip_traffic_test):    # noqa F811
+                                      counters_sanity_check, ip_version):
         """Verify that we respect rule priorites in the forwarding case."""
         src_ip = "20.0.0.7" if ip_version == "ipv4" else "60c0:a800::7"
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(20)
 
     def test_rules_priority_dropped(self, setup, direction, ptfadapter,
-                                    counters_sanity_check, ip_version, skip_traffic_test):      # noqa F811
+                                    counters_sanity_check, ip_version):
         """Verify that we respect rule priorites in the drop case."""
         src_ip = "20.0.0.3" if ip_version == "ipv4" else "60c0:a800::4"
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(7)
 
     def test_dest_ip_match_forwarded(self, setup, direction, ptfadapter,
-                                     counters_sanity_check, ip_version, vlan_name, skip_traffic_test):  # noqa F811
+                                     counters_sanity_check, ip_version, vlan_name):
         """Verify that we can match and forward a packet on destination IP."""
         dst_ip = DOWNSTREAM_IP_TO_ALLOW[ip_version] \
             if direction == "uplink->downlink" else UPSTREAM_IP_TO_ALLOW[ip_version]
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dst_ip=dst_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         # Because m0_l3_scenario use differnet IPs, so need to verify different acl rules.
         if direction == "uplink->downlink":
             if setup["topo"] == "m0_l3":
@@ -1037,13 +1036,13 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         counters_sanity_check.append(rule_id)
 
     def test_dest_ip_match_dropped(self, setup, direction, ptfadapter,
-                                   counters_sanity_check, ip_version, vlan_name, skip_traffic_test):    # noqa F811
+                                   counters_sanity_check, ip_version, vlan_name):
         """Verify that we can match and drop a packet on destination IP."""
         dst_ip = DOWNSTREAM_IP_TO_BLOCK[ip_version] \
             if direction == "uplink->downlink" else UPSTREAM_IP_TO_BLOCK[ip_version]
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dst_ip=dst_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         # Because m0_l3_scenario use differnet IPs, so need to verify different acl rules.
         if direction == "uplink->downlink":
             if setup["topo"] == "m0_l3":
@@ -1063,165 +1062,162 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         counters_sanity_check.append(rule_id)
 
     def test_source_ip_match_dropped(self, setup, direction, ptfadapter,
-                                     counters_sanity_check, ip_version, skip_traffic_test):     # noqa F811
+                                     counters_sanity_check, ip_version):
         """Verify that we can match and drop a packet on source IP."""
         src_ip = "20.0.0.6" if ip_version == "ipv4" else "60c0:a800::3"
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(14)
 
     def test_udp_source_ip_match_forwarded(self, setup, direction, ptfadapter,
-                                           counters_sanity_check, ip_version, skip_traffic_test):       # noqa F811
+                                           counters_sanity_check, ip_version):
         """Verify that we can match and forward a UDP packet on source IP."""
         src_ip = "20.0.0.4" if ip_version == "ipv4" else "60c0:a800::8"
         pkt = self.udp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(13)
 
     def test_udp_source_ip_match_dropped(self, setup, direction, ptfadapter,
-                                         counters_sanity_check, ip_version, skip_traffic_test):     # noqa F811
+                                         counters_sanity_check, ip_version):
         """Verify that we can match and drop a UDP packet on source IP."""
         src_ip = "20.0.0.8" if ip_version == "ipv4" else "60c0:a800::2"
         pkt = self.udp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(26)
 
     def test_icmp_source_ip_match_dropped(self, setup, direction, ptfadapter,
-                                          counters_sanity_check, ip_version, skip_traffic_test):    # noqa F811
+                                          counters_sanity_check, ip_version):
         """Verify that we can match and drop an ICMP packet on source IP."""
         src_ip = "20.0.0.8" if ip_version == "ipv4" else "60c0:a800::2"
         pkt = self.icmp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(25)
 
     def test_icmp_source_ip_match_forwarded(self, setup, direction, ptfadapter,
-                                            counters_sanity_check, ip_version, skip_traffic_test):  # noqa F811
+                                            counters_sanity_check, ip_version):
         """Verify that we can match and forward an ICMP packet on source IP."""
         src_ip = "20.0.0.4" if ip_version == "ipv4" else "60c0:a800::8"
         pkt = self.icmp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(12)
 
     def test_l4_dport_match_forwarded(self, setup, direction, ptfadapter,
-                                      counters_sanity_check, ip_version, skip_traffic_test):        # noqa F811
+                                      counters_sanity_check, ip_version):
         """Verify that we can match and forward on L4 destination port."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dport=0x1217)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(9)
 
     def test_l4_sport_match_forwarded(self, setup, direction, ptfadapter,
-                                      counters_sanity_check, ip_version, skip_traffic_test):        # noqa F811
+                                      counters_sanity_check, ip_version):
         """Verify that we can match and forward on L4 source port."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, sport=0x120D)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(4)
 
     def test_l4_dport_range_match_forwarded(self, setup, direction, ptfadapter,
-                                            counters_sanity_check, ip_version, skip_traffic_test):  # noqa F811
+                                            counters_sanity_check, ip_version):
         """Verify that we can match and forward on a range of L4 destination ports."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dport=0x123B)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(11)
 
     def test_l4_sport_range_match_forwarded(self, setup, direction, ptfadapter,
-                                            counters_sanity_check, ip_version, skip_traffic_test):  # noqa F811
+                                            counters_sanity_check, ip_version):
         """Verify that we can match and forward on a range of L4 source ports."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, sport=0x123A)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(10)
 
     def test_l4_dport_range_match_dropped(self, setup, direction, ptfadapter,
-                                          counters_sanity_check, ip_version, skip_traffic_test):    # noqa F811
+                                          counters_sanity_check, ip_version):
         """Verify that we can match and drop on a range of L4 destination ports."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dport=0x127B)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(22)
 
     def test_l4_sport_range_match_dropped(self, setup, direction, ptfadapter,
-                                          counters_sanity_check, ip_version, skip_traffic_test):    # noqa F811
+                                          counters_sanity_check, ip_version):
         """Verify that we can match and drop on a range of L4 source ports."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, sport=0x1271)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(17)
 
     def test_ip_proto_match_forwarded(self, setup, direction, ptfadapter,
-                                      counters_sanity_check, ip_version, skip_traffic_test):        # noqa F811
+                                      counters_sanity_check, ip_version):
         """Verify that we can match and forward on the IP protocol."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, proto=0x7E)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(5)
 
     def test_tcp_flags_match_forwarded(self, setup, direction, ptfadapter,
-                                       counters_sanity_check, ip_version, skip_traffic_test):       # noqa F811
+                                       counters_sanity_check, ip_version):
         """Verify that we can match and forward on the TCP flags."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, flags=0x1B)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(6)
 
     def test_l4_dport_match_dropped(self, setup, direction, ptfadapter,
-                                    counters_sanity_check, ip_version, skip_traffic_test):          # noqa F811
+                                    counters_sanity_check, ip_version):
         """Verify that we can match and drop on L4 destination port."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, dport=0x127B)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(22)
 
     def test_l4_sport_match_dropped(self, setup, direction, ptfadapter,
-                                    counters_sanity_check, ip_version, skip_traffic_test):          # noqa F811
+                                    counters_sanity_check, ip_version):
         """Verify that we can match and drop on L4 source port."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, sport=0x1271)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(17)
 
     def test_ip_proto_match_dropped(self, setup, direction, ptfadapter,
-                                    counters_sanity_check, ip_version, skip_traffic_test):          # noqa F811
+                                    counters_sanity_check, ip_version):
         """Verify that we can match and drop on the IP protocol."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, proto=0x7F)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(18)
 
     def test_tcp_flags_match_dropped(self, setup, direction, ptfadapter,
-                                     counters_sanity_check, ip_version, skip_traffic_test):         # noqa F811
+                                     counters_sanity_check, ip_version):
         """Verify that we can match and drop on the TCP flags."""
         pkt = self.tcp_packet(setup, direction, ptfadapter, ip_version, flags=0x24)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, True, ip_version)
         counters_sanity_check.append(19)
 
     def test_icmp_match_forwarded(self, setup, direction, ptfadapter,
-                                  counters_sanity_check, ip_version, skip_traffic_test):            # noqa F811
+                                  counters_sanity_check, ip_version):
         """Verify that we can match and drop on the TCP flags."""
         src_ip = "20.0.0.10" if ip_version == "ipv4" else "60c0:a800::10"
         pkt = self.icmp_packet(setup, direction, ptfadapter, ip_version, src_ip=src_ip, icmp_type=3, icmp_code=1)
 
-        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version, skip_traffic_test)
+        self._verify_acl_traffic(setup, direction, ptfadapter, pkt, False, ip_version)
         counters_sanity_check.append(29)
 
-    def _verify_acl_traffic(self, setup, direction, ptfadapter, pkt, dropped, ip_version, skip_traffic_test):   # noqa F811
+    def _verify_acl_traffic(self, setup, direction, ptfadapter, pkt, dropped, ip_version):
         exp_pkt = self.expected_mask_routed_packet(pkt, ip_version)
 
         if ip_version == "ipv4":
             downstream_dst_port = DOWNSTREAM_IP_PORT_MAP.get(pkt[packet.IP].dst)
         else:
             downstream_dst_port = DOWNSTREAM_IP_PORT_MAP.get(pkt[packet.IPv6].dst)
-
-        if skip_traffic_test:
-            return
 
         ptfadapter.dataplane.flush()
         testutils.send(ptfadapter, self.src_port, pkt)
@@ -1299,7 +1295,7 @@ class TestAclWithReboot(TestBasicAcl):
     upon startup.
     """
 
-    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts): # noqa F811
+    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):     # noqa F811
         """Save configuration and reboot after rules are applied.
 
         Args:
@@ -1344,7 +1340,7 @@ class TestAclWithPortToggle(TestBasicAcl):
     Verify that ACLs still function as expected after links flap.
     """
 
-    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):  # noqa F811
+    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):     # noqa F811
         """Toggle ports after rules are applied.
 
         Args:

--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -556,6 +556,10 @@ class AclVlanOuterTest_Base(object):
                 testutils.send(ptfadapter, port, mac_pkt)
 
         table_name = ACL_TABLE_NAME_TEMPLATE.format(stage, ip_version)
+        asic_type = duthost.facts['asic_type']
+        if asic_type == 'vs':
+            logger.info("Skip ACL verification on VS platform")
+            return
         try:
             self._setup_acl_rules(duthost, stage, ip_version, outer_vlan_id, action)
 

--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -14,7 +14,7 @@ from scapy.all import Ether, IP
 from tests.common.utilities import wait_until
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert, pytest_require
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses, skip_traffic_test    # noqa F401
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses    # noqa F401
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from abc import abstractmethod
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
@@ -515,7 +515,7 @@ class AclVlanOuterTest_Base(object):
             self.post_running_hook(rand_selected_dut, ptfhost, ip_version)
 
     def _do_verification(self, ptfadapter, duthost, tbinfo, vlan_setup_info,
-                         ip_version, tagged_mode, action, skip_traffic_test):   # noqa F811
+                         ip_version, tagged_mode, action):   # noqa F811
         vlan_setup, _, _, _ = vlan_setup_info
         test_setup_config = self.setup_cfg(duthost, tbinfo, vlan_setup, tagged_mode, ip_version)
 
@@ -558,15 +558,15 @@ class AclVlanOuterTest_Base(object):
         table_name = ACL_TABLE_NAME_TEMPLATE.format(stage, ip_version)
         try:
             self._setup_acl_rules(duthost, stage, ip_version, outer_vlan_id, action)
-            if not skip_traffic_test:
-                count_before = get_acl_counter(duthost, table_name, RULE_1, timeout=0)
-                send_and_verify_traffic(ptfadapter, pkt, exp_pkt, src_port, dst_port, pkt_action=action)
-                count_after = get_acl_counter(duthost, table_name, RULE_1)
 
-                logger.info("Verify Acl counter incremented {} > {}".format(count_after, count_before))
-                pytest_assert(count_after >= count_before + 1,
-                              "Unexpected results, counter_after {} > counter_before {}"
-                              .format(count_after, count_before))
+            count_before = get_acl_counter(duthost, table_name, RULE_1, timeout=0)
+            send_and_verify_traffic(ptfadapter, pkt, exp_pkt, src_port, dst_port, pkt_action=action)
+            count_after = get_acl_counter(duthost, table_name, RULE_1)
+
+            logger.info("Verify Acl counter incremented {} > {}".format(count_after, count_before))
+            pytest_assert(count_after >= count_before + 1,
+                          "Unexpected results, counter_after {} > counter_before {}"
+                          .format(count_after, count_before))
         except Exception as e:
             raise (e)
         finally:
@@ -574,83 +574,75 @@ class AclVlanOuterTest_Base(object):
 
     @pytest.mark.po2vlan
     def test_tagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
-                              skip_traffic_test):   # noqa F811
+                              ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
         """
         Verify packet is forwarded by ACL rule on tagged interface
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_TAGGED, ACTION_FORWARD, skip_traffic_test)
+                              ip_version, TYPE_TAGGED, ACTION_FORWARD)
 
     @pytest.mark.po2vlan
     def test_tagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                            ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
-                            skip_traffic_test):   # noqa F811
+                            ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
         """
         Verify packet is dropped by ACL rule on tagged interface
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_TAGGED, ACTION_DROP, skip_traffic_test)
+                              ip_version, TYPE_TAGGED, ACTION_DROP)
 
     @pytest.mark.po2vlan
     def test_untagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                                ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
-                                skip_traffic_test):   # noqa F811
+                                ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
         """
         Verify packet is forwarded by ACL rule on untagged interface
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_UNTAGGED, ACTION_FORWARD, skip_traffic_test)
+                              ip_version, TYPE_UNTAGGED, ACTION_FORWARD)
 
     @pytest.mark.po2vlan
     def test_untagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
-                              skip_traffic_test):   # noqa F811
+                              ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
         """
         Verify packet is dropped by ACL rule on untagged interface
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_UNTAGGED, ACTION_DROP, skip_traffic_test)
+                              ip_version, TYPE_UNTAGGED, ACTION_DROP)
 
     @pytest.mark.po2vlan
     def test_combined_tagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                                       ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
-                                       skip_traffic_test):   # noqa F811
+                                       ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
         """
         Verify packet is forwarded by ACL rule on tagged interface, and the interface belongs to two vlans
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_COMBINE_TAGGED, ACTION_FORWARD, skip_traffic_test)
+                              ip_version, TYPE_COMBINE_TAGGED, ACTION_FORWARD)
 
     @pytest.mark.po2vlan
     def test_combined_tagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                                     ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
-                                     skip_traffic_test):   # noqa F811
+                                     ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
         """
         Verify packet is dropped by ACL rule on tagged interface, and the interface belongs to two vlans
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_COMBINE_TAGGED, ACTION_DROP, skip_traffic_test)
+                              ip_version, TYPE_COMBINE_TAGGED, ACTION_DROP)
 
     @pytest.mark.po2vlan
     def test_combined_untagged_forwarded(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                                         ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
-                                         skip_traffic_test):   # noqa F811
+                                         ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
         """
         Verify packet is forwarded by ACL rule on untagged interface, and the interface belongs to two vlans
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_COMBINE_UNTAGGED, ACTION_FORWARD, skip_traffic_test)
+                              ip_version, TYPE_COMBINE_UNTAGGED, ACTION_FORWARD)
 
     @pytest.mark.po2vlan
     def test_combined_untagged_dropped(self, ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                                       ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa F811
-                                       skip_traffic_test):   # noqa F811
+                                       ip_version, toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
         """
         Verify packet is dropped by ACL rule on untagged interface, and the interface belongs to two vlans
         """
         self._do_verification(ptfadapter, rand_selected_dut, tbinfo, vlan_setup_info,
-                              ip_version, TYPE_COMBINE_UNTAGGED, ACTION_DROP, skip_traffic_test)
+                              ip_version, TYPE_COMBINE_UNTAGGED, ACTION_DROP)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -7,7 +7,6 @@ from ptf import mask, packet
 from collections import defaultdict
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa F401
 from tests.common.utilities import wait_until
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test   # noqa F401
 
 pytestmark = [
     pytest.mark.topology("t0", "t1", "m0", "mx"),
@@ -119,7 +118,7 @@ def prepare_test_port(rand_selected_dut, tbinfo):
 
 
 def verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
-                     acl_rule_list, del_rule_id, verity_status, skip_traffic_test):     # noqa F811
+                     acl_rule_list, del_rule_id, verity_status):
 
     for acl_id in acl_rule_list:
         ip_addr1 = acl_id % 256
@@ -146,13 +145,12 @@ def verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
         exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
         exp_pkt.set_do_not_care_scapy(packet.IP, "chksum")
 
-        if not skip_traffic_test:
-            ptfadapter.dataplane.flush()
-            testutils.send(test=ptfadapter, port_id=ptf_src_port, pkt=pkt)
-            if verity_status == "forward" or acl_id == del_rule_id:
-                testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt, ports=ptf_dst_ports)
-            elif verity_status == "drop" and acl_id != del_rule_id:
-                testutils.verify_no_packet_any(test=ptfadapter, pkt=exp_pkt, ports=ptf_dst_ports)
+        ptfadapter.dataplane.flush()
+        testutils.send(test=ptfadapter, port_id=ptf_src_port, pkt=pkt)
+        if verity_status == "forward" or acl_id == del_rule_id:
+            testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt, ports=ptf_dst_ports)
+        elif verity_status == "drop" and acl_id != del_rule_id:
+            testutils.verify_no_packet_any(test=ptfadapter, pkt=exp_pkt, ports=ptf_dst_ports)
 
 
 def acl_rule_loaded(rand_selected_dut, acl_rule_list):
@@ -168,7 +166,7 @@ def acl_rule_loaded(rand_selected_dut, acl_rule_list):
 
 def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_file,
                             prepare_test_port, get_function_completeness_level,
-                            toggle_all_simulator_ports_to_rand_selected_tor, skip_traffic_test):   # noqa F811
+                            toggle_all_simulator_ports_to_rand_selected_tor):   # noqa F811
 
     ptf_src_port, ptf_dst_ports, dut_port = prepare_test_port
 
@@ -186,7 +184,7 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
     rand_selected_dut.shell(cmd_create_table)
     acl_rule_list = list(range(1, ACL_RULE_NUMS + 1))
     verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
-                     acl_rule_list, 0, "forward", skip_traffic_test)
+                     acl_rule_list, 0, "forward")
     try:
         loops = 0
         while loops <= loop_times:
@@ -204,7 +202,7 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
 
             wait_until(wait_timeout, 2, 0, acl_rule_loaded, rand_selected_dut, acl_rule_list)
             verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
-                             acl_rule_list, 0, "drop", skip_traffic_test)
+                             acl_rule_list, 0, "drop")
 
             del_rule_id = random.choice(acl_rule_list)
             rand_selected_dut.shell('sonic-db-cli CONFIG_DB del "ACL_RULE|STRESS_ACL| RULE_{}"'.format(del_rule_id))
@@ -212,7 +210,7 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
 
             wait_until(wait_timeout, 2, 0, acl_rule_loaded, rand_selected_dut, acl_rule_list)
             verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
-                             acl_rule_list, del_rule_id, "drop", skip_traffic_test)
+                             acl_rule_list, del_rule_id, "drop")
 
             loops += 1
     finally:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently we are using conditional mark to add marker, then use pytest hook to redirect testutils.verify function to a function always return True to skip traffic test. With this change, the skip_traffic_test fixture is no longer needed in test cases, streamlining the test code and improving clarity.
#### How did you do it?
Remove skip_traffic_test in testcases
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
