### PR TITLE
[dualtor][test_bgp_session] Skip reboot test type on dualtor

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -4,6 +4,7 @@ import time
 from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_require
 from tests.common.reboot import reboot
 
 logger = logging.getLogger(__name__)
@@ -101,13 +102,19 @@ def verify_bgp_session_down(duthost, bgp_neighbor):
 @pytest.mark.parametrize("failure_type", ["interface", "neighbor"])
 @pytest.mark.disable_loganalyzer
 def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts, localhost,
-                                    nbrhosts, setup, test_type, failure_type):
+                                    nbrhosts, setup, test_type, failure_type, tbinfo):
     '''
     1: check all bgp sessions are up
     2: inject failure, shutdown fanout physical interface or neighbor port or neighbor session
     4: do the test, reset bgp or swss or do the reboot
     5: Verify all bgp sessions are up
     '''
+    # Skip the test on dualtor with reboot test type
+    pytest_require(
+        ("dualtor" not in tbinfo["topo"]["name"] or test_type != "reboot"),
+        "warm reboot is not supported on dualtor"
+    )
+
     duthost = duthosts[rand_one_dut_hostname]
 
     # Skip the test on Virtual Switch due to fanout switch dependency and warm reboot


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Skip the warm reboot test type, as it will leave the DUT in an error state, and causes failures of following cases:
```
bgp/test_bgp_session.py::test_bgp_session_interface_down[interface-bgp_docker] PASSED [ 16%]
bgp/test_bgp_session.py::test_bgp_session_interface_down[interface-swss_docker] PASSED [ 33%]
bgp/test_bgp_session.py::test_bgp_session_interface_down[interface-reboot] FAILED [ 50%]
bgp/test_bgp_session.py::test_bgp_session_interface_down[neighbor-bgp_docker] FAILED [ 66%]
bgp/test_bgp_session.py::test_bgp_session_interface_down[neighbor-swss_docker] FAILED [ 83%]
bgp/test_bgp_session.py::test_bgp_session_interface_down[neighbor-reboot] FAILED [100%]
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
If test type is reboot (warm reboot), skip on dualtor.

#### How did you verify/test it?
```
bgp/test_bgp_session.py::test_bgp_session_interface_down[neighbor-reboot] SKIPPED (warm reboot is not supported on dualtor)                                                                                                                                            [100%]
bgp/test_bgp_session.py::test_bgp_session_interface_down[neighbor-bgp_docker] PASSED                                                                                                                                                                                   [100%]
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
