### PR TITLE
Xfail qos/test_qos_dscp_mapping.py for Cisco-8122

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1361,6 +1361,12 @@ qos/test_pfc_pause.py::test_pfc_pause_lossless:
   skip:
     reason: "Fanout needs to send PFC frames fast enough to completely pause the queue"
 
+qos/test_qos_dscp_mapping.py:
+  skip:
+    reason: "ECN marking in combination with tunnel decap not yet supported"
+    conditions:
+      - "asic_type in ['cisco-8000'] and platform in ['x86_64-8122_64eh_o-r0']"
+
 qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to_queue_mapping_pipe_mode:
   skip:
     reason: "Pipe decap mode not supported due to either SAI or platform limitation / M0/MX topo does not support qos"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1362,8 +1362,9 @@ qos/test_pfc_pause.py::test_pfc_pause_lossless:
     reason: "Fanout needs to send PFC frames fast enough to completely pause the queue"
 
 qos/test_qos_dscp_mapping.py:
-  skip:
+  xfail:
     reason: "ECN marking in combination with tunnel decap not yet supported"
+    strict: True
     conditions:
       - "asic_type in ['cisco-8000'] and platform in ['x86_64-8122_64eh_o-r0']"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Xfail qos/test_qos_dscp_mapping.py for Cisco-8122.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This test uses ECT bit marked packets in combination with tunnel decap. ECT bit preservation is not yet supported on Cisco-8122. 

#### How did you do it?

Marking the test as xfail with strict checking, so later when the test begins passing it will be easier to see and remove the xfail. 

#### How did you verify/test it?
Verified on 8122 cisco platform that it reports an xfail. 

#### Any platform specific information?
Cisco-8122 only. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
