### PR TITLE
Cisco-8122 Increase buffer pool watermark test margin

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -461,8 +461,9 @@ class QosParamCisco(object):
                                "pkts_num_fill_ingr_min": 0,
                                "pkts_num_trig_pfc": self.lossless_drop_thr // self.buffer_size // packet_buffs,
                                "cell_size": self.buffer_size,
-                               "packet_size": packet_size,
-                               "pkts_num_margin": 8}
+                               "packet_size": packet_size}
+            if self.dutAsic == "gr2":
+                lossless_params["pkts_num_margin"] = 8
             self.write_params("wm_buf_pool_lossless", lossless_params)
         if self.should_autogen(["wm_buf_pool_lossy"]):
             lossy_params = {"dscp": self.dscp_queue0,
@@ -472,8 +473,9 @@ class QosParamCisco(object):
                             "pkts_num_trig_egr_drp": self.lossy_drop_bytes // self.buffer_size // packet_buffs,
                             "pkts_num_fill_egr_min": 0,
                             "cell_size": self.buffer_size,
-                            "packet_size": packet_size,
-                            "pkts_num_margin": 8}
+                            "packet_size": packet_size}
+            if self.dutAsic == "gr2":
+                lossy_params["pkts_num_margin"] = 8
             self.write_params("wm_buf_pool_lossy", lossy_params)
 
     def __define_q_shared_watermark(self):

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -461,7 +461,8 @@ class QosParamCisco(object):
                                "pkts_num_fill_ingr_min": 0,
                                "pkts_num_trig_pfc": self.lossless_drop_thr // self.buffer_size // packet_buffs,
                                "cell_size": self.buffer_size,
-                               "packet_size": packet_size}
+                               "packet_size": packet_size,
+                               "pkts_num_margin": 8}
             self.write_params("wm_buf_pool_lossless", lossless_params)
         if self.should_autogen(["wm_buf_pool_lossy"]):
             lossy_params = {"dscp": self.dscp_queue0,
@@ -471,7 +472,8 @@ class QosParamCisco(object):
                             "pkts_num_trig_egr_drp": self.lossy_drop_bytes // self.buffer_size // packet_buffs,
                             "pkts_num_fill_egr_min": 0,
                             "cell_size": self.buffer_size,
-                            "packet_size": packet_size}
+                            "packet_size": packet_size,
+                            "pkts_num_margin": 8}
             self.write_params("wm_buf_pool_lossy", lossy_params)
 
     def __define_q_shared_watermark(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Increase buffer pool watermark test margin for Cisco-8122.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

Cisco-8000 series uses a base watermark. During capture of the base, it ends up being slightly higher due to background traffic. This makes the overall "new_wmk - base_wmk" slightly low, bumping against the lower bound default 2-packet margin. 
Proposed solution is to increase the margin to 8 packets, but only for 8122 series. The problem is exacerbated on 8122 since it uses small 64B packets rather than the other 8000 series larger packet sizes, making it more sensitive to tiny deviations. 

#### How did you verify/test it?

Verified on Cisco-8122 T1 device, repeated test several times to help ensure it's not flaky. 

#### Any platform specific information?
Cisco-8122 only. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
