### PR TITLE
Skip chassis watchdog API test for unsupported S6000 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -663,7 +663,7 @@ platform_tests/api/test_watchdog.py:
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['barefoot'] and hwsku in ['newport', 'montara'] or ('sw_to3200k' in hwsku)"
-      - "platform in ['x86_64-nokia_ixr7250e_sup-r0', 'x86_64-nokia_ixr7250e_36x400g-r0']"
+      - "platform in ['x86_64-nokia_ixr7250e_sup-r0', 'x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-dell_s6000_s1220-r0']"
 
 #######################################
 #####           broadcom          #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -68,6 +68,7 @@ platform_tests/api/test_chassis.py::TestChassisApi::test_get_watchdog:
     conditions:
       - "asic_type in ['barefoot'] and hwsku in ['newport']"
       - "'sw_to3200k' in hwsku"
+      - "'Force10-S6000' in hwsku"
 
 platform_tests/api/test_chassis.py::TestChassisApi::test_status_led:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

This PR adds a conditional mark to skip the get_watchdog chassis API and test_watchdog API tests for the unsupported S6000 HWSKU.

Summary:
Fixes Microsoft ADO: 29921065

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
get_watchdog() is unsupported on the S6000 HWSKU and therefore is not a valid test.

#### How did you do it?
Added a conditional mark to skip the test for S6000 platform.

#### How did you verify/test it?
Added the conditional mark and ran the sonic-mgmt test, and verified that it was skipped:

```
collected 1 item

platform_tests/api/test_chassis.py::TestChassisApi::test_get_watchdog[sonic-s6000-device] SKIPPED (Unsupported platform API)                                                       [100%]

=================================================================================== warnings summary ===================================================================================
../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/var/src/sonic-mgmt-int/tests/platform_tests/api/test_chassis.py::TestChassisApi::test_get_watchdog.xml -------------

-------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------
09:41:55 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
=============================================================================== short test summary info ================================================================================
SKIPPED [1] platform_tests/api/test_chassis.py: Unsupported platform API
============================================================================ 1 skipped, 1 warning in 49.67s ============================================================================
INFO:root:Can not get Allure report URL. Please check logs

```

API tests:

```
----------------------------------------------------------------------------------------------------- live log sessionfinish -----------------------------------------------------------------------------------------------------
20:09:11 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
==================================================================================================== short test summary info =====================================================================================================
SKIPPED [1] platform_tests/api/test_watchdog.py:94: Unsupported platform API
SKIPPED [1] platform_tests/api/test_watchdog.py:141: Unsupported platform API
SKIPPED [1] platform_tests/api/test_watchdog.py:170: Unsupported platform API
SKIPPED [1] platform_tests/api/test_watchdog.py:192: Unsupported platform API
SKIPPED [1] platform_tests/api/test_watchdog.py:214: Unsupported platform API
SKIPPED [1] platform_tests/api/test_watchdog.py:237: Unsupported platform API
SKIPPED [1] platform_tests/api/test_watchdog.py:251: Unsupported platform API
=========================================================================================== 7 skipped, 3 warnings in 78.09s (0:01:18) ============================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_arm_negative_timeout[str-s6000-acs-10]>

```

#### Any platform specific information?
Only applies to S6000 platforms.
