### PR TITLE
Updating TESTBED_FIELDS_RECOMMENDED with value 'is_smartswitch'

### DIFF
--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -24,7 +24,7 @@ class TestbedInfo(object):
                                  'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'comment')
     TESTBED_FIELDS_RECOMMENDED = ('conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf',
                                   'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut',
-                                  'inv_name', 'auto_recover', 'comment')
+                                  'inv_name', 'auto_recover', 'is_smartswitch', 'comment')
     TOPOLOGY_FILEPATH = "../../ansible/vars/"
 
     def __init__(self, testbed_file):


### PR DESCRIPTION
The value is_smartswitch is missing from TESTBED_FIELDS_RECOMENDED

### Description of PR
The value 'is_smartswitch' is missing from TESTBED_FIELDS_RECOMMENDED and causes an error when running test_pretest.py.  Without adding 'Is_smartswitch' the following error will output at end of a test:

ValueError: Unsupported testbed fields ['conf-name', 'group-name', 'topo', 'ptf_image_name', 'ptf', 'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut', 'inv_name', 'auto_recover', 'is_smartswitch', 'comment']


### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
To add value 'is_smartswitch' as a recognized field within sonic-mgmt.

#### How did you do it?
Attempted to run test_pretest.py with a smartswitch testbed

#### How did you verify/test it?
Attempted to run locally in my development container

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

