### PR TITLE
Fixing the import error and KeyError in snappi_test/multidut executions.

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -1137,6 +1137,9 @@ def get_interface_stats(duthost, port):
 
     n_out = parse_portstat(duthost.command('portstat -i {}'.format(port))['stdout_lines'])[port]
     i_stats[duthost.hostname][port] = n_out
+    for k in ['rx_ok', 'rx_err', 'rx_drp', 'rx_ovr', 'tx_ok', 'tx_err', 'tx_drp', 'tx_ovr']:
+        i_stats[duthost.hostname][port][k] = int("".join(i_stats[duthost.hostname][port][k].split(',')))
+
     # rx_err, rx_ovr and rx_drp are counted in single counter rx_fail
     # tx_err, tx_ovr and tx_drp are counted in single counter tx_fail
     rx_err = ['rx_err', 'rx_ovr', 'rx_drp']
@@ -1144,9 +1147,9 @@ def get_interface_stats(duthost, port):
     rx_fail = 0
     tx_fail = 0
     for m in rx_err:
-        rx_fail = rx_fail + int(n_out[m].replace(',', ''))
+        rx_fail = rx_fail + n_out[m]
     for m in tx_err:
-        tx_fail = tx_fail + int(n_out[m].replace(',', ''))
+        tx_fail = tx_fail + n_out[m]
 
     # Any throughput below 1MBps is measured as 0 for simplicity.
     thrput = n_out['rx_bps']
@@ -1160,8 +1163,8 @@ def get_interface_stats(duthost, port):
     else:
         i_stats[duthost.hostname][port]['rx_thrput_Mbps'] = 0
 
-    i_stats[duthost.hostname][port]['rx_pkts'] = int(n_out['rx_ok'].replace(',', ''))
-    i_stats[duthost.hostname][port]['tx_pkts'] = int(n_out['tx_ok'].replace(',', ''))
+    i_stats[duthost.hostname][port]['rx_pkts'] = n_out['rx_ok']
+    i_stats[duthost.hostname][port]['tx_pkts'] = n_out['tx_ok']
     i_stats[duthost.hostname][port]['rx_fail'] = rx_fail
     i_stats[duthost.hostname][port]['tx_fail'] = tx_fail
 

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
@@ -141,7 +141,7 @@ def run_lossless_response_to_external_pause_storms_test(api,
     dut_rx_port1 = tx_port[0]['peer_port']
     dut_rx_port2 = tx_port[1]['peer_port']
     # Fetch relevant statistics
-    pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[ingress_duthost.hostname][dut_tx_port]['tx_drp']
+    pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
     rx_pkts_1 = get_interface_stats(ingress_duthost, dut_rx_port1)[ingress_duthost.hostname][dut_rx_port1]['rx_ok']
     rx_pkts_2 = get_interface_stats(ingress_duthost, dut_rx_port2)[ingress_duthost.hostname][dut_rx_port2]['rx_ok']
     # Calculate the total received packets

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
@@ -148,7 +148,7 @@ def run_lossless_response_to_throttling_pause_storms_test(api,
     dut_rx_port1 = tx_port[0]['peer_port']
     dut_rx_port2 = tx_port[1]['peer_port']
     # Fetch relevant statistics
-    pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[ingress_duthost.hostname][dut_tx_port]['tx_drp']
+    pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
     rx_pkts_1 = get_interface_stats(ingress_duthost, dut_rx_port1)[ingress_duthost.hostname][dut_rx_port1]['rx_ok']
     rx_pkts_2 = get_interface_stats(ingress_duthost, dut_rx_port2)[ingress_duthost.hostname][dut_rx_port2]['rx_ok']
     # Calculate the total received packets

--- a/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -130,7 +130,7 @@ def run_m2o_fluctuating_lossless_test(api,
     dut_rx_port1 = tx_port[0]['peer_port']
     dut_rx_port2 = tx_port[1]['peer_port']
     # Fetch relevant statistics
-    pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[ingress_duthost.hostname][dut_tx_port]['tx_drp']
+    pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
     rx_pkts_1 = get_interface_stats(ingress_duthost, dut_rx_port1)[ingress_duthost.hostname][dut_rx_port1]['rx_ok']
     rx_pkts_2 = get_interface_stats(ingress_duthost, dut_rx_port2)[ingress_duthost.hostname][dut_rx_port2]['rx_ok']
     # Calculate the total received packets

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_helper.py
@@ -133,7 +133,7 @@ def run_m2o_oversubscribe_lossless_test(api,
     dut_rx_port1 = tx_port[0]['peer_port']
     dut_rx_port2 = tx_port[1]['peer_port']
     # Fetch relevant statistics
-    pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[ingress_duthost.hostname][dut_tx_port]['tx_drp']
+    pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
     rx_pkts_1 = get_interface_stats(ingress_duthost, dut_rx_port1)[ingress_duthost.hostname][dut_rx_port1]['rx_ok']
     rx_pkts_2 = get_interface_stats(ingress_duthost, dut_rx_port2)[ingress_duthost.hostname][dut_rx_port2]['rx_ok']
     # Calculate the total received packets

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -138,7 +138,7 @@ def run_pfc_m2o_oversubscribe_lossless_lossy_test(api,
     dut_rx_port2 = tx_port[1]['peer_port']
     dut_tx_port = rx_port['peer_port']
     # Fetch relevant statistics
-    pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[ingress_duthost.hostname][dut_tx_port]['tx_drp']
+    pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
     rx_pkts_1 = get_interface_stats(ingress_duthost, dut_rx_port1)[ingress_duthost.hostname][dut_rx_port1]['rx_ok']
     rx_pkts_2 = get_interface_stats(ingress_duthost, dut_rx_port2)[ingress_duthost.hostname][dut_rx_port2]['rx_ok']
     # Calculate the total received packets

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossy_helper.py
@@ -139,7 +139,7 @@ def run_pfc_m2o_oversubscribe_lossy_test(api,
     dut_rx_port1 = tx_port[0]['peer_port']
     dut_rx_port2 = tx_port[1]['peer_port']
 
-    pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[ingress_duthost.hostname][dut_tx_port]['tx_drp']
+    pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
     rx_pkts_1 = get_interface_stats(ingress_duthost, dut_rx_port1)[ingress_duthost.hostname][dut_rx_port1]['rx_ok']
     rx_pkts_2 = get_interface_stats(ingress_duthost, dut_rx_port2)[ingress_duthost.hostname][dut_rx_port2]['rx_ok']
     # Calculate the total received packets

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
@@ -170,8 +170,6 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
                                                 conn_graph_facts,           # noqa F811
                                                 fanout_graph_facts_multidut,         # noqa F811
                                                 localhost,
-                                                duthosts,
-                                                enum_dut_lossless_prio_with_completeness_level,   # noqa: F811
                                                 lossless_prio_list,         # noqa F811
                                                 tbinfo,      # noqa: F811
                                                 prio_dscp_map,              # noqa F811

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
@@ -16,7 +16,7 @@ from tests.common.utilities import wait_until                       # noqa: F401
 from tests.snappi_tests.multidut.pfcwd.files.pfcwd_multidut_basic_helper import run_pfcwd_basic_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import skip_pfcwd_test, reboot_duts, \
-    setup_ports_and_dut   # noqa: F401
+    setup_ports_and_dut, multidut_port_info   # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
@@ -175,6 +175,7 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
                                                 lossless_prio_list,         # noqa F811
                                                 tbinfo,      # noqa: F811
                                                 prio_dscp_map,              # noqa F811
+                                                setup_ports_and_dut,        # noqa: F811
                                                 reboot_duts,                # noqa: F811
                                                 trigger_pfcwd):
     """

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
@@ -172,6 +172,7 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
                                                 localhost,
                                                 duthosts,
                                                 enum_dut_lossless_prio_with_completeness_level,   # noqa: F811
+                                                lossless_prio_list,         # noqa F811
                                                 tbinfo,      # noqa: F811
                                                 prio_dscp_map,              # noqa F811
                                                 reboot_duts,                # noqa: F811


### PR DESCRIPTION
@sdszhang : This PR attempts to fix the fixture-not-found error and KeyError that you are seeing in the snappi_test multidut runs. Pls let me know if this works for you.