### PR TITLE
[Snappi] Fixing dut/port mapping for counters

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1116,7 +1116,7 @@ def get_snappi_ports_single_dut(duthosts,  # noqa: F811
 
     dut_hostname, dut_port = rand_one_dut_portname_oper_up.split('|')
     pytest_require(rand_one_dut_hostname == dut_hostname,
-                   "Port is not mapped to the expected DUT")
+                   "{} Port is not mapped to the expected DUT".format(rand_one_dut_portname_oper_up))
 
     """ Generate L1 config """
     snappi_fanout = get_peer_snappi_chassis(conn_data=conn_graph_facts,

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
@@ -82,10 +82,10 @@ def run_lossless_response_to_external_pause_storms_test(api,
 
     tx_port = [snappi_extra_params.multi_dut_params.multi_dut_ports[1],
                snappi_extra_params.multi_dut_params.multi_dut_ports[2]]
-    ingress_duthost = tx_port[0]['duthost']
 
     # Append the ingress here for run_traffic to clear its counters
-    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost)
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(tx_port[0]['duthost'])
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(tx_port[1]['duthost'])
 
     tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
     # add ingress DUT into the set
@@ -138,12 +138,14 @@ def run_lossless_response_to_external_pause_storms_test(api,
                                                    snappi_extra_params=snappi_extra_params)
 
     dut_tx_port = rx_port['peer_port']
-    dut_rx_port1 = tx_port[0]['peer_port']
-    dut_rx_port2 = tx_port[1]['peer_port']
+    ingress_dut1 = tx_port[0]['duthost']
+    ingress_dut2 = tx_port[1]['duthost']
+    ingress_port1 = tx_port[0]['peer_port']
+    ingress_port2 = tx_port[1]['peer_port']
     # Fetch relevant statistics
     pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
-    rx_pkts_1 = get_interface_stats(ingress_duthost, dut_rx_port1)[ingress_duthost.hostname][dut_rx_port1]['rx_ok']
-    rx_pkts_2 = get_interface_stats(ingress_duthost, dut_rx_port2)[ingress_duthost.hostname][dut_rx_port2]['rx_ok']
+    rx_pkts_1 = get_interface_stats(ingress_dut1, ingress_port1)[ingress_dut1.hostname][ingress_port1]['rx_ok']
+    rx_pkts_2 = get_interface_stats(ingress_dut2, ingress_port2)[ingress_dut2.hostname][ingress_port2]['rx_ok']
     # Calculate the total received packets
     total_rx_pkts = rx_pkts_1 + rx_pkts_2
     # Calculate the drop percentage

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
@@ -88,10 +88,10 @@ def run_lossless_response_to_throttling_pause_storms_test(api,
 
     tx_port = [snappi_extra_params.multi_dut_params.multi_dut_ports[1],
                snappi_extra_params.multi_dut_params.multi_dut_ports[2]]
-    ingress_duthost = tx_port[0]['duthost']
 
     # Append the ingress here for run_traffic to clear its counters
-    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost)
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(tx_port[0]['duthost'])
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(tx_port[1]['duthost'])
 
     tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
     # add ingress DUT into the set
@@ -145,12 +145,14 @@ def run_lossless_response_to_throttling_pause_storms_test(api,
                                                    snappi_extra_params=snappi_extra_params)
 
     dut_tx_port = rx_port['peer_port']
-    dut_rx_port1 = tx_port[0]['peer_port']
-    dut_rx_port2 = tx_port[1]['peer_port']
+    ingress_dut1 = tx_port[0]['duthost']
+    ingress_dut2 = tx_port[1]['duthost']
+    ingress_port1 = tx_port[0]['peer_port']
+    ingress_port2 = tx_port[1]['peer_port']
     # Fetch relevant statistics
     pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
-    rx_pkts_1 = get_interface_stats(ingress_duthost, dut_rx_port1)[ingress_duthost.hostname][dut_rx_port1]['rx_ok']
-    rx_pkts_2 = get_interface_stats(ingress_duthost, dut_rx_port2)[ingress_duthost.hostname][dut_rx_port2]['rx_ok']
+    rx_pkts_1 = get_interface_stats(ingress_dut1, ingress_port1)[ingress_dut1.hostname][ingress_port1]['rx_ok']
+    rx_pkts_2 = get_interface_stats(ingress_dut2, ingress_port2)[ingress_dut2.hostname][ingress_port2]['rx_ok']
     # Calculate the total received packets
     total_rx_pkts = rx_pkts_1 + rx_pkts_2
     # Calculate the drop percentage

--- a/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -75,10 +75,10 @@ def run_m2o_fluctuating_lossless_test(api,
 
     tx_port = [snappi_extra_params.multi_dut_params.multi_dut_ports[1],
                snappi_extra_params.multi_dut_params.multi_dut_ports[2]]
-    ingress_duthost = tx_port[0]['duthost']
 
     # Append the ingress here for run_traffic to clear its counters
-    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost)
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(tx_port[0]['duthost'])
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(tx_port[1]['duthost'])
 
     tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
     # add ingress DUT into the set
@@ -127,12 +127,14 @@ def run_m2o_fluctuating_lossless_test(api,
                                                    snappi_extra_params=snappi_extra_params)
 
     dut_tx_port = rx_port['peer_port']
-    dut_rx_port1 = tx_port[0]['peer_port']
-    dut_rx_port2 = tx_port[1]['peer_port']
+    ingress_dut1 = tx_port[0]['duthost']
+    ingress_dut2 = tx_port[1]['duthost']
+    ingress_port1 = tx_port[0]['peer_port']
+    ingress_port2 = tx_port[1]['peer_port']
     # Fetch relevant statistics
     pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
-    rx_pkts_1 = get_interface_stats(ingress_duthost, dut_rx_port1)[ingress_duthost.hostname][dut_rx_port1]['rx_ok']
-    rx_pkts_2 = get_interface_stats(ingress_duthost, dut_rx_port2)[ingress_duthost.hostname][dut_rx_port2]['rx_ok']
+    rx_pkts_1 = get_interface_stats(ingress_dut1, ingress_port1)[ingress_dut1.hostname][ingress_port1]['rx_ok']
+    rx_pkts_2 = get_interface_stats(ingress_dut2, ingress_port2)[ingress_dut2.hostname][ingress_port2]['rx_ok']
     # Calculate the total received packets
     total_rx_pkts = rx_pkts_1 + rx_pkts_2
     # Calculate the drop percentage

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_helper.py
@@ -76,10 +76,10 @@ def run_m2o_oversubscribe_lossless_test(api,
 
     tx_port = [snappi_extra_params.multi_dut_params.multi_dut_ports[1],
                snappi_extra_params.multi_dut_params.multi_dut_ports[2]]
-    ingress_duthost = tx_port[0]['duthost']
 
     # Append the ingress here for run_traffic to clear its counters
-    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost)
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(tx_port[0]['duthost'])
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(tx_port[1]['duthost'])
 
     tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
     # add ingress DUT into the set
@@ -130,12 +130,14 @@ def run_m2o_oversubscribe_lossless_test(api,
                                                    snappi_extra_params=snappi_extra_params)
 
     dut_tx_port = rx_port['peer_port']
-    dut_rx_port1 = tx_port[0]['peer_port']
-    dut_rx_port2 = tx_port[1]['peer_port']
+    ingress_dut1 = tx_port[0]['duthost']
+    ingress_dut2 = tx_port[1]['duthost']
+    ingress_port1 = tx_port[0]['peer_port']
+    ingress_port2 = tx_port[1]['peer_port']
     # Fetch relevant statistics
     pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
-    rx_pkts_1 = get_interface_stats(ingress_duthost, dut_rx_port1)[ingress_duthost.hostname][dut_rx_port1]['rx_ok']
-    rx_pkts_2 = get_interface_stats(ingress_duthost, dut_rx_port2)[ingress_duthost.hostname][dut_rx_port2]['rx_ok']
+    rx_pkts_1 = get_interface_stats(ingress_dut1, ingress_port1)[ingress_dut1.hostname][ingress_port1]['rx_ok']
+    rx_pkts_2 = get_interface_stats(ingress_dut2, ingress_port2)[ingress_dut2.hostname][ingress_port2]['rx_ok']
     # Calculate the total received packets
     total_rx_pkts = rx_pkts_1 + rx_pkts_2
     # Calculate the drop percentage

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -83,10 +83,10 @@ def run_pfc_m2o_oversubscribe_lossless_lossy_test(api,
 
     tx_port = [snappi_extra_params.multi_dut_params.multi_dut_ports[1],
                snappi_extra_params.multi_dut_params.multi_dut_ports[2]]
-    ingress_duthost = tx_port[0]['duthost']
 
     # Append the ingress here for run_traffic to clear its counters
-    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost)
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(tx_port[0]['duthost'])
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(tx_port[1]['duthost'])
 
     tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
     # add ingress DUT into the set
@@ -134,13 +134,15 @@ def run_pfc_m2o_oversubscribe_lossless_lossy_test(api,
                                                    exp_dur_sec=DATA_FLOW_DURATION_SEC + DATA_FLOW_DELAY_SEC,
                                                    snappi_extra_params=snappi_extra_params)
 
-    dut_rx_port1 = tx_port[0]['peer_port']
-    dut_rx_port2 = tx_port[1]['peer_port']
     dut_tx_port = rx_port['peer_port']
+    ingress_dut1 = tx_port[0]['duthost']
+    ingress_dut2 = tx_port[1]['duthost']
+    ingress_port1 = tx_port[0]['peer_port']
+    ingress_port2 = tx_port[1]['peer_port']
     # Fetch relevant statistics
     pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
-    rx_pkts_1 = get_interface_stats(ingress_duthost, dut_rx_port1)[ingress_duthost.hostname][dut_rx_port1]['rx_ok']
-    rx_pkts_2 = get_interface_stats(ingress_duthost, dut_rx_port2)[ingress_duthost.hostname][dut_rx_port2]['rx_ok']
+    rx_pkts_1 = get_interface_stats(ingress_dut1, ingress_port1)[ingress_dut1.hostname][ingress_port1]['rx_ok']
+    rx_pkts_2 = get_interface_stats(ingress_dut2, ingress_port2)[ingress_dut2.hostname][ingress_port2]['rx_ok']
     # Calculate the total received packets
     total_rx_pkts = rx_pkts_1 + rx_pkts_2
     # Calculate the drop percentage

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossy_helper.py
@@ -81,10 +81,10 @@ def run_pfc_m2o_oversubscribe_lossy_test(api,
 
     tx_port = [snappi_extra_params.multi_dut_params.multi_dut_ports[1],
                snappi_extra_params.multi_dut_params.multi_dut_ports[2]]
-    ingress_duthost = tx_port[0]['duthost']
 
     # Append the ingress here for run_traffic to clear its counters
-    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost)
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(tx_port[0]['duthost'])
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(tx_port[1]['duthost'])
 
     tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
     # add ingress DUT into the set
@@ -136,12 +136,13 @@ def run_pfc_m2o_oversubscribe_lossy_test(api,
                                                    snappi_extra_params=snappi_extra_params)
 
     dut_tx_port = rx_port['peer_port']
-    dut_rx_port1 = tx_port[0]['peer_port']
-    dut_rx_port2 = tx_port[1]['peer_port']
-
+    ingress_dut1 = tx_port[0]['duthost']
+    ingress_dut2 = tx_port[1]['duthost']
+    ingress_port1 = tx_port[0]['peer_port']
+    ingress_port2 = tx_port[1]['peer_port']
     pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
-    rx_pkts_1 = get_interface_stats(ingress_duthost, dut_rx_port1)[ingress_duthost.hostname][dut_rx_port1]['rx_ok']
-    rx_pkts_2 = get_interface_stats(ingress_duthost, dut_rx_port2)[ingress_duthost.hostname][dut_rx_port2]['rx_ok']
+    rx_pkts_1 = get_interface_stats(ingress_dut1, ingress_port1)[ingress_dut1.hostname][ingress_port1]['rx_ok']
+    rx_pkts_2 = get_interface_stats(ingress_dut2, ingress_port2)[ingress_dut2.hostname][ingress_port2]['rx_ok']
     # Calculate the total received packets
     total_rx_pkts = rx_pkts_1 + rx_pkts_2
     # Calculate the drop percentage


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixing dut port mapping when retrieving counter. Otherwise, ingress duthost maybe used to retrieve egress counters.

In Snappi ports, the ingress dut and port maybe different for each port. 
In current code, it uses same ingress dut for both ports.
```
    dut_rx_port1 = tx_port[0]['peer_port']
    dut_rx_port2 = tx_port[1]['peer_port']
    rx_pkts_1 = get_interface_stats(ingress_duthost, dut_rx_port1)[ingress_duthost.hostname][dut_rx_port1]['rx_ok']
    rx_pkts_2 = get_interface_stats(ingress_duthost, dut_rx_port2)[ingress_duthost.hostname][dut_rx_port2]['rx_ok']
```
which results in the counter was retrieved on incorrect dut, and get the following error:

```
FAILED snappi_tests/multidut/pfc/test_lossless_response_to_throttling_pause_storms.py::test_lossless_response_to_throttling_pause_storms[multidut_port_info0]

......
        pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
        rx_pkts_1 = get_interface_stats(ingress_duthost, dut_rx_port1)[ingress_duthost.hostname][dut_rx_port1]['rx_ok']
        rx_pkts_2 = get_interface_stats(ingress_duthost, dut_rx_port2)[ingress_duthost.hostname][dut_rx_port2]['rx_ok']
        # Calculate the total received packets
        total_rx_pkts = rx_pkts_1 + rx_pkts_2
        # Calculate the drop percentage
>       drop_percentage = 100 * pkt_drop / total_rx_pkts
E       ZeroDivisionError: division by zero
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fixing dut port mapping when retrieving counter.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
