### PR TITLE
route_perf: Fix destination mac for multi asic

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -335,11 +335,12 @@ def test_perf_add_remove_routes(
             if ip_versions == 4:
                 ip_dst = generate_ips(1, dst_nw, [])
                 send_and_verify_traffic(
-                    duthost, ptfadapter, tbinfo, ip_dst, ptf_dst_ports, ptf_src_port
+                    asichost, duthost, ptfadapter, tbinfo, ip_dst, ptf_dst_ports, ptf_src_port
                 )
             else:
                 ip_dst = dst_nw.split("/")[0] + "1"
                 send_and_verify_traffic(
+                    asichost,
                     duthost,
                     ptfadapter,
                     tbinfo,
@@ -366,11 +367,11 @@ def test_perf_add_remove_routes(
 
 
 def send_and_verify_traffic(
-    duthost, ptfadapter, tbinfo, ip_dst, expected_ports, ptf_src_port, ipv6=False
+    asichost, duthost, ptfadapter, tbinfo, ip_dst, expected_ports, ptf_src_port, ipv6=False
 ):
     if ipv6:
         pkt = testutils.simple_tcpv6_packet(
-            eth_dst=duthost.facts["router_mac"],
+            eth_dst=asichost.get_router_mac().lower(),
             eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port),
             ipv6_src="2001:db8:85a3::8a2e:370:7334",
             ipv6_dst=ip_dst,
@@ -380,7 +381,7 @@ def send_and_verify_traffic(
         )
     else:
         pkt = testutils.simple_tcp_packet(
-            eth_dst=duthost.facts["router_mac"],
+            eth_dst=asichost.get_router_mac().lower(),
             eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port),
             ip_src="1.1.1.1",
             ip_dst=ip_dst,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
Issue: Packets dropped on DUT due to incorrect destination MAC address.
Fix: Use interface MAC address instead. For multi-asic, use MAC address per ASIC and not eth0 router MAC address.

Summary:
Fixes # (issue)
Use interface MAC address instead. For multi-asic, use MAC address per ASIC and not eth0 router MAC address.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified on T2

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
