### PR TITLE
[multi-asic fix] fix new change in test_route_perf.py to support multi-asic

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -428,6 +428,7 @@ multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py
   - bgp/test_bgp_fact.py
   - bgp/test_bgp_update_timer.py
+  - route/test_route_perf.py
   - snmp/test_snmp_default_route.py
   - snmp/test_snmp_link_local.py
   - snmp/test_snmp_loopback.py

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -55,15 +55,17 @@ def get_route_scale_per_role(tbinfo, ip_version):
 
 
 @pytest.fixture
-def check_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
+def check_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index, tbinfo):
     if tbinfo["topo"]["type"] in ["m0", "mx"]:
         return
 
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic = duthost.facts["asic_type"]
+    asic_id = enum_rand_one_frontend_asic_index
 
     if (asic == "broadcom"):
-        alpm_enable = duthost.command('bcmcmd "conf show l3_alpm_enable"')["stdout_lines"][2].strip()
+        broadcom_cmd = "bcmcmd -n " + asic_id if asic_id else "bcmcmd"
+        alpm_enable = duthost.command("{} {}".format(broadcom_cmd, "conf show l3_alpm_enable"))
         logger.info("Checking config: {}".format(alpm_enable))
         pytest_assert(alpm_enable == "l3_alpm_enable=2", "l3_alpm_enable is not set for route scaling")
 

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -65,7 +65,8 @@ def check_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_
 
     if (asic == "broadcom"):
         broadcom_cmd = "bcmcmd -n " + str(asic_id) if duthost.is_multi_asic else "bcmcmd"
-        alpm_enable = duthost.command("{} {}".format(broadcom_cmd, "conf show l3_alpm_enable"))["stdout_lines"][2].strip()
+        alpm_cmd = "{} {}".format(broadcom_cmd, "conf show l3_alpm_enable")
+        alpm_enable = duthost.command(alpm_cmd)["stdout_lines"][2].strip()
         logger.info("Checking config: {}".format(alpm_enable))
         pytest_assert(alpm_enable == "l3_alpm_enable=2", "l3_alpm_enable is not set for route scaling")
 

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -64,8 +64,8 @@ def check_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_
     asic_id = enum_rand_one_frontend_asic_index
 
     if (asic == "broadcom"):
-        broadcom_cmd = "bcmcmd -n " + asic_id if asic_id else "bcmcmd"
-        alpm_enable = duthost.command("{} {}".format(broadcom_cmd, "conf show l3_alpm_enable"))
+        broadcom_cmd = "bcmcmd -n " + str(asic_id) if duthost.is_multi_asic else "bcmcmd"
+        alpm_enable = duthost.command("{} {}".format(broadcom_cmd, "conf show l3_alpm_enable"))["stdout_lines"][2].strip()
         logger.info("Checking config: {}".format(alpm_enable))
         pytest_assert(alpm_enable == "l3_alpm_enable=2", "l3_alpm_enable is not set for route scaling")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
for multi-asic devices, when asic is broadcom, using "bcmcmd" needs to specify asic id.

TODO:
depending on type of asic, e.g. xgs/dnx, we need to confirm with broadcom if the asic supports "conf show l3_alpm_enable" command, if not, skip for that platform.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
