### PR TITLE
Update packet size value of qos sai test

### DIFF
--- a/tests/qos/files/mellanox/special_qos_config.yml
+++ b/tests/qos/files/mellanox/special_qos_config.yml
@@ -5,34 +5,34 @@ qos_params:
         profile:
             pkts_num_leak_out: 1
             xoff_1:
-                packet_size: 600
+                packet_size: 800
             xoff_2:
-                packet_size: 600
+                packet_size: 800
             xoff_3:
-                packet_size: 600
+                packet_size: 800
             xoff_4:
-                packet_size: 600
+                packet_size: 800
             wm_pg_headroom:
-                packet_size: 600
+                packet_size: 800
             wm_q_shared_lossless:
-                packet_size: 600
+                packet_size: 700
             hdrm_pool_size:
-                packet_size: 600
+                packet_size: 800
         xon_1:
-            packet_size: 600
+            packet_size: 800
         xon_2:
-            packet_size: 600
+            packet_size: 800
         xon_3:
-            packet_size: 600
+            packet_size: 800
         xon_4:
-            packet_size: 600
+            packet_size: 800
         lossy_queue_1:
-            packet_size: 600
+            packet_size: 800
         wm_pg_shared_lossless:
-            packet_size: 600
+            packet_size: 800
             pkts_num_margin: 7
         wm_pg_shared_lossy:
-            packet_size: 600
+            packet_size: 800
             pkts_num_margin: 5
         wm_q_shared_lossy:
-            packet_size: 600
+            packet_size: 800


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Due to more shared buffer resource defined in the new hwskus(Mellanox-SN5600-C256S1) 
Update packet size value of qos sai test for spc4 platform

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Qos sai test failure at new hwsku(Mellanox-SN5600-C256S1) 
#### How did you do it?
Update packet size value of qos sai test for spc4 platform
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?
x86_64-nvidia_sn5600-r0
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
