### PR TITLE
Support ptp in get_testbed_type

### DIFF
--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -255,7 +255,7 @@ class TestbedInfo(object):
         return sai_topo
 
     def get_testbed_type(self, topo_name):
-        pattern = re.compile(r'^(wan|t0|t1|ptf|fullmesh|dualtor|t2|tgen|mgmttor|m0|mc0|mx|dpu)')
+        pattern = re.compile(r'^(wan|t0|t1|ptf|fullmesh|dualtor|t2|tgen|mgmttor|m0|mc0|mx|dpu|ptp)')
         match = pattern.match(topo_name)
         if match is None:
             logger.warning("Unsupported testbed type - {}".format(topo_name))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to support topology `ptp` in function `get_testbed_type`.
The change will fix the warning message
```
23:49:33 testbed.get_testbed_type                 L0261 WARNING| Unsupported testbed type - ptp-256
23:49:33 testbed.get_testbed_type                 L0261 WARNING| Unsupported testbed type - ptp-256
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
This PR is to support topology `ptp` in function `get_testbed_type`.

#### How did you do it?
Add `ptp` into the regex list.

#### How did you verify/test it?
Verified by running test on a physical testbed. The warning message doesn't show up any more.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
