### PR TITLE
[T2:multidut]: Change reboot to reboot-fixture in pfcwd_basic.

### DIFF
--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -9,30 +9,34 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     get_snappi_ports                                         # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list                         # noqa F401
-from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED   # noqa: F401
 from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_pfc_test
-from tests.common.reboot import reboot
-from tests.common.utilities import wait_until
 import logging
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.snappi_tests.files.helper import skip_warm_reboot
+from tests.snappi_tests.files.helper import reboot_duts, setup_ports_and_dut, multidut_port_info  # noqa: F401
 logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
+@pytest.fixture(autouse=True)
+def number_of_tx_rx_ports():
+    yield (1, 1)
+
+
 def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
                                      conn_graph_facts,          # noqa: F811
                                      fanout_graph_facts_multidut,        # noqa: F811
                                      duthosts,
                                      enum_dut_lossy_prio,
-                                     prio_dscp_map,                   # noqa: F811
-                                     lossy_prio_list,              # noqa: F811
-                                     all_prio_list,                   # noqa: F811
-                                     get_snappi_ports,             # noqa: F811
-                                     tbinfo,           # noqa: F811
-                                     multidut_port_info):        # noqa: F811
+                                     prio_dscp_map,             # noqa: F811
+                                     lossy_prio_list,           # noqa: F811
+                                     all_prio_list,             # noqa: F811
+                                     lossless_prio_list,        # noqa: F811
+                                     get_snappi_ports,          # noqa: F811
+                                     tbinfo,                    # noqa: F811
+                                     setup_ports_and_dut        # noqa: F811
+                                     ):
     """
     Test if PFC will impact a single lossy priority in multidut setup
 
@@ -51,31 +55,7 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
-
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
     _, lossy_prio = enum_dut_lossy_prio.split('|')
     lossy_prio = int(lossy_prio)
@@ -99,10 +79,8 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
                  snappi_extra_params=snappi_extra_params)
-    cleanup_config(duthosts, snappi_ports)
 
 
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
                                     conn_graph_facts,       # noqa: F811
                                     fanout_graph_facts_multidut,     # noqa: F811
@@ -112,14 +90,14 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
                                     lossless_prio_list,              # noqa: F811
                                     get_snappi_ports,         # noqa: F811
                                     tbinfo,                # noqa: F811
-                                    multidut_port_info):                 # noqa: F811
+                                    setup_ports_and_dut):                 # noqa: F811
     """
     Test if PFC will impact multiple lossy priorities in multidut setup
 
     Args:
         snappi_api (pytest fixture): SNAPPI session
         conn_graph_facts (pytest fixture): connection graph
-        fanout_graph_facts (pytest fixture): fanout graph
+        fanout_graph_facts_multidut (pytest fixture): fanout graph
         duthosts (pytest fixture): list of DUTs
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
         lossless_prio_list (pytest fixture): list of all the lossless priorities
@@ -129,31 +107,7 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
-
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
     pause_prio_list = lossy_prio_list
     test_prio_list = lossy_prio_list
@@ -174,35 +128,33 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
                  snappi_extra_params=snappi_extra_params)
-    cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
-@pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
                                             conn_graph_facts,       # noqa: F811
                                             fanout_graph_facts_multidut,     # noqa: F811
                                             duthosts,
                                             localhost,
-                                            enum_dut_lossy_prio_with_completeness_level,
-                                            prio_dscp_map,                   # noqa: F811
-                                            lossy_prio_list,              # noqa: F811
-                                            all_prio_list,                   # noqa: F811
-                                            get_snappi_ports,         # noqa: F811
+                                            enum_dut_lossy_prio,
+                                            prio_dscp_map,          # noqa: F811
+                                            lossy_prio_list,        # noqa: F811
+                                            all_prio_list,          # noqa: F811
+                                            lossless_prio_list,     # noqa: F811
+                                            get_snappi_ports,       # noqa: F811
                                             tbinfo,                 # noqa: F811
-                                            reboot_type,
-                                            multidut_port_info):
+                                            setup_ports_and_dut,    # noqa: F811
+                                            reboot_duts):           # noqa: F811
     """
     Test if PFC will impact a single lossy priority after various kinds of reboots in multidut setup
 
     Args:
         snappi_api (pytest fixture): SNAPPI session
         conn_graph_facts (pytest fixture): connection graph
-        fanout_graph_facts (pytest fixture): fanout graph
+        fanout_graph_facts_multidut (pytest fixture): fanout graph
         duthosts (pytest fixture): list of DUTs
         localhost (pytest fixture): localhost handle
-        enum_dut_lossy_prio_with_completeness_level (str): lossy priority to test, e.g., 's6100-1|2'
+        enum_dut_lossy_prio (str): name of lossy priority to test, e.g., 's6100-1|2'
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
         lossy_prio_list (pytest fixture): list of all the lossy priorities
         all_prio_list (pytest fixture): list of all the priorities
@@ -212,47 +164,14 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
-
-    skip_warm_reboot(snappi_ports[0]['duthost'], reboot_type)
-    skip_warm_reboot(snappi_ports[1]['duthost'], reboot_type)
-
-    _, lossy_prio = enum_dut_lossy_prio_with_completeness_level.split('|')
+    _, lossy_prio = enum_dut_lossy_prio.split('|')
     lossy_prio = int(lossy_prio)
     pause_prio_list = [lossy_prio]
     test_prio_list = [lossy_prio]
     bg_prio_list = [p for p in all_prio_list]
     bg_prio_list.remove(lossy_prio)
-
-    for duthost in set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]):
-        logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-        reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
-        logger.info("Wait until the system is stable")
-        wait_until(180, 20, 0, duthost.critical_services_fully_started)
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
@@ -269,24 +188,21 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
                  snappi_extra_params=snappi_extra_params)
-    cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
-@pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
                                            conn_graph_facts,    # noqa: F811
                                            fanout_graph_facts_multidut,  # noqa: F811
                                            duthosts,
                                            localhost,
-                                           prio_dscp_map,       # noqa: F811
-                                           lossy_prio_list,     # noqa: F811
-                                           lossless_prio_list,  # noqa: F811
+                                           prio_dscp_map,        # noqa: F811
+                                           lossy_prio_list,      # noqa: F811
+                                           lossless_prio_list,   # noqa: F811
                                            get_snappi_ports,     # noqa: F811
-                                           tbinfo,              # noqa: F811
-                                           reboot_type,
-                                           multidut_port_info):
+                                           tbinfo,               # noqa: F811
+                                           setup_ports_and_dut,  # noqa: F811
+                                           reboot_duts):         # noqa: F811
     """
     Test if PFC will impact multiple lossy priorities after various kinds of reboots
 
@@ -294,7 +210,7 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
         snappi_api (pytest fixture): SNAPPI session
         snappi_testbed_config (pytest fixture): testbed configuration information
         conn_graph_facts (pytest fixture): connection graph
-        fanout_graph_facts (pytest fixture): fanout graph
+        fanout_graph_facts_multidut (pytest fixture): fanout graph
         localhost (pytest fixture): localhost handle
         duthosts (pytest fixture): list of DUTs
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
@@ -306,43 +222,11 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
-
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
-    skip_warm_reboot(snappi_ports[0]['duthost'], reboot_type)
-    skip_warm_reboot(snappi_ports[1]['duthost'], reboot_type)
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
     pause_prio_list = lossy_prio_list
     test_prio_list = lossy_prio_list
     bg_prio_list = lossless_prio_list
-
-    for duthost in set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]):
-        logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-        reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
-        logger.info("Wait until the system is stable")
-        wait_until(180, 20, 0, duthost.critical_services_fully_started)
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
@@ -359,4 +243,3 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
                  snappi_extra_params=snappi_extra_params)
-    cleanup_config(duthosts, snappi_ports)

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
@@ -11,28 +11,36 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     get_snappi_ports_multi_dut, is_snappi_multidut, \
     snappi_api, snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config      # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list      # noqa F401
-from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED    # noqa: F401
 from tests.common.reboot import reboot                              # noqa: F401
 from tests.common.utilities import wait_until                       # noqa: F401
 from tests.snappi_tests.multidut.pfcwd.files.pfcwd_multidut_basic_helper import run_pfcwd_basic_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.snappi_tests.files.helper import skip_warm_reboot, skip_pfcwd_test  # noqa: F401
+from tests.snappi_tests.files.helper import skip_pfcwd_test, reboot_duts, \
+    setup_ports_and_dut, multidut_port_info  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
+WAIT_TIME = 600
+INTERVAL = 40
+
+
+@pytest.fixture(autouse=True)
+def number_of_tx_rx_ports():
+    yield (1, 1)
+
 
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_pfcwd_basic_single_lossless_prio(snappi_api,                   # noqa: F811
                                           conn_graph_facts,             # noqa: F811
                                           fanout_graph_facts_multidut,           # noqa: F811
                                           duthosts,
                                           lossless_prio_list,    # noqa: F811
-                                          get_snappi_ports,      # noqa: F811
-                                          tbinfo,      # noqa: F811
-                                          multidut_port_info,
-                                          prio_dscp_map,            # noqa F811
-                                          trigger_pfcwd):
+                                          tbinfo,                # noqa: F811
+                                          prio_dscp_map,         # noqa F811
+                                          setup_ports_and_dut,   # noqa: F811
+                                          trigger_pfcwd,         # noqa: F811
+                                          ):
     """
     Run PFC watchdog basic test on a single lossless priority
 
@@ -47,33 +55,7 @@ def test_pfcwd_basic_single_lossless_prio(snappi_api,                   # noqa: 
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
-
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
-    skip_pfcwd_test(duthost=snappi_ports[0]['duthost'], trigger_pfcwd=trigger_pfcwd)
-    skip_pfcwd_test(duthost=snappi_ports[1]['duthost'], trigger_pfcwd=trigger_pfcwd)
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
     lossless_prio = random.sample(lossless_prio_list, 1)
     lossless_prio = int(lossless_prio[0])
@@ -92,20 +74,16 @@ def test_pfcwd_basic_single_lossless_prio(snappi_api,                   # noqa: 
                          trigger_pfcwd=trigger_pfcwd,
                          snappi_extra_params=snappi_extra_params)
 
-    cleanup_config(duthosts, snappi_ports)
-
 
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_pfcwd_basic_multi_lossless_prio(snappi_api,                # noqa F811
                                          conn_graph_facts,          # noqa F811
                                          fanout_graph_facts_multidut,        # noqa F811
                                          duthosts,
                                          lossless_prio_list,    # noqa: F811
-                                         get_snappi_ports,    # noqa: F811
                                          tbinfo,      # noqa: F811
-                                         multidut_port_info,
                                          prio_dscp_map,             # noqa F811
+                                         setup_ports_and_dut,       # noqa: F811
                                          trigger_pfcwd):
     """
     Run PFC watchdog basic test on multiple lossless priorities
@@ -122,31 +100,7 @@ def test_pfcwd_basic_multi_lossless_prio(snappi_api,                # noqa F811
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
-
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
@@ -162,25 +116,21 @@ def test_pfcwd_basic_multi_lossless_prio(snappi_api,                # noqa F811
                          trigger_pfcwd=trigger_pfcwd,
                          snappi_extra_params=snappi_extra_params)
 
-    cleanup_config(duthosts, snappi_ports)
-
 
 @pytest.mark.disable_loganalyzer
-@pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_pfcwd_basic_single_lossless_prio_reboot(snappi_api,                # noqa F811
                                                  conn_graph_facts,          # noqa F811
                                                  fanout_graph_facts_multidut,        # noqa F811
                                                  localhost,
                                                  duthosts,
-                                                 enum_dut_lossless_prio_with_completeness_level,   # noqa: F811
-                                                 get_snappi_ports,   # noqa: F811
+                                                 lossless_prio_list,   # noqa: F811
                                                  tbinfo,      # noqa: F811
-                                                 multidut_port_info,
-                                                 prio_dscp_map,             # noqa F811
-                                                 reboot_type,
-                                                 trigger_pfcwd):
+                                                 prio_dscp_map,             # noqa: F811
+                                                 setup_ports_and_dut,       # noqa: F811
+                                                 reboot_duts,               # noqa: F811
+                                                 trigger_pfcwd              # noqa: F811
+                                                 ):
     """
     Verify PFC watchdog basic test works on a single lossless priority after various types of reboot
 
@@ -190,7 +140,6 @@ def test_pfcwd_basic_single_lossless_prio_reboot(snappi_api,                # no
         fanout_graph_facts_multidut (pytest fixture): fanout graph
         localhost (pytest fixture): localhost handle
         duthosts (pytest fixture): list of DUTs
-        enum_dut_lossless_prio_with_completeness_level (str): lossless priority to test, e.g., 's6100-1|3'
         prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority)
         reboot_type (str): reboot type to be issued on the DUT
         trigger_pfcwd (bool): if PFC watchdog is expected to be triggered
@@ -199,45 +148,12 @@ def test_pfcwd_basic_single_lossless_prio_reboot(snappi_api,                # no
         N/A
     """
 
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
-    skip_warm_reboot(snappi_ports[0]['duthost'], reboot_type)
-    skip_warm_reboot(snappi_ports[1]['duthost'], reboot_type)
-
-    _, lossless_prio = enum_dut_lossless_prio_with_completeness_level.split('|')
-    lossless_prio = int(lossless_prio)
+    lossless_prio = random.sample(lossless_prio_list, 1)
+    lossless_prio = int(lossless_prio[0])
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
-
-    for duthost in set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]):
-        logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-        reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
-        logger.info("Wait until the system is stable")
-        pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                      "Not all critical services are fully started")
 
     run_pfcwd_basic_test(api=snappi_api,
                          testbed_config=testbed_config,
@@ -250,24 +166,19 @@ def test_pfcwd_basic_single_lossless_prio_reboot(snappi_api,                # no
                          trigger_pfcwd=trigger_pfcwd,
                          snappi_extra_params=snappi_extra_params)
 
-    cleanup_config(duthosts, snappi_ports)
-
 
 @pytest.mark.disable_loganalyzer
-@pytest.mark.parametrize('reboot_type', ['warm', 'cold', 'fast'])
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # noqa F811
                                                 conn_graph_facts,           # noqa F811
                                                 fanout_graph_facts_multidut,         # noqa F811
                                                 localhost,
                                                 duthosts,
-                                                lossless_prio_list,   # noqa: F811
-                                                get_snappi_ports,    # noqa: F811
-                                                tbinfo,      # noqa: F811
-                                                multidut_port_info,
-                                                prio_dscp_map,              # noqa F811
-                                                reboot_type,
+                                                lossless_prio_list,    # noqa: F811
+                                                tbinfo,                # noqa: F811
+                                                prio_dscp_map,         # noqa F811
+                                                setup_ports_and_dut,   # noqa: F811
+                                                reboot_duts,           # noqa: F811
                                                 trigger_pfcwd):
     """
     Verify PFC watchdog basic test works on multiple lossless priorities after various kinds of reboots
@@ -286,41 +197,7 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
-
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
-
-    skip_warm_reboot(snappi_ports[0]['duthost'], reboot_type)
-    skip_warm_reboot(snappi_ports[1]['duthost'], reboot_type)
-
-    for duthost in set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]):
-        logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
-        reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
-        logger.info("Wait until the system is stable")
-        pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                      "Not all critical services are fully started")
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
@@ -336,24 +213,20 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
                          trigger_pfcwd=trigger_pfcwd,
                          snappi_extra_params=snappi_extra_params)
 
-    cleanup_config(duthosts, snappi_ports)
-
 
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('restart_service', ['swss'])
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,               # noqa F811
                                                           conn_graph_facts,         # noqa F811
                                                           fanout_graph_facts_multidut,       # noqa F811
                                                           duthosts,
                                                           lossless_prio_list,   # noqa: F811
-                                                          get_snappi_ports,    # noqa: F811
                                                           tbinfo,      # noqa: F811
-                                                          multidut_port_info,
-                                                          prio_dscp_map,            # noqa F811
+                                                          prio_dscp_map,            # noqa: F811
                                                           restart_service,
-                                                          trigger_pfcwd):
+                                                          trigger_pfcwd,
+                                                          setup_ports_and_dut):     # noqa: F811
     """
     Verify PFC watchdog basic test works on a single lossless priority after various service restarts
 
@@ -369,31 +242,7 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
-
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
     lossless_prio = random.sample(lossless_prio_list, 1)
     lossless_prio = int(lossless_prio[0])
 
@@ -406,24 +255,27 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
             ports_dict[k] = list(set(ports_dict[k]))
 
         logger.info('Port dictionary:{}'.format(ports_dict))
-        for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
+        for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):
+            # Record current state of critical services.
+            duthost.critical_services_fully_started()
+
             asic_list = ports_dict[duthost.hostname]
-            for asic in asic_list:
-                asic_id = re.match(r"(asic)(\d+)", asic).group(2)
-                proc = 'swss@' + asic_id
-                logger.info("Issuing a restart of service {} on the dut {}".format(proc, duthost.hostname))
-                duthost.command("sudo systemctl reset-failed {}".format(proc))
-                duthost.command("sudo systemctl restart {}".format(proc))
-                logger.info("Wait until the system is stable")
-                pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                              "Not all critical services are fully started")
+            asic = random.sample(asic_list, 1)[0]
+            asic_id = re.match(r"(asic)(\d+)", asic).group(2)
+            proc = 'swss@' + asic_id
+            logger.info("Issuing a restart of service {} on the dut {}".format(proc, duthost.hostname))
+            duthost.command("sudo systemctl reset-failed {}".format(proc))
+            duthost.command("sudo systemctl restart {}".format(proc))
+            logger.info("Wait until the system is stable")
+            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
+                          "Not all critical services are fully started")
     else:
-        for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
+        for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):
             logger.info("Issuing a restart of service {} on the dut {}".format(restart_service, duthost.hostname))
             duthost.command("systemctl reset-failed {}".format(restart_service))
             duthost.command("systemctl restart {}".format(restart_service))
             logger.info("Wait until the system is stable")
-            pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
+            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
                           "Not all critical services are fully started")
 
     snappi_extra_params = SnappiTestParams()
@@ -440,23 +292,19 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
                          trigger_pfcwd=trigger_pfcwd,
                          snappi_extra_params=snappi_extra_params)
 
-    cleanup_config(duthosts, snappi_ports)
-
 
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('restart_service', ['swss'])
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,                # noqa F811
                                                          conn_graph_facts,          # noqa F811
                                                          fanout_graph_facts_multidut,        # noqa F811
                                                          duthosts,
                                                          lossless_prio_list,    # noqa: F811
-                                                         get_snappi_ports,   # noqa: F811
                                                          tbinfo,      # noqa: F811
-                                                         multidut_port_info,
                                                          prio_dscp_map,             # noqa F811
                                                          restart_service,
+                                                         setup_ports_and_dut,       # noqa: F811
                                                          trigger_pfcwd):
     """
     Verify PFC watchdog basic test works on multiple lossless priorities after various service restarts
@@ -474,31 +322,8 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                      "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
 
-        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
-                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
     if (snappi_ports[0]['duthost'].is_multi_asic):
         ports_dict = defaultdict(list)
@@ -509,7 +334,7 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
             ports_dict[k] = list(set(ports_dict[k]))
 
         logger.info('Port dictionary:{}'.format(ports_dict))
-        for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
+        for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):
             asic_list = ports_dict[duthost.hostname]
             for asic in asic_list:
                 asic_id = re.match(r"(asic)(\d+)", asic).group(2)
@@ -518,15 +343,15 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
                 duthost.command("sudo systemctl reset-failed {}".format(proc))
                 duthost.command("sudo systemctl restart {}".format(proc))
                 logger.info("Wait until the system is stable")
-                pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
+                pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
                               "Not all critical services are fully started")
     else:
-        for duthost in [snappi_ports[0]['duthost'], snappi_ports[1]['duthost']]:
+        for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):
             logger.info("Issuing a restart of service {} on the dut {}".format(restart_service, duthost.hostname))
             duthost.command("systemctl reset-failed {}".format(restart_service))
             duthost.command("systemctl restart {}".format(restart_service))
             logger.info("Wait until the system is stable")
-            pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
+            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
                           "Not all critical services are fully started")
 
     snappi_extra_params = SnappiTestParams()
@@ -541,5 +366,3 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
                          prio_dscp_map=prio_dscp_map,
                          trigger_pfcwd=trigger_pfcwd,
                          snappi_extra_params=snappi_extra_params)
-
-    cleanup_config(duthosts, snappi_ports)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
As per PR:15099, change test_multidut_pfcwd_basic_with_snappi.py  and test_multidut_pfc_pause_lossy_with_snappi.py to use the new fixtures.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] Test case(improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Fix for: "ARP not resolved issue" in reboot cases in pause_lossy, and pfcwd_basic.

#### How did you do it?
1. Moved the reboot logic to the fixture, and calling the fixture in the tests.
2. Removed the repeated code in all tests.
#### How did you verify/test it?
Ran it on my T2 TB:
```
------------------------------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------------------------------
06:40:51 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================================================== short test summary info ===================================================================================================================
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info0-yy39top-lc4|0]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info0-yy39top-lc4|1]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info0-yy39top-lc4|2]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info0-yy39top-lc4|5]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info0-yy39top-lc4|6]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info1-yy39top-lc4|0]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info1-yy39top-lc4|1]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info1-yy39top-lc4|2]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info1-yy39top-lc4|5]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info1-yy39top-lc4|6]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_multi_lossy_prio[multidut_port_info0]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_multi_lossy_prio[multidut_port_info1]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot[multidut_port_info0-cold-yy39top-lc4|0]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot[multidut_port_info0-cold-yy39top-lc4|1]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot[multidut_port_info0-cold-yy39top-lc4|2]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot[multidut_port_info0-cold-yy39top-lc4|5]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot[multidut_port_info0-cold-yy39top-lc4|6]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot[multidut_port_info1-cold-yy39top-lc4|0]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot[multidut_port_info1-cold-yy39top-lc4|1]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot[multidut_port_info1-cold-yy39top-lc4|2]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot[multidut_port_info1-cold-yy39top-lc4|5]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio_reboot[multidut_port_info1-cold-yy39top-lc4|6]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_multi_lossy_prio_reboot[multidut_port_info0-cold]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_multi_lossy_prio_reboot[multidut_port_info1-cold]
SKIPPED [10] snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py:135: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [10] snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py:135: Reboot type fast is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py:195: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py:195: Reboot type fast is not supported on cisco-8000 switches
ERROR snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info0-yy39top-lc4|0] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost yy39top-lc4>']" failed with exit code "1"
ERROR snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info0-yy39top-lc4|5] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost yy39top-lc4>']" failed with exit code "1"
ERROR snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info0-yy39top-lc4|6] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost yy39top-lc4>']" failed with exit code "1"
ERROR snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info1-yy39top-lc4|1] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost yy39top-lc4>']" failed with exit code "1"
ERROR snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info1-yy39top-lc4|2] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost yy39top-lc4>']" failed with exit code "1"
ERROR snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info1-yy39top-lc4|5] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost yy39top-lc4>']" failed with exit code "1"
ERROR snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_multi_lossy_prio[multidut_port_info0] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost yy39top-lc4>']" failed with exit code "1"
ERROR snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_multi_lossy_prio[multidut_port_info1] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost yy39top-lc4>']" failed with exit code "1"
============================================================================================ 24 passed, 24 skipped, 28 warnings, 8 errors in 20375.01s (5:39:35) =============================================================================================
sonic@ixia-sonic-mgmt-whitebox:/data/tests$ 
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
