### PR TITLE
fix: return all BGP neighbors for config reload

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -215,7 +215,7 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
         time.sleep(wait)
 
     if wait_for_bgp:
-        bgp_neighbors = sonic_host.get_bgp_neighbors_per_asic()
+        bgp_neighbors = sonic_host.get_bgp_neighbors_per_asic(state="all")
         pytest_assert(
             wait_until(wait + 120, 10, 0, sonic_host.check_bgp_session_state_all_asics, bgp_neighbors),
             "Not all bgp sessions are established after config reload",

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -549,7 +549,8 @@ class MultiAsicSonicHost(object):
         Get a diction of BGP neighbor states
 
         Args:
-        state: BGP session state, return neighbor IP of sessions that match this state
+        state: BGP session state, return neighbor IP of sessions that match this state. If state is "all",
+               return all neighbors regardless of state.
         Returns: dictionary {namespace: { (neighbor_ip : info_dict)* }}
 
         """
@@ -557,9 +558,10 @@ class MultiAsicSonicHost(object):
         for asic in self.asics:
             bgp_neigh[asic.namespace] = {}
             bgp_info = asic.bgp_facts()["ansible_facts"]["bgp_neighbors"]
-            for k, v in list(bgp_info.items()):
-                if v["state"] != state:
-                    bgp_info.pop(k)
+            if state != "all":
+                for k, v in list(bgp_info.items()):
+                    if v["state"] != state:
+                        bgp_info.pop(k)
             bgp_neigh[asic.namespace].update(bgp_info)
 
         return bgp_neigh
@@ -598,7 +600,7 @@ class MultiAsicSonicHost(object):
         """
         for asic in self.asics:
             if asic.namespace in bgp_neighbors:
-                neigh_ips = [k.lower() for k, v in list(bgp_neighbors[asic.namespace].items()) if v["state"] == state]
+                neigh_ips = [k.lower() for k, v in list(bgp_neighbors[asic.namespace].items())]
                 if not asic.check_bgp_session_state(neigh_ips, state):
                     return False
         return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) #15630: wait_for_bgp is not working in config_reload

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
`get_bgp_neighbors_per_asic()` only returns BGP neighbors with Established status, so the wait_until always returns directly without any wait.

#### How did you do it?
I fixed the logic and made `get_bgp_neighbors_per_asic()` in `config_reload()` to return all BGP neighbors regardless of their status. Then I fixed the logic in `check_bgp_session_state_all_asics()` to check if all BGP session states are equal to the target state.

#### How did you verify/test it?
I ran the updated code and can confirm it's now checking all BGP neighbors

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
