### PR TITLE
Update j2cli to jinjanator.

### DIFF
--- a/ansible/setup-management-network.sh
+++ b/ansible/setup-management-network.sh
@@ -33,10 +33,10 @@ echo "Refreshing apt package lists..."
 apt-get update
 echo
 
-echo "STEP 1: Checking for j2cli package..."
-if ! command -v j2; then
-    echo "j2cli not found, installing j2cli"
-    cmd="install --user j2cli==0.3.10"
+echo "STEP 1: Checking for jinjanator package..."
+if ! command -v jinjanate; then
+    echo "jinjanator not found, installing jinjanator"
+    cmd="install --user jinjanator==24.4.0"
     if ! command -v pip &> /dev/null; then
         pip3 $cmd
     else

--- a/docs/testbed/README.testbed.Setup.md
+++ b/docs/testbed/README.testbed.Setup.md
@@ -20,7 +20,7 @@ This document describes the steps to setup the testbed and deploy a topology.
     ```
 - Install Python prerequisites
     ```
-    sudo pip3 install j2cli
+    sudo pip3 install jinjanator
     ```
 - Install Docker (all credits to https://docs.docker.com/engine/install/ubuntu/ )
     ```

--- a/docs/testbed/README.testbed.VsSetup.md
+++ b/docs/testbed/README.testbed.VsSetup.md
@@ -22,7 +22,7 @@ First, we need to prepare the host where we will be configuring the virtual test
         ```
         sudo apt install python python-pip openssh-server
         # v0.3.10 Jinja2 is required, lower version may cause uncompatible issue
-        sudo pip install j2cli==0.3.10
+        sudo pip install jinjanate==24.4.0
         ```
 
 3. Run the host setup script to install required packages and initialize the management bridge network

--- a/setup-container.sh
+++ b/setup-container.sh
@@ -275,7 +275,7 @@ ROOT_PASS=${ROOT_PASS}
 EOF
 
     log_info "generate a Dockerfile: ${TMP_DIR}/Dockerfile"
-    j2 -o "${TMP_DIR}/Dockerfile" "${TMP_DIR}/Dockerfile.j2" "${TMP_DIR}/data.env" || \
+    jinjanate -o "${TMP_DIR}/Dockerfile" "${TMP_DIR}/Dockerfile.j2" "${TMP_DIR}/data.env" || \
     log_error "failed to generate a Dockerfile: ${TMP_DIR}/Dockerfile"
 
     log_info "building docker image from ${TMP_DIR}: ${LOCAL_IMAGE} ..."
@@ -445,8 +445,8 @@ if docker ps -a --format "{{.Names}}" | grep -q "^${CONTAINER_NAME}$"; then
     fi
 fi
 
-if ! which j2 &> /dev/null; then
-    exit_failure "missing Jinja2 templates support: make sure j2cli package is installed"
+if ! which jinjanate &> /dev/null; then
+    exit_failure "missing Jinja2 templates support: make sure jinjanate package is installed"
 fi
 
 pull_sonic_mgmt_docker_image

--- a/setup-container.sh
+++ b/setup-container.sh
@@ -446,7 +446,13 @@ if docker ps -a --format "{{.Names}}" | grep -q "^${CONTAINER_NAME}$"; then
 fi
 
 if ! which jinjanate &> /dev/null; then
-    exit_failure "missing Jinja2 templates support: make sure jinjanate package is installed"
+    echo "jinjanator not found, installing jinjanator"
+    cmd="install --user jinjanator==24.4.0"
+    if ! command -v pip &> /dev/null; then
+        pip3 $cmd
+    else
+        pip $cmd
+    fi
 fi
 
 pull_sonic_mgmt_docker_image


### PR DESCRIPTION
### Description of PR

Summary:
j2cli is not being maintained anymore and will start to fail to work on ubuntu 24.04, because it is trying to load the imp module, which is deprecated now.

![image](https://github.com/user-attachments/assets/56beeee4-248c-4f3e-add4-26e8b3b2f0cf)

However, [j2cli](https://github.com/kolypto/j2cli) is being archived not being maintained anymore. The author recommends using other alternatives that is actively being maintained, such as [jinjanator](https://github.com/kpfleming/jinjanator).

Hence, making this change in order to support the latest OS.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

Changed j2cli to jinjanator.

In setup-container.sh, we also try to install the jinjanator if it is not found. The reason is that setup-management-network is running under root privilege, so even with `--user` the jinanator installed there will be installed under /root folder. The regular user will not have access to it.

#### How did you verify/test it?

Run on Ubuntu 24.04:

![image](https://github.com/user-attachments/assets/0557fd8b-c990-47fd-abdb-835f179a9dc0)

![image](https://github.com/user-attachments/assets/ac977eb8-6811-4baf-a43e-59da2290a954)

Run on Ubuntu 22.04:

![image](https://github.com/user-attachments/assets/53acb1ae-14ef-4ea4-b6c5-9c3a7cc2ca86)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
