### PR TITLE
Update SSH session gen to generate tmuxinator configurations

### DIFF
--- a/ansible/devutil/device_inventory.py
+++ b/ansible/devutil/device_inventory.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import csv
 import glob
@@ -22,7 +23,7 @@ class DeviceInfo(object):
         self.device_type = device_type
         self.protocol = protocol
         self.os = os
-        self.console_device = None
+        self.physical_hostname = None
         self.console_port = 0
 
     @staticmethod
@@ -50,6 +51,107 @@ class DeviceInfo(object):
         return True
 
 
+class DeviceLinkInfo:
+    """Device link information."""
+
+    def __init__(
+        self,
+        start_device: str,
+        start_port: str,
+        end_device: str,
+        end_port: str,
+        bandwidth: int,
+        vlan_ranges: List[range],
+        vlan_mode: str,
+        auto_neg: str
+    ):
+        self.start_device = start_device
+        self.start_port = start_port
+        self.end_device = end_device
+        self.end_port = end_port
+        self.bandwidth = bandwidth
+        self.vlan_ranges = vlan_ranges
+        self.vlan_mode = vlan_mode
+        self.auto_neg = auto_neg
+
+    @staticmethod
+    def from_csv_row(row: List[str]) -> "DeviceLinkInfo":
+        vlan_list = row[5] if row[5] else ""
+        vlan_ranges_str = vlan_list.split(",") if vlan_list != "" else []
+        vlan_ranges = []
+        for vlan_range_str in vlan_ranges_str:
+            vlan_range = vlan_range_str.split("-")
+            if len(vlan_range) == 1:
+                vlan_ranges.append(range(int(vlan_range[0]), int(vlan_range[0]) + 1))
+            elif len(vlan_range) == 2:
+                vlan_ranges.append(range(int(vlan_range[0]), int(vlan_range[1]) + 1))
+            else:
+                raise ValueError(f"Invalid vlan range: {vlan_range_str}")
+
+        return DeviceLinkInfo(
+            start_device=row[0],
+            start_port=row[1],
+            end_device=row[2],
+            end_port=row[3],
+            bandwidth=int(row[4]),
+            vlan_ranges=vlan_ranges,
+            vlan_mode=row[6],
+            auto_neg=row[7] if len(row) > 7 else ""
+        )
+
+    def create_reverse_link(self) -> "DeviceLinkInfo":
+        return DeviceLinkInfo(
+            start_device=self.end_device,
+            start_port=self.end_port,
+            end_device=self.start_device,
+            end_port=self.start_port,
+            bandwidth=self.bandwidth,
+            vlan_ranges=self.vlan_ranges,
+            vlan_mode=self.vlan_mode,
+            auto_neg=self.auto_neg
+        )
+
+
+class DeviceLinkMap:
+    """Device link map."""
+
+    @staticmethod
+    def from_csv_file(file_path: str) -> "DeviceLinkMap":
+        links = DeviceLinkMap()
+        with open(file_path, newline="") as file:
+            reader = csv.reader(file)
+
+            # Skip the header line
+            next(reader)
+
+            for row in reader:
+                if row:
+                    device_link = DeviceLinkInfo.from_csv_row(row)
+                    links.add_link(device_link)
+
+        return links
+
+    def __init__(self):
+        self.links: Dict[str, Dict[str, DeviceLinkInfo]] = {}
+
+    def add_link(self, link: DeviceLinkInfo):
+        if link.start_device not in self.links:
+            self.links[link.start_device] = {}
+        self.links[link.start_device][link.start_port] = link
+
+        reverse_link = link.create_reverse_link()
+        if reverse_link.start_device not in self.links:
+            self.links[reverse_link.start_device] = {}
+        self.links[reverse_link.start_device][reverse_link.start_port] = reverse_link
+
+    def get_links(self, device: str) -> Optional[Dict[str, DeviceLinkInfo]]:
+        return self.links.get(device)
+
+    def get_link(self, device: str, port: str) -> Optional[DeviceLinkInfo]:
+        links = self.get_links(device)
+        return links.get(port) if links else None
+
+
 class DeviceInventory(object):
     """Device inventory from csv files."""
 
@@ -59,15 +161,22 @@ class DeviceInventory(object):
         self.inv_name = inv_name
         self.device_file_name = device_file_name
         self.devices = devices
+        self.links = DeviceLinkMap()
 
     @staticmethod
     def from_device_files(device_file_pattern: str) -> "List[DeviceInventory]":
         inv: List[DeviceInventory] = []
         for file_path in glob.glob(device_file_pattern):
             device_inventory = DeviceInventory.from_device_file(file_path)
+
             console_links_file_path = file_path.replace("_devices", "_console_links")
             if os.path.exists(console_links_file_path):
                 device_inventory.load_console_links_info(console_links_file_path)
+
+            device_links_file_path = file_path.replace("_devices", "_links")
+            if os.path.exists(device_links_file_path):
+                device_inventory.load_device_link_map(device_links_file_path)
+
             inv.append(device_inventory)
 
         return inv
@@ -116,8 +225,17 @@ class DeviceInventory(object):
                     if not device_info:
                         print(f"Unknown device hostname {device_hostname}, skipping")
                         continue
-                    device_info.console_device = console_device_info
-                    device_info.console_port = console_port
+
+                    device_console_device = copy.deepcopy(console_device_info)
+                    device_console_device.hostname = f"{device_hostname}-console"
+                    device_console_device.device_type = "Console"  # Make it different from ConsoleServer
+                    device_console_device.physical_hostname = console_hostname
+                    device_console_device.console_port = console_port
+                    self.devices[device_console_device.hostname] = device_console_device
+
+    def load_device_link_map(self, file_path: str):
+        print(f"Loading device links inventory: {file_path}")
+        self.links = DeviceLinkMap.from_csv_file(file_path)
 
     def get_device(self, hostname: str) -> Optional[DeviceInfo]:
         return self.devices.get(hostname)

--- a/ansible/devutil/testbed.py
+++ b/ansible/devutil/testbed.py
@@ -150,9 +150,9 @@ class TestBed(object):
             elif linked_device.device_type == "Server":
                 self.server_nodes[linked_device.hostname] = linked_device
                 # print(f"  Server: {linked_device.hostname}")
-            elif linked_device.device_type == "DevSonic":
-                raise ValueError(f"Found VLAN ID being used by 2 DUTs: {dut.hostname} and "
-                                 f"{linked_device.hostname}! Please fix the testbed config.")
+            elif "Dev" in linked_device.device_type:
+                print(f"ERROR: Conflicting VLAN ID is found between 2 DUTs: {dut.hostname} and "
+                      f"{linked_device.hostname}! Please fix the testbed config.")
             else:
                 raise ValueError(f"Unknown device type: {linked_device.device_type} "
                                  f"(DUT: {dut.hostname}, Linked: {linked_device.hostname})")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This change updates the SSH session gen to generate tmuxinator configurations. This helps us to find all relative devices for a testbed, so we can easily connect all and debug.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

When debugging the testbed, we need to access related devices to find the issues, such as fanout, root, ptf and so on. However, finding these devices every time in mgmt repo and connect them one by one is tedious.

#### How did you do it?

This change updates SSH session gen to load the link information as a link map. Then using BFS, we easily use the VLAN information to find all related devices.

With this, we can generate a tmuxinator configuration for each testbed, which helps us to connect to all fanout, root, ptf, and server that is related to the DUT.

Each type of the connection are put in different tmux window, while each device of the same type are put as panes within that window.

#### How did you verify/test it?

Ran the configuration locally.

![image](https://github.com/user-attachments/assets/2e4259ba-3e98-4ede-867b-d87d6e14dda3)

#### Any platform specific information?

No.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
