### PR TITLE
Fix flaky container_autorestart

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -27,7 +27,6 @@ DHCP_RELAY = "dhcp_relay"
 DHCP_SERVER = "dhcp_server"
 POST_CHECK_INTERVAL_SECS = 1
 POST_CHECK_THRESHOLD_SECS = 360
-POST_CHECK_THRESHOLD_SECS_T2 = 600
 PROGRAM_STATUS = "RUNNING"
 
 
@@ -460,7 +459,7 @@ def postcheck_critical_processes_status(duthost, feature_autorestart_states, up_
             if is_hiting_start_limit(duthost, feature_name):
                 clear_failed_flag_and_restart(duthost, feature_name, feature_name)
 
-    post_check_threshold = POST_CHECK_THRESHOLD_SECS_T2 if duthost.get_facts().get("modular_chassis") \
+    post_check_threshold = get_t2_threshold(up_bgp_neighbors) if duthost.get_facts().get("modular_chassis") \
         else POST_CHECK_THRESHOLD_SECS
 
     critical_proceses = wait_until(
@@ -474,6 +473,16 @@ def postcheck_critical_processes_status(duthost, feature_autorestart_states, up_
     )
 
     return critical_proceses, bgp_check
+
+
+def get_t2_threshold(up_bgp_neighbors):
+    number_of_neighbor = 0
+
+    for asic_neighbor in up_bgp_neighbors:
+        number_of_neighbor += len(asic_neighbor)
+
+    # Allow 1 minute per bgp neighbor to go up
+    return number_of_neighbor * 60
 
 
 def is_process_running(duthost, container_name, program_name):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
tests/autorestart/test_container_autorestart.py is flaky for several nightly while waiting for bgp neighbor to be up. Previously we were modified to increase from 360 seconds to 600 seconds (10 minutes). However on our T2 devices we have up to 15 bgp neighbors. This essentially give less than 1 minute for a neighbor to be up.

This change make sure each neighbor get at least 1 minute


Summary:
Fixes # (issue) 30265202

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?


#### How did you do it?
Fix flaky container restart by allowing up to 1 minute per bgp neighbor

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
