### PR TITLE
[ipfwd/test_nhop_group]: Support multi-asic in interface flap test

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -836,7 +836,7 @@ def test_nhop_group_interface_flap(duthosts, enum_rand_one_per_hwsku_frontend_ho
 
         # Enable kernel flag to not evict ARP entries when the interface goes down
         # and shut the fanout switch ports.
-        duthost.shell(arp_noevict_cmd % gather_facts['src_router_intf_name'])
+        asic.command(arp_noevict_cmd % gather_facts['src_router_intf_name'])
         for i in range(0, len(gather_facts['src_port'])):
             fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, duthost.hostname,
                                                             gather_facts['src_port'][i])
@@ -876,6 +876,6 @@ def test_nhop_group_interface_flap(duthosts, enum_rand_one_per_hwsku_frontend_ho
         logger.info("portstats: %s", result['stdout'])
 
     finally:
-        duthost.shell(arp_evict_cmd % gather_facts['src_router_intf_name'])
+        asic.command(arp_evict_cmd % gather_facts['src_router_intf_name'])
         nhop.delete_routes()
         arplist.clean_up()


### PR DESCRIPTION

### Description of PR
Arp eviction commands need to respect the asic namespace when being applied to multi-asic devices, as the procfs entries are for each individual asic.

Summary:
Fixes #15495

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Ran on t2 multi asic and single asic LCs
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
