### PR TITLE
Remove skip_traffic_test fixture in span tests

### DIFF
--- a/tests/span/span_helpers.py
+++ b/tests/span/span_helpers.py
@@ -5,7 +5,7 @@ Helper functions for span tests
 import ptf.testutils as testutils
 
 
-def send_and_verify_mirrored_packet(ptfadapter, src_port, monitor, skip_traffic_test=False):
+def send_and_verify_mirrored_packet(ptfadapter, src_port, monitor):
     '''
     Send packet from ptf and verify it on monitor port
 
@@ -18,8 +18,6 @@ def send_and_verify_mirrored_packet(ptfadapter, src_port, monitor, skip_traffic_
 
     pkt = testutils.simple_icmp_packet(eth_src=src_mac, eth_dst='ff:ff:ff:ff:ff:ff')
 
-    if skip_traffic_test is True:
-        return
     ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, src_port, pkt)
     testutils.verify_packet(ptfadapter, pkt, monitor)

--- a/tests/span/test_port_mirroring.py
+++ b/tests/span/test_port_mirroring.py
@@ -5,7 +5,6 @@ Test local port mirroring on SONiC
 import pytest
 
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses    # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa F401
 from span_helpers import send_and_verify_mirrored_packet
 
 pytestmark = [
@@ -13,7 +12,7 @@ pytestmark = [
 ]
 
 
-def test_mirroring_rx(ptfadapter, setup_session, skip_traffic_test):    # noqa F811
+def test_mirroring_rx(ptfadapter, setup_session):
     '''
     Test case #1
     Verify ingress direction session
@@ -27,11 +26,10 @@ def test_mirroring_rx(ptfadapter, setup_session, skip_traffic_test):    # noqa F
     '''
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source1_index'],
-                                    setup_session['destination_index'],
-                                    skip_traffic_test=skip_traffic_test)
+                                    setup_session['destination_index'])
 
 
-def test_mirroring_tx(ptfadapter, setup_session, skip_traffic_test):    # noqa F811
+def test_mirroring_tx(ptfadapter, setup_session):
     '''
     Test case #2
     Verify egress direction session
@@ -45,11 +43,10 @@ def test_mirroring_tx(ptfadapter, setup_session, skip_traffic_test):    # noqa F
     '''
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source2_index'],
-                                    setup_session['destination_index'],
-                                    skip_traffic_test=skip_traffic_test)
+                                    setup_session['destination_index'])
 
 
-def test_mirroring_both(ptfadapter, setup_session, skip_traffic_test):    # noqa F811
+def test_mirroring_both(ptfadapter, setup_session):
     '''
     Test case #3
     Verify bidirectional session
@@ -66,16 +63,14 @@ def test_mirroring_both(ptfadapter, setup_session, skip_traffic_test):    # noqa
     '''
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source1_index'],
-                                    setup_session['destination_index'],
-                                    skip_traffic_test=skip_traffic_test)
+                                    setup_session['destination_index'])
 
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source2_index'],
-                                    setup_session['destination_index'],
-                                    skip_traffic_test=skip_traffic_test)
+                                    setup_session['destination_index'])
 
 
-def test_mirroring_multiple_source(ptfadapter, setup_session, skip_traffic_test):    # noqa F811
+def test_mirroring_multiple_source(ptfadapter, setup_session):
     '''
     Test case #4
     Verify ingress direction session with multiple source ports
@@ -92,10 +87,8 @@ def test_mirroring_multiple_source(ptfadapter, setup_session, skip_traffic_test)
     '''
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source1_index'],
-                                    setup_session['destination_index'],
-                                    skip_traffic_test=skip_traffic_test)
+                                    setup_session['destination_index'])
 
     send_and_verify_mirrored_packet(ptfadapter,
                                     setup_session['source2_index'],
-                                    setup_session['destination_index'],
-                                    skip_traffic_test=skip_traffic_test)
+                                    setup_session['destination_index'])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently we are using conditional mark to add marker, then use pytest hook to redirect testutils.verify function to a function always return True to skip traffic test. With this change, the skip_traffic_test fixture is no longer needed in test cases, streamlining the test code and improving clarity.
#### How did you do it?
Remove skip_traffic_test fixture in span tests
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
