### PR TITLE
[gnmi] skip tests which require ports when sup is selected

### DIFF
--- a/tests/gnmi/test_gnmi_configdb.py
+++ b/tests/gnmi/test_gnmi_configdb.py
@@ -69,6 +69,8 @@ def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, ptfhost):
     Toggle interface admin status
     '''
     duthost = duthosts[rand_one_dut_hostname]
+    if duthost.is_supervisor_node():
+        pytest.skip("gnmi test relies on port data not present on supervisor card '%s'" % rand_one_dut_hostname)
     file_name = "port.txt"
     interface = get_first_interface(duthost)
     assert interface is not None, "Invalid interface"
@@ -236,6 +238,8 @@ def test_gnmi_configdb_full_01(duthosts, rand_one_dut_hostname, ptfhost):
     Toggle interface admin status
     '''
     duthost = duthosts[rand_one_dut_hostname]
+    if duthost.is_supervisor_node():
+        pytest.skip("gnmi test relies on port data not present on supervisor card '%s'" % rand_one_dut_hostname)
     interface = get_first_interface(duthost)
     assert interface is not None, "Invalid interface"
 


### PR DESCRIPTION
### Description of PR
Skip runs of `test_gnmi_configdb_incremental_01 ` and `test_gnmi_configdb_full_01 ` where the selected dut to host the gnmi_server is the supervisor.
This is because these tests require port data which isn't present on the supervisor.

Summary:
Fixes #15629 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405