### PR TITLE
ACL testcase fix for Cisco 8122 Platform

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -807,10 +807,8 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
                     continue
                 counters_after[PACKETS_COUNT] += acl_facts[duthost]['after'][rule][PACKETS_COUNT]
                 counters_after[BYTES_COUNT] += acl_facts[duthost]['after'][rule][BYTES_COUNT]
-                if (duthost.facts["hwsku"] == "Cisco-8111-O64" or
-                        duthost.facts["hwsku"] == "Cisco-8111-O32" or
-                        duthost.facts["hwsku"] == "Cisco-8111-C32" or
-                        duthost.facts["hwsku"] == "Cisco-8111-O62C2"):
+                if (duthost.facts["platform"] == "x86_64-8111_32eh_o-r0" or
+                    duthost.facts["platform"] == "x86_64-8122_64eh_o-r0"):
                     skip_byte_accounting = True
 
             logger.info("Counters for ACL rule \"{}\" after traffic:\n{}"

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -807,8 +807,8 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
                     continue
                 counters_after[PACKETS_COUNT] += acl_facts[duthost]['after'][rule][PACKETS_COUNT]
                 counters_after[BYTES_COUNT] += acl_facts[duthost]['after'][rule][BYTES_COUNT]
-                if (duthost.facts["platform"] == "x86_64-8111_32eh_o-r0" or
-                    duthost.facts["platform"] == "x86_64-8122_64eh_o-r0"):
+                if duthost.facts["platform"] in ["x86_64-8111_32eh_o-r0",
+                                                 "x86_64-8122_64eh_o-r0", "x86_64-8122_64ehf_o-r0"]:
                     skip_byte_accounting = True
 
             logger.info("Counters for ACL rule \"{}\" after traffic:\n{}"


### PR DESCRIPTION

### Description of PR
ACL test fix for 8122, Added Platform check to skip the Byte Accounting.


Summary:
Fixes # (issue)
ACL byte counters not supported in Cisco 8122 and test_acl.py tests (32 Testcases) fails due to assertion for byte counters.


### Type of change


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Add Fix for failing testcase in test_acl.py.


#### How did you do it?
Added check to skip byte accounting for Cisco 8122 Platform



#### How did you verify/test it?
Verified that all the ACL testcases are passing for Cisco 8122 Platform 



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
