### PR TITLE
Remove skip_traffic_test fixture in vxlan tests

### DIFF
--- a/tests/vxlan/test_vxlan_bfd_tsa.py
+++ b/tests/vxlan/test_vxlan_bfd_tsa.py
@@ -14,7 +14,6 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test           # noqa F401
 from tests.ptf_runner import ptf_runner
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 from tests.common.config_reload import config_system_checks_passed
@@ -238,8 +237,7 @@ class Test_VxLAN_BFD_TSA():
                                    random_sport=False,
                                    random_src_ip=False,
                                    tolerance=None,
-                                   payload=None,
-                                   skip_traffic_test=False):        # noqa F811
+                                   payload=None):
         '''
            Just a wrapper for dump_info_to_ptf to avoid entering 30 lines
            everytime.
@@ -291,9 +289,6 @@ class Test_VxLAN_BFD_TSA():
         Logger.info(
             "dest->nh mapping:%s", self.vxlan_test_setup[encap_type]['dest_to_nh_map'])
 
-        if skip_traffic_test is True:
-            Logger.info("Skipping traffic test.")
-            return
         ptf_runner(self.vxlan_test_setup['ptfhost'],
                    "ptftests",
                    "vxlan_traffic.VxLAN_in_VxLAN" if payload == 'vxlan'
@@ -411,7 +406,7 @@ class Test_VxLAN_BFD_TSA():
                     return False
         return True
 
-    def test_tsa_case1(self, setUp, encap_type, skip_traffic_test):     # noqa F811
+    def test_tsa_case1(self, setUp, encap_type):
         '''
             tc1: This test checks the basic TSA removal of BFD sessions.
             1) Create Vnet route with 4 endpoints and BFD monitors.
@@ -428,7 +423,7 @@ class Test_VxLAN_BFD_TSA():
 
         dest, ep_list = self.create_vnet_route(encap_type)
 
-        self.dump_self_info_and_run_ptf("test1", encap_type, True, [], skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("test1", encap_type, True, [])
 
         self.apply_tsa()
         pytest_assert(self.in_maintainence())
@@ -437,11 +432,11 @@ class Test_VxLAN_BFD_TSA():
         self.apply_tsb()
         pytest_assert(not self.in_maintainence())
 
-        self.dump_self_info_and_run_ptf("test1b", encap_type, True, [], skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("test1b", encap_type, True, [])
 
         self.delete_vnet_route(encap_type, dest)
 
-    def test_tsa_case2(self, setUp, encap_type, skip_traffic_test):    # noqa F811
+    def test_tsa_case2(self, setUp, encap_type):
         '''
             tc2: This test checks the basic route application while in TSA.
             1) apply TSA.
@@ -464,11 +459,11 @@ class Test_VxLAN_BFD_TSA():
         self.apply_tsb()
         pytest_assert(not self.in_maintainence())
 
-        self.dump_self_info_and_run_ptf("test2", encap_type, True, [], skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("test2", encap_type, True, [])
 
         self.delete_vnet_route(encap_type, dest)
 
-    def test_tsa_case3(self, setUp, encap_type, skip_traffic_test):     # noqa F811
+    def test_tsa_case3(self, setUp, encap_type):
         '''
             tc3: This test checks for lasting impact of TSA and TSB.
             1) apply TSA.
@@ -491,11 +486,11 @@ class Test_VxLAN_BFD_TSA():
 
         dest, ep_list = self.create_vnet_route(encap_type)
 
-        self.dump_self_info_and_run_ptf("test3", encap_type, True, [], skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("test3", encap_type, True, [])
 
         self.delete_vnet_route(encap_type, dest)
 
-    def test_tsa_case4(self, setUp, encap_type, skip_traffic_test):     # noqa F811
+    def test_tsa_case4(self, setUp, encap_type):
         '''
             tc4: This test checks basic Vnet route state retention during config reload.
             1) Create Vnet route with 4 endpoints and BFD monitors.
@@ -514,7 +509,7 @@ class Test_VxLAN_BFD_TSA():
         duthost.shell("sudo config save -y",
                       executable="/bin/bash", module_ignore_errors=True)
 
-        self.dump_self_info_and_run_ptf("test4", encap_type, True, [], skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("test4", encap_type, True, [])
 
         duthost.shell("sudo config reload -y",
                       executable="/bin/bash", module_ignore_errors=True)
@@ -524,11 +519,11 @@ class Test_VxLAN_BFD_TSA():
         ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=4789, dutmac=self.vxlan_test_setup['dut_mac'])
         dest, ep_list = self.create_vnet_route(encap_type)
 
-        self.dump_self_info_and_run_ptf("test4b", encap_type, True, [], skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("test4b", encap_type, True, [])
 
         self.delete_vnet_route(encap_type, dest)
 
-    def test_tsa_case5(self, setUp, encap_type, skip_traffic_test):    # noqa F811
+    def test_tsa_case5(self, setUp, encap_type):
         '''
             tc4: This test checks TSA state retention w.r.t BFD accross config reload.
             1) Create Vnet route with 4 endpoints and BFD monitors.
@@ -552,7 +547,7 @@ class Test_VxLAN_BFD_TSA():
         duthost.shell("sudo config save -y",
                       executable="/bin/bash", module_ignore_errors=True)
 
-        self.dump_self_info_and_run_ptf("test5", encap_type, True, [], skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("test5", encap_type, True, [])
 
         self.apply_tsa()
         pytest_assert(self.in_maintainence())
@@ -569,11 +564,11 @@ class Test_VxLAN_BFD_TSA():
         self.apply_tsb()
         pytest_assert(not self.in_maintainence())
 
-        self.dump_self_info_and_run_ptf("test5b", encap_type, True, [], skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("test5b", encap_type, True, [])
 
         self.delete_vnet_route(encap_type, dest)
 
-    def test_tsa_case6(self, setUp, encap_type, skip_traffic_test):     # noqa F811
+    def test_tsa_case6(self, setUp, encap_type):
         '''
             tc6: This test checks that the BFD doesnt come up while device
             is in TSA and remains down accross config reload.
@@ -615,6 +610,6 @@ class Test_VxLAN_BFD_TSA():
         self.apply_tsb()
         pytest_assert(not self.in_maintainence())
 
-        self.dump_self_info_and_run_ptf("test6", encap_type, True, [], skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("test6", encap_type, True, [])
 
         self.delete_vnet_route(encap_type, dest)

--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -14,7 +14,6 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # no
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses    # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py   # noqa F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses     # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test       # noqa F401
 from tests.ptf_runner import ptf_runner
 from tests.common.dualtor.mux_simulator_control import mux_server_url,\
     toggle_all_simulator_ports_to_rand_selected_tor_m   # noqa F401
@@ -185,7 +184,7 @@ def vxlan_status(setup, request, duthosts, rand_one_dut_hostname):
 
 
 def test_vxlan_decap(setup, vxlan_status, duthosts, rand_one_dut_hostname, tbinfo,
-                     ptfhost, creds, toggle_all_simulator_ports_to_rand_selected_tor_m, skip_traffic_test):    # noqa F811
+                     ptfhost, creds, toggle_all_simulator_ports_to_rand_selected_tor_m):    # noqa F811
     duthost = duthosts[rand_one_dut_hostname]
 
     sonic_admin_alt_password = duthost.host.options['variable_manager'].\
@@ -199,9 +198,6 @@ def test_vxlan_decap(setup, vxlan_status, duthosts, rand_one_dut_hostname, tbinf
     log_file = "/tmp/vxlan-decap.Vxlan.{}.{}.log".format(
         scenario, datetime.now().strftime('%Y-%m-%d-%H:%M:%S'))
 
-    if skip_traffic_test is True:
-        logger.info("Skip traffic test")
-        return
     ptf_runner(ptfhost,
                "ptftests",
                "vxlan-decap.Vxlan",

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -60,7 +60,6 @@ import copy
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test           # noqa F401
 from tests.common.utilities import wait_until
 from tests.ptf_runner import ptf_runner
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
@@ -394,8 +393,7 @@ class Test_VxLAN():
                                    random_sport=False,
                                    random_src_ip=False,
                                    tolerance=None,
-                                   payload=None,
-                                   skip_traffic_test=False):        # noqa F811
+                                   payload=None):
         '''
            Just a wrapper for dump_info_to_ptf to avoid entering 30 lines
            everytime.
@@ -450,9 +448,6 @@ class Test_VxLAN():
         Logger.info(
             "dest->nh mapping:%s", self.vxlan_test_setup[encap_type]['dest_to_nh_map'])
 
-        if skip_traffic_test is True:
-            Logger.info("Skipping traffic test.")
-            return
         ptf_runner(self.vxlan_test_setup['ptfhost'],
                    "ptftests",
                    "vxlan_traffic.VxLAN_in_VxLAN" if payload == 'vxlan'
@@ -510,18 +505,16 @@ class Test_VxLAN_route_tests(Test_VxLAN):
         Common class for the basic route test cases.
     '''
 
-    def test_vxlan_single_endpoint(self, setUp, encap_type, skip_traffic_test):     # noqa F811
+    def test_vxlan_single_endpoint(self, setUp, encap_type):
         '''
             tc1:Create a tunnel route to a single endpoint a.
             Send packets to the route prefix dst.
         '''
         self.vxlan_test_setup = setUp
-        self.dump_self_info_and_run_ptf("tc1", encap_type, True, skip_traffic_test=skip_traffic_test)
-        self.dump_self_info_and_run_ptf("tc1", encap_type, True,
-                                        payload="vxlan", skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc1", encap_type, True)
+        self.dump_self_info_and_run_ptf("tc1", encap_type, True, payload="vxlan")
 
-    def test_vxlan_modify_route_different_endpoint(
-            self, setUp, request, encap_type, skip_traffic_test):       # noqa F811
+    def test_vxlan_modify_route_different_endpoint(self, setUp, request, encap_type):
         '''
             tc2: change the route to different endpoint.
             Packets are received only at endpoint b.")
@@ -571,9 +564,9 @@ class Test_VxLAN_route_tests(Test_VxLAN):
 
         Logger.info(
             "Copy the new set of configs to the PTF and run the tests.")
-        self.dump_self_info_and_run_ptf("tc2", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc2", encap_type, True)
 
-    def test_vxlan_remove_all_route(self, setUp, encap_type, skip_traffic_test):        # noqa F811
+    def test_vxlan_remove_all_route(self, setUp, encap_type):
         '''
             tc3: remove the tunnel route.
             Send packets to the route prefix dst. packets should not
@@ -588,7 +581,7 @@ class Test_VxLAN_route_tests(Test_VxLAN):
                 ecmp_utils.get_payload_version(encap_type),
                 "DEL")
             Logger.info("Verify that the traffic is not coming back.")
-            self.dump_self_info_and_run_ptf("tc3", encap_type, False, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("tc3", encap_type, False)
         finally:
             Logger.info("Restore the routes in the DUT.")
             ecmp_utils.set_routes_in_dut(
@@ -605,7 +598,7 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
         create testcases.
     '''
 
-    def test_vxlan_configure_route1_ecmp_group_a(self, setUp, encap_type, skip_traffic_test):       # noqa F811
+    def test_vxlan_configure_route1_ecmp_group_a(self, setUp, encap_type):
         '''
             tc4:create tunnel route 1 with two endpoints a = {a1, a2...}. send
             packets to the route 1's prefix dst. packets are received at either
@@ -646,12 +639,12 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
 
         Logger.info("Verify that the new config takes effect and run traffic.")
 
-        self.dump_self_info_and_run_ptf("tc4", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc4", encap_type, True)
         # Add vxlan payload testing as well.
         self.dump_self_info_and_run_ptf("tc4", encap_type, True,
-                                        payload="vxlan", skip_traffic_test=skip_traffic_test)
+                                        payload="vxlan")
 
-    def test_vxlan_remove_ecmp_route1(self, setUp, encap_type, skip_traffic_test):      # noqa F811
+    def test_vxlan_remove_ecmp_route1(self, setUp, encap_type):
         '''
             Remove tunnel route 1. Send multiple packets (varying tuple) to the
             route 1's prefix dst.
@@ -695,7 +688,7 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             ecmp_route1_end_point_list)
 
         Logger.info("Verify that the new config takes effect and run traffic.")
-        self.dump_self_info_and_run_ptf("tc5", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc5", encap_type, True)
 
         # Deleting Tunnel route 1
         ecmp_utils.create_and_apply_config(
@@ -710,13 +703,13 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             {ecmp_route1_new_dest: ecmp_route1_end_point_list}
 
         Logger.info("Verify that the new config takes effect and run traffic.")
-        self.dump_self_info_and_run_ptf("tc5", encap_type, False, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc5", encap_type, False)
 
         # Restoring dest_to_nh_map to old values
         self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet] = copy.deepcopy(backup_dest)
-        self.dump_self_info_and_run_ptf("tc5", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc5", encap_type, True)
 
-    def test_vxlan_configure_route1_ecmp_group_b(self, setUp, encap_type, skip_traffic_test):       # noqa F811
+    def test_vxlan_configure_route1_ecmp_group_b(self, setUp, encap_type):
         '''
             tc5: set tunnel route 2 to endpoint group a = {a1, a2}. send
             packets to route 2"s prefix dst. packets are received at either a1
@@ -725,7 +718,7 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
         self.vxlan_test_setup = setUp
         self.setup_route2_ecmp_group_b(encap_type)
         Logger.info("Verify the configs work and traffic flows correctly.")
-        self.dump_self_info_and_run_ptf("tc5", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc5", encap_type, True)
 
     def setup_route2_ecmp_group_b(self, encap_type):
         '''
@@ -767,7 +760,7 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
 
         self.vxlan_test_setup[encap_type]['tc5_dest'] = tc5_new_dest
 
-    def test_vxlan_configure_route2_ecmp_group_b(self, setUp, encap_type, skip_traffic_test):       # noqa F811
+    def test_vxlan_configure_route2_ecmp_group_b(self, setUp, encap_type):
         '''
             tc6: set tunnel route 2 to endpoint group b = {b1, b2}. send
             packets to route 2"s prefix dst. packets are received at either
@@ -809,13 +802,12 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             tc6_end_point_list)
         Logger.info("Verify that the traffic works.")
 
-        self.dump_self_info_and_run_ptf("tc6", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc6", encap_type, True)
 
     @pytest.mark.skipif(
         "config.option.bfd is False",
         reason="This test will be run only if '--bfd=True' is provided.")
-    def test_vxlan_bfd_health_state_change_a2down_a1up(
-            self, setUp, encap_type, skip_traffic_test):        # noqa F811
+    def test_vxlan_bfd_health_state_change_a2down_a1up(self, setUp, encap_type):
         '''
             Set BFD state for a1' to UP and a2' to Down. Send multiple packets
             (varying tuple) to the route 1's prefix dst. Packets are received
@@ -863,12 +855,12 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             end_point_list[1])
 
         Logger.info("Verify that the new config takes effect and run traffic.")
-        self.dump_self_info_and_run_ptf("tc_a2down_a1up", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc_a2down_a1up", encap_type, True)
 
     @pytest.mark.skipif(
         "config.option.bfd is False",
         reason="This test will be run only if '--bfd=True' is provided.")
-    def test_vxlan_bfd_health_state_change_a1a2_down(self, setUp, encap_type, skip_traffic_test):       # noqa F811
+    def test_vxlan_bfd_health_state_change_a1a2_down(self, setUp, encap_type):
         '''
             Set BFD state for a1' to Down and a2' to Down. Send multiple
             packets (varying tuple) to the route 1's prefix dst. Packets
@@ -915,14 +907,13 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             "a1a2_down",
             encap_type,
             True,
-            packet_count=4,
-            skip_traffic_test=skip_traffic_test)
+            packet_count=4)
 
     @pytest.mark.skipif(
         "config.option.bfd is False",
         reason="This test will be run only if '--bfd=True' is provided.")
     def test_vxlan_bfd_health_state_change_a2up_a1down(
-            self, setUp, encap_type, skip_traffic_test):        # noqa F811
+            self, setUp, encap_type):
         '''
             Set BFD state for a2' to UP. Send packets to the route 1's prefix
             dst. Packets are received only at endpoint a2. Verify advertise
@@ -970,9 +961,9 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
             end_point_list[0])
 
         Logger.info("Verify that the new config takes effect and run traffic.")
-        self.dump_self_info_and_run_ptf("a2up_a1down", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("a2up_a1down", encap_type, True)
 
-    def test_vxlan_bfd_health_state_change_a1a2_up(self, setUp, encap_type, skip_traffic_test):     # noqa F811
+    def test_vxlan_bfd_health_state_change_a1a2_up(self, setUp, encap_type):
         '''
             Set BFD state for a1' & a2' to UP. Send multiple packets (varying
             tuple) to the route 1's prefix dst. Packets are received at both
@@ -1015,7 +1006,7 @@ class Test_VxLAN_ecmp_create(Test_VxLAN):
 
         Logger.info("Verify that the new config takes effect and run traffic.")
 
-        self.dump_self_info_and_run_ptf("tc4", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc4", encap_type, True)
 
         # perform cleanup by removing all the routes added by this test class.
         # reset to add only the routes added in the setup phase.
@@ -1206,7 +1197,7 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             encap_type,
             tc9_new_nhs)
 
-    def test_vxlan_remove_route2(self, setUp, encap_type, skip_traffic_test):       # noqa F811
+    def test_vxlan_remove_route2(self, setUp, encap_type):
         '''
             tc7:send packets to route 1's prefix dst. by removing route 2 from
             group a, no change expected to route 1.
@@ -1252,7 +1243,7 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             encap_type,
             tc7_end_point_list)
         Logger.info("Verify the setup works.")
-        self.dump_self_info_and_run_ptf("tc7", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc7", encap_type, True)
         Logger.info("End of setup.")
 
         Logger.info("Remove one of the routes.")
@@ -1272,7 +1263,7 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             "DEL")
 
         Logger.info("Verify the rest of the traffic still works.")
-        self.dump_self_info_and_run_ptf("tc7", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc7", encap_type, True)
 
         # perform cleanup by removing all the routes added by this test class.
         # reset to add only the routes added in the setup phase.
@@ -1289,18 +1280,18 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             ecmp_utils.get_payload_version(encap_type),
             "SET")
 
-    def test_vxlan_route2_single_nh(self, setUp, encap_type, skip_traffic_test):        # noqa F811
+    def test_vxlan_route2_single_nh(self, setUp, encap_type):
         '''
             tc8: set tunnel route 2 to single endpoint b1.
             Send packets to route 2's prefix dst.
         '''
         self.vxlan_test_setup = setUp
         self.setup_route2_single_endpoint(encap_type)
-        self.dump_self_info_and_run_ptf("tc8", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc8", encap_type, True)
         self.dump_self_info_and_run_ptf("tc8", encap_type, True,
-                                        payload="vxlan", skip_traffic_test=skip_traffic_test)
+                                        payload="vxlan")
 
-    def test_vxlan_route2_shared_nh(self, setUp, encap_type, skip_traffic_test):        # noqa F811
+    def test_vxlan_route2_shared_nh(self, setUp, encap_type):
         '''
             tc9: set tunnel route 2 to shared endpoints a1 and b1.
             Send packets to route 2's
@@ -1308,9 +1299,9 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
         '''
         self.vxlan_test_setup = setUp
         self.setup_route2_shared_endpoints(encap_type)
-        self.dump_self_info_and_run_ptf("tc9", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc9", encap_type, True)
 
-    def test_vxlan_route2_shared_different_nh(self, setUp, encap_type, skip_traffic_test):      # noqa F811
+    def test_vxlan_route2_shared_different_nh(self, setUp, encap_type):
         '''
             tc9.2: set tunnel route 2 to 2 completely different
             shared(no-reuse) endpoints a1 and b1. send packets
@@ -1318,9 +1309,9 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
         '''
         self.vxlan_test_setup = setUp
         self.setup_route2_shared_different_endpoints(encap_type)
-        self.dump_self_info_and_run_ptf("tc9.2", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc9.2", encap_type, True)
 
-    def test_vxlan_remove_ecmp_route2(self, setUp, encap_type, skip_traffic_test):      # noqa F811
+    def test_vxlan_remove_ecmp_route2(self, setUp, encap_type):
         '''
             tc10: remove tunnel route 2. send packets to route 2's prefix dst.
         '''
@@ -1369,7 +1360,7 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
                 tc10_nhs
 
             Logger.info("The deleted route should fail to receive traffic.")
-            self.dump_self_info_and_run_ptf("tc10", encap_type, False, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("tc10", encap_type, False)
 
             # all others should be working.
             # Housekeeping:
@@ -1380,7 +1371,7 @@ class Test_VxLAN_NHG_Modify(Test_VxLAN):
             del_needed = False
 
             Logger.info("Check the traffic is working in the other routes.")
-            self.dump_self_info_and_run_ptf("tc10", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("tc10", encap_type, True)
 
         except BaseException:
             self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet] = full_map.copy()
@@ -1399,7 +1390,7 @@ class Test_VxLAN_ecmp_random_hash(Test_VxLAN):
         Class for testing different tcp ports for payload.
     '''
 
-    def test_vxlan_random_hash(self, setUp, encap_type, skip_traffic_test):     # noqa F811
+    def test_vxlan_random_hash(self, setUp, encap_type):
         '''
             tc11: set tunnel route 3 to endpoint group c = {c1, c2, c3}.
             Ensure c1, c2, and c3 matches to underlay default route.
@@ -1448,8 +1439,7 @@ class Test_VxLAN_ecmp_random_hash(Test_VxLAN):
             "tc11",
             encap_type,
             True,
-            packet_count=1000,
-            skip_traffic_test=skip_traffic_test)
+            packet_count=1000)
 
 
 @pytest.mark.skipif(
@@ -1461,8 +1451,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
         Class for all test cases that modify the underlay default route.
     '''
     @pytest.mark.parametrize("ecmp_path_count", [1, 2])
-    def test_vxlan_modify_underlay_default(
-            self, setUp, minigraph_facts, encap_type, ecmp_path_count, skip_traffic_test):      # noqa F811
+    def test_vxlan_modify_underlay_default(self, setUp, minigraph_facts, encap_type, ecmp_path_count):
         '''
             tc12: modify the underlay default route nexthop/s. send packets to
             route 3's prefix dst.
@@ -1534,8 +1523,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                 "tc12",
                 encap_type,
                 True,
-                packet_count=1000,
-                skip_traffic_test=skip_traffic_test)
+                packet_count=1000)
 
             Logger.info(
                 "Reverse the action: bring up the selected_intfs"
@@ -1582,8 +1570,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                 "tc12",
                 encap_type,
                 True,
-                packet_count=1000,
-                skip_traffic_test=skip_traffic_test)
+                packet_count=1000)
 
             Logger.info("Recovery. Bring all up, and verify traffic works.")
             for intf in all_t2_intfs:
@@ -1611,8 +1598,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                 "tc12",
                 encap_type,
                 True,
-                packet_count=1000,
-                skip_traffic_test=skip_traffic_test)
+                packet_count=1000)
 
         except Exception:
             # If anything goes wrong in the try block, atleast bring the intf
@@ -1640,8 +1626,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
     def test_vxlan_remove_add_underlay_default(self,
                                                setUp,
                                                minigraph_facts,
-                                               encap_type,
-                                               skip_traffic_test):      # noqa F811
+                                               encap_type):
         '''
            tc13: remove the underlay default route.
            tc14: add the underlay default route.
@@ -1682,7 +1667,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                 "BGP neighbors have not reached the required state after "
                 "T2 intf are shutdown.")
             Logger.info("Verify that traffic is not flowing through.")
-            self.dump_self_info_and_run_ptf("tc13", encap_type, False, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("tc13", encap_type, False)
 
             # tc14: Re-add the underlay default route.
             Logger.info("Bring up the T2 interfaces.")
@@ -1704,8 +1689,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                 "tc14",
                 encap_type,
                 True,
-                packet_count=1000,
-                skip_traffic_test=skip_traffic_test)
+                packet_count=1000)
         except Exception:
             Logger.info(
                 "If anything goes wrong in the try block,"
@@ -1724,7 +1708,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                 " interfaces have been brought up.")
             raise
 
-    def test_underlay_specific_route(self, setUp, minigraph_facts, encap_type, skip_traffic_test):      # noqa F811
+    def test_underlay_specific_route(self, setUp, minigraph_facts, encap_type):
         '''
             Create a more specific underlay route to c1.
             Verify c1 packets are received only on the c1's nexthop interface
@@ -1795,8 +1779,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
         self.dump_self_info_and_run_ptf(
             "underlay_specific_route",
             encap_type,
-            True,
-            skip_traffic_test=skip_traffic_test)
+            True)
         # Deletion of all static routes
         gateway = all_t2_neighbors[t2_neighbor][outer_layer_version].lower()
         for _, nexthops in list(endpoint_nhmap.items()):
@@ -1844,14 +1827,12 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
         self.dump_self_info_and_run_ptf(
             "underlay_specific_route",
             encap_type,
-            True,
-            skip_traffic_test=skip_traffic_test)
+            True)
 
     def test_underlay_portchannel_shutdown(self,
                                            setUp,
                                            minigraph_facts,
-                                           encap_type,
-                                           skip_traffic_test):      # noqa F811
+                                           encap_type):
         '''
             Bring down one of the port-channels.
             Packets are equally recieved at c1, c2 or c3
@@ -1859,7 +1840,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
         self.vxlan_test_setup = setUp
 
         # Verification of traffic before shutting down port channel
-        self.dump_self_info_and_run_ptf("tc12", encap_type, True, skip_traffic_test=skip_traffic_test)
+        self.dump_self_info_and_run_ptf("tc12", encap_type, True)
 
         # Gathering all portchannels
         all_t2_portchannel_intfs = \
@@ -1894,7 +1875,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                 self.vxlan_test_setup[encap_type]['t2_ports'],
                 list(self.vxlan_test_setup['list_of_bfd_monitors']))
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("tc12", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("tc12", encap_type, True)
 
             for intf in all_t2_portchannel_members[selected_portchannel]:
                 self.vxlan_test_setup['duthost'].shell(
@@ -1906,7 +1887,7 @@ class Test_VxLAN_underlay_ecmp(Test_VxLAN):
                 self.vxlan_test_setup[encap_type]['t2_ports'],
                 list(self.vxlan_test_setup['list_of_bfd_monitors']))
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("tc12", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("tc12", encap_type, True)
         except BaseException:
             for intf in all_t2_portchannel_members[selected_portchannel]:
                 self.vxlan_test_setup['duthost'].shell(
@@ -1936,8 +1917,7 @@ class Test_VxLAN_entropy(Test_VxLAN):
             random_sport=False,
             random_dport=True,
             random_src_ip=False,
-            tolerance=None,
-            skip_traffic_test=False):       # noqa F811
+            tolerance=None):
         '''
             Function to be reused by the entropy testcases. Sets up a couple of
             endpoints on the top of the existing ones, and performs the traffic
@@ -1981,10 +1961,9 @@ class Test_VxLAN_entropy(Test_VxLAN):
             random_dport=random_dport,
             random_src_ip=random_src_ip,
             packet_count=1000,
-            tolerance=tolerance,
-            skip_traffic_test=skip_traffic_test)
+            tolerance=tolerance)
 
-    def test_verify_entropy(self, setUp, encap_type, skip_traffic_test):            # noqa F811
+    def test_verify_entropy(self, setUp, encap_type):
         '''
         Verification of entropy - Create tunnel route 4 to endpoint group A.
         Send packets (fixed tuple) to route 4's prefix dst
@@ -1995,10 +1974,9 @@ class Test_VxLAN_entropy(Test_VxLAN):
             random_dport=True,
             random_sport=True,
             random_src_ip=True,
-            tolerance=0.75,         # More tolerance since this varies entropy a lot.
-            skip_traffic_test=skip_traffic_test)
+            tolerance=0.75)         # More tolerance since this varies entropy a lot.
 
-    def test_vxlan_random_dst_port(self, setUp, encap_type, skip_traffic_test):     # noqa F811
+    def test_vxlan_random_dst_port(self, setUp, encap_type):
         '''
         Verification of entropy - Change the udp dst port of original packet to
         route 4's prefix dst
@@ -2006,7 +1984,7 @@ class Test_VxLAN_entropy(Test_VxLAN):
         self.vxlan_test_setup = setUp
         self.verify_entropy(encap_type, tolerance=0.03)
 
-    def test_vxlan_random_src_port(self, setUp, encap_type, skip_traffic_test):     # noqa F811
+    def test_vxlan_random_src_port(self, setUp, encap_type):
         '''
         Verification of entropy - Change the udp src port of original packet
         to route 4's prefix dst
@@ -2016,10 +1994,9 @@ class Test_VxLAN_entropy(Test_VxLAN):
             encap_type,
             random_dport=False,
             random_sport=True,
-            tolerance=0.03,
-            skip_traffic_test=skip_traffic_test)
+            tolerance=0.03)
 
-    def test_vxlan_varying_src_ip(self, setUp, encap_type, skip_traffic_test):      # noqa F811
+    def test_vxlan_varying_src_ip(self, setUp, encap_type):
         '''
         Verification of entropy - Change the udp src ip of original packet to
         route 4's prefix dst
@@ -2029,5 +2006,4 @@ class Test_VxLAN_entropy(Test_VxLAN):
             encap_type,
             random_dport=False,
             random_src_ip=True,
-            tolerance=0.03,
-            skip_traffic_test=skip_traffic_test)
+            tolerance=0.03)

--- a/tests/vxlan/test_vxlan_ecmp_switchover.py
+++ b/tests/vxlan/test_vxlan_ecmp_switchover.py
@@ -11,7 +11,6 @@ import json
 import pytest
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
-from tests.common.fixtures.ptfhost_utils import skip_traffic_test           # noqa F401
 from tests.ptf_runner import ptf_runner
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 
@@ -222,8 +221,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                                    random_sport=False,
                                    random_src_ip=False,
                                    tolerance=None,
-                                   payload=None,
-                                   skip_traffic_test=False):    # noqa F811
+                                   payload=None):
         '''
            Just a wrapper for dump_info_to_ptf to avoid entering 30 lines
            everytime.
@@ -276,9 +274,6 @@ class Test_VxLAN_ECMP_Priority_endpoints():
         Logger.info(
             "dest->nh mapping:%s", self.vxlan_test_setup[encap_type]['dest_to_nh_map'])
 
-        if skip_traffic_test is True:
-            Logger.info("Skipping traffic test.")
-            return
         ptf_runner(self.vxlan_test_setup['ptfhost'],
                    "ptftests",
                    "vxlan_traffic.VxLAN_in_VxLAN" if payload == 'vxlan'
@@ -292,7 +287,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                        datetime.now().strftime('%Y-%m-%d-%H:%M:%S')),
                    is_python3=True)
 
-    def test_vxlan_priority_single_pri_sec_switchover(self, setUp, encap_type, skip_traffic_test):  # noqa F811
+    def test_vxlan_priority_single_pri_sec_switchover(self, setUp, encap_type):
         '''
             tc1:create tunnel route 1 with two endpoints a = {a1, b1}. a1 is primary, b1 is secondary.
             1) both a1,b1 are UP.
@@ -369,7 +364,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                         ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)]))
             assert str(result['stdout']) == ecmp_utils.OVERLAY_DMAC
 
-            self.dump_self_info_and_run_ptf("test1", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test1", encap_type, True)
 
             # Single primary-secondary switchover.
             # Endpoint list = [A, A`], Primary[A] | Active NH=[A] |
@@ -387,7 +382,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               tc1_end_point_list[0], "down")
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("test1", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test1", encap_type, True)
 
             # Single primary recovery.
             # Endpoint list = [A, A`], Primary[A] | Active NH=[A`] |
@@ -405,7 +400,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               tc1_end_point_list[0], "up")
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("test1", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test1", encap_type, True)
 
             # Single primary backup Failure.
             # Endpoint list = [A, A`]. Primary[A]| Active  NH=[A`]  A is DOWN  |
@@ -427,7 +422,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                                               tc1_end_point_list[0], "down")
 
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("test1", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test1", encap_type, True)
             ecmp_utils.create_and_apply_priority_config(
                 self.vxlan_test_setup['duthost'],
                 vnet,
@@ -447,7 +442,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                 [tc1_end_point_list[0]],
                 "DEL")
 
-    def test_vxlan_priority_multi_pri_sec_switchover(self, setUp, encap_type, skip_traffic_test):   # noqa F811
+    def test_vxlan_priority_multi_pri_sec_switchover(self, setUp, encap_type):
         '''
             tc2:create tunnel route 1 with 6 endpoints a = {A, B, A`, B`}. A,B
             are primary, A`,B` are secondary.
@@ -545,7 +540,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
             self.vxlan_test_setup['list_of_downed_endpoints'] = set(inactive_list)
             time.sleep(10)
             # ensure that the traffic is distributed to all 3 primary Endpoints.
-            self.dump_self_info_and_run_ptf("test2", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
 
             # Multiple primary backups. Single primary failure.
             # Endpoint list = [A, B, A`, B`], Primary = [A, B] | active NH = [A, B] |
@@ -563,7 +558,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[0], "down")
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("test2", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
 
             # Multiple primary backups.  All primary failure.
             # Endpoint list = [A, B, A`, B`] Primary = [A, B] | A is Down. active NH = [B] |
@@ -580,7 +575,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[1], "down")
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("test2", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
 
             # Multiple primary backups. Backup Failure.
             # Endpoint list = [A, B, A`, B`] Primary = [A, B] |
@@ -599,7 +594,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               secondary_nhg[1], "down")
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("test2", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
 
             # Multiple primary backups. Single primary recovery.
             # Endpoint list = [A, B, A`, B`] Primary = [A, B] | Active NH = [A`] |
@@ -617,7 +612,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               primary_nhg[0], "up")
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("test2", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
 
             # Multiple primary backups. Multiple primary & backup recovery.
             # Edpoint list = [A, B, A`, B`] Primary = [A, B] | Active NH = [A] |
@@ -639,7 +634,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                                               secondary_nhg[1], "up")
 
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("test2", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
 
             # Multiple primary backups. Multiple primary & backup all failure.
             # Edpoint list = [A, B, A`, B`] Primary = [A, B] | Active NH = [A,B] |
@@ -668,7 +663,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               secondary_nhg[1], "down")
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("test2", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
 
             # Multiple primary backups. Multiple primary & backup recovery.
             # Edpoint list = [A, B, A`, B`] Primary = [A, B] | Active NH = [] |
@@ -698,7 +693,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                                               secondary_nhg[1], "up")
 
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("test2", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
 
             # Multiple primary backups. Multiple primary & backup all failure 2.
             # Edpoint list = [A, B, A`, B`] Primary = [A, B] | Active NH = [A,B] |
@@ -727,7 +722,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                                               ecmp_utils.HOST_MASK[ecmp_utils.get_payload_version(encap_type)],
                                               secondary_nhg[1], "down")
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("test2", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
 
             # Multiple primary backups. Multiple primary & backup recovery of secondary.
             # Edpoint list = [A, B, A`, B`] Primary = [A, B] | Active NH = [] |
@@ -749,7 +744,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                                               secondary_nhg[1], "up")
 
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("test2", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
 
             # Multiple primary backups. Multiple primary & backup recovery of primary after secondary.
             # Edpoint list = [A, B, A`, B`] Primary = [A, B] | Active NH = [A`, B`] |
@@ -771,7 +766,7 @@ class Test_VxLAN_ECMP_Priority_endpoints():
                                               primary_nhg[1], "up")
 
             time.sleep(10)
-            self.dump_self_info_and_run_ptf("test2", encap_type, True, skip_traffic_test=skip_traffic_test)
+            self.dump_self_info_and_run_ptf("test2", encap_type, True)
             ecmp_utils.create_and_apply_priority_config(
                 self.vxlan_test_setup['duthost'],
                 vnet,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently we are using conditional mark to add marker, then use pytest hook to redirect testutils.verify function to a function always return True to skip traffic test. With this change, the skip_traffic_test fixture is no longer needed in test cases, streamlining the test code and improving clarity.
#### How did you do it?
Remove skip_traffic_test fixture in vxlan tests
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
