### PR TITLE
Revert "[202311][conflict]Add GCU timeout for qualification"

### DIFF
--- a/tests/generic_config_updater/gu_utils.py
+++ b/tests/generic_config_updater/gu_utils.py
@@ -2,7 +2,6 @@ import json
 import logging
 import pytest
 import os
-import time
 from jsonpointer import JsonPointer
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
@@ -14,7 +13,6 @@ CONTAINER_SERVICES_LIST = ["swss", "syncd", "radv", "lldp", "dhcp_relay", "teamd
 DEFAULT_CHECKPOINT_NAME = "test"
 GCU_FIELD_OPERATION_CONF_FILE = "gcu_field_operation_validators.conf.json"
 GET_HWSKU_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.hwsku"
-GCUTIMEOUT = 240
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 FILES_DIR = os.path.join(BASE_DIR, "files")
@@ -47,12 +45,7 @@ def apply_patch(duthost, json_data, dest_file):
     cmds = 'config apply-patch {}'.format(dest_file)
 
     logger.info("Commands: {}".format(cmds))
-    start_time = time.time()
     output = duthost.shell(cmds, module_ignore_errors=True)
-    elapsed_time = time.time() - start_time
-    if elapsed_time > GCUTIMEOUT:
-        logger.error("Command took too long: {} seconds".format(elapsed_time))
-        raise TimeoutError("Command execution timeout: {} seconds".format(elapsed_time))
 
     return output
 


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#14910

This introduces nightly regression to dualtor.

```
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_scale_rules[default-Vlan1000] 
-------------------------------- live log call ---------------------------------
20:18:33 gu_utils.apply_patch                     L0054 ERROR  | Command took too long: 264.4831771850586 seconds
20:18:34 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 1788, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/azp/_work/27/s/tests/generic_config_updater/test_dynamic_acl.py", line 1248, in test_gcu_acl_scale_rules
    dynamic_acl_apply_forward_scale_rules(rand_selected_dut, setup)
  File "/azp/_work/27/s/tests/generic_config_updater/test_dynamic_acl.py", line 976, in dynamic_acl_apply_forward_scale_rules
    outputs = apply_formed_json_patch(duthost, json_patch, setup)
  File "/azp/_work/27/s/tests/generic_config_updater/gu_utils.py", line 443, in apply_formed_json_patch
    output = apply_patch(dut, json_data=json_patch, dest_file=tmpfile)
  File "/azp/_work/27/s/tests/generic_config_updater/gu_utils.py", line 55, in apply_patch
    raise TimeoutError("Command execution timeout: {} seconds".format(elapsed_time))
TimeoutError: Command execution timeout: 264.4831771850586 seconds
```