### PR TITLE
Install azure-cli step by step to fix dpkg lock failure

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -192,12 +192,11 @@ steps:
         echo "Add the Azure CLI software repository"
         AZ_DIST=$(lsb_release -cs)
         echo "Types: deb
-        URIs: https://packages.microsoft.com/repos/azure-cli/
-        Suites: ${AZ_DIST}
-        Components: main
-        Architectures: $(dpkg --print-architecture)
-        Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
-        cat /etc/apt/sources.list.d/azure-cli.sources
+      URIs: https://packages.microsoft.com/repos/azure-cli/
+      Suites: ${AZ_DIST}
+      Components: main
+      Architectures: $(dpkg --print-architecture)
+      Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
 
         echo "Update repository information and install the azure-cli package"
         sudo apt-get -o DPkg::Lock::Timeout=600 update

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -197,6 +197,7 @@ steps:
         Components: main
         Architectures: $(dpkg --print-architecture)
         Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
+        cat /etc/apt/sources.list.d/azure-cli.sources
 
         echo "Update repository information and install the azure-cli package"
         sudo apt-get -o DPkg::Lock::Timeout=600 update

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -178,6 +178,7 @@ steps:
       # Check if azure cli is installed. If not, try to install it
       if ! command -v az; then
         echo "Azure CLI is not installed. Trying to install it..."
+
         echo "Get packages needed for the installation process"
         sudo apt-get -o DPkg::Lock::Timeout=600 update
         sudo apt-get -o DPkg::Lock::Timeout=600 -y install apt-transport-https ca-certificates curl gnupg lsb-release

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -180,7 +180,7 @@ steps:
         echo "Azure CLI is not installed. Trying to install it..."
         echo "Get packages needed for the installation process"
         sudo apt-get -o DPkg::Lock::Timeout=600 update
-        sudo apt-get -o DPkg::Lock::Timeout=600 install apt-transport-https ca-certificates curl gnupg lsb-release
+        sudo apt-get -o DPkg::Lock::Timeout=600 -y install apt-transport-https ca-certificates curl gnupg lsb-release
 
         echo "Download and install the Microsoft signing key"
         sudo mkdir -p /etc/apt/keyrings
@@ -198,8 +198,8 @@ steps:
         Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
 
         echo "Update repository information and install the azure-cli package"
-        sudo apt-get update
-        sudo apt-get -o DPkg::Lock::Timeout=600 install azure-cli
+        sudo apt-get -o DPkg::Lock::Timeout=600 update
+        sudo apt-get -o DPkg::Lock::Timeout=600 -y install azure-cli
       else
         echo "Azure CLI is already installed"
       fi

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -178,7 +178,28 @@ steps:
       # Check if azure cli is installed. If not, try to install it
       if ! command -v az; then
         echo "Azure CLI is not installed. Trying to install it..."
-        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+        echo "Get packages needed for the installation process"
+        sudo apt-get -o DPkg::Lock::Timeout=600 update
+        sudo apt-get -o DPkg::Lock::Timeout=600 install apt-transport-https ca-certificates curl gnupg lsb-release
+
+        echo "Download and install the Microsoft signing key"
+        sudo mkdir -p /etc/apt/keyrings
+        curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
+          gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
+        sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
+
+        echo "Add the Azure CLI software repository"
+        AZ_DIST=$(lsb_release -cs)
+        echo "Types: deb
+        URIs: https://packages.microsoft.com/repos/azure-cli/
+        Suites: ${AZ_DIST}
+        Components: main
+        Architectures: $(dpkg --print-architecture)
+        Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
+
+        echo "Update repository information and install the azure-cli package"
+        sudo apt-get update
+        sudo apt-get -o DPkg::Lock::Timeout=600 install azure-cli
       else
         echo "Azure CLI is already installed"
       fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
PR/nightly test have a chance to fail in installing azure-cli for unable to acquire dpkg lock, which means there are 2 or more processes are running apt install at the same time
#### How did you do it?
Install azure-cli step by step, and add a timeout for all apt action to acquire dpkg lock
Ref: https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
