### PR TITLE
Updating J2C+ qos_yaml for 400G_2k profile

### DIFF
--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -481,7 +481,7 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_trig_egr_drp: 655770
+                    pkts_num_trig_egr_drp: 2179770
                     pkts_num_margin: 100
                 wm_pg_shared_lossless:
                     dscp: 3
@@ -497,7 +497,7 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 655770
+                    pkts_num_trig_egr_drp: 2179770
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -523,7 +523,7 @@ qos_params:
                     ecn: 1
                     queue: 0
                     pkts_num_fill_min: 0
-                    pkts_num_trig_egr_drp: 655770
+                    pkts_num_trig_egr_drp: 2179770
                     cell_size: 4096
                 wm_buf_pool_lossy:
                     dscp: 8

--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -427,6 +427,113 @@ qos_params:
                     pkts_num_trig_egr_drp: 2396745
                     pkts_num_fill_egr_min: 0
                     cell_size: 4096
+            400000_2000m:
+                pkts_num_leak_out: 140
+                internal_hdr_size: 48
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 657523
+                    pkts_num_trig_ingr_drp: 670430
+                    pkts_num_margin: 100
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 657523
+                    pkts_num_trig_ingr_drp: 670430
+                    pkts_num_margin: 100
+                hdrm_pool_size:
+                    dscps: [ 3, 4 ]
+                    ecn: 1
+                    pgs: [ 3, 4 ]
+                    src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
+                    dst_port_id: 18
+                    pgs_num: 18
+                    pkts_num_trig_pfc: 657523
+                    pkts_num_hdrm_full: 622850
+                    pkts_num_hdrm_partial: 622750
+                    margin: 300
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 657523
+                    pkts_num_trig_ingr_drp: 670430
+                    cell_size: 4096
+                    pkts_num_margin: 30
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 657523
+                    pkts_num_dismiss_pfc: 12985
+                    pkts_num_margin: 150
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 657523
+                    pkts_num_dismiss_pfc: 12985
+                    pkts_num_margin: 150
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 655770
+                    pkts_num_margin: 100
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 657523
+                    packet_size: 64
+                    cell_size: 4096
+                    pkts_num_margin: 40
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 655770
+                    packet_size: 64
+                    cell_size: 4096
+                    pkts_num_margin: 40
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 670430
+                    cell_size: 4096
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_pfc: 28160
+                    pkts_num_trig_ingr_drp: 750848
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 4096
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 655770
+                    cell_size: 4096
+                wm_buf_pool_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    queue: 0
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_egr_drp: 2396745
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 4096
             400000_120000m:
                 pkts_num_leak_out: 140
                 internal_hdr_size: 48


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When initially 400G & 100G profiles were added with cable length 12km & 2km, 400G_2km profile was skipped due to no visibility of adding 400G line card to downstream network for t2 topology.
Adding it back again, so that it can be used in future, if 400G line cards used as leafrouters  
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [x] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
If 400G cards used as leafrouters , we need 400G_2k qos profile to run qos test cases
#### How did you do it?
Verified qos test cases with 400G_2k profile and verify the results
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
