### PR TITLE
Cisco-8000 Revise TX XOFF counter check

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3494,16 +3494,7 @@ class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             pfc_tx_cnt_base = get_pfc_tx_cnt(src_port_id, pg_cntr_idx)
             time.sleep(2)
             xoff_txd = get_pfc_tx_cnt(src_port_id, pg_cntr_idx) - pfc_tx_cnt_base
-            print("Verifying XOFF TX, count {}".format(xoff_txd), file=sys.stderr)
-            assert xoff_txd != 0, "Expected XOFF"
-
-            # TODO: Revisit when TX counter in this case is correctly handled
-            send_packet(self, src_port_id, pkt, 1)
-            time.sleep(2)
-            pfc_tx_cnt_base = get_pfc_tx_cnt(src_port_id, pg_cntr_idx)
-            time.sleep(2)
-            xoff_txd = get_pfc_tx_cnt(src_port_id, pg_cntr_idx) - pfc_tx_cnt_base
-            print("Verifying XOFF TX stopped, count {}".format(xoff_txd), file=sys.stderr)
+            print("Verifying no XOFF TX, count {}".format(xoff_txd), file=sys.stderr)
             assert xoff_txd == 0, "Unexpected XOFF"
 
         finally:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Follow up on TODO item for when the TX XOFF counter behavior changed for Cisco-8000 series devices. 

Needed in 202311 as well, as the TODO code is present there as well. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified on Cisco-8111 device to reproduce the xoff !=0 assertion failure consistently, then revised test appropriately for new TX XOFF counter behavior. 

#### Any platform specific information?
Cisco-8000 series test only. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
