### PR TITLE
Re-configure ExaBGP http-api (for py3 only)

### DIFF
--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -78,6 +78,16 @@ def run_command():
     return "OK\\n"
 
 if __name__ == '__main__':
+    # with werkzeug 3.x the default size of max_form_memory_size
+    # is 500K. Routes reach a bit beyond that and the client
+    # receives HTTP 413.
+    # Configure the max size to 4 MB to be safe.
+    if not six.PY2:
+        from werkzeug import Request
+        max_content_length = 4 * 1024 * 1024
+        Request.max_content_length = max_content_length
+        Request.max_form_memory_size = max_content_length
+        Request.max_form_parts = max_content_length
     app.run(host='0.0.0.0', port=sys.argv[1])
 '''
 


### PR DESCRIPTION
### Description of PR

Re-configure ExaBGP's http-api (for Py3 only). With Python 3 only environment using ExaBGP 4 with Flask 3.x the `werkzeug` Requests max form memory is capped to 500k (https://werkzeug.palletsprojects.com/en/stable/request_data/#limiting-request-data). This breaks announce routes. This PR increases the limit.

Summary:
Fixes # NA

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

Backport is not applicable as it is part of new feature for Py3 only `docker-ptf`.

### Approach
#### What is the motivation for this PR?

Fix issue.

#### How did you do it?

Increase the Flask `werkzeug` request memory limit.

#### How did you verify/test it?

By running "restart-ptf" on testbeds.

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

Not applicable

### Documentation

Not applicable