### PR TITLE
[dualtor] Fix snmp/* tests failure on fixture teardown

### DIFF
--- a/tests/snmp/conftest.py
+++ b/tests/snmp/conftest.py
@@ -68,14 +68,15 @@ def setup_check_snmp_ready(duthosts, localhost):
             if 'LOCATION' not in snmp_location_redis_vals:
                 duthost.shell(f'sudo config snmp location add {yaml_snmp_location}')  # set snmp cli
 
-        yield
+    yield
 
+    for duthost in duthosts:
         # rollback configuration
         rollback(duthost, SETUP_ENV_CP)
 
-        # remove snmp files downloaded
-        local_command = "find ./snmp/ -type f -name 'snmp.yml' -exec rm -f {} +"
-        localhost.shell(local_command)
+    # remove snmp files downloaded
+    local_command = "find ./snmp/ -type f -name 'snmp.yml' -exec rm -f {} +"
+    localhost.shell(local_command)
 
 
 def extract_redis_keys(item):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Move `yield` statement out of for loop in snmp fixture `setup_check_snmp_ready`
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/307


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/pull/15359 has introduced a "yield" statement inside the for loop of duthosts which is causing fixture teardown to fail with `Failed: fixture function has more than one 'yield'` message.

#### How did you do it?
Move "yield" statement out of this for loop of duthosts and do config rollback in a seperate for loop of duthosts.

#### How did you verify/test it?
Ran tests under `snmp` folder and tests are passing on `Arista-7260CX3-D108C8` platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
