### PR TITLE
Remove skip_traffic_test fixture in arp tests

### DIFF
--- a/tests/arp/test_unknown_mac.py
+++ b/tests/arp/test_unknown_mac.py
@@ -14,7 +14,6 @@ import ptf.packet as packet
 from tests.common import constants
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses    # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py   # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
@@ -260,7 +259,7 @@ class TrafficSendVerify(object):
     """ Send traffic and check interface counters and ptf ports """
     @initClassVars
     def __init__(self, duthost, ptfadapter, dst_ip, ptf_dst_port, ptf_vlan_ports,
-                 intfs, ptf_ports, arp_entry, dscp, skip_traffic_test):     # noqa F811
+                 intfs, ptf_ports, arp_entry, dscp):     # noqa F811
         """
         Args:
             duthost(AnsibleHost) : dut instance
@@ -278,7 +277,6 @@ class TrafficSendVerify(object):
         self.pkt_map = dict()
         self.pre_rx_drops = dict()
         self.dut_mac = duthost.facts['router_mac']
-        self.skip_traffic_test = skip_traffic_test
 
     def _constructPacket(self):
         """
@@ -361,7 +359,8 @@ class TrafficSendVerify(object):
         self._constructPacket()
         logger.info("Clear all counters before test run")
         self.duthost.command("sonic-clear counters")
-        if not self.skip_traffic_test:
+        asic_type = self.duthost.facts["asic_type"]
+        if asic_type != "vs":
             time.sleep(1)
             logger.info("Collect drop counters before test run")
             self._verifyIntfCounters(pretest=True)
@@ -378,7 +377,7 @@ class TrafficSendVerify(object):
 
 class TestUnknownMac(object):
     @pytest.mark.parametrize("dscp", ["dscp-3", "dscp-4", "dscp-8"])
-    def test_unknown_mac(self, unknownMacSetup, dscp, duthosts, rand_one_dut_hostname, ptfadapter, skip_traffic_test):  # noqa F811
+    def test_unknown_mac(self, unknownMacSetup, dscp, duthosts, rand_one_dut_hostname, ptfadapter):
         """
         Verify unknown mac behavior for lossless and lossy priority
 
@@ -404,7 +403,6 @@ class TestUnknownMac(object):
         self.ptf_vlan_ports = setup['ptf_vlan_ports']
         self.intfs = setup['intfs']
         self.ptf_ports = setup['ptf_ports']
-        self.skip_traffic_test = skip_traffic_test
         self.validateEntries()
         self.run()
 
@@ -422,5 +420,5 @@ class TestUnknownMac(object):
         thandle = TrafficSendVerify(self.duthost, self.ptfadapter, self.dst_ip, self.ptf_dst_port,
                                     self.ptf_vlan_ports,
                                     self.intfs, self.ptf_ports,
-                                    self.arp_entry, self.dscp, self.skip_traffic_test)
+                                    self.arp_entry, self.dscp)
         thandle.runTest()

--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -4,7 +4,6 @@ import pytest
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                             # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                                # noqa F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses                                 # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test                                   # noqa F401
 from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies     # noqa F401
 from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_until
@@ -68,7 +67,7 @@ def warmRebootSystemFlag(duthost):
         duthost.shell(cmd='sonic-db-cli STATE_DB hset "WARM_RESTART_ENABLE_TABLE|system" enable false')
 
 
-def test_wr_arp(request, duthost, ptfhost, creds, skip_traffic_test):   # noqa F811
+def test_wr_arp(request, duthost, ptfhost, creds):
     '''
         Control Plane Assistant test for Warm-Reboot.
 
@@ -85,10 +84,10 @@ def test_wr_arp(request, duthost, ptfhost, creds, skip_traffic_test):   # noqa F
         Returns:
             None
     '''
-    testWrArp(request, duthost, ptfhost, creds, skip_traffic_test)
+    testWrArp(request, duthost, ptfhost, creds)
 
 
-def test_wr_arp_advance(request, duthost, ptfhost, creds, skip_traffic_test):    # noqa F811
+def test_wr_arp_advance(request, duthost, ptfhost, creds):
     testDuration = request.config.getoption('--test_duration', default=DEFAULT_TEST_DURATION)
     ptfIp = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
     dutIp = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
@@ -96,8 +95,7 @@ def test_wr_arp_advance(request, duthost, ptfhost, creds, skip_traffic_test):   
     logger.info('Warm-Reboot Control-Plane assist feature')
     sonicadmin_alt_password = duthost.host.options['variable_manager'].\
         _hostvars[duthost.hostname]['sonic_default_passwords']
-    if skip_traffic_test is True:
-        return
+
     ptf_runner(
         ptfhost,
         'ptftests',

--- a/tests/common/arp_utils.py
+++ b/tests/common/arp_utils.py
@@ -179,7 +179,7 @@ def tear_down(duthost, route, ptfIp, gwIp):
     teardownRouteToPtfhost(duthost, route, ptfIp, gwIp)
 
 
-def testWrArp(request, duthost, ptfhost, creds, skip_traffic_test):
+def testWrArp(request, duthost, ptfhost, creds):
     testDuration = request.config.getoption('--test_duration', default=DEFAULT_TEST_DURATION)
     ptfIp = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
     dutIp = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
@@ -187,8 +187,7 @@ def testWrArp(request, duthost, ptfhost, creds, skip_traffic_test):
     logger.info('Warm-Reboot Control-Plane assist feature')
     sonicadmin_alt_password = duthost.host.options['variable_manager']. \
         _hostvars[duthost.hostname]['sonic_default_passwords']
-    if skip_traffic_test is True:
-        return
+
     ptf_runner(
         ptfhost,
         'ptftests',

--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -15,8 +15,6 @@ from .vnet_utils import generate_dut_config_files, safe_open_template, \
 
 from tests.common.flow_counter.flow_counter_utils import RouteFlowCounterTestContext, is_route_flow_counter_supported  # noqa F401
 from tests.common.arp_utils import set_up, tear_down, testWrArp
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test
-
 from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)
@@ -159,7 +157,7 @@ def vxlan_status(setup, request, duthosts, rand_one_dut_hostname,
     elif request.param == "WR_ARP":
         route, ptfIp, gwIp = set_up(duthost, ptfhost, tbinfo)
         try:
-            testWrArp(request, duthost, ptfhost, creds, skip_traffic_test)
+            testWrArp(request, duthost, ptfhost, creds)
         finally:
             tear_down(duthost, route, ptfIp, gwIp)
 
@@ -190,7 +188,7 @@ def is_neigh_reachable(duthost, vnet_config):
 
 
 def test_vnet_vxlan(setup, vxlan_status, duthosts, rand_one_dut_hostname, ptfhost,
-                    vnet_test_params, creds, is_route_flow_counter_supported, skip_traffic_test):  # noqa F811
+                    vnet_test_params, creds, is_route_flow_counter_supported):  # noqa F811
     """
     Test case for VNET VxLAN
 
@@ -229,9 +227,6 @@ def test_vnet_vxlan(setup, vxlan_status, duthosts, rand_one_dut_hostname, ptfhos
         logger.info("Skipping cleanup")
         pytest.skip("Skip cleanup specified")
 
-    if skip_traffic_test is True:
-        logger.info("Skipping traffic test")
-        return
     logger.debug("Starting PTF runner")
     if scenario == 'Enabled' and vxlan_enabled:
         route_pattern = 'Vnet1|100.1.1.1/32'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently we are using conditional mark to add marker, then use pytest hook to redirect testutils.verify function to a function always return True to skip traffic test. With this change, the skip_traffic_test fixture is no longer needed in test cases, streamlining the test code and improving clarity.
#### How did you do it?
Remove skip_traffic_test fixture in arp tests
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
