### PR TITLE
Add timeout for Cisco 8800 snmp

### DIFF
--- a/ansible/library/snmp_facts.py
+++ b/ansible/library/snmp_facts.py
@@ -463,9 +463,10 @@ def main():
         elif current_oid == v.sysLocation:
             results['ansible_syslocation'] = current_val
 
+    # Cisco 8800 has lots of interfacts, add timeout to tolerate the latency
     errorIndication, errorStatus, errorIndex, varTable = cmdGen.nextCmd(
         snmp_auth,
-        cmdgen.UdpTransportTarget((m_args['host'], 161)),
+        cmdgen.UdpTransportTarget((m_args['host'], 161), timeout=m_args['timeout']),
         cmdgen.MibVariable(p.ifIndex,),
         cmdgen.MibVariable(p.ifDescr,),
         cmdgen.MibVariable(p.ifType,),
@@ -890,9 +891,10 @@ def main():
                 ifIndex = int(current_oid.split('.')[12])
                 results['snmp_interfaces'][ifIndex]['lldpRemManAddrOID'] = current_val
 
+    # Cisco 8800 has lots of interfacts, add timeout to tolerate the latency
     errorIndication, errorStatus, errorIndex, varTable = cmdGen.nextCmd(
         snmp_auth,
-        cmdgen.UdpTransportTarget((m_args['host'], 161)),
+        cmdgen.UdpTransportTarget((m_args['host'], 161), timeout=m_args['timeout']),
         cmdgen.MibVariable(p.cpfcIfRequests,),
         cmdgen.MibVariable(p.cpfcIfIndications,),
         cmdgen.MibVariable(p.requestsPerPriority,),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes MSFT ADO 30112399

BY default, the snmp timeout is 1s,
Cisco 8800 has lots of interfacts, this causes the high chance of the timeout of snmp.
Add timeout to tolerate the latency.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix the snmp timeout issues on Cisco 8800 chassis.
#### How did you do it?
Enable timeout for snmp query.
#### How did you verify/test it?
Locally test on physical chassis testbed:
snmp/test_snmp_psu.py::test_snmp_numpsu[x-sup-2] PASSED                                                                                                                                                                            [ 50%]
snmp/test_snmp_psu.py::test_snmp_psu_status[x-sup-2] PASSED                                                                                                                                                                     [100%]
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
