### PR TITLE
[VOQ-Chassis] bgp-queue: skip internal nbrs for voq-chassis

### DIFF
--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -60,8 +60,11 @@ def test_bgp_queues(duthosts, enum_frontend_dut_hostname, enum_asic_index, tbinf
         # Only consider established bgp sessions
         if v['state'] == 'established':
             # For "peer group" if it's internal it will be "INTERNAL_PEER_V4" or "INTERNAL_PEER_V6"
+            # or "VOQ_CHASSIS_PEER_V4" or "VOQ_CHASSIS_PEER_V6" for VOQ_CHASSIS
             # If it's external it will be "RH_V4", "RH_V6", "AH_V4", "AH_V6", ...
-            if "INTERNAL" in v["peer group"] and duthost.get_facts().get('modular_chassis'):
+            # Skip internal neighbors for VOQ_CHASSIS until BRCM fixes iBGP traffic in 2024011
+            if ("INTERNAL" in v["peer group"] or 'VOQ_CHASSIS' in v["peer group"]) and \
+                    duthost.get_facts().get('modular_chassis'):
                 # Skip iBGP neighbors since we only want to verify eBGP
                 continue
             assert (k in arp_dict.keys() or k in ndp_dict.keys())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- In addition to skipping internal neighbors belong to peer-group "_INTERNAL_PEER_V4_", "_INTERNAL_PEER_V6_" by #14310, skip VOQ_CHASSIS peer group internal neighbors as well for testing _test_bgp_queue_
- This change can be **removed** once BRCM fixes iBGP traffic over queue 7 and as per discussion it would be available in 202411.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

- '_test_bgp_queue_' tests fail for VOQ-CHASSIS, when the interface selected is 'Ethernet-IB0'.

#### How did you do it?

- In addition to the current internal peer group, add 'VOQ_CHASSIS' peer groups as well for skipping internal neighbors as part of the test.

#### How did you verify/test it?
- Ran '_test_bgp_queue_' tests on T2 VOQ-Chassis and made sure the expected tests are passing.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/user-attachments/assets/50c7cc43-7eec-4e96-a1fe-70b0b5ff976e)
