### PR TITLE
change swapsyncd to module level.

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -575,7 +575,7 @@ class QosSaiBase(QosBase):
                 None
         """
         if 'dualtor' in tbinfo['topo']['name']:
-            dut_list = lower_tor_host
+            dut_list = [lower_tor_host]
         else:
             dut_list = duthosts.frontend_nodes
         swapSyncd = request.config.getoption("--qos_swap_syncd")
@@ -1875,7 +1875,7 @@ class QosSaiBase(QosBase):
     @pytest.fixture(scope='module', autouse=True)
     def dut_disable_ipv6(self, duthosts, tbinfo, lower_tor_host, swapSyncd_on_selected_duts): # noqa F811
         if 'dualtor' in tbinfo['topo']['name']:
-            dut_list = lower_tor_host
+            dut_list = [lower_tor_host]
         else:
             dut_list = duthosts.frontend_nodes
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
change swapsyncd and disable_ipv6 to module level. 
Running time on T2 reduced by around 140 minutes (from 685.08 minutes to 543.95 minutes).

Existing code will do swapSyncd for selected dut only in each iteration.  In a T2 full test, it was around 8 LC which needs to do swapsyncd, including setup and teardown for each iteration.
| select_src_dst_dut_and_asic |  selected DUT to do swapsyncd (Existing) |
| --- | --- |
| single_asic | one downstream  LC |
| single_dut_multi_asic |  one downstream LC |
| multi_dut_longlink_to_shortlink |  one upstream LC, one downstream LC |
| multi_dut_shortlink_to_shortlink |  two downstream LC |
| multi_dut_shortlink_to_longlink |  one upstream LC, one downstream LC  |

After the fix, swapsyncd will be done for all LCs at the beginning of the test. Saved around 5 LC swapsyncd time

| select_src_dst_dut_and_asic |  selected DUT to do swapsyncd (after fix) |
| --- | --- |
| Setup |  one upstream LC, two downstream LC |
| single_asic | none |
| single_dut_multi_asic |  none |
| multi_dut_longlink_to_shortlink | none |
| multi_dut_shortlink_to_shortlink |  none |
| multi_dut_shortlink_to_longlink |  none |
| Teardown |  one upstream LC, two downstream LC |


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Reduce the run time for test_qos_sai module.

#### How did you do it?
change the swapsyncd fixture to module level. replace all dut with rpcsyncd container, instead of replacing selected dut multiple times for each iteration.

#### How did you verify/test it?
verified the physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
