### PR TITLE
fix 7260 headroom pool watermark test failure

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3158,6 +3158,9 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             sys.stderr.flush()
 
             upper_bound = 2 * margin + 1
+            if (hwsku == 'Arista-7260CX3-D108C8' and self.testbed_type in ('t0-116', 'dualtor-120')) \
+                or (hwsku == 'Arista-7260CX3-C64' and self.testbed_type in ('dualtor-aa-56', 't1-64-lag')):
+                upper_bound = 2 * margin + self.pgs_num
             if self.wm_multiplier:
                 hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(
                     self.src_client, self.buf_pool_roid)

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3159,7 +3159,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
             upper_bound = 2 * margin + 1
             if (hwsku == 'Arista-7260CX3-D108C8' and self.testbed_type in ('t0-116', 'dualtor-120')) \
-                or (hwsku == 'Arista-7260CX3-C64' and self.testbed_type in ('dualtor-aa-56', 't1-64-lag')):
+                    or (hwsku == 'Arista-7260CX3-C64' and self.testbed_type in ('dualtor-aa-56', 't1-64-lag')):
                 upper_bound = 2 * margin + self.pgs_num
             if self.wm_multiplier:
                 hdrm_pool_wm = sai_thrift_read_headroom_pool_watermark(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

observed consistent headroom wartermark test failure on 7260
and it's known issue of test script, as below RCA:

RCA:

summarize test step first:

1. PTF send lots of pkt to multiple src ports to fill multiple PG's share buffer
2. PTF send one or a few pkts to multiple src ports to trigger pfc on multiple PG
3. check watermark before test headroom's watermark
4. PTF send pkt to multiple src port to consum headroom pool, and test if watermark changes as expected
after step2,

already send 20 pkts into headroom to trigger PFC on 10 src ports (20 PG)
but, so far, "upper_bound" value is static hardcode "2 * margin + 1", didn't consider headroom pool consumption in step2.
since we use dynamically threshold calculating, it can get accurate threshold value, we pretty sure the headroom pool consumption equal "pgs_num" in step2.
so I change "upper_bound" value to "2 * margin + self.pgs_num", and it pass the tests.


#### How did you do it?

change "upper_bound" value to "2 * margin + self.pgs_num"

#### How did you verify/test it?

this change already verified in MSFT nightly for 202305 and 202311 branch, just commit to github.

#### Any platform specific information?

this change is dedicated to below platform and topology:
```
            if (hwsku == 'Arista-7260CX3-D108C8' and self.testbed_type in ('t0-116', 'dualtor-120')) \
                or (hwsku == 'Arista-7260CX3-C64' and self.testbed_type in ('dualtor-aa-56', 't1-64-lag')):
                upper_bound = 2 * margin + self.pgs_num
```
if other platform and topology have hit similar issue, can add affected platform and topo to above condition checking.
Note:
for generic fix,  qos refactor project will covert.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
