### PR TITLE
Fix for shared res size test

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3478,22 +3478,23 @@ class SharedResSizeTest(sai_base_test.ThriftInterfaceDataPlane):
             # Verify no ingress/egress drops for all ports
             pg_drop_counters = {port_id: sai_thrift_read_pg_drop_counters(
                 self.src_client, port_list['src'][port_id]) for port_id in uniq_srcs}
-            for src_port_id in uniq_srcs:
-                for pg in range(len(pg_drop_counters[src_port_id])):
-                    drops = pg_drop_counters[src_port_id][pg] - pg_drop_counters_bases[src_port_id][pg]
+            for uniq_src_port_id in uniq_srcs:
+                for pg in range(len(pg_drop_counters[uniq_src_port_id])):
+                    drops = pg_drop_counters[uniq_src_port_id][pg] - pg_drop_counters_bases[uniq_src_port_id][pg]
                     if pg in [3, 4]:
-                        assert drops == 0, "Detected %d lossless drops on PG %d src port %d" % (drops, pg, src_port_id)
+                        assert drops == 0, \
+                            "Detected %d lossless drops on PG %d src port %d" % (drops, pg, uniq_src_port_id)
                     elif drops > 0:
                         # When memory is full, any new lossy background traffic is dropped.
                         print("Observed lossy drops %d on PG %d src port %d, expected." %
-                              (drops, pg, src_port_id), file=sys.stderr)
+                              (drops, pg, uniq_src_port_id), file=sys.stderr)
             xmit_counters_list = {port_id: sai_thrift_read_port_counters(
                 self.dst_client, self.asic_type, port_list['dst'][port_id])[0] for port_id in uniq_dsts}
-            for dst_port_id in uniq_dsts:
+            for uniq_dst_port_id in uniq_dsts:
                 for cntr in self.egress_counters:
-                    drops = xmit_counters_list[dst_port_id][cntr] - \
-                        xmit_counters_bases[dst_port_id][cntr]
-                    assert drops == 0, "Detected %d egress drops on dst port id %d" % (drops, dst_port_id)
+                    drops = xmit_counters_list[uniq_dst_port_id][cntr] - \
+                        xmit_counters_bases[uniq_dst_port_id][cntr]
+                    assert drops == 0, "Detected %d egress drops on dst port id %d" % (drops, uniq_dst_port_id)
 
             first_port_id = self.dst_port_ids[0]
             last_port_id = self.dst_port_ids[-1]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes issue with incorrect src port ID usage. 
Issue is present in 202311 and 202405 branches. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Issue where depending on the ordering of the src port ids used, the incorrect src port may be used in later TX counter verification. 

#### How did you do it?
Renamed variables to avoid overwrite issue. 

#### How did you verify/test it?
- Verified on 8101, fixes 202405 regression. 

#### Any platform specific information?
Cisco-8000 only. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
