### PR TITLE
[dualtor-io] Support using fix source IP for upstream packets

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -161,14 +161,15 @@ def verify_and_report(tor_IO, verify, delay, allowed_disruption,
 def run_test(
     duthosts, activehost, ptfhost, ptfadapter, vmhost, action,
     tbinfo, tor_vlan_port, send_interval, traffic_direction,
-    stop_after, cable_type=CableType.active_standby     # noqa F811
+    stop_after, cable_type=CableType.active_standby, random_dst=None     # noqa F811
 ):
     io_ready = threading.Event()
 
     peerhost = get_peerhost(duthosts, activehost)
     tor_IO = DualTorIO(
         activehost, peerhost, ptfhost, ptfadapter, vmhost, tbinfo,
-        io_ready, tor_vlan_port=tor_vlan_port, send_interval=send_interval, cable_type=cable_type
+        io_ready, tor_vlan_port=tor_vlan_port, send_interval=send_interval, cable_type=cable_type,
+        random_dst=random_dst
     )
     tor_IO.generate_traffic(traffic_direction)
 
@@ -330,7 +331,7 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
     def server_to_t1_io_test(activehost, tor_vlan_port=None,
                              delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.01,
-                             stop_after=None):
+                             stop_after=None, random_dst=None):
         """
         Helper method for `send_server_to_t1_with_action`.
         Starts sender and sniffer before performing the action on the tor host.
@@ -357,7 +358,7 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
         tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
                           action, tbinfo, tor_vlan_port, send_interval,
                           traffic_direction="server_to_t1", stop_after=stop_after,
-                          cable_type=cable_type)
+                          cable_type=cable_type, random_dst=random_dst)
 
         # If a delay is allowed but no numebr of allowed disruptions
         # is specified, default to 1 allowed disruption

--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -182,7 +182,7 @@ def test_active_tor_shutdown_bgp_sessions_upstream(
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            action=lambda: shutdown_bgp_sessions(upper_tor_host)
+            action=lambda: shutdown_bgp_sessions(upper_tor_host), random_dst=False
         )
 
     if cable_type == CableType.active_active:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Let's make the packets for each server belongs to same TCP flow, SONiC will use the same route to forward it.
So any route change will forward/drop all the packets from the same server.

#### How did you do it?
Use fixed IP to generate packets for a single server.

#### How did you verify/test it?

```
dualtor_io/test_tor_bgp_failure.py::test_active_tor_kill_bgpd_upstream[active-standby] PASSED                                                                                                                                                                          [100%]^
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
