### PR TITLE
[Marvell] Skip RX_DRP check in test_drop_l3_ip_packet_non_dut_mac

### DIFF
--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -741,7 +741,7 @@ class TestIPPacket(object):
                       "Received {} packets in rx, not in expected range".format(rx_ok))
         asic_type = duthost.facts["asic_type"]
         # Packet is dropped silently on Mellanox platform if the destination MAC address is not the router MAC
-        if asic_type not in ["mellanox"]:
+        if asic_type not in ["mellanox", "marvell"]:
             pytest_assert(rx_drp >= self.PKT_NUM_MIN,
                           "Dropped {} packets in rx, not in expected range".format(rx_drp))
         pytest_assert(tx_ok <= self.PKT_NUM_ZERO,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip RX_DRP check in test_drop_l3_ip_packet_non_dut_mac.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Skip RX_DRP check in test_drop_l3_ip_packet_non_dut_mac, current ASIC behavior can't support RX_DRP counter.

#### How did you do it?
Skip RX_DRP check in test_drop_l3_ip_packet_non_dut_mac,

#### How did you verify/test it?
Verified on Nokia-7215 M0 testbed:
```
ip/test_ip_packet.py::TestIPPacket::test_drop_l3_ip_packet_non_dut_mac[7215-6] PASSED                                                [100%]
===================================================== 1 passed, 1 warning in 442.12s (0:07:22) ======================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
