### PR TITLE
check pg_profile_lookup.ini in multiasic specific path.

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -203,8 +203,11 @@ def load_lossless_headroom_data(duthost):
         dut_platform = duthost.facts["platform"]
         skudir = "/usr/share/sonic/device/{}/{}/".format(
             dut_platform, dut_hwsku)
+        asic_index = ""
+        if duthost.is_multi_asic:
+            asic_index = duthost.asic_instance().asic_index
         lines = duthost.shell(
-            'cat {}/pg_profile_lookup.ini'.format(skudir))["stdout"]
+            f'cat {skudir}/{asic_index}/pg_profile_lookup.ini')["stdout"]
         DEFAULT_LOSSLESS_HEADROOM_DATA = {}
         for line in lines.split('\n'):
             if line[0] == '#':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
tests/qos/test_buffers.py is failing in mAsic platforms since the pg_profile_lookup.ini path

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
The script: qos/test_buffers.py is using wrong path for multi-asic platforms. It gives this error:
```
        if (res.is_failed or 'exception' in res) and not module_ignore_errors:
&gt;           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
E           tests.common.errors.RunAnsibleModuleFail: run module shell failed, Ansible Results =&gt;
E           {"changed": true, "cmd": "cat /usr/share/sonic/device/x86_64-8800_rp-r0/Cisco-8800-RP//pg_profile_lookup.ini", "delta": "0:00:00.006060", "end": "2024-10-31 14:58:57.717623", "failed": true, "msg": "non-zero return code", "rc": 1, "start": "2024-10-31 14:58:57.711563", "stderr": "cat: /usr/share/sonic/device/x86_64-8800_rp-r0/Cisco-8800-RP//pg_profile_lookup.ini: No such file or directory", "stderr_lines": ["cat: /usr/share/sonic/device/x86_64-8800_rp-r0/Cisco-8800-RP//pg_profile_lookup.ini: No such file or directory"], "stdout": "", "stdout_lines": []}
```

#### How did you do it?
Updated the script to use asic-specific path for this file.

#### How did you verify/test it?
Ran it on my TB. For cisco-8000 this script skips:
```
--------------------------------------------------------------------------- generated xml file: /run_logs/buffer/2024-11-15-01-17-03/pfcwd/qos/test_buffer_2024-11-15-01-17-03.xml ---------------------------------------------------------------------------
------------------------------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------------------------------
01:30:05 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================================================== short test summary info ===================================================================================================================
SKIPPED [17] qos/test_buffer.py: These tests don't apply to cisco 8000 platforms or T2 or m0/mx, since they support only traditional model.
SKIPPED [1] qos/test_buffer.py:2390: These tests don't apply to cisco 8000 platforms or T2 or m0/mx, since they support only traditional model.
SKIPPED [1] qos/test_buffer.py:400: Skip test in traditional model
========================================================================================================= 19 skipped, 1 warning in 780.02s (0:13:00) =========================================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_buffer_deployment[xx37-lc7]>
```