### PR TITLE
Move some stable test to PR test set and add ptf_asym to skip PR test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -220,6 +220,10 @@ t0:
   - telemetry/test_telemetry.py
   - platform_tests/test_cont_warm_reboot.py
   - snmp/test_snmp_link_local.py
+  - arp/test_arp_update.py
+  - decap/test_subnet_decap.py
+  - fdb/test_fdb_mac_learning.py
+  - ip/test_mgmt_ipv6_only.py
 
 t0-2vlans:
   - dhcp_relay/test_dhcp_relay.py
@@ -423,6 +427,8 @@ t1-lag:
   - generic_config_updater/test_cacl.py
   - telemetry/test_telemetry.py
   - snmp/test_snmp_link_local.py
+  - mpls/test_mpls.py
+  - vxlan/test_vxlan_route_advertisement.py
 
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py
@@ -464,17 +470,9 @@ onboarding_t0:
   - lldp/test_lldp_syncd.py
   # Flaky, we will triage and fix it later, move to onboarding to unblock pr check
   - dhcp_relay/test_dhcp_relay_stress.py
-  - arp/test_arp_update.py
-  - decap/test_subnet_decap.py
-  - fdb/test_fdb_mac_learning.py
-  - ip/test_mgmt_ipv6_only.py
-
 
 onboarding_t1:
   - lldp/test_lldp_syncd.py
-  - mpls/test_mpls.py
-  - vxlan/test_vxlan_route_advertisement.py
-
 
 specific_param:
   t0-sonic:

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -22,6 +22,8 @@ t0:
   - ospf/test_ospf.py
   - ospf/test_ospf_bfd.py
   # Test is not supported on vs testbed
+  - pfc_asym/test_pfc_asym.py
+  # Test is not supported on vs testbed
   - platform_tests/test_intf_fec.py
   # Platform api needs the module `sonic_platform`, which is not included in vs
   # So skip these scripts


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Some dataplane test scripts have been added to PR test and put into optional onboarding job to test case performance, I calculated the success rate of test scripts in recent 3 days, I think I can move high success rate test scripts to t0/t1 job now

TestbedName | FilePath | TestCase | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-t1-lag | mpls/test_mpls.py | test_pop_label | 45 | 0 | 45 | 1
vms-kvm-t1-lag | mpls/test_mpls.py | test_swap_label | 45 | 0 | 45 | 1
vms-kvm-t1-lag | mpls/test_mpls.py | test_push_label | 45 | 0 | 45 | 1
vms-kvm-t1-lag | mpls/test_mpls.py | test_swap_labelstack | 45 | 0 | 45 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_route_advertisement.py | test_basic_route_advertisement[v4_in_v4] | 48 | 1 | 49 | 0.9796
vms-kvm-t1-lag | vxlan/test_vxlan_route_advertisement.py | test_basic_route_advertisement_with_community[v4_in_v4] | 48 | 0 | 48 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_route_advertisement.py | test_basic_route_advertisement_with_community_change[v4_in_v4] | 48 | 0 | 48 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_route_advertisement.py | test_route_advertisement_without_and_with_community[v4_in_v4] | 48 | 0 | 48 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_route_advertisement.py | test_scale_route_advertisement_with_community[v4_in_v4] | 48 | 0 | 48 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_route_advertisement.py | test_basic_route_advertisement[v6_in_v4] | 48 | 0 | 48 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_route_advertisement.py | test_basic_route_advertisement_with_community[v6_in_v4] | 48 | 0 | 48 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_route_advertisement.py | test_basic_route_advertisement_with_community_change[v6_in_v4] | 48 | 0 | 48 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_route_advertisement.py | test_route_advertisement_without_and_with_community[v6_in_v4] | 48 | 0 | 48 | 1
vms-kvm-t1-lag | vxlan/test_vxlan_route_advertisement.py | test_scale_route_advertisement_with_community[v6_in_v4] | 48 | 0 | 48 | 1
vms-kvm-t0 | arp/test_arp_update.py | test_kernel_asic_mac_mismatch[ipv4] | 45 | 1 | 46 | 0.9783
vms-kvm-t0 | arp/test_arp_update.py | test_kernel_asic_mac_mismatch[ipv6] | 45 | 0 | 45 | 1
vms-kvm-t0 | decap/test_subnet_decap.py | test_vlan_subnet_decap[positive-IPv4] | 45 | 1 | 46 | 0.9783
vms-kvm-t0 | decap/test_subnet_decap.py | test_vlan_subnet_decap[positive-IPv6] | 45 | 0 | 45 | 1
vms-kvm-t0 | decap/test_subnet_decap.py | test_vlan_subnet_decap[negative-IPv4] | 45 | 0 | 45 | 1
vms-kvm-t0 | decap/test_subnet_decap.py | test_vlan_subnet_decap[negative-IPv6] | 45 | 0 | 45 | 1
vms-kvm-t0 | fdb/test_fdb_mac_learning.py | testFdbMacLearning | 45 | 1 | 46 | 0.9783
vms-kvm-t0 | fdb/test_fdb_mac_learning.py | testARPCompleted | 45 | 0 | 45 | 1
vms-kvm-t0 | ip/test_mgmt_ipv6_only.py | test_bgp_facts_ipv6_only[vlab-01-None] | 46 | 0 | 46 | 1
vms-kvm-t0 | ip/test_mgmt_ipv6_only.py | test_show_features_ipv6_only[vlab-01] | 46 | 0 | 46 | 1
vms-kvm-t0 | ip/test_mgmt_ipv6_only.py | test_image_download_ipv6_only[vlab-01] | 46 | 0 | 46 | 1
vms-kvm-t0 | ip/test_mgmt_ipv6_only.py | test_syslog_ipv6_only[fd82:b34f:cc99::100-None] | 46 | 0 | 46 | 1
vms-kvm-t0 | ip/test_mgmt_ipv6_only.py | test_syslog_ipv6_only[fd82:b34f:cc99::100-fd82:b34f:cc99::200] | 46 | 0 | 46 | 1
vms-kvm-t0 | ip/test_mgmt_ipv6_only.py | test_snmp_ipv6_only[vlab-01] | 46 | 0 | 46 | 1
vms-kvm-t0 | ip/test_mgmt_ipv6_only.py | test_ro_user_ipv6_only[vlab-01] | 46 | 0 | 46 | 1
vms-kvm-t0 | ip/test_mgmt_ipv6_only.py | test_rw_user_ipv6_only[vlab-01] | 46 | 0 | 46 | 1
vms-kvm-t0 | ip/test_mgmt_ipv6_only.py | test_telemetry_output_ipv6_only[vlab-01-True] | 46 | 0 | 46 | 1
vms-kvm-t0 | ip/test_mgmt_ipv6_only.py | test_ntp_ipv6_only[True] | 46 | 0 | 46 | 1

#### How did you do it?
Move test from onboarding job to t0/t1 job
Move pfc_asym test to skip PR test set since it's only supported on barefoot platform
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
