### PR TITLE
Fix some issue in the advanced reboot

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -411,6 +411,7 @@ class ReloadTest(BaseTest):
             # TimeoutError and Exception's from func
             # captured here
             signal.set()
+            self.log("{}: {}".format(message, traceback_msg))
             raise type(err)("{}: {}".format(message, traceback_msg))
         return res
 
@@ -954,11 +955,13 @@ class ReloadTest(BaseTest):
         time.sleep(5)
 
     def get_warmboot_finalizer_state(self):
+        self.log("get the finalizer_state with: 'sudo systemctl is-active warmboot-finalizer.service'")
         stdout, stderr, _ = self.dut_connection.execCommand(
             'sudo systemctl is-active warmboot-finalizer.service')
         if stderr:
             self.fails['dut'].add("Error collecting Finalizer state. stderr: {}, stdout:{}".format(
                 str(stderr), str(stdout)))
+            self.log("Error collecting Finalizer state. stderr: {}, stdout:{}".format(str(stderr), str(stdout)))
             raise Exception("Error collecting Finalizer state. stderr: {}, stdout:{}".format(
                 str(stderr), str(stdout)))
         if not stdout:
@@ -966,6 +969,7 @@ class ReloadTest(BaseTest):
             return ''
 
         finalizer_state = stdout[0].strip()
+        self.log("The returned finalizer_state is {}".format(finalizer_state))
         return finalizer_state
 
     def get_now_time(self):
@@ -997,6 +1001,7 @@ class ReloadTest(BaseTest):
             if time_passed > finalizer_timeout:
                 self.fails['dut'].add(
                     'warmboot-finalizer never reached state "activating"')
+                self.log('TimeoutError: warmboot-finalizer never reached state "activating"')
                 raise TimeoutError
             self.finalizer_state = self.get_warmboot_finalizer_state()
 
@@ -1011,6 +1016,7 @@ class ReloadTest(BaseTest):
             if count * 10 > int(self.test_params['warm_up_timeout_secs']):
                 self.fails['dut'].add(
                     'warmboot-finalizer.service did not finish')
+                self.log('TimeoutError: warmboot-finalizer.service did not finish')
                 raise TimeoutError
             count += 1
         self.log('warmboot-finalizer service finished')
@@ -1464,6 +1470,7 @@ class ReloadTest(BaseTest):
             if time_passed > teamd_shutdown_timeout:
                 self.fails['dut'].add(
                     'Teamd service did not go down')
+                self.log('TimeoutError: Teamd service did not go down')
                 raise TimeoutError
             teamd_state = self.get_teamd_state()
 
@@ -1797,7 +1804,6 @@ class ReloadTest(BaseTest):
             curr_time = time.time()
             if curr_time - time_start > timeout:
                 break
-            time_start = curr_time
 
         self.log("Going to kill all tcpdump processes by SIGTERM")
         for process in processes_list:
@@ -1961,6 +1967,7 @@ class ReloadTest(BaseTest):
             received_vlan_to_t1 = 0
             missed_vlan_to_t1 = 0
             missed_t1_to_vlan = 0
+            flooded_pkts = []
             self.disruption_start, self.disruption_stop = None, None
             for packet in packets:
                 if packet[scapyall.Ether].dst == self.dut_mac or packet[scapyall.Ether].dst == self.vlan_mac:
@@ -1969,6 +1976,8 @@ class ReloadTest(BaseTest):
                     #   t1->server sent pkt will have dst MAC as dut_mac,
                     #   and server->t1 sent pkt will have dst MAC as vlan_mac
                     sent_payload = int(bytes(packet[scapyall.TCP].payload))
+                    if sent_payload in sent_packets:
+                        flooded_pkts.append(sent_payload)
                     sent_packets[sent_payload] = packet.time
                     sent_counter += 1
                     continue
@@ -2053,6 +2062,7 @@ class ReloadTest(BaseTest):
             self.log("*********** received packets captured - vlan-to-t1 - {}".format(received_vlan_to_t1))
             self.log("*********** Missed received packets - t1-to-vlan - {}".format(missed_t1_to_vlan))
             self.log("*********** Missed received packets - vlan-to-t1 - {}".format(missed_vlan_to_t1))
+            self.log("*********** Flooded pkts - {}".format(flooded_pkts))
             self.log("**************************************************************")
         self.fails['dut'].add("Sniffer failed to filter any traffic from DUT")
         self.assertTrue(received_counter,
@@ -2097,11 +2107,12 @@ class ReloadTest(BaseTest):
         total_validation_packets = received_t1_to_vlan + \
             received_vlan_to_t1 + missed_t1_to_vlan + missed_vlan_to_t1
         # In some cases DUT may flood original packet to all members of VLAN, we do check that we do not flood too much
-        allowed_number_of_flooded_original_packets = 150
+        allowed_number_of_flooded_original_packets = 250
         if (sent_counter - total_validation_packets) > allowed_number_of_flooded_original_packets:
             self.dataplane_loss_checked_successfully = False
             self.fails["dut"].add("Unexpected count of sent packets available in pcap file. "
-                                  "Could be issue with DUT flooding for original packets which was sent to DUT")
+                                  "Could be issue with DUT flooding for original packets which was sent to DUT, "
+                                  "flooded count is: {}".format(sent_counter - total_validation_packets))
 
         if prev_payload != (self.sent_packet_count - 1):
             # Specific case when packet loss started but final lost packet not detected


### PR DESCRIPTION
1. fix the dead loop in the test
2. Increase the limit of the flooded pkt count from 150 to 250 for the fast-reboot
3. Add more logs in the code.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run  the dast-reboot and warm-reboot, it could pass
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
