### PR TITLE
Fix for inconsistent container autorestart state for multi_asic chassis

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1138,6 +1138,14 @@ def disable_container_autorestart():
         # Dump autorestart state to file
         with open(state_file_name, "w") as f:
             json.dump(container_autorestart_states, f)
+        # For multi-asic duthost make sure the container
+        # autorestart state is same at asic level
+        if duthost.sonichost.is_multi_asic:
+            for container, state in container_autorestart_states.items():
+                if container in feature_list:
+                    for dut_asic, asic in enumerate(duthost.frontend_asics):
+                        duthost.shell("sudo ip netns exec asic{} config feature autorestart {} {}".format(
+                            dut_asic, container, state))
         # Disable autorestart for all containers
         logging.info("Disable container autorestart")
         cmd_disable = "config feature autorestart {} disabled"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1142,7 +1142,7 @@ def disable_container_autorestart():
         # autorestart state is same at asic level
         if duthost.sonichost.is_multi_asic:
             for container, state in container_autorestart_states.items():
-                if container in feature_list:
+                if feature_list and container in feature_list:
                     for dut_asic, asic in enumerate(duthost.frontend_asics):
                         duthost.shell("sudo ip netns exec asic{} config feature autorestart {} {}".format(
                             dut_asic, container, state))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

The disable_container_autorestart func in tests/conftest.py sometimes fails in qos test for multi_asic chassis due to the container inconsistent autorestart state across namespace.
Prior running qos test, few services are stopped and container autorestart feature is disabled. While disabling, if the autorestart state of the feature at asic-level is not in sync with the host level, the test error with 
**Feature 'xxx' auto-restart is not consistent across namespaces**

:~$ show feature autorestart
Feature     AutoRestart
----------  --------------
acms        enabled
**bgp         enabled**
database    always_enabled
dhcp_relay  enabled
lldp        enabled
macsec      enabled
mux         enabled
pmon        enabled
radv        enabled
restapi     enabled
snmp        enabled
swss        enabled
syncd       enabled
teamd       enabled
telemetry   enabled
:~$ sudo ip netns exec asic0 show feature autorestart
Feature     AutoRestart
----------  --------------
acms        enabled
**bgp         disabled**
database    always_enabled
dhcp_relay  enabled
lldp        enabled
macsec      enabled
mux         enabled
pmon        enabled
radv        enabled
restapi     enabled
snmp        enabled
swss        enabled
syncd       enabled
teamd       enabled
telemetry   enabled
:~$ sudo ip netns exec asic1 show feature autorestart
Feature     AutoRestart
----------  --------------
acms        enabled
**bgp         enabled**
database    always_enabled
dhcp_relay  enabled
lldp        enabled
macsec      enabled
mux         enabled
pmon        enabled
radv        enabled
restapi     enabled
snmp        enabled
swss        enabled
syncd       enabled
teamd       enabled
telemetry   enabled
:~$ sudo config feature autorestart bgp  disabled
Feature 'bgp' auto-restart is not consistent across namespaces
Summary:

Fixes # (issue)
Feature 'xxx' auto-restart is not consistent across namespaces
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [x] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
For the multi_asic chassis,
Before disabling the container autorestart, make sure the autorestart state of the selected container is same at asic-level and host level 

#### What is the motivation for this PR?
qos test failures with error "Feature 'xxx' auto-restart is not consistent across namespaces"
#### How did you do it?

#### How did you verify/test it?
Ran qos test suite and verify the results 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
