### PR TITLE
Adding cisco smartswitch support

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -437,6 +437,11 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             # this device simulates 32 ports, with 4 as the step for port naming.
             for i in range(0, 32, 4):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
+        elif hwsku == "Cisco-8102-28FH-DPU-O-T1":
+            for i in range(0, 28, 8):
+                port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
+            for i in range(0, 8, 1):
+                port_alias_to_name_map["Ethernet-BP%d" % i] = "Ethernet-BP%d" % i
         else:
             if "Arista-7800" in hwsku:
                 assert False, "Please add port_alias_to_name_map for new modular SKU %s." % hwsku


### PR DESCRIPTION
Adding additional ports for Cisco smartswitch


### Description of PR
This PR is to add support for Cisco smartswitch when creating ports.

Summary:
Fixes # (issue)

### Type of change


- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
This PR is to add support for cisco smartswitch when creating ports.

#### How did you do it?
Local dev container within my own test environment 

#### How did you verify/test it?
Added new lines to existing script and ran it within my own container.

#### Any platform specific information?
Cisco-8192-28FH

#### Supported testbed topology if it's a new test case?

### Documentation

