### PR TITLE
[snappi] skip multidut bgp instead of assert if testbed doesn't support.

### DIFF
--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_port_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_port_flap.py
@@ -68,7 +68,7 @@ def test_bgp_outbound_downlink_port_flap(snappi_api,                            
     snappi_extra_params.multi_dut_params.flap_details = FLAP_DETAILS
     snappi_extra_params.test_name = "T1 Interconnectivity flap"
     if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_assert(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
+        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
 
     ansible_dut_hostnames = []
     for duthost in duthosts:
@@ -78,7 +78,7 @@ def test_bgp_outbound_downlink_port_flap(snappi_api,                            
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
+            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
         if t1_t2_device_hostnames[0] in duthost.hostname:

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_process_crash.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_process_crash.py
@@ -66,7 +66,7 @@ def test_bgp_outbound_downlink_process_crash(snappi_api,                        
                                                         }
     snappi_extra_params.multi_dut_params.host_name = t1_t2_device_hostnames[2]
     if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_assert(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
+        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
 
     ansible_dut_hostnames = []
     for duthost in duthosts:
@@ -76,7 +76,7 @@ def test_bgp_outbound_downlink_process_crash(snappi_api,                        
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
+            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
         if t1_t2_device_hostnames[0] in duthost.hostname:

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_tsa.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_tsa.py
@@ -62,7 +62,7 @@ def test_dut_configuration(multidut_snappi_ports_for_bgp,                  # noq
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
+            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
         if t1_t2_device_hostnames[0] in duthost.hostname:
@@ -103,7 +103,7 @@ def test_bgp_outbound_uplink_tsa(snappi_api,                                    
     snappi_extra_params.device_name = t1_t2_device_hostnames[1]
 
     if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_assert(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
+        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
 
     ansible_dut_hostnames = []
     for duthost in duthosts:
@@ -113,7 +113,7 @@ def test_bgp_outbound_uplink_tsa(snappi_api,                                    
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
+            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
         if t1_t2_device_hostnames[0] in duthost.hostname:
@@ -161,7 +161,7 @@ def test_bgp_outbound_downlink_tsa(snappi_api,                                  
     snappi_extra_params.device_name = t1_t2_device_hostnames[2]
 
     if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_assert(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
+        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
 
     ansible_dut_hostnames = []
     for duthost in duthosts:
@@ -171,7 +171,7 @@ def test_bgp_outbound_downlink_tsa(snappi_api,                                  
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
+            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
         if t1_t2_device_hostnames[0] in duthost.hostname:
@@ -217,7 +217,7 @@ def test_bgp_outbound_supervisor_tsa(snappi_api,                                
     snappi_extra_params.device_name = t1_t2_device_hostnames[3]
 
     if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_assert(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
+        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
 
     ansible_dut_hostnames = []
     for duthost in duthosts:
@@ -227,7 +227,7 @@ def test_bgp_outbound_supervisor_tsa(snappi_api,                                
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
+            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
         if t1_t2_device_hostnames[0] in duthost.hostname:

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_multi_po_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_multi_po_flap.py
@@ -62,7 +62,7 @@ def test_dut_configuration(multidut_snappi_ports_for_bgp,                  # noq
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
+            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
         if t1_t2_device_hostnames[0] in duthost.hostname:
@@ -103,7 +103,7 @@ def test_bgp_outbound_uplink_complete_blackout(snappi_api,                      
     snappi_extra_params.multi_dut_params.BLACKOUT_PERCENTAGE = 100
 
     if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_assert(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
+        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
 
     ansible_dut_hostnames = []
     for duthost in duthosts:
@@ -112,7 +112,7 @@ def test_bgp_outbound_uplink_complete_blackout(snappi_api,                      
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
+            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
         if t1_t2_device_hostnames[0] in duthost.hostname:
@@ -156,7 +156,7 @@ def test_bgp_outbound_uplink_partial_blackout(snappi_api,                       
     snappi_extra_params.multi_dut_params.BLACKOUT_PERCENTAGE = 50
 
     if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_assert(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
+        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
 
     ansible_dut_hostnames = []
     for duthost in duthosts:
@@ -165,7 +165,7 @@ def test_bgp_outbound_uplink_partial_blackout(snappi_api,                       
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
+            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
         if t1_t2_device_hostnames[0] in duthost.hostname:

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_flap.py
@@ -68,7 +68,7 @@ def test_bgp_outbound_uplink_po_flap(snappi_api,                                
     snappi_extra_params.multi_dut_params.flap_details = FLAP_DETAILS
 
     if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_assert(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
+        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
 
     ansible_dut_hostnames = []
     for duthost in duthosts:
@@ -77,7 +77,7 @@ def test_bgp_outbound_uplink_po_flap(snappi_api,                                
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
+            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
         if t1_t2_device_hostnames[0] in duthost.hostname:

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_member_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_member_flap.py
@@ -68,7 +68,7 @@ def test_bgp_outbound_uplink_po_member_flap(snappi_api,                         
     snappi_extra_params.multi_dut_params.flap_details = FLAP_DETAILS
 
     if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_assert(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
+        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
 
     ansible_dut_hostnames = []
     for duthost in duthosts:
@@ -77,7 +77,7 @@ def test_bgp_outbound_uplink_po_member_flap(snappi_api,                         
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
+            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
         if t1_t2_device_hostnames[0] in duthost.hostname:

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_process_crash.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_process_crash.py
@@ -66,7 +66,7 @@ def test_bgp_outbound_uplink_process_crash(snappi_api,                          
                                                         }
     snappi_extra_params.multi_dut_params.host_name = t1_t2_device_hostnames[1]
     if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_assert(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
+        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
 
     ansible_dut_hostnames = []
     for duthost in duthosts:
@@ -76,7 +76,7 @@ def test_bgp_outbound_uplink_process_crash(snappi_api,                          
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
+            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
         if t1_t2_device_hostnames[0] in duthost.hostname:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test case fails if the testbed doesn't support snappi bgp convergence setup.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
If a testbed doesn't satisfy the requirement of a test case, the test case should be skipped.

#### How did you do it?
use pytest_require() instead of pytest_assert()

#### How did you verify/test it?
tested on physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
