### PR TITLE
Adding log analyzer ignore messages based on Cisco Chassis

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -285,6 +285,10 @@ r, ".* INFO .*[duty_cycle_map]: illegal pwm value .*"
 r, ".* INFO .*command '/usr/sbin/smartctl' failed: [116] Stale file handle.*"
 r, ".* INFO healthd.*Key 'TEMPERATURE_INFO|ASIC' field 'high_threshold' unavailable in database 'STATE_DB'.*"
 r, ".* INFO healthd.*Key 'TEMPERATURE_INFO|ASIC' field 'temperature' unavailable in database 'STATE_DB'.*"
+r, ".* ERR kernel:.*cisco-fpga-p2pm-m-slot p2pm-m-slot\.\d+: cisco_fpga_select_new_acpi_companion: searching for child status\d+ 0x[0-9a-f]+; fpga_id 0x[0-9a-f]+.*"
+r, ".* ERR kernel:.*cisco-fpga-pci \d+:\d+:\d+\.\d+: cisco_fpga_select_new_acpi_companion: searching for child status\d+ 0x[0-9a-f]+; fpga_id 0x[0-9a-f]+.*"
+r, ".* WARNING kernel:.*pcieport.*device.*error.*status/mask=.*"
+
 
 # Ignore rsyslog librelp error if rsyslogd on host or container is down or going down
 r, ".* ERR .*#rsyslogd: librelp error 10008 forwarding to server .* - suspending.*"


### PR DESCRIPTION
### Description of PR
Adding log analyzer ignore messages based on Cisco Chassis. These messages are harmless messages. Adding it to loganalyzer ignore file

WARNING kernel: [55926.179286] pcieport 0000:0a:00.0:   device [10b5:8713] error status/mask=00002001/0000e000
ERR kernel: [39978.088854] cisco-fpga-p2pm-m-slot p2pm-m-slot.2: cisco_fpga_select_new_acpi_companion: searching for child status0 0x2420017a; fpga_id 0x42
ERR kernel: [    8.160032] cisco-fpga-pci 0000:5f:00.0: cisco_fpga_select_new_acpi_companion: searching for child status0 0x26100179; fpga_id 0x61 create a loganalyzer ignore

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To ignore harmless log messages that can cause testcase errors.

#### How did you do it?
Adding the messages as part of log analyzer ignore file

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
