### PR TITLE
Update initial_tsa_check_before_and_after_test to be autouse fixture

### DIFF
--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -7,7 +7,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.platform.processes_utils import wait_critical_processes, _all_critical_processes_healthy
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
-from tests.bgp.bgp_helpers import initial_tsa_check_before_and_after_test
+from tests.bgp.bgp_helpers import force_tsb_before_and_after_test # noqa F401
 from tests.bgp.traffic_checker import get_traffic_shift_state, check_tsa_persistence_support
 from tests.bgp.route_checker import parse_routes_on_neighbors, check_and_log_routes_diff, \
     verify_current_routes_announced_to_neighs, verify_only_loopback_routes_are_announced_to_neighs
@@ -182,9 +182,6 @@ def test_tsa_tsb_service_with_dut_cold_reboot(duthosts, localhost, enum_rand_one
     if not check_tsa_persistence_support(duthost):
         pytest.skip("TSA persistence not supported in the image")
 
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    initial_tsa_check_before_and_after_test(duthosts)
-
     up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
 
     try:
@@ -253,8 +250,6 @@ def test_tsa_tsb_service_with_dut_cold_reboot(duthosts, localhost, enum_rand_one
                 pytest.fail("Not all ipv6 routes are announced to neighbors")
 
     finally:
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        initial_tsa_check_before_and_after_test(duthosts)
         # Verify DUT is in normal state after cold reboot scenario.
         if not (int_status_result and crit_process_check and TS_NORMAL == get_traffic_shift_state(duthost)):
             logger.info("DUT's current interface status is {}, critical process check is {} "
@@ -285,9 +280,6 @@ def test_tsa_tsb_service_with_dut_abnormal_reboot(duthosts, localhost, enum_rand
     dut_ip = duthost.mgmt_ip
     if not check_tsa_persistence_support(duthost):
         pytest.skip("TSA persistence not supported in the image")
-
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    initial_tsa_check_before_and_after_test(duthosts)
 
     up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
 
@@ -373,8 +365,6 @@ def test_tsa_tsb_service_with_dut_abnormal_reboot(duthosts, localhost, enum_rand
                 pytest.fail("Not all ipv6 routes are announced to neighbors")
 
     finally:
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        initial_tsa_check_before_and_after_test(duthosts)
         # Verify DUT is in normal state after abnormal reboot scenario.
         if not (int_status_result and crit_process_check and TS_NORMAL == get_traffic_shift_state(duthost)):
             logger.info("DUT's current interface status is {}, critical process check is {} "
@@ -421,8 +411,6 @@ def test_tsa_tsb_service_with_supervisor_cold_reboot(duthosts, localhost, enum_s
         if not check_tsa_persistence_support(linecard):
             pytest.skip("TSA persistence not supported in the image")
         up_bgp_neighbors[linecard] = linecard.get_bgp_neighbors_per_asic("established")
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    initial_tsa_check_before_and_after_test(duthosts)
 
     try:
         for linecard in duthosts.frontend_nodes:
@@ -501,9 +489,6 @@ def test_tsa_tsb_service_with_supervisor_cold_reboot(duthosts, localhost, enum_s
                     pytest.fail("Not all ipv6 routes are announced to neighbors")
 
     finally:
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        initial_tsa_check_before_and_after_test(duthosts)
-
         # Make sure DUT is in normal state after supervisor cold reboot
         for linecard in duthosts.frontend_nodes:
             if not (int_status_result[linecard] and crit_process_check[linecard] and
@@ -553,9 +538,6 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
         if not check_tsa_persistence_support(linecard):
             pytest.skip("TSA persistence not supported in the image")
         up_bgp_neighbors[linecard] = linecard.get_bgp_neighbors_per_asic("established")
-
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    initial_tsa_check_before_and_after_test(duthosts)
 
     try:
         for linecard in duthosts.frontend_nodes:
@@ -655,9 +637,6 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
                     pytest.fail("Not all ipv6 routes are announced to neighbors")
 
     finally:
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        initial_tsa_check_before_and_after_test(duthosts)
-
         # Make sure DUT is in normal state after supervisor abnormal reboot
         for linecard in duthosts.frontend_nodes:
             if not (int_status_result[linecard] and crit_process_check[linecard] and
@@ -708,9 +687,6 @@ def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, enum_rand_one_p
     orig_v4_routes, orig_v6_routes = {}, {}
     if not check_tsa_persistence_support(duthost):
         pytest.skip("TSA persistence not supported in the image")
-
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    initial_tsa_check_before_and_after_test(duthosts)
 
     up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
 
@@ -815,9 +791,6 @@ def test_user_init_tsa_while_service_run_on_dut(duthosts, localhost, enum_rand_o
     dut_nbrhosts = nbrhosts_to_dut(duthost, nbrhosts)
     if not check_tsa_persistence_support(duthost):
         pytest.skip("TSA persistence not supported in the image")
-
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    initial_tsa_check_before_and_after_test(duthosts)
 
     up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
 
@@ -932,9 +905,6 @@ def test_user_init_tsb_while_service_run_on_dut(duthosts, localhost, enum_rand_o
     if not check_tsa_persistence_support(duthost):
         pytest.skip("TSA persistence not supported in the image")
 
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    initial_tsa_check_before_and_after_test(duthosts)
-
     up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
 
     try:
@@ -1003,8 +973,6 @@ def test_user_init_tsb_while_service_run_on_dut(duthosts, localhost, enum_rand_o
                 pytest.fail("Not all ipv6 routes are announced to neighbors")
 
     finally:
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        initial_tsa_check_before_and_after_test(duthosts)
         # Verify DUT is in normal state after cold reboot scenario.
         if not (int_status_result and crit_process_check and TS_NORMAL == get_traffic_shift_state(duthost)):
             logger.info("DUT's current interface status is {}, critical process check is {} "
@@ -1046,9 +1014,6 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost,
         if not check_tsa_persistence_support(linecard):
             pytest.skip("TSA persistence not supported in the image")
         up_bgp_neighbors[linecard] = linecard.get_bgp_neighbors_per_asic("established")
-
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    initial_tsa_check_before_and_after_test(duthosts)
 
     try:
         for linecard in duthosts.frontend_nodes:
@@ -1134,9 +1099,6 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost,
                     pytest.fail("Not all ipv6 routes are announced to neighbors")
 
     finally:
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        initial_tsa_check_before_and_after_test(duthosts)
-
         for linecard in duthosts.frontend_nodes:
             # Make sure linecards are in Normal state and save the config to proceed further
             if not (int_status_result[linecard] and crit_process_check[linecard] and
@@ -1174,9 +1136,6 @@ def test_tsa_tsb_timer_efficiency(duthosts, localhost, enum_rand_one_per_hwsku_f
         pytest.skip("startup_tsa_tsb.service is not supported on the {}".format(duthost.hostname))
     if not check_tsa_persistence_support(duthost):
         pytest.skip("TSA persistence not supported in the image")
-
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    initial_tsa_check_before_and_after_test(duthosts)
 
     try:
         # Get all routes on neighbors before doing reboot
@@ -1253,8 +1212,6 @@ def test_tsa_tsb_timer_efficiency(duthosts, localhost, enum_rand_one_per_hwsku_f
                 pytest.fail("Not all ipv6 routes are announced to neighbors")
 
     finally:
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        initial_tsa_check_before_and_after_test(duthosts)
         # Verify DUT is in normal state after cold reboot scenario.
         if not (int_status_result and crit_process_check and TS_NORMAL == get_traffic_shift_state(duthost)):
             logger.info("DUT's current interface status is {}, critical process check is {} "
@@ -1295,8 +1252,6 @@ def test_tsa_tsb_service_with_tsa_on_sup(duthosts, localhost,
                       "DUT is not in normal state")
         if not check_tsa_persistence_support(linecard):
             pytest.skip("TSA persistence not supported in the image")
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    initial_tsa_check_before_and_after_test(duthosts)
     try:
         # Execute user initiated TSA from supervisor card
         suphost.shell("TSA")
@@ -1364,9 +1319,6 @@ def test_tsa_tsb_service_with_tsa_on_sup(duthosts, localhost,
                 "Failed to verify routes on nbr in TSA")
 
     finally:
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        initial_tsa_check_before_and_after_test(duthosts)
-
         for linecard in duthosts.frontend_nodes:
             # Make sure linecards are in Normal state and save the config to proceed further
             if not (int_status_result[linecard] and crit_process_check[linecard] and

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -768,8 +768,6 @@ def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, enum_rand_one_p
         reboot_cause = get_reboot_cause(duthost)
         pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
                       "Reboot cause {} did not match the trigger {}".format(reboot_cause, COLD_REBOOT_CAUSE))
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        initial_tsa_check_before_and_after_test(duthosts)
 
 
 @pytest.mark.disable_loganalyzer
@@ -882,8 +880,6 @@ def test_user_init_tsa_while_service_run_on_dut(duthosts, localhost, enum_rand_o
         reboot_cause = get_reboot_cause(duthost)
         pytest_assert(reboot_cause == COLD_REBOOT_CAUSE,
                       "Reboot cause {} did not match the trigger {}".format(reboot_cause, COLD_REBOOT_CAUSE))
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        initial_tsa_check_before_and_after_test(duthosts)
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -3,7 +3,7 @@ import re
 import pytest
 from tests.common.devices.eos import EosHost
 from tests.bgp.bgp_helpers import get_routes_not_announced_to_bgpmon, remove_bgp_neighbors, restore_bgp_neighbors, \
-    initial_tsa_check_before_and_after_test
+    force_tsb_before_and_after_test # noqa F401
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.constants import DEFAULT_ASIC_ID
@@ -70,9 +70,6 @@ def test_TSA(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    if tbinfo['topo']['type'] == 't2':
-        initial_tsa_check_before_and_after_test(duthosts)
     try:
         # Issue TSA on DUT
         duthost.shell("TSA")
@@ -94,9 +91,6 @@ def test_TSA(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
     finally:
         # Recover to Normal state
         duthost.shell("TSB")
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        if tbinfo['topo']['type'] == 't2':
-            initial_tsa_check_before_and_after_test(duthosts)
 
 
 def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts, bgpmon_setup_teardown, tbinfo):
@@ -106,9 +100,6 @@ def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrho
     and all routes are announced to neighbors
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    if tbinfo['topo']['type'] == 't2':
-        initial_tsa_check_before_and_after_test(duthosts)
     # Ensure that the DUT is not in maintenance already before start of the test
     pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
                   "DUT is not in normal state")
@@ -142,10 +133,6 @@ def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrho
         if not check_and_log_routes_diff(duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
             pytest.fail("Not all ipv6 routes are announced to neighbors")
 
-    # Bring back the supervisor and line cards to the BGP operational normal state
-    if tbinfo['topo']['type'] == 't2':
-        initial_tsa_check_before_and_after_test(duthosts)
-
 
 def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                                    bgpmon_setup_teardown, nbrhosts, core_dump_and_config_check, tbinfo):
@@ -156,9 +143,6 @@ def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_ho
     bgp_neighbors = {}
     duts_data = core_dump_and_config_check
     asic_index = 0 if duthost.is_multi_asic else DEFAULT_ASIC_ID
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    if tbinfo['topo']['type'] == 't2':
-        initial_tsa_check_before_and_after_test(duthosts)
     # Ensure that the DUT is not in maintenance already before start of the test
     pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
                   "DUT is not in normal state")
@@ -211,10 +195,6 @@ def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_ho
             if not check_and_log_routes_diff(duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
                 pytest.fail("Not all ipv6 routes are announced to neighbors")
 
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        if tbinfo['topo']['type'] == 't2':
-            initial_tsa_check_before_and_after_test(duthosts)
-
 
 @pytest.mark.disable_loganalyzer
 def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts,
@@ -224,9 +204,6 @@ def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    if tbinfo['topo']['type'] == 't2':
-        initial_tsa_check_before_and_after_test(duthosts)
     # Ensure that the DUT is not in maintenance already before start of the test
     pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
                   "DUT is not in normal state")
@@ -280,9 +257,6 @@ def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
                           duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
             if not check_and_log_routes_diff(duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
                 pytest.fail("Not all ipv6 routes are announced to neighbors")
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        if tbinfo['topo']['type'] == 't2':
-            initial_tsa_check_before_and_after_test(duthosts)
 
 
 @pytest.mark.disable_loganalyzer
@@ -294,9 +268,6 @@ def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsk
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    if tbinfo['topo']['type'] == 't2':
-        initial_tsa_check_before_and_after_test(duthosts)
     # Ensure that the DUT is not in maintenance already before start of the test
     pytest_assert(TS_NORMAL == get_traffic_shift_state(duthost),
                   "DUT is not in normal state")
@@ -347,7 +318,3 @@ def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsk
                           duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
             if not check_and_log_routes_diff(duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
                 pytest.fail("Not all ipv6 routes are announced to neighbors")
-
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        if tbinfo['topo']['type'] == 't2':
-            initial_tsa_check_before_and_after_test(duthosts)

--- a/tests/bgp/test_traffic_shift_sup.py
+++ b/tests/bgp/test_traffic_shift_sup.py
@@ -4,7 +4,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common import config_reload
 from tests.bgp.constants import TS_NORMAL, TS_MAINTENANCE
 from tests.bgp.traffic_checker import get_traffic_shift_state
-from tests.bgp.bgp_helpers import initial_tsa_check_before_and_after_test
+from tests.bgp.bgp_helpers import force_tsb_before_and_after_test # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t2')
@@ -47,8 +47,6 @@ def test_TSA(duthosts, enum_supervisor_dut_hostname):
     Test TSA
     Verify all linecards transition to maintenance state after TSA on supervisor
     """
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    initial_tsa_check_before_and_after_test(duthosts)
     suphost = duthosts[enum_supervisor_dut_hostname]
     try:
         # Make sure LCs are in normal mode before tests starts
@@ -58,8 +56,6 @@ def test_TSA(duthosts, enum_supervisor_dut_hostname):
         suphost.shell("TSA")
         # Verify DUT is in maintenance state.
         verify_traffic_shift_state_all_lcs(duthosts, TS_MAINTENANCE, "maintenance")
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        initial_tsa_check_before_and_after_test(duthosts)
     except Exception as e:
         # Log exception
         logger.error("Exception caught in TSB test. Error message: {}".format(e))
@@ -73,8 +69,6 @@ def test_TSB(duthosts, enum_supervisor_dut_hostname):
     Test TSB
     Verify all linecards transition back to normal state from maintenance after TSB on supervisor
     """
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    initial_tsa_check_before_and_after_test(duthosts)
     suphost = duthosts[enum_supervisor_dut_hostname]
     try:
         # Make sure LCs are in normal mode before tests starts
@@ -88,8 +82,6 @@ def test_TSB(duthosts, enum_supervisor_dut_hostname):
         suphost.shell("TSB")
         # Verify DUT is in normal state
         verify_traffic_shift_state_all_lcs(duthosts, TS_NORMAL, "normal")
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        initial_tsa_check_before_and_after_test(duthosts)
     except Exception as e:
         # Log exception
         logger.error("Exception caught in TSB test. Error message: {}".format(e))
@@ -102,8 +94,6 @@ def test_TSA_TSB_chassis_with_config_reload(duthosts, enum_supervisor_dut_hostna
     Verify all linecards remain in Maintenance state after TSA and config reload on supervisor
     Verify all linecards remain in Normal state after TSB and config reload on supervisor
     """
-    # Initially make sure both supervisor and line cards are in BGP operational normal state
-    initial_tsa_check_before_and_after_test(duthosts)
     suphost = duthosts[enum_supervisor_dut_hostname]
     try:
         # Make sure LCs are in normal mode before tests starts
@@ -131,5 +121,3 @@ def test_TSA_TSB_chassis_with_config_reload(duthosts, enum_supervisor_dut_hostna
 
         # Verify DUT is in normal state.
         verify_traffic_shift_state_all_lcs(duthosts, TS_NORMAL, "normal")
-        # Bring back the supervisor and line cards to the BGP operational normal state
-        initial_tsa_check_before_and_after_test(duthosts)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update initial_tsa_check_before_and_after_test to be autouse fixture

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Reduce clutter from having check before and after every test, by having it as an autouse fixture, we can make sure every test in a test file that needs it will have it run.

It is also important to have TSB set properly before and after these tests, we have seen tests that fail and don't successfully recover in try/finally block due to any number of reasons, causing other tests to fail.
#### How did you do it?
Make the check/set an autouse fixture that runs at setup and teardown, remove the redundant check/set from the tests
#### How did you verify/test it?
Tested the affected test files on a physical T2 testbed to ensure that it behaves as expected
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A