### PR TITLE
[M0-2VLAN] Update test_vlan_ping for m0-2vlan topo

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -60,15 +60,15 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo, 
     vm_host_info = {}
 
     vm_name, vm_info = None, None
-    topo_name = tbinfo["topo"]["name"]
+    topo_type = tbinfo["topo"]["type"]
     for nbr_name, nbr_info in list(nbrhosts.items()):
-        if topo_name != "m0" or (topo_name == "m0" and "M1" in nbr_name):
+        if topo_type != "m0" or (topo_type == "m0" and "M1" in nbr_name):
             vm_name = nbr_name
             vm_info = nbr_info
             break
 
     py_assert(vm_name is not None, "Can't get neighbor vm")
-    if topo_name == "mx":
+    if topo_type == "mx":
         vm_ip_with_prefix = six.ensure_text(vm_info['conf']['interfaces']['Ethernet1']['ipv4'])
         output = vm_info['host'].command("ip addr show dev eth1")
     else:
@@ -104,7 +104,7 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo, 
         # Get the bgp neighbor connected to the selected VM
         if a_bgp_nbr['name'] == vm_name and a_bgp_nbr['addr'] == str(vm_host_info['ipv4']):
             # Find the interface that connects to the selected VM
-            if topo_name == "mx":
+            if topo_type == "mx":
                 for intf in mg_facts['minigraph_interfaces']:
                     if intf['peer_addr'] == str(vm_host_info['ipv4']):
                         vm_host_info['port_index_list'] = [mg_facts['minigraph_ptf_indices'][intf['attachto']]]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update test_vlan_ping for m0-2vlan topo.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Update test_vlan_ping for m0-2vlan topo.

#### How did you do it?
Use `topo_type` instead of `topo_name`.

#### How did you verify/test it?

Verified on Nokia-7215 M0-2VLAN testbed.
```
vlan/test_vlan_ping.py::test_vlan_ping PASSED                                                                                   [100%]
============================================== 1 passed, 1 warning in 441.79s (0:07:21) ===============================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
