### PR TITLE
Fix t0-isolated-d128u128s1

### DIFF
--- a/ansible/vars/topo_t0-isolated-d128u128s1.yml
+++ b/ansible/vars/topo_t0-isolated-d128u128s1.yml
@@ -825,7 +825,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.65/31
         ipv6: fc00::82/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.2/24
       ipv6: fc0a::2/64
   ARISTA02T1:
@@ -844,7 +844,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.67/31
         ipv6: fc00::86/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.3/24
       ipv6: fc0a::3/64
   ARISTA03T1:
@@ -863,7 +863,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.69/31
         ipv6: fc00::8a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.4/24
       ipv6: fc0a::4/64
   ARISTA04T1:
@@ -882,7 +882,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.71/31
         ipv6: fc00::8e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.5/24
       ipv6: fc0a::5/64
   ARISTA05T1:
@@ -901,7 +901,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.73/31
         ipv6: fc00::92/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.6/24
       ipv6: fc0a::6/64
   ARISTA06T1:
@@ -920,7 +920,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.75/31
         ipv6: fc00::96/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.7/24
       ipv6: fc0a::7/64
   ARISTA07T1:
@@ -939,7 +939,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.77/31
         ipv6: fc00::9a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.8/24
       ipv6: fc0a::8/64
   ARISTA08T1:
@@ -958,7 +958,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.79/31
         ipv6: fc00::9e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.9/24
       ipv6: fc0a::9/64
   ARISTA09T1:
@@ -977,7 +977,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.81/31
         ipv6: fc00::a2/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.10/24
       ipv6: fc0a::a/64
   ARISTA10T1:
@@ -996,7 +996,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.83/31
         ipv6: fc00::a6/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.11/24
       ipv6: fc0a::b/64
   ARISTA11T1:
@@ -1015,7 +1015,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.85/31
         ipv6: fc00::aa/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.12/24
       ipv6: fc0a::c/64
   ARISTA12T1:
@@ -1034,7 +1034,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.87/31
         ipv6: fc00::ae/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.13/24
       ipv6: fc0a::d/64
   ARISTA13T1:
@@ -1053,7 +1053,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.89/31
         ipv6: fc00::b2/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.14/24
       ipv6: fc0a::e/64
   ARISTA14T1:
@@ -1072,7 +1072,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.91/31
         ipv6: fc00::b6/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.15/24
       ipv6: fc0a::f/64
   ARISTA15T1:
@@ -1091,7 +1091,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.93/31
         ipv6: fc00::ba/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.16/24
       ipv6: fc0a::10/64
   ARISTA16T1:
@@ -1110,7 +1110,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.95/31
         ipv6: fc00::be/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.17/24
       ipv6: fc0a::11/64
   ARISTA17T1:
@@ -1129,7 +1129,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.97/31
         ipv6: fc00::c2/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.18/24
       ipv6: fc0a::12/64
   ARISTA18T1:
@@ -1148,7 +1148,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.99/31
         ipv6: fc00::c6/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.19/24
       ipv6: fc0a::13/64
   ARISTA19T1:
@@ -1167,7 +1167,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.101/31
         ipv6: fc00::ca/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.20/24
       ipv6: fc0a::14/64
   ARISTA20T1:
@@ -1186,7 +1186,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.103/31
         ipv6: fc00::ce/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.21/24
       ipv6: fc0a::15/64
   ARISTA21T1:
@@ -1205,7 +1205,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.105/31
         ipv6: fc00::d2/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.22/24
       ipv6: fc0a::16/64
   ARISTA22T1:
@@ -1224,7 +1224,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.107/31
         ipv6: fc00::d6/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.23/24
       ipv6: fc0a::17/64
   ARISTA23T1:
@@ -1243,7 +1243,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.109/31
         ipv6: fc00::da/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.24/24
       ipv6: fc0a::18/64
   ARISTA24T1:
@@ -1262,7 +1262,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.111/31
         ipv6: fc00::de/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.25/24
       ipv6: fc0a::19/64
   ARISTA25T1:
@@ -1281,7 +1281,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.113/31
         ipv6: fc00::e2/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.26/24
       ipv6: fc0a::1a/64
   ARISTA26T1:
@@ -1300,7 +1300,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.115/31
         ipv6: fc00::e6/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.27/24
       ipv6: fc0a::1b/64
   ARISTA27T1:
@@ -1319,7 +1319,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.117/31
         ipv6: fc00::ea/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.28/24
       ipv6: fc0a::1c/64
   ARISTA28T1:
@@ -1338,7 +1338,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.119/31
         ipv6: fc00::ee/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.29/24
       ipv6: fc0a::1d/64
   ARISTA29T1:
@@ -1357,7 +1357,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.121/31
         ipv6: fc00::f2/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.30/24
       ipv6: fc0a::1e/64
   ARISTA30T1:
@@ -1376,7 +1376,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.123/31
         ipv6: fc00::f6/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.31/24
       ipv6: fc0a::1f/64
   ARISTA31T1:
@@ -1395,7 +1395,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.125/31
         ipv6: fc00::fa/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.32/24
       ipv6: fc0a::20/64
   ARISTA32T1:
@@ -1414,7 +1414,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.127/31
         ipv6: fc00::fe/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.33/24
       ipv6: fc0a::21/64
   ARISTA33T1:
@@ -1433,7 +1433,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.129/31
         ipv6: fc00::102/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.34/24
       ipv6: fc0a::22/64
   ARISTA34T1:
@@ -1452,7 +1452,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.131/31
         ipv6: fc00::106/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.35/24
       ipv6: fc0a::23/64
   ARISTA35T1:
@@ -1471,7 +1471,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.133/31
         ipv6: fc00::10a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.36/24
       ipv6: fc0a::24/64
   ARISTA36T1:
@@ -1490,7 +1490,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.135/31
         ipv6: fc00::10e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.37/24
       ipv6: fc0a::25/64
   ARISTA37T1:
@@ -1509,7 +1509,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.137/31
         ipv6: fc00::112/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.38/24
       ipv6: fc0a::26/64
   ARISTA38T1:
@@ -1528,7 +1528,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.139/31
         ipv6: fc00::116/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.39/24
       ipv6: fc0a::27/64
   ARISTA39T1:
@@ -1547,7 +1547,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.141/31
         ipv6: fc00::11a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.40/24
       ipv6: fc0a::28/64
   ARISTA40T1:
@@ -1566,7 +1566,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.143/31
         ipv6: fc00::11e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.41/24
       ipv6: fc0a::29/64
   ARISTA41T1:
@@ -1585,7 +1585,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.145/31
         ipv6: fc00::122/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.42/24
       ipv6: fc0a::2a/64
   ARISTA42T1:
@@ -1604,7 +1604,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.147/31
         ipv6: fc00::126/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.43/24
       ipv6: fc0a::2b/64
   ARISTA43T1:
@@ -1623,7 +1623,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.149/31
         ipv6: fc00::12a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.44/24
       ipv6: fc0a::2c/64
   ARISTA44T1:
@@ -1642,7 +1642,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.151/31
         ipv6: fc00::12e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.45/24
       ipv6: fc0a::2d/64
   ARISTA45T1:
@@ -1661,7 +1661,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.153/31
         ipv6: fc00::132/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.46/24
       ipv6: fc0a::2e/64
   ARISTA46T1:
@@ -1680,7 +1680,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.155/31
         ipv6: fc00::136/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.47/24
       ipv6: fc0a::2f/64
   ARISTA47T1:
@@ -1699,7 +1699,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.157/31
         ipv6: fc00::13a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.48/24
       ipv6: fc0a::30/64
   ARISTA48T1:
@@ -1718,7 +1718,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.159/31
         ipv6: fc00::13e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.49/24
       ipv6: fc0a::31/64
   ARISTA49T1:
@@ -1737,7 +1737,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.161/31
         ipv6: fc00::142/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.50/24
       ipv6: fc0a::32/64
   ARISTA50T1:
@@ -1756,7 +1756,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.163/31
         ipv6: fc00::146/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.51/24
       ipv6: fc0a::33/64
   ARISTA51T1:
@@ -1775,7 +1775,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.165/31
         ipv6: fc00::14a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.52/24
       ipv6: fc0a::34/64
   ARISTA52T1:
@@ -1794,7 +1794,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.167/31
         ipv6: fc00::14e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.53/24
       ipv6: fc0a::35/64
   ARISTA53T1:
@@ -1813,7 +1813,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.169/31
         ipv6: fc00::152/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.54/24
       ipv6: fc0a::36/64
   ARISTA54T1:
@@ -1832,7 +1832,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.171/31
         ipv6: fc00::156/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.55/24
       ipv6: fc0a::37/64
   ARISTA55T1:
@@ -1851,7 +1851,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.173/31
         ipv6: fc00::15a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.56/24
       ipv6: fc0a::38/64
   ARISTA56T1:
@@ -1870,7 +1870,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.175/31
         ipv6: fc00::15e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.57/24
       ipv6: fc0a::39/64
   ARISTA57T1:
@@ -1889,7 +1889,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.177/31
         ipv6: fc00::162/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.58/24
       ipv6: fc0a::3a/64
   ARISTA58T1:
@@ -1908,7 +1908,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.179/31
         ipv6: fc00::166/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.59/24
       ipv6: fc0a::3b/64
   ARISTA59T1:
@@ -1927,7 +1927,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.181/31
         ipv6: fc00::16a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.60/24
       ipv6: fc0a::3c/64
   ARISTA60T1:
@@ -1946,7 +1946,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.183/31
         ipv6: fc00::16e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.61/24
       ipv6: fc0a::3d/64
   ARISTA61T1:
@@ -1965,7 +1965,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.185/31
         ipv6: fc00::172/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.62/24
       ipv6: fc0a::3e/64
   ARISTA62T1:
@@ -1984,7 +1984,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.187/31
         ipv6: fc00::176/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.63/24
       ipv6: fc0a::3f/64
   ARISTA63T1:
@@ -2003,7 +2003,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.189/31
         ipv6: fc00::17a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.64/24
       ipv6: fc0a::40/64
   ARISTA64T1:
@@ -2022,7 +2022,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.0.191/31
         ipv6: fc00::17e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.65/24
       ipv6: fc0a::41/64
   ARISTA65T1:
@@ -2041,7 +2041,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.65/31
         ipv6: fc00::282/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.66/24
       ipv6: fc0a::42/64
   ARISTA66T1:
@@ -2060,7 +2060,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.67/31
         ipv6: fc00::286/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.67/24
       ipv6: fc0a::43/64
   ARISTA67T1:
@@ -2079,7 +2079,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.69/31
         ipv6: fc00::28a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.68/24
       ipv6: fc0a::44/64
   ARISTA68T1:
@@ -2098,7 +2098,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.71/31
         ipv6: fc00::28e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.69/24
       ipv6: fc0a::45/64
   ARISTA69T1:
@@ -2117,7 +2117,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.73/31
         ipv6: fc00::292/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.70/24
       ipv6: fc0a::46/64
   ARISTA70T1:
@@ -2136,7 +2136,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.75/31
         ipv6: fc00::296/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.71/24
       ipv6: fc0a::47/64
   ARISTA71T1:
@@ -2155,7 +2155,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.77/31
         ipv6: fc00::29a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.72/24
       ipv6: fc0a::48/64
   ARISTA72T1:
@@ -2174,7 +2174,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.79/31
         ipv6: fc00::29e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.73/24
       ipv6: fc0a::49/64
   ARISTA73T1:
@@ -2193,7 +2193,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.81/31
         ipv6: fc00::2a2/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.74/24
       ipv6: fc0a::4a/64
   ARISTA74T1:
@@ -2212,7 +2212,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.83/31
         ipv6: fc00::2a6/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.75/24
       ipv6: fc0a::4b/64
   ARISTA75T1:
@@ -2231,7 +2231,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.85/31
         ipv6: fc00::2aa/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.76/24
       ipv6: fc0a::4c/64
   ARISTA76T1:
@@ -2250,7 +2250,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.87/31
         ipv6: fc00::2ae/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.77/24
       ipv6: fc0a::4d/64
   ARISTA77T1:
@@ -2269,7 +2269,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.89/31
         ipv6: fc00::2b2/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.78/24
       ipv6: fc0a::4e/64
   ARISTA78T1:
@@ -2288,7 +2288,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.91/31
         ipv6: fc00::2b6/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.79/24
       ipv6: fc0a::4f/64
   ARISTA79T1:
@@ -2307,7 +2307,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.93/31
         ipv6: fc00::2ba/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.80/24
       ipv6: fc0a::50/64
   ARISTA80T1:
@@ -2326,7 +2326,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.95/31
         ipv6: fc00::2be/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.81/24
       ipv6: fc0a::51/64
   ARISTA81T1:
@@ -2345,7 +2345,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.97/31
         ipv6: fc00::2c2/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.82/24
       ipv6: fc0a::52/64
   ARISTA82T1:
@@ -2364,7 +2364,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.99/31
         ipv6: fc00::2c6/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.83/24
       ipv6: fc0a::53/64
   ARISTA83T1:
@@ -2383,7 +2383,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.101/31
         ipv6: fc00::2ca/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.84/24
       ipv6: fc0a::54/64
   ARISTA84T1:
@@ -2402,7 +2402,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.103/31
         ipv6: fc00::2ce/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.85/24
       ipv6: fc0a::55/64
   ARISTA85T1:
@@ -2421,7 +2421,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.105/31
         ipv6: fc00::2d2/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.86/24
       ipv6: fc0a::56/64
   ARISTA86T1:
@@ -2440,7 +2440,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.107/31
         ipv6: fc00::2d6/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.87/24
       ipv6: fc0a::57/64
   ARISTA87T1:
@@ -2459,7 +2459,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.109/31
         ipv6: fc00::2da/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.88/24
       ipv6: fc0a::58/64
   ARISTA88T1:
@@ -2478,7 +2478,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.111/31
         ipv6: fc00::2de/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.89/24
       ipv6: fc0a::59/64
   ARISTA89T1:
@@ -2497,7 +2497,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.113/31
         ipv6: fc00::2e2/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.90/24
       ipv6: fc0a::5a/64
   ARISTA90T1:
@@ -2516,7 +2516,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.115/31
         ipv6: fc00::2e6/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.91/24
       ipv6: fc0a::5b/64
   ARISTA91T1:
@@ -2535,7 +2535,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.117/31
         ipv6: fc00::2ea/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.92/24
       ipv6: fc0a::5c/64
   ARISTA92T1:
@@ -2554,7 +2554,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.119/31
         ipv6: fc00::2ee/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.93/24
       ipv6: fc0a::5d/64
   ARISTA93T1:
@@ -2573,7 +2573,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.121/31
         ipv6: fc00::2f2/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.94/24
       ipv6: fc0a::5e/64
   ARISTA94T1:
@@ -2592,7 +2592,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.123/31
         ipv6: fc00::2f6/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.95/24
       ipv6: fc0a::5f/64
   ARISTA95T1:
@@ -2611,7 +2611,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.125/31
         ipv6: fc00::2fa/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.96/24
       ipv6: fc0a::60/64
   ARISTA96T1:
@@ -2630,7 +2630,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.127/31
         ipv6: fc00::2fe/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.97/24
       ipv6: fc0a::61/64
   ARISTA97T1:
@@ -2649,7 +2649,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.129/31
         ipv6: fc00::302/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.98/24
       ipv6: fc0a::62/64
   ARISTA98T1:
@@ -2668,7 +2668,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.131/31
         ipv6: fc00::306/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.99/24
       ipv6: fc0a::63/64
   ARISTA99T1:
@@ -2687,7 +2687,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.133/31
         ipv6: fc00::30a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.100/24
       ipv6: fc0a::64/64
   ARISTA100T1:
@@ -2706,7 +2706,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.135/31
         ipv6: fc00::30e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.101/24
       ipv6: fc0a::65/64
   ARISTA101T1:
@@ -2725,7 +2725,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.137/31
         ipv6: fc00::312/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.102/24
       ipv6: fc0a::66/64
   ARISTA102T1:
@@ -2744,7 +2744,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.139/31
         ipv6: fc00::316/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.103/24
       ipv6: fc0a::67/64
   ARISTA103T1:
@@ -2763,7 +2763,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.141/31
         ipv6: fc00::31a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.104/24
       ipv6: fc0a::68/64
   ARISTA104T1:
@@ -2782,7 +2782,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.143/31
         ipv6: fc00::31e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.105/24
       ipv6: fc0a::69/64
   ARISTA105T1:
@@ -2801,7 +2801,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.145/31
         ipv6: fc00::322/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.106/24
       ipv6: fc0a::6a/64
   ARISTA106T1:
@@ -2820,7 +2820,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.147/31
         ipv6: fc00::326/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.107/24
       ipv6: fc0a::6b/64
   ARISTA107T1:
@@ -2839,7 +2839,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.149/31
         ipv6: fc00::32a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.108/24
       ipv6: fc0a::6c/64
   ARISTA108T1:
@@ -2858,7 +2858,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.151/31
         ipv6: fc00::32e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.109/24
       ipv6: fc0a::6d/64
   ARISTA109T1:
@@ -2877,7 +2877,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.153/31
         ipv6: fc00::332/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.110/24
       ipv6: fc0a::6e/64
   ARISTA110T1:
@@ -2896,7 +2896,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.155/31
         ipv6: fc00::336/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.111/24
       ipv6: fc0a::6f/64
   ARISTA111T1:
@@ -2915,7 +2915,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.157/31
         ipv6: fc00::33a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.112/24
       ipv6: fc0a::70/64
   ARISTA112T1:
@@ -2934,7 +2934,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.159/31
         ipv6: fc00::33e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.113/24
       ipv6: fc0a::71/64
   ARISTA113T1:
@@ -2953,7 +2953,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.161/31
         ipv6: fc00::342/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.114/24
       ipv6: fc0a::72/64
   ARISTA114T1:
@@ -2972,7 +2972,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.163/31
         ipv6: fc00::346/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.115/24
       ipv6: fc0a::73/64
   ARISTA115T1:
@@ -2991,7 +2991,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.165/31
         ipv6: fc00::34a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.116/24
       ipv6: fc0a::74/64
   ARISTA116T1:
@@ -3010,7 +3010,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.167/31
         ipv6: fc00::34e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.117/24
       ipv6: fc0a::75/64
   ARISTA117T1:
@@ -3029,7 +3029,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.169/31
         ipv6: fc00::352/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.118/24
       ipv6: fc0a::76/64
   ARISTA118T1:
@@ -3048,7 +3048,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.171/31
         ipv6: fc00::356/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.119/24
       ipv6: fc0a::77/64
   ARISTA119T1:
@@ -3067,7 +3067,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.173/31
         ipv6: fc00::35a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.120/24
       ipv6: fc0a::78/64
   ARISTA120T1:
@@ -3086,7 +3086,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.175/31
         ipv6: fc00::35e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.121/24
       ipv6: fc0a::79/64
   ARISTA121T1:
@@ -3105,7 +3105,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.177/31
         ipv6: fc00::362/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.122/24
       ipv6: fc0a::7a/64
   ARISTA122T1:
@@ -3124,7 +3124,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.179/31
         ipv6: fc00::366/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.123/24
       ipv6: fc0a::7b/64
   ARISTA123T1:
@@ -3143,7 +3143,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.181/31
         ipv6: fc00::36a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.124/24
       ipv6: fc0a::7c/64
   ARISTA124T1:
@@ -3162,7 +3162,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.183/31
         ipv6: fc00::36e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.125/24
       ipv6: fc0a::7d/64
   ARISTA125T1:
@@ -3181,7 +3181,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.185/31
         ipv6: fc00::372/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.126/24
       ipv6: fc0a::7e/64
   ARISTA126T1:
@@ -3200,7 +3200,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.187/31
         ipv6: fc00::376/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.127/24
       ipv6: fc0a::7f/64
   ARISTA127T1:
@@ -3219,7 +3219,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.189/31
         ipv6: fc00::37a/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.128/24
       ipv6: fc0a::80/64
   ARISTA128T1:
@@ -3238,7 +3238,7 @@ configuration:
       Ethernet1:
         ipv4: 10.0.1.191/31
         ipv6: fc00::37e/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.129/24
       ipv6: fc0a::81/64
   ARISTA01PT0:
@@ -3257,6 +3257,6 @@ configuration:
       Ethernet1:
         ipv4: 10.0.2.1/31
         ipv6: fc00::402/126
-    bp_interfaces:
+    bp_interface:
       ipv4: 10.10.246.130/24
       ipv6: fc0a::82/64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To achieve a functional t0-isolated-d128u128s1 for use in sonic-mgmt tests.
#### How did you do it?
Fix syntax in bp_interface 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
