### PR TITLE
Move fixture `platform_api_conn` to common place. 

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -6,6 +6,7 @@ import traceback
 import os
 import json
 import glob
+import http.client
 from datetime import datetime
 from collections import OrderedDict
 from tests.common.utilities import wait_until
@@ -938,3 +939,15 @@ def advanceboot_neighbor_restore(duthosts, enum_rand_one_per_hwsku_frontend_host
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     from tests.common.plugins.sanity_check.recover import neighbor_vm_restore
     neighbor_vm_restore(duthost, nbrhosts, tbinfo)
+
+
+@pytest.fixture(scope='function')
+def platform_api_conn(duthosts, enum_rand_one_per_hwsku_hostname, start_platform_api_service):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dut_ip = duthost.mgmt_ip
+
+    conn = http.client.HTTPConnection(dut_ip, 8000)
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import http.client
 
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
@@ -84,18 +83,6 @@ def stop_platform_api_service(duthosts):
                 # no longer have the rule we added in the start_platform_api_service fixture, even if the
                 # platform_api_server is running.
                 duthost.command(IPTABLES_DELETE_RULE_CMD, module_ignore_errors=True)
-
-
-@pytest.fixture(scope='function')
-def platform_api_conn(duthosts, enum_rand_one_per_hwsku_hostname, start_platform_api_service):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dut_ip = duthost.mgmt_ip
-
-    conn = http.client.HTTPConnection(dut_ip, SERVER_PORT)
-    try:
-        yield conn
-    finally:
-        conn.close()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -122,8 +122,7 @@ class TestChassisApi(PlatformApiTestBase):
     # Functions to test methods inherited from DeviceBase class
     #
 
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn     # noqa F811
-                      ):
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):     # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         name = chassis.get_name(platform_api_conn)
         pytest_assert(name is not None, "Unable to retrieve chassis name")

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -188,7 +188,6 @@ class TestChassisApi(PlatformApiTestBase):
 
     def test_get_system_eeprom_info(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
                                     platform_api_conn):  # noqa F811
-
         ''' Test that we can retrieve sane system EEPROM info from the DUT via the platform API
         '''
         # OCP ONIE TlvInfo EEPROM type codes defined here:

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -11,6 +11,7 @@ from tests.common.utilities import get_inventory_files
 from tests.common.utilities import get_host_visible_vars
 from tests.common.utilities import skip_release
 from tests.common.platform.interface_utils import get_physical_port_indices
+from tests.common.platform.device_utils import platform_api_conn    # noqa F401
 from tests.platform_tests.cli.util import get_skip_mod_list
 from .platform_api_test_base import PlatformApiTestBase
 
@@ -121,53 +122,61 @@ class TestChassisApi(PlatformApiTestBase):
     # Functions to test methods inherited from DeviceBase class
     #
 
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn     # noqa F811
+                      ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         name = chassis.get_name(platform_api_conn)
         pytest_assert(name is not None, "Unable to retrieve chassis name")
         pytest_assert(isinstance(name, STRING_TYPE), "Chassis name appears incorrect")
         self.compare_value_with_platform_facts(duthost, 'name', name)
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn # noqa F811
+                          ):
         presence = chassis.get_presence(platform_api_conn)
         pytest_assert(presence is not None, "Unable to retrieve chassis presence")
         pytest_assert(isinstance(presence, bool), "Chassis presence appears incorrect")
         # Chassis should always be present
         pytest_assert(presence is True, "Chassis is not present")
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                       ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         model = chassis.get_model(platform_api_conn)
         pytest_assert(model is not None, "Unable to retrieve chassis model")
         pytest_assert(isinstance(model, STRING_TYPE), "Chassis model appears incorrect")
         self.compare_value_with_device_facts(duthost, 'model', model)
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
+                        ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         serial = chassis.get_serial(platform_api_conn)
         pytest_assert(serial is not None, "Unable to retrieve chassis serial number")
         pytest_assert(isinstance(serial, STRING_TYPE), "Chassis serial number appears incorrect")
         self.compare_value_with_device_facts(duthost, 'serial', serial)
 
-    def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn     # noqa F811
+                          ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release(duthost, ["201811", "201911", "202012"])
         revision = chassis.get_revision(platform_api_conn)
         pytest_assert(revision is not None, "Unable to retrieve chassis revision")
         pytest_assert(isinstance(revision, STRING_TYPE), "Revision appears incorrect")
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                        ):
         status = chassis.get_status(platform_api_conn)
         pytest_assert(status is not None, "Unable to retrieve chassis status")
         pytest_assert(isinstance(status, bool), "Chassis status appears incorrect")
 
-    def test_get_position_in_parent(self, platform_api_conn):
+    def test_get_position_in_parent(self, platform_api_conn   # noqa F811
+                                    ):
         position = chassis.get_position_in_parent(platform_api_conn)
         if self.expect(position is not None, "Failed to perform get_position_in_parent"):
             self.expect(isinstance(position, int), "Position value must be an integer value")
         self.assert_expectations()
 
-    def test_is_replaceable(self, platform_api_conn):
+    def test_is_replaceable(self, platform_api_conn # noqa F811
+                            ):
         replaceable = chassis.is_replaceable(platform_api_conn)
         if self.expect(replaceable is not None, "Failed to perform is_replaceable"):
             self.expect(isinstance(replaceable, bool), "Replaceable value must be a bool value")
@@ -177,7 +186,8 @@ class TestChassisApi(PlatformApiTestBase):
     # Functions to test methods defined in ChassisBase class
     #
 
-    def test_get_base_mac(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_base_mac(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                          ):
         # Ensure the base MAC address is sane
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         base_mac = chassis.get_base_mac(platform_api_conn)
@@ -185,7 +195,9 @@ class TestChassisApi(PlatformApiTestBase):
         pytest_assert(re.match(REGEX_MAC_ADDRESS, base_mac), "Base MAC address appears to be incorrect")
         self.compare_value_with_device_facts(duthost, 'base_mac', base_mac, False)
 
-    def test_get_system_eeprom_info(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_system_eeprom_info(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                    platform_api_conn  # noqa F811
+                                    ):
         ''' Test that we can retrieve sane system EEPROM info from the DUT via the platform API
         '''
         # OCP ONIE TlvInfo EEPROM type codes defined here:
@@ -258,7 +270,9 @@ class TestChassisApi(PlatformApiTestBase):
                           format(field, syseeprom_info_dict[field],
                                  expected_syseeprom_info_dict[field], duthost.hostname))
 
-    def test_get_reboot_cause(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_reboot_cause(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                              platform_api_conn    # noqa F811
+                              ):
         # TODO: Compare return values to potential combinations
         reboot_cause = chassis.get_reboot_cause(platform_api_conn)
 
@@ -268,7 +282,8 @@ class TestChassisApi(PlatformApiTestBase):
         pytest_assert(isinstance(reboot_cause, list) and len(reboot_cause) == 2,
                       "Reboot cause appears to be incorrect")
 
-    def test_components(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_components(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
+                        ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
         try:
@@ -297,7 +312,8 @@ class TestChassisApi(PlatformApiTestBase):
                         "Component {} is incorrect".format(i))
         self.assert_expectations()
 
-    def test_modules(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_modules(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn     # noqa F811
+                     ):
         try:
             num_modules = int(chassis.get_num_modules(platform_api_conn))
         except Exception:
@@ -319,7 +335,8 @@ class TestChassisApi(PlatformApiTestBase):
             self.expect(module_index == i, "Module index {} is not correct".format(module_index))
         self.assert_expectations()
 
-    def test_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                  ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         try:
             num_fans = int(chassis.get_num_fans(platform_api_conn))
@@ -344,7 +361,8 @@ class TestChassisApi(PlatformApiTestBase):
             self.expect(fan and fan == fan_list[i], "Fan {} is incorrect".format(i))
         self.assert_expectations()
 
-    def test_fan_drawers(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_fan_drawers(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn     # noqa F811
+                         ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         try:
             num_fan_drawers = int(chassis.get_num_fan_drawers(platform_api_conn))
@@ -371,7 +389,8 @@ class TestChassisApi(PlatformApiTestBase):
                         "Fan drawer {} is incorrect".format(i))
         self.assert_expectations()
 
-    def test_psus(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_psus(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                  ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         try:
             num_psus = int(chassis.get_num_psus(platform_api_conn))
@@ -396,7 +415,8 @@ class TestChassisApi(PlatformApiTestBase):
             self.expect(psu and psu == psu_list[i], "PSU {} is incorrect".format(i))
         self.assert_expectations()
 
-    def test_thermals(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_thermals(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                      ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         try:
             num_thermals = int(chassis.get_num_thermals(platform_api_conn))
@@ -424,7 +444,8 @@ class TestChassisApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_sfps(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                  localhost, platform_api_conn, physical_port_indices):
+                  localhost, platform_api_conn,     # noqa F811
+                  physical_port_indices):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         if duthost.is_supervisor_node():
             pytest.skip("skipping for supervisor node")
@@ -463,7 +484,8 @@ class TestChassisApi(PlatformApiTestBase):
             self.expect(sfp and sfp in sfp_list, "SFP object for PORT{} NOT found".format(index))
         self.assert_expectations()
 
-    def test_status_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_status_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
+                        ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         # TODO: Get a platform-specific list of available colors for the status LED
 
@@ -537,19 +559,24 @@ class TestChassisApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_thermal_manager(self, localhost, platform_api_conn, thermal_manager_enabled):
+    def test_get_thermal_manager(self, localhost, platform_api_conn,    # noqa F811
+                                 thermal_manager_enabled):
         thermal_mgr = chassis.get_thermal_manager(platform_api_conn)
         pytest_assert(thermal_mgr is not None, "Failed to retrieve thermal manager")
 
-    def test_get_watchdog(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_watchdog(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                          ):
         watchdog = chassis.get_watchdog(platform_api_conn)
         pytest_assert(watchdog is not None, "Failed to retrieve watchdog")
 
-    def test_get_eeprom(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_eeprom(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
+                        ):
         eeprom = chassis.get_eeprom(platform_api_conn)
         pytest_assert(eeprom is not None, "Failed to retrieve system EEPROM")
 
-    def test_get_supervisor_slot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_supervisor_slot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                 platform_api_conn # noqa F811
+                                 ):
         if chassis.is_modular_chassis(platform_api_conn):
             sup_slot = chassis.get_supervisor_slot(platform_api_conn)
             pytest_assert(isinstance(sup_slot, int) or isinstance(sup_slot, STRING_TYPE),
@@ -557,7 +584,8 @@ class TestChassisApi(PlatformApiTestBase):
         else:
             pytest.skip("skipped as this test is applicable to modular chassis only")
 
-    def test_get_my_slot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_my_slot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn     # noqa F811
+                         ):
         if chassis.is_modular_chassis(platform_api_conn):
             my_slot = chassis.get_my_slot(platform_api_conn)
             pytest_assert(isinstance(my_slot, int) or isinstance(my_slot, STRING_TYPE),

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -130,53 +130,46 @@ class TestChassisApi(PlatformApiTestBase):
         pytest_assert(isinstance(name, STRING_TYPE), "Chassis name appears incorrect")
         self.compare_value_with_platform_facts(duthost, 'name', name)
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn # noqa F811
-                          ):
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn): # noqa F811
         presence = chassis.get_presence(platform_api_conn)
         pytest_assert(presence is not None, "Unable to retrieve chassis presence")
         pytest_assert(isinstance(presence, bool), "Chassis presence appears incorrect")
         # Chassis should always be present
         pytest_assert(presence is True, "Chassis is not present")
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                       ):
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         model = chassis.get_model(platform_api_conn)
         pytest_assert(model is not None, "Unable to retrieve chassis model")
         pytest_assert(isinstance(model, STRING_TYPE), "Chassis model appears incorrect")
         self.compare_value_with_device_facts(duthost, 'model', model)
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
-                        ):
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         serial = chassis.get_serial(platform_api_conn)
         pytest_assert(serial is not None, "Unable to retrieve chassis serial number")
         pytest_assert(isinstance(serial, STRING_TYPE), "Chassis serial number appears incorrect")
         self.compare_value_with_device_facts(duthost, 'serial', serial)
 
-    def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn     # noqa F811
-                          ):
+    def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):     # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release(duthost, ["201811", "201911", "202012"])
         revision = chassis.get_revision(platform_api_conn)
         pytest_assert(revision is not None, "Unable to retrieve chassis revision")
         pytest_assert(isinstance(revision, STRING_TYPE), "Revision appears incorrect")
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                        ):
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         status = chassis.get_status(platform_api_conn)
         pytest_assert(status is not None, "Unable to retrieve chassis status")
         pytest_assert(isinstance(status, bool), "Chassis status appears incorrect")
 
-    def test_get_position_in_parent(self, platform_api_conn   # noqa F811
-                                    ):
+    def test_get_position_in_parent(self, platform_api_conn):   # noqa F811
         position = chassis.get_position_in_parent(platform_api_conn)
         if self.expect(position is not None, "Failed to perform get_position_in_parent"):
             self.expect(isinstance(position, int), "Position value must be an integer value")
         self.assert_expectations()
 
-    def test_is_replaceable(self, platform_api_conn # noqa F811
-                            ):
+    def test_is_replaceable(self, platform_api_conn):     # noqa F811
         replaceable = chassis.is_replaceable(platform_api_conn)
         if self.expect(replaceable is not None, "Failed to perform is_replaceable"):
             self.expect(isinstance(replaceable, bool), "Replaceable value must be a bool value")
@@ -186,8 +179,7 @@ class TestChassisApi(PlatformApiTestBase):
     # Functions to test methods defined in ChassisBase class
     #
 
-    def test_get_base_mac(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                          ):
+    def test_get_base_mac(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         # Ensure the base MAC address is sane
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         base_mac = chassis.get_base_mac(platform_api_conn)
@@ -196,8 +188,8 @@ class TestChassisApi(PlatformApiTestBase):
         self.compare_value_with_device_facts(duthost, 'base_mac', base_mac, False)
 
     def test_get_system_eeprom_info(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                                    platform_api_conn  # noqa F811
-                                    ):
+                                    platform_api_conn):  # noqa F811
+
         ''' Test that we can retrieve sane system EEPROM info from the DUT via the platform API
         '''
         # OCP ONIE TlvInfo EEPROM type codes defined here:
@@ -271,8 +263,7 @@ class TestChassisApi(PlatformApiTestBase):
                                  expected_syseeprom_info_dict[field], duthost.hostname))
 
     def test_get_reboot_cause(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                              platform_api_conn    # noqa F811
-                              ):
+                              platform_api_conn):    # noqa F811
         # TODO: Compare return values to potential combinations
         reboot_cause = chassis.get_reboot_cause(platform_api_conn)
 
@@ -282,8 +273,7 @@ class TestChassisApi(PlatformApiTestBase):
         pytest_assert(isinstance(reboot_cause, list) and len(reboot_cause) == 2,
                       "Reboot cause appears to be incorrect")
 
-    def test_components(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
-                        ):
+    def test_components(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
         try:
@@ -312,8 +302,7 @@ class TestChassisApi(PlatformApiTestBase):
                         "Component {} is incorrect".format(i))
         self.assert_expectations()
 
-    def test_modules(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn     # noqa F811
-                     ):
+    def test_modules(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):     # noqa F811
         try:
             num_modules = int(chassis.get_num_modules(platform_api_conn))
         except Exception:
@@ -335,8 +324,7 @@ class TestChassisApi(PlatformApiTestBase):
             self.expect(module_index == i, "Module index {} is not correct".format(module_index))
         self.assert_expectations()
 
-    def test_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                  ):
+    def test_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         try:
             num_fans = int(chassis.get_num_fans(platform_api_conn))
@@ -361,8 +349,7 @@ class TestChassisApi(PlatformApiTestBase):
             self.expect(fan and fan == fan_list[i], "Fan {} is incorrect".format(i))
         self.assert_expectations()
 
-    def test_fan_drawers(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn     # noqa F811
-                         ):
+    def test_fan_drawers(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         try:
             num_fan_drawers = int(chassis.get_num_fan_drawers(platform_api_conn))
@@ -389,8 +376,7 @@ class TestChassisApi(PlatformApiTestBase):
                         "Fan drawer {} is incorrect".format(i))
         self.assert_expectations()
 
-    def test_psus(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                  ):
+    def test_psus(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         try:
             num_psus = int(chassis.get_num_psus(platform_api_conn))
@@ -415,8 +401,7 @@ class TestChassisApi(PlatformApiTestBase):
             self.expect(psu and psu == psu_list[i], "PSU {} is incorrect".format(i))
         self.assert_expectations()
 
-    def test_thermals(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                      ):
+    def test_thermals(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         try:
             num_thermals = int(chassis.get_num_thermals(platform_api_conn))
@@ -444,8 +429,7 @@ class TestChassisApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_sfps(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                  localhost, platform_api_conn,     # noqa F811
-                  physical_port_indices):
+                  localhost, platform_api_conn, physical_port_indices):    # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         if duthost.is_supervisor_node():
             pytest.skip("skipping for supervisor node")
@@ -484,8 +468,7 @@ class TestChassisApi(PlatformApiTestBase):
             self.expect(sfp and sfp in sfp_list, "SFP object for PORT{} NOT found".format(index))
         self.assert_expectations()
 
-    def test_status_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
-                        ):
+    def test_status_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         # TODO: Get a platform-specific list of available colors for the status LED
 
@@ -559,24 +542,20 @@ class TestChassisApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_thermal_manager(self, localhost, platform_api_conn,    # noqa F811
-                                 thermal_manager_enabled):
+    def test_get_thermal_manager(self, localhost, platform_api_conn, thermal_manager_enabled):    # noqa F811
         thermal_mgr = chassis.get_thermal_manager(platform_api_conn)
         pytest_assert(thermal_mgr is not None, "Failed to retrieve thermal manager")
 
-    def test_get_watchdog(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                          ):
+    def test_get_watchdog(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         watchdog = chassis.get_watchdog(platform_api_conn)
         pytest_assert(watchdog is not None, "Failed to retrieve watchdog")
 
-    def test_get_eeprom(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
-                        ):
+    def test_get_eeprom(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         eeprom = chassis.get_eeprom(platform_api_conn)
         pytest_assert(eeprom is not None, "Failed to retrieve system EEPROM")
 
     def test_get_supervisor_slot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                                 platform_api_conn # noqa F811
-                                 ):
+                                 platform_api_conn): # noqa F811
         if chassis.is_modular_chassis(platform_api_conn):
             sup_slot = chassis.get_supervisor_slot(platform_api_conn)
             pytest_assert(isinstance(sup_slot, int) or isinstance(sup_slot, STRING_TYPE),
@@ -584,8 +563,7 @@ class TestChassisApi(PlatformApiTestBase):
         else:
             pytest.skip("skipped as this test is applicable to modular chassis only")
 
-    def test_get_my_slot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn     # noqa F811
-                         ):
+    def test_get_my_slot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa F811
         if chassis.is_modular_chassis(platform_api_conn):
             my_slot = chassis.get_my_slot(platform_api_conn)
             pytest_assert(isinstance(my_slot, int) or isinstance(my_slot, STRING_TYPE),

--- a/tests/platform_tests/api/test_component.py
+++ b/tests/platform_tests/api/test_component.py
@@ -42,8 +42,7 @@ class TestComponentApi(PlatformApiTestBase):
     # it relies on the platform_api_conn fixture, which is scoped at the function
     # level, so we must do the same here to prevent a scope mismatch.
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, platform_api_conn   # noqa F811
-              ):
+    def setup(self, platform_api_conn):   # noqa F811
         if self.num_components is None:
             try:
                 self.num_components = int(chassis.get_num_components(platform_api_conn))
@@ -75,8 +74,7 @@ class TestComponentApi(PlatformApiTestBase):
     # Functions to test methods inherited from DeviceBase class
     #
 
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                      ):
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
         for i in range(self.num_components):
@@ -86,9 +84,7 @@ class TestComponentApi(PlatformApiTestBase):
                 self.compare_value_with_platform_facts(duthost, 'name', name, i)
         self.assert_expectations()
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                          ):
-
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa F811
         for i in range(self.num_components):
             presence = component.get_presence(platform_api_conn, i)
             if self.expect(presence is not None, "Component {}: Unable to retrieve presence".format(i)):
@@ -97,18 +93,14 @@ class TestComponentApi(PlatformApiTestBase):
                 self.expect(presence is True, "Component {} not present".format(i))
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
-                       ):
-
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa F811
         for i in range(self.num_components):
             model = component.get_model(platform_api_conn, i)
             if self.expect(model is not None, "Component {}: Unable to retrieve model".format(i)):
                 self.expect(isinstance(model, STRING_TYPE), "Component {}: Model appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
-                        ):
-
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for i in range(self.num_components):
             serial = component.get_serial(platform_api_conn, i)
             if self.expect(serial is not None, "Component {}: Unable to retrieve serial number".format(i)):
@@ -116,17 +108,14 @@ class TestComponentApi(PlatformApiTestBase):
                             "Component {}: Serial number appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
-                        ):
-
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for i in range(self.num_components):
             status = component.get_status(platform_api_conn, i)
             if self.expect(status is not None, "Component {}: Unable to retrieve status".format(i)):
                 self.expect(isinstance(status, bool), "Component {}: Status appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_position_in_parent(self, platform_api_conn     # noqa F811
-                                    ):
+    def test_get_position_in_parent(self, platform_api_conn):     # noqa F811
         for i in range(self.num_components):
             position = component.get_position_in_parent(platform_api_conn, i)
             if self.expect(position is not None,
@@ -135,8 +124,7 @@ class TestComponentApi(PlatformApiTestBase):
                             "Position value must be an integer value for component {}".format(i))
         self.assert_expectations()
 
-    def test_is_replaceable(self, platform_api_conn     # noqa F811
-                            ):
+    def test_is_replaceable(self, platform_api_conn):     # noqa F811
         for i in range(self.num_components):
             replaceable = component.is_replaceable(platform_api_conn, i)
             if self.expect(replaceable is not None,
@@ -149,9 +137,8 @@ class TestComponentApi(PlatformApiTestBase):
     # Functions to test methods defined in ComponentBase class
     #
 
-    def test_get_description(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
-                             ):
-
+    def test_get_description(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                             platform_api_conn):  # noqa F811
         for i in range(self.num_components):
             description = component.get_description(platform_api_conn, i)
             if self.expect(description is not None, "Component {}: Failed to retrieve description".format(i)):
@@ -160,9 +147,7 @@ class TestComponentApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_firmware_version(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                                  platform_api_conn     # noqa F811
-                                  ):
-
+                                  platform_api_conn):     # noqa F811
         for i in range(self.num_components):
             fw_version = component.get_firmware_version(platform_api_conn, i)
             if self.expect(fw_version is not None, "Component {}: Failed to retrieve firmware version".format(i)):
@@ -171,8 +156,7 @@ class TestComponentApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_available_firmware_version(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                            localhost, platform_api_conn    # noqa F811
-                                            ):
+                                            localhost, platform_api_conn):    # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["nokia"])
 
@@ -188,8 +172,7 @@ class TestComponentApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_firmware_update_notification(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                              localhost, platform_api_conn      # noqa F811
-                                              ):
+                                              localhost, platform_api_conn):      # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["nokia"])
 
@@ -203,8 +186,7 @@ class TestComponentApi(PlatformApiTestBase):
                                   .format(i, image))
 
     def test_install_firmware(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                              platform_api_conn    # noqa F811
-                              ):
+                              platform_api_conn):    # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["nokia"])
 
@@ -219,8 +201,7 @@ class TestComponentApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_update_firmware(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                             platform_api_conn     # noqa F811
-                             ):
+                             platform_api_conn):     # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["nokia"])
 

--- a/tests/platform_tests/api/test_component.py
+++ b/tests/platform_tests/api/test_component.py
@@ -5,6 +5,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import chassis, component
 from .platform_api_test_base import PlatformApiTestBase
 from tests.common.utilities import skip_release_for_platform
+from tests.common.platform.device_utils import platform_api_conn    # noqa F401
 
 ###################################################
 # TODO: Remove this after we transition to Python 3
@@ -41,7 +42,8 @@ class TestComponentApi(PlatformApiTestBase):
     # it relies on the platform_api_conn fixture, which is scoped at the function
     # level, so we must do the same here to prevent a scope mismatch.
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, platform_api_conn):
+    def setup(self, platform_api_conn   # noqa F811
+              ):
         if self.num_components is None:
             try:
                 self.num_components = int(chassis.get_num_components(platform_api_conn))
@@ -73,7 +75,8 @@ class TestComponentApi(PlatformApiTestBase):
     # Functions to test methods inherited from DeviceBase class
     #
 
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                      ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
         for i in range(self.num_components):
@@ -83,7 +86,8 @@ class TestComponentApi(PlatformApiTestBase):
                 self.compare_value_with_platform_facts(duthost, 'name', name, i)
         self.assert_expectations()
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                          ):
 
         for i in range(self.num_components):
             presence = component.get_presence(platform_api_conn, i)
@@ -93,7 +97,8 @@ class TestComponentApi(PlatformApiTestBase):
                 self.expect(presence is True, "Component {} not present".format(i))
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
+                       ):
 
         for i in range(self.num_components):
             model = component.get_model(platform_api_conn, i)
@@ -101,7 +106,8 @@ class TestComponentApi(PlatformApiTestBase):
                 self.expect(isinstance(model, STRING_TYPE), "Component {}: Model appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
+                        ):
 
         for i in range(self.num_components):
             serial = component.get_serial(platform_api_conn, i)
@@ -110,7 +116,8 @@ class TestComponentApi(PlatformApiTestBase):
                             "Component {}: Serial number appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
+                        ):
 
         for i in range(self.num_components):
             status = component.get_status(platform_api_conn, i)
@@ -118,7 +125,8 @@ class TestComponentApi(PlatformApiTestBase):
                 self.expect(isinstance(status, bool), "Component {}: Status appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_position_in_parent(self, platform_api_conn):
+    def test_get_position_in_parent(self, platform_api_conn     # noqa F811
+                                    ):
         for i in range(self.num_components):
             position = component.get_position_in_parent(platform_api_conn, i)
             if self.expect(position is not None,
@@ -127,7 +135,8 @@ class TestComponentApi(PlatformApiTestBase):
                             "Position value must be an integer value for component {}".format(i))
         self.assert_expectations()
 
-    def test_is_replaceable(self, platform_api_conn):
+    def test_is_replaceable(self, platform_api_conn     # noqa F811
+                            ):
         for i in range(self.num_components):
             replaceable = component.is_replaceable(platform_api_conn, i)
             if self.expect(replaceable is not None,
@@ -140,7 +149,8 @@ class TestComponentApi(PlatformApiTestBase):
     # Functions to test methods defined in ComponentBase class
     #
 
-    def test_get_description(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_description(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
+                             ):
 
         for i in range(self.num_components):
             description = component.get_description(platform_api_conn, i)
@@ -149,7 +159,9 @@ class TestComponentApi(PlatformApiTestBase):
                             "Component {}: Description appears to be incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_firmware_version(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_firmware_version(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                  platform_api_conn     # noqa F811
+                                  ):
 
         for i in range(self.num_components):
             fw_version = component.get_firmware_version(platform_api_conn, i)
@@ -159,7 +171,8 @@ class TestComponentApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_available_firmware_version(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                            localhost, platform_api_conn):
+                                            localhost, platform_api_conn    # noqa F811
+                                            ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["nokia"])
 
@@ -175,7 +188,8 @@ class TestComponentApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_firmware_update_notification(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                              localhost, platform_api_conn):
+                                              localhost, platform_api_conn      # noqa F811
+                                              ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["nokia"])
 
@@ -188,7 +202,9 @@ class TestComponentApi(PlatformApiTestBase):
                                   "Component {}: Firmware update notification appears to be incorrect from image {}"
                                   .format(i, image))
 
-    def test_install_firmware(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_install_firmware(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                              platform_api_conn    # noqa F811
+                              ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["nokia"])
 
@@ -202,7 +218,9 @@ class TestComponentApi(PlatformApiTestBase):
                                 .format(i, image))
         self.assert_expectations()
 
-    def test_update_firmware(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_update_firmware(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                             platform_api_conn     # noqa F811
+                             ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["nokia"])
 

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 
 from tests.common.helpers.platform_api import chassis, fan_drawer
+from tests.common.platform.device_utils import platform_api_conn    # noqa F401
 
 from .platform_api_test_base import PlatformApiTestBase
 
@@ -39,7 +40,8 @@ class TestFanDrawerApi(PlatformApiTestBase):
     # it relies on the platform_api_conn fixture, which is scoped at the function
     # level, so we must do the same here to prevent a scope mismatch.
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, duthost, platform_api_conn):
+    def setup(self, duthost, platform_api_conn  # noqa F811
+              ):
         if self.num_fan_drawers is None:
             try:
                 self.num_fan_drawers = int(chassis.get_num_fan_drawers(platform_api_conn))
@@ -87,7 +89,8 @@ class TestFanDrawerApi(PlatformApiTestBase):
     #
     # Functions to test methods inherited from DeviceBase class
     #
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                      ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for i in range(self.num_fan_drawers):
             name = fan_drawer.get_name(platform_api_conn, i)
@@ -98,7 +101,8 @@ class TestFanDrawerApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                          ):
         for i in range(self.num_fan_drawers):
             presence = fan_drawer.get_presence(platform_api_conn, i)
 
@@ -108,7 +112,8 @@ class TestFanDrawerApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
+                       ):
         for i in range(self.num_fan_drawers):
             model = fan_drawer.get_model(platform_api_conn, i)
 
@@ -117,7 +122,8 @@ class TestFanDrawerApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
+                        ):
         for i in range(self.num_fan_drawers):
             serial = fan_drawer.get_serial(platform_api_conn, i)
 
@@ -126,7 +132,8 @@ class TestFanDrawerApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
+                        ):
         for i in range(self.num_fan_drawers):
             status = fan_drawer.get_status(platform_api_conn, i)
 
@@ -135,7 +142,8 @@ class TestFanDrawerApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_position_in_parent(self, platform_api_conn):
+    def test_get_position_in_parent(self, platform_api_conn     # noqa F811
+                                    ):
         for i in range(self.num_fan_drawers):
             position = fan_drawer.get_position_in_parent(platform_api_conn, i)
             if self.expect(position is not None,
@@ -144,7 +152,8 @@ class TestFanDrawerApi(PlatformApiTestBase):
                             "Position value must be an integer value for fan drawer {}".format(i))
         self.assert_expectations()
 
-    def test_is_replaceable(self, platform_api_conn):
+    def test_is_replaceable(self, platform_api_conn     # noqa F811
+                            ):
         for i in range(self.num_fan_drawers):
             replaceable = fan_drawer.is_replaceable(platform_api_conn, i)
             if self.expect(replaceable is not None, "Failed to perform is_replaceable for fan drawer {}".format(i)):
@@ -155,7 +164,8 @@ class TestFanDrawerApi(PlatformApiTestBase):
     #
     # Functions to test methods defined in Fan_drawerBase class
     #
-    def test_get_num_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_num_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                          ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for i in range(self.num_fan_drawers):
 
@@ -166,7 +176,8 @@ class TestFanDrawerApi(PlatformApiTestBase):
                 self.compare_value_with_platform_facts(duthost, 'num_fans', num_fans, i)
         self.assert_expectations()
 
-    def test_get_all_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_all_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                          ):
         for i in range(self.num_fan_drawers):
 
             fans_list = fan_drawer.get_all_fans(platform_api_conn, i)
@@ -175,7 +186,9 @@ class TestFanDrawerApi(PlatformApiTestBase):
                             "fan drawer {} list of fans appear to be incorrect".format(i))
         self.assert_expectations()
 
-    def test_set_fan_drawers_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_set_fan_drawers_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                 platform_api_conn # noqa F811
+                                 ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
         FAULT_LED_COLOR_LIST = [
@@ -253,7 +266,8 @@ class TestFanDrawerApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_maximum_consumed_power(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                        localhost, platform_api_conn):
+                                        localhost, platform_api_conn    # noqa F811
+                                        ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         max_power_skipped = 0
 

--- a/tests/platform_tests/api/test_fan_drawer.py
+++ b/tests/platform_tests/api/test_fan_drawer.py
@@ -40,8 +40,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
     # it relies on the platform_api_conn fixture, which is scoped at the function
     # level, so we must do the same here to prevent a scope mismatch.
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, duthost, platform_api_conn  # noqa F811
-              ):
+    def setup(self, duthost, platform_api_conn):  # noqa F811
         if self.num_fan_drawers is None:
             try:
                 self.num_fan_drawers = int(chassis.get_num_fan_drawers(platform_api_conn))
@@ -89,8 +88,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
     #
     # Functions to test methods inherited from DeviceBase class
     #
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                      ):
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for i in range(self.num_fan_drawers):
             name = fan_drawer.get_name(platform_api_conn, i)
@@ -101,8 +99,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                          ):
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for i in range(self.num_fan_drawers):
             presence = fan_drawer.get_presence(platform_api_conn, i)
 
@@ -112,8 +109,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
-                       ):
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa F811
         for i in range(self.num_fan_drawers):
             model = fan_drawer.get_model(platform_api_conn, i)
 
@@ -122,8 +118,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
-                        ):
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for i in range(self.num_fan_drawers):
             serial = fan_drawer.get_serial(platform_api_conn, i)
 
@@ -132,8 +127,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
-                        ):
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for i in range(self.num_fan_drawers):
             status = fan_drawer.get_status(platform_api_conn, i)
 
@@ -142,8 +136,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_position_in_parent(self, platform_api_conn     # noqa F811
-                                    ):
+    def test_get_position_in_parent(self, platform_api_conn):     # noqa F811
         for i in range(self.num_fan_drawers):
             position = fan_drawer.get_position_in_parent(platform_api_conn, i)
             if self.expect(position is not None,
@@ -152,8 +145,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
                             "Position value must be an integer value for fan drawer {}".format(i))
         self.assert_expectations()
 
-    def test_is_replaceable(self, platform_api_conn     # noqa F811
-                            ):
+    def test_is_replaceable(self, platform_api_conn):     # noqa F811
         for i in range(self.num_fan_drawers):
             replaceable = fan_drawer.is_replaceable(platform_api_conn, i)
             if self.expect(replaceable is not None, "Failed to perform is_replaceable for fan drawer {}".format(i)):
@@ -164,8 +156,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
     #
     # Functions to test methods defined in Fan_drawerBase class
     #
-    def test_get_num_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                          ):
+    def test_get_num_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for i in range(self.num_fan_drawers):
 
@@ -176,8 +167,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
                 self.compare_value_with_platform_facts(duthost, 'num_fans', num_fans, i)
         self.assert_expectations()
 
-    def test_get_all_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                          ):
+    def test_get_all_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for i in range(self.num_fan_drawers):
 
             fans_list = fan_drawer.get_all_fans(platform_api_conn, i)
@@ -187,8 +177,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_set_fan_drawers_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                                 platform_api_conn # noqa F811
-                                 ):
+                                 platform_api_conn): # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
         FAULT_LED_COLOR_LIST = [
@@ -266,8 +255,7 @@ class TestFanDrawerApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_maximum_consumed_power(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                        localhost, platform_api_conn    # noqa F811
-                                        ):
+                                        localhost, platform_api_conn):    # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         max_power_skipped = 0
 

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -42,8 +42,7 @@ class TestPsuApi(PlatformApiTestBase):
     chassis_facts = None
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, platform_api_conn, # noqa F811
-              duthosts, enum_rand_one_per_hwsku_hostname):
+    def setup(self, platform_api_conn, duthosts, enum_rand_one_per_hwsku_hostname): # noqa F811
         if self.num_psus is None:
             try:
                 self.num_psus = int(chassis.get_num_psus(platform_api_conn))
@@ -84,8 +83,7 @@ class TestPsuApi(PlatformApiTestBase):
 
         return def_value
 
-    def skip_absent_psu(self, psu_num, platform_api_conn    # noqa F811
-                        ):
+    def skip_absent_psu(self, psu_num, platform_api_conn):    # noqa F811
         name = psu.get_name(platform_api_conn, psu_num)
         if name in self.psu_skip_list:
             logger.info("Skipping PSU {} since it is part of psu_skip_list".format(name))
@@ -106,8 +104,7 @@ class TestPsuApi(PlatformApiTestBase):
     # Functions to test methods inherited from DeviceBase class
     #
 
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                      ):
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for i in range(self.num_psus):
             if self.skip_absent_psu(i, platform_api_conn):
@@ -118,8 +115,7 @@ class TestPsuApi(PlatformApiTestBase):
                 self.compare_value_with_platform_facts(duthost, 'name', name, i)
         self.assert_expectations()
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                          ):
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for i in range(self.num_psus):
             presence = psu.get_presence(platform_api_conn, i)
             name = psu.get_name(platform_api_conn, i)
@@ -132,8 +128,7 @@ class TestPsuApi(PlatformApiTestBase):
                     #       that the psu is not present when in the skip list
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
-                       ):
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa F811
         for i in range(self.num_psus):
             if self.skip_absent_psu(i, platform_api_conn):
                 continue
@@ -142,8 +137,7 @@ class TestPsuApi(PlatformApiTestBase):
                 self.expect(isinstance(model, STRING_TYPE), "PSU {} model appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
-                        ):
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for i in range(self.num_psus):
             if self.skip_absent_psu(i, platform_api_conn):
                 continue
@@ -152,8 +146,7 @@ class TestPsuApi(PlatformApiTestBase):
                 self.expect(isinstance(serial, STRING_TYPE), "PSU {} serial number appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                          ):
+    def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release(duthost, ["201811", "201911", "202012"])
         for i in range(self.num_psus):
@@ -164,8 +157,7 @@ class TestPsuApi(PlatformApiTestBase):
                 self.expect(isinstance(revision, STRING_TYPE), "PSU {} serial number appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
-                        ):
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for i in range(self.num_psus):
             if self.skip_absent_psu(i, platform_api_conn):
                 continue
@@ -174,8 +166,7 @@ class TestPsuApi(PlatformApiTestBase):
                 self.expect(isinstance(status, bool), "PSU {} status appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_position_in_parent(self, platform_api_conn     # noqa F811
-                                    ):
+    def test_get_position_in_parent(self, platform_api_conn):     # noqa F811
         for psu_id in range(self.num_psus):
             if self.skip_absent_psu(psu_id, platform_api_conn):
                 continue
@@ -186,8 +177,7 @@ class TestPsuApi(PlatformApiTestBase):
                             "Position value must be an integer value for psu id {}".format(psu_id))
         self.assert_expectations()
 
-    def test_is_replaceable(self, platform_api_conn     # noqa F811
-                            ):
+    def test_is_replaceable(self, platform_api_conn):     # noqa F811
         for psu_id in range(self.num_psus):
             if self.skip_absent_psu(psu_id, platform_api_conn):
                 continue
@@ -202,8 +192,7 @@ class TestPsuApi(PlatformApiTestBase):
     # Functions to test methods defined in PsuBase class
     #
 
-    def test_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                  ):
+    def test_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         ''' PSU fan test '''
         for psu_id in range(self.num_psus):
             try:
@@ -222,8 +211,7 @@ class TestPsuApi(PlatformApiTestBase):
                     self.expect(fan and fan == fan_list[i], "Fan {} of PSU {} is incorrect".format(i, psu_id))
         self.assert_expectations()
 
-    def test_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
-                   ):
+    def test_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa F811
         ''' PSU power test '''
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
@@ -284,8 +272,7 @@ class TestPsuApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn     # noqa F811
-                         ):
+    def test_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa F811
         ''' PSU temperature test '''
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
@@ -320,8 +307,7 @@ class TestPsuApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn     # noqa F811
-                 ):
+    def test_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):     # noqa F811
         ''' PSU status led test '''
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         FAULT_LED_COLOR_LIST = [
@@ -412,8 +398,7 @@ class TestPsuApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_thermals(self, platform_api_conn   # noqa F811
-                      ):
+    def test_thermals(self, platform_api_conn):   # noqa F811
         for psu_id in range(self.num_psus):
             if self.skip_absent_psu(psu_id, platform_api_conn):
                 continue
@@ -434,8 +419,7 @@ class TestPsuApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_master_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
-                        ):
+    def test_master_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         FAULT_LED_COLOR_LIST = [
             STATUS_LED_COLOR_AMBER,

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -7,6 +7,7 @@ from tests.common.utilities import skip_release
 from tests.platform_tests.cli.util import get_skip_mod_list
 from .platform_api_test_base import PlatformApiTestBase
 from tests.common.utilities import skip_release_for_platform, wait_until
+from tests.common.platform.device_utils import platform_api_conn    # noqa F401
 
 
 ###################################################
@@ -41,7 +42,8 @@ class TestPsuApi(PlatformApiTestBase):
     chassis_facts = None
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, platform_api_conn, duthosts, enum_rand_one_per_hwsku_hostname):
+    def setup(self, platform_api_conn, # noqa F811
+              duthosts, enum_rand_one_per_hwsku_hostname):
         if self.num_psus is None:
             try:
                 self.num_psus = int(chassis.get_num_psus(platform_api_conn))
@@ -82,7 +84,8 @@ class TestPsuApi(PlatformApiTestBase):
 
         return def_value
 
-    def skip_absent_psu(self, psu_num, platform_api_conn):
+    def skip_absent_psu(self, psu_num, platform_api_conn    # noqa F811
+                        ):
         name = psu.get_name(platform_api_conn, psu_num)
         if name in self.psu_skip_list:
             logger.info("Skipping PSU {} since it is part of psu_skip_list".format(name))
@@ -103,7 +106,8 @@ class TestPsuApi(PlatformApiTestBase):
     # Functions to test methods inherited from DeviceBase class
     #
 
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                      ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for i in range(self.num_psus):
             if self.skip_absent_psu(i, platform_api_conn):
@@ -114,7 +118,8 @@ class TestPsuApi(PlatformApiTestBase):
                 self.compare_value_with_platform_facts(duthost, 'name', name, i)
         self.assert_expectations()
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                          ):
         for i in range(self.num_psus):
             presence = psu.get_presence(platform_api_conn, i)
             name = psu.get_name(platform_api_conn, i)
@@ -127,7 +132,8 @@ class TestPsuApi(PlatformApiTestBase):
                     #       that the psu is not present when in the skip list
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
+                       ):
         for i in range(self.num_psus):
             if self.skip_absent_psu(i, platform_api_conn):
                 continue
@@ -136,7 +142,8 @@ class TestPsuApi(PlatformApiTestBase):
                 self.expect(isinstance(model, STRING_TYPE), "PSU {} model appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
+                        ):
         for i in range(self.num_psus):
             if self.skip_absent_psu(i, platform_api_conn):
                 continue
@@ -145,7 +152,8 @@ class TestPsuApi(PlatformApiTestBase):
                 self.expect(isinstance(serial, STRING_TYPE), "PSU {} serial number appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                          ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release(duthost, ["201811", "201911", "202012"])
         for i in range(self.num_psus):
@@ -156,7 +164,8 @@ class TestPsuApi(PlatformApiTestBase):
                 self.expect(isinstance(revision, STRING_TYPE), "PSU {} serial number appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
+                        ):
         for i in range(self.num_psus):
             if self.skip_absent_psu(i, platform_api_conn):
                 continue
@@ -165,7 +174,8 @@ class TestPsuApi(PlatformApiTestBase):
                 self.expect(isinstance(status, bool), "PSU {} status appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_position_in_parent(self, platform_api_conn):
+    def test_get_position_in_parent(self, platform_api_conn     # noqa F811
+                                    ):
         for psu_id in range(self.num_psus):
             if self.skip_absent_psu(psu_id, platform_api_conn):
                 continue
@@ -176,7 +186,8 @@ class TestPsuApi(PlatformApiTestBase):
                             "Position value must be an integer value for psu id {}".format(psu_id))
         self.assert_expectations()
 
-    def test_is_replaceable(self, platform_api_conn):
+    def test_is_replaceable(self, platform_api_conn     # noqa F811
+                            ):
         for psu_id in range(self.num_psus):
             if self.skip_absent_psu(psu_id, platform_api_conn):
                 continue
@@ -191,7 +202,8 @@ class TestPsuApi(PlatformApiTestBase):
     # Functions to test methods defined in PsuBase class
     #
 
-    def test_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                  ):
         ''' PSU fan test '''
         for psu_id in range(self.num_psus):
             try:
@@ -210,7 +222,8 @@ class TestPsuApi(PlatformApiTestBase):
                     self.expect(fan and fan == fan_list[i], "Fan {} of PSU {} is incorrect".format(i, psu_id))
         self.assert_expectations()
 
-    def test_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
+                   ):
         ''' PSU power test '''
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
@@ -271,7 +284,8 @@ class TestPsuApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn     # noqa F811
+                         ):
         ''' PSU temperature test '''
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
@@ -306,7 +320,8 @@ class TestPsuApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn     # noqa F811
+                 ):
         ''' PSU status led test '''
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         FAULT_LED_COLOR_LIST = [
@@ -397,7 +412,8 @@ class TestPsuApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_thermals(self, platform_api_conn):
+    def test_thermals(self, platform_api_conn   # noqa F811
+                      ):
         for psu_id in range(self.num_psus):
             if self.skip_absent_psu(psu_id, platform_api_conn):
                 continue
@@ -418,7 +434,8 @@ class TestPsuApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_master_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_master_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
+                        ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         FAULT_LED_COLOR_LIST = [
             STATUS_LED_COLOR_AMBER,

--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -47,8 +47,7 @@ class TestPsuFans(PlatformApiTestBase):
     # level, so we must do the same here to prevent a scope mismatch.
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, platform_api_conn   # noqa F811
-              ):
+    def setup(self, platform_api_conn):   # noqa F811
         if self.num_psus is None:
             try:
                 self.num_psus = chassis.get_num_psus(platform_api_conn)
@@ -98,8 +97,7 @@ class TestPsuFans(PlatformApiTestBase):
     #
     # Functions to test methods inherited from DeviceBase class
     #
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                      ):
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
@@ -136,9 +134,7 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                          ):
-
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
 
@@ -154,9 +150,7 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
-                       ):
-
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa F811
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
 
@@ -168,9 +162,7 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
-                        ):
-
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
 
@@ -183,9 +175,7 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
-                        ):
-
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
 
@@ -197,8 +187,7 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_position_in_parent(self, platform_api_conn     # noqa F811
-                                    ):
+    def test_get_position_in_parent(self, platform_api_conn):     # noqa F811
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
             for i in range(num_fans):
@@ -209,8 +198,7 @@ class TestPsuFans(PlatformApiTestBase):
                                 "Position value must be an integer value for PSU {} fan {}".format(j, i))
         self.assert_expectations()
 
-    def test_is_replaceable(self, platform_api_conn     # noqa F811
-                            ):
+    def test_is_replaceable(self, platform_api_conn):     # noqa F811
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
             for i in range(num_fans):
@@ -226,8 +214,7 @@ class TestPsuFans(PlatformApiTestBase):
     # Functions to test methods defined in FanBase class
     #
 
-    def test_get_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
-                       ):
+    def test_get_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
@@ -246,8 +233,7 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_direction(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
-                           ):
+    def test_get_direction(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn): # noqa F811
         # Ensure the fan speed is sane
         FAN_DIRECTION_LIST = [
             "intake",
@@ -267,9 +253,7 @@ class TestPsuFans(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_fans_target_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                                   platform_api_conn   # noqa F811
-                                   ):
-
+                                   platform_api_conn):   # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         psus_skipped = 0
 
@@ -309,9 +293,7 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_set_fans_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
-                            ):
-
+    def test_set_fans_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn): # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         psus_skipped = 0
 
@@ -352,8 +334,7 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_set_fans_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
-                          ):
+    def test_set_fans_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         LED_COLOR_LIST = [
             "off",
             "red",

--- a/tests/platform_tests/api/test_psu_fans.py
+++ b/tests/platform_tests/api/test_psu_fans.py
@@ -5,6 +5,7 @@ import os
 import pytest
 
 from tests.common.helpers.platform_api import chassis, psu, psu_fan
+from tests.common.platform.device_utils import platform_api_conn    # noqa F401
 
 from .platform_api_test_base import PlatformApiTestBase
 
@@ -46,7 +47,8 @@ class TestPsuFans(PlatformApiTestBase):
     # level, so we must do the same here to prevent a scope mismatch.
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, platform_api_conn):
+    def setup(self, platform_api_conn   # noqa F811
+              ):
         if self.num_psus is None:
             try:
                 self.num_psus = chassis.get_num_psus(platform_api_conn)
@@ -96,7 +98,8 @@ class TestPsuFans(PlatformApiTestBase):
     #
     # Functions to test methods inherited from DeviceBase class
     #
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                      ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
@@ -133,7 +136,8 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                          ):
 
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
@@ -150,7 +154,8 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
+                       ):
 
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
@@ -163,7 +168,8 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
+                        ):
 
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
@@ -177,7 +183,8 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
+                        ):
 
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
@@ -190,7 +197,8 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_position_in_parent(self, platform_api_conn):
+    def test_get_position_in_parent(self, platform_api_conn     # noqa F811
+                                    ):
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
             for i in range(num_fans):
@@ -201,7 +209,8 @@ class TestPsuFans(PlatformApiTestBase):
                                 "Position value must be an integer value for PSU {} fan {}".format(j, i))
         self.assert_expectations()
 
-    def test_is_replaceable(self, platform_api_conn):
+    def test_is_replaceable(self, platform_api_conn     # noqa F811
+                            ):
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
             for i in range(num_fans):
@@ -217,7 +226,8 @@ class TestPsuFans(PlatformApiTestBase):
     # Functions to test methods defined in FanBase class
     #
 
-    def test_get_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
+                       ):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for j in range(self.num_psus):
             num_fans = psu.get_num_fans(platform_api_conn, j)
@@ -236,7 +246,8 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_direction(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_direction(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn   # noqa F811
+                           ):
         # Ensure the fan speed is sane
         FAN_DIRECTION_LIST = [
             "intake",
@@ -255,7 +266,9 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_fans_target_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_fans_target_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                   platform_api_conn   # noqa F811
+                                   ):
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         psus_skipped = 0
@@ -296,7 +309,8 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_set_fans_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_set_fans_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn  # noqa F811
+                            ):
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         psus_skipped = 0
@@ -338,7 +352,8 @@ class TestPsuFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_set_fans_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_set_fans_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn    # noqa F811
+                          ):
         LED_COLOR_LIST = [
             "off",
             "red",

--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -6,6 +6,7 @@ import yaml
 import pytest
 from tests.common.helpers.platform_api import watchdog
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.device_utils import platform_api_conn    # noqa F401
 from .platform_api_test_base import PlatformApiTestBase
 
 from collections import OrderedDict
@@ -40,7 +41,8 @@ class TestWatchdogApi(PlatformApiTestBase):
     ''' Hardware watchdog platform API test cases '''
 
     @pytest.fixture(scope='function', autouse=True)
-    def watchdog_not_running(self, platform_api_conn, duthosts, enum_rand_one_per_hwsku_hostname):
+    def watchdog_not_running(self, platform_api_conn,   # noqa F811
+                             duthosts, enum_rand_one_per_hwsku_hostname):
         ''' Fixture that automatically runs on each test case and
         verifies that watchdog is not running before the test begins
         and disables it after the test ends'''
@@ -92,7 +94,9 @@ class TestWatchdogApi(PlatformApiTestBase):
         return config
 
     @pytest.mark.dependency()
-    def test_arm_disarm_states(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn, conf):
+    def test_arm_disarm_states(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                               platform_api_conn,  # noqa F811
+                               conf):
         ''' arm watchdog with a valid timeout value, verify it is in armed state,
         disarm watchdog and verify it is in disarmed state
         '''
@@ -139,7 +143,8 @@ class TestWatchdogApi(PlatformApiTestBase):
         self.assert_expectations()
 
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
-    def test_remaining_time(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn, conf):
+    def test_remaining_time(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn,    # noqa F811
+                            conf):
         ''' arm watchdog with a valid timeout and verify that remaining time API works correctly '''
 
         watchdog_timeout = conf['valid_timeout']
@@ -168,7 +173,8 @@ class TestWatchdogApi(PlatformApiTestBase):
         self.assert_expectations()
 
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
-    def test_periodic_arm(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn, conf):
+    def test_periodic_arm(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn,  # noqa F811
+                          conf):
         ''' arm watchdog several times as watchdog deamon would and verify API behaves correctly '''
 
         watchdog_timeout = conf['valid_timeout']
@@ -190,7 +196,9 @@ class TestWatchdogApi(PlatformApiTestBase):
         self.assert_expectations()
 
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
-    def test_arm_different_timeout_greater(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn, conf):
+    def test_arm_different_timeout_greater(self, duthosts, enum_rand_one_per_hwsku_hostname,
+                                           platform_api_conn, # noqa F811
+                                           conf):
         ''' arm the watchdog with greater timeout value and verify new timeout was accepted;
         If platform accepts only single valid timeout value, @greater_timeout should be None.
         '''
@@ -212,7 +220,9 @@ class TestWatchdogApi(PlatformApiTestBase):
         self.assert_expectations()
 
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
-    def test_arm_different_timeout_smaller(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn, conf):
+    def test_arm_different_timeout_smaller(self, duthosts, enum_rand_one_per_hwsku_hostname,
+                                           platform_api_conn,   # noqa F811
+                                           conf):
         ''' arm the watchdog with smaller timeout value and verify new timeout was accepted;
         If platform accepts only single valid timeout value, @greater_timeout should be None.
         '''
@@ -235,7 +245,8 @@ class TestWatchdogApi(PlatformApiTestBase):
         self.assert_expectations()
 
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
-    def test_arm_too_big_timeout(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn, conf):
+    def test_arm_too_big_timeout(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn,   # noqa F811
+                                 conf):
         ''' try to arm the watchdog with timeout that is too big for hardware watchdog;
         If no such limitation exist, @too_big_timeout should be None for such platform.
         '''
@@ -249,7 +260,8 @@ class TestWatchdogApi(PlatformApiTestBase):
         self.assert_expectations()
 
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
-    def test_arm_negative_timeout(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn):
+    def test_arm_negative_timeout(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn   # noqa F811
+                                  ):
         ''' try to arm the watchdog with negative value '''
 
         watchdog_timeout = -1

--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -41,8 +41,7 @@ class TestWatchdogApi(PlatformApiTestBase):
     ''' Hardware watchdog platform API test cases '''
 
     @pytest.fixture(scope='function', autouse=True)
-    def watchdog_not_running(self, platform_api_conn,   # noqa F811
-                             duthosts, enum_rand_one_per_hwsku_hostname):
+    def watchdog_not_running(self, platform_api_conn, duthosts, enum_rand_one_per_hwsku_hostname):  # noqa F811
         ''' Fixture that automatically runs on each test case and
         verifies that watchdog is not running before the test begins
         and disables it after the test ends'''
@@ -95,8 +94,7 @@ class TestWatchdogApi(PlatformApiTestBase):
 
     @pytest.mark.dependency()
     def test_arm_disarm_states(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                               platform_api_conn,  # noqa F811
-                               conf):
+                               platform_api_conn, conf):  # noqa F811
         ''' arm watchdog with a valid timeout value, verify it is in armed state,
         disarm watchdog and verify it is in disarmed state
         '''
@@ -143,8 +141,7 @@ class TestWatchdogApi(PlatformApiTestBase):
         self.assert_expectations()
 
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
-    def test_remaining_time(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn,    # noqa F811
-                            conf):
+    def test_remaining_time(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn, conf):    # noqa F811
         ''' arm watchdog with a valid timeout and verify that remaining time API works correctly '''
 
         watchdog_timeout = conf['valid_timeout']
@@ -173,8 +170,7 @@ class TestWatchdogApi(PlatformApiTestBase):
         self.assert_expectations()
 
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
-    def test_periodic_arm(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn,  # noqa F811
-                          conf):
+    def test_periodic_arm(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn, conf):  # noqa F811
         ''' arm watchdog several times as watchdog deamon would and verify API behaves correctly '''
 
         watchdog_timeout = conf['valid_timeout']
@@ -197,8 +193,7 @@ class TestWatchdogApi(PlatformApiTestBase):
 
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
     def test_arm_different_timeout_greater(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                           platform_api_conn, # noqa F811
-                                           conf):
+                                           platform_api_conn, conf): # noqa F811
         ''' arm the watchdog with greater timeout value and verify new timeout was accepted;
         If platform accepts only single valid timeout value, @greater_timeout should be None.
         '''
@@ -221,8 +216,7 @@ class TestWatchdogApi(PlatformApiTestBase):
 
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
     def test_arm_different_timeout_smaller(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                           platform_api_conn,   # noqa F811
-                                           conf):
+                                           platform_api_conn, conf):   # noqa F811
         ''' arm the watchdog with smaller timeout value and verify new timeout was accepted;
         If platform accepts only single valid timeout value, @greater_timeout should be None.
         '''
@@ -245,8 +239,8 @@ class TestWatchdogApi(PlatformApiTestBase):
         self.assert_expectations()
 
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
-    def test_arm_too_big_timeout(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn,   # noqa F811
-                                 conf):
+    def test_arm_too_big_timeout(self, duthosts, enum_rand_one_per_hwsku_hostname,
+                                 platform_api_conn, conf):   # noqa F811
         ''' try to arm the watchdog with timeout that is too big for hardware watchdog;
         If no such limitation exist, @too_big_timeout should be None for such platform.
         '''
@@ -260,8 +254,7 @@ class TestWatchdogApi(PlatformApiTestBase):
         self.assert_expectations()
 
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
-    def test_arm_negative_timeout(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn   # noqa F811
-                                  ):
+    def test_arm_negative_timeout(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn):   # noqa F811
         ''' try to arm the watchdog with negative value '''
 
         watchdog_timeout = -1

--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -4,14 +4,15 @@ Helper script for DPU  operations
 import logging
 import pytest
 from tests.common.devices.sonic import *  # noqa: F401,F403
-from tests.platform_tests.api.conftest import *  # noqa: F401,F403
+from tests.common.platform.device_utils import platform_api_conn  # noqa: F401,F403
 from tests.common.helpers.platform_api import chassis, module
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 
 
 @pytest.fixture(scope='function')
-def num_dpu_modules(platform_api_conn):
+def num_dpu_modules(platform_api_conn   # noqa F811
+                    ):
     """
     Returns the number of DPU modules
     """
@@ -25,7 +26,8 @@ def num_dpu_modules(platform_api_conn):
 @pytest.fixture(scope='function', autouse=True)
 def check_smartswitch_and_dark_mode(duthosts,
                                     enum_rand_one_per_hwsku_hostname,
-                                    platform_api_conn, num_dpu_modules):
+                                    platform_api_conn,  # noqa F811
+                                    num_dpu_modules):
     """
     Checks whether given testbed is running
     202405 image or below versions
@@ -40,14 +42,15 @@ def check_smartswitch_and_dark_mode(duthosts,
     if "DPUS" not in duthost.facts:
         pytest.skip("Test is not supported for this testbed")
 
-    darkmode = is_dark_mode_enabled(duthost, platform_api_conn,
+    darkmode = is_dark_mode_enabled(duthost, platform_api_conn, # noqa F811
                                     num_dpu_modules)
 
     if darkmode:
         dpu_power_on(duthost, platform_api_conn, num_dpu_modules)
 
 
-def is_dark_mode_enabled(duthost, platform_api_conn, num_dpu_modules):
+def is_dark_mode_enabled(duthost, platform_api_conn,    # noqa F811
+                         num_dpu_modules):
     """
     Checks the liveliness of DPU
     Returns:
@@ -76,7 +79,8 @@ def is_dark_mode_enabled(duthost, platform_api_conn, num_dpu_modules):
     return False
 
 
-def dpu_power_on(duthost, platform_api_conn, num_dpu_modules):
+def dpu_power_on(duthost, platform_api_conn,    # noqa F811
+                 num_dpu_modules):
     """
     Executes power on all DPUs
     Returns:

--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -25,7 +25,6 @@ def num_dpu_modules(platform_api_conn):   # noqa F811
 @pytest.fixture(scope='function', autouse=True)
 def check_smartswitch_and_dark_mode(duthosts, enum_rand_one_per_hwsku_hostname,
                                     platform_api_conn, num_dpu_modules):  # noqa F811
-
     """
     Checks whether given testbed is running
     202405 image or below versions

--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -11,8 +11,7 @@ from tests.common.helpers.assertions import pytest_assert
 
 
 @pytest.fixture(scope='function')
-def num_dpu_modules(platform_api_conn   # noqa F811
-                    ):
+def num_dpu_modules(platform_api_conn):   # noqa F811
     """
     Returns the number of DPU modules
     """
@@ -24,10 +23,9 @@ def num_dpu_modules(platform_api_conn   # noqa F811
 
 
 @pytest.fixture(scope='function', autouse=True)
-def check_smartswitch_and_dark_mode(duthosts,
-                                    enum_rand_one_per_hwsku_hostname,
-                                    platform_api_conn,  # noqa F811
-                                    num_dpu_modules):
+def check_smartswitch_and_dark_mode(duthosts, enum_rand_one_per_hwsku_hostname,
+                                    platform_api_conn, num_dpu_modules):  # noqa F811
+
     """
     Checks whether given testbed is running
     202405 image or below versions
@@ -42,15 +40,13 @@ def check_smartswitch_and_dark_mode(duthosts,
     if "DPUS" not in duthost.facts:
         pytest.skip("Test is not supported for this testbed")
 
-    darkmode = is_dark_mode_enabled(duthost, platform_api_conn, # noqa F811
-                                    num_dpu_modules)
+    darkmode = is_dark_mode_enabled(duthost, platform_api_conn, num_dpu_modules) # noqa F811
 
     if darkmode:
         dpu_power_on(duthost, platform_api_conn, num_dpu_modules)
 
 
-def is_dark_mode_enabled(duthost, platform_api_conn,    # noqa F811
-                         num_dpu_modules):
+def is_dark_mode_enabled(duthost, platform_api_conn, num_dpu_modules):   # noqa F811
     """
     Checks the liveliness of DPU
     Returns:
@@ -79,8 +75,7 @@ def is_dark_mode_enabled(duthost, platform_api_conn,    # noqa F811
     return False
 
 
-def dpu_power_on(duthost, platform_api_conn,    # noqa F811
-                 num_dpu_modules):
+def dpu_power_on(duthost, platform_api_conn, num_dpu_modules):    # noqa F811
     """
     Executes power on all DPUs
     Returns:

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -14,7 +14,7 @@ from tests.common.reboot import reboot, wait_for_startup, REBOOT_TYPE_COLD
 from tests.common.config_reload import config_force_option_supported, config_system_checks_passed  # noqa: F401, E501
 from tests.smartswitch.common.device_utils_dpu import *  # noqa: F401,F403,E501
 from tests.common.helpers.platform_api import chassis, module  # noqa: F401
-from tests.platform_tests.api.conftest import *  # noqa: F401,F403
+from tests.common.platform.device_utils import platform_api_conn  # noqa: F401,F403
 
 pytestmark = [
     pytest.mark.topology('smartswitch')
@@ -22,7 +22,7 @@ pytestmark = [
 
 
 def test_dpu_ping_after_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                               localhost, platform_api_conn,
+                               localhost, platform_api_conn,    # noqa F811
                                num_dpu_modules):
     """
     @summary: Verify output of `config chassis modules startup <DPU_Number>`
@@ -52,7 +52,7 @@ def test_dpu_ping_after_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_show_ping_int_after_reload(duthosts, enum_rand_one_per_hwsku_hostname,
-                                    localhost, platform_api_conn,
+                                    localhost, platform_api_conn,   # noqa F811
                                     num_dpu_modules):
     """
     @summary: To Check Ping between NPU and DPU

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -22,8 +22,7 @@ pytestmark = [
 
 
 def test_dpu_ping_after_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
-                               localhost, platform_api_conn,    # noqa F811
-                               num_dpu_modules):
+                               localhost, platform_api_conn, num_dpu_modules):    # noqa F811
     """
     @summary: Verify output of `config chassis modules startup <DPU_Number>`
     """
@@ -52,8 +51,7 @@ def test_dpu_ping_after_reboot(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_show_ping_int_after_reload(duthosts, enum_rand_one_per_hwsku_hostname,
-                                    localhost, platform_api_conn,   # noqa F811
-                                    num_dpu_modules):
+                                    localhost, platform_api_conn, num_dpu_modules):   # noqa F811
     """
     @summary: To Check Ping between NPU and DPU
               after configuration reload on NPU

--- a/tests/smartswitch/platform_tests/test_show_platform_dpu.py
+++ b/tests/smartswitch/platform_tests/test_show_platform_dpu.py
@@ -16,9 +16,7 @@ pytestmark = [
 ]
 
 
-def test_midplane_ip(duthosts, enum_rand_one_per_hwsku_hostname,
-                     platform_api_conn  # noqa F811
-                     ):
+def test_midplane_ip(duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn):  # noqa F811
     """
     @summary: Verify `Midplane ip address between NPU and DPU`
     """
@@ -40,8 +38,7 @@ def test_midplane_ip(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_shutdown_power_up_dpu(duthosts, enum_rand_one_per_hwsku_hostname,
-                               platform_api_conn,   # noqa F811
-                               num_dpu_modules):
+                               platform_api_conn, num_dpu_modules):   # noqa F811
     """
     @summary: Verify `shut down and power up DPU`
     """
@@ -65,8 +62,7 @@ def test_shutdown_power_up_dpu(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_reboot_cause(duthosts, enum_rand_one_per_hwsku_hostname,
-                      platform_api_conn,    # noqa F811
-                      num_dpu_modules):
+                      platform_api_conn, num_dpu_modules):    # noqa F811
     """
     @summary: Verify `Reboot Cause`
     """
@@ -91,8 +87,7 @@ def test_reboot_cause(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_pcie_link(duthosts, enum_rand_one_per_hwsku_hostname,
-                   platform_api_conn,   # noqa F811
-                   num_dpu_modules):
+                   platform_api_conn, num_dpu_modules):   # noqa F811
     """
     @summary: Verify `PCIe link`
     """

--- a/tests/smartswitch/platform_tests/test_show_platform_dpu.py
+++ b/tests/smartswitch/platform_tests/test_show_platform_dpu.py
@@ -8,7 +8,7 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.smartswitch.common.device_utils_dpu import *  # noqa: F403,F401,E501
 from tests.common.helpers.platform_api import chassis, module  # noqa: F401
-from tests.platform_tests.api.conftest import *  # noqa: F401,F403
+from tests.common.platform.device_utils import platform_api_conn  # noqa: F401,F403
 from tests.common.devices.sonic import *  # noqa: 403
 
 pytestmark = [
@@ -17,7 +17,8 @@ pytestmark = [
 
 
 def test_midplane_ip(duthosts, enum_rand_one_per_hwsku_hostname,
-                     platform_api_conn):
+                     platform_api_conn  # noqa F811
+                     ):
     """
     @summary: Verify `Midplane ip address between NPU and DPU`
     """
@@ -39,7 +40,8 @@ def test_midplane_ip(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_shutdown_power_up_dpu(duthosts, enum_rand_one_per_hwsku_hostname,
-                               platform_api_conn, num_dpu_modules):
+                               platform_api_conn,   # noqa F811
+                               num_dpu_modules):
     """
     @summary: Verify `shut down and power up DPU`
     """
@@ -63,7 +65,8 @@ def test_shutdown_power_up_dpu(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_reboot_cause(duthosts, enum_rand_one_per_hwsku_hostname,
-                      platform_api_conn, num_dpu_modules):
+                      platform_api_conn,    # noqa F811
+                      num_dpu_modules):
     """
     @summary: Verify `Reboot Cause`
     """
@@ -88,7 +91,8 @@ def test_reboot_cause(duthosts, enum_rand_one_per_hwsku_hostname,
 
 
 def test_pcie_link(duthosts, enum_rand_one_per_hwsku_hostname,
-                   platform_api_conn, num_dpu_modules):
+                   platform_api_conn,   # noqa F811
+                   num_dpu_modules):
     """
     @summary: Verify `PCIe link`
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The `platform_api_conn` fixture is utilized by scripts in both the `smatswitch` and `platform_tests` directories. To reduce cross-feature dependencies and improve code organization, I relocated the fixture to a shared common location, making it accessible without creating unnecessary interdependencies between these feature-specific directories.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
The `platform_api_conn` fixture is utilized by scripts in both the `smatswitch` and `platform_tests` directories. To reduce cross-feature dependencies and improve code organization, I relocated the fixture to a shared common location, making it accessible without creating unnecessary interdependencies between these feature-specific directories.

#### How did you do it?
I relocated the fixture `platform_api_conn` to a shared common location

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
