### PR TITLE
Move function `get_bgp_speaker_runningconfig` to common place.

### DIFF
--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -12,7 +12,7 @@ from tests.common.utilities import wait_tcp_connection
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from bgp_helpers import update_routes
-from tests.generic_config_updater.test_bgp_speaker import get_bgp_speaker_runningconfig
+from tests.common.gu_utils import get_bgp_speaker_runningconfig
 from tests.common.gu_utils import apply_patch, expect_op_success
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import (

--- a/tests/generic_config_updater/test_bgp_speaker.py
+++ b/tests/generic_config_updater/test_bgp_speaker.py
@@ -7,6 +7,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.gu_utils import apply_patch, expect_op_success
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
+from tests.common.gu_utils import get_bgp_speaker_runningconfig
 
 pytestmark = [
     pytest.mark.topology('t0'),     # BGP Speaker is limited to t0 only
@@ -54,27 +55,6 @@ def lo_intf_ips(rand_selected_dut, tbinfo):
         if ip and ipv6:
             return ip, ipv6
     pytest_assert(True, "Required ipv4 and ipv6 to start the test")
-
-
-def get_bgp_speaker_runningconfig(duthost):
-    """ Get bgp speaker config that contains src_address and ip_range
-
-    Sample output in t0:
-    ['\n neighbor BGPSLBPassive update-source 10.1.0.32',
-     '\n neighbor BGPVac update-source 10.1.0.32',
-     '\n bgp listen range 10.255.0.0/25 peer-group BGPSLBPassive',
-     '\n bgp listen range 192.168.0.0/21 peer-group BGPVac']
-    """
-    cmds = "show runningconfiguration bgp"
-    output = duthost.shell(cmds)
-    pytest_assert(not output['rc'], "'{}' failed with rc={}".format(cmds, output['rc']))
-
-    # Sample:
-    # neighbor BGPSLBPassive update-source 10.1.0.32
-    # bgp listen range 192.168.0.0/21 peer-group BGPVac
-    bgp_speaker_pattern = r"\s+neighbor.*update-source.*|\s+bgp listen range.*"
-    bgp_speaker_config = re.findall(bgp_speaker_pattern, output['stdout'])
-    return bgp_speaker_config
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In script `test_bgp_dual_asn.py`, there is an import from the folder `tests/generic_config_updater`. To minimize cross-module dependencies, we have refactored this function to a common location.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In script `test_bgp_dual_asn.py`, there is an import from the folder `tests/generic_config_updater`. To minimize cross-module dependencies, we have refactored this function to a common location.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
