### PR TITLE
Revert "[action] [PR:14232] Update test_qos_sai for ComputeAI config"

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -1,5 +1,4 @@
 import logging
-from tests.qos.qos_sai_base import QosSaiBase
 logger = logging.getLogger(__name__)
 
 
@@ -82,82 +81,6 @@ class QosParamCisco(object):
             self.log("Pre-pad drop thr bytes:    {}".format(pre_pad_drop))
             self.log("Drop thr bytes:            {}".format(self.drop_thr))
             self.log("Reduced pause thr bytes:   {}".format(self.reduced_pause_thr))
-        self.config_facts = duthost.get_running_config_facts()
-        # DSCP value for lossy
-        self.dscp_queue0 = self.get_one_dscp_from_queue(0)
-        self.dscp_queue1 = self.get_one_dscp_from_queue(1)
-        # DSCP, queue, weight list
-        self.dscp_list, self.q_list, self.weight_list = self.get_dscp_q_weight_list()
-
-    def get_one_dscp_from_queue(self, queue):
-        '''
-        Get one dscp value which is mapped to given queue
-        '''
-        dscp_to_tc_map = self.config_facts['DSCP_TO_TC_MAP']['AZURE']
-        tc_to_queue_map = self.config_facts['TC_TO_QUEUE_MAP']['AZURE']
-        queue = str(queue)
-        tc = list(tc_to_queue_map.keys())[list(tc_to_queue_map.values()).index(queue)]
-        dscp = list(dscp_to_tc_map.keys())[list(dscp_to_tc_map.values()).index(tc)]
-        return int(dscp)
-
-    def get_scheduler_cfg(self):
-        '''
-        Get scheduler configuration
-        '''
-        return self.config_facts['SCHEDULER']
-
-    def get_queue_cfg(self):
-        '''
-        Get queue configuration of first interface
-        '''
-        queue_cfg = self.config_facts['QUEUE']
-        interface = list(queue_cfg.keys())[0]
-        return queue_cfg[interface]
-
-    def get_queues_from_scheduler(self, scheduler):
-        '''
-        Get queue list which are mapped to given scheduler
-        '''
-        queue_list = []
-        for q, value in self.get_queue_cfg().items():
-            if scheduler == value['scheduler']:
-                queue_list.append(int(q))
-        return queue_list
-
-    def get_scheduler_from_queue(self, queue):
-        '''
-        Get scheduler for given queue
-        '''
-        return self.get_queue_cfg()[str(queue)]["scheduler"]
-
-    def get_queues_on_same_scheduler(self, queue):
-        '''
-        Get queue list on the same scheduler for given queue
-        '''
-        scheduler = self.get_scheduler_from_queue(queue)
-        return self.get_queues_from_scheduler(scheduler)
-
-    def get_queue_dscp_weight_dict(self):
-        q_dscp_weight_dict = {}
-        scheduler_cfg = self.get_scheduler_cfg()
-        for q, value in self.get_queue_cfg().items():
-            queue = int(q)
-            scheduler = value['scheduler']
-            q_dscp_weight_dict[queue] = {}
-            q_dscp_weight_dict[queue]["dscp"] = self.get_one_dscp_from_queue(queue)
-            q_dscp_weight_dict[queue]["weight"] = int(scheduler_cfg[scheduler]["weight"])
-        return q_dscp_weight_dict
-
-    def get_dscp_q_weight_list(self):
-        dscp_list = []
-        q_list = []
-        weight_list = []
-        q_dscp_weight_dict = self.get_queue_dscp_weight_dict()
-        for queue, value in q_dscp_weight_dict.items():
-            q_list.append(queue)
-            weight_list.append(value["weight"])
-            dscp_list.append(value["dscp"])
-        return dscp_list, q_list, weight_list
 
     def run(self):
         '''
@@ -179,8 +102,6 @@ class QosParamCisco(object):
         self.__define_lossless_voq()
         self.__define_q_watermark_all_ports()
         self.__define_pg_drop()
-        self.__define_wrr()
-        self.__define_wrr_chg()
         return self.qos_params
 
     def gr_get_mantissa_exp(self, thr):
@@ -256,9 +177,7 @@ class QosParamCisco(object):
             return
         if self.is_large_sms:
             if self.is_deep_buffer:
-                res_1 = {"dscps": [self.dscp_queue0, self.dscp_queue0,
-                                   self.dscp_queue1, self.dscp_queue1,
-                                   3, 4, 3, 4, 3, 4, 3],
+                res_1 = {"dscps": [8, 8, 1, 1, 3, 4, 3, 4, 3, 4, 3],
                          "pgs": [0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3],
                          "queues": [0, 0, 1, 1, 3, 4, 3, 4, 3, 4, 3],
                          "src_port_i": [0, 1, 0, 1, 0, 0, 1, 1, 2, 2, 4],
@@ -360,7 +279,7 @@ class QosParamCisco(object):
             self.write_params("wm_pg_shared_lossless", lossless_params)
         if self.should_autogen(["wm_pg_shared_lossy"]):
             lossy_params = common_params.copy()
-            lossy_params.update({"dscp": self.dscp_queue0,
+            lossy_params.update({"dscp": 8,
                                  "pg": 0,
                                  "pkts_num_trig_egr_drp": self.max_depth // self.buffer_size})
             self.write_params("wm_pg_shared_lossy", lossy_params)
@@ -379,7 +298,7 @@ class QosParamCisco(object):
                                "packet_size": packet_size}
             self.write_params("wm_buf_pool_lossless", lossless_params)
         if self.should_autogen(["wm_buf_pool_lossy"]):
-            lossy_params = {"dscp": self.dscp_queue0,
+            lossy_params = {"dscp": 8,
                             "ecn": 1,
                             "pg": 0,
                             "queue": 0,
@@ -400,7 +319,7 @@ class QosParamCisco(object):
                                "cell_size": self.buffer_size}
             self.write_params("wm_q_shared_lossless", lossless_params)
         if self.should_autogen(["wm_q_shared_lossy"]):
-            lossy_params = {"dscp": self.dscp_queue0,
+            lossy_params = {"dscp": 8,
                             "ecn": 1,
                             "queue": 0,
                             "pkts_num_fill_min": 0,
@@ -411,7 +330,7 @@ class QosParamCisco(object):
 
     def __define_lossy_queue_voq(self):
         if self.should_autogen(["lossy_queue_voq_1"]):
-            params = {"dscp": self.dscp_queue0,
+            params = {"dscp": 8,
                       "ecn": 1,
                       "pg": 0,
                       "flow_config": self.flow_config,
@@ -421,7 +340,7 @@ class QosParamCisco(object):
                       "cell_size": self.buffer_size}
             self.write_params("lossy_queue_voq_1", params)
         if self.should_autogen(["lossy_queue_voq_2"]):
-            params = {"dscp": self.dscp_queue0,
+            params = {"dscp": 8,
                       "ecn": 1,
                       "pg": 0,
                       "flow_config": "shared",
@@ -431,7 +350,7 @@ class QosParamCisco(object):
                       "cell_size": self.buffer_size}
             self.write_params("lossy_queue_voq_2", params)
         if self.should_autogen(["lossy_queue_voq_3"]):
-            params = {"dscp": self.dscp_queue0,
+            params = {"dscp": 8,
                       "ecn": 1,
                       "pg": 0,
                       "pkts_num_trig_egr_drp": self.max_depth // self.buffer_size,
@@ -442,7 +361,7 @@ class QosParamCisco(object):
 
     def __define_lossy_queue(self):
         if self.should_autogen(["lossy_queue_1"]):
-            params = {"dscp": self.dscp_queue0,
+            params = {"dscp": 8,
                       "ecn": 1,
                       "pg": 0,
                       "pkts_num_trig_egr_drp": self.max_depth // self.buffer_size,
@@ -511,41 +430,3 @@ class QosParamCisco(object):
                       "pkts_num_margin": margin,
                       "iterations": 100}
             self.write_params("pg_drop", params)
-
-    def __define_wrr(self):
-        q_pkt_cnt = []
-        pkt_cnt_multiplier = 470/sum(self.weight_list)
-        for weight in self.weight_list:
-            q_pkt_cnt.append(int(weight * pkt_cnt_multiplier))
-        if self.should_autogen(["wrr"]):
-            params = {"ecn": 1,
-                      "dscp_list": self.dscp_list,
-                      "q_list": self.q_list,
-                      "q_pkt_cnt": q_pkt_cnt,
-                      "limit": 80}
-            self.write_params("wrr", params)
-
-    def __define_wrr_chg(self):
-        q_pkt_cnt = []
-        weight_list = []
-        lossy_queues_chg = self.get_queues_on_same_scheduler(QosSaiBase.TARGET_LOSSY_QUEUE_SCHED)
-        lossless_queues_chg = self.get_queues_on_same_scheduler(QosSaiBase.TARGET_LOSSLESS_QUEUE_SCHED)
-        for queue, weight in zip(self.q_list, self.weight_list):
-            if queue in lossy_queues_chg:
-                weight_list.append(8)
-            elif queue in lossless_queues_chg:
-                weight_list.append(30)
-            else:
-                weight_list.append(weight)
-        pkt_cnt_multiplier = 470/sum(weight_list)
-        for weight in weight_list:
-            q_pkt_cnt.append(int(weight * pkt_cnt_multiplier))
-        if self.should_autogen(["wrr_chg"]):
-            params = {"ecn": 1,
-                      "dscp_list": self.dscp_list,
-                      "q_list": self.q_list,
-                      "q_pkt_cnt": q_pkt_cnt,
-                      "limit": 80,
-                      "lossy_weight": 8,
-                      "lossless_weight": 30}
-            self.write_params("wrr_chg", params)

--- a/tests/qos/files/qos_params.gr.yaml
+++ b/tests/qos/files/qos_params.gr.yaml
@@ -1,6 +1,24 @@
 qos_params:
     gr:
         topo-any:
+            wm_pg_shared_lossy:
+                dscp: 8
+                ecn: 1
+                pg: 0
+                pkts_num_trig_egr_drp: 64000
+                pkts_num_fill_min: 0
+                pkts_num_margin: 4
+                packet_size: 1350
+                cell_size: 384
+            wm_buf_pool_lossy:
+                dscp: 8
+                ecn: 1
+                pg: 0
+                queue: 0
+                pkts_num_trig_egr_drp: 16000
+                pkts_num_fill_egr_min: 0
+                cell_size: 384
+                packet_size: 1350
             shared_res_size_1:
                 ecn: 1
                 packet_size: 1350
@@ -11,5 +29,27 @@ qos_params:
                 packet_size: 1350
                 cell_size: 384
                 pkts_num_margin: 1
+            wrr_chg:
+                ecn: 1
+                q0_num_of_pkts: 40
+                q1_num_of_pkts: 40
+                q2_num_of_pkts: 40
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 40
+                q6_num_of_pkts: 40
+                limit: 80
+                lossy_weight: 8
+                lossless_weight: 30
+            wrr:
+                ecn: 1
+                q0_num_of_pkts: 70
+                q1_num_of_pkts: 70
+                q2_num_of_pkts: 70
+                q3_num_of_pkts: 75
+                q4_num_of_pkts: 75
+                q5_num_of_pkts: 70
+                q6_num_of_pkts: 70
+                limit: 80
             hdrm_pool_wm_multiplier: 1
             cell_size: 384

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1305,8 +1305,7 @@ class TestQosSai(QosSaiBase):
             raise
 
     def testQosSaiDscpQueueMapping(
-        self, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dut_qos_maps, # noqa F811
-        tc_to_dscp_count
+        self, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dut_qos_maps # noqa F811
     ):
         """
             Test QoS SAI DSCP to queue mapping
@@ -1318,7 +1317,6 @@ class TestQosSai(QosSaiBase):
                 dutConfig (Fixture, dict): Map of DUT config containing dut interfaces, test port IDs, test port IPs,
                     and test ports
                 dut_qos_maps(Fixture): A fixture, return qos maps on DUT host
-                tc_to_dscp_count(Fixture): A fixture, return tc to dscp_count map on DUT host
             Returns:
                 None
 
@@ -1342,8 +1340,7 @@ class TestQosSai(QosSaiBase):
             "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
             "hwsku": dutTestParams['hwsku'],
             "dual_tor": dutConfig['dualTor'],
-            "dual_tor_scenario": dutConfig['dualTorScenario'],
-            "tc_to_dscp_count_map": tc_to_dscp_count
+            "dual_tor_scenario": dutConfig['dualTorScenario']
         })
 
         if "platform_asic" in dutTestParams["basicParams"]:
@@ -1720,7 +1717,8 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiPGDrop(
-        self, ptfhost, dutTestParams, dutConfig, dutQosConfig, skip_400g_longlink
+        self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+        _check_ingress_speed_gte_400g
     ):
         """
             Test QoS SAI PG drop counter

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -822,7 +822,6 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
         dual_tor = self.test_params.get('dual_tor', None)
         leaf_downstream = self.test_params.get('leaf_downstream', None)
         asic_type = self.test_params['sonic_asic_type']
-        tc_to_dscp_count_map = self.test_params.get('tc_to_dscp_count_map', None)
         exp_ip_id = 101
         exp_ttl = 63
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
@@ -931,39 +930,33 @@ class DscpMappingPB(sai_base_test.ThriftInterfaceDataPlane):
             # queue 3/4  1                 1               1                                                1                                         1                         # noqa E501
             # queue 5    1                 1               1                                                1                                         1                         # noqa E501
             # queue 7    0                 1               1                                                1                                         1                         # noqa E501
-
-            if tc_to_dscp_count_map:
-                for tc in range(7):
-                    assert (queue_results[tc] == tc_to_dscp_count_map[tc] + queue_results_base[tc])
-                assert (queue_results[7] >= tc_to_dscp_count_map[7] + queue_results_base[7])
+            assert (queue_results[QUEUE_0] == 1 + queue_results_base[QUEUE_0])
+            assert (queue_results[QUEUE_3] == 1 + queue_results_base[QUEUE_3])
+            assert (queue_results[QUEUE_4] == 1 + queue_results_base[QUEUE_4])
+            assert (queue_results[QUEUE_5] == 1 + queue_results_base[QUEUE_5])
+            if dual_tor or (dual_tor_scenario is False) or (leaf_downstream is False):
+                assert (queue_results[QUEUE_2] == 1 +
+                        queue_results_base[QUEUE_2])
+                assert (queue_results[QUEUE_6] == 1 +
+                        queue_results_base[QUEUE_6])
             else:
-                assert (queue_results[QUEUE_0] == 1 + queue_results_base[QUEUE_0])
-                assert (queue_results[QUEUE_3] == 1 + queue_results_base[QUEUE_3])
-                assert (queue_results[QUEUE_4] == 1 + queue_results_base[QUEUE_4])
-                assert (queue_results[QUEUE_5] == 1 + queue_results_base[QUEUE_5])
-                if dual_tor or (dual_tor_scenario is False) or (leaf_downstream is False):
-                    assert (queue_results[QUEUE_2] == 1 +
-                            queue_results_base[QUEUE_2])
-                    assert (queue_results[QUEUE_6] == 1 +
-                            queue_results_base[QUEUE_6])
+                assert (queue_results[QUEUE_2] == queue_results_base[QUEUE_2])
+                assert (queue_results[QUEUE_6] == queue_results_base[QUEUE_6])
+            if dual_tor_scenario:
+                if (dual_tor is False) or leaf_downstream:
+                    assert (queue_results[QUEUE_1] ==
+                            59 + queue_results_base[QUEUE_1])
                 else:
-                    assert (queue_results[QUEUE_2] == queue_results_base[QUEUE_2])
-                    assert (queue_results[QUEUE_6] == queue_results_base[QUEUE_6])
-                if dual_tor_scenario:
-                    if (dual_tor is False) or leaf_downstream:
-                        assert (queue_results[QUEUE_1] ==
-                                59 + queue_results_base[QUEUE_1])
-                    else:
-                        assert (queue_results[QUEUE_1] ==
-                                57 + queue_results_base[QUEUE_1])
-                    # LAG ports can have LACP packets on queue 7, hence using >= comparison
-                    assert (queue_results[QUEUE_7] >= 1 +
-                            queue_results_base[QUEUE_7])
-                else:
-                    assert (queue_results[QUEUE_1] == 58 +
-                            queue_results_base[QUEUE_1])
-                    # LAG ports can have LACP packets on queue 7, hence using >= comparison
-                    assert (queue_results[QUEUE_7] >= queue_results_base[QUEUE_7])
+                    assert (queue_results[QUEUE_1] ==
+                            57 + queue_results_base[QUEUE_1])
+                # LAG ports can have LACP packets on queue 7, hence using >= comparison
+                assert (queue_results[QUEUE_7] >= 1 +
+                        queue_results_base[QUEUE_7])
+            else:
+                assert (queue_results[QUEUE_1] == 58 +
+                        queue_results_base[QUEUE_1])
+                # LAG ports can have LACP packets on queue 7, hence using >= comparison
+                assert (queue_results[QUEUE_7] >= queue_results_base[QUEUE_7])
 
         finally:
             print("END OF TEST", file=sys.stderr)
@@ -3683,46 +3676,37 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
         topo = self.test_params['topo']
         platform_asic = self.test_params['platform_asic']
-        prio_list = self.test_params.get('dscp_list', [])
-        q_pkt_cnt = self.test_params.get('q_pkt_cnt', [])
-        q_list = self.test_params.get('q_list', [])
 
-        self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id], enable_port_by_unblock_queue=False)
-
-        if not (prio_list and q_pkt_cnt and q_list):
-            if 'backend' not in topo:
-                if not qos_remap_enable:
-                    # When qos_remap is disabled, the map is as below
-                    # DSCP TC QUEUE
-                    # 3    3    3
-                    # 4    4    4
-                    # 8    0    0
-                    # 0    1    1
-                    # 5    2    2
-                    # 46   5    5
-                    # 48   6    6
-                    prio_list = [3, 4, 8, 0, 5, 46, 48]
-                    q_pkt_cnt = [queue_3_num_of_pkts, queue_4_num_of_pkts, queue_0_num_of_pkts,
-                                 queue_1_num_of_pkts, queue_2_num_of_pkts, queue_5_num_of_pkts, queue_6_num_of_pkts]
-                    q_list = [3, 4, 0, 1, 2, 5, 6]
-                else:
-                    # When qos_remap is enabled, the map is as below
-                    # DSCP TC QUEUE
-                    # 3    3    3
-                    # 4    4    4
-                    # 8    0    0
-                    # 0    1    1
-                    # 46   5    5
-                    # 48   7    7
-                    prio_list = [3, 4, 8, 0, 46, 48]
-                    q_pkt_cnt = [queue_3_num_of_pkts, queue_4_num_of_pkts, queue_0_num_of_pkts,
-                                 queue_1_num_of_pkts, queue_5_num_of_pkts, queue_7_num_of_pkts]
-                    q_list = [3, 4, 0, 1, 5, 7]
+        if 'backend' not in topo:
+            if not qos_remap_enable:
+                # When qos_remap is disabled, the map is as below
+                # DSCP TC QUEUE
+                # 3    3    3
+                # 4    4    4
+                # 8    0    0
+                # 0    1    1
+                # 5    2    2
+                # 46   5    5
+                # 48   6    6
+                prio_list = [3, 4, 8, 0, 5, 46, 48]
+                q_pkt_cnt = [queue_3_num_of_pkts, queue_4_num_of_pkts, queue_0_num_of_pkts,
+                             queue_1_num_of_pkts, queue_2_num_of_pkts, queue_5_num_of_pkts, queue_6_num_of_pkts]
             else:
-                prio_list = [3, 4, 1, 0, 2, 5, 6]
-                q_pkt_cnt = [queue_3_num_of_pkts, queue_4_num_of_pkts, queue_1_num_of_pkts,
-                             queue_0_num_of_pkts, queue_2_num_of_pkts, queue_5_num_of_pkts, queue_6_num_of_pkts]
-                q_list = [3, 4, 1, 0, 2, 5, 6]
+                # When qos_remap is enabled, the map is as below
+                # DSCP TC QUEUE
+                # 3    3    3
+                # 4    4    4
+                # 8    0    0
+                # 0    1    1
+                # 46   5    5
+                # 48   7    7
+                prio_list = [3, 4, 8, 0, 46, 48]
+                q_pkt_cnt = [queue_3_num_of_pkts, queue_4_num_of_pkts, queue_0_num_of_pkts,
+                             queue_1_num_of_pkts, queue_5_num_of_pkts, queue_7_num_of_pkts]
+        else:
+            prio_list = [3, 4, 1, 0, 2, 5, 6]
+            q_pkt_cnt = [queue_3_num_of_pkts, queue_4_num_of_pkts, queue_1_num_of_pkts,
+                         queue_0_num_of_pkts, queue_2_num_of_pkts, queue_5_num_of_pkts, queue_6_num_of_pkts]
         q_cnt_sum = sum(q_pkt_cnt)
         # Send packets to leak out
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
@@ -3761,7 +3745,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
             self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
         # Send packets to each queue based on priority/dscp field
-        for prio, pkt_cnt, queue in zip(prio_list, q_pkt_cnt, q_list):
+        for prio, pkt_cnt in zip(prio_list, q_pkt_cnt):
             pkt = construct_ip_pkt(default_packet_length,
                                    pkt_dst_mac,
                                    src_port_mac,
@@ -3772,26 +3756,11 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                                    ip_id=exp_ip_id,
                                    ecn=ecn,
                                    ttl=64)
-            if 'cisco-8000' in asic_type and pkt_cnt > 0:
-                fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type)
-                pkt_cnt -= 1
             send_packet(self, src_port_id, pkt, pkt_cnt)
 
         # Set receiving socket buffers to some big value
         for p in list(self.dataplane.ports.values()):
             p.socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 41943040)
-
-        # recv packets for leakout
-        if 'cisco-8000' in asic_type:
-            recv_pkt = scapy.Ether()
-
-            while recv_pkt:
-                received = self.dataplane.poll(
-                    device_number=0, port_number=dst_port_id, timeout=2)
-                if isinstance(received, self.dataplane.PollFailure):
-                    recv_pkt = None
-                    break
-                recv_pkt = scapy.Ether(received.packet)
 
         # Release port
         self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id], enable_port_by_unblock_queue=False)
@@ -3819,8 +3788,8 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                 # Ignore captured non-IP packet
                 continue
 
-        queue_pkt_counters = [0] * (max(prio_list) + 1)
-        queue_num_of_pkts = [0] * (max(prio_list) + 1)
+        queue_pkt_counters = [0] * (prio_list[-1] + 1)
+        queue_num_of_pkts = [0] * (prio_list[-1] + 1)
         for prio, q_cnt in zip(prio_list, q_pkt_cnt):
             queue_num_of_pkts[prio] = q_cnt
 


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#14759

This causes nightly regression to dualtor testbed.

```
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_asic] 
-------------------------------- live log setup --------------------------------
21:52:21 __init__._fixture_generator_decorator    L0088 ERROR  | 
KeyError(8)
Traceback (most recent call last):
  File "/azp/_work/30/s/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/azp/_work/30/s/tests/qos/qos_sai_base.py", line 2337, in tc_to_dscp_count
    tc_to_dscp_count_map[int(tc)] += 1
KeyError: 8
ERRO