### PR TITLE
Fix fixture 'advanceboot_neighbor_restore' not found issue

### DIFF
--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -8,7 +8,7 @@ from tests.common.fixtures.duthost_utils import backup_and_restore_config_db    
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot           # noqa F401
 from tests.platform_tests.verify_dut_health import add_fail_step_to_reboot      # noqa F401
 from tests.common.platform.warmboot_sad_cases import get_sad_case_list, SAD_CASE_LIST
-from tests.common.platform.device_utils import advanceboot_loganalyzer, verify_dut_health       # noqa F401
+from tests.common.platform.device_utils import advanceboot_loganalyzer, verify_dut_health, advanceboot_neighbor_restore       # noqa F401
 
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service    # noqa F401
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip, show_muxcable_status


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
test_advanced_reboot script failed on fixture 'advanceboot_neighbor_restore' not found, which caused by missing import advanceboot_neighbor_restore in test_advanced_reboot.py.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
test_advanced_reboot test failed due to fixture 'advanceboot_neighbor_restore' not found
#### How did you do it?
Add missed fixture "advanceboot_neighbor_restore"
#### How did you verify/test it?
https://elastictest.org/scheduler/testplan/672838a18317d3b3441bd1dc?testcase=platform_tests%2ftest_advanced_reboot.py&type=console&leftSideViewMode=detail
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
