### PR TITLE
Skip srv6/test_srv6_basic_sanity.py for non cisco vs topologies

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1781,7 +1781,7 @@ srv6/test_srv6_basic_sanity.py:
   skip:
     reason: "It's a new test case, skip it for other topologies except cisco vs nodes."
     conditions:
-      - topo_name not in ["ciscovs-7nodes", "ciscovs-5-nodes"]
+      - topo_name not in ["ciscovs-7nodes", "ciscovs-5nodes"]
 
 #######################################
 #####             ssh             #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1775,6 +1775,15 @@ span/test_port_mirroring.py:
       - "https://github.com/sonic-net/sonic-mgmt/issues/9647 and 'dualtor' in topo_name and asic_type in ['mellanox']"
 
 #######################################
+#####            srv6             #####
+#######################################
+srv6/test_srv6_basic_sanity.py:
+  skip:
+    reason: "It's a new test case, skip it for other topologies except cisco vs nodes."
+    conditions:
+      - topo_name not in ["ciscovs-7nodes", "ciscovs-5-nodes"]
+
+#######################################
 #####             ssh             #####
 #######################################
 ssh/test_ssh_default_password:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
PR introduced new srv6 script, it failed on other topologies, skip it for non cisco vs topologies.

https://github.com/sonic-net/sonic-mgmt/pull/13785

#### How did you do it?
skip it for non cisco vs topologies.

#### How did you verify/test it?
Run srv6/test_srv6_basic_sanity.py on t0 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
