### PR TITLE
Added Multi-Asic Handling for test_gnmi_configdb_full_01 TC

### DIFF
--- a/tests/gnmi/test_gnmi_configdb.py
+++ b/tests/gnmi/test_gnmi_configdb.py
@@ -51,6 +51,18 @@ def get_interface_status(duthost, field, interface='Ethernet0'):
     return output["stdout"]
 
 
+def get_sonic_cfggen_output(duthost, namespace=None):
+    '''
+    Fetch and return the sonic-cfggen output
+    '''
+    cmd = "sonic-cfggen -d --print-data"
+    if namespace:
+        cmd = f"sonic-cfggen -n {namespace} -d --print-data"
+    output = duthost.shell(cmd)
+    assert (not output['rc']), "No output"
+    return (json.loads(output["stdout"]))
+
+
 def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, ptfhost):
     '''
     Verify GNMI native write, incremental config for configDB
@@ -224,12 +236,19 @@ def test_gnmi_configdb_full_01(duthosts, rand_one_dut_hostname, ptfhost):
     Toggle interface admin status
     '''
     duthost = duthosts[rand_one_dut_hostname]
-    output = duthost.shell("sonic-cfggen -d --print-data")
-    assert (not output['rc']), "No output"
-    dic = json.loads(output["stdout"])
-    assert "PORT" in dic, "Failed to read running config"
     interface = get_first_interface(duthost)
     assert interface is not None, "Invalid interface"
+
+    # Get ASIC namespace and check interface
+    if duthost.sonichost.is_multi_asic:
+        for asic in duthost.frontend_asics:
+            dic = get_sonic_cfggen_output(duthost, asic.namespace)
+            if interface in dic["PORT"]:
+                break
+    else:
+        dic = get_sonic_cfggen_output(duthost)
+
+    assert "PORT" in dic, "Failed to read running config"
     assert interface in dic["PORT"], "Failed to get interface %s" % interface
     assert "admin_status" in dic["PORT"][interface], "Failed to get interface %s" % interface
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: For Multi-Asic devices, `test_gnmi_configdb_full_01` TC isn't using asic specific namespace, due to which PORT keys received from `get_interface_status` & one in `config_db` are not in sync. 

Fixes # (issue)
Checks whether DUT is multi-asic or not; if yes, then generates configuration based on the asic namespace which contains the PORT key returned by `get_inerface_status`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
- [Issue 15407 : Multi-asic support for test_gnmi_configdb TCs](https://github.com/sonic-net/sonic-mgmt/issues/15407)
- This PR just adds the multi-asic support; but still TC would fail because Multi-Asic support for `ApplyPatchDb` API has to be provided, [Issue link](https://github.com/sonic-net/sonic-buildimage/issues/20874)

#### How did you do it?
Checks whether DUT is multi-asic or not; if yes, then generates configuration based on the asic namespace which contains the PORT key returned by `get_inerface_status`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
