### PR TITLE
Add nhop group test to onboarding PR test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -473,6 +473,7 @@ onboarding_t0:
 
 onboarding_t1:
   - lldp/test_lldp_syncd.py
+  - ipfwd/test_nhop_group.py
 
 specific_param:
   t0-sonic:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -279,6 +279,12 @@ ipfwd/test_dir_bcast.py:
     conditions:
       - "asic_type in ['vs']"
 
+ipfwd/test_nhop_group.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
 #######################################
 #####            route            #####
 #######################################

--- a/tests/common/vs_data.py
+++ b/tests/common/vs_data.py
@@ -1,0 +1,2 @@
+def is_vs_device(dut):
+    return dut.facts["asic_type"] == "vs"

--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -15,6 +15,7 @@ from tests.common.helpers.assertions import pytest_require, pytest_assert
 from tests.common.cisco_data import is_cisco_device
 from tests.common.mellanox_data import is_mellanox_device, get_chip_type
 from tests.common.innovium_data import is_innovium_device
+from tests.common.vs_data import is_vs_device
 from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import fanout_switch_port_lookup, toggle_one_link
 
@@ -457,6 +458,8 @@ def test_nhop_group_member_count(duthost, tbinfo, loganalyzer):
         )
     elif is_mellanox_device(duthost):
         logger.info("skip this check on Mellanox as ASIC resources are shared")
+    elif is_vs_device(duthost):
+        logger.info("skip this check on VS as no real ASIC")
     else:
         pytest_assert(
             crm_after["available_nhop_grp"] == 0,
@@ -516,8 +519,13 @@ def test_nhop_group_member_order_capability(duthost, tbinfo, ptfadapter, gather_
         for flow_count in range(50):
             pkt, exp_pkt = build_pkt(rtr_mac, ip_route, ip_ttl, flow_count)
             testutils.send(ptfadapter, gather_facts['dst_port_ids'][0], pkt, 10)
-            (_, recv_pkt) = testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt,
+            verify_result = testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt,
                                                              ports=gather_facts['src_port_ids'])
+            if isinstance(verify_result, bool):
+                logger.info("Using dummy testutils to skip traffic test.")
+                return
+            else:
+                _, recv_pkt = verify_result
 
             assert recv_pkt
 
@@ -564,7 +572,8 @@ def test_nhop_group_member_order_capability(duthost, tbinfo, ptfadapter, gather_
                 asic.stop_service("bgp")
                 time.sleep(15)
                 logger.info("Toggle link {} on {}".format(fanout_port, fanout))
-                toggle_one_link(duthost, gather_facts['src_port'][0], fanout, fanout_port)
+                if is_vs_device(duthost) is False:
+                    toggle_one_link(duthost, gather_facts['src_port'][0], fanout, fanout_port)
                 time.sleep(15)
 
                 built_and_send_tcp_ip_packet()
@@ -774,6 +783,10 @@ def test_nhop_group_member_order_capability(duthost, tbinfo, ptfadapter, gather_
     hostvars = duthost.host.options['variable_manager']._hostvars[duthost.hostname]
     mgFacts = duthost.get_extended_minigraph_facts(tbinfo)
     dutAsic = None
+    if vendor == "vs":
+        logger.info("Skipping following traffic validation on VS platform")
+        return
+
     for asic, nexthop_map in list(SUPPORTED_ASIC_TO_NEXTHOP_SELECTED_MAP.items()):
         vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
         if vendorAsic in list(hostvars.keys()) and mgFacts["minigraph_hwsku"] in hostvars[vendorAsic]:
@@ -841,7 +854,8 @@ def test_nhop_group_interface_flap(duthosts, enum_rand_one_per_hwsku_frontend_ho
             fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, duthost.hostname,
                                                             gather_facts['src_port'][i])
             logger.debug("Shut fanout sw: %s, port: %s", fanout, fanout_port)
-            fanout.shutdown(fanout_port)
+            if is_vs_device(duthost) is False:
+                fanout.no_shutdown(fanout_port)
         nhop.add_ip_route(ip_prefix, ips)
 
         nhop.program_routes()
@@ -860,13 +874,19 @@ def test_nhop_group_interface_flap(duthosts, enum_rand_one_per_hwsku_frontend_ho
             fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, duthost.hostname,
                                                             gather_facts['src_port'][i])
             logger.debug("No Shut fanout sw: %s, port: %s", fanout, fanout_port)
-            fanout.no_shutdown(fanout_port)
+            if is_vs_device(duthost) is False:
+                fanout.no_shutdown(fanout_port)
         time.sleep(20)
         duthost.shell("portstat -c")
         ptfadapter.dataplane.flush()
         testutils.send(ptfadapter, gather_facts['dst_port_ids'][0], pkt, pkt_count)
-        (_, recv_pkt) = testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt,
+        verify_result = testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt,
                                                          ports=gather_facts['src_port_ids'])
+        if isinstance(verify_result, bool):
+            logger.info("Using dummy testutils to skip traffic test.")
+            return
+        else:
+            _, recv_pkt = verify_result
         # Make sure routing is done
         pytest_assert(scapy.Ether(recv_pkt).ttl == (ip_ttl - 1), "Routed Packet TTL not decremented")
         pytest_assert(scapy.Ether(recv_pkt).src == rtr_mac, "Routed Packet Source Mac is not router MAC")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed
#### How did you do it?
Add nhop group test to onboarding PR test and skip traffic test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
