### PR TITLE
[FRR Upgrade] Remove deprecated code for bgpStatusCodes/bgpOriginCodes

### DIFF
--- a/ansible/library/bgp_route.py
+++ b/ansible/library/bgp_route.py
@@ -177,7 +177,7 @@ class BgpRoutes(object):
         for k, rt in res['advertisedRoutes'].items():
             entry = dict()
             entry['nexthop'] = rt['nextHop']
-            entry['origin'] = rt['bgpOriginCode']
+            entry['origin'] = rt.get('bgpOriginCode', rt['origin'])  # Use bgpOriginCode if present, else origin
             entry['weigh'] = rt['weight']
             entry['aspath'] = rt['path'].split()
             self.facts['bgp_route_neiadv']["{}/{}".format(


### PR DESCRIPTION
Why I did it
FRR has deprecated the code for bgpStatusCodes/bgpOriginCodes in below checkin. Hence updating the ansible library to handle this change. As FRR is being upgraded to 10.0.1 version.
https://github.com/FRRouting/frr/pull/14981

Signed-off-by: Kishore Kunal <kishore.kunal@broadcom.com>