### PR TITLE
Fix - bgp-asn-community test for sonic nbrs

### DIFF
--- a/tests/bgp/test_4-byte_asn_community.py
+++ b/tests/bgp/test_4-byte_asn_community.py
@@ -493,7 +493,12 @@ def run_bgp_4_byte_asn_community_sonic(setup):
     output = setup['duthost'].shell("show ip bgp neighbors {} routes".format(setup['neigh_ip_v4']))['stdout']
     assert str(neighbor_4byte_asn) in str(output.split('\n')[9].split()[5])
     output = setup['duthost'].shell("show ipv6 bgp neighbors {} routes".format(setup['neigh_ip_v6'].lower()))['stdout']
-    assert str(neighbor_4byte_asn) in str(output.split('\n')[9].split()[5])
+    # Command output 'show ipv6 bgp neighbors <xxx> routes'  may split into two lines, hence checking both the lines
+    #    Network          Next Hop             Metric LocPrf Weight Path
+    # *> 2064:100::1/128  fe80::4cc2:44ff:feee:73ff
+    #                                                       0 400001 i
+    assert (str(neighbor_4byte_asn) in str(output.split('\n')[9]) or
+            str(neighbor_4byte_asn) in str(output.split('\n')[10]))
 
     output = setup['neighhost'].shell("show ip bgp summary | grep {}".format(setup['dut_ip_v4']))['stdout']
     assert str(dut_4byte_asn) in output.split()[2]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

-  This PR fixes '_test_4_byte_asn_community_' test for sonic neighbors' case.
-  The above test fails when asserting '_neighbor_4byte_asn_' variable for '_show ipv6 neighbors _xxxxx_ routes_' command output.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

- Test '_test_4_byte_asn_community_' fails for sonic neighbors' case when asserting '_neighbor_4byte_asn_' variable for '_show ipv6 neighbors _xxxxx_ routes_' command output with the following error.

```python
	File "/data/tests/bgp/test_4-byte_asn_community.py", line 500, in run_bgp_4_byte_asn_community_sonic
	assert str(neighbor_4byte_asn) in str(output.split('\n')[9].split()[5])
	IndexError: list index out of range
``` 

#### How did you do it?

- Assert neighbor_4byte_asn on the line numbers 9 or 10 from the output of '_show ipv6 neighbors xxxxx routes_' command.
- Because sometimes it may come on line number 10 as shown below,
```shell
BGP table version is 2, local router ID is 8.0.0.2, vrf id 0
\nDefault local pref 100, local AS 400003
\nStatus codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
\n               i internal, r RIB-failure, S Stale, R Removed
\nNexthop codes: @NNN nexthop's vrf id, < announce-nh-self
\nOrigin codes:  i - IGP, e - EGP, ? - incomplete
\nRPKI validation codes: V valid, I invalid, N Not found
\n
\n    Network          Next Hop            Metric LocPrf Weight Path
\n *> 2064:100::1/128  fe80::4cc2:44ff:feee:73ff
\n                                                           0 400001 i
\n
\nDisplayed  1 routes and 2 total paths
``` 

#### How did you verify/test it?

- Ran the above test on T2 duts connected to both sonic and eos neighbors, made sure the tests are working as expected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/user-attachments/assets/80461f68-20df-41b8-8a1f-245ae8c4bbaa)
