### PR TITLE
feat: add support for clearing counter for ingress

### DIFF
--- a/tests/common/snappi_tests/multi_dut_params.py
+++ b/tests/common/snappi_tests/multi_dut_params.py
@@ -16,3 +16,5 @@ class MultiDUTParams():
         self.duthost1 = None
         self.duthost2 = None
         self.multi_dut_ports = None
+        self.ingress_duthosts = []
+        self.egress_duthosts = []

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -344,10 +344,10 @@ def run_traffic(duthost,
         cs.state = cs.START
         api.set_capture_state(cs)
 
-    for duthost in [*snappi_extra_params.multi_dut_params.ingress_duthosts,
-                    *snappi_extra_params.multi_dut_params.egress_duthosts]:
-        clear_dut_interface_counters(duthost)
-        clear_dut_que_counters(duthost)
+    for host in set([*snappi_extra_params.multi_dut_params.ingress_duthosts,
+                     *snappi_extra_params.multi_dut_params.egress_duthosts, duthost]):
+        clear_dut_interface_counters(host)
+        clear_dut_que_counters(host)
 
     logger.info("Starting transmit on all flows ...")
     ts = api.transmit_state()

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -344,9 +344,10 @@ def run_traffic(duthost,
         cs.state = cs.START
         api.set_capture_state(cs)
 
-    clear_dut_interface_counters(duthost)
-
-    clear_dut_que_counters(duthost)
+    for duthost in [*snappi_extra_params.multi_dut_params.ingress_duthosts,
+                    *snappi_extra_params.multi_dut_params.egress_duthosts]:
+        clear_dut_interface_counters(duthost)
+        clear_dut_que_counters(duthost)
 
     logger.info("Starting transmit on all flows ...")
     ts = api.transmit_state()

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
@@ -74,11 +74,19 @@ def run_lossless_response_to_external_pause_storms_test(api,
     rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
     rx_port_id_list = [rx_port["port_id"]]
     egress_duthost = rx_port['duthost']
+
+    # Append the egress here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.egress_duthosts.append(egress_duthost)
+
     dut_asics_to_be_configured.add((egress_duthost, rx_port['asic_value']))
 
     tx_port = [snappi_extra_params.multi_dut_params.multi_dut_ports[1],
                snappi_extra_params.multi_dut_params.multi_dut_ports[2]]
     ingress_duthost = tx_port[0]['duthost']
+
+    # Append the ingress here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost)
+
     tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
     # add ingress DUT into the set
     dut_asics_to_be_configured.add((tx_port[0]['duthost'], tx_port[0]['asic_value']))

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
@@ -80,11 +80,19 @@ def run_lossless_response_to_throttling_pause_storms_test(api,
     rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
     rx_port_id_list = [rx_port["port_id"]]
     egress_duthost = rx_port['duthost']
+
+    # Append the egress here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.egress_duthosts.append(egress_duthost)
+
     dut_asics_to_be_configured.add((egress_duthost, rx_port['asic_value']))
 
     tx_port = [snappi_extra_params.multi_dut_params.multi_dut_ports[1],
                snappi_extra_params.multi_dut_params.multi_dut_ports[2]]
     ingress_duthost = tx_port[0]['duthost']
+
+    # Append the ingress here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost)
+
     tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
     # add ingress DUT into the set
     dut_asics_to_be_configured.add((tx_port[0]['duthost'], tx_port[0]['asic_value']))

--- a/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -67,11 +67,19 @@ def run_m2o_fluctuating_lossless_test(api,
     rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
     rx_port_id_list = [rx_port["port_id"]]
     egress_duthost = rx_port['duthost']
+
+    # Append the egress here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.egress_duthosts.append(egress_duthost)
+
     dut_asics_to_be_configured.add((egress_duthost, rx_port['asic_value']))
 
     tx_port = [snappi_extra_params.multi_dut_params.multi_dut_ports[1],
                snappi_extra_params.multi_dut_params.multi_dut_ports[2]]
     ingress_duthost = tx_port[0]['duthost']
+
+    # Append the ingress here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost)
+
     tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
     # add ingress DUT into the set
     dut_asics_to_be_configured.add((tx_port[0]['duthost'], tx_port[0]['asic_value']))

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_helper.py
@@ -71,9 +71,16 @@ def run_m2o_oversubscribe_lossless_test(api,
     egress_duthost = rx_port['duthost']
     dut_asics_to_be_configured.add((egress_duthost, rx_port['asic_value']))
 
+    # Append the egress here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.egress_duthosts.append(egress_duthost)
+
     tx_port = [snappi_extra_params.multi_dut_params.multi_dut_ports[1],
                snappi_extra_params.multi_dut_params.multi_dut_ports[2]]
     ingress_duthost = tx_port[0]['duthost']
+
+    # Append the ingress here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost)
+
     tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
     # add ingress DUT into the set
     dut_asics_to_be_configured.add((tx_port[0]['duthost'], tx_port[0]['asic_value']))

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -74,11 +74,19 @@ def run_pfc_m2o_oversubscribe_lossless_lossy_test(api,
     rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
     rx_port_id_list = [rx_port["port_id"]]
     egress_duthost = rx_port['duthost']
+
+    # Append the egress here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.egress_duthosts.append(egress_duthost)
+
     dut_asics_to_be_configured.add((egress_duthost, rx_port['asic_value']))
 
     tx_port = [snappi_extra_params.multi_dut_params.multi_dut_ports[1],
                snappi_extra_params.multi_dut_params.multi_dut_ports[2]]
     ingress_duthost = tx_port[0]['duthost']
+
+    # Append the ingress here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost)
+
     tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
     # add ingress DUT into the set
     dut_asics_to_be_configured.add((tx_port[0]['duthost'], tx_port[0]['asic_value']))

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossy_helper.py
@@ -73,11 +73,19 @@ def run_pfc_m2o_oversubscribe_lossy_test(api,
     rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
     rx_port_id_list = [rx_port["port_id"]]
     egress_duthost = rx_port['duthost']
+
+    # Append the egress here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.egress_duthosts.append(egress_duthost)
+
     dut_asics_to_be_configured.add((egress_duthost, rx_port['asic_value']))
 
     tx_port = [snappi_extra_params.multi_dut_params.multi_dut_ports[1],
                snappi_extra_params.multi_dut_params.multi_dut_ports[2]]
     ingress_duthost = tx_port[0]['duthost']
+
+    # Append the ingress here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost)
+
     tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
     # add ingress DUT into the set
     dut_asics_to_be_configured.add((tx_port[0]['duthost'], tx_port[0]['asic_value']))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) Az 30112879

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Ingress port does not get cleared before running the test. This change will make sure both ingress and egress are cleared
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
