### PR TITLE
Remove skip_traffic_test fixture in decap tests

### DIFF
--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -21,7 +21,6 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # no
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test           # noqa F401
 from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active
 from tests.common.fixtures.fib_utils import fib_info_files                  # noqa F401
 from tests.common.fixtures.fib_utils import single_fib_for_duts             # noqa F401
@@ -193,8 +192,7 @@ def simulate_vxlan_teardown(duthosts, ptfhost, tbinfo):
 
 def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,                                   # noqa F811
                toggle_all_simulator_ports_to_random_side, supported_ttl_dscp_params, ip_ver, loopback_ips,  # noqa F811
-               duts_running_config_facts, duts_minigraph_facts, mux_status_from_nic_simulator,              # noqa F811
-               skip_traffic_test):                                                                          # noqa F811
+               duts_running_config_facts, duts_minigraph_facts, mux_status_from_nic_simulator):             # noqa F811
     setup_info = setup_teardown
     asic_type = duthosts[0].facts["asic_type"]
     ecn_mode = "copy_from_outer"
@@ -213,9 +211,6 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,       
             simulate_vxlan_teardown(duthosts, ptfhost, tbinfo)
         else:
             apply_decap_cfg(duthosts, ip_ver, loopback_ips, ttl_mode, dscp_mode, ecn_mode, 'SET')
-
-        if skip_traffic_test:
-            return
 
         if 'dualtor' in tbinfo['topo']['name']:
             wait(30, 'Wait some time for mux active/standby state to be stable after toggled mux state')

--- a/tests/decap/test_subnet_decap.py
+++ b/tests/decap/test_subnet_decap.py
@@ -9,7 +9,6 @@ import ptf.packet as packet
 import ptf.testutils as testutils
 from ptf.mask import Mask
 from tests.common.dualtor.dual_tor_utils import rand_selected_interface     # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test           # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py       # noqa F401
 from tests.common.config_reload import config_reload
 
@@ -192,23 +191,20 @@ def build_expected_vlan_subnet_packet(encapsulated_packet, ip_version, stage, de
 
 
 def verify_packet_with_expected(ptfadapter, stage, pkt, exp_pkt, send_port,
-                                recv_ports=[], recv_port=None, timeout=10, skip_traffic_test=False):    # noqa F811
-    if skip_traffic_test is True:
-        logger.info("Skip traffic test")
-        return
+                                recv_ports=[], recv_port=None, timeout=10):    # noqa F811
     ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, send_port, pkt)
     if stage == "positive":
-        testutils.verify_packet_any_port(ptfadapter, exp_pkt, recv_ports, timeout=10)
+        testutils.verify_packet_any_port(ptfadapter, exp_pkt, recv_ports, timeout=timeout)
     elif stage == "negative":
-        testutils.verify_packet(ptfadapter, exp_pkt, recv_port, timeout=10)
+        testutils.verify_packet(ptfadapter, exp_pkt, recv_port, timeout=timeout)
 
 
 @pytest.mark.parametrize("ip_version", ["IPv4", "IPv6"])
 @pytest.mark.parametrize("stage", ["positive", "negative"])
 def test_vlan_subnet_decap(request, rand_selected_dut, tbinfo, ptfhost, ptfadapter, ip_version, stage,
                            prepare_subnet_decap_config, prepare_vlan_subnet_test_port,
-                           prepare_negative_ip_port_map, setup_arp_responder, skip_traffic_test):     # noqa F811
+                           prepare_negative_ip_port_map, setup_arp_responder):     # noqa F811
     ptf_src_port, _, upstream_port_ids = prepare_vlan_subnet_test_port
 
     encapsulated_packet = build_encapsulated_vlan_subnet_packet(ptfadapter, rand_selected_dut, ip_version, stage)
@@ -221,5 +217,4 @@ def test_vlan_subnet_decap(request, rand_selected_dut, tbinfo, ptfhost, ptfadapt
         ptf_target_port = None
 
     verify_packet_with_expected(ptfadapter, stage, encapsulated_packet, exp_pkt,
-                                ptf_src_port, recv_ports=upstream_port_ids, recv_port=ptf_target_port,
-                                skip_traffic_test=skip_traffic_test)
+                                ptf_src_port, recv_ports=upstream_port_ids, recv_port=ptf_target_port)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently we are using conditional mark to add marker, then use pytest hook to redirect testutils.verify function to a function always return True to skip traffic test. With this change, the skip_traffic_test fixture is no longer needed in test cases, streamlining the test code and improving clarity.
#### How did you do it?
Remove skip_traffic_test fixture in decap tests
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
