### PR TITLE
Ignore test_bgp_prefix.py::test_bgp_prefix_tc1_suite for Cisco 8122 backend compute ai deployment

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -793,7 +793,7 @@ generic_config_updater:
     conditions:
       - "'t2' in topo_name"
 
-generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite[empty]
+generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite[empty]:
   skip:
     reason: "Cisco 8122 backend compute ai platform is not supported."
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -793,6 +793,12 @@ generic_config_updater:
     conditions:
       - "'t2' in topo_name"
 
+generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite[empty]
+  skip:
+    reason: "Cisco 8122 backend compute ai platform is not supported."
+    conditions:
+      - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
+
 generic_config_updater/test_dhcp_relay.py:
   skip:
     reason: "Need to skip for platform x86_64-8111_32eh_o-r0 or backend topology / generic_config_updater is not a supported feature for T2"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Ignore test_bgp_prefix.py::test_bgp_prefix_tc1_suite for Cisco 8122 backend compute ai deployment

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Testcase failed:
2024 Nov 14 08:57:04.106664 str3-8122-01 ERR bgp#bgpcfgd: BGPAllowListMgr::Default action community value is not found. route-map 'ALLOW_LIST_DEPLOYMENT_ID_0_V4' entry. seq_no=65535

Cisco 8122 backend compute ai deployment uses totally different BGP teamplate. The above check is meaningless.
So, we shoud ignore test_bgp_prefix.py::test_bgp_prefix_tc1_suite.

#### How did you do it?
Ignore test_bgp_prefix.py::test_bgp_prefix_tc1_suite for Cisco 8122 backend compute ai deployment

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
