### PR TITLE
Add support for skipping tests on the smartswitch DPU

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -14,6 +14,7 @@ import pytest
 
 from tests.common.testbed import TestbedInfo
 from .issue import check_issues
+from tests.common.utilities import get_duts_from_host_pattern
 
 logger = logging.getLogger(__name__)
 
@@ -157,27 +158,25 @@ def load_dut_basic_facts(inv_name, dut_name):
     return results
 
 
-def get_basic_facts(session):
-    testbed_name = session.config.option.testbed
-
-    testbed_name_cached = session.config.cache.get('TB_NAME', None)
-    basic_facts_cached = session.config.cache.get('BASIC_FACTS', None)
-
-    if testbed_name_cached != testbed_name:
-        # clear chche
-        session.config.cache.set('TB_NAME', None)
-        session.config.cache.set('BASIC_FACTS', None)
-
-        # get basic facts
-        basic_facts = load_basic_facts(session)
-
-        # update cache
-        session.config.cache.set('TB_NAME', testbed_name)
-        session.config.cache.set('BASIC_FACTS', basic_facts)
+def get_dut_name(session):
+    host_pattern = session.config.option.ansible_host_pattern
+    if host_pattern == 'all':
+        testbed_name = session.config.option.testbed
+        testbed_file = session.config.option.testbed_file
+        tbinfo = TestbedInfo(testbed_file).testbed_topo.get(testbed_name, None)
+        dut_name = tbinfo['duts'][0]
     else:
-        if not basic_facts_cached:
-            basic_facts = load_basic_facts(session)
-            session.config.cache.set('BASIC_FACTS', basic_facts)
+        dut_name = get_duts_from_host_pattern(host_pattern)[0]
+    return dut_name
+
+
+def get_basic_facts(session):
+    dut_name = get_dut_name(session)
+    cached_facts_name = f'BASIC_FACTS_{dut_name}'
+    basic_facts_cached = session.config.cache.get(cached_facts_name, None)
+    if not basic_facts_cached:
+        basic_facts = load_basic_facts(dut_name, session)
+        session.config.cache.set(cached_facts_name, basic_facts)
 
 
 def get_http_proxies(inv_name):
@@ -340,12 +339,13 @@ def load_console_facts(inv_name, dut_name):
     return results
 
 
-def load_basic_facts(session):
+def load_basic_facts(dut_name, session):
     """Load some basic facts that can be used in condition statement evaluation.
 
     The facts will be a 1 level dictionary. The dict keys can be used as variables in condition statements evaluation.
 
     Args:
+        dut_name (str): The name of the dut
         session (obj): Pytest session object.
 
     Returns:
@@ -361,8 +361,6 @@ def load_basic_facts(session):
     results['topo_type'] = tbinfo['topo']['type']
     results['topo_name'] = tbinfo['topo']['name']
     results['testbed'] = testbed_name
-
-    dut_name = tbinfo['duts'][0]
     if session.config.option.customize_inventory_file:
         inv_name = session.config.option.customize_inventory_file
     elif 'inv_name' in list(tbinfo.keys()):
@@ -600,7 +598,9 @@ def pytest_collection_modifyitems(session, config, items):
         logger.debug('No mark condition is defined')
         return
 
-    basic_facts = config.cache.get('BASIC_FACTS', None)
+    dut_name = get_dut_name(session)
+    cached_facts_name = f'BASIC_FACTS_{dut_name}'
+    basic_facts = config.cache.get(cached_facts_name, None)
     if not basic_facts:
         logger.debug('No basic facts')
         return

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1386,3 +1386,11 @@ def kill_process_by_pid(duthost, container_name, program_name, program_pid):
 
     logger.info("Program '{}' in container '{}' was stopped successfully"
                 .format(program_name, container_name))
+
+
+def get_duts_from_host_pattern(host_pattern):
+    if ';' in host_pattern:
+        duts = host_pattern.replace('[', '').replace(']', '').split(';')
+    else:
+        duts = host_pattern.split(',')
+    return duts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,7 @@ from tests.common.utilities import get_test_server_host
 from tests.common.utilities import str2bool
 from tests.common.utilities import safe_filename
 from tests.common.utilities import get_dut_current_passwd
+from tests.common.utilities import get_duts_from_host_pattern
 from tests.common.helpers.dut_utils import is_supervisor_node, is_frontend_node
 from tests.common.cache import FactsCache
 from tests.common.config_reload import config_reload
@@ -379,11 +380,8 @@ def get_specified_duts(request):
     host_pattern = request.config.getoption("--host-pattern")
     if host_pattern == 'all':
         return testbed_duts
-
-    if ';' in host_pattern:
-        specified_duts = host_pattern.replace('[', '').replace(']', '').split(';')
     else:
-        specified_duts = host_pattern.split(',')
+        specified_duts = get_duts_from_host_pattern(host_pattern)
 
     if any([dut not in testbed_duts for dut in specified_duts]):
         pytest.fail("One of the specified DUTs {} does not belong to the testbed {}".format(specified_duts, tbname))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to add the support for skipping tests on the smartswitch DPU.
With the change in PR(https://github.com/sonic-net/sonic-mgmt/pull/15695), we are able to run a test directly on a smartswitch DPU. But we need to also be able to skip tests on a DPU based on the conditional marks.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Add support for skipping tests on the smartswitch DPU
#### How did you do it?
There are 2 main changes in this PR:
1. When getting the basic facts of the DUT in the conditional mark plugin, use the dut name in the --host-pattern parameter instead of the first dut defined in the testbed file. By this change, we will be able to get the dpu facts when running the test only on the dpu.
2. Update the cache logic to save the cache with the dut name. So that in a same regression run, we are able to save and get cache for both the switch and the dpu.
#### How did you verify/test it?
Run regression in our internal regression. It works fine.
#### Any platform specific information?
This change is only for the smartswitch testbed, and it will not harm the regular testbeds. 
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
