### PR TITLE
[M0/Mx] Fix test_route_flap

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1875,7 +1875,11 @@ def enum_rand_one_frontend_asic_index(request):
 
 @pytest.fixture(scope='module')
 def enum_upstream_dut_hostname(duthosts, tbinfo):
-    if tbinfo["topo"]["type"] == "t0":
+    if tbinfo["topo"]["type"] == "m0":
+        upstream_nbr_type = "M1"
+    elif tbinfo["topo"]["type"] == "mx":
+        upstream_nbr_type = "M0"
+    elif tbinfo["topo"]["type"] == "t0":
         upstream_nbr_type = "T1"
     elif tbinfo["topo"]["type"] == "t1":
         upstream_nbr_type = "T2"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
PR #14804 caused test_route_flap fail on M0/Mx with below error:
```
>       pytest.fail("Did not find a dut in duthosts that for topo type {} that has upstream nbr type {}".
                    format(tbinfo["topo"]["type"], upstream_nbr_type))
E       Failed: Did not find a dut in duthosts that for topo type m0 that has upstream nbr type T3
```
Creating this PR to fix.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix test_route_flap on M0/Mx topo.

#### How did you do it?
Support upstream neighbor on M0/Mx.

#### How did you verify/test it?
Verified on Nokia-7215 M0.
Verified on Arista-720DT M0.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
