### PR TITLE
[Chassis][Voq] Ignore iBGP sessions for voq chassis.

### DIFF
--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -61,7 +61,10 @@ def test_bgp_queues(duthosts, enum_frontend_dut_hostname, enum_asic_index, tbinf
         if v['state'] == 'established':
             # For "peer group" if it's internal it will be "INTERNAL_PEER_V4" or "INTERNAL_PEER_V6"
             # If it's external it will be "RH_V4", "RH_V6", "AH_V4", "AH_V6", ...
-            if "INTERNAL" in v["peer group"] and duthost.get_facts().get('modular_chassis'):
+            peer_group = v.get('peer group', None)
+            if duthost.get_facts().get('modular_chassis') and \
+                peer_group in ['VOQ_CHASSIS_V4_PEER', 'VOQ_CHASSIS_V6_PEER',
+                                'INTERNAL_PEER_V4', 'INTERNAL_PEER_V6']:
                 # Skip iBGP neighbors since we only want to verify eBGP
                 continue
             assert (k in arp_dict.keys() or k in ndp_dict.keys())

--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -64,7 +64,7 @@ def test_bgp_queues(duthosts, enum_frontend_dut_hostname, enum_asic_index, tbinf
             peer_group = v.get('peer group', None)
             if duthost.get_facts().get('modular_chassis') and \
                 peer_group in ['VOQ_CHASSIS_V4_PEER', 'VOQ_CHASSIS_V6_PEER',
-                                'INTERNAL_PEER_V4', 'INTERNAL_PEER_V6']:
+                               'INTERNAL_PEER_V4', 'INTERNAL_PEER_V6']:
                 # Skip iBGP neighbors since we only want to verify eBGP
                 continue
             assert (k in arp_dict.keys() or k in ndp_dict.keys())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
The test_bgp_queue  is failing for iBGP sessions because the bgp packets after recirc is not sent on the UC7. The change here is ignore the iBGP sessions for the check the bgp packets. 

#### How did you do it?
Update the test to ignore `VOQ_CHASSIS_V4_PEER` and `VOQ_CHASSIS_V6_PEER`
#### How did you verify/test it?

#### Any platform specific information?
Run test on SONiC Voq chassis 
```
bgp/test_bgp_queue.py::test_bgp_queues[str3-sonic-lc3-1-0] PASSED                                                                                                                                                                   [ 16%]
bgp/test_bgp_queue.py::test_bgp_queues[str3-sonic-lc3-1-1] PASSED                                                                                                                                                                   [ 33%]
bgp/test_bgp_queue.py::test_bgp_queues[str3-sonic-lc4-1-0] PASSED                                                                                                                                                                   [ 50%]
bgp/test_bgp_queue.py::test_bgp_queues[str3-sonic-lc4-1-1] PASSED                                                                                                                                                                   [ 66%]
bgp/test_bgp_queue.py::test_bgp_queues[str3-sonic-lc5-1-0] PASSED                                                                                                                                                    [ 83%]
bgp/test_bgp_queue.py::test_bgp_queues[str3-sonic-lc5-1-1] PASSED 
```
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
