### PR TITLE
Fix the wrong reboot wait/timeout setting on test_link_down

### DIFF
--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -26,7 +26,6 @@ pytestmark = [
 MAX_TIME_TO_REBOOT = 120
 
 
-@pytest.fixture(scope='function')
 def set_max_to_reboot(duthost):
     """
     For chassis testbeds, we need to specify plt_reboot_ctrl in inventory file,
@@ -148,12 +147,13 @@ def check_interfaces_and_services_all_LCs(duthosts, conn_graph_facts, xcvr_skip_
 
 
 def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostname,
-                                 conn_graph_facts, set_max_to_reboot,
+                                 conn_graph_facts,
                                  fanouthosts, xcvr_skip_list):
     if len(duthosts.nodes) == 1:
         pytest.skip("Skip single-host dut for this test")
 
     duthost = duthosts[enum_supervisor_dut_hostname]
+    set_max_to_reboot(duthost)
 
     # There are some errors due to reboot happened before this test file for some reason,
     # and SUP may not have enough time to recover all dockers and the wait for process wait for 300 secs in
@@ -203,9 +203,10 @@ def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostna
 
 
 def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname,
-                                    conn_graph_facts, set_max_to_reboot,
+                                    conn_graph_facts,
                                     fanouthosts, xcvr_skip_list):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    set_max_to_reboot(duthost)
     hostname = duthost.hostname
 
     # Before test, check all interfaces and services are up


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix the wait ssh timeout.
set_max_to_reboot is expected to set max wait time due to different duthost,
But previously it auto uses the fixture duthost, which always return the first dut in duthosts,
For example, if duthosts= [lc1,lc2,rp]
the duthost=lc.

But for test case test_link_down_on_sup_reboot, we should get the configuration for rp.
Hence update the logic, explicitly pass the target duthost to the function.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix the failure for chassis on test_link_down
#### How did you do it?
explicitly pass the target duthost to the set_max_to_reboot .
#### How did you verify/test it?
run it locally with physical testbes
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
