### PR TITLE
Revert "[action] [PR:13384] Adjust packet size for testQosSaiLossyQueueVoqMultiSrc"

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -436,7 +436,7 @@ class QosParamCisco(object):
                       "pg": 0,
                       "pkts_num_trig_egr_drp": self.max_depth // self.buffer_size,
                       "pkts_num_margin": 4,
-                      "packet_size": 1350,
+                      "packet_size": 64,
                       "cell_size": self.buffer_size}
             self.write_params("lossy_queue_voq_3", params)
 


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#14760

This causes nightly regression to dualtor testbed.

```
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_asic] 
-------------------------------- live log setup --------------------------------
21:52:21 __init__._fixture_generator_decorator    L0088 ERROR  | 
KeyError(8)
Traceback (most recent call last):
  File "/azp/_work/30/s/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/azp/_work/30/s/tests/qos/qos_sai_base.py", line 2337, in tc_to_dscp_count
    tc_to_dscp_count_map[int(tc)] += 1
KeyError: 8
ERROR   
```