### PR TITLE
T2 ECN test: ECN comparative marking based on % of traffic 

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -114,6 +114,13 @@ def generate_test_flows(testbed_config,
     test_flow_name_dut_rx_port_map = {}
     test_flow_name_dut_tx_port_map = {}
 
+    # Check if flow_rate_percent is a dictionary
+    if isinstance(data_flow_config["flow_rate_percent"], (int, float)):
+        # Create a dictionary with priorities as keys and the flow rate percent as the value for each key
+        data_flow_config["flow_rate_percent"] = {
+            prio: data_flow_config["flow_rate_percent"] for prio in test_flow_prio_list
+        }
+
     for prio in test_flow_prio_list:
         test_flow_name = "{} Prio {}".format(data_flow_config["flow_name"], prio)
         test_flow = testbed_config.flows.flow(name=test_flow_name)[-1]
@@ -141,7 +148,7 @@ def generate_test_flows(testbed_config,
             ipv4.priority.dscp.ecn.CAPABLE_TRANSPORT_1)
 
         test_flow.size.fixed = data_flow_config["flow_pkt_size"]
-        test_flow.rate.percentage = data_flow_config["flow_rate_percent"]
+        test_flow.rate.percentage = data_flow_config["flow_rate_percent"][prio]
         if data_flow_config["flow_traffic_type"] == traffic_flow_mode.FIXED_DURATION:
             test_flow.duration.fixed_seconds.seconds = data_flow_config["flow_dur_sec"]
             test_flow.duration.fixed_seconds.delay.nanoseconds = int(sec_to_nanosec
@@ -344,10 +351,9 @@ def run_traffic(duthost,
         cs.state = cs.START
         api.set_capture_state(cs)
 
-    for host in set([*snappi_extra_params.multi_dut_params.ingress_duthosts,
-                     *snappi_extra_params.multi_dut_params.egress_duthosts, duthost]):
-        clear_dut_interface_counters(host)
-        clear_dut_que_counters(host)
+    clear_dut_interface_counters(duthost)
+
+    clear_dut_que_counters(duthost)
 
     logger.info("Starting transmit on all flows ...")
     ts = api.transmit_state()

--- a/tests/snappi_tests/multidut/ecn/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/ecn/files/multidut_helper.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts             # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
@@ -11,6 +12,7 @@ from tests.common.snappi_tests.read_pcap import get_ipv4_pkts
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, generate_test_flows, \
     generate_pause_flows, run_traffic                                       # noqa: F401
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +21,132 @@ DATA_START_DELAY_SEC = 0.1
 SNAPPI_POLL_DELAY_SEC = 2
 PAUSE_FLOW_NAME = 'Pause Storm'
 DATA_FLOW_NAME = 'Data Flow'
+
+
+def get_npu_voq_queue_counters(duthost, interface, priority):
+
+    asic_namespace_string = ""
+    if duthost.is_multi_asic:
+        asic = duthost.get_port_asic_instance(interface)
+        asic_namespace_string = " -n " + asic.namespace
+
+    full_line = "".join(duthost.shell(
+        "show platform npu voq queue_counters -t {} -i {} -d{}".
+        format(priority, interface, asic_namespace_string))['stdout_lines'])
+    dict_output = json.loads(full_line)
+    for entry, value in zip(dict_output['stats_name'], dict_output['counters']):
+        dict_output[entry] = value
+
+    return dict_output
+
+
+def verify_ecn_counters(ecn_counters, link_state_toggled=False):
+
+    toggle_msg = " post link state toggle" if link_state_toggled else ""
+    # verify that each flow had packets
+    init_ctr_3, post_ctr_3 = ecn_counters[0]
+    init_ctr_4, post_ctr_4 = ecn_counters[1]
+    flow3_total = post_ctr_3['SAI_QUEUE_STAT_PACKETS'] - init_ctr_3['SAI_QUEUE_STAT_PACKETS']
+
+    pytest_assert(flow3_total > 0,
+                  'Queue 3 counters at start {} at end {} did not increment{}'.format(
+                   init_ctr_3['SAI_QUEUE_STAT_PACKETS'], post_ctr_3['SAI_QUEUE_STAT_PACKETS'], toggle_msg))
+
+    flow4_total = post_ctr_4['SAI_QUEUE_STAT_PACKETS'] - init_ctr_4['SAI_QUEUE_STAT_PACKETS']
+
+    pytest_assert(flow4_total > 0,
+                  'Queue 4 counters at start {} at end {} did not increment{}'.format(
+                   init_ctr_4['SAI_QUEUE_STAT_PACKETS'], post_ctr_4['SAI_QUEUE_STAT_PACKETS'], toggle_msg))
+
+    flow3_ecn = post_ctr_3['SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS'] -\
+        init_ctr_3['SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS']
+    flow4_ecn = post_ctr_4['SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS'] -\
+        init_ctr_4['SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS']
+
+    pytest_assert(flow3_ecn > 0,
+                  'Must have ecn marked packets on flow 3{}'.
+                  format(toggle_msg))
+
+    pytest_assert(flow4_ecn > 0,
+                  'Must have ecn marked packets on flow 4{}'.
+                  format(toggle_msg))
+
+
+def verify_ecn_counters_for_flow_percent(ecn_counters, test_flow_percent):
+
+    # verify that each flow had packets
+    init_ctr_3, post_ctr_3 = ecn_counters[0]
+    init_ctr_4, post_ctr_4 = ecn_counters[1]
+    flow3_total = post_ctr_3['SAI_QUEUE_STAT_PACKETS'] - init_ctr_3['SAI_QUEUE_STAT_PACKETS']
+
+    drop_ctr_3 = post_ctr_3['SAI_QUEUE_STAT_DROPPED_PACKETS'] -\
+        init_ctr_3['SAI_QUEUE_STAT_DROPPED_PACKETS']
+    wred_drop_ctr_3 = post_ctr_3['SAI_QUEUE_STAT_WRED_DROPPED_PACKETS'] -\
+        init_ctr_3['SAI_QUEUE_STAT_WRED_DROPPED_PACKETS']
+
+    drop_ctr_4 = post_ctr_4['SAI_QUEUE_STAT_DROPPED_PACKETS'] -\
+        init_ctr_4['SAI_QUEUE_STAT_DROPPED_PACKETS']
+    wred_drop_ctr_4 = post_ctr_4['SAI_QUEUE_STAT_WRED_DROPPED_PACKETS'] -\
+        init_ctr_4['SAI_QUEUE_STAT_WRED_DROPPED_PACKETS']
+
+    pytest_assert(drop_ctr_3 == 0 and wred_drop_ctr_3 == 0, 'Queue 3 Drop not expected')
+
+    pytest_assert(drop_ctr_4 == 0 and wred_drop_ctr_4 == 0, 'Queue 4 Drop not expected')
+
+    pytest_assert(flow3_total > 0,
+                  'Queue 3 counters at start {} at end {} did not increment'.format(
+                   init_ctr_3['SAI_QUEUE_STAT_PACKETS'], post_ctr_3['SAI_QUEUE_STAT_PACKETS']))
+
+    flow4_total = post_ctr_4['SAI_QUEUE_STAT_PACKETS'] - init_ctr_4['SAI_QUEUE_STAT_PACKETS']
+
+    pytest_assert(flow4_total > 0,
+                  'Queue 4 counters at start {} at end {} did not increment'.format(
+                   init_ctr_4['SAI_QUEUE_STAT_PACKETS'], post_ctr_4['SAI_QUEUE_STAT_PACKETS']))
+
+    flow3_ecn = post_ctr_3['SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS'] -\
+        init_ctr_3['SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS']
+    flow4_ecn = post_ctr_4['SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS'] -\
+        init_ctr_4['SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS']
+
+    if sum(test_flow_percent) < 100:
+        pytest_assert(
+                        flow3_ecn == 0,
+                        'Must have no ecn marked packets on flow 3 without congestion, percent {}'.
+                        format(test_flow_percent))
+        pytest_assert(
+                        flow4_ecn == 0,
+                        'Must have no ecn marked packets on flow 4 without congestion, percent {}'.
+                        format(test_flow_percent))
+    elif sum(test_flow_percent) >= 100:
+        if test_flow_percent[0] > 50:
+            pytest_assert(
+                            flow3_ecn > 0,
+                            'Must have ecn marked packets on flow 3, percent {}'.
+                            format(test_flow_percent))
+
+        if test_flow_percent[1] > 50:
+            pytest_assert(
+                            flow4_ecn > 0,
+                            'Must have ecn marked packets on flow 4, percent {}'.
+                            format(test_flow_percent))
+
+        if test_flow_percent[0] < 50:
+            pytest_assert(
+                            flow3_ecn == 0,
+                            'Must not have ecn marked packets on flow 3, percent {}'.
+                            format(test_flow_percent))
+
+        if test_flow_percent[1] < 50:
+            pytest_assert(
+                            flow4_ecn == 0,
+                            'Must not have ecn marked packets on flow 4, percent {}'.
+                            format(test_flow_percent))
+
+        if test_flow_percent[0] == 50 and test_flow_percent[1] == 50:
+            pytest_assert(
+                            flow3_ecn > 0 and flow4_ecn > 0,
+                            'Must have ecn marked packets on flows 3, 4, percent {}'.
+                            format(test_flow_percent))
 
 
 def run_ecn_test(api,
@@ -181,3 +309,339 @@ def run_ecn_test(api,
         result.append(get_ipv4_pkts(snappi_extra_params.packet_capture_file + ".pcapng"))
 
     return result
+
+
+def run_ecn_marking_port_toggle_test(
+                                    api,
+                                    testbed_config,
+                                    port_config_list,
+                                    dut_port,
+                                    test_prio_list,
+                                    prio_dscp_map,
+                                    snappi_extra_params=None):
+
+    """
+    Run a ECN test
+    Args:
+        api (obj): snappi session
+        testbed_config (obj): testbed L1/L2/L3 configuration
+        port_config_list (list): list of port configuration
+        conn_data (dict): the dictionary returned by conn_graph_fact.
+        fanout_data (dict): the dictionary returned by fanout_graph_fact.
+        dut_port (str): DUT port to test
+        test_prio_list (list): priorities of test flows
+        prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
+        snappi_extra_params (SnappiTestParams obj): additional parameters for Snappi traffic
+    Returns:
+        N/A
+    """
+
+    pytest_assert(testbed_config is not None, 'Fail to get L2/3 testbed config')
+    pytest_assert(len(test_prio_list) >= 2, 'Must have atleast two lossless priorities')
+
+    test_flow_percent = [99.98] * len(test_prio_list)
+
+    TEST_FLOW_NAME = ['Test Flow 3', 'Test Flow 4']
+    DATA_FLOW_PKT_SIZE = 1350
+    DATA_FLOW_DURATION_SEC = 2
+    DATA_FLOW_DELAY_SEC = 1
+
+    if snappi_extra_params is None:
+        snappi_extra_params = SnappiTestParams()
+
+    # Traffic flow:
+    # tx_port (TGEN) --- ingress DUT --- egress DUT --- rx_port (TGEN)
+
+    rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
+    egress_duthost = rx_port['duthost']
+
+    tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
+    ingress_duthost = tx_port['duthost']
+
+    pytest_assert(testbed_config is not None, 'Failed to get L2/3 testbed config')
+
+    logger.info("Stopping PFC watchdog")
+    stop_pfcwd(egress_duthost, rx_port['asic_value'])
+    stop_pfcwd(ingress_duthost, tx_port['asic_value'])
+    logger.info("Disabling packet aging if necessary")
+    disable_packet_aging(egress_duthost)
+    disable_packet_aging(ingress_duthost)
+
+    duthost = egress_duthost
+
+    init_ctr_3 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[0])
+    init_ctr_4 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[1])
+
+    port_id = 0
+    # Generate base traffic config
+    base_flow_config1 = setup_base_traffic_config(testbed_config=testbed_config,
+                                                  port_config_list=port_config_list,
+                                                  port_id=port_id)
+    port_config_list2 = [x for x in port_config_list if x != base_flow_config1['tx_port_config']]
+    base_flow_config2 = setup_base_traffic_config(testbed_config=testbed_config,
+                                                  port_config_list=port_config_list2,
+                                                  port_id=port_id)
+
+    # Create a dictionary with priorities as keys and flow rates as values
+    flow_rate_dict = {
+        prio: round(flow / len(test_prio_list), 2) for prio, flow in zip(test_prio_list, test_flow_percent)
+    }
+
+    snappi_extra_params.base_flow_config = base_flow_config1
+
+    # Set default traffic flow configs if not set
+    if snappi_extra_params.traffic_flow_config.data_flow_config is None:
+        snappi_extra_params.traffic_flow_config.data_flow_config = {
+            "flow_name": TEST_FLOW_NAME[0],
+            "flow_dur_sec": DATA_FLOW_DURATION_SEC,
+            "flow_rate_percent": flow_rate_dict,
+            "flow_rate_pps": None,
+            "flow_rate_bps": None,
+            "flow_pkt_size": DATA_FLOW_PKT_SIZE,
+            "flow_pkt_count": None,
+            "flow_delay_sec": DATA_FLOW_DELAY_SEC,
+            "flow_traffic_type": traffic_flow_mode.FIXED_DURATION
+        }
+
+    generate_test_flows(testbed_config=testbed_config,
+                        test_flow_prio_list=test_prio_list,
+                        prio_dscp_map=prio_dscp_map,
+                        snappi_extra_params=snappi_extra_params)
+
+    snappi_extra_params.base_flow_config = base_flow_config2
+
+    snappi_extra_params.traffic_flow_config.data_flow_config = {
+            "flow_name": TEST_FLOW_NAME[1],
+            "flow_dur_sec": DATA_FLOW_DURATION_SEC,
+            "flow_rate_percent": flow_rate_dict,
+            "flow_rate_pps": None,
+            "flow_rate_bps": None,
+            "flow_pkt_size": DATA_FLOW_PKT_SIZE,
+            "flow_pkt_count": None,
+            "flow_delay_sec": DATA_FLOW_DELAY_SEC,
+            "flow_traffic_type": traffic_flow_mode.FIXED_DURATION
+        }
+    generate_test_flows(testbed_config=testbed_config,
+                        test_flow_prio_list=test_prio_list,
+                        prio_dscp_map=prio_dscp_map,
+                        snappi_extra_params=snappi_extra_params)
+
+    flows = testbed_config.flows
+
+    all_flow_names = [flow.name for flow in flows]
+    data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
+
+    # Clear PFC and queue counters before traffic run
+    duthost.command("pfcstat -c")
+    duthost.command("sonic-clear queuecounters")
+
+    """ Run traffic """
+    _tgen_flow_stats, _switch_flow_stats, _in_flight_flow_metrics = run_traffic(
+                                                                duthost,
+                                                                api=api,
+                                                                config=testbed_config,
+                                                                data_flow_names=data_flow_names,
+                                                                all_flow_names=all_flow_names,
+                                                                exp_dur_sec=DATA_FLOW_DURATION_SEC +
+                                                                DATA_FLOW_DELAY_SEC,
+                                                                snappi_extra_params=snappi_extra_params)
+
+    post_ctr_3 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[0])
+    post_ctr_4 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[1])
+
+    ecn_counters = [
+        (init_ctr_3, post_ctr_3),
+        (init_ctr_4, post_ctr_4)
+    ]
+
+    verify_ecn_counters(ecn_counters)
+
+    # Get the current configuration
+    config = api.get_config()
+    # Collect all port names
+    port_names = [port.name for port in config.ports]
+    # Create a link state object for all ports
+    link_state = api.link_state()
+    # Apply the state to all ports
+    link_state.port_names = port_names
+    # Set all ports down (shut)
+    link_state.state = link_state.DOWN
+    api.set_link_state(link_state)
+    logger.info("All Snappi ports are set to DOWN")
+    time.sleep(0.2)
+    # Unshut all ports
+    link_state.state = link_state.UP
+    api.set_link_state(link_state)
+    logger.info("All Snappi ports are set to UP")
+
+    init_ctr_3 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[0])
+    init_ctr_4 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[1])
+
+    """ Run traffic """
+    _tgen_flow_stats, _switch_flow_stats, _in_flight_flow_metrics = run_traffic(
+                                                                duthost,
+                                                                api=api,
+                                                                config=testbed_config,
+                                                                data_flow_names=data_flow_names,
+                                                                all_flow_names=all_flow_names,
+                                                                exp_dur_sec=DATA_FLOW_DURATION_SEC +
+                                                                DATA_FLOW_DELAY_SEC,
+                                                                snappi_extra_params=snappi_extra_params)
+
+    post_ctr_3 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[0])
+    post_ctr_4 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[1])
+
+    ecn_counters = [
+        (init_ctr_3, post_ctr_3),
+        (init_ctr_4, post_ctr_4)
+    ]
+
+    verify_ecn_counters(ecn_counters, link_state_toggled=True)
+
+
+def run_ecn_marking_test(api,
+                         testbed_config,
+                         port_config_list,
+                         dut_port,
+                         test_prio_list,
+                         prio_dscp_map,
+                         test_flow_percent,
+                         snappi_extra_params=None):
+
+    """
+    Run a ECN test
+    Args:
+        api (obj): snappi session
+        testbed_config (obj): testbed L1/L2/L3 configuration
+        port_config_list (list): list of port configuration
+        conn_data (dict): the dictionary returned by conn_graph_fact.
+        fanout_data (dict): the dictionary returned by fanout_graph_fact.
+        dut_port (str): DUT port to test
+        test_prio_list (list): priorities of test flows
+        prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
+        snappi_extra_params (SnappiTestParams obj): additional parameters for Snappi traffic
+
+    Returns:
+        N/A
+    """
+
+    pytest_assert(testbed_config is not None, 'Fail to get L2/3 testbed config')
+    pytest_assert(len(test_prio_list) >= 2, 'Must have atleast two lossless priorities')
+
+    pytest_assert(len(test_flow_percent) == len(test_prio_list),
+                  "The length of test_flow_percent must match the length of test_prio_list")
+
+    TEST_FLOW_NAME = ['Test Flow 3', 'Test Flow 4']
+    DATA_FLOW_PKT_SIZE = 1350
+    DATA_FLOW_DURATION_SEC = 2
+    DATA_FLOW_DELAY_SEC = 1
+
+    if snappi_extra_params is None:
+        snappi_extra_params = SnappiTestParams()
+
+    # Traffic flow:
+    # tx_port (TGEN) --- ingress DUT --- egress DUT --- rx_port (TGEN)
+
+    rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
+    egress_duthost = rx_port['duthost']
+
+    tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
+    ingress_duthost = tx_port['duthost']
+
+    pytest_assert(testbed_config is not None, 'Failed to get L2/3 testbed config')
+
+    logger.info("Stopping PFC watchdog")
+    stop_pfcwd(egress_duthost, rx_port['asic_value'])
+    stop_pfcwd(ingress_duthost, tx_port['asic_value'])
+    logger.info("Disabling packet aging if necessary")
+    disable_packet_aging(egress_duthost)
+    disable_packet_aging(ingress_duthost)
+
+    duthost = egress_duthost
+
+    init_ctr_3 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[0])
+    init_ctr_4 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[1])
+
+    port_id = 0
+    # Generate base traffic config
+    base_flow_config1 = setup_base_traffic_config(testbed_config=testbed_config,
+                                                  port_config_list=port_config_list,
+                                                  port_id=port_id)
+    port_config_list2 = [x for x in port_config_list if x != base_flow_config1['tx_port_config']]
+    base_flow_config2 = setup_base_traffic_config(testbed_config=testbed_config,
+                                                  port_config_list=port_config_list2,
+                                                  port_id=port_id)
+
+    # Create a dictionary with priorities as keys and flow rates as values
+    flow_rate_dict = {
+        prio: round(flow / len(test_prio_list), 2) for prio, flow in zip(test_prio_list, test_flow_percent)
+    }
+
+    snappi_extra_params.base_flow_config = base_flow_config1
+
+    # Set default traffic flow configs if not set
+    if snappi_extra_params.traffic_flow_config.data_flow_config is None:
+        snappi_extra_params.traffic_flow_config.data_flow_config = {
+            "flow_name": TEST_FLOW_NAME[0],
+            "flow_dur_sec": DATA_FLOW_DURATION_SEC,
+            "flow_rate_percent": flow_rate_dict,
+            "flow_rate_pps": None,
+            "flow_rate_bps": None,
+            "flow_pkt_size": DATA_FLOW_PKT_SIZE,
+            "flow_pkt_count": None,
+            "flow_delay_sec": DATA_FLOW_DELAY_SEC,
+            "flow_traffic_type": traffic_flow_mode.FIXED_DURATION
+        }
+
+    generate_test_flows(testbed_config=testbed_config,
+                        test_flow_prio_list=test_prio_list,
+                        prio_dscp_map=prio_dscp_map,
+                        snappi_extra_params=snappi_extra_params)
+
+    snappi_extra_params.base_flow_config = base_flow_config2
+
+    snappi_extra_params.traffic_flow_config.data_flow_config = {
+            "flow_name": TEST_FLOW_NAME[1],
+            "flow_dur_sec": DATA_FLOW_DURATION_SEC,
+            "flow_rate_percent": flow_rate_dict,
+            "flow_rate_pps": None,
+            "flow_rate_bps": None,
+            "flow_pkt_size": DATA_FLOW_PKT_SIZE,
+            "flow_pkt_count": None,
+            "flow_delay_sec": DATA_FLOW_DELAY_SEC,
+            "flow_traffic_type": traffic_flow_mode.FIXED_DURATION
+        }
+    generate_test_flows(testbed_config=testbed_config,
+                        test_flow_prio_list=test_prio_list,
+                        prio_dscp_map=prio_dscp_map,
+                        snappi_extra_params=snappi_extra_params)
+
+    flows = testbed_config.flows
+
+    all_flow_names = [flow.name for flow in flows]
+    data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
+
+    # Clear PFC and queue counters before traffic run
+    duthost.command("pfcstat -c")
+    duthost.command("sonic-clear queuecounters")
+
+    """ Run traffic """
+    _tgen_flow_stats, _switch_flow_stats, _in_flight_flow_metrics = run_traffic(
+                                                                duthost,
+                                                                api=api,
+                                                                config=testbed_config,
+                                                                data_flow_names=data_flow_names,
+                                                                all_flow_names=all_flow_names,
+                                                                exp_dur_sec=DATA_FLOW_DURATION_SEC +
+                                                                DATA_FLOW_DELAY_SEC,
+                                                                snappi_extra_params=snappi_extra_params)
+
+    post_ctr_3 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[0])
+    post_ctr_4 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[1])
+
+    ecn_counters = [
+        (init_ctr_3, post_ctr_3),
+        (init_ctr_4, post_ctr_4)
+    ]
+
+    verify_ecn_counters_for_flow_percent(ecn_counters, test_flow_percent)

--- a/tests/snappi_tests/multidut/ecn/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/ecn/files/multidut_helper.py
@@ -432,7 +432,7 @@ def run_ecn_marking_port_toggle_test(
     data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
 
     # Clear PFC and queue counters before traffic run
-    duthost.command("pfcstat -c")
+    duthost.command("sonic-clear pfccounters")
     duthost.command("sonic-clear queuecounters")
 
     """ Run traffic """
@@ -622,7 +622,7 @@ def run_ecn_marking_test(api,
     data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
 
     # Clear PFC and queue counters before traffic run
-    duthost.command("pfcstat -c")
+    duthost.command("sonic-clear pfccounters")
     duthost.command("sonic-clear queuecounters")
 
     """ Run traffic """

--- a/tests/snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py
@@ -1,0 +1,250 @@
+import pytest
+import logging
+from tabulate import tabulate # noqa F401
+from tests.common.helpers.assertions import pytest_assert, pytest_require    # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut         # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
+    snappi_api, snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config, \
+    is_snappi_multidut, get_snappi_ports_multi_dut   # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
+    lossless_prio_list   # noqa F401
+from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+from tests.snappi_tests.multidut.ecn.files.multidut_helper import run_ecn_marking_test, run_ecn_marking_port_toggle_test
+from tests.common.snappi_tests.common_helpers import packet_capture # noqa F401
+from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.common.cisco_data import is_cisco_device
+logger = logging.getLogger(__name__)
+pytestmark = [pytest.mark.topology('multidut-tgen')]
+
+
+def validate_snappi_ports(snappi_ports):
+
+    if not is_cisco_device(snappi_ports[0]['duthost']):
+        return True
+
+    '''
+        One ingress port and the egress port should be on the same DUT and asic.
+        The second ingress port can be on diff asic or DUT.
+        This is needed to avoid tail drops caused by use of default voq in case
+        both the BP ports of egress port are on the same slice
+
+        All ingress and egress port on the same DUT and asic is fine.
+    '''
+
+    # Extract duthost and peer_port values for rx_dut and tx_dut configurations
+    rx_dut = snappi_ports[0]['duthost']
+    rx_peer_port = snappi_ports[0]['peer_port']
+    tx_dut_1 = snappi_ports[1]['duthost']
+    tx_peer_port_1 = snappi_ports[1]['peer_port']
+    tx_dut_2 = snappi_ports[2]['duthost']
+    tx_peer_port_2 = snappi_ports[2]['peer_port']
+
+    # get the ASIC namespace for a given duthost and peer_port
+    def get_asic(duthost, peer_port):
+        return duthost.get_port_asic_instance(peer_port).namespace
+
+    # Retrieve ASIC namespace
+    rx_asic = get_asic(rx_dut, rx_peer_port)
+    tx_asic_1 = get_asic(tx_dut_1, tx_peer_port_1)
+    tx_asic_2 = get_asic(tx_dut_2, tx_peer_port_2)
+
+    # Check if all duthosts and their ASICs are the same
+    if (rx_dut == tx_dut_1 == tx_dut_2) and (rx_asic == tx_asic_1 == tx_asic_2):
+        return True
+
+    # Check if rx_dut and its ASIC matches either of the tx_dut and their ASIC
+    if (rx_dut == tx_dut_1 and rx_asic == tx_asic_1) or (rx_dut == tx_dut_2 and rx_asic == tx_asic_2):
+        return True
+
+    return False
+
+
+@pytest.mark.parametrize("multidut_port_info", [
+    pytest.param(
+        multidut_port_info,
+        id=f"multidut_port_keys={'_'.join(multidut_port_info.keys())}"
+    )
+    for multidut_port_info in MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]
+])
+def test_ecn_marking_port_toggle(
+                                snappi_api,                       # noqa: F811
+                                conn_graph_facts,                 # noqa: F811
+                                fanout_graph_facts_multidut,               # noqa: F811
+                                duthosts,
+                                lossless_prio_list,     # noqa: F811
+                                get_snappi_ports,     # noqa: F811
+                                tbinfo,      # noqa: F811
+                                multidut_port_info,     # noqa: F811
+                                prio_dscp_map):                    # noqa: F811
+    """
+    Verify ECN marking both pre and post port shut/no shut toggle
+    Args:
+        request (pytest fixture): pytest request object
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        lossless_prio_list (pytest fixture): list of all the lossless priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        tbinfo (pytest fixture): fixture provides information about testbed
+        get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
+    Returns:
+        N/A
+    """
+
+    for testbed_subtype, rdma_ports in multidut_port_info.items():
+        tx_port_count = 2
+        rx_port_count = 1
+        snappi_port_list = get_snappi_ports
+        pytest_assert(MULTIDUT_TESTBED == tbinfo['conf-name'],
+                      "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
+        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                      "Need Minimum of {} ports defined in ansible/files/*links.csv file".
+                      format(tx_port_count + rx_port_count))
+
+        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
+                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
+                      testbed {}, subtype {} in variables.py'.
+                      format(MULTIDUT_TESTBED, testbed_subtype))
+
+        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
+                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
+                      testbed {}, subtype {} in variables.py'.
+                      format(MULTIDUT_TESTBED, testbed_subtype))
+
+        # Collect port names from rx_ports and tx_ports into a set for uniqueness
+        all_ports_set = set(port['port_name'] for port in rdma_ports['rx_ports'] + rdma_ports['tx_ports'])
+        pytest_assert(len(all_ports_set) >= tx_port_count + rx_port_count,
+                      'MULTIDUT_PORT_INFO doesn\'t have at least {} unique ports for \
+                      testbed {}, subtype {} in variables.py'.
+                      format(tx_port_count + rx_port_count, MULTIDUT_TESTBED, testbed_subtype))
+
+        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+
+        if is_snappi_multidut(duthosts):
+            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        else:
+            snappi_ports = snappi_port_list
+
+        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
+                                                                                snappi_ports,
+                                                                                snappi_api)
+
+    logger.info("Snappi Ports : {}".format(snappi_ports))
+    snappi_extra_params = SnappiTestParams()
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    try:
+        run_ecn_marking_port_toggle_test(
+                                api=snappi_api,
+                                testbed_config=testbed_config,
+                                port_config_list=port_config_list,
+                                dut_port=snappi_ports[0]['peer_port'],
+                                test_prio_list=lossless_prio_list,
+                                prio_dscp_map=prio_dscp_map,
+                                snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
+
+
+test_flow_percent_list = [[90, 15], [53, 49], [15, 90], [49, 49], [50, 50]]
+
+
+@pytest.mark.parametrize("multidut_port_info, test_flow_percent", [
+    pytest.param(
+        multidut_port_info,
+        test_flow_percent,
+        id=f"multidut_port_info={key}-test_flow_percent={test_flow_percent}"
+    )
+    for multidut_port_info in MULTIDUT_PORT_INFO[MULTIDUT_TESTBED]
+    for key in multidut_port_info.keys()
+    for test_flow_percent in test_flow_percent_list
+])
+def test_ecn_marking_lossless_prio(
+                                snappi_api,                       # noqa: F811
+                                conn_graph_facts,                 # noqa: F811
+                                fanout_graph_facts_multidut,               # noqa: F811
+                                duthosts,
+                                lossless_prio_list,     # noqa: F811
+                                get_snappi_ports,     # noqa: F811
+                                tbinfo,      # noqa: F811
+                                multidut_port_info,     # noqa: F811
+                                test_flow_percent,
+                                prio_dscp_map):                    # noqa: F811
+    """
+    Verify ECN marking on lossless prio with same DWRR weight
+
+    Args:
+        request (pytest fixture): pytest request object
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        lossless_prio_list (pytest fixture): list of all the lossless priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        tbinfo (pytest fixture): fixture provides information about testbed
+        test_flow_percent: Percentage of flow rate used for the two lossless prio
+        get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
+    Returns:
+        N/A
+    """
+
+    for testbed_subtype, rdma_ports in multidut_port_info.items():
+        tx_port_count = 2
+        rx_port_count = 1
+        snappi_port_list = get_snappi_ports
+        pytest_assert(MULTIDUT_TESTBED == tbinfo['conf-name'],
+                      "The testbed name from testbed file doesn't match with MULTIDUT_TESTBED in variables.py ")
+        pytest_assert(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                      "Need Minimum of {} ports defined in ansible/files/*links.csv file".
+                      format(tx_port_count + rx_port_count))
+
+        pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
+                      'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
+                      testbed {}, subtype {} in variables.py'.
+                      format(MULTIDUT_TESTBED, testbed_subtype))
+
+        pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
+                      'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
+                      testbed {}, subtype {} in variables.py'.
+                      format(MULTIDUT_TESTBED, testbed_subtype))
+
+        # Collect port names from rx_ports and tx_ports into a set for uniqueness
+        all_ports_set = set(port['port_name'] for port in rdma_ports['rx_ports'] + rdma_ports['tx_ports'])
+        pytest_assert(len(all_ports_set) >= tx_port_count + rx_port_count,
+                      'MULTIDUT_PORT_INFO doesn\'t have at least {} unique ports for \
+                      testbed {}, subtype {} in variables.py'.
+                      format(tx_port_count + rx_port_count, MULTIDUT_TESTBED, testbed_subtype))
+
+        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+
+        if is_snappi_multidut(duthosts):
+            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        else:
+            snappi_ports = snappi_port_list
+
+        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
+                                                                                snappi_ports,
+                                                                                snappi_api)
+
+    pytest_assert(validate_snappi_ports(snappi_ports), "Invalid combination of duthosts or ASICs in snappi_ports")
+
+    logger.info("Snappi Ports : {}".format(snappi_ports))
+    snappi_extra_params = SnappiTestParams()
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    try:
+        run_ecn_marking_test(
+                                api=snappi_api,
+                                testbed_config=testbed_config,
+                                port_config_list=port_config_list,
+                                dut_port=snappi_ports[0]['peer_port'],
+                                test_prio_list=lossless_prio_list,
+                                prio_dscp_map=prio_dscp_map,
+                                test_flow_percent=test_flow_percent,
+                                snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

Add ECN test for comparative marking of traffic based on flow rate

#### How did you do it?

Added testcase to provide different combination of flow percent for both lossless prior
1)Injected traffic to ingress port and 1 egress port causing congestion
2) the resulting congestion results in ecn marking
3) Verify the ecn marking is happening as expected based on the flow percent


#### How did you verify/test it?

Verified on T2 Ixia setup with multi asic DUT

```
========================================== short test summary info ====================================================================================================================================
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_keys=single-dut-multi-asic]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_keys=single-dut-single-asic]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info=single-dut-multi-asic-test_flow_percent=[90, 15]]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info=single-dut-multi-asic-test_flow_percent=[53, 49]]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info=single-dut-multi-asic-test_flow_percent=[15, 90]]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info=single-dut-multi-asic-test_flow_percent=[49, 49]]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info=single-dut-multi-asic-test_flow_percent=[50, 50]]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info=single-dut-single-asic-test_flow_percent=[90, 15]]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info=single-dut-single-asic-test_flow_percent=[53, 49]]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info=single-dut-single-asic-test_flow_percent=[15, 90]]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info=single-dut-single-asic-test_flow_percent=[49, 49]]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info=single-dut-single-asic-test_flow_percent=[50, 50]]
========================================================================================================================= 12 passed, 15 warnings in 1947.37s (0:32:27) ==========================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
