### PR TITLE
The value of modular_chassis if string, not a bool, should not take it as bool

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -192,7 +192,7 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
         sonic_host.shell(cmd, executable="/bin/bash")
 
     modular_chassis = sonic_host.get_facts().get("modular_chassis")
-    wait = max(wait, 900) if modular_chassis else wait
+    wait = max(wait, 900) if modular_chassis == "True" else wait
 
     if safe_reload:
         # The wait time passed in might not be guaranteed to cover the actual

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -352,7 +352,7 @@ def recover_on_sanity_check_failure(duthosts, failed_results, fanouthosts, local
             action()
 
         is_modular_chassis = duthosts[0].get_facts().get("modular_chassis")
-        if is_modular_chassis:
+        if is_modular_chassis == "True":
             recover_chassis(duthosts)
         else:
             for dut_name, dut_results in list(dut_failed_results.items()):

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -103,7 +103,7 @@ def check_interfaces(duthosts):
 
         networking_uptime = dut.get_networking_uptime().seconds
         timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 0)
-        if dut.get_facts().get("modular_chassis"):
+        if dut.get_facts().get("modular_chassis") == "True":
             timeout = max(timeout, 900)
         interval = 20
         logger.info("networking_uptime=%d seconds, timeout=%d seconds, interval=%d seconds" %
@@ -231,7 +231,7 @@ def check_bgp(duthosts, tbinfo):
             max_timeout = 500
         else:
             max_timeout = SYSTEM_STABILIZE_MAX_TIME - networking_uptime + 480
-        if dut.get_facts().get("modular_chassis"):
+        if dut.get_facts().get("modular_chassis") == "True":
             max_timeout = max(max_timeout, 900)
         timeout = max(max_timeout, 1)
         interval = 20

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -279,6 +279,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     wait_for_startup(duthost, localhost, delay, timeout)
 
     logger.info('waiting for switch {} to initialize'.format(hostname))
+    wait = max(wait, 900) if duthost.get_facts().get("modular_chassis") == "True" else wait
     if safe_reboot:
         # The wait time passed in might not be guaranteed to cover the actual
         # time it takes for containers to come back up. Therefore, add 5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2666,7 +2666,7 @@ def core_dump_and_config_check(duthosts, tbinfo, request,
                                .format(module_name, json.dumps(check_result)))
 
                 is_modular_chassis = duthosts[0].get_facts().get("modular_chassis")
-                if is_modular_chassis:
+                if is_modular_chassis == "True":
                     recover_chassis(duthosts)
                 else:
                     results = parallel_run(__dut_reload, (), {"duts_data": duts_data}, duthosts, timeout=360)


### PR DESCRIPTION
The value of modular_chassis if string, not a bool, should not take it as bool
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix the issue introduced by https://github.com/sonic-net/sonic-mgmt/pull/14368
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
