### PR TITLE
Revert "sonic-mgmt: Assert if Arista Hwsku is not found in port_utils"

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -437,9 +437,9 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             # this device simulates 32 ports, with 4 as the step for port naming.
             for i in range(0, 32, 4):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
-        elif "Arista" in hwsku and "FM" not in hwsku:
-            assert False, "Please add hwsku %s to port_alias_to_name_map" % hwsku
         else:
+            if "Arista-7800" in hwsku:
+                assert False, "Please add port_alias_to_name_map for new modular SKU %s." % hwsku
             for i in range(0, 128, 4):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
 


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#15287

Get conn_graph_facts would loop all devices in inventory, once some Arista hwskus not included in the exception elif like Arista-7260CX3 with import error, read dut minigraph would always fail, so need to revert this PR