### PR TITLE
Add warm reboot finalizer state check for fast reboot

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -66,6 +66,7 @@ reboot_ctrl_dict = {
         "command": "fast-reboot",
         "timeout": 180,
         "wait": 120,
+        "warmboot_finalizer_timeout": 180,
         "cause": "fast-reboot",
         "test_reboot_cause_only": False
     },
@@ -295,7 +296,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         time.sleep(wait)
 
     # Wait warmboot-finalizer service
-    if reboot_type == REBOOT_TYPE_WARM and wait_warmboot_finalizer:
+    if (reboot_type == REBOOT_TYPE_WARM or reboot_type == REBOOT_TYPE_FAST) and wait_warmboot_finalizer:
         logger.info('waiting for warmboot-finalizer service to finish on {}'.format(hostname))
         ret = wait_until(warmboot_finalizer_timeout, 5, 0, check_warmboot_finalizer_inactive, duthost)
         if not ret:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add warm reboot finalizer state check for fast reboot

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Case bgp.test_bgp_slb#test_bgp_slb_neighbor_persistence_across_advanced_reboot would fail from time to time
#### How did you do it?
According to the https://github.com/sonic-net/SONiC/blob/master/doc/fast-reboot/Fast-reboot_Flow_Improvements_HLD.md, the warm reboot finalizer had started to support check for fast-reboot. So I added the state check for fast-reboot.
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
