### PR TITLE
Generate PFC storm using PFC backpressure on Arista DCS-7060X6 devices

### DIFF
--- a/tests/common/helpers/pfc_gen_th5.py
+++ b/tests/common/helpers/pfc_gen_th5.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+
+"""
+Script to generate PFC storm.
+
+"""
+import binascii
+import sys
+import optparse
+import logging
+import logging.handlers
+import re
+import signal
+import subprocess
+import time
+
+
+logger = logging.getLogger('MyLogger')
+logger.setLevel(logging.DEBUG)
+
+
+class SignalCleanup():
+    def __init__(self, fanoutPfcStorm, endMsg):
+        self.fanoutPfcStorm = fanoutPfcStorm
+        self.endMsg = endMsg
+        signal.signal(signal.SIGTERM, self.sigHandler)
+
+    def sigHandler(self, *args):
+        self.fanoutPfcStorm.endAllPfcStorm()
+
+        logger.debug(self.endMsg)
+        sys.exit(0)
+
+
+class FanoutPfcStorm():
+    '''
+    Expects all interfaces to be in the front panel interface format
+    ex. Ethernet1/1 and not et1_1
+    '''
+    def __init__(self, priority):
+        self.intfToMmuPort = self._parseInterfaceMapFull()
+        self.intfsEnabled = []
+        self.priority = priority
+
+    def _cliCmd(self, cmd):
+        output = ""
+        result = subprocess.run(
+            ["Cli", "-c", f"{cmd}"], capture_output=True, text=True)
+        if result.returncode == 0:
+            output = result.stdout
+        return output
+
+    def _bcmltshellCmd(self, cmd):
+        return self._cliCmd(f"en\nplatform trident shell\nbcmltshell\n{cmd}") 
+
+    def _parseInterfaceMapFull(self):
+        intfToMmuPort = {}
+
+        output = self._cliCmd(f"en\nshow platform trident interface map full")
+
+        for line in output.splitlines():
+            mo = re.search('Intf: (?P<intf>Ethernet\S+).{1,100}P2M\[ {0,3}\d+\]: {1,3}(?P<mmu>\S+)', line)
+            if mo is None:
+                continue
+            intfToMmuPort[mo.group('intf')] = mo.group('mmu')
+
+        return intfToMmuPort
+
+    def _endPfcStorm(self, intf):
+        '''
+        Intf format is Ethernet1/1
+
+        The users of this class are only expected to call
+        startPfcStorm and endAllPfcStorm
+        '''
+        mmuPort = self.intfToMmuPort[intf]
+        self._bcmltshellCmd(f"pt MMU_INTFO_XPORT_BKP_HW_UPDATE_DISr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP=0")
+        self._bcmltshellCmd(f"pt MMU_INTFO_TO_XPORT_BKPr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP=0")
+        self._cliCmd(f"en\nconf\n\nint {intf}\nno priority-flow-control on")
+        for prio in range(8):
+            self._cliCmd(f"en\nconf\n\nint {intf}\nno priority-flow-control priority {prio} no-drop")
+
+    def startPfcStorm(self, intf):
+        if intf in self.intfsEnabled:
+            return
+        self.intfsEnabled.append(intf)
+
+        mmuPort = self.intfToMmuPort[intf]
+        self._cliCmd(f"en\nconf\n\nint {intf}\npriority-flow-control on")
+        for prio in range(8):
+            if (1 << prio) & self.priority:
+                self._cliCmd(f"en\nconf\n\nint {intf}\npriority-flow-control priority {prio} no-drop")
+        self._bcmltshellCmd(f"pt MMU_INTFO_XPORT_BKP_HW_UPDATE_DISr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP=1")
+        self._bcmltshellCmd(f"pt MMU_INTFO_TO_XPORT_BKPr set BCMLT_PT_PORT={mmuPort} PAUSE_PFC_BKP=0xff")
+
+
+    def endAllPfcStorm(self):
+        for intf in self.intfsEnabled:
+            self._endPfcStorm(intf)
+
+
+def main():
+    usage = "usage: %prog [options] arg1 arg2"
+    parser = optparse.OptionParser(usage=usage)
+    parser.add_option("-i", "--interface", type="string", dest="interface",
+                      help="Interface list to send packets, separated by ','", metavar="Interface")
+    parser.add_option('-p', "--priority", type="int", dest="priority",
+                      help="PFC class enable bitmap.", metavar="Priority", default=-1)
+    parser.add_option("-r", "--rsyslog-server", type="string", dest="rsyslog_server",
+                      default="127.0.0.1", help="Rsyslog server IPv4 address", metavar="IPAddress")
+
+    (options, args) = parser.parse_args()
+
+    if options.interface is None:
+        print("Need to specify the interface to send PFC pause frame packets.")
+        parser.print_help()
+        sys.exit(1)
+
+    if options.priority > 255 or options.priority < 0:
+        print("Enable class bitmap is not valid. Need to be in range 0-255.")
+        parser.print_help()
+        sys.exit(1)
+
+    # Configure logging
+    handler = logging.handlers.SysLogHandler(address=(options.rsyslog_server, 514))
+    logger.addHandler(handler)
+
+    # List of front panel kernel intfs
+    interfaces = options.interface.split(',')
+
+    fs = FanoutPfcStorm(options.priority)
+    fsCleanup = SignalCleanup(fs, 'PFC_STORM_END')
+
+    logger.debug('PFC_STORM_DEBUG')
+    for intf in interfaces:
+       fs.startPfcStorm( frontPanelIntfFromKernelIntfName(intf))
+    logger.debug('PFC_STORM_START')
+
+    # wait forever until stop
+    while True:
+       time.sleep(100)
+
+def frontPanelIntfFromKernelIntfName(intf):
+   return intf.replace("et", "Ethernet").replace("_", "/")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -114,11 +114,21 @@ class PFCStorm(object):
         if not out['stat']['exists'] or not out['stat']['isdir']:
             self.peer_device.file(path=pfc_gen_fpath, state="touch")
 
+    def _get_eos_fanout_version(self):
+        """
+        Create the pfc generation file on the fanout if it does not exist
+        """
+        cmd = 'Cli -c "show version"'
+        return self.peer_device.shell(cmd)['stdout_lines']
+
     def deploy_pfc_gen(self):
         """
         Deploy the pfc generation file on the fanout
         """
         if self.peer_device.os in ('eos', 'sonic'):
+            if  self.peer_device.os == 'eos' and self._get_eos_fanout_version()[0].startswith('Arista DCS-7060X6'):
+                self.pfc_gen_file = "pfc_gen_th5.py"
+                self.pfc_gen_file_test_name = "pfc_gen_th5.py"
             src_pfc_gen_file = "common/helpers/{}".format(self.pfc_gen_file)
             self._create_pfc_gen()
             if self.fanout_asic_type == 'mellanox':
@@ -198,6 +208,9 @@ class PFCStorm(object):
         elif self.fanout_asic_type == 'mellanox' and self.peer_device.os == 'sonic':
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_mlnx_{}.j2".format(self.peer_device.os))
+        elif self.peer_device.os == 'eos' and self._get_eos_fanout_version()[0].startswith('Arista DCS-7060X6'):
+            self.pfc_start_template = os.path.join(
+                TEMPLATES_DIR, "pfc_storm_arista_{}.j2".format(self.peer_device.os))
         else:
             self.pfc_start_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_{}.j2".format(self.peer_device.os))
@@ -214,6 +227,9 @@ class PFCStorm(object):
         elif self.fanout_asic_type == 'mellanox' and self.peer_device.os == 'sonic':
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_mlnx_{}.j2".format(self.peer_device.os))
+        elif self.peer_device.os == 'eos' and self._get_eos_fanout_version()[0].startswith('Arista DCS-7060X6'):
+            self.pfc_stop_template = os.path.join(
+                TEMPLATES_DIR, "pfc_storm_stop_arista_{}.j2".format(self.peer_device.os))
         else:
             self.pfc_stop_template = os.path.join(
                 TEMPLATES_DIR, "pfc_storm_stop_{}.j2".format(self.peer_device.os))

--- a/tests/common/templates/pfc_storm_arista_eos.j2
+++ b/tests/common/templates/pfc_storm_arista_eos.j2
@@ -1,0 +1,9 @@
+bash
+cd {{pfc_gen_dir}}
+{% if (pfc_asym is defined) and (pfc_asym == True) %}
+{% if pfc_storm_defer_time is defined %}sleep {{pfc_storm_defer_time}} &&{% endif %} sudo python3 {{pfc_gen_file}} -p {{pfc_queue_index}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} > /dev/null 2>&1 &
+{% else %}
+{% if pfc_storm_defer_time is defined %}sleep {{pfc_storm_defer_time}} &&{% endif %} sudo python3 {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}} > /dev/null 2>&1 &
+{% endif %}
+exit
+exit

--- a/tests/common/templates/pfc_storm_stop_arista_eos.j2
+++ b/tests/common/templates/pfc_storm_stop_arista_eos.j2
@@ -1,0 +1,9 @@
+bash
+cd {{pfc_gen_dir}}
+{% if (pfc_asym is defined) and (pfc_asym == True) %}
+{% if pfc_storm_stop_defer_time is defined %}sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f 'python3 {{pfc_gen_file}} -p {{pfc_queue_index}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}}' > /dev/null 2>&1 &
+{% else %}
+{% if pfc_storm_stop_defer_time is defined %}sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f 'python3 {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}}' > /dev/null 2>&1 &
+{% endif %}
+exit
+exit


### PR DESCRIPTION
### Description of PR

Add a pfc_gen script for Arista DCS-7060X6 fanout devices to generate pfc pause frames by setting PFC backpressure status in hardware.  Enable the storm generation to use this script on interfaces that are connected to Arista DCS-7060X6 fanout devices running EOS.

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Adds more reliable PFC storm generation for interfaces connected to Arista DCS-7060X6 fanout devices

#### How did you do it?

#### How did you verify/test it?
Ran the pfcwd tests on t1 switch with interfaces connected to Arista DCS-7060X6 device, ensured the new script was used and pfc storm was appropriately detected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
