### PR TITLE
`bgp/test_bgp_session_flap.py` Fix condition intended to skip iBGP neighbors to work on single-asic

### DIFF
--- a/tests/bgp/test_bgp_session_flap.py
+++ b/tests/bgp/test_bgp_session_flap.py
@@ -66,7 +66,8 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand_one_
     tor_neighbors = dict()
     neigh_asn = dict()
     for k, v in bgp_facts['bgp_neighbors'].items():
-        if 'asic' not in v['description'].lower():
+        # Skip iBGP neighbors
+        if "INTERNAL" not in v["peer group"] and "VOQ_CHASSIS" not in v["peer group"]:
             neigh_keys.append(v['description'])
             neigh_asn[v['description']] = v['remote AS']
             tor_neighbors[v['description']] = nbrhosts[v['description']]["host"]


### PR DESCRIPTION
### Description of PR
https://github.com/sonic-net/sonic-mgmt/pull/13662 added support for running `bgp/test_bgp_session_flap.py` on `T2` topology.
However, the condition it added to skip iBGP neighbors only works on multi-asic LCs:
`if 'asic' not in v['description'].lower():`

E.G. here is a switch which has 3 LCs (LC4 - multi-asic, LC5 - multi-asic, LC6 - single-asic)
```
root@cmp206-4:~# show ip bgp summary -d all
...
Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200       4113       6364         0      0       0  01:21:00            34050  ARISTA01T3
...
10.0.0.63      4  65200       4033       6720         0      0       0  01:19:44            34050  ARISTA32T3
10.0.254.1     4  65100      20415      27839         0      0       0  02:09:35           340512  ASIC0
10.0.254.3     4  65100      27839      20415         0      0       0  02:09:34           476708  ASIC1
10.0.254.5     4  65100       4737      23014         0      0       0  01:33:32             2067  cmp206-5-ASIC0
10.0.254.5     4  65100       4738      31515         0      0       0  01:33:33             2067  cmp206-5-ASIC0
10.0.254.7     4  65100       5803      27835         0      0       0  02:09:27             4131  cmp206-5-ASIC1
10.0.254.7     4  65100       5844      20415         0      0       0  02:09:34             4131  cmp206-5-ASIC1
10.0.254.9     4  65100       7197      20394         0      0       0  02:09:01             6196  cmp206-6
10.0.254.9     4  65100       7197      26987         0      0       0  02:09:03             6196  cmp206-6
```
Note that LC4 and LC5 neighbor iBGPs will be skipped because `ASIC` is in the name but LC6 won't because it's single ASIC.

The better solution is to check the BGP session's `peer group` which will indicate if it's internal or not regardless of single-asic or multi-asic
```
Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.254.1     4  65100       6818       6818         0      0       0  03:10:58            68104  ASIC0
10.0.254.5     4  65100       5731       7122         0      0       0  02:35:12             1037  cmp314-4
```
(Pdb) bgp_facts['bgp_neighbors']['10.0.254.5']
{'admin': 'up', 'accepted prefixes': 7, 'ip_version': 4, 'remote AS': 65100, 'local AS': 65100, **'description': 'cmp314-4'**, **'peer group': 'VOQ_CHASSIS_V4_PEER'**, 'remote routerid': '8.0.0.7', 'state': 'established', 'capabilities': {'peer restart timer': 120}, 'message statistics': {'Opens': {'sent': 3, 'rcvd': 3}, 'Notifications': {'sent': 0, 'rcvd': 0}, 'Updates': {'sent': 1634, 'rcvd': 243}, 'Keepalives': {'sent': 2373, 'rcvd': 2373}, 'Route Refresh': {'sent': 0, 'rcvd': 0}, 'Capability': {'sent': 0, 'rcvd': 0}, 'Total': {'sent': 4010, 'rcvd': 2619}}, 'mrai': 0, 'connections established': 3, 'connections dropped': 2}
(Pdb) bgp_facts['bgp_neighbors']['10.0.254.1']
{'admin': 'up', 'accepted prefixes': 4, 'ip_version': 4, 'remote AS': 65100, 'local AS': 65100, **'description': 'ASIC0'**, **'peer group': 'VOQ_CHASSIS_V4_PEER'**, 'remote routerid': '8.0.0.2', 'state': 'established', 'capabilities': {'peer restart timer': 120}, 'message statistics': {'Opens': {'sent': 1, 'rcvd': 1}, 'Notifications': {'sent': 0, 'rcvd': 0}, 'Updates': {'sent': 1088, 'rcvd': 1088}, 'Keepalives': {'sent': 2612, 'rcvd': 2612}, 'Route Refresh': {'sent': 0, 'rcvd': 0}, 'Capability': {'sent': 0, 'rcvd': 0}, 'Total': {'sent': 3701, 'rcvd': 3701}}, 'mrai': 0, 'connections established': 1, 'connections dropped': 0}

Note: I included `INTERNAL` as another keyword to indicate an iBGP neighbor as I believe that's what non-voq chassis will have as their neighbor name (Took this from https://github.com/sonic-net/sonic-mgmt/blob/master/tests/bgp/test_bgp_queue.py#L64)

Summary:
Fixes #15410 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405