### PR TITLE
Remove skip_traffic_test fixture in sub_port_interfaces tests

### DIFF
--- a/tests/sub_port_interfaces/sub_ports_helpers.py
+++ b/tests/sub_port_interfaces/sub_ports_helpers.py
@@ -86,7 +86,7 @@ def create_packet(eth_dst, eth_src, ip_dst, ip_src, vlan_vid, tr_type, ttl, dl_v
 
 def generate_and_verify_traffic(duthost, ptfadapter, src_port, dst_port, ptfhost=None, ip_src='', ip_dst='',
                                 pkt_action=None, type_of_traffic='ICMP', ttl=64, pktlen=100, ip_tunnel=None,
-                                skip_traffic_test=False, **kwargs):
+                                **kwargs):
     """
     Send packet from PTF to DUT and
     verify that DUT sends/doesn't packet to PTF.
@@ -105,9 +105,6 @@ def generate_and_verify_traffic(duthost, ptfadapter, src_port, dst_port, ptfhost
         pktlen: packet length
         ip_tunnel: Tunnel IP address of DUT
     """
-    if skip_traffic_test is True:
-        logger.info("Skipping traffic test")
-        return
     type_of_traffic = [type_of_traffic] if not isinstance(type_of_traffic, list) else type_of_traffic
 
     for tr_type in type_of_traffic:
@@ -150,6 +147,7 @@ def generate_and_verify_tcp_udp_traffic(duthost, ptfadapter, src_port, dst_port,
     src_dl_vlan_enable = False
     dst_dl_vlan_enable = False
     router_mac = duthost.facts['router_mac']
+    asic_type = duthost.facts['asic_type']
     src_port_number = int(get_port_number(src_port))
     dst_port_number = int(get_port_number(dst_port))
     src_mac = ptfadapter.dataplane.get_mac(0, src_port_number).decode()
@@ -198,7 +196,8 @@ def generate_and_verify_tcp_udp_traffic(duthost, ptfadapter, src_port, dst_port,
 
     pkt_in_buffer = pkt_filter.filter_pkt_in_buffer()
 
-    pytest_assert(pkt_in_buffer is True, "Expected packet not available:\n{}".format(pkt_in_buffer))
+    if asic_type != 'vs':
+        pytest_assert(pkt_in_buffer is True, "Expected packet not available:\n{}".format(pkt_in_buffer))
 
 
 def generate_and_verify_icmp_traffic(duthost, ptfadapter, src_port, dst_port, ip_src, ip_dst, pkt_action, tr_type,
@@ -288,6 +287,7 @@ def generate_and_verify_decap_traffic(duthost, ptfadapter, src_port, dst_port, i
         ip_tunnel: Tunnel IP address of DUT
     """
     router_mac = duthost.facts['router_mac']
+    asic_type = duthost.facts['asic_type']
     src_port_number = int(get_port_number(src_port))
     dst_port_number = int(get_port_number(dst_port))
 
@@ -327,7 +327,8 @@ def generate_and_verify_decap_traffic(duthost, ptfadapter, src_port, dst_port, i
 
     pkt_in_buffer = pkt_filter.filter_pkt_in_buffer()
 
-    pytest_assert(pkt_in_buffer is True, "Expected packet not available:\n{}".format(pkt_in_buffer))
+    if asic_type != 'vs':
+        pytest_assert(pkt_in_buffer is True, "Expected packet not available:\n{}".format(pkt_in_buffer))
 
 
 def generate_and_verify_balancing_traffic(duthost, ptfhost, ptfadapter, src_port, dst_port, ip_src, ip_dst,
@@ -347,6 +348,7 @@ def generate_and_verify_balancing_traffic(duthost, ptfhost, ptfadapter, src_port
         ttl: Time to live
     """
     router_mac = duthost.facts['router_mac']
+    asic_type = duthost.facts['asic_type']
     src_port_number = int(get_port_number(src_port))
     src_mac = ptfadapter.dataplane.get_mac(0, src_port_number)
     ip_src = '10.0.0.1'
@@ -403,9 +405,10 @@ def generate_and_verify_balancing_traffic(duthost, ptfhost, ptfadapter, src_port
 
     pkt_in_buffer = pkt_filter.filter_pkt_in_buffer()
 
-    pytest_assert(pkt_in_buffer is True, "Expected packet not available:\n{}".format(pkt_in_buffer))
-    pytest_assert(check_balancing(pkt_filter.matched_index),
-                  "Balancing error:\n{}".format(pkt_filter.matched_index))
+    if asic_type != 'vs':
+        pytest_assert(pkt_in_buffer is True, "Expected packet not available:\n{}".format(pkt_in_buffer))
+        pytest_assert(check_balancing(pkt_filter.matched_index),
+                      "Balancing error:\n{}".format(pkt_filter.matched_index))
 
 
 def shutdown_port(duthost, interface):

--- a/tests/sub_port_interfaces/test_sub_port_interfaces.py
+++ b/tests/sub_port_interfaces/test_sub_port_interfaces.py
@@ -15,7 +15,6 @@ from sub_ports_helpers import remove_vlan
 from sub_ports_helpers import check_sub_port
 from sub_ports_helpers import remove_sub_port
 from sub_ports_helpers import create_sub_port_on_dut
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t0', 't1')
@@ -347,7 +346,7 @@ class TestSubPorts(object):
                                             pktlen=pktlen)
 
     def test_tunneling_between_sub_ports(self, duthost, ptfadapter, apply_tunnel_table_to_dut,
-                                         apply_route_config, skip_traffic_test):    # noqa F811
+                                         apply_route_config):
         """
         Validates that packets are routed between sub-ports.
 
@@ -380,11 +379,10 @@ class TestSubPorts(object):
                                             ip_tunnel=sub_ports[src_port]['ip'],
                                             pkt_action='fwd',
                                             type_of_traffic='decap',
-                                            ttl=63,
-                                            skip_traffic_test=skip_traffic_test)
+                                            ttl=63)
 
     def test_balancing_sub_ports(self, duthost, ptfhost, ptfadapter,
-                                 apply_balancing_config, skip_traffic_test):        # noqa F811
+                                 apply_balancing_config):
         """
         Validates load-balancing when sub-port is part of ECMP
         Test steps:
@@ -417,13 +415,12 @@ class TestSubPorts(object):
                                         dst_port=dst_ports,
                                         ip_dst=ip_dst,
                                         type_of_traffic='balancing',
-                                        ttl=63,
-                                        skip_traffic_test=skip_traffic_test)
+                                        ttl=63)
 
 
 class TestSubPortsNegative(object):
     def test_packet_routed_with_invalid_vlan(self, duthost, ptfadapter, apply_config_on_the_dut,
-                                             apply_config_on_the_ptf, skip_traffic_test):       # noqa F811
+                                             apply_config_on_the_ptf):
         """
         Validates that packet aren't routed if sub-ports have invalid VLAN ID.
 
@@ -447,13 +444,12 @@ class TestSubPortsNegative(object):
                                         ip_src=value['neighbor_ip'],
                                         dst_port=sub_port,
                                         ip_dst=value['ip'],
-                                        pkt_action='drop',
-                                        skip_traffic_test=skip_traffic_test)
+                                        pkt_action='drop')
 
 
 class TestSubPortStress(object):
     def test_max_numbers_of_sub_ports(self, duthost, ptfadapter, apply_config_on_the_dut,
-                                      apply_config_on_the_ptf, skip_traffic_test):      # noqa F811
+                                      apply_config_on_the_ptf):
         """
         Validates that 256 sub-ports can be created per port or LAG
 
@@ -486,5 +482,4 @@ class TestSubPortStress(object):
                                         ip_src=value['neighbor_ip'],
                                         dst_port=sub_port,
                                         ip_dst=value['ip'],
-                                        pkt_action='fwd',
-                                        skip_traffic_test=skip_traffic_test)
+                                        pkt_action='fwd')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently we are using conditional mark to add marker, then use pytest hook to redirect testutils.verify function to a function always return True to skip traffic test. With this change, the skip_traffic_test fixture is no longer needed in test cases, streamlining the test code and improving clarity.
#### How did you do it?
Remove skip_traffic_test fixture in sub_port_interfaces tests
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
