### PR TITLE
Update vlan_ping_setup method to get correct vm_host_info with correct port index list

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -126,7 +126,6 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo, 
                             portchannel = intf['attachto']
                             for iface in mg_facts['minigraph_portchannels'][portchannel]['members']:
                                 ifaces_list.append(mg_facts['minigraph_ptf_indices'][iface])
-                            break
                 vm_host_info['port_index_list'] = ifaces_list
             break
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

The vlan_ping_setup method was affected by [PR #14225](https://github.com/sonic-net/sonic-mgmt/pull/14225) 
The port index list of vm_host_info would be a null list 
In the end, there is no received ptf port generated, it would lead to case failure

Change-Id: I417229fb411120edb2372933106e87ab96280d0b

Summary:
Fixes # (issue)
The port index list of vm_host_info would be a null list 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The port index list of vm_host_info would be a null list 
#### How did you do it?
Update the fixture vlan_ping_setup
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
