### PR TITLE
sonic-mgmt / IXIA : T2 test  to verify ECN Counter operation pre and post port state toggle

### DIFF
--- a/tests/snappi_tests/multidut/ecn/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/ecn/files/multidut_helper.py
@@ -71,6 +71,7 @@ def verify_ecn_counters(ecn_counters, link_state_toggled=False):
                   'Must have ecn marked packets on flow 4{}'.
                   format(toggle_msg))
 
+
 def verify_ecn_counters_for_flow_percent(ecn_counters, test_flow_percent):
 
     # verify that each flow had packets
@@ -146,6 +147,7 @@ def verify_ecn_counters_for_flow_percent(ecn_counters, test_flow_percent):
                             flow3_ecn > 0 and flow4_ecn > 0,
                             'Must have ecn marked packets on flows 3, 4, percent {}'.
                             format(test_flow_percent))
+
 
 def run_ecn_test(api,
                  testbed_config,
@@ -308,24 +310,6 @@ def run_ecn_test(api,
 
     return result
 
-def toggle_dut_port_state(api):
-    # Get the current configuration
-    config = api.get_config()
-    # Collect all port names
-    port_names = [port.name for port in config.ports]
-    # Create a link state object for all ports
-    link_state = api.link_state()
-    # Apply the state to all ports
-    link_state.port_names = port_names
-    # Set all ports down (shut)
-    link_state.state = link_state.DOWN
-    api.set_link_state(link_state)
-    logger.info("All Snappi ports are set to DOWN")
-    time.sleep(0.2)
-    # Unshut all ports
-    link_state.state = link_state.UP
-    api.set_link_state(link_state)
-    logger.info("All Snappi ports are set to UP")
 
 def toggle_dut_port_state(api):
     # Get the current configuration
@@ -505,6 +489,7 @@ def run_ecn_marking_port_toggle_test(
     ]
 
     verify_ecn_counters(ecn_counters, link_state_toggled=True)
+
 
 def run_ecn_marking_test(api,
                          testbed_config,

--- a/tests/snappi_tests/multidut/ecn/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/ecn/files/multidut_helper.py
@@ -6,7 +6,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
      snappi_api                                                                                     # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, config_wred, \
-    enable_ecn, config_ingress_lossless_buffer_alpha, stop_pfcwd, disable_packet_aging, \
+    enable_ecn, config_ingress_lossless_buffer_alpha, stop_pfcwd, disable_packet_aging,\
     config_capture_pkt, traffic_flow_mode, calc_pfc_pause_flow_rate  # noqa: F401
 from tests.common.snappi_tests.read_pcap import get_ipv4_pkts
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
@@ -327,6 +327,26 @@ def toggle_dut_port_state(api):
     api.set_link_state(link_state)
     logger.info("All Snappi ports are set to UP")
 
+def toggle_dut_port_state(api):
+    # Get the current configuration
+    config = api.get_config()
+    # Collect all port names
+    port_names = [port.name for port in config.ports]
+    # Create a link state object for all ports
+    link_state = api.link_state()
+    # Apply the state to all ports
+    link_state.port_names = port_names
+    # Set all ports down (shut)
+    link_state.state = link_state.DOWN
+    api.set_link_state(link_state)
+    logger.info("All Snappi ports are set to DOWN")
+    time.sleep(0.2)
+    # Unshut all ports
+    link_state.state = link_state.UP
+    api.set_link_state(link_state)
+    logger.info("All Snappi ports are set to UP")
+
+
 def run_ecn_marking_port_toggle_test(
                                     api,
                                     testbed_config,
@@ -370,18 +390,6 @@ def run_ecn_marking_port_toggle_test(
 
     rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
     egress_duthost = rx_port['duthost']
-
-    tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
-    ingress_duthost = tx_port['duthost']
-
-    pytest_assert(testbed_config is not None, 'Failed to get L2/3 testbed config')
-
-    logger.info("Stopping PFC watchdog")
-    stop_pfcwd(egress_duthost, rx_port['asic_value'])
-    stop_pfcwd(ingress_duthost, tx_port['asic_value'])
-    logger.info("Disabling packet aging if necessary")
-    disable_packet_aging(egress_duthost)
-    disable_packet_aging(ingress_duthost)
 
     duthost = egress_duthost
 

--- a/tests/snappi_tests/multidut/ecn/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/ecn/files/multidut_helper.py
@@ -71,7 +71,6 @@ def verify_ecn_counters(ecn_counters, link_state_toggled=False):
                   'Must have ecn marked packets on flow 4{}'.
                   format(toggle_msg))
 
-
 def verify_ecn_counters_for_flow_percent(ecn_counters, test_flow_percent):
 
     # verify that each flow had packets
@@ -147,7 +146,6 @@ def verify_ecn_counters_for_flow_percent(ecn_counters, test_flow_percent):
                             flow3_ecn > 0 and flow4_ecn > 0,
                             'Must have ecn marked packets on flows 3, 4, percent {}'.
                             format(test_flow_percent))
-
 
 def run_ecn_test(api,
                  testbed_config,
@@ -310,7 +308,6 @@ def run_ecn_test(api,
 
     return result
 
-
 def toggle_dut_port_state(api):
     # Get the current configuration
     config = api.get_config()
@@ -329,7 +326,6 @@ def toggle_dut_port_state(api):
     link_state.state = link_state.UP
     api.set_link_state(link_state)
     logger.info("All Snappi ports are set to UP")
-
 
 def run_ecn_marking_port_toggle_test(
                                     api,
@@ -501,7 +497,6 @@ def run_ecn_marking_port_toggle_test(
     ]
 
     verify_ecn_counters(ecn_counters, link_state_toggled=True)
-
 
 def run_ecn_marking_test(api,
                          testbed_config,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
MIGSMSFT-630 Add sonic-mgmt / IXIA test for cisco platforms to verify ECN Counter operation.

#### How did you do it?

Create two flows one for each lossless TC per Ixia port each at half of 99.98% rate

- Inject traffic and read ECN Counters and verify it incremented.

- flap the interface state (shut, wait for 0.2 seconds, no shut the interfaces of Ixia)

- restart the traffic streams

- verify that the ECN counters increment from the baseline value (new values read MUST NOT be zero)

#### How did you verify/test it?


Verified on T2 DUT setup

```
============================================================================================================================================ PASSES =============================================================================================================================================
____________________________________________________________________________________________________________ test_ecn_marking_port_toggle[multidut_port_keys=single-dut-multi-asic] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_port_toggle[multidut_port_keys=single-dut-single-asic] ____________________________________________________________________________________________________________
---------------------------------------------------------------------------------------------------- generated xml file: /run_logs/ixia/17467/2024-11-15-16-20-28/tr_2024-11-15-16-20-28.xml ----------------------------------------------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------------------------------------------------------ live log sessionfinish -------------------------------------------------------------------------------------------------------------------------------------
16:34:46 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
==================================================================================================================================== short test summary info ====================================================================================================================================
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_keys=single-dut-multi-asic]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_keys=single-dut-single-asic]
=========================================================================================================================== 2 passed, 5 warnings in 856.18s (0:14:16) ==========================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
