### PR TITLE
Remove skip_traffic_test fixture in dualtor tests

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -241,7 +241,7 @@ def save_pcap(request, pytestconfig):
 
 @pytest.fixture
 def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
-                                  cable_type, vmhost, save_pcap, skip_traffic_test=False):       # noqa F811
+                                  cable_type, vmhost, save_pcap):       # noqa F811
     """
     Starts IO test from T1 router to server.
     As part of IO test the background thread sends and sniffs packets.
@@ -263,8 +263,7 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
     def t1_to_server_io_test(activehost, tor_vlan_port=None,
                              delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.1,
-                             stop_after=None, allow_disruption_before_traffic=False,
-                             skip_traffic_test=False):
+                             stop_after=None, allow_disruption_before_traffic=False):
         """
         Helper method for `send_t1_to_server_with_action`.
         Starts sender and sniffer before performing the action on the tor host.
@@ -299,9 +298,6 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
         if delay and not allowed_disruption:
             allowed_disruption = 1
 
-        if skip_traffic_test is True:
-            logging.info("Skipping traffic test")
-            return
         return verify_and_report(tor_IO, verify, delay, allowed_disruption, allow_disruption_before_traffic)
 
     yield t1_to_server_io_test
@@ -311,7 +307,7 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
 @pytest.fixture
 def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
-                                  cable_type, vmhost, save_pcap, skip_traffic_test=False):   # noqa F811
+                                  cable_type, vmhost, save_pcap):   # noqa F811
     """
     Starts IO test from server to T1 router.
     As part of IO test the background thread sends and sniffs packets.
@@ -334,7 +330,7 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
     def server_to_t1_io_test(activehost, tor_vlan_port=None,
                              delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.01,
-                             stop_after=None, skip_traffic_test=False):
+                             stop_after=None):
         """
         Helper method for `send_server_to_t1_with_action`.
         Starts sender and sniffer before performing the action on the tor host.
@@ -368,8 +364,9 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
         if delay and not allowed_disruption:
             allowed_disruption = 1
 
-        if skip_traffic_test is True:
-            logging.info("Skipping traffic test")
+        asic_type = duthosts[0].facts["asic_type"]
+        if asic_type == "vs":
+            logging.info("Skipping verify on VS platform")
             return
         return verify_and_report(tor_IO, verify, delay, allowed_disruption)
 
@@ -380,13 +377,13 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
 @pytest.fixture
 def send_soc_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
-                               cable_type, vmhost, save_pcap, skip_traffic_test=False):      # noqa F811
+                               cable_type, vmhost, save_pcap):      # noqa F811
 
     arp_setup(ptfhost)
 
     def soc_to_t1_io_test(activehost, tor_vlan_port=None,
                           delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.01,
-                          stop_after=None, skip_traffic_test=False):
+                          stop_after=None):
 
         tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
                           action, tbinfo, tor_vlan_port, send_interval,
@@ -396,8 +393,9 @@ def send_soc_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
         if delay and not allowed_disruption:
             allowed_disruption = 1
 
-        if skip_traffic_test is True:
-            logging.info("Skipping traffic test")
+        asic_type = duthosts[0].facts["asic_type"]
+        if asic_type == "vs":
+            logging.info("Skipping verify on VS platform")
             return
         return verify_and_report(tor_IO, verify, delay, allowed_disruption)
 
@@ -408,13 +406,13 @@ def send_soc_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
 @pytest.fixture
 def send_t1_to_soc_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
-                               cable_type, vmhost, save_pcap, skip_traffic_test=False):      # noqa F811
+                               cable_type, vmhost, save_pcap):      # noqa F811
 
     arp_setup(ptfhost)
 
     def t1_to_soc_io_test(activehost, tor_vlan_port=None,
                           delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.01,
-                          stop_after=None, skip_traffic_test=False):
+                          stop_after=None):
 
         tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
                           action, tbinfo, tor_vlan_port, send_interval,
@@ -426,8 +424,9 @@ def send_t1_to_soc_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
         if delay and not allowed_disruption:
             allowed_disruption = 1
 
-        if skip_traffic_test is True:
-            logging.info("Skipping traffic test")
+        asic_type = duthosts[0].facts["asic_type"]
+        if asic_type == "vs":
+            logging.info("Skipping verify on VS platform")
             return
         return verify_and_report(tor_IO, verify, delay, allowed_disruption)
 
@@ -454,13 +453,13 @@ def select_test_mux_ports(active_active_ports, active_standby_ports):           
 
 @pytest.fixture
 def send_server_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
-                                      cable_type, vmhost, save_pcap, skip_traffic_test=False):   # noqa F811
+                                      cable_type, vmhost, save_pcap):   # noqa F811
 
     arp_setup(ptfhost)
 
     def server_to_server_io_test(activehost, test_mux_ports, delay=0,
                                  allowed_disruption=0, action=None,
-                                 verify=False, send_interval=0.01, stop_after=None, skip_traffic_test=False):
+                                 verify=False, send_interval=0.01, stop_after=None):
         tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
                           action, tbinfo, test_mux_ports, send_interval,
                           traffic_direction="server_to_server", stop_after=stop_after,
@@ -471,8 +470,9 @@ def send_server_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
         if delay and not allowed_disruption:
             allowed_disruption = 1
 
-        if skip_traffic_test is True:
-            logging.info("Skipping traffic test")
+        asic_type = duthosts[0].facts["asic_type"]
+        if asic_type == "vs":
+            logging.info("Skipping verify on VS platform")
             return
         return verify_and_report(tor_IO, verify, delay, allowed_disruption)
 

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -883,7 +883,7 @@ def mux_cable_server_ip(dut):
 def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip,
                          standby_tor_ip, selected_port, target_server_ip,
                          target_server_ipv6, target_server_port, ptf_portchannel_indices,
-                         completeness_level, check_ipv6=False, skip_traffic_test=False):
+                         completeness_level, check_ipv6=False):
     """
     Function for testing traffic distribution among all avtive T1.
     A test script will be running on ptf to generate traffic to standby interface, and the traffic will be forwarded to
@@ -901,9 +901,6 @@ def check_tunnel_balance(ptfhost, standby_tor_mac, vlan_mac, active_tor_ip,
     Returns:
         None.
     """
-    if skip_traffic_test is True:
-        logging.info("Skip checking tunnel balance due to traffic test was skipped")
-        return
     HASH_KEYS = ["src-port", "dst-port", "src-ip"]
     params = {
         "server_ip": target_server_ip,
@@ -1158,7 +1155,7 @@ def check_nexthops_balance(rand_selected_dut, ptfadapter, dst_server_addr,
                     pc))
 
 
-def check_nexthops_single_uplink(portchannel_ports, port_packet_count, expect_packet_num, skip_traffic_test=False):
+def check_nexthops_single_uplink(portchannel_ports, port_packet_count, expect_packet_num):
     for pc, intfs in portchannel_ports.items():
         count = 0
         # Collect the packets count within a single portchannel
@@ -1167,16 +1164,14 @@ def check_nexthops_single_uplink(portchannel_ports, port_packet_count, expect_pa
             count = count + port_packet_count.get(uplink_int, 0)
         logging.info("Packets received on portchannel {}: {}".format(pc, count))
 
-        if skip_traffic_test is True:
-            logging.info("Skip checking single uplink balance due to traffic test was skipped")
-            continue
         if count > 0 and count != expect_packet_num:
             pytest.fail("Packets not sent up single standby port {}".format(pc))
 
 
 # verify nexthops are only sent to single active or standby mux
 def check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_addr,
-                                   tbinfo, downlink_ints, skip_traffic_test=False):
+                                   tbinfo, downlink_ints):
+    asic_type = rand_selected_dut.facts["asic_type"]
     HASH_KEYS = ["src-port", "dst-port", "src-ip"]
     expect_packet_num = 1000
     expect_packet_num_high = expect_packet_num * (0.90)
@@ -1191,9 +1186,7 @@ def check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_add
     port_packet_count = dict()
     packets_to_send = generate_hashed_packet_to_server(ptfadapter, rand_selected_dut, HASH_KEYS, dst_server_addr,
                                                        expect_packet_num)
-    if skip_traffic_test is True:
-        logging.info("Skip checking single downlink balance due to traffic test was skipped")
-        return
+
     for send_packet, exp_pkt, exp_tunnel_pkt in packets_to_send:
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), send_packet, count=1)
         # expect multi-mux nexthops to focus packets to one downlink
@@ -1203,6 +1196,10 @@ def check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_add
 
         for ptf_idx, pkt_count in ptf_port_count.items():
             port_packet_count[ptf_idx] = port_packet_count.get(ptf_idx, 0) + pkt_count
+
+    if asic_type == "vs":
+        logging.info("Skipping validation on VS platform")
+        return
 
     logging.info("Received packets in ports: {}".format(str(port_packet_count)))
     for downlink_int in expected_downlink_ports:
@@ -1215,11 +1212,11 @@ def check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_add
     if len(downlink_ints) == 0:
         # All nexthops are now connected to standby mux, and the packets will be sent towards a single portchanel int
         # Check if uplink distribution is towards a single portchannel
-        check_nexthops_single_uplink(portchannel_ports, port_packet_count, expect_packet_num, skip_traffic_test)
+        check_nexthops_single_uplink(portchannel_ports, port_packet_count, expect_packet_num)
 
 
 def verify_upstream_traffic(host, ptfadapter, tbinfo, itfs, server_ip,
-                            pkt_num=100, drop=False, skip_traffic_test=False):
+                            pkt_num=100, drop=False):
     """
     @summary: Helper function for verifying upstream packets
     @param host: The dut host
@@ -1272,9 +1269,7 @@ def verify_upstream_traffic(host, ptfadapter, tbinfo, itfs, server_ip,
 
     logger.info("Verifying upstream traffic. packet number = {} interface = {} \
                 server_ip = {} expect_drop = {}".format(pkt_num, itfs, server_ip, drop))
-    if skip_traffic_test is True:
-        logger.info("Skip verifying upstream traffic due to traffic test was skipped")
-        return
+
     for i in range(0, pkt_num):
         ptfadapter.dataplane.flush()
         testutils.send(ptfadapter, tx_port, pkt, count=1)

--- a/tests/common/dualtor/server_traffic_utils.py
+++ b/tests/common/dualtor/server_traffic_utils.py
@@ -56,8 +56,7 @@ class ServerTrafficMonitor(object):
     VLAN_INTERFACE_TEMPLATE = "{external_port}.{vlan_id}"
 
     def __init__(self, duthost, ptfhost, vmhost, tbinfo, dut_iface,
-                 conn_graph_facts, exp_pkt, existing=True, is_mocked=False,
-                 skip_traffic_test=False):
+                 conn_graph_facts, exp_pkt, existing=True, is_mocked=False):
         """
         @summary: Initialize the monitor.
 
@@ -82,7 +81,7 @@ class ServerTrafficMonitor(object):
         self.conn_graph_facts = conn_graph_facts
         self.captured_packets = []
         self.matched_packets = []
-        self.skip_traffic_test = skip_traffic_test
+
         if is_mocked:
             mg_facts = self.duthost.get_extended_minigraph_facts(self.tbinfo)
             ptf_iface = "eth%s" % mg_facts['minigraph_ptf_indices'][self.dut_iface]
@@ -128,8 +127,9 @@ class ServerTrafficMonitor(object):
         logging.info("the expected packet:\n%s", str(self.exp_pkt))
         self.matched_packets = [p for p in self.captured_packets if match_exp_pkt(self.exp_pkt, p)]
         logging.info("received %d matched packets", len(self.matched_packets))
-        if self.skip_traffic_test is True:
-            logging.info("Skip matched_packets verify due to traffic test was skipped.")
+        asic_type = self.duthost.facts["asic_type"]
+        if asic_type == "vs":
+            logging.info("Skipping matched_packets verify on VS platform.")
             return
         if self.matched_packets:
             logging.info(

--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -250,7 +250,7 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
             return " ,".join(check_res)
 
         def __init__(self, standby_tor, active_tor=None, existing=True, inner_packet=None,
-                     check_items=("ttl", "tos", "queue"), packet_count=10, skip_traffic_test=False):
+                     check_items=("ttl", "tos", "queue"), packet_count=10):
             """
             Init the tunnel traffic monitor.
 
@@ -262,7 +262,6 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
             self.listen_ports = sorted(self._get_t1_ptf_port_indexes(standby_tor, tbinfo))
             self.ptfadapter = ptfadapter
             self.packet_count = packet_count
-            self.skip_traffic_test = skip_traffic_test
 
             standby_tor_cfg_facts = self.standby_tor.config_facts(
                 host=self.standby_tor.hostname, source="running"
@@ -292,9 +291,6 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
 
         def __exit__(self, *exc_info):
             if exc_info[0]:
-                return
-            if self.skip_traffic_test is True:
-                logging.info("Skip tunnel traffic verify due to traffic test was skipped.")
                 return
             try:
                 result = testutils.verify_packet_any_port(

--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -28,7 +28,6 @@ from tests.common.utilities import is_ipv4_address, wait_until
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder          # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_garp_service            # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test           # noqa F401
 from tests.common.utilities import dump_scapy_packet_show_output
 from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby                 # noqa F401
 from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup                        # noqa F401
@@ -105,7 +104,7 @@ def build_expected_packet_to_server(encapsulated_packet, decrease_ttl=False):
 def test_decap_active_tor(
     build_encapsulated_packet, request, ptfhost,
     rand_selected_interface, ptfadapter,                    # noqa F401
-    tbinfo, rand_selected_dut, tunnel_traffic_monitor, skip_traffic_test):  # noqa F811
+    tbinfo, rand_selected_dut, tunnel_traffic_monitor):     # noqa F811
 
     @contextlib.contextmanager
     def stop_garp(ptfhost):
@@ -129,9 +128,6 @@ def test_decap_active_tor(
 
     ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
     logging.info("send encapsulated packet from ptf t1 interface %s", ptf_t1_intf)
-    if skip_traffic_test is True:
-        logging.info("Skip following traffic test")
-        return
     with stop_garp(ptfhost):
         ptfadapter.dataplane.flush()
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), encapsulated_packet)
@@ -141,7 +137,7 @@ def test_decap_active_tor(
 def test_decap_standby_tor(
     build_encapsulated_packet, request,
     rand_selected_interface, ptfadapter,                    # noqa F401
-    tbinfo, rand_selected_dut, tunnel_traffic_monitor, skip_traffic_test       # noqa F401
+    tbinfo, rand_selected_dut, tunnel_traffic_monitor       # noqa F401
 ):
 
     def verify_downstream_packet_to_server(ptfadapter, port, exp_pkt):
@@ -170,9 +166,6 @@ def test_decap_standby_tor(
 
     ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
     logging.info("send encapsulated packet from ptf t1 interface %s", ptf_t1_intf)
-    if skip_traffic_test is True:
-        logging.info("Skip following traffic test")
-        return
     with tunnel_traffic_monitor(tor, existing=False):
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), encapsulated_packet, count=10)
         time.sleep(2)
@@ -302,7 +295,7 @@ def setup_active_active_ports(active_active_ports, rand_selected_dut, rand_unsel
 def test_encap_with_mirror_session(rand_selected_dut, rand_selected_interface,              # noqa F811
                                    ptfadapter, tbinfo, setup_mirror_session,
                                    toggle_all_simulator_ports_to_rand_unselected_tor,       # noqa F811
-                                   tunnel_traffic_monitor, skip_traffic_test,               # noqa F811
+                                   tunnel_traffic_monitor,                                  # noqa F811
                                    setup_standby_ports_on_rand_selected_tor):               # noqa F811
     """
     A test case to verify the bounced back packet from Standby ToR to T1 doesn't have an unexpected vlan id (4095)
@@ -321,8 +314,5 @@ def test_encap_with_mirror_session(rand_selected_dut, rand_selected_interface,  
     logging.info("Sending packet from ptf t1 interface {}".format(src_port_id))
     inner_packet = pkt_to_server[scapy.all.IP].copy()
     inner_packet[IP].ttl -= 1
-    if skip_traffic_test is True:
-        logging.info("Skip following traffic test")
-        return
     with tunnel_traffic_monitor(rand_selected_dut, inner_packet=inner_packet, check_items=()):
         testutils.send(ptfadapter, src_port_id, pkt_to_server)

--- a/tests/dualtor/test_orchagent_active_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_active_tor_downstream.py
@@ -5,7 +5,6 @@ import random
 
 from ipaddress import ip_address
 from ptf import testutils
-from tests.common.dualtor.dual_tor_mock import *        # noqa F403
 from tests.common.dualtor.dual_tor_utils import dualtor_info
 from tests.common.dualtor.dual_tor_utils import flush_neighbor
 from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
@@ -15,13 +14,13 @@ from tests.common.dualtor.dual_tor_utils import get_interface_server_map
 from tests.common.dualtor.dual_tor_utils import check_nexthops_single_downlink
 from tests.common.dualtor.dual_tor_utils import add_nexthop_routes, remove_static_routes
 from tests.common.dualtor.dual_tor_mock import set_mux_state
+from tests.common.dualtor.dual_tor_mock import is_mocked_dualtor
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports   # noqa F401
 from tests.common.dualtor.server_traffic_utils import ServerTrafficMonitor
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor        # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder                  # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_garp_service                    # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test                   # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 
@@ -68,7 +67,7 @@ def neighbor_reachable(duthost, neighbor_ip):
 def test_active_tor_remove_neighbor_downstream_active(
     conn_graph_facts, ptfadapter, ptfhost, testbed_setup,
     rand_selected_dut, tbinfo, set_crm_polling_interval,
-    tunnel_traffic_monitor, vmhost, skip_traffic_test      # noqa F811
+    tunnel_traffic_monitor, vmhost      # noqa F811
 ):
     """
     @Verify those two scenarios:
@@ -103,9 +102,9 @@ def test_active_tor_remove_neighbor_downstream_active(
         logging.info("send traffic to server %s from ptf t1 interface %s", server_ip, ptf_t1_intf)
         server_traffic_monitor = ServerTrafficMonitor(
             tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
-            existing=True, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test       # noqa F405
+            existing=True, is_mocked=is_mocked_dualtor(tbinfo)
         )
-        tunnel_monitor = tunnel_traffic_monitor(tor, existing=False, skip_traffic_test=skip_traffic_test)
+        tunnel_monitor = tunnel_traffic_monitor(tor, existing=False)
         with crm_neighbor_checker(tor, ip_version, expect_change=ip_version == "ipv6"), \
                 tunnel_monitor, server_traffic_monitor:
             testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), pkt, count=10)
@@ -113,7 +112,7 @@ def test_active_tor_remove_neighbor_downstream_active(
         logging.info("send traffic to server %s after removing neighbor entry", server_ip)
         server_traffic_monitor = ServerTrafficMonitor(
             tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
-            existing=False, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test      # noqa F405
+            existing=False, is_mocked=is_mocked_dualtor(tbinfo)
         )
         remove_neighbor_ct = remove_neighbor(ptfhost, tor, server_ip, ip_version, removed_neighbor)
         with crm_neighbor_checker(tor, ip_version, expect_change=ip_version == "ipv6"), \
@@ -126,7 +125,7 @@ def test_active_tor_remove_neighbor_downstream_active(
         logging.info("send traffic to server %s after neighbor entry is restored", server_ip)
         server_traffic_monitor = ServerTrafficMonitor(
             tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
-            existing=True, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test       # noqa F405
+            existing=True, is_mocked=is_mocked_dualtor(tbinfo)
         )
         with crm_neighbor_checker(tor, ip_version, expect_change=ip_version == "ipv6"), \
                 tunnel_monitor, server_traffic_monitor:
@@ -146,10 +145,10 @@ def test_active_tor_remove_neighbor_downstream_active(
 
 def test_downstream_ecmp_nexthops(
     ptfadapter, rand_selected_dut, tbinfo,
-    toggle_all_simulator_ports, tor_mux_intfs, ip_version, skip_traffic_test   # noqa F811
+    toggle_all_simulator_ports, tor_mux_intfs, ip_version   # noqa F811
 ):
     nexthops_count = 4
-    set_mux_state(rand_selected_dut, tbinfo, 'active', tor_mux_intfs, toggle_all_simulator_ports)        # noqa F405
+    set_mux_state(rand_selected_dut, tbinfo, 'active', tor_mux_intfs, toggle_all_simulator_ports)
     iface_server_map = get_interface_server_map(rand_selected_dut, nexthops_count)
 
     if ip_version == "ipv4":
@@ -172,7 +171,7 @@ def test_downstream_ecmp_nexthops(
     try:
         logging.info("Verify traffic to this route destination is sent to single downlink or uplink")
         check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_addr,
-                                       tbinfo, nexthop_interfaces, skip_traffic_test)
+                                       tbinfo, nexthop_interfaces)
 
         nexthop_interfaces_copy = nexthop_interfaces.copy()
 
@@ -183,7 +182,7 @@ def test_downstream_ecmp_nexthops(
             nexthop_interfaces_copy.remove(interface)
             logging.info("Verify traffic to this route destination is sent to single downlink or uplink")
             check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_addr,
-                                           tbinfo, nexthop_interfaces_copy, skip_traffic_test)
+                                           tbinfo, nexthop_interfaces_copy)
 
         # Revert two mux states to active
         for index, interface in reversed(list(enumerate(nexthop_interfaces))):
@@ -192,7 +191,7 @@ def test_downstream_ecmp_nexthops(
             nexthop_interfaces_copy.append(interface)
             logging.info("Verify traffic to this route destination is sent to single downlink or uplink")
             check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_addr,
-                                           tbinfo, nexthop_interfaces_copy, skip_traffic_test)
+                                           tbinfo, nexthop_interfaces_copy)
     finally:
         # Remove the nexthop route
         remove_static_routes(rand_selected_dut, dst_server_addr)

--- a/tests/dualtor/test_orchagent_mac_move.py
+++ b/tests/dualtor/test_orchagent_mac_move.py
@@ -3,7 +3,8 @@ import pytest
 import random
 
 from ptf import testutils
-from tests.common.dualtor.dual_tor_mock import *                                # noqa F403
+from tests.common.dualtor.dual_tor_mock import is_mocked_dualtor
+from tests.common.dualtor.dual_tor_mock import set_dual_tor_state_to_orchagent
 from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
 from tests.common.dualtor.dual_tor_utils import crm_neighbor_checker
 from tests.common.dualtor.dual_tor_utils import build_packet_to_server
@@ -13,7 +14,6 @@ from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor    
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder              # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_garp_service                # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses            # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test               # noqa F401
 from tests.common.utilities import dump_scapy_packet_show_output
 
 
@@ -85,7 +85,7 @@ def test_mac_move(
     announce_new_neighbor, apply_active_state_to_orchagent,
     conn_graph_facts, ptfadapter, ptfhost,
     rand_selected_dut, set_crm_polling_interval,
-    tbinfo, tunnel_traffic_monitor, vmhost, skip_traffic_test          # noqa F811
+    tbinfo, tunnel_traffic_monitor, vmhost          # noqa F811
 ):
     tor = rand_selected_dut
     ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
@@ -96,23 +96,23 @@ def test_mac_move(
     announce_new_neighbor.send(None)
     logging.info("let new neighbor learnt on active port %s", test_port)
     pkt, exp_pkt = build_packet_to_server(tor, ptfadapter, NEW_NEIGHBOR_IPV4_ADDR)
-    tunnel_monitor = tunnel_traffic_monitor(tor, existing=False, skip_traffic_test=skip_traffic_test)
+    tunnel_monitor = tunnel_traffic_monitor(tor, existing=False)
     server_traffic_monitor = ServerTrafficMonitor(
         tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
-        existing=True, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test   # noqa F405
+        existing=True, is_mocked=is_mocked_dualtor(tbinfo)
     )
     with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
         testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)
 
     # mac move to a standby port
     test_port = next(announce_new_neighbor)
-    announce_new_neighbor.send(lambda iface: set_dual_tor_state_to_orchagent(tor, "standby", [iface]))  # noqa F405
+    announce_new_neighbor.send(lambda iface: set_dual_tor_state_to_orchagent(tor, "standby", [iface]))
     logging.info("mac move to a standby port %s", test_port)
     pkt, exp_pkt = build_packet_to_server(tor, ptfadapter, NEW_NEIGHBOR_IPV4_ADDR)
-    tunnel_monitor = tunnel_traffic_monitor(tor, existing=True, skip_traffic_test=skip_traffic_test)
+    tunnel_monitor = tunnel_traffic_monitor(tor, existing=True)
     server_traffic_monitor = ServerTrafficMonitor(
         tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
-        existing=False, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test  # noqa F405
+        existing=False, is_mocked=is_mocked_dualtor(tbinfo)
     )
     with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
         testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)
@@ -121,7 +121,7 @@ def test_mac_move(
     tor.shell("fdbclear")
     server_traffic_monitor = ServerTrafficMonitor(
         tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
-        existing=False, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test  # noqa F405
+        existing=False, is_mocked=is_mocked_dualtor(tbinfo)
     )
     with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
         testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)
@@ -131,10 +131,10 @@ def test_mac_move(
     announce_new_neighbor.send(None)
     logging.info("mac move to another active port %s", test_port)
     pkt, exp_pkt = build_packet_to_server(tor, ptfadapter, NEW_NEIGHBOR_IPV4_ADDR)
-    tunnel_monitor = tunnel_traffic_monitor(tor, existing=False, skip_traffic_test=skip_traffic_test)
+    tunnel_monitor = tunnel_traffic_monitor(tor, existing=False)
     server_traffic_monitor = ServerTrafficMonitor(
         tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
-        existing=True, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test   # noqa F405
+        existing=True, is_mocked=is_mocked_dualtor(tbinfo)
     )
     with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
         testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)
@@ -145,7 +145,7 @@ def test_mac_move(
         tor.shell("fdbclear")
         server_traffic_monitor = ServerTrafficMonitor(
             tor, ptfhost, vmhost, tbinfo, test_port, conn_graph_facts, exp_pkt,
-            existing=False, is_mocked=is_mocked_dualtor(tbinfo), skip_traffic_test=skip_traffic_test  # noqa F405
+            existing=False, is_mocked=is_mocked_dualtor(tbinfo)
         )
         with crm_neighbor_checker(tor), tunnel_monitor, server_traffic_monitor:
             testutils.send(ptfadapter, ptf_t1_intf_index, pkt, count=10)

--- a/tests/dualtor/test_orchagent_slb.py
+++ b/tests/dualtor/test_orchagent_slb.py
@@ -2,7 +2,6 @@ import ipaddress
 import pytest
 import random
 import time
-import logging
 import scapy.all as scapyall
 
 from ptf import testutils
@@ -20,7 +19,6 @@ from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor    
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder                                  # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                                # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                             # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test                                   # noqa F401
 from tests.common.helpers import bgp
 from tests.common.utilities import is_ipv4_address
 
@@ -217,7 +215,7 @@ def test_orchagent_slb(
     force_active_tor, upper_tor_host, lower_tor_host,       # noqa F811
     ptfadapter, ptfhost, setup_interfaces,
     toggle_all_simulator_ports_to_upper_tor, tbinfo,        # noqa F811
-    tunnel_traffic_monitor, vmhost, skip_traffic_test       # noqa F811
+    tunnel_traffic_monitor, vmhost                          # noqa F811
 ):
 
     def verify_bgp_session(duthost, bgp_neighbor):
@@ -235,11 +233,8 @@ def test_orchagent_slb(
         else:
             assert len(existing_route["nexthops"]) == 0
 
-    def verify_traffic(duthost, connection, route, is_duthost_active=True, is_route_existed=True,
-                       skip_traffic_test=skip_traffic_test):
-        if skip_traffic_test is True:
-            logging.info("Skip traffic test.")
-            return
+    def verify_traffic(duthost, connection, route, is_duthost_active=True, is_route_existed=True):
+
         prefix = ipaddress.ip_network(route["prefix"])
         dst_host = str(next(prefix.hosts()))
         pkt, exp_pkt = build_packet_to_server(duthost, ptfadapter, dst_host)
@@ -295,11 +290,11 @@ def test_orchagent_slb(
         # STEP 3: verify the route by sending some downstream traffic
         verify_traffic(
             upper_tor_host, connections["upper_tor"], constants.route,
-            is_duthost_active=True, is_route_existed=True, skip_traffic_test=skip_traffic_test
+            is_duthost_active=True, is_route_existed=True
         )
         verify_traffic(
             lower_tor_host, connections["lower_tor"], constants.route,
-            is_duthost_active=False, is_route_existed=True, skip_traffic_test=skip_traffic_test
+            is_duthost_active=False, is_route_existed=True
         )
 
         # STEP 4: withdraw the announced route to both ToRs
@@ -314,11 +309,11 @@ def test_orchagent_slb(
         # STEP 5: verify the route is removed by verifying that downstream traffic is dropped
         verify_traffic(
             upper_tor_host, connections["upper_tor"], constants.route,
-            is_duthost_active=True, is_route_existed=False, skip_traffic_test=skip_traffic_test
+            is_duthost_active=True, is_route_existed=False
         )
         verify_traffic(
             lower_tor_host, connections["lower_tor"], constants.route,
-            is_duthost_active=False, is_route_existed=False, skip_traffic_test=skip_traffic_test
+            is_duthost_active=False, is_route_existed=False
         )
 
         # STEP 6: toggle mux state change
@@ -341,11 +336,11 @@ def test_orchagent_slb(
         # STEP 8: verify the route by sending some downstream traffic
         verify_traffic(
             upper_tor_host, connections["upper_tor"], constants.route,
-            is_duthost_active=False, is_route_existed=True, skip_traffic_test=skip_traffic_test
+            is_duthost_active=False, is_route_existed=True
         )
         verify_traffic(
             lower_tor_host, connections["lower_tor"], constants.route,
-            is_duthost_active=True, is_route_existed=True, skip_traffic_test=skip_traffic_test
+            is_duthost_active=True, is_route_existed=True
         )
 
         # STEP 9: verify teardown

--- a/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
+++ b/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
@@ -10,7 +10,7 @@ from tests.common.utilities import compare_crm_facts
 from tests.common.config_reload import config_reload
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses, run_garp_service, \
-                                                run_icmp_responder, skip_traffic_test  # noqa F401
+                                                run_icmp_responder                  # noqa F401
 
 logger = logging.getLogger(__file__)
 
@@ -34,7 +34,7 @@ def test_cleanup(rand_selected_dut):
 
 def test_standby_tor_upstream_mux_toggle(
     rand_selected_dut, tbinfo, ptfadapter, rand_selected_interface,                     # noqa F811
-    toggle_all_simulator_ports, set_crm_polling_interval, skip_traffic_test):           # noqa F811
+    toggle_all_simulator_ports, set_crm_polling_interval):                              # noqa F811
     itfs, ip = rand_selected_interface
     PKT_NUM = 100
     # Step 1. Set mux state to standby and verify traffic is dropped by ACL rule and drop counters incremented
@@ -49,8 +49,7 @@ def test_standby_tor_upstream_mux_toggle(
                             itfs=itfs,
                             server_ip=ip['server_ipv4'].split('/')[0],
                             pkt_num=PKT_NUM,
-                            drop=True,
-                            skip_traffic_test=skip_traffic_test)
+                            drop=True)
 
     time.sleep(5)
     # Step 2. Toggle mux state to active, and verify traffic is not dropped by ACL and fwd-ed to uplinks;
@@ -65,8 +64,7 @@ def test_standby_tor_upstream_mux_toggle(
                             itfs=itfs,
                             server_ip=ip['server_ipv4'].split('/')[0],
                             pkt_num=PKT_NUM,
-                            drop=False,
-                            skip_traffic_test=skip_traffic_test)
+                            drop=False)
 
     # Step 3. Toggle mux state to standby, and verify traffic is dropped by ACL;
     # verify CRM show and no nexthop objects are stale
@@ -80,8 +78,7 @@ def test_standby_tor_upstream_mux_toggle(
                             itfs=itfs,
                             server_ip=ip['server_ipv4'].split('/')[0],
                             pkt_num=PKT_NUM,
-                            drop=True,
-                            skip_traffic_test=skip_traffic_test)
+                            drop=True)
     crm_facts1 = rand_selected_dut.get_crm_facts()
     unmatched_crm_facts = compare_crm_facts(crm_facts0, crm_facts1)
     pt_assert(len(unmatched_crm_facts) == 0, 'Unmatched CRM facts: {}'

--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -253,7 +253,12 @@ def verify_ecn_on_received_packet(
     """
     Verify ECN value on the received packet w.r.t expected packet
     """
-    _, rec_pkt = testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=[exp_ptf_port_index], timeout=10)
+    result = testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=[exp_ptf_port_index], timeout=10)
+    if isinstance(result, tuple):
+        _, rec_pkt = result
+    elif isinstance(result, bool):
+        logging.info("Using dummy testutils to skip traffic test, skip following verify steps.")
+        return
     rec_pkt = Ether(rec_pkt)
     logging.info("received packet:\n%s", dump_scapy_packet_show_output(rec_pkt))
 
@@ -305,7 +310,12 @@ def test_dscp_to_queue_during_decap_on_active(
         exp_dscp = exp_tos >> 2
         exp_queue = derive_queue_id_from_dscp(duthost, exp_dscp, False)
 
-        _, rec_pkt = testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=[exp_ptf_port_index], timeout=10)
+        result = testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=[exp_ptf_port_index], timeout=10)
+        if isinstance(result, tuple):
+            _, rec_pkt = result
+        elif isinstance(result, bool):
+            logging.info("Using dummy testutils to skip traffic test, skip following verify steps.")
+            return
         rec_pkt = Ether(rec_pkt)
         logging.info("received decap packet:\n%s", dump_scapy_packet_show_output(rec_pkt))
 

--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -28,7 +28,6 @@ from tests.common.utilities import is_ipv4_address
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder              # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_garp_service                # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses            # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test               # noqa F401
 from tests.common.utilities import dump_scapy_packet_show_output
 from tests.common.dualtor.tunnel_traffic_utils import derive_queue_id_from_dscp, derive_out_dscp_from_inner_dscp
 from tests.common.dualtor.dual_tor_utils import config_active_active_dualtor_active_standby      # noqa F401
@@ -276,7 +275,7 @@ def test_dscp_to_queue_during_decap_on_active(
     inner_dscp, ptfhost, setup_dualtor_tor_active,
     request, rand_selected_interface, ptfadapter,           # noqa F811
     tbinfo, rand_selected_dut, tunnel_traffic_monitor,      # noqa F811
-    duthosts, rand_one_dut_hostname, skip_traffic_test      # noqa F811
+    duthosts, rand_one_dut_hostname
 ):
     """
     Test if DSCP to Q mapping for inner header is matching with outer header during decap on active
@@ -296,9 +295,6 @@ def test_dscp_to_queue_during_decap_on_active(
     duthost.shell('sonic-clear queuecounters')
     logging.info("Clearing queue counters before starting traffic")
 
-    if skip_traffic_test is True:
-        logging.info("Skip following test due traffic test skipped")
-        return
     with stop_garp(ptfhost):
         ptfadapter.dataplane.flush()
         ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
@@ -351,7 +347,6 @@ def test_dscp_to_queue_during_encap_on_standby(
     rand_one_dut_hostname,
     write_standby,
     setup_standby_ports_on_rand_selected_tor,       # noqa F811
-    skip_traffic_test                               # noqa F811
 ):
     """
     Test if DSCP to Q mapping for outer header is matching with inner header during encap on standby
@@ -372,9 +367,6 @@ def test_dscp_to_queue_during_encap_on_standby(
     ptfadapter.dataplane.flush()
     ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
     logging.info("send IP packet from ptf t1 interface %s", ptf_t1_intf)
-    if skip_traffic_test is True:
-        logging.info("Skip following test due traffic test skipped")
-        return
     with tunnel_traffic_monitor(tor, existing=True, packet_count=PACKET_NUM):
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), non_encapsulated_packet, count=PACKET_NUM)
 
@@ -384,7 +376,6 @@ def test_ecn_during_decap_on_active(
     inner_dscp, ptfhost, setup_dualtor_tor_active,
     request, rand_selected_interface, ptfadapter,           # noqa F811
     tbinfo, rand_selected_dut, tunnel_traffic_monitor,      # noqa F811
-    skip_traffic_test                                       # noqa F811
 ):
     """
     Test if the ECN stamping on inner header is matching with outer during decap on active
@@ -405,9 +396,6 @@ def test_ecn_during_decap_on_active(
     exp_tos = encapsulated_packet[IP].payload[IP].tos
     exp_ecn = exp_tos & 3
 
-    if skip_traffic_test is True:
-        logging.info("Skip following test due traffic test skipped")
-        return
     with stop_garp(ptfhost):
         tor.shell("portstat -c")
         tor.shell("show arp")
@@ -425,7 +413,6 @@ def test_ecn_during_encap_on_standby(
     tbinfo, rand_selected_dut, tunnel_traffic_monitor,      # noqa F811
     write_standby,
     setup_standby_ports_on_rand_selected_tor,               # noqa F811
-    skip_traffic_test                                       # noqa F811
 ):
     """
     Test if the ECN stamping on outer header is matching with inner during encap on standby
@@ -440,8 +427,5 @@ def test_ecn_during_encap_on_standby(
 
     ptf_t1_intf = random.choice(get_t1_ptf_ports(tor, tbinfo))
     logging.info("send IP packet from ptf t1 interface %s", ptf_t1_intf)
-    if skip_traffic_test is True:
-        logging.info("Skip following test due traffic test skipped")
-        return
     with tunnel_traffic_monitor(tor, existing=True, packet_count=PACKET_NUM):
         testutils.send(ptfadapter, int(ptf_t1_intf.strip("eth")), non_encapsulated_packet, count=PACKET_NUM)

--- a/tests/dualtor/test_tunnel_memory_leak.py
+++ b/tests/dualtor/test_tunnel_memory_leak.py
@@ -22,7 +22,6 @@ from tests.common.dualtor.dual_tor_utils import build_packet_to_server
 from tests.common.dualtor.dual_tor_utils import delete_neighbor
 from tests.common.helpers.dut_utils import get_program_info
 from tests.common.fixtures.ptfhost_utils import run_garp_service, run_icmp_responder    # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test                       # noqa F401
 from tests.common.utilities import wait_until
 
 
@@ -118,8 +117,7 @@ def check_memory_leak(duthost, target_mem_usage, delay=10, timeout=15, interval=
 
 
 def test_tunnel_memory_leak(toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa F811
-                            ptfhost, ptfadapter, conn_graph_facts, tbinfo, vmhost, run_arp_responder,   # noqa F811
-                            skip_traffic_test):                                                         # noqa F811
+                            ptfhost, ptfadapter, conn_graph_facts, tbinfo, vmhost, run_arp_responder):  # noqa F811
     """
     Test if there is memory leak for service tunnel_packet_handler.
     Send ip packets from standby TOR T1 to Server, standby TOR will
@@ -173,9 +171,6 @@ def test_tunnel_memory_leak(toggle_all_simulator_ports_to_upper_tor, upper_tor_h
 
             pkt, exp_pkt = build_packet_to_server(lower_tor_host, ptfadapter, server_ipv4)
 
-            if skip_traffic_test is True:
-                logging.info("Skip traffic test.")
-                continue
             server_traffic_monitor = ServerTrafficMonitor(
                 upper_tor_host, ptfhost, vmhost, tbinfo, iface,
                 conn_graph_facts, exp_pkt, existing=True, is_mocked=False

--- a/tests/dualtor/test_tunnel_memory_leak.py
+++ b/tests/dualtor/test_tunnel_memory_leak.py
@@ -153,6 +153,7 @@ def test_tunnel_memory_leak(toggle_all_simulator_ports_to_upper_tor, upper_tor_h
     all_servers_ips = mux_cable_server_ip(upper_tor_host)
     unexpected_count = 0
     expected_count = 0
+    asic_type = upper_tor_host.facts["asic_type"]
 
     with prepare_services(ptfhost):
         # Delete the neighbors
@@ -170,6 +171,10 @@ def test_tunnel_memory_leak(toggle_all_simulator_ports_to_upper_tor, upper_tor_h
             logging.info("Select DUT interface {} and server IP {} to test.".format(iface, server_ipv4))
 
             pkt, exp_pkt = build_packet_to_server(lower_tor_host, ptfadapter, server_ipv4)
+
+            if asic_type == "vs":
+                logging.info("ServerTrafficMonitor do not support on KVM dualtor, skip following steps.")
+                return
 
             server_traffic_monitor = ServerTrafficMonitor(
                 upper_tor_host, ptfhost, vmhost, tbinfo, iface,

--- a/tests/dualtor_io/test_heartbeat_failure.py
+++ b/tests/dualtor_io/test_heartbeat_failure.py
@@ -1,5 +1,4 @@
 import pytest
-import logging
 
 from tests.common.dualtor.control_plane_utils import verify_tor_states
 from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action, \
@@ -10,7 +9,6 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.dualtor.tor_failure_utils import shutdown_tor_heartbeat                       # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
                                                 copy_ptftests_directory, change_mac_addresses   # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test                               # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import cable_type                                     # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
@@ -36,18 +34,16 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
 
 
 def test_active_tor_heartbeat_failure_upstream(
-    toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,     # noqa F811
-    send_server_to_t1_with_action, shutdown_tor_heartbeat, cable_type, skip_traffic_test        # noqa F811
+    toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa F811
+    send_server_to_t1_with_action, shutdown_tor_heartbeat, cable_type           # noqa F811
 ):
     """
     Send upstream traffic and stop the LinkProber module on the active ToR.
     Confirm switchover and disruption lasts < 1 second.
     """
-    logging.info("skip_traffic_test: {}".format(skip_traffic_test))
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=lambda: shutdown_tor_heartbeat(upper_tor_host),
-        skip_traffic_test=skip_traffic_test
+        action=lambda: shutdown_tor_heartbeat(upper_tor_host)
     )
 
     if cable_type == CableType.active_standby:
@@ -68,7 +64,7 @@ def test_active_tor_heartbeat_failure_upstream(
 @pytest.mark.enable_active_active
 def test_active_tor_heartbeat_failure_downstream_active(
     toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa F811
-    send_t1_to_server_with_action, shutdown_tor_heartbeat, cable_type, skip_traffic_test        # noqa F811
+    send_t1_to_server_with_action, shutdown_tor_heartbeat, cable_type           # noqa F811
 ):
     """
     Send downstream traffic from T1 to the active ToR and stop the LinkProber module on the active ToR.
@@ -76,8 +72,7 @@ def test_active_tor_heartbeat_failure_downstream_active(
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=lambda: shutdown_tor_heartbeat(upper_tor_host),
-        skip_traffic_test=skip_traffic_test
+        action=lambda: shutdown_tor_heartbeat(upper_tor_host)
     )
 
     if cable_type == CableType.active_standby:
@@ -97,15 +92,14 @@ def test_active_tor_heartbeat_failure_downstream_active(
 
 def test_active_tor_heartbeat_failure_downstream_standby(
     toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa F811
-    send_t1_to_server_with_action, shutdown_tor_heartbeat, skip_traffic_test):                     # noqa F811
+    send_t1_to_server_with_action, shutdown_tor_heartbeat):                     # noqa F811
     """
     Send downstream traffic from T1 to the standby ToR and stop the LinkProber module on the active ToR.
     Confirm switchover and disruption lasts < 1 second.
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=lambda: shutdown_tor_heartbeat(upper_tor_host),
-        skip_traffic_test=skip_traffic_test
+        action=lambda: shutdown_tor_heartbeat(upper_tor_host)
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -115,15 +109,14 @@ def test_active_tor_heartbeat_failure_downstream_standby(
 
 def test_standby_tor_heartbeat_failure_upstream(
     toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa F811
-    send_server_to_t1_with_action, shutdown_tor_heartbeat, skip_traffic_test):                     # noqa F811
+    send_server_to_t1_with_action, shutdown_tor_heartbeat):                     # noqa F811
     """
     Send upstream traffic and stop the LinkProber module on the standby ToR.
     Confirm no switchover and no disruption.
     """
     send_server_to_t1_with_action(
         upper_tor_host, verify=True,
-        action=lambda: shutdown_tor_heartbeat(lower_tor_host),
-        skip_traffic_test=skip_traffic_test
+        action=lambda: shutdown_tor_heartbeat(lower_tor_host)
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -133,15 +126,14 @@ def test_standby_tor_heartbeat_failure_upstream(
 
 def test_standby_tor_heartbeat_failure_downstream_active(
     toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa F811
-    send_t1_to_server_with_action, shutdown_tor_heartbeat, skip_traffic_test):                     # noqa F811
+    send_t1_to_server_with_action, shutdown_tor_heartbeat):                     # noqa F811
     """
     Send downstream traffic from T1 to the active ToR and stop the LinkProber module on the standby ToR.
     Confirm no switchover and no disruption.
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True,
-        action=lambda: shutdown_tor_heartbeat(lower_tor_host),
-        skip_traffic_test=skip_traffic_test
+        action=lambda: shutdown_tor_heartbeat(lower_tor_host)
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -151,15 +143,14 @@ def test_standby_tor_heartbeat_failure_downstream_active(
 
 def test_standby_tor_heartbeat_failure_downstream_standby(
     toggle_all_simulator_ports_to_upper_tor, upper_tor_host, lower_tor_host,    # noqa F811
-    send_t1_to_server_with_action, shutdown_tor_heartbeat, skip_traffic_test):                     # noqa F811
+    send_t1_to_server_with_action, shutdown_tor_heartbeat):                     # noqa F811
     """
     Send downstream traffic from T1 to the standby ToR and stop the LinkProber module on the standby ToR.
     Confirm no switchover and no disruption.
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True,
-        action=lambda: shutdown_tor_heartbeat(lower_tor_host),
-        skip_traffic_test=skip_traffic_test
+        action=lambda: shutdown_tor_heartbeat(lower_tor_host)
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,

--- a/tests/dualtor_io/test_link_drop.py
+++ b/tests/dualtor_io/test_link_drop.py
@@ -18,7 +18,6 @@ from tests.common.dualtor.nic_simulator_control import TrafficDirection
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service            # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                            # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                         # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test                               # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import ActiveActivePortID
 from tests.common.dualtor.dual_tor_common import active_active_ports                            # noqa F401
@@ -97,7 +96,7 @@ def drop_flow_upper_tor_active_active(active_active_ports, set_drop_active_activ
 def test_active_link_drop_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, drop_flow_upper_tor_all,   # noqa F811
-    drop_flow_upper_tor_active_active, cable_type, skip_traffic_test    # noqa F811
+    drop_flow_upper_tor_active_active, cable_type                       # noqa F811
 ):
     """
     Send traffic from servers to T1 and remove the flow between the servers and the active ToR.
@@ -109,8 +108,7 @@ def test_active_link_drop_upstream(
             verify=True,
             delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=3,
-            action=drop_flow_upper_tor_all,
-            skip_traffic_test=skip_traffic_test
+            action=drop_flow_upper_tor_all
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -125,8 +123,7 @@ def test_active_link_drop_upstream(
             verify=True,
             delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=1,
-            action=drop_flow_upper_tor_active_active,
-            skip_traffic_test=skip_traffic_test
+            action=drop_flow_upper_tor_active_active
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -141,7 +138,7 @@ def test_active_link_drop_upstream(
 def test_active_link_drop_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, drop_flow_upper_tor_all,   # noqa F811
-    drop_flow_upper_tor_active_active, cable_type, skip_traffic_test    # noqa F811
+    drop_flow_upper_tor_active_active, cable_type                       # noqa F811
 ):
     """
     Send traffic from the T1s to the servers via the active Tor and remove the flow between the
@@ -154,8 +151,7 @@ def test_active_link_drop_downstream_active(
             verify=True,
             delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=3,
-            action=drop_flow_upper_tor_all,
-            skip_traffic_test=skip_traffic_test
+            action=drop_flow_upper_tor_all
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -170,8 +166,7 @@ def test_active_link_drop_downstream_active(
             verify=True,
             delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
             allowed_disruption=1,
-            action=drop_flow_upper_tor_active_active,
-            skip_traffic_test=skip_traffic_test
+            action=drop_flow_upper_tor_active_active
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -184,8 +179,7 @@ def test_active_link_drop_downstream_active(
 
 def test_active_link_drop_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
-    toggle_all_simulator_ports_to_upper_tor, drop_flow_upper_tor_all,   # noqa F811
-    skip_traffic_test                                                   # noqa F811
+    toggle_all_simulator_ports_to_upper_tor, drop_flow_upper_tor_all    # noqa F811
 ):
     """
     Send traffic from the T1s to the servers via the standby Tor and remove the flow between the
@@ -197,8 +191,7 @@ def test_active_link_drop_downstream_standby(
         verify=True,
         delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         allowed_disruption=3,
-        action=drop_flow_upper_tor_all,
-        skip_traffic_test=skip_traffic_test
+        action=drop_flow_upper_tor_all
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -210,7 +203,7 @@ def test_active_link_drop_downstream_standby(
 def test_standby_link_drop_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     check_simulator_flap_counter, drop_flow_lower_tor_all,              # noqa F811
-    toggle_all_simulator_ports_to_upper_tor, skip_traffic_test          # noqa F811
+    toggle_all_simulator_ports_to_upper_tor                             # noqa F811
 ):
     """
     Send traffic from servers to T1 and remove the flow between the servers and the standby ToR.
@@ -221,8 +214,7 @@ def test_standby_link_drop_upstream(
         verify=True,
         delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         allowed_disruption=2,
-        action=drop_flow_lower_tor_all,
-        skip_traffic_test=skip_traffic_test
+        action=drop_flow_lower_tor_all
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -235,7 +227,7 @@ def test_standby_link_drop_upstream(
 def test_standby_link_drop_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     check_simulator_flap_counter, drop_flow_lower_tor_all,              # noqa F811
-    toggle_all_simulator_ports_to_upper_tor, skip_traffic_test          # noqa F811
+    toggle_all_simulator_ports_to_upper_tor                             # noqa F811
 ):
     """
     Send traffic from the T1s to the servers via the active Tor and remove the flow between the
@@ -247,8 +239,7 @@ def test_standby_link_drop_downstream_active(
         verify=True,
         delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         allowed_disruption=2,
-        action=drop_flow_lower_tor_all,
-        skip_traffic_test=skip_traffic_test
+        action=drop_flow_lower_tor_all
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -261,7 +252,7 @@ def test_standby_link_drop_downstream_active(
 def test_standby_link_drop_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     check_simulator_flap_counter, drop_flow_lower_tor_all,              # noqa F811
-    toggle_all_simulator_ports_to_upper_tor, skip_traffic_test          # noqa F811
+    toggle_all_simulator_ports_to_upper_tor                             # noqa F811
 ):
     """
     Send traffic from the T1s to the servers via the standby Tor and remove the flow between the
@@ -273,8 +264,7 @@ def test_standby_link_drop_downstream_standby(
         verify=True,
         delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         allowed_disruption=2,
-        action=drop_flow_lower_tor_all,
-        skip_traffic_test=skip_traffic_test
+        action=drop_flow_lower_tor_all
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -11,7 +11,6 @@ from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter    
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor      # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
                                                 copy_ptftests_directory, change_mac_addresses       # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test                                   # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import active_active_ports                                # noqa F401
 from tests.common.dualtor.dual_tor_common import cable_type                                         # noqa F401
@@ -28,7 +27,7 @@ pytestmark = [
 def test_active_link_down_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_fanout_upper_tor_intfs, cable_type, skip_traffic_test      # noqa F811
+    shutdown_fanout_upper_tor_intfs, cable_type                         # noqa F811
 ):
     """
     Send traffic from server to T1 and shutdown the active ToR link.
@@ -37,8 +36,7 @@ def test_active_link_down_upstream(
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=1, action=shutdown_fanout_upper_tor_intfs,
-            skip_traffic_test=skip_traffic_test
+            allowed_disruption=1, action=shutdown_fanout_upper_tor_intfs
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -51,8 +49,7 @@ def test_active_link_down_upstream(
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs,
-            skip_traffic_test=skip_traffic_test
+            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
         )
 
         verify_tor_states(
@@ -67,7 +64,7 @@ def test_active_link_down_upstream(
 def test_active_link_down_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_fanout_upper_tor_intfs, cable_type, skip_traffic_test      # noqa F811
+    shutdown_fanout_upper_tor_intfs, cable_type                         # noqa F811
 ):
     """
     Send traffic from T1 to active ToR and shutdown the active ToR link.
@@ -76,8 +73,7 @@ def test_active_link_down_downstream_active(
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs,
-            skip_traffic_test=skip_traffic_test
+            allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -88,8 +84,7 @@ def test_active_link_down_downstream_active(
     if cable_type == CableType.active_active:
         send_t1_to_server_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=1, action=shutdown_fanout_upper_tor_intfs,
-            skip_traffic_test=skip_traffic_test
+            allowed_disruption=1, action=shutdown_fanout_upper_tor_intfs
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -103,7 +98,7 @@ def test_active_link_down_downstream_active(
 def test_active_link_down_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_fanout_upper_tor_intfs, skip_traffic_test                  # noqa F811
+    shutdown_fanout_upper_tor_intfs                                     # noqa F811
 ):
     """
     Send traffic from T1 to standby ToR and shutdown the active ToR link.
@@ -111,8 +106,7 @@ def test_active_link_down_downstream_standby(
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs,
-        skip_traffic_test=skip_traffic_test
+        allowed_disruption=3, action=shutdown_fanout_upper_tor_intfs
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -124,7 +118,7 @@ def test_active_link_down_downstream_standby(
 def test_standby_link_down_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_fanout_lower_tor_intfs, skip_traffic_test                  # noqa F811
+    shutdown_fanout_lower_tor_intfs                                     # noqa F811
 ):
     """
     Send traffic from server to T1 and shutdown the standby ToR link.
@@ -132,8 +126,7 @@ def test_standby_link_down_upstream(
     """
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs,
-        skip_traffic_test=skip_traffic_test
+        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -145,7 +138,7 @@ def test_standby_link_down_upstream(
 def test_standby_link_down_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_fanout_lower_tor_intfs, skip_traffic_test                  # noqa F811
+    shutdown_fanout_lower_tor_intfs                                     # noqa F811
 ):
     """
     Send traffic from T1 to active ToR and shutdown the standby ToR link.
@@ -153,8 +146,7 @@ def test_standby_link_down_downstream_active(
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs,
-        skip_traffic_test=skip_traffic_test
+        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -166,7 +158,7 @@ def test_standby_link_down_downstream_active(
 def test_standby_link_down_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_fanout_lower_tor_intfs, skip_traffic_test                  # noqa F811
+    shutdown_fanout_lower_tor_intfs                                     # noqa F811
 ):
     """
     Send traffic from T1 to standby ToR and shutdwon the standby ToR link.
@@ -174,8 +166,7 @@ def test_standby_link_down_downstream_standby(
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs,
-        skip_traffic_test=skip_traffic_test
+        allowed_disruption=2, action=shutdown_fanout_lower_tor_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -187,7 +178,7 @@ def test_standby_link_down_downstream_standby(
 def test_active_tor_downlink_down_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_upper_tor_downlink_intfs, skip_traffic_test                # noqa F811
+    shutdown_upper_tor_downlink_intfs                                   # noqa F811
 ):
     """
     Send traffic from server to T1 and shutdown the active ToR downlink on DUT.
@@ -195,8 +186,7 @@ def test_active_tor_downlink_down_upstream(
     """
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs,
-        skip_traffic_test=skip_traffic_test
+        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -208,7 +198,7 @@ def test_active_tor_downlink_down_upstream(
 def test_active_tor_downlink_down_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_upper_tor_downlink_intfs, skip_traffic_test                # noqa F811
+    shutdown_upper_tor_downlink_intfs                                   # noqa F811
 ):
     """
     Send traffic from T1 to active ToR and shutdown the active ToR downlink on DUT.
@@ -216,8 +206,7 @@ def test_active_tor_downlink_down_downstream_active(
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs,
-        skip_traffic_test=skip_traffic_test
+        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -229,7 +218,7 @@ def test_active_tor_downlink_down_downstream_active(
 def test_active_tor_downlink_down_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_upper_tor_downlink_intfs, skip_traffic_test                # noqa F811
+    shutdown_upper_tor_downlink_intfs                                   # noqa F811
 ):
     """
     Send traffic from T1 to standby ToR and shutdown the active ToR downlink on DUT.
@@ -237,8 +226,7 @@ def test_active_tor_downlink_down_downstream_standby(
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs,
-        skip_traffic_test=skip_traffic_test
+        allowed_disruption=1, action=shutdown_upper_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -250,7 +238,7 @@ def test_active_tor_downlink_down_downstream_standby(
 def test_standby_tor_downlink_down_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_lower_tor_downlink_intfs, skip_traffic_test                # noqa F811
+    shutdown_lower_tor_downlink_intfs                                   # noqa F811
 ):
     """
     Send traffic from server to T1 and shutdown the standby ToR downlink on DUT.
@@ -258,8 +246,7 @@ def test_standby_tor_downlink_down_upstream(
     """
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs,
-        skip_traffic_test=skip_traffic_test
+        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -271,7 +258,7 @@ def test_standby_tor_downlink_down_upstream(
 def test_standby_tor_downlink_down_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_lower_tor_downlink_intfs, skip_traffic_test                # noqa F811
+    shutdown_lower_tor_downlink_intfs                                   # noqa F811
 ):
     """
     Send traffic from T1 to active ToR and shutdown the standby ToR downlink on DUT.
@@ -279,8 +266,7 @@ def test_standby_tor_downlink_down_downstream_active(
     """
     send_t1_to_server_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs,
-        skip_traffic_test=skip_traffic_test
+        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -292,7 +278,7 @@ def test_standby_tor_downlink_down_downstream_active(
 def test_standby_tor_downlink_down_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_lower_tor_downlink_intfs, skip_traffic_test                # noqa F811
+    shutdown_lower_tor_downlink_intfs                                   # noqa F811
 ):
     """
     Send traffic from T1 to standby ToR and shutdwon the standby ToR downlink on DUT.
@@ -300,8 +286,7 @@ def test_standby_tor_downlink_down_downstream_standby(
     """
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs,
-        skip_traffic_test=skip_traffic_test
+        allowed_disruption=1, action=shutdown_lower_tor_downlink_intfs
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -14,7 +14,6 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter                        # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
                                                 copy_ptftests_directory, change_mac_addresses       # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test                                   # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC, CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
@@ -29,19 +28,16 @@ pytestmark = [
 def test_normal_op_upstream(upper_tor_host, lower_tor_host,             # noqa F811
                             send_server_to_t1_with_action,              # noqa F811
                             toggle_all_simulator_ports_to_upper_tor,    # noqa F811
-                            cable_type,                                 # noqa F811
-                            skip_traffic_test):                         # noqa F811
+                            cable_type):                                # noqa F811
     """Send upstream traffic and confirm no disruption or switchover occurs"""
     if cable_type == CableType.active_standby:
-        send_server_to_t1_with_action(upper_tor_host, verify=True,
-                                      stop_after=60, skip_traffic_test=skip_traffic_test)
+        send_server_to_t1_with_action(upper_tor_host, verify=True, stop_after=60)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host,
                           skip_tunnel_route=False)
 
     if cable_type == CableType.active_active:
-        send_server_to_t1_with_action(upper_tor_host, verify=True,
-                                      stop_after=60, skip_traffic_test=skip_traffic_test)
+        send_server_to_t1_with_action(upper_tor_host, verify=True, stop_after=60)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type,
@@ -52,21 +48,18 @@ def test_normal_op_upstream(upper_tor_host, lower_tor_host,             # noqa F
 def test_normal_op_downstream_upper_tor(upper_tor_host, lower_tor_host,             # noqa F811
                                         send_t1_to_server_with_action,              # noqa F811
                                         toggle_all_simulator_ports_to_upper_tor,    # noqa F811
-                                        cable_type,                                 # noqa F811
-                                        skip_traffic_test):                         # noqa F811
+                                        cable_type):                                # noqa F811
     """
     Send downstream traffic to the upper ToR and confirm no disruption or
     switchover occurs
     """
     if cable_type == CableType.active_standby:
-        send_t1_to_server_with_action(upper_tor_host, verify=True,
-                                      stop_after=60, skip_traffic_test=skip_traffic_test)
+        send_t1_to_server_with_action(upper_tor_host, verify=True, stop_after=60)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host)
 
     if cable_type == CableType.active_active:
-        send_t1_to_server_with_action(upper_tor_host, verify=True,
-                                      stop_after=60, skip_traffic_test=skip_traffic_test)
+        send_t1_to_server_with_action(upper_tor_host, verify=True, stop_after=60)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type)
@@ -76,21 +69,18 @@ def test_normal_op_downstream_upper_tor(upper_tor_host, lower_tor_host,         
 def test_normal_op_downstream_lower_tor(upper_tor_host, lower_tor_host,             # noqa F811
                                         send_t1_to_server_with_action,              # noqa F811
                                         toggle_all_simulator_ports_to_upper_tor,    # noqa F811
-                                        cable_type,                                 # noqa F811
-                                        skip_traffic_test):                         # noqa F811
+                                        cable_type):                                # noqa F811
     """
     Send downstream traffic to the lower ToR and confirm no disruption or
     switchover occurs
     """
     if cable_type == CableType.active_standby:
-        send_t1_to_server_with_action(lower_tor_host, verify=True,
-                                      stop_after=60, skip_traffic_test=skip_traffic_test)
+        send_t1_to_server_with_action(lower_tor_host, verify=True, stop_after=60)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host)
 
     if cable_type == CableType.active_active:
-        send_t1_to_server_with_action(lower_tor_host, verify=True,
-                                      stop_after=60, skip_traffic_test=skip_traffic_test)
+        send_t1_to_server_with_action(lower_tor_host, verify=True, stop_after=60)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type)
@@ -101,8 +91,7 @@ def test_normal_op_active_server_to_active_server(upper_tor_host, lower_tor_host
                                                   send_server_to_server_with_action,            # noqa F811
                                                   toggle_all_simulator_ports_to_upper_tor,      # noqa F811
                                                   cable_type,                                   # noqa F811
-                                                  select_test_mux_ports,                        # noqa F811
-                                                  skip_traffic_test):                           # noqa F811
+                                                  select_test_mux_ports):                       # noqa F811
     """
     Send server to server traffic in active-active setup and confirm no disruption or switchover occurs.
     """
@@ -110,15 +99,13 @@ def test_normal_op_active_server_to_active_server(upper_tor_host, lower_tor_host
     test_mux_ports = select_test_mux_ports(cable_type, 2)
 
     if cable_type == CableType.active_standby:
-        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True,
-                                          stop_after=60, skip_traffic_test=skip_traffic_test)
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host,
                           skip_tunnel_route=False)
 
     if cable_type == CableType.active_active:
-        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True,
-                                          stop_after=60, skip_traffic_test=skip_traffic_test)
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type,
@@ -130,8 +117,7 @@ def test_normal_op_active_server_to_standby_server(upper_tor_host, lower_tor_hos
                                                    send_server_to_server_with_action,               # noqa F811
                                                    toggle_all_simulator_ports_to_upper_tor,         # noqa F811
                                                    cable_type, force_standby_tor,                   # noqa F811
-                                                   select_test_mux_ports,                           # noqa F811
-                                                   skip_traffic_test):                              # noqa F811
+                                                   select_test_mux_ports):                          # noqa F811
     """
     Send server to server traffic in active-standby setup and confirm no disruption or switchover occurs.
     """
@@ -147,12 +133,10 @@ def test_normal_op_active_server_to_standby_server(upper_tor_host, lower_tor_hos
                   "failed to toggle mux port %s to standby on DUT %s" % (tx_mux_port, upper_tor_host.hostname))
 
     if cable_type == CableType.active_standby:
-        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True,
-                                          stop_after=60, skip_traffic_test=skip_traffic_test)
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
 
     if cable_type == CableType.active_active:
-        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True,
-                                          stop_after=60, skip_traffic_test=skip_traffic_test)
+        send_server_to_server_with_action(upper_tor_host, test_mux_ports, verify=True, stop_after=60)
 
     # TODO: Add per-port db check
 
@@ -162,8 +146,7 @@ def test_normal_op_active_server_to_standby_server(upper_tor_host, lower_tor_hos
 def test_upper_tor_config_reload_upstream(upper_tor_host, lower_tor_host,               # noqa F811
                                           send_server_to_t1_with_action,                # noqa F811
                                           toggle_all_simulator_ports_to_upper_tor,      # noqa F811
-                                          cable_type,                                   # noqa F811
-                                          skip_traffic_test):                           # noqa F811
+                                          cable_type):                                  # noqa F811
     """
     Send upstream traffic and `config reload` the active ToR.
     Confirm switchover occurs and disruption lasted < 1 second for active-standby ports.
@@ -171,15 +154,13 @@ def test_upper_tor_config_reload_upstream(upper_tor_host, lower_tor_host,       
     """
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(upper_tor_host, verify=True, delay=CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: config_reload(upper_tor_host, wait=0),
-                                      skip_traffic_test=skip_traffic_test)
+                                      action=lambda: config_reload(upper_tor_host, wait=0))
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host)
 
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: config_reload(upper_tor_host, wait=0),
-                                      skip_traffic_test=skip_traffic_test)
+                                      action=lambda: config_reload(upper_tor_host, wait=0))
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type)
@@ -189,16 +170,14 @@ def test_upper_tor_config_reload_upstream(upper_tor_host, lower_tor_host,       
 def test_lower_tor_config_reload_upstream(upper_tor_host, lower_tor_host,               # noqa F811
                                           send_server_to_t1_with_action,                # noqa F811
                                           toggle_all_simulator_ports_to_upper_tor,      # noqa F811
-                                          cable_type,                                   # noqa F811
-                                          skip_traffic_test):                           # noqa F811
+                                          cable_type):                                  # noqa F811
     """
     Send upstream traffic and `config reload` the lower ToR.
     Confirm no switchover occurs and no disruption.
     """
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(upper_tor_host, verify=True,
-                                      action=lambda: config_reload(lower_tor_host, wait=0),
-                                      skip_traffic_test=skip_traffic_test)
+                                      action=lambda: config_reload(lower_tor_host, wait=0))
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host)
 
@@ -208,23 +187,20 @@ def test_lower_tor_config_reload_upstream(upper_tor_host, lower_tor_host,       
 def test_lower_tor_config_reload_downstream_upper_tor(upper_tor_host, lower_tor_host,           # noqa F811
                                                       send_t1_to_server_with_action,            # noqa F811
                                                       toggle_all_simulator_ports_to_upper_tor,  # noqa F811
-                                                      cable_type,                               # noqa F811
-                                                      skip_traffic_test):                       # noqa F811
+                                                      cable_type):                              # noqa F811
     """
     Send downstream traffic to the upper ToR and `config reload` the lower ToR.
     Confirm no switchover occurs and no disruption
     """
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(upper_tor_host, verify=True,
-                                      action=lambda: config_reload(lower_tor_host, wait=0),
-                                      skip_traffic_test=skip_traffic_test)
+                                      action=lambda: config_reload(lower_tor_host, wait=0))
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host)
 
     if cable_type == CableType.active_active:
         send_t1_to_server_with_action(upper_tor_host, verify=True,
-                                      action=lambda: config_reload(lower_tor_host, wait=0),
-                                      skip_traffic_test=skip_traffic_test)
+                                      action=lambda: config_reload(lower_tor_host, wait=0))
         verify_tor_states(expected_active_host=[upper_tor_host, lower_tor_host],
                           expected_standby_host=None,
                           cable_type=cable_type)
@@ -234,8 +210,7 @@ def test_lower_tor_config_reload_downstream_upper_tor(upper_tor_host, lower_tor_
 def test_upper_tor_config_reload_downstream_lower_tor(upper_tor_host, lower_tor_host,           # noqa F811
                                                       send_t1_to_server_with_action,            # noqa F811
                                                       toggle_all_simulator_ports_to_upper_tor,  # noqa F811
-                                                      cable_type,                               # noqa F811
-                                                      skip_traffic_test):                       # noqa F811
+                                                      cable_type):                              # noqa F811
     """
     Send downstream traffic to the lower ToR and `config reload` the upper ToR.
     Confirm switchover occurs and disruption lasts < 1 second for active-standby ports.
@@ -243,8 +218,7 @@ def test_upper_tor_config_reload_downstream_lower_tor(upper_tor_host, lower_tor_
     """
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(lower_tor_host, verify=True, delay=CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: config_reload(upper_tor_host, wait=0),
-                                      skip_traffic_test=skip_traffic_test)
+                                      action=lambda: config_reload(upper_tor_host, wait=0))
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host)
 
@@ -254,8 +228,7 @@ def test_tor_switch_upstream(upper_tor_host, lower_tor_host,                # no
                              send_server_to_t1_with_action,                 # noqa F811
                              toggle_all_simulator_ports_to_upper_tor,       # noqa F811
                              force_active_tor, force_standby_tor,           # noqa F811
-                             cable_type,                                    # noqa F811
-                             skip_traffic_test):                            # noqa F811
+                             cable_type):                                   # noqa F811
     """
     Send upstream traffic and perform switchover via CLI.
     Confirm switchover occurs and disruption lasts < 1 second for active-standby ports.
@@ -263,15 +236,13 @@ def test_tor_switch_upstream(upper_tor_host, lower_tor_host,                # no
     """
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_active_tor(lower_tor_host, 'all'),
-                                      skip_traffic_test=skip_traffic_test)
+                                      action=lambda: force_active_tor(lower_tor_host, 'all'))
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host)
 
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_standby_tor(upper_tor_host, 'all'),
-                                      skip_traffic_test=skip_traffic_test)
+                                      action=lambda: force_standby_tor(upper_tor_host, 'all'))
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host,
                           expected_standby_health="healthy",
@@ -283,8 +254,7 @@ def test_tor_switch_downstream_active(upper_tor_host, lower_tor_host,           
                                       send_t1_to_server_with_action,                # noqa F811
                                       toggle_all_simulator_ports_to_upper_tor,      # noqa F811
                                       force_active_tor, force_standby_tor,          # noqa F811
-                                      cable_type,                                   # noqa F811
-                                      skip_traffic_test):                           # noqa F811
+                                      cable_type):                                  # noqa F811
     """
     Send downstream traffic to the upper ToR and perform switchover via CLI.
     Confirm switchover occurs and disruption lasts < 1 second for active-standby ports.
@@ -292,15 +262,13 @@ def test_tor_switch_downstream_active(upper_tor_host, lower_tor_host,           
     """
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_active_tor(lower_tor_host, 'all'),
-                                      skip_traffic_test=skip_traffic_test)
+                                      action=lambda: force_active_tor(lower_tor_host, 'all'))
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host)
 
     if cable_type == CableType.active_active:
         send_t1_to_server_with_action(upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_standby_tor(upper_tor_host, 'all'),
-                                      skip_traffic_test=skip_traffic_test)
+                                      action=lambda: force_standby_tor(upper_tor_host, 'all'))
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host,
                           expected_standby_health="healthy",
@@ -312,8 +280,7 @@ def test_tor_switch_downstream_standby(upper_tor_host, lower_tor_host,          
                                        send_t1_to_server_with_action,               # noqa F811
                                        toggle_all_simulator_ports_to_upper_tor,     # noqa F811
                                        force_active_tor, force_standby_tor,         # noqa F811
-                                       cable_type,                                  # noqa F811
-                                       skip_traffic_test):                          # noqa F811
+                                       cable_type):                                 # noqa F811
     """
     Send downstream traffic to the lower ToR and perform switchover via CLI.
     Confirm switchover occurs and disruption lasts < 1 second for active-standby ports.
@@ -321,15 +288,13 @@ def test_tor_switch_downstream_standby(upper_tor_host, lower_tor_host,          
     """
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-                                      action=lambda: force_active_tor(lower_tor_host, 'all'),
-                                      skip_traffic_test=skip_traffic_test)
+                                      action=lambda: force_active_tor(lower_tor_host, 'all'))
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host)
 
     if cable_type == CableType.active_active:
         send_t1_to_server_with_action(lower_tor_host, verify=True,
-                                      action=lambda: force_standby_tor(upper_tor_host, 'all'),
-                                      skip_traffic_test=skip_traffic_test)
+                                      action=lambda: force_standby_tor(upper_tor_host, 'all'))
         verify_tor_states(expected_active_host=lower_tor_host,
                           expected_standby_host=upper_tor_host,
                           expected_standby_health="healthy",

--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -11,7 +11,6 @@ from tests.common.dualtor.tor_failure_utils import shutdown_bgp_sessions        
 from tests.common.dualtor.tor_failure_utils import shutdown_bgp_sessions_on_duthost
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
                                                 copy_ptftests_directory, change_mac_addresses       # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test                                   # noqa F401
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor                        # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import cable_type                                         # noqa F401
@@ -80,7 +79,7 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
 
 def test_active_tor_kill_bgpd_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
-    toggle_all_simulator_ports_to_upper_tor, kill_bgpd, skip_traffic_test):                # noqa F811
+    toggle_all_simulator_ports_to_upper_tor, kill_bgpd):                # noqa F811
     '''
     Case: Server -> ToR -> T1 (Active ToR BGP Down)
     Action: Shutdown all BGP sessions on the active ToR
@@ -92,8 +91,7 @@ def test_active_tor_kill_bgpd_upstream(
     '''
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=lambda: kill_bgpd(upper_tor_host),
-        skip_traffic_test=skip_traffic_test
+        action=lambda: kill_bgpd(upper_tor_host)
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -103,7 +101,7 @@ def test_active_tor_kill_bgpd_upstream(
 
 def test_standby_tor_kill_bgpd_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
-    toggle_all_simulator_ports_to_upper_tor, kill_bgpd, skip_traffic_test):                # noqa F811
+    toggle_all_simulator_ports_to_upper_tor, kill_bgpd):                # noqa F811
     '''
     Case: Server -> ToR -> T1 (Standby ToR BGP Down)
     Action: Shutdown all BGP sessions on the standby ToR
@@ -114,8 +112,7 @@ def test_standby_tor_kill_bgpd_upstream(
     '''
     send_server_to_t1_with_action(
         upper_tor_host, verify=True,
-        action=lambda: kill_bgpd(lower_tor_host),
-        skip_traffic_test=skip_traffic_test
+        action=lambda: kill_bgpd(lower_tor_host)
     )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -126,7 +123,7 @@ def test_standby_tor_kill_bgpd_upstream(
 def test_standby_tor_kill_bgpd_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, kill_bgpd,                 # noqa F811
-    tunnel_traffic_monitor, skip_traffic_test):                         # noqa F811
+    tunnel_traffic_monitor):                                            # noqa F811
     '''
     Case: T1 -> Active ToR -> Server (Standby ToR BGP Down)
     Action: Shutdown all BGP sessions on the standby ToR
@@ -137,8 +134,7 @@ def test_standby_tor_kill_bgpd_downstream_active(
     with tunnel_traffic_monitor(lower_tor_host, existing=False):
         send_t1_to_server_with_action(
             upper_tor_host, verify=True,
-            action=lambda: kill_bgpd(lower_tor_host),
-            skip_traffic_test=skip_traffic_test
+            action=lambda: kill_bgpd(lower_tor_host)
         )
     verify_tor_states(
         expected_active_host=upper_tor_host,
@@ -149,7 +145,7 @@ def test_standby_tor_kill_bgpd_downstream_active(
 def test_active_tor_kill_bgpd_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, kill_bgpd,                 # noqa F811
-    tunnel_traffic_monitor, skip_traffic_test):                         # noqa F811
+    tunnel_traffic_monitor):                                            # noqa F811
     '''
     Case: T1 -> Standby ToR -> Server (Active ToR BGP Down)
     Action: Shutdown all BGP sessions on the active ToR
@@ -160,8 +156,7 @@ def test_active_tor_kill_bgpd_downstream_standby(
     '''
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-        action=lambda: kill_bgpd(upper_tor_host),
-        skip_traffic_test=skip_traffic_test
+        action=lambda: kill_bgpd(upper_tor_host)
     )
     verify_tor_states(
         expected_active_host=lower_tor_host,
@@ -173,7 +168,7 @@ def test_active_tor_kill_bgpd_downstream_standby(
 def test_active_tor_shutdown_bgp_sessions_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor,                            # noqa F811
-    shutdown_bgp_sessions, cable_type, skip_traffic_test                # noqa F811
+    shutdown_bgp_sessions, cable_type                                   # noqa F811
 ):
     """
     Case: Server -> ToR -> T1 (Active ToR BGP Down)
@@ -187,15 +182,13 @@ def test_active_tor_shutdown_bgp_sessions_upstream(
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            action=lambda: shutdown_bgp_sessions(upper_tor_host),
-            skip_traffic_test=skip_traffic_test
+            action=lambda: shutdown_bgp_sessions(upper_tor_host)
         )
 
     if cable_type == CableType.active_active:
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            action=lambda: shutdown_bgp_sessions(upper_tor_host),
-            skip_traffic_test=skip_traffic_test
+            action=lambda: shutdown_bgp_sessions(upper_tor_host)
         )
 
     if cable_type == CableType.active_active:

--- a/tests/dualtor_mgmt/test_ingress_drop.py
+++ b/tests/dualtor_mgmt/test_ingress_drop.py
@@ -16,8 +16,6 @@ from tests.common.dualtor.nic_simulator_control import ForwardingState
 from tests.common.dualtor.nic_simulator_control import mux_status_from_nic_simulator    # noqa F401
 from tests.common.dualtor.nic_simulator_control import stop_nic_simulator               # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder                      # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test                       # noqa F401
-
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 
@@ -104,7 +102,7 @@ def selected_mux_port(cable_type, active_active_ports, active_standby_ports):   
 
 
 @pytest.mark.enable_active_active
-def test_ingress_drop(cable_type, ptfadapter, setup_mux, tbinfo, selected_mux_port, upper_tor_host, skip_traffic_test):    # noqa F811
+def test_ingress_drop(cable_type, ptfadapter, setup_mux, tbinfo, selected_mux_port, upper_tor_host):    # noqa F811
     """
     Aims to verify if orchagent installs ingress drop ACL when the port comes to standby.
 
@@ -131,7 +129,7 @@ def test_ingress_drop(cable_type, ptfadapter, setup_mux, tbinfo, selected_mux_po
 
     if cable_type == CableType.active_active:
         verify_upstream_traffic(upper_tor_host, ptfadapter, tbinfo, selected_mux_port,
-                                server_ip, pkt_num=10, drop=False, skip_traffic_test=skip_traffic_test)
+                                server_ip, pkt_num=10, drop=False)
     elif cable_type == CableType.active_standby:
         verify_upstream_traffic(upper_tor_host, ptfadapter, tbinfo, selected_mux_port,
-                                server_ip, pkt_num=10, drop=True, skip_traffic_test=skip_traffic_test)
+                                server_ip, pkt_num=10, drop=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently we are using conditional mark to add marker, then use pytest hook to redirect testutils.verify function to a function always return True to skip traffic test. With this change, the skip_traffic_test fixture is no longer needed in test cases, streamlining the test code and improving clarity.
#### How did you do it?
Remove skip_traffic_test in dualtor testcases
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
