### PR TITLE
[Bugfix] Add missing conditions for extended entries in `qos/test_buffer.py:`

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1353,6 +1353,7 @@ qos/test_buffer.py::test_buffer_model_test:
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['mellanox'] or asic_subtype in ['broadcom-dnx']"
+      - "asic_type in ['cisco-8000'] or 't2' in topo_name"
       - "topo_type in ['m0', 'mx']"
 
 qos/test_buffer_traditional.py:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In #14912, we added conditions for longer matching entries in conditional marks. However, some conditions were missed under the entry `qos/test_buffer.py:`. This PR adds these missing conditions to entries that start with and extend beyond `qos/test_buffer.py:`

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In #14912, we added conditions for longer matching entries in conditional marks. However, some conditions were missed under the entry `qos/test_buffer.py:`. This PR adds these missing conditions to entries that start with and extend beyond `qos/test_buffer.py:`

#### How did you do it?
This PR adds these missing conditions to entries that start with and extend beyond `qos/test_buffer.py:`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
