### PR TITLE
Add dualtor stanalone and swithover faulty ycable test to PR test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -245,7 +245,9 @@ dualtor:
   - arp/test_arp_dualtor.py
   - arp/test_arp_extended.py
   - dualtor/test_ipinip.py
+  - dualtor/test_standalone_tunnel_route.py
   - dualtor/test_switchover_failure.py
+  - dualtor/test_switchover_faulty_ycable.py
   - dualtor/test_tor_ecn.py
   - dualtor/test_tunnel_memory_leak.py
   - dualtor_io/test_heartbeat_failure.py

--- a/tests/common/dualtor/tunnel_traffic_utils.py
+++ b/tests/common/dualtor/tunnel_traffic_utils.py
@@ -262,6 +262,7 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
             self.listen_ports = sorted(self._get_t1_ptf_port_indexes(standby_tor, tbinfo))
             self.ptfadapter = ptfadapter
             self.packet_count = packet_count
+            self.asic_type = standby_tor.facts["asic_type"]
 
             standby_tor_cfg_facts = self.standby_tor.config_facts(
                 host=self.standby_tor.hostname, source="running"
@@ -292,17 +293,15 @@ def tunnel_traffic_monitor(ptfadapter, tbinfo):
         def __exit__(self, *exc_info):
             if exc_info[0]:
                 return
+            if self.asic_type == "vs":
+                logging.info("Skipping traffic check on VS platform.")
+                return
             try:
-                result = testutils.verify_packet_any_port(
+                port_index, rec_pkt = testutils.verify_packet_any_port(
                     ptfadapter,
                     self.exp_pkt,
                     ports=self.listen_ports
                 )
-                if isinstance(result, tuple):
-                    port_index, rec_pkt = result
-                elif isinstance(result, bool):
-                    logging.info("Using dummy testutils to skip traffic test.")
-                    return
             except AssertionError as detail:
                 logging.debug("Error occurred in polling for tunnel traffic", exc_info=True)
                 if "Did not receive expected packet on any of ports" in str(detail):

--- a/tests/dualtor/test_switchover_faulty_ycable.py
+++ b/tests/dualtor/test_switchover_faulty_ycable.py
@@ -21,6 +21,18 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loganalyzer):
+    # Ignore in KVM test
+    KVMIgnoreRegex = [
+        ".*Could not establish the active side for Y cable port.*",
+    ]
+    duthost = duthosts[rand_one_dut_hostname]
+    if loganalyzer:  # Skip if loganalyzer is disabled
+        if duthost.facts["asic_type"] == "vs":
+            loganalyzer[duthost.hostname].ignore_regex.extend(KVMIgnoreRegex)
+
+
 @pytest.fixture(scope="module")
 def simulated_faulty_side(rand_unselected_dut):
     return rand_unselected_dut


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed
#### How did you do it?
Add dualtor stanalone and swithover faulty ycable test to PR test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
