### PR TITLE
Add fixtures to call dpus on smartswtich directly

### DIFF
--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -165,6 +165,8 @@ function read_yaml
   dut=${line_arr[11]}
   duts=$(python -c "from __future__ import print_function; print(','.join(eval(\"$dut\")))")
   inv_name=${line_arr[12]}
+  # Remove the dpu duts by the keyword 'dpu' in the dut name
+  duts=$(echo $duts | sed "s/,[^,]*dpu[^,]*//g")
 }
 
 function read_file
@@ -283,7 +285,7 @@ function add_topo
 
   cache_files_path_value=$(is_cache_exist)
   if [[ -n $cache_files_path_value ]]; then
-    echo "$testbed_name" > $cache_files_path_value/$dut
+    echo "$testbed_name" > $cache_files_path_value/$duts
   fi
 
   echo Done
@@ -694,7 +696,7 @@ function deploy_topo_with_cache
   fi
 
   read_file ${testbed_name}
-  setup_name=$dut
+  setup_name=$duts
   if [[ "$setup_name" == "" ]]; then
       echo "No such testbed: $testbed_name, exiting..."
       exit


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The mgmt IP of dpus on smartswitch is private IP(169.254.200.0/24), we cannot access it directly out of the switch. To operate dpu like operating switch when impmenting the test case(**dash, platform on dup**), we add two fixtures: **dpuhost and fixture_dpuhosts**. They are same as duthost and fixture_duthosts.
Before the calling the fixtures, we need to do the steps as follows:

1.  Enable the NAT configuation on SmartSwitch by running  sonic-dpu-mgmt-traffic.sh
https://github.com/sonic-net/sonic-buildimage/pull/20635
e.g.

> sonic-dpu-mgmt-traffic.sh inbound -e --dpus all --ports 5021,5022,5023,5024

2.  Add dpu information to ansible/inventory(Notes: the **ansible_ssh_port** should be same as the above config of NAT)
e.g.

> smartswtich-01  ansible_host=10.200.100.2  sonic_version=v2  sonic_hwsku=Mellanox-SN4280-O28 switch_type="switch"....
> smartswtich-01-**dpu-0** ansible_host=10.200.100.2  **ansible_ssh_port=5021** sonic_version=v2  sonic_hwsku=Nvidia-bf3-
> com-dpu switch_type="dpu" ....
> smartswtich-01-**dpu-1** ansible_host=10.200.100.2  **ansible_ssh_port=5022** sonic_version=v2  sonic_hwsku=Nvidia-bf3-
> com-dpu switch_type="dpu" ....
> smartswtich-01-**dpu-2** ansible_host=10.200.100.2  **ansible_ssh_port=5023** sonic_version=v2  sonic_hwsku=Nvidia-bf3-
> com-dpu switch_type="dpu" ....
> smartswtich-01-**dpu-3** ansible_host=10.200.100.2  **ansible_ssh_port=5024** sonic_version=v2  sonic_hwsku=Nvidia-bf3-
> com-dpu switch_type="dpu" ....


3. Add dpu information to ansible/testbed.yaml
e.g.

> - conf-name: smartswtich-01-t1-28-lag
>   group-name: vm-t2
>   topo: t1-28-lag
>   ptf_image_name: docker-ptf-mlnx
>   ptf: ptf-smartswtich-01
>   ptf_ip: 10.200.100.12/24
>   ptf_ipv6:
>   server: server_72
>   vm_base: VM3701
>   dut:
>     - smartswtich-01
>     - smartswtich-01-**dpu-0**
>     - smartswtich-01-**dpu-1**
>     - smartswtich-01-**dpu-2**
>     - smartswtich-01-**dpu-3**
>   comment: smartswitch testbed

4. Add dpu infromation to ansible/lab

> smartswtich-01-dpu-0      ansible_host=10.200.100.2 ansible_ssh_port=5021 ansible_hostv6="fe80::966d:aeff:fe04:1f58" sonic_version=v2 hwsku="Nvidia-bf3-com-dpu" iface_speed=100000  mgmt_subnet_mask_length=22 vm_base=VM0000
> smartswtich-01-dpu-1      ansible_host=10.200.100.2 ansible_ssh_port=5022 ansible_hostv6="fe80::966d:aeff:fe04:1f58" sonic_version=v2 hwsku="Nvidia-bf3-com-dpu" iface_speed=100000  mgmt_subnet_mask_length=22 vm_base=VM0000
> smartswtich-01-dpu-2      ansible_host=10.200.100.2 ansible_ssh_port=5023 ansible_hostv6="fe80::966d:aeff:fe04:1f58" sonic_version=v2 hwsku="Nvidia-bf3-com-dpu" iface_speed=100000  mgmt_subnet_mask_length=22 vm_base=VM0000
> smartswtich-01-dpu-3      ansible_host=10.200.100.2 ansible_ssh_port=5024 ansible_hostv6="fe80::966d:aeff:fe04:1f58" sonic_version=v2 hwsku="Nvidia-bf3-com-dpu" iface_speed=100000  mgmt_subnet_mask_length=22 vm_base=VM0000

So, we can access the dpu directly out of switch such as  "**ssh admin@10.200.100.2 -p 5021**"

Run tests usage:
When runing case only on dpu（For the exsiting tests such as platform, techsupport, we can run them without any case change）:

> python3 -m pytest platform_tests/cli/test_show_platform.py  --testbed smartswitch-01-t1-28-lag  **--host-pattern smartswitch-01-dpu-0**  ....

When running case on smartswitch(NPU) and dpu:

> python3 -m pytest dash/test_dash_privatelink.py   --testbed smartswitch-01-t1-28-lag **--host-pattern smartswitch-01  --dpu-pattern smartswitch-01-dpu-0,smartswitch-01-dpu-1,smartswitch-01-dpu-2,smartswitch-01-dpu-3** .....



Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Add fixtures to operate dup directly out of switch like operating switch

#### How did you do it?
Add fixures :  duthost and fixture_duthosts

#### How did you verify/test it?
run platform case on dpu only and dash case on smartswitch

#### Any platform specific information?
SmartSwtich

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
