### PR TITLE
[dut_console]: conditionally skip connect tests for arista 7800 chassis

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -622,13 +622,13 @@ dut_console/test_console_baud_rate.py::test_baud_rate_boot_connect:
   skip:
     reason: "Platform linecards do not have console ports"
     conditions:
-      - "'arista_7800' in platform"
+      - "asic_type in ['vs'] or 'arista_7800' in platform"
 
 dut_console/test_console_baud_rate.py::test_baud_rate_sonic_connect:
   skip:
     reason: "Platform linecards do not have console ports"
     conditions:
-      - "'arista_7800' in platform"
+      - "asic_type in ['vs'] or 'arista_7800' in platform"
 
 #######################################
 #####             ecmp            #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -618,6 +618,18 @@ dut_console:
     conditions:
       - "asic_type in ['vs']"
 
+dut_console/test_console_baud_rate.py::test_baud_rate_boot_connect:
+  skip:
+    reason: "Platform linecards do not have console ports"
+    conditions:
+      - "'arista_7800' in platform"
+
+dut_console/test_console_baud_rate.py::test_baud_rate_sonic_connect:
+  skip:
+    reason: "Platform linecards do not have console ports"
+    conditions:
+      - "'arista_7800' in platform"
+
 #######################################
 #####             ecmp            #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Skip dut console connect tests for arista 7800 as the linecards do not have console ports

Summary:
Fixes #15518

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x ] 202405

### Approach
#### What is the motivation for this PR?
Test was failing on setup due to no mgmt ip for console, as there isnt a console for the linecards
#### How did you do it?
conditionally skip for 7800 chassis
#### How did you verify/test it?
ran locally, tests are skipped
#### Any platform specific information?
arista 7800 specific
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
