### PR TITLE
[sonic-mgmt][dualtor-aa] Fix fdb/test_fdb_mac_learning.py failures

### DIFF
--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -14,6 +14,7 @@ pytestmark = [
 ]
 logger = logging.getLogger(__name__)
 
+
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
 
@@ -25,6 +26,7 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
             loganalyzer[duthost.hostname].ignore_regex.extend(ignore_errors)
 
     return None
+
 
 class TestFdbMacLearning:
     """
@@ -192,7 +194,7 @@ class TestFdbMacLearning:
         """
         for port in ports:
             res = duthost.show_and_parse(f"show muxcable status {port}")
-            if not res or res[0]['status']!=res[0]['server_status']:
+            if not res or res[0]['status'] != res[0]['server_status']:
                 return False
         return True
 
@@ -232,7 +234,11 @@ class TestFdbMacLearning:
                       .format(target_ports_to_ptf_mapping[0][0]))
 
         # unshut 3 more ports and populate fdb for those ports
-        target_ports = [target_ports_to_ptf_mapping[1][0], target_ports_to_ptf_mapping[2][0], target_ports_to_ptf_mapping[3][0]]
+        target_ports = [
+            target_ports_to_ptf_mapping[1][0],
+            target_ports_to_ptf_mapping[2][0],
+            target_ports_to_ptf_mapping[3][0]
+        ]
         duthost.shell("sudo config interface startup {}-{}".format(target_ports[0], target_ports[2][8:]))
         pytest_assert(wait_until(150, 5, 0, self.check_mux_status_consistency, duthost, target_ports))
         self.dynamic_fdb_oper(duthost, tbinfo, ptfhost, target_ports_to_ptf_mapping[1:])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [dualtor-aa] Fix "fdb/test_fdb_mac_learning.py" failures
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/329

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

Test is currently failing on `dualtor-aa` topologies due to
1) Packet sometimes going to unselected dut (due to active-active topology) and thus lead to mac learning failure.

2) After bringing up interfaces (from shutdown state), there is time.sleep of 30 seconds which seem to be not enough for muxcable status on duthost to become consistent with mux `server_status` (see `SERVER_STATUS` shown as `unknown` below). We need to wait for SERVER_STATUS to match with STATUS field for mac learning to happen.
```~$ show mux status Ethernet0
PORT       STATUS    SERVER_STATUS    HEALTH     HWSTATUS      LAST_SWITCHOVER_TIME
---------  --------  ---------------  ---------  ------------  ----------------------
Ethernet0  active    unknown          unhealthy  inconsistent
```

3) As test is bringing down all the interfaces (including portchannels), `ERR swss#tunnel_packet_handler.py: All portchannels failed to come up within 3 minutes, exiting.` is coming during the test and causing test faiure (as log_analyzer is complaining)

#### How did you do it?
1) Add fixture to setup topo in active-standby mode. This is needed to make sure packets goto selected dut (for mac 
    learning to happen correctly).
2) Introduce logic to wait for mux status to become consistent before sending traffic (instead of relying on time.sleep delay).
3) Ignore "All port channels failed to come up ..." syslog, which seems to be expected as test is bringing down all the 
    portchannels.

#### How did you verify/test it?
Stressed the test on  `Arista-7260CX3-D108C8` platform with `dualtor-aa[-56]` deployed and test is passing.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
