### PR TITLE
Skip l3_alpm_enable check on broadcom-dnx platforms

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -60,6 +60,10 @@ def check_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_
         return
 
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    if (duthost.facts.get('platform_asic') == 'broadcom-dnx'):
+        # CS00012377343 - l3_alpm_enable isn't supported on dnx
+        return
+
     asic = duthost.facts["asic_type"]
     asic_id = enum_rand_one_frontend_asic_index
 


### PR DESCRIPTION
### Description of PR
Broadcom confirmed that `l3_alpm_enable` soc property is only used in `XGS` platforms (CS00012377343)
Therefor we should skip the check for this soc property on `DNX` platforms.

Summary:
Fixes #15511 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405