### PR TITLE
Fix dualtor/test_switchover_failure.py

### DIFF
--- a/tests/dualtor/test_switchover_failure.py
+++ b/tests/dualtor/test_switchover_failure.py
@@ -137,6 +137,11 @@ def common_setup_teardown(
 
     rand_selected_dut.shell_cmds(cmds=cmds)
 
+    # If the test was skipped then early exit from teardown
+    if "rep_call" in request.node.__dict__ and request.node.rep_call.skipped or \
+            "rep_setup" in request.node.__dict__ and request.node.rep_setup.skipped:
+        return
+
     # if the test failed, assume linkmgrd/swss are stuck in a bad state and require a restart
     if not hasattr(request.node, "rep_call") or request.node.rep_call.failed:
         logger.warning("Test failed, restarting swss")

--- a/tests/dualtor/test_switchover_failure.py
+++ b/tests/dualtor/test_switchover_failure.py
@@ -138,8 +138,8 @@ def common_setup_teardown(
     rand_selected_dut.shell_cmds(cmds=cmds)
 
     # If the test was skipped then early exit from teardown
-    if "rep_call" in request.node.__dict__ and request.node.rep_call.skipped or \
-            "rep_setup" in request.node.__dict__ and request.node.rep_setup.skipped:
+    if hasattr(request.node, "rep_call") and request.node.rep_call.skipped or \
+            hasattr(request.node, "rep_setup") and request.node.rep_setup.skipped:
         return
 
     # if the test failed, assume linkmgrd/swss are stuck in a bad state and require a restart


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes [#328](https://github.com/aristanetworks/sonic-qual.msft/issues/328)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
dualtor/test_switchover_failure.py failure for active-active dualtor.

```
        if (res.is_failed or 'exception' in res) and not module_ignore_errors:
&gt;           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
E           tests.common.errors.RunAnsibleModuleFail: run module shell failed, Ansible Results =&gt;
E           failed = True
E           changed = True
E           rc = 1
E           cmd = config mux mode standby Ethernet0
E           start = 2024-11-16 00:39:44.410652
E           end = 2024-11-16 00:39:45.124954
E           delta = 0:00:00.714302
E           msg = non-zero return code
E           invocation = {'module_args': {'_raw_params': 'config mux mode standby Ethernet0', '_uses_shell': True, 'warn': False, 'stdin_add_newline': True, 'strip_empty_ends': True, 'argv': None, 'chdir': None, 'executable': None, 'creates': None, 'removes': None, 'stdin': None}}
E           _ansible_no_log = None
E           stdout =
E           this is not a valid port present on mux_cablestderr =

complex_args = {}
filename   = '/data/sonic-mgmt/tests/common/devices/multi_asic.py'
```

We have root caused it to the active-standby testcase that gets skipped. Even if the test gets skipped this condition hits in teradown: https://github.com/sonic-net/sonic-mgmt/blob/master/tests/dualtor/test_switchover_failure.py#L140-L146

Due to swss/mux restart the proceeding testcase fails with the above signature.

#### How did you do it?
Proposed fix is to skip restart of swss and mux if the testcase was skipped.

#### How did you verify/test it?
Stressed dualtor/test_switchover_failure.py with dualtor-aa-56 topology on Arista-7260CX3

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
