### PR TITLE
[sonic-mgmt] Fix "fdb/test_fdb_mac_move.py" AttributeError failure

### DIFF
--- a/tests/fdb/utils.py
+++ b/tests/fdb/utils.py
@@ -31,10 +31,12 @@ def IntToMac(intMac):
 def get_crm_resources(duthost, resource, status):
     retry_count = 5
     count = 0
-    while len(duthost.get_crm_resources()) == 0 and count < retry_count:
+    while len(duthost.get_crm_resources().get("main_resources")) == 0 and count < retry_count:
         logger.debug("CRM resources not fully populated, retry after 2 seconds: count: {}".format(count))
         time.sleep(2)
         count = count + 1
+    pytest_assert(resource in duthost.get_crm_resources().get("main_resources"),
+                  "{} not populated in CRM resources".format(resource))
     return duthost.get_crm_resources().get("main_resources").get(resource).get(status)
 
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix "fdb/test_fdb_mac_move.py" failure with `AttributeError:  'NoneType' object has no attribute...`
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/330

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Test is relying on duthost method `get_crm_resources` method (parses info from `crm show resources all` output)  to get "fdb_entry" crm resource values. If output is empty for some reason then `duthost.get_crm_resources().get("main_resources")` will be empty and thus lead to `AttributeError: 'NoneType' object has no attribute 'get' during get_crm_resources()` failure if we try to access "fdb_entry" key.

#### How did you do it?
https://github.com/sonic-net/sonic-mgmt/pull/11127 has introduced retry mechanism in case of empty output but condition is incorrect (`len(duthost.get_crm_resources())` will never be 0, as `duthost.get_crm_resources()` will return `{'main_resources': {}, 'acl_resources': [], 'table_resources': []}` if command output is empty). Correcting this PR change to check for "main_resources" fixes the issue.

#### How did you verify/test it?
Stressed the test and failure is not observed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
