### PR TITLE
Fix an issue of all lldp entries take some time to be in DB after reboot in scaling setup.

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -89,6 +89,7 @@ def get_show_lldp_table_output(duthost):
     interface_list = [line.split()[0] for line in lines]
     return interface_list
 
+
 # Check if number of LLDP_ENTRY_TABLE keys match given number
 def check_lldp_table_keys(db_instance, num):
     lldp_entry_keys = get_lldp_entry_keys(db_instance)


### PR DESCRIPTION
### Description of PR
It's found in scaling setup (34K BGP routes) test_lldp_entry_table_after_reboot test may fail as lldp table entries in DB and from show are not in sync. Further analysis shows that after reboot, full lldp entries takes longer time to come back into DB. Entries are coming to DB one by one and takes few seconds to have full data there. 

Current test is calling reboot and check all critical services are up and all admin up ports are back to line then will begin lldp entries check. This could be too early as lldp packets are coming in one by one and lldp entries are written to DB one by one. The following few lldp queries could be out of sync in this scenario.

Solution is to take a query of how many lldp entries are in DB before reboot. After reboot will wait to check till all the lldp entries are in DB before further queries.

With this check the test passed on scaling setup.

Summary:
Fixes # (issue)

### Type of change
- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Fix test failure
#### How did you verify/test it?
Run lldp syncd OC tests with the fix. Did not see the issue.
