### PR TITLE
Remove skip_traffic_test fixture in everflow tests

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -753,8 +753,7 @@ class BaseEverflowTest(object):
                                       src_port=None,
                                       dest_ports=None,
                                       expect_recv=True,
-                                      valid_across_namespace=True,
-                                      skip_traffic_test=False):
+                                      valid_across_namespace=True):
 
         # In Below logic idea is to send traffic in such a way so that mirror traffic
         # will need to go across namespaces and within namespace. If source and mirror destination
@@ -789,9 +788,6 @@ class BaseEverflowTest(object):
                 src_port_set.add(dest_ports[0])
                 src_port_metadata_map[dest_ports[0]] = (None, 2)
 
-        if skip_traffic_test is True:
-            logging.info("Skipping traffic test")
-            return
         # Loop through Source Port Set and send traffic on each source port of the set
         for src_port in src_port_set:
             expected_mirror_packet = BaseEverflowTest.get_expected_mirror_packet(mirror_session,

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -806,10 +806,15 @@ class BaseEverflowTest(object):
 
             if expect_recv:
                 time.sleep(STABILITY_BUFFER)
-                _, received_packet = testutils.verify_packet_any_port(ptfadapter,
-                                                                      expected_mirror_packet,
-                                                                      ports=dest_ports)
+                result = testutils.verify_packet_any_port(ptfadapter,
+                                                          expected_mirror_packet,
+                                                          ports=dest_ports)
 
+                if isinstance(result, bool):
+                    logging.info("Using dummy testutils to skip traffic test, skip following checks")
+                    return
+
+                _, received_packet = result
                 logging.info("Received packet: %s", packet.Ether(received_packet).summary())
 
                 inner_packet = self._extract_mirror_payload(received_packet, len(mirror_packet_sent))

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -13,7 +13,6 @@ import random
 # Module-level fixtures
 from .everflow_test_utilities import setup_info      # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor      # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa: F401
 
 pytestmark = [
     pytest.mark.topology("t0", "t1", "t2", "m0")
@@ -155,8 +154,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_src_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
                                 setup_standby_ports_on_rand_unselected_tor_unconditionally,             # noqa F811
-                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
-                                skip_traffic_test):     # noqa F811
+                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):   # noqa F811
         """Verify that we can match on Source IPv6 addresses."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -170,13 +168,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_dst_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
                                 setup_standby_ports_on_rand_unselected_tor_unconditionally,             # noqa F811
-                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
-                                skip_traffic_test):     # noqa F811
+                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):   # noqa F811
         """Verify that we can match on Destination IPv6 addresses."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -190,13 +186,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_next_header_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
                                    setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                                   skip_traffic_test):      # noqa F811
+                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):    # noqa F811
         """Verify that we can match on the Next Header field."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, next_header=0x7E)
 
@@ -205,13 +199,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_src_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
                                    setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                                   skip_traffic_test):      # noqa F811
+                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):    # noqa F811
         """Verify that we can match on the L4 Source Port."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, sport=9000)
 
@@ -220,13 +212,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_dst_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
                                    setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                                   skip_traffic_test):      # noqa F811
+                                   everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):    # noqa F811
         """Verify that we can match on the L4 Destination Port."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, dport=9001)
 
@@ -235,14 +225,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_src_port_range_mirroring(self, setup_info, setup_mirror_session,                # noqa F811
                                          ptfadapter, everflow_dut, everflow_direction,
                                          setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                                         toggle_all_simulator_ports_to_rand_selected_tor,       # noqa F811
-                                         skip_traffic_test):    # noqa F811
+                                         toggle_all_simulator_ports_to_rand_selected_tor):      # noqa F811
         """Verify that we can match on a range of L4 Source Ports."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, sport=10200)
 
@@ -251,14 +239,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_dst_port_range_mirroring(self, setup_info, setup_mirror_session,                # noqa F811
                                          ptfadapter, everflow_dut, everflow_direction,
                                          setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                                         toggle_all_simulator_ports_to_rand_selected_tor,       # noqa F811
-                                         skip_traffic_test):    # noqa F811
+                                         toggle_all_simulator_ports_to_rand_selected_tor):      # noqa F811
         """Verify that we can match on a range of L4 Destination Ports."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, dport=10700)
 
@@ -267,13 +253,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_tcp_flags_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,          # noqa F811
                                  setup_standby_ports_on_rand_unselected_tor_unconditionally,                # noqa F811
-                                 everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,       # noqa F811
-                                 skip_traffic_test):        # noqa F811
+                                 everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):      # noqa F811
         """Verify that we can match on TCP Flags."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, flags=0x1B)
 
@@ -282,13 +266,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_dscp_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,               # noqa F811
                             setup_standby_ports_on_rand_unselected_tor_unconditionally,                     # noqa F811
-                            everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,            # noqa F811
-                            skip_traffic_test):             # noqa F811
+                            everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):           # noqa F811
         """Verify that we can match on DSCP."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, dscp=37)
 
@@ -297,13 +279,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_l4_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,           # noqa F811
                                 setup_standby_ports_on_rand_unselected_tor_unconditionally,                 # noqa F811
-                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,        # noqa F811
-                                skip_traffic_test):         # noqa F811
+                                everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):       # noqa F811
         """Verify that we can match from a source port to a range of destination ports and vice-versa."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -320,8 +300,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -338,13 +317,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_tcp_response_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
                                     setup_standby_ports_on_rand_unselected_tor_unconditionally,             # noqa F811
-                                    everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
-                                    skip_traffic_test):     # noqa F811
+                                    everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):   # noqa F811
         """Verify that we can match a SYN -> SYN-ACK pattern."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -360,8 +337,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -377,14 +353,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_tcp_application_mirroring(self, setup_info, setup_mirror_session,              # noqa F811
                                        ptfadapter, everflow_dut, everflow_direction,
                                        setup_standby_ports_on_rand_unselected_tor_unconditionally,                 # noqa F811
-                                       toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                                       skip_traffic_test):   # noqa F811
+                                       toggle_all_simulator_ports_to_rand_selected_tor):    # noqa F811
         """Verify that we can match a TCP handshake between a client and server."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -402,8 +376,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -421,14 +394,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_udp_application_mirroring(self, setup_info, setup_mirror_session,              # noqa F811
                                        ptfadapter, everflow_dut, everflow_direction,
                                        setup_standby_ports_on_rand_unselected_tor_unconditionally,                 # noqa F811
-                                       toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                                       skip_traffic_test):  # noqa F811
+                                       toggle_all_simulator_ports_to_rand_selected_tor):    # noqa F811
         """Verify that we can match UDP traffic between a client and server application."""
         test_packet = self._base_udpv6_packet(
             everflow_direction,
@@ -446,8 +417,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
         test_packet = self._base_udpv6_packet(
             everflow_direction,
             ptfadapter,
@@ -464,13 +434,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_any_protocol(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,         # noqa F811
                           setup_standby_ports_on_rand_unselected_tor_unconditionally,               # noqa F811
-                          everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
-                          skip_traffic_test):       # noqa F811
+                          everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):     # noqa F811
         """Verify that the protocol number is ignored if it is not specified in the ACL rule."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -485,8 +453,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
         test_packet = self._base_udpv6_packet(
             everflow_direction,
@@ -501,8 +468,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
         test_packet = self._base_udpv6_packet(
             everflow_direction,
@@ -518,14 +484,12 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_any_transport_protocol(self, setup_info, setup_mirror_session,                 # noqa F811
                                     ptfadapter, everflow_dut, everflow_direction,
                                     setup_standby_ports_on_rand_unselected_tor_unconditionally,                 # noqa F811
-                                    toggle_all_simulator_ports_to_rand_selected_tor,        # noqa F811
-                                    skip_traffic_test):     # noqa F811
+                                    toggle_all_simulator_ports_to_rand_selected_tor):       # noqa F811
         """Verify that src port and dst port rules match regardless of whether TCP or UDP traffic is sent."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -542,8 +506,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
         test_packet = self._base_udpv6_packet(
             everflow_direction,
@@ -560,13 +523,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_invalid_tcp_rule(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,         # noqa F811
                               setup_standby_ports_on_rand_unselected_tor_unconditionally,               # noqa F811
-                              everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
-                              skip_traffic_test):       # noqa F811
+                              everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):     # noqa F811
         """Verify that the ASIC does not reject rules with TCP flags if the protocol is not TCP."""
         pass
 
@@ -577,8 +538,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     def test_source_subnet(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,            # noqa F811
                            setup_standby_ports_on_rand_unselected_tor_unconditionally,                  # noqa F811
-                           everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,         # noqa F811
-                           skip_traffic_test):          # noqa F811
+                           everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):        # noqa F811
         """Verify that we can match packets with a Source IPv6 Subnet."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -595,13 +555,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_dest_subnet(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,          # noqa F811
                          setup_standby_ports_on_rand_unselected_tor_unconditionally,                # noqa F811
-                         everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,       # noqa F811
-                         skip_traffic_test):            # noqa F811
+                         everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):      # noqa F811
         """Verify that we can match packets with a Destination IPv6 Subnet."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -618,13 +576,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_both_subnets(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,         # noqa F811
                           setup_standby_ports_on_rand_unselected_tor_unconditionally,               # noqa F811
-                          everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
-                          skip_traffic_test):           # noqa F811
+                          everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):     # noqa F811
         """Verify that we can match packets with both source and destination subnets."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -641,13 +597,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def test_fuzzy_subnets(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
                            setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
-                           everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                           skip_traffic_test):          # noqa F811
+                           everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):    # noqa F811
         """Verify that we can match packets with non-standard subnet sizes."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -664,8 +618,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            ptfadapter,
                                            everflow_dut,
                                            test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
-                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
-                                           skip_traffic_test=skip_traffic_test)
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids)
 
     def _base_tcpv6_packet(self,
                            direction,

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -13,7 +13,6 @@ from tests.common.helpers.assertions import pytest_require
 
 from .everflow_test_utilities import setup_info, EVERFLOW_DSCP_RULES    # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa: F401
 
 pytestmark = [
     pytest.mark.topology("any")
@@ -181,8 +180,7 @@ def send_and_verify_packet(ptfadapter, packet, expected_packet, tx_port, rx_port
 
 
 def test_everflow_per_interface(ptfadapter, setup_info, apply_acl_rule, tbinfo,                 # noqa F811
-                                toggle_all_simulator_ports_to_rand_selected_tor, ip_ver,        # noqa F811
-                                skip_traffic_test):                                             # noqa F811
+                                toggle_all_simulator_ports_to_rand_selected_tor, ip_ver):       # noqa F811
     """Verify packet ingress from candidate ports are captured by EVERFLOW, while packets
     ingress from unselected ports are not captured
     """
@@ -191,9 +189,6 @@ def test_everflow_per_interface(ptfadapter, setup_info, apply_acl_rule, tbinfo, 
                                                  everflow_config['mirror_session_info'],
                                                  setup_info[UP_STREAM]['ingress_router_mac'], setup_info, ip_ver)
     uplink_ports = everflow_config["monitor_port_ptf_ids"]
-
-    if skip_traffic_test:
-        return
 
     # Verify that packet ingressed from INPUT_PORTS (candidate ports) are mirrored
     for port, ptf_idx in list(everflow_config['candidate_ports'].items()):

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -15,7 +15,6 @@ from .everflow_test_utilities import TARGET_SERVER_IP, BaseEverflowTest, DOWN_ST
 # Module-level fixtures
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                 # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_acstests_directory                                 # noqa: F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test                                       # noqa: F401
 from .everflow_test_utilities import setup_info, setup_arp_responder, EVERFLOW_DSCP_RULES               # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py                                   # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
@@ -135,8 +134,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
     def test_everflow_basic_forwarding(self, setup_info, setup_mirror_session,              # noqa F811
                                        dest_port_type, ptfadapter, tbinfo,
                                        toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
-                                       setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
-                                       skip_traffic_test):    # noqa F811
+                                       setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa F811
         """
         Verify basic forwarding scenarios for the Everflow feature.
 
@@ -170,8 +168,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             [tx_port_ptf_id],
-            dest_port_type,
-            skip_traffic_test=skip_traffic_test
+            dest_port_type
         )
 
         # Add a (better) unresolved route to the mirror session destination IP
@@ -188,8 +185,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             [tx_port_ptf_id],
-            dest_port_type,
-            skip_traffic_test=skip_traffic_test
+            dest_port_type
         )
 
         # Remove the unresolved route
@@ -212,8 +208,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             [tx_port_ptf_id],
-            dest_port_type,
-            skip_traffic_test=skip_traffic_test
+            dest_port_type
         )
 
         # Remove the better route.
@@ -230,8 +225,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             [tx_port_ptf_id],
-            dest_port_type,
-            skip_traffic_test=skip_traffic_test
+            dest_port_type
         )
 
         remote_dut.shell(remote_dut.get_vtysh_cmd_for_namespace(
@@ -241,8 +235,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
     def test_everflow_neighbor_mac_change(self, setup_info, setup_mirror_session,               # noqa F811
                                           dest_port_type, ptfadapter, tbinfo,
                                           toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
-                                          setup_standby_ports_on_rand_unselected_tor_unconditionally,   # noqa F811
-                                          skip_traffic_test):    # noqa F811
+                                          setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa F811
         """Verify that session destination MAC address is changed after neighbor MAC address update."""
 
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
@@ -265,8 +258,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             [tx_port_ptf_id],
-            dest_port_type,
-            skip_traffic_test=skip_traffic_test
+            dest_port_type
         )
 
         # Update the MAC on the neighbor interface for the route we installed
@@ -286,8 +278,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                 everflow_dut,
                 rx_port_ptf_id,
                 [tx_port_ptf_id],
-                dest_port_type,
-                skip_traffic_test=skip_traffic_test
+                dest_port_type
             )
 
         finally:
@@ -308,15 +299,13 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             [tx_port_ptf_id],
-            dest_port_type,
-            skip_traffic_test=skip_traffic_test
+            dest_port_type
         )
 
     def test_everflow_remove_unused_ecmp_next_hop(self, setup_info, setup_mirror_session,               # noqa F811
                                                   dest_port_type, ptfadapter, tbinfo,
                                                   toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
-                                                  setup_standby_ports_on_rand_unselected_tor_unconditionally,   # noqa F811
-                                                  skip_traffic_test):    # noqa F811
+                                                  setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa F811
         """Verify that session is still active after removal of next hop from ECMP route that was not in use."""
 
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
@@ -348,8 +337,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             tx_port_ptf_ids,
-            dest_port_type,
-            skip_traffic_test=skip_traffic_test
+            dest_port_type
         )
 
         # Remaining Scenario not applicable for this topology
@@ -374,8 +362,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             [tx_port_ptf_id],
             dest_port_type,
             expect_recv=False,
-            valid_across_namespace=False,
-            skip_traffic_test=skip_traffic_test
+            valid_across_namespace=False
         )
 
         # Remove the extra hop
@@ -393,8 +380,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             [tx_port_ptf_id],
             dest_port_type,
             expect_recv=False,
-            valid_across_namespace=False,
-            skip_traffic_test=skip_traffic_test
+            valid_across_namespace=False
         )
 
         # Verify that mirrored traffic is still sent to one of the original next hops
@@ -405,15 +391,13 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             tx_port_ptf_ids,
-            dest_port_type,
-            skip_traffic_test=skip_traffic_test
+            dest_port_type
         )
 
     def test_everflow_remove_used_ecmp_next_hop(self, setup_info, setup_mirror_session,                 # noqa F811
                                                 dest_port_type, ptfadapter, tbinfo,
                                                 toggle_all_simulator_ports_to_rand_selected_tor,        # noqa F811
-                                                setup_standby_ports_on_rand_unselected_tor_unconditionally,     # noqa F811
-                                                skip_traffic_test):    # noqa F811
+                                                setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa F811
         """Verify that session is still active after removal of next hop from ECMP route that was in use."""
 
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
@@ -444,8 +428,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             [tx_port_ptf_id],
-            dest_port_type,
-            skip_traffic_test=skip_traffic_test
+            dest_port_type
         )
 
         # Add two new ECMP next hops
@@ -469,8 +452,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             rx_port_ptf_id,
             [tx_port_ptf_id],
             dest_port_type,
-            valid_across_namespace=False,
-            skip_traffic_test=skip_traffic_test
+            valid_across_namespace=False
         )
 
         # Verify that traffic is not sent along either of the new next hops
@@ -487,8 +469,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             tx_port_ptf_ids,
             dest_port_type,
             expect_recv=False,
-            valid_across_namespace=False,
-            skip_traffic_test=skip_traffic_test
+            valid_across_namespace=False
         )
 
         # Remove the original next hop
@@ -505,8 +486,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             rx_port_ptf_id,
             [tx_port_ptf_id],
             dest_port_type,
-            expect_recv=False,
-            skip_traffic_test=skip_traffic_test
+            expect_recv=False
         )
 
         # Verify that mirrored traffis is now sent along either of the new next hops
@@ -517,8 +497,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             everflow_dut,
             rx_port_ptf_id,
             tx_port_ptf_ids,
-            dest_port_type,
-            skip_traffic_test=skip_traffic_test
+            dest_port_type
         )
 
     def test_everflow_dscp_with_policer(
@@ -530,8 +509,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             config_method,
             tbinfo,
             toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
-            setup_standby_ports_on_rand_unselected_tor_unconditionally,    # noqa F811
-            skip_traffic_test                                   # noqa F811
+            setup_standby_ports_on_rand_unselected_tor_unconditionally  # noqa F811
     ):
         """Verify that we can rate-limit mirrored traffic from the MIRROR_DSCP table.
         This tests single rate three color policer mode and specifically checks CIR value
@@ -617,9 +595,6 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                        config_method,
                                        rules=EVERFLOW_DSCP_RULES)
 
-            if skip_traffic_test is True:
-                return
-
             # Run test with expected CIR/CBS in packets/sec and tolerance %
             partial_ptf_runner(setup_info,
                                dest_port_type,
@@ -635,8 +610,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                cir=rate_limit,
                                cbs=rate_limit,
                                send_time=send_time,
-                               tolerance=everflow_tolerance,
-                               skip_traffic_test=skip_traffic_test)
+                               tolerance=everflow_tolerance)
         finally:
             # Clean up ACL rules and routes
             BaseEverflowTest.remove_acl_rule_config(everflow_dut, table_name, config_method)
@@ -651,8 +625,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
     def test_everflow_frwd_with_bkg_trf(self,
                                         setup_info,  # noqa F811
                                         setup_mirror_session,
-                                        dest_port_type, ptfadapter, tbinfo,
-                                        skip_traffic_test  # noqa F811
+                                        dest_port_type, ptfadapter, tbinfo
                                         ):
         """
         Verify basic forwarding scenarios for the Everflow feature with background traffic.
@@ -743,8 +716,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                 everflow_dut,
                 rx_port_ptf_id,
                 [tx_port_ptf_id],
-                dest_port_type,
-                skip_traffic_test=skip_traffic_test
+                dest_port_type
             )
 
             # Add a (better) unresolved route to the mirror session destination IP
@@ -762,8 +734,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                 everflow_dut,
                 rx_port_ptf_id,
                 [tx_port_ptf_id],
-                dest_port_type,
-                skip_traffic_test=skip_traffic_test
+                dest_port_type
             )
 
             # Remove the unresolved route
@@ -786,8 +757,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                 everflow_dut,
                 rx_port_ptf_id,
                 [tx_port_ptf_id],
-                dest_port_type,
-                skip_traffic_test=skip_traffic_test
+                dest_port_type
             )
 
             # Remove the better route.
@@ -804,8 +774,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                 everflow_dut,
                 rx_port_ptf_id,
                 [tx_port_ptf_id],
-                dest_port_type,
-                skip_traffic_test=skip_traffic_test
+                dest_port_type
             )
 
             remote_dut.shell(remote_dut.get_vtysh_cmd_for_namespace(
@@ -820,8 +789,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             background_traffic(run_count=1)
 
     def _run_everflow_test_scenarios(self, ptfadapter, setup, mirror_session, duthost, rx_port,
-                                     tx_ports, direction, expect_recv=True, valid_across_namespace=True,
-                                     skip_traffic_test=False):      # noqa F811
+                                     tx_ports, direction, expect_recv=True, valid_across_namespace=True):
         # FIXME: In the ptf_runner version of these tests, LAGs were passed down to the tests
         # as comma-separated strings of LAG member port IDs (e.g. portchannel0001 -> "2,3").
         # Because the DSCP test is still using ptf_runner we will preserve this for now,
@@ -859,8 +827,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                 src_port=rx_port,
                 dest_ports=tx_port_ids,
                 expect_recv=expect_recv,
-                valid_across_namespace=valid_across_namespace,
-                skip_traffic_test=skip_traffic_test,
+                valid_across_namespace=valid_across_namespace
             )
 
     def _base_tcp_packet(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently we are using conditional mark to add marker, then use pytest hook to redirect testutils.verify function to a function always return True to skip traffic test. With this change, the skip_traffic_test fixture is no longer needed in test cases, streamlining the test code and improving clarity.
#### How did you do it?
Remove skip_traffic_test fixture in everflow tests
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
