### PR TITLE
Use asichost mac when DUT is multi-asic system

### DIFF
--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -475,13 +475,6 @@ def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
         }.get(x, 10)
     divisor = switch(tbinfo["topo"]["name"])
     route_index = route_nums/divisor
-
-    # Traffic tests are not run if number of routes learnt are less than
-    # 1000 in t2 role, less than 100 in t1 role. log message in that scenario
-    if route_index < 1:
-        logger.info(" No of routes {} in topo {} is less, skipping \
-                test ".format(route_nums, tbinfo["topo"]["name"]))
-
     while loop_times > 0:
         logger.info("Round %s" % loop_times)
         route_index = 1

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -405,7 +405,6 @@ def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
     # in multi-asic scenarios
     if duthost.is_multi_asic:
         dut_mac = asichost.get_router_mac().lower()
-
     vlan_mac = ""
     if is_dualtor(tbinfo):
         # Just let it crash if missing vlan configs on dual-tor
@@ -474,7 +473,6 @@ def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
             't1': 100,
         }.get(x, 10)
     divisor = switch(tbinfo["topo"]["name"])
-    route_index = route_nums/divisor
     while loop_times > 0:
         logger.info("Round %s" % loop_times)
         route_index = 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Changes to support DUT with  Multi-ASIC 
Fixes # (issue)
Packets send to DUT should have ASIC MAC has DMAC instead of DUT MAC. Fixed the same
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
pass all sonic mgmt tests on multi-asic systems
#### How did you do it?
Ran scripts with multi-asic system as DUT and recorded the list
#### How did you verify/test it?
Ran the test_stress_arp.py script with fix and test-case passed
#### Any platform specific information?
if all ASIC in platform share the same MAC as DUT MAC this fix is not needed
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
