### PR TITLE
Skip dualtor check_nexthops_single_downlink earlier on VS platform

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1184,6 +1184,10 @@ def check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_add
 
     ptf_t1_intf = random.choice(get_t1_ptf_ports(rand_selected_dut, tbinfo))
     port_packet_count = dict()
+
+    if asic_type == "vs":
+        logging.info("Skipping validation on VS platform")
+        return
     packets_to_send = generate_hashed_packet_to_server(ptfadapter, rand_selected_dut, HASH_KEYS, dst_server_addr,
                                                        expect_packet_num)
 
@@ -1196,10 +1200,6 @@ def check_nexthops_single_downlink(rand_selected_dut, ptfadapter, dst_server_add
 
         for ptf_idx, pkt_count in ptf_port_count.items():
             port_packet_count[ptf_idx] = port_packet_count.get(ptf_idx, 0) + pkt_count
-
-    if asic_type == "vs":
-        logging.info("Skipping validation on VS platform")
-        return
 
     logging.info("Received packets in ports: {}".format(str(port_packet_count)))
     for downlink_int in expected_downlink_ports:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In PR test, check_nexthops_single_downlink have chance to take more than 1 hour because it needs to run several rounds of traffic test, each round would take more than 20 mins, it would easily cause PR test timeout
#### How did you do it?
Skip earlier in check_nexthops_single_downlink for VS platform, needn't go deep into traffic test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
