### PR TITLE
[sonic-mgmt] Correct conditional_mark for testcase "test_standby_tor_downstream_loopback_route_readded"

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -472,9 +472,9 @@ dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_bg
 
 dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_loopback_route_readded:
   skip:
-    reason: "This testcase is designed for single tor testbed with mock dualtor config and dualtor."
+    reason: "This testcase is designed for single tor testbed with mock dualtor config."
     conditions:
-      - "(topo_type not in ['t0'])"
+      - "(topo_type not in ['t0']) or ('dualtor' in topo_name)"
 
 dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_t1_link_recovered:
   skip:

--- a/tests/dualtor/test_orchagent_standby_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_standby_tor_downstream.py
@@ -41,23 +41,6 @@ pytestmark = [
 logger = logging.getLogger(__file__)
 
 
-@pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
-
-    ignore_errors = [
-        r".* ERR syncd#syncd: .*SAI_API_TUNNEL:_brcm_sai_mptnl_tnl_route_event_add:\d+ ecmp table entry lookup "
-        "failed with error.*",
-        r".* ERR syncd#syncd: .*SAI_API_TUNNEL:_brcm_sai_mptnl_process_route_add_mode_default_and_host:\d+ "
-        "_brcm_sai_mptnl_tnl_route_event_add failed with error.*"
-    ]
-
-    if loganalyzer:
-        for duthost in duthosts:
-            loganalyzer[duthost.hostname].ignore_regex.extend(ignore_errors)
-
-    return None
-
-
 @pytest.fixture(params=['ipv4', 'ipv6'])
 def ip_version(request):
     """Traffic IP version to test."""
@@ -279,7 +262,7 @@ def test_standby_tor_downstream_loopback_route_readded(
         rand_unselected_dut.shell("config bgp start all")
     pt_assert(
         wait_until(
-            60, 1, 0,
+            10, 1, 0,
             lambda: route_matches_expected_state(rand_selected_dut, active_tor_loopback0, expect_route=True)),
         "Expected route {} not found on {}".format(active_tor_loopback0, rand_selected_dut)
     )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Correct conditional_mark for testcase "test_standby_tor_downstream_loopback_route_readded"
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/303

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
`dualtor/test_orchagent_standby_tor_downstream.py::test_standby_tor_downstream_loopback_route_readded` was being skipped earlier with reason `This testcase is designed for single tor testbed with mock dualtor config`. This has started running recently after infra changes done for conditional_mark through https://github.com/sonic-net/sonic-mgmt/pull/14395.

#### How did you do it?
Updated conditional_mark to skip this test for dualtor topologies (to be in consistent with earlier behaviour as the test was getting skipped earlier).

#### How did you verify/test it?
With the above change verified that test is getting skipped on dualtor topologies.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
