### PR TITLE
T2-snappi: Split udp stream to 6 ports for lossy, but only one for lossless.

### DIFF
--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -196,11 +196,16 @@ def run_pfc_test(api,
         snappi_extra_params.traffic_flow_config.pause_flow_config["flow_traffic_type"] = \
             traffic_flow_mode.FIXED_DURATION
 
+    no_of_streams = 1
+    if egress_duthost.fatcs['asic_type'] == "cisco-8000":
+        if not test_flow_is_lossless:
+            no_of_streams = 6
+
     # Generate test flow config
     generate_test_flows(testbed_config=testbed_config,
                         test_flow_prio_list=test_prio_list,
                         prio_dscp_map=prio_dscp_map,
-                        number_of_streams=1 if test_flow_is_lossless else 6,
+                        number_of_streams=no_of_streams,
                         snappi_extra_params=snappi_extra_params)
 
     if snappi_extra_params.gen_background_traffic:

--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -49,6 +49,7 @@ def run_pfc_test(api,
                  bg_prio_list,
                  prio_dscp_map,
                  test_traffic_pause,
+                 test_flow_is_lossless=True,
                  snappi_extra_params=None):
     """
     Run a multidut PFC test
@@ -199,6 +200,7 @@ def run_pfc_test(api,
     generate_test_flows(testbed_config=testbed_config,
                         test_flow_prio_list=test_prio_list,
                         prio_dscp_map=prio_dscp_map,
+                        number_of_streams=1 if test_flow_is_lossless else 6,
                         snappi_extra_params=snappi_extra_params)
 
     if snappi_extra_params.gen_background_traffic:

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -78,6 +78,7 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
                  bg_prio_list=bg_prio_list,
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
+                 test_flow_is_lossless=False,
                  snappi_extra_params=snappi_extra_params)
 
 
@@ -127,6 +128,7 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
                  bg_prio_list=bg_prio_list,
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
+                 test_flow_is_lossless=False,
                  snappi_extra_params=snappi_extra_params)
 
 
@@ -187,6 +189,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
                  bg_prio_list=bg_prio_list,
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
+                 test_flow_is_lossless=False,
                  snappi_extra_params=snappi_extra_params)
 
 
@@ -242,4 +245,5 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
                  bg_prio_list=bg_prio_list,
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
+                 test_flow_is_lossless=False,
                  snappi_extra_params=snappi_extra_params)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test: test_pfc_pause_single_lossy_prio is resulting in flaky results. On inspecting the failed state, we find that the cisco-8000 backplane load-balancing is the cause for flakiness. It needs six streams to have higher chance of traffic being equally distributed in the backplane, and the traffic can be sent without being dropped.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Flakiness of test_pfc_pause_single_lossy_prio test.

#### How did you do it?
Changed to 6 udp streams for lossy traffic.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
