### PR TITLE
Wait BGP sessions after changing mgmt IP

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -754,7 +754,7 @@ def convert_and_restore_config_db_to_ipv6_only(duthosts):
         if config_db_modified[duthost.hostname]:
             logger.info(f"config changed. Doing config reload for {duthost.hostname}")
             try:
-                config_reload(duthost, wait=120)
+                config_reload(duthost, wait=120, wait_for_bgp=True)
             except AnsibleConnectionFailure as e:
                 # IPV4 mgmt interface been deleted by config reload
                 # In latest SONiC, config reload command will exit after mgmt interface restart


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The PR is to add a wait in `config_reload` after changing mgmt IP to ensure BGP sessions are up.
Without this fix, `test_bgp_facts_ipv6_only` is flaky on some testbed with below errors.
```
>           assert state_fact[0] == "Established"
E           AssertionError
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The PR is to add a wait in `config_reload` after changing mgmt IP to ensure BGP sessions are up.

#### How did you do it?
Set `wait_for_bgp=True` in `config_reload`.

#### How did you verify/test it?
The change is verified on a physical testbed.
```
collected 1 item                                                                                                                                                                                      

ip/test_mgmt_ipv6_only.py::test_bgp_facts_ipv6_only[bjw2-can-4600c-5-None] 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
21:34:57 duthost_utils.convert_and_restore_config L0762 WARNING| Exception after config reload: Host unreachable
PASSED
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
