### PR TITLE
Remove skip_traffic_test fixture in ecmp tests

### DIFF
--- a/tests/ecmp/inner_hashing/test_inner_hashing.py
+++ b/tests/ecmp/inner_hashing/test_inner_hashing.py
@@ -13,7 +13,6 @@ from retry.api import retry_call
 from tests.ptf_runner import ptf_runner
 from tests.ecmp.inner_hashing.conftest import get_src_dst_ip_range, FIB_INFO_FILE_DST,\
     VXLAN_PORT, PTF_QLEN, check_pbh_counters, OUTER_ENCAP_FORMATS, NVGRE_TNI, IP_VERSIONS_LIST, config_pbh
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test   # noqa F401
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +34,7 @@ class TestDynamicInnerHashing():
 
     def test_inner_hashing(self, request, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
                            vlan_ptf_ports, symmetric_hashing, duthost, lag_mem_ptf_ports_groups,
-                           get_function_completeness_level, skip_traffic_test):     # noqa F811
+                           get_function_completeness_level):
         logging.info("Executing dynamic inner hash test for outer {} and inner {} with symmetric_hashing set to {}"
                      .format(outer_ipver, inner_ipver, str(symmetric_hashing)))
         with allure.step('Run ptf test InnerHashTest'):
@@ -73,22 +72,22 @@ class TestDynamicInnerHashing():
                           "symmetric_hashing": symmetric_hashing}
 
             duthost.shell("sonic-clear pbh statistics")
-            if not skip_traffic_test:
-                ptf_runner(ptfhost,
-                           "ptftests",
-                           "inner_hash_test.InnerHashTest",
-                           platform_dir="ptftests",
-                           params=ptf_params,
-                           log_file=log_file,
-                           qlen=PTF_QLEN,
-                           socket_recv_size=16384,
-                           is_python3=True)
 
-                retry_call(check_pbh_counters,
-                           fargs=[duthost, outer_ipver, inner_ipver, balancing_test_times,
-                                  symmetric_hashing, hash_keys, lag_mem_ptf_ports_groups],
-                           tries=5,
-                           delay=5)
+            ptf_runner(ptfhost,
+                       "ptftests",
+                       "inner_hash_test.InnerHashTest",
+                       platform_dir="ptftests",
+                       params=ptf_params,
+                       log_file=log_file,
+                       qlen=PTF_QLEN,
+                       socket_recv_size=16384,
+                       is_python3=True)
+
+            retry_call(check_pbh_counters,
+                       fargs=[duthost, outer_ipver, inner_ipver, balancing_test_times,
+                              symmetric_hashing, hash_keys, lag_mem_ptf_ports_groups],
+                       tries=5,
+                       delay=5)
 
         if update_outer_ipver == outer_ipver and update_inner_ipver == inner_ipver:
             logging.info("Validate dynamic inner hash Edit Flow for outer {} and inner {} ip versions with"
@@ -105,8 +104,7 @@ class TestDynamicInnerHashing():
             with allure.step('Run again the ptf test InnerHashTest after updating the rules'):
                 logging.info('Run again the ptf test InnerHashTest after updating the rules')
                 duthost.shell("sonic-clear pbh statistics")
-                if skip_traffic_test is True:
-                    return
+
                 ptf_runner(ptfhost,
                            "ptftests",
                            "inner_hash_test.InnerHashTest",
@@ -128,7 +126,7 @@ class TestDynamicInnerHashing():
 class TestStaticInnerHashing():
 
     def test_inner_hashing(self, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
-                           vlan_ptf_ports, symmetric_hashing, lag_mem_ptf_ports_groups, skip_traffic_test):     # noqa F811
+                           vlan_ptf_ports, symmetric_hashing, lag_mem_ptf_ports_groups):
         logging.info("Executing static inner hash test for outer {} and inner {} with symmetric_hashing set to {}"
                      .format(outer_ipver, inner_ipver, str(symmetric_hashing)))
         timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
@@ -138,8 +136,6 @@ class TestStaticInnerHashing():
         outer_src_ip_range, outer_dst_ip_range = get_src_dst_ip_range(outer_ipver)
         inner_src_ip_range, inner_dst_ip_range = get_src_dst_ip_range(inner_ipver)
 
-        if skip_traffic_test is True:
-            return
         ptf_runner(ptfhost,
                    "ptftests",
                    "inner_hash_test.InnerHashTest",

--- a/tests/ecmp/inner_hashing/test_inner_hashing_lag.py
+++ b/tests/ecmp/inner_hashing/test_inner_hashing_lag.py
@@ -12,7 +12,6 @@ from retry.api import retry_call
 from tests.ptf_runner import ptf_runner
 from tests.ecmp.inner_hashing.conftest import get_src_dst_ip_range, FIB_INFO_FILE_DST,\
     VXLAN_PORT, PTF_QLEN, check_pbh_counters, OUTER_ENCAP_FORMATS, NVGRE_TNI, setup_lag_config, config_pbh_lag
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test   # noqa F401
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +32,7 @@ class TestDynamicInnerHashingLag():
 
     def test_inner_hashing(self, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
                            vlan_ptf_ports, symmetric_hashing, duthost, lag_mem_ptf_ports_groups,
-                           get_function_completeness_level, skip_traffic_test):     # noqa F811
+                           get_function_completeness_level):
         logging.info("Executing dynamic inner hash test for outer {} and inner {} with symmetric_hashing set to {}"
                      .format(outer_ipver, inner_ipver, str(symmetric_hashing)))
         with allure.step('Run ptf test InnerHashTest'):
@@ -54,8 +53,6 @@ class TestDynamicInnerHashingLag():
                 balancing_test_times = 20
                 balancing_range = 0.5
 
-            if skip_traffic_test is True:
-                return
             ptf_runner(ptfhost,
                        "ptftests",
                        "inner_hash_test.InnerHashTest",

--- a/tests/ecmp/inner_hashing/test_wr_inner_hashing.py
+++ b/tests/ecmp/inner_hashing/test_wr_inner_hashing.py
@@ -9,7 +9,6 @@ from tests.common import reboot
 from tests.ecmp.inner_hashing.conftest import get_src_dst_ip_range, FIB_INFO_FILE_DST, VXLAN_PORT,\
     PTF_QLEN, OUTER_ENCAP_FORMATS, NVGRE_TNI, config_pbh
 from tests.ptf_runner import ptf_runner
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test   # noqa F401
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +28,7 @@ class TestWRDynamicInnerHashing():
 
     def test_inner_hashing(self, duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
                            vlan_ptf_ports, symmetric_hashing, localhost, lag_mem_ptf_ports_groups,
-                           get_function_completeness_level, skip_traffic_test):     # noqa F811
+                           get_function_completeness_level):
         logging.info("Executing warm boot dynamic inner hash test for outer {} and inner {} with symmetric_hashing"
                      " set to {}".format(outer_ipver, inner_ipver, str(symmetric_hashing)))
         with allure.step('Run ptf test InnerHashTest and warm-reboot in parallel'):
@@ -57,52 +56,6 @@ class TestWRDynamicInnerHashing():
             reboot_thr = threading.Thread(target=reboot, args=(duthost, localhost, 'warm', 10, 0, 0, True, True,))
             reboot_thr.start()
 
-            if not skip_traffic_test:
-                ptf_runner(ptfhost,
-                           "ptftests",
-                           "inner_hash_test.InnerHashTest",
-                           platform_dir="ptftests",
-                           params={"fib_info": FIB_INFO_FILE_DST,
-                                   "router_mac": router_mac,
-                                   "src_ports": vlan_ptf_ports,
-                                   "exp_port_groups": lag_mem_ptf_ports_groups,
-                                   "hash_keys": hash_keys,
-                                   "vxlan_port": VXLAN_PORT,
-                                   "inner_src_ip_range": ",".join(inner_src_ip_range),
-                                   "inner_dst_ip_range": ",".join(inner_dst_ip_range),
-                                   "outer_src_ip_range": ",".join(outer_src_ip_range),
-                                   "outer_dst_ip_range": ",".join(outer_dst_ip_range),
-                                   "balancing_test_times": balancing_test_times,
-                                   "balancing_range": balancing_range,
-                                   "outer_encap_formats": outer_encap_format,
-                                   "nvgre_tni": NVGRE_TNI,
-                                   "symmetric_hashing": symmetric_hashing},
-                           log_file=log_file,
-                           qlen=PTF_QLEN,
-                           socket_recv_size=16384,
-                           is_python3=True)
-            reboot_thr.join()
-
-
-@pytest.mark.static_config
-class TestWRStaticInnerHashing():
-
-    def test_inner_hashing(self, duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
-                           vlan_ptf_ports, symmetric_hashing, localhost, lag_mem_ptf_ports_groups, skip_traffic_test):   # noqa F811
-        logging.info("Executing static inner hash test for outer {} and inner {} with symmetric_hashing set to {}"
-                     .format(outer_ipver, inner_ipver, str(symmetric_hashing)))
-        timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
-        log_file = "/tmp/wr_inner_hash_test.StaticInnerHashTest.{}.{}.{}.log"\
-                   .format(outer_ipver, inner_ipver, timestamp)
-        logging.info("PTF log file: %s" % log_file)
-
-        outer_src_ip_range, outer_dst_ip_range = get_src_dst_ip_range(outer_ipver)
-        inner_src_ip_range, inner_dst_ip_range = get_src_dst_ip_range(inner_ipver)
-
-        reboot_thr = threading.Thread(target=reboot, args=(duthost, localhost, 'warm', 10, 0, 0, True, True,))
-        reboot_thr.start()
-
-        if not skip_traffic_test:
             ptf_runner(ptfhost,
                        "ptftests",
                        "inner_hash_test.InnerHashTest",
@@ -117,10 +70,54 @@ class TestWRStaticInnerHashing():
                                "inner_dst_ip_range": ",".join(inner_dst_ip_range),
                                "outer_src_ip_range": ",".join(outer_src_ip_range),
                                "outer_dst_ip_range": ",".join(outer_dst_ip_range),
-                               "outer_encap_formats": OUTER_ENCAP_FORMATS,
+                               "balancing_test_times": balancing_test_times,
+                               "balancing_range": balancing_range,
+                               "outer_encap_formats": outer_encap_format,
+                               "nvgre_tni": NVGRE_TNI,
                                "symmetric_hashing": symmetric_hashing},
                        log_file=log_file,
                        qlen=PTF_QLEN,
                        socket_recv_size=16384,
                        is_python3=True)
+            reboot_thr.join()
+
+
+@pytest.mark.static_config
+class TestWRStaticInnerHashing():
+
+    def test_inner_hashing(self, duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
+                           vlan_ptf_ports, symmetric_hashing, localhost, lag_mem_ptf_ports_groups):
+        logging.info("Executing static inner hash test for outer {} and inner {} with symmetric_hashing set to {}"
+                     .format(outer_ipver, inner_ipver, str(symmetric_hashing)))
+        timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+        log_file = "/tmp/wr_inner_hash_test.StaticInnerHashTest.{}.{}.{}.log"\
+                   .format(outer_ipver, inner_ipver, timestamp)
+        logging.info("PTF log file: %s" % log_file)
+
+        outer_src_ip_range, outer_dst_ip_range = get_src_dst_ip_range(outer_ipver)
+        inner_src_ip_range, inner_dst_ip_range = get_src_dst_ip_range(inner_ipver)
+
+        reboot_thr = threading.Thread(target=reboot, args=(duthost, localhost, 'warm', 10, 0, 0, True, True,))
+        reboot_thr.start()
+
+        ptf_runner(ptfhost,
+                   "ptftests",
+                   "inner_hash_test.InnerHashTest",
+                   platform_dir="ptftests",
+                   params={"fib_info": FIB_INFO_FILE_DST,
+                           "router_mac": router_mac,
+                           "src_ports": vlan_ptf_ports,
+                           "exp_port_groups": lag_mem_ptf_ports_groups,
+                           "hash_keys": hash_keys,
+                           "vxlan_port": VXLAN_PORT,
+                           "inner_src_ip_range": ",".join(inner_src_ip_range),
+                           "inner_dst_ip_range": ",".join(inner_dst_ip_range),
+                           "outer_src_ip_range": ",".join(outer_src_ip_range),
+                           "outer_dst_ip_range": ",".join(outer_dst_ip_range),
+                           "outer_encap_formats": OUTER_ENCAP_FORMATS,
+                           "symmetric_hashing": symmetric_hashing},
+                   log_file=log_file,
+                   qlen=PTF_QLEN,
+                   socket_recv_size=16384,
+                   is_python3=True)
         reboot_thr.join()

--- a/tests/ecmp/inner_hashing/test_wr_inner_hashing_lag.py
+++ b/tests/ecmp/inner_hashing/test_wr_inner_hashing_lag.py
@@ -9,7 +9,6 @@ from tests.common import reboot
 from tests.ecmp.inner_hashing.conftest import get_src_dst_ip_range, FIB_INFO_FILE_DST, VXLAN_PORT,\
     PTF_QLEN, OUTER_ENCAP_FORMATS, NVGRE_TNI, setup_lag_config, config_pbh_lag
 from tests.ptf_runner import ptf_runner
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test   # noqa F401
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +30,7 @@ class TestWRDynamicInnerHashingLag():
 
     def test_inner_hashing(self, duthost, hash_keys, ptfhost, outer_ipver, inner_ipver, router_mac,
                            vlan_ptf_ports, symmetric_hashing, localhost, lag_mem_ptf_ports_groups,
-                           get_function_completeness_level, skip_traffic_test):     # noqa F811
+                           get_function_completeness_level):
         logging.info("Executing warm boot dynamic inner hash test for outer {} and inner {} with symmetric_hashing"
                      " set to {}".format(outer_ipver, inner_ipver, str(symmetric_hashing)))
         timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
@@ -58,28 +57,27 @@ class TestWRDynamicInnerHashingLag():
         reboot_thr = threading.Thread(target=reboot, args=(duthost, localhost, 'warm', 10, 0, 0, True, True,))
         reboot_thr.start()
 
-        if not skip_traffic_test:
-            ptf_runner(ptfhost,
-                       "ptftests",
-                       "inner_hash_test.InnerHashTest",
-                       platform_dir="ptftests",
-                       params={"fib_info": FIB_INFO_FILE_DST,
-                               "router_mac": router_mac,
-                               "src_ports": vlan_ptf_ports,
-                               "exp_port_groups": lag_mem_ptf_ports_groups,
-                               "hash_keys": hash_keys,
-                               "vxlan_port": VXLAN_PORT,
-                               "inner_src_ip_range": ",".join(inner_src_ip_range),
-                               "inner_dst_ip_range": ",".join(inner_dst_ip_range),
-                               "outer_src_ip_range": ",".join(outer_src_ip_range),
-                               "outer_dst_ip_range": ",".join(outer_dst_ip_range),
-                               "balancing_test_times": balancing_test_times,
-                               "balancing_range": balancing_range,
-                               "outer_encap_formats": outer_encap_format,
-                               "nvgre_tni": NVGRE_TNI,
-                               "symmetric_hashing": symmetric_hashing},
-                       log_file=log_file,
-                       qlen=PTF_QLEN,
-                       socket_recv_size=16384,
-                       is_python3=True)
+        ptf_runner(ptfhost,
+                   "ptftests",
+                   "inner_hash_test.InnerHashTest",
+                   platform_dir="ptftests",
+                   params={"fib_info": FIB_INFO_FILE_DST,
+                           "router_mac": router_mac,
+                           "src_ports": vlan_ptf_ports,
+                           "exp_port_groups": lag_mem_ptf_ports_groups,
+                           "hash_keys": hash_keys,
+                           "vxlan_port": VXLAN_PORT,
+                           "inner_src_ip_range": ",".join(inner_src_ip_range),
+                           "inner_dst_ip_range": ",".join(inner_dst_ip_range),
+                           "outer_src_ip_range": ",".join(outer_src_ip_range),
+                           "outer_dst_ip_range": ",".join(outer_dst_ip_range),
+                           "balancing_test_times": balancing_test_times,
+                           "balancing_range": balancing_range,
+                           "outer_encap_formats": outer_encap_format,
+                           "nvgre_tni": NVGRE_TNI,
+                           "symmetric_hashing": symmetric_hashing},
+                   log_file=log_file,
+                   qlen=PTF_QLEN,
+                   socket_recv_size=16384,
+                   is_python3=True)
         reboot_thr.join()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently we are using conditional mark to add marker, then use pytest hook to redirect testutils.verify function to a function always return True to skip traffic test. With this change, the skip_traffic_test fixture is no longer needed in test cases, streamlining the test code and improving clarity.
#### How did you do it?
Remove skip_traffic_test fixture in ecmp tests
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
