### PR TITLE
[T2][Chassis] - Fix regex for supervisor reboot scenarios

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -116,7 +116,7 @@ reboot_ctrl_dict = {
         "timeout": 300,
         "wait": 120,
         # When linecards are rebooted due to supervisor cold reboot
-        "cause": r"^Reboot from Supervisor$|^reboot from Supervisor$",
+        "cause": r"Reboot from Supervisor|reboot from Supervisor",
         "test_reboot_cause_only": False
     },
     REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS: {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes the failures w.r.t supervisor reboot cause introduced as part of #14986.
- The modified new regex for this cause seems to be not working for our platform.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

- Some of the _startup-tsa-tsb_ testcases with supervisor reboot scenarios fail with '_reboot-cause_' as shown below, where '_unknown_' reboot cause is shown instead of the actual '_reboot from Supervisor_' string.

**Failure:**

```python
           for linecard in duthosts.frontend_nodes:
                # Make sure the dut's reboot cause is as expected
                logger.info("Check reboot cause of the dut {}".format(linecard))
                reboot_cause = get_reboot_cause(linecard)
>               pytest_assert(reboot_cause == SUP_REBOOT_CAUSE,
                              "Reboot cause {} did not match the trigger {}".format(reboot_cause, SUP_REBOOT_CAUSE))
E               Failed: Reboot cause Unknown did not match the trigger Reboot from Supervisor
``` 

**Actual output:**
```
DEBUG    tests.common.devices.base:base.py:71 /data/tests/common/devices/multi_asic.py::_run_on_asics#135: [ixre-egl-board15] AnsibleModule::shell, args=["**show reboot-cause**"], kwargs={}
DEBUG    tests.common.devices.base:base.py:108 /data/tests/common/devices/multi_asic.py::_run_on_asics#135: [ixre-egl-board15] AnsibleModule::shell Result => {"changed": true, "stdout": "User issued 'reboot from Supervisor' command [User: admin, Time: Sun 03 Nov 2024 04:57:38 AM UTC]", "stderr": "", "rc": 0, "cmd": "show reboot-cause", "start": "2024-11-03 05:19:50.505538", "end": "2024-11-03 05:19:51.143426", "delta": "0:00:00.637888", "msg": "", "invocation": {"module_args": {"_raw_params": "show reboot-cause", "_uses_shell": true, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["**User issued 'reboot from Supervisor' command [User: admin, Time: Sun 03 Nov 2024 04:57:38 AM UTC]**"], "stderr_lines": [], "_ansible_no_log": null, "failed": false}
``` 
<details><summary>Reboot Cause String</summary>
<p>

DEBUG    tests.common.devices.base:base.py:71 /data/tests/common/devices/multi_asic.py::_run_on_asics#135: [ixre-egl-board15] AnsibleModule::shell, args=["**show reboot-cause**"], kwargs={}
DEBUG    tests.common.devices.base:base.py:108 /data/tests/common/devices/multi_asic.py::_run_on_asics#135: [ixre-egl-board15] AnsibleModule::shell Result => {"changed": true, "stdout": "User issued 'reboot from Supervisor' command [User: admin, Time: Sun 03 Nov 2024 04:57:38 AM UTC]", "stderr": "", "rc": 0, "cmd": "show reboot-cause", "start": "2024-11-03 05:19:50.505538", "end": "2024-11-03 05:19:51.143426", "delta": "0:00:00.637888", "msg": "", "invocation": {"module_args": {"_raw_params": "show reboot-cause", "_uses_shell": true, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["**User issued 'reboot from Supervisor' command [User: admin, Time: Sun 03 Nov 2024 04:57:38 AM UTC]**"], "stderr_lines": [], "_ansible_no_log": null, "failed": false}

</p>
</details> 

#### How did you do it?

- #14986 modified regex to expect the cause string as start and end of string, which is not true for all platforms.
- Modified the expectation to just match the string.

#### How did you verify/test it?
- Ran the specific supervisor reboot test cases on a T2 chassis and made sure tests passed with expected behavior.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/user-attachments/assets/80e99e5b-0f5c-4877-89c5-1bcf958125e8)
