### PR TITLE
Fix the parameters for AllPortQueueWaterMark Testcase.

### DIFF
--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -414,7 +414,7 @@ qos_params:
                 wm_q_wm_all_ports:
                     ecn: 1
                     pkt_count: 3000
-                    pkts_num_margin: 1024
+                    pkts_num_margin: 3072
                     cell_size: 384
                 xon_1:
                     dscp: 3
@@ -538,7 +538,7 @@ qos_params:
                 wm_q_wm_all_ports:
                     ecn: 1
                     pkt_count: 3000
-                    pkts_num_margin: 1024
+                    pkts_num_margin: 3072
                     cell_size: 384
                     packet_size: 1350
                 xon_1:
@@ -729,7 +729,7 @@ qos_params:
                 wm_q_wm_all_ports:
                     ecn: 1
                     pkt_count: 855
-                    pkts_num_margin: 1024
+                    pkts_num_margin: 3072
                     cell_size: 6144
                     packet_size: 6144
             400000_120000m:

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -2178,7 +2178,9 @@ class TestQosSai(QosSaiBase):
             "src_port_id": src_port_id,
             "src_port_ip": src_port_ip,
             "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
-            "pkts_num_leak_out": qosConfig[queueProfile]["pkts_num_leak_out"],
+            "pkts_num_leak_out":  qosConfig[queueProfile]["pkts_num_leak_out"]
+            if ("pkts_num_leak_out" in qosConfig[queueProfile]) else
+            qosConfig["pkts_num_leak_out"],
             "pkt_count": qosConfig[queueProfile]["pkt_count"],
             "cell_size": qosConfig[queueProfile]["cell_size"],
             "hwsku": dutTestParams['hwsku'],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The testcase test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts is failing due to much narrower margins in the lossy queue counter case. So this PR attempts to increase the margin, and also handle a case where the required qos.yml key is not present in the TC's params, but in the params for port-speed structure itself.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
