### PR TITLE
[T2][Chassis] tsa-tsb: Add additional timer check before checking tsa-tsb service status

### DIFF
--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -130,6 +130,15 @@ def check_tsc_command_error(duthost):
     return False
 
 
+def check_tsa_tsb_service_run_time_diff(service_uptime, configured_service_timer):
+    """
+    @summary: Determine time difference between service runtime and configured value
+    """
+    current_time = datetime.datetime.now()
+    actual_service_timer = (current_time - service_uptime).total_seconds()
+    return int(actual_service_timer) < configured_service_timer
+
+
 def nbrhosts_to_dut(duthost, nbrhosts):
     """
     @summary: Fetch the neighbor hosts' details for duthost
@@ -1102,7 +1111,8 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost,
         suphost.shell('TSB')
 
         for linecard in duthosts.frontend_nodes:
-            if get_tsa_tsb_service_status(linecard, 'running'):
+            if get_tsa_tsb_service_status(linecard, 'running') and \
+                    check_tsa_tsb_service_run_time_diff(service_uptime, tsa_tsb_timer[linecard]):
                 # Verify DUT continues to be in maintenance state if the timer is running.
                 pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(linecard, cmd='TSC no-stats'),
                               "DUT is not in maintenance state when startup_tsa_tsb service is running")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes a corner case w.r.t '_test_user_init_tsb_on_sup_while_service_run_on_dut_' test under '_test_startup_tsa_tsb_service_.py' and adds more check while fetching the '_tsa-tsb_' service status on the line cards after applying '_TSB_' on supervisor card.
- The fix makes sure if the service is '_Active_' running state and the service uptime is not the same as configured time.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

- The test '_test_user_init_tsb_on_sup_while_service_run_on_dut_' fails with the following reason for one of the line card,
```python
            # Issue user initiated TSB on the supervisor
            suphost.shell('TSB')
    
            for linecard in duthosts.frontend_nodes:
                if get_tsa_tsb_service_status(linecard, 'running'):
                    # Verify DUT continues to be in maintenance state if the timer is running.
>                   pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(linecard, cmd='TSC no-stats'),
                                  "DUT is not in maintenance state when startup_tsa_tsb service is running")
E                                 Failed: DUT is not in maintenance state when startup_tsa_tsb service is running
``` 

- This is because when the service status is checked for the second line card after the service run is completed for the first line card, there are chances the following would happen. Service would show as running and runtime also shows the configured time value (_900 seconds = 15 min_) and the 'TSC' command shows the state as **NORMAL** already.

`**"stdout": "     Active: active (running) since Sat 2024-11-16 20:19:21 UTC; 15min ago",**`

```shell
AnsibleModule::shell, args=["sudo systemctl status startup_tsa_tsb.service | grep 'Active'"], kwargs={}
AnsibleModule::shell Result => {"changed": true, "stdout": "     Active: active (running) since Sat 2024-11-16 20:19:21 UTC; 15min ago", "stderr": "", "rc": 0, "cmd": "sudo systemctl status startup_tsa_tsb.service | grep 'Active'", "start": "2024-11-16 20:34:32.082092", "end": "2024-11-16 20:34:32.107746", "delta": "0:00:00.025654", "msg": "", "invocation": {"module_args": {"_raw_params": "sudo systemctl status startup_tsa_tsb.service | grep 'Active'", "_uses_shell": true, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["     Active: active (running) since Sat 2024-11-16 20:19:21 UTC; 15min ago"], "stderr_lines": [], "_ansible_no_log": null, "failed": false}
AnsibleModule::shell, args=["TSC no-stats"], kwargs={}
AnsibleModule::shell Result => {"changed": true, "stdout": "BGP0 : System Mode: Normal\nBGP1 : System Mode: Normal", "stderr": "", "rc": 0, "cmd": "TSC no-stats", "start": "2024-11-16 20:34:33.002669", "end": "2024-11-16 20:34:39.089304", "delta": "0:00:06.086635", "msg": "", "invocation": {"module_args": {"_raw_params": "TSC no-stats", "_uses_shell": true, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["BGP0 : System Mode: Normal", "BGP1 : System Mode: Normal"], "stderr_lines": [], "_ansible_no_log": null, "failed": false}

``` 

Note: only this test case requires this change, other tests won't get into this corner case.
#### How did you do it?

- Add a timer check in addition to the existing check, where service runtime is lesser than the configured timer value.

#### How did you verify/test it?

- Ran the above-mentioned test case on a T2 chassis and made sure the test passed without any issues.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
