### PR TITLE
Remove skip_traffic_test fixture in fib tests

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -10,7 +10,6 @@ from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # no
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa F401
 from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active, ptf_test_port_map
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test           # noqa F401
 
 from tests.ptf_runner import ptf_runner
 from tests.common.dualtor.mux_simulator_control import mux_server_url       # noqa F401
@@ -84,8 +83,7 @@ def test_basic_fib(duthosts, ptfhost, ipv4, ipv6, mtu,
                    mux_status_from_nic_simulator,
                    ignore_ttl, single_fib_for_duts,                     # noqa F401
                    duts_running_config_facts, duts_minigraph_facts,
-                   validate_active_active_dualtor_setup,                # noqa F401
-                   skip_traffic_test):                                  # noqa F811
+                   validate_active_active_dualtor_setup):               # noqa F811
 
     if 'dualtor' in updated_tbinfo['topo']['name']:
         wait(30, 'Wait some time for mux active/standby state to be stable after toggled mux state')
@@ -105,8 +103,6 @@ def test_basic_fib(duthosts, ptfhost, ipv4, ipv6, mtu,
     log_file = "/tmp/fib_test.FibTest.ipv4.{}.ipv6.{}.{}.log".format(
         ipv4, ipv6, timestamp)
     logging.info("PTF log file: %s" % log_file)
-    if skip_traffic_test is True:
-        return
     ptf_runner(
         ptfhost,
         "ptftests",
@@ -319,7 +315,7 @@ def test_hash(add_default_route_to_dut, duthosts, fib_info_files_per_function, s
               hash_keys, ptfhost, ipver, toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa F811
               updated_tbinfo, mux_server_url, mux_status_from_nic_simulator, ignore_ttl,        # noqa F811
               single_fib_for_duts, duts_running_config_facts, duts_minigraph_facts,             # noqa F811
-              setup_active_active_ports, active_active_ports, skip_traffic_test):               # noqa F811
+              setup_active_active_ports, active_active_ports):                                  # noqa F811
 
     if 'dualtor' in updated_tbinfo['topo']['name']:
         wait(30, 'Wait some time for mux active/standby state to be stable after toggled mux state')
@@ -335,8 +331,6 @@ def test_hash(add_default_route_to_dut, duthosts, fib_info_files_per_function, s
     else:
         src_ip_range = SRC_IPV6_RANGE
         dst_ip_range = DST_IPV6_RANGE
-    if skip_traffic_test is True:
-        return
     ptf_runner(
         ptfhost,
         "ptftests",
@@ -371,7 +365,7 @@ def test_hash(add_default_route_to_dut, duthosts, fib_info_files_per_function, s
 def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files_per_function,  # noqa F811
                      hash_keys, ptfhost, ipver, tbinfo, mux_server_url,             # noqa F811
                      ignore_ttl, single_fib_for_duts, duts_running_config_facts,    # noqa F811
-                     duts_minigraph_facts, skip_traffic_test):                      # noqa F811
+                     duts_minigraph_facts):                                         # noqa F811
     # Skip test on none T1 testbed
     pytest_require('t1' == tbinfo['topo']['type'],
                    "The test case runs on T1 topology")
@@ -385,8 +379,6 @@ def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files
     else:
         src_ip_range = SRC_IPV6_RANGE
         dst_ip_range = DST_IPV6_RANGE
-    if skip_traffic_test is True:
-        return
     ptf_runner(ptfhost,
                "ptftests",
                "hash_test.IPinIPHashTest",
@@ -413,8 +405,7 @@ def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files
 
 def test_ipinip_hash_negative(add_default_route_to_dut, duthosts, fib_info_files_per_function,          # noqa F811
                               ptfhost, ipver, tbinfo, mux_server_url, ignore_ttl, single_fib_for_duts,  # noqa F811
-                              duts_running_config_facts, duts_minigraph_facts, mux_status_from_nic_simulator,
-                              skip_traffic_test):                                                       # noqa F811
+                              duts_running_config_facts, duts_minigraph_facts, mux_status_from_nic_simulator):
     hash_keys = ['inner_length']
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     log_file = "/tmp/hash_test.IPinIPHashTest.{}.{}.log".format(
@@ -426,8 +417,6 @@ def test_ipinip_hash_negative(add_default_route_to_dut, duthosts, fib_info_files
     else:
         src_ip_range = SRC_IPV6_RANGE
         dst_ip_range = DST_IPV6_RANGE
-    if skip_traffic_test is True:
-        return
     ptf_runner(ptfhost,
                "ptftests",
                "hash_test.IPinIPHashTest",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently we are using conditional mark to add marker, then use pytest hook to redirect testutils.verify function to a function always return True to skip traffic test. With this change, the skip_traffic_test fixture is no longer needed in test cases, streamlining the test code and improving clarity.
#### How did you do it?
Remove skip_traffic_test fixture in fib tests
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
