### PR TITLE
[testbed] announce routes with routes generation switch, aggregate routes and variable ipv6 address pattern

### DIFF
--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -23,15 +23,14 @@
     exabgp_action: start
   when: exabgp_action is not defined
 
-- name: Set facts
-  set_fact:
-    ptf_local_ipv4: "{{ configuration_properties.common.nhipv4|default('10.10.246.254') }}"
-    ptf_local_ipv6: "{{ configuration_properties.common.nhipv6|default('fc0a::ff') }}"
 - block:
   - name: Configure and start exabpg process for IPV4
     when: configuration_properties.common.enable_ipv4_routes_generation | default(True)
     block:
-  
+
+    - set_fact:
+        ptf_local_ipv4: "{{ configuration_properties.common.nhipv4|default('10.10.246.254') }}"
+
     - name: Configure exabgp processes for IPv4 on PTF
       exabgp:
         name: "{{ vm_item.key }}"
@@ -79,7 +78,10 @@
   - name: Configure and start exabpg process for IPV6
     when: configuration_properties.common.enable_ipv6_routes_generation | default(True)
     block:
-  
+
+    - set_fact:
+        ptf_local_ipv6: "{{ configuration_properties.common.nhipv6|default('fc0a::ff') }}"
+
     - name: configure exabgp processes for IPv6 on PTF
       exabgp:
         name: "{{ vm_item.key }}-v6"

--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -28,9 +28,6 @@
     ptf_local_ipv4: "{{ configuration_properties.common.nhipv4|default('10.10.246.254') }}"
     ptf_local_ipv6: "{{ configuration_properties.common.nhipv6|default('fc0a::ff') }}"
 
--  set_fact:
-    topo_vms: "{{ topology['VMs'] | get_vms_by_dut_interfaces(dut_interfaces | default('')) }}"
-
 - name: Configure and start exabpg process for IPV4
   when: configuration_properties.common.enable_ipv4_routes_generation | default(True)
   block:
@@ -62,7 +59,7 @@
     delegate_to: "{{ ptf_host }}"
 
   - name: Add exabgpv4 supervisor config and start related processes
-    when: "{{ topo_vms | length > 0 }}"
+    when: "{{ topology['VMs'] | length > 0 }}"
     supervisorctl:
       name: "exabgpv4:"
       state: present  # present contains `supervisorctl reread` and `supervisorctl add`
@@ -71,10 +68,10 @@
   - name: Verify that exabgp processes for IPv4 are started
     wait_for:
       host: "{{ ptf_host_ip }}"
-      port: "{{ 5000 + topo_vms[vm_item.key].vm_offset|int }}"
+      port: "{{ 5000 + topology['VMs'][vm_item.key].vm_offset|int }}"
       state: "started"
       timeout: 180
-    loop: "{{ topo_vms|dict2items }}"
+    loop: "{{ topology['VMs']|dict2items }}"
     loop_control:
       loop_var: vm_item
     delegate_to: localhost

--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -23,11 +23,17 @@
     exabgp_action: start
   when: exabgp_action is not defined
 
-- block:
-  - name: Set facts
-    set_fact:
-      ptf_local_ipv4: "{{ configuration_properties.common.nhipv4|default('10.10.246.254') }}"
-      ptf_local_ipv6: "{{ configuration_properties.common.nhipv6|default('fc0a::ff') }}"
+- name: Set facts
+  set_fact:
+    ptf_local_ipv4: "{{ configuration_properties.common.nhipv4|default('10.10.246.254') }}"
+    ptf_local_ipv6: "{{ configuration_properties.common.nhipv6|default('fc0a::ff') }}"
+
+-  set_fact:
+    topo_vms: "{{ topology['VMs'] | get_vms_by_dut_interfaces(dut_interfaces | default('')) }}"
+
+- name: Configure and start exabpg process for IPV4
+  when: configuration_properties.common.enable_ipv4_routes_generation | default(True)
+  block:
 
   - name: Configure exabgp processes for IPv4 on PTF
     exabgp:
@@ -55,6 +61,28 @@
       dest: "/etc/supervisor/conf.d/exabgpv4.conf"
     delegate_to: "{{ ptf_host }}"
 
+  - name: Add exabgpv4 supervisor config and start related processes
+    when: "{{ topo_vms | length > 0 }}"
+    supervisorctl:
+      name: "exabgpv4:"
+      state: present  # present contains `supervisorctl reread` and `supervisorctl add`
+    delegate_to: "{{ ptf_host }}"
+
+  - name: Verify that exabgp processes for IPv4 are started
+    wait_for:
+      host: "{{ ptf_host_ip }}"
+      port: "{{ 5000 + topo_vms[vm_item.key].vm_offset|int }}"
+      state: "started"
+      timeout: 180
+    loop: "{{ topo_vms|dict2items }}"
+    loop_control:
+      loop_var: vm_item
+    delegate_to: localhost
+
+- name: Configure and start exabpg process for IPV6
+  when: configuration_properties.common.enable_ipv6_routes_generation | default(True)
+  block:
+
   - name: configure exabgp processes for IPv6 on PTF
     exabgp:
       name: "{{ vm_item.key }}-v6"
@@ -81,30 +109,12 @@
       dest: "/etc/supervisor/conf.d/exabgpv6.conf"
     delegate_to: "{{ ptf_host }}"
 
-  - name: Add exabgpv4 supervisor config and start related processes
-    when: "{{ topology['VMs'] | length > 0 }}"
-    supervisorctl:
-      name: "exabgpv4:"
-      state: present  # present contains `supervisorctl reread` and `supervisorctl add`
-    delegate_to: "{{ ptf_host }}"
-
   - name: Add exabgpv6 supervisor config and start related processes
     when: "{{ topology['VMs'] | length > 0 }}"
     supervisorctl:
       name: "exabgpv6:"
       state: present  # present contains `supervisorctl reread` and `supervisorctl add`
     delegate_to: "{{ ptf_host }}"
-
-  - name: Verify that exabgp processes for IPv4 are started
-    wait_for:
-      host: "{{ ptf_host_ip }}"
-      port: "{{ 5000 + topology.VMs[vm_item.key].vm_offset|int }}"
-      state: "started"
-      timeout: 180
-    loop: "{{ topology['VMs']|dict2items }}"
-    loop_control:
-      loop_var: vm_item
-    delegate_to: localhost
 
   - name: Verify that exabgp processes for IPv6 are started
     wait_for:
@@ -117,9 +127,10 @@
       loop_var: vm_item
     delegate_to: localhost
 
-  - name: Announce routes
-    announce_routes:
-      topo_name: "{{ topo }}"
-      ptf_ip: "{{ ptf_host_ip }}"
-    delegate_to: localhost
+- name: Announce routes
+  announce_routes:
+    topo_name: "{{ topo }}"
+    ptf_ip: "{{ ptf_host_ip }}"
+    dut_interfaces: "{{ dut_interfaces | default('') }}"
+  delegate_to: localhost
   when: exabgp_action == 'start'

--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -27,106 +27,106 @@
   set_fact:
     ptf_local_ipv4: "{{ configuration_properties.common.nhipv4|default('10.10.246.254') }}"
     ptf_local_ipv6: "{{ configuration_properties.common.nhipv6|default('fc0a::ff') }}"
-
-- name: Configure and start exabpg process for IPV4
-  when: configuration_properties.common.enable_ipv4_routes_generation | default(True)
-  block:
-
-  - name: Configure exabgp processes for IPv4 on PTF
-    exabgp:
-      name: "{{ vm_item.key }}"
-      state: "configure"
-      router_id: "{{ ptf_local_ipv4 }}"
-      local_ip: "{{ ptf_local_ipv4 }}"
-      peer_ip: "{{ configuration[vm_item.key].bp_interface.ipv4.split('/')[0] }}"
-      local_asn: "{{ configuration[vm_item.key].bgp.asn }}"
-      peer_asn: "{{ configuration[vm_item.key].bgp.asn }}"
-      port: "{{ 5000 + vm_item.value.vm_offset|int }}"
-    loop: "{{ topology['VMs']|dict2items }}"
-    loop_control:
-      loop_var: vm_item
-    delegate_to: "{{ ptf_host }}"
-
-  - name: Gather exabgp v4 programs
-    set_fact:
-      program_group_name: "exabgpv4"
-      program_group_programs: "{{ topology['VMs'].keys() | map('regex_replace', '^(.*)$', 'exabgp-\\1') | join(',')}}"
-
-  - name: Configure exabgpv4 group
-    template:
-      src: "roles/vm_set/templates/exabgp.conf.j2"
-      dest: "/etc/supervisor/conf.d/exabgpv4.conf"
-    delegate_to: "{{ ptf_host }}"
-
-  - name: Add exabgpv4 supervisor config and start related processes
-    when: "{{ topology['VMs'] | length > 0 }}"
-    supervisorctl:
-      name: "exabgpv4:"
-      state: present  # present contains `supervisorctl reread` and `supervisorctl add`
-    delegate_to: "{{ ptf_host }}"
-
-  - name: Verify that exabgp processes for IPv4 are started
-    wait_for:
-      host: "{{ ptf_host_ip }}"
-      port: "{{ 5000 + topology['VMs'][vm_item.key].vm_offset|int }}"
-      state: "started"
-      timeout: 180
-    loop: "{{ topology['VMs']|dict2items }}"
-    loop_control:
-      loop_var: vm_item
+- block:
+  - name: Configure and start exabpg process for IPV4
+    when: configuration_properties.common.enable_ipv4_routes_generation | default(True)
+    block:
+  
+    - name: Configure exabgp processes for IPv4 on PTF
+      exabgp:
+        name: "{{ vm_item.key }}"
+        state: "configure"
+        router_id: "{{ ptf_local_ipv4 }}"
+        local_ip: "{{ ptf_local_ipv4 }}"
+        peer_ip: "{{ configuration[vm_item.key].bp_interface.ipv4.split('/')[0] }}"
+        local_asn: "{{ configuration[vm_item.key].bgp.asn }}"
+        peer_asn: "{{ configuration[vm_item.key].bgp.asn }}"
+        port: "{{ 5000 + vm_item.value.vm_offset|int }}"
+      loop: "{{ topology['VMs']|dict2items }}"
+      loop_control:
+        loop_var: vm_item
+      delegate_to: "{{ ptf_host }}"
+  
+    - name: Gather exabgp v4 programs
+      set_fact:
+        program_group_name: "exabgpv4"
+        program_group_programs: "{{ topology['VMs'].keys() | map('regex_replace', '^(.*)$', 'exabgp-\\1') | join(',')}}"
+  
+    - name: Configure exabgpv4 group
+      template:
+        src: "roles/vm_set/templates/exabgp.conf.j2"
+        dest: "/etc/supervisor/conf.d/exabgpv4.conf"
+      delegate_to: "{{ ptf_host }}"
+  
+    - name: Add exabgpv4 supervisor config and start related processes
+      when: "{{ topology['VMs'] | length > 0 }}"
+      supervisorctl:
+        name: "exabgpv4:"
+        state: present  # present contains `supervisorctl reread` and `supervisorctl add`
+      delegate_to: "{{ ptf_host }}"
+  
+    - name: Verify that exabgp processes for IPv4 are started
+      wait_for:
+        host: "{{ ptf_host_ip }}"
+        port: "{{ 5000 + topology['VMs'][vm_item.key].vm_offset|int }}"
+        state: "started"
+        timeout: 180
+      loop: "{{ topology['VMs']|dict2items }}"
+      loop_control:
+        loop_var: vm_item
+      delegate_to: localhost
+  
+  - name: Configure and start exabpg process for IPV6
+    when: configuration_properties.common.enable_ipv6_routes_generation | default(True)
+    block:
+  
+    - name: configure exabgp processes for IPv6 on PTF
+      exabgp:
+        name: "{{ vm_item.key }}-v6"
+        state: "configure"
+        router_id: "{{ ptf_local_ipv4 }}"
+        local_ip: "{{ ptf_local_ipv6 }}"
+        peer_ip: "{{ configuration[vm_item.key].bp_interface.ipv6.split('/')[0] }}"
+        local_asn: "{{ configuration[vm_item.key].bgp.asn }}"
+        peer_asn: "{{ configuration[vm_item.key].bgp.asn }}"
+        port: "{{ 6000 + vm_item.value.vm_offset|int }}"
+      loop: "{{ topology['VMs']|dict2items }}"
+      loop_control:
+        loop_var: vm_item
+      delegate_to: "{{ ptf_host }}"
+  
+    - name: Gather exabgp v6 programs
+      set_fact:
+        program_group_name: "exabgpv6"
+        program_group_programs: "{{ topology['VMs'].keys() | map('regex_replace', '^(.*)$', 'exabgp-\\1-v6') | join(',')}}"
+  
+    - name: Configure exabgpv6 group
+      template:
+        src: "roles/vm_set/templates/exabgp.conf.j2"
+        dest: "/etc/supervisor/conf.d/exabgpv6.conf"
+      delegate_to: "{{ ptf_host }}"
+  
+    - name: Add exabgpv6 supervisor config and start related processes
+      when: "{{ topology['VMs'] | length > 0 }}"
+      supervisorctl:
+        name: "exabgpv6:"
+        state: present  # present contains `supervisorctl reread` and `supervisorctl add`
+      delegate_to: "{{ ptf_host }}"
+  
+    - name: Verify that exabgp processes for IPv6 are started
+      wait_for:
+        host: "{{ ptf_host_ip }}"
+        port: "{{ 6000 + topology.VMs[vm_item.key].vm_offset|int }}"
+        state: "started"
+        timeout: 180
+      loop: "{{ topology['VMs']|dict2items }}"
+      loop_control:
+        loop_var: vm_item
+      delegate_to: localhost
+  
+  - name: Announce routes
+    announce_routes:
+      topo_name: "{{ topo }}"
+      ptf_ip: "{{ ptf_host_ip }}"
     delegate_to: localhost
-
-- name: Configure and start exabpg process for IPV6
-  when: configuration_properties.common.enable_ipv6_routes_generation | default(True)
-  block:
-
-  - name: configure exabgp processes for IPv6 on PTF
-    exabgp:
-      name: "{{ vm_item.key }}-v6"
-      state: "configure"
-      router_id: "{{ ptf_local_ipv4 }}"
-      local_ip: "{{ ptf_local_ipv6 }}"
-      peer_ip: "{{ configuration[vm_item.key].bp_interface.ipv6.split('/')[0] }}"
-      local_asn: "{{ configuration[vm_item.key].bgp.asn }}"
-      peer_asn: "{{ configuration[vm_item.key].bgp.asn }}"
-      port: "{{ 6000 + vm_item.value.vm_offset|int }}"
-    loop: "{{ topology['VMs']|dict2items }}"
-    loop_control:
-      loop_var: vm_item
-    delegate_to: "{{ ptf_host }}"
-
-  - name: Gather exabgp v6 programs
-    set_fact:
-      program_group_name: "exabgpv6"
-      program_group_programs: "{{ topology['VMs'].keys() | map('regex_replace', '^(.*)$', 'exabgp-\\1-v6') | join(',')}}"
-
-  - name: Configure exabgpv6 group
-    template:
-      src: "roles/vm_set/templates/exabgp.conf.j2"
-      dest: "/etc/supervisor/conf.d/exabgpv6.conf"
-    delegate_to: "{{ ptf_host }}"
-
-  - name: Add exabgpv6 supervisor config and start related processes
-    when: "{{ topology['VMs'] | length > 0 }}"
-    supervisorctl:
-      name: "exabgpv6:"
-      state: present  # present contains `supervisorctl reread` and `supervisorctl add`
-    delegate_to: "{{ ptf_host }}"
-
-  - name: Verify that exabgp processes for IPv6 are started
-    wait_for:
-      host: "{{ ptf_host_ip }}"
-      port: "{{ 6000 + topology.VMs[vm_item.key].vm_offset|int }}"
-      state: "started"
-      timeout: 180
-    loop: "{{ topology['VMs']|dict2items }}"
-    loop_control:
-      loop_var: vm_item
-    delegate_to: localhost
-
-- name: Announce routes
-  announce_routes:
-    topo_name: "{{ topo }}"
-    ptf_ip: "{{ ptf_host_ip }}"
-  delegate_to: localhost
   when: exabgp_action == 'start'

--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -45,25 +45,25 @@
       loop_control:
         loop_var: vm_item
       delegate_to: "{{ ptf_host }}"
-  
+
     - name: Gather exabgp v4 programs
       set_fact:
         program_group_name: "exabgpv4"
         program_group_programs: "{{ topology['VMs'].keys() | map('regex_replace', '^(.*)$', 'exabgp-\\1') | join(',')}}"
-  
+
     - name: Configure exabgpv4 group
       template:
         src: "roles/vm_set/templates/exabgp.conf.j2"
         dest: "/etc/supervisor/conf.d/exabgpv4.conf"
       delegate_to: "{{ ptf_host }}"
-  
+
     - name: Add exabgpv4 supervisor config and start related processes
       when: "{{ topology['VMs'] | length > 0 }}"
       supervisorctl:
         name: "exabgpv4:"
         state: present  # present contains `supervisorctl reread` and `supervisorctl add`
       delegate_to: "{{ ptf_host }}"
-  
+
     - name: Verify that exabgp processes for IPv4 are started
       wait_for:
         host: "{{ ptf_host_ip }}"
@@ -74,7 +74,7 @@
       loop_control:
         loop_var: vm_item
       delegate_to: localhost
-  
+
   - name: Configure and start exabpg process for IPV6
     when: configuration_properties.common.enable_ipv6_routes_generation | default(True)
     block:
@@ -96,25 +96,25 @@
       loop_control:
         loop_var: vm_item
       delegate_to: "{{ ptf_host }}"
-  
+
     - name: Gather exabgp v6 programs
       set_fact:
         program_group_name: "exabgpv6"
         program_group_programs: "{{ topology['VMs'].keys() | map('regex_replace', '^(.*)$', 'exabgp-\\1-v6') | join(',')}}"
-  
+
     - name: Configure exabgpv6 group
       template:
         src: "roles/vm_set/templates/exabgp.conf.j2"
         dest: "/etc/supervisor/conf.d/exabgpv6.conf"
       delegate_to: "{{ ptf_host }}"
-  
+
     - name: Add exabgpv6 supervisor config and start related processes
       when: "{{ topology['VMs'] | length > 0 }}"
       supervisorctl:
         name: "exabgpv6:"
         state: present  # present contains `supervisorctl reread` and `supervisorctl add`
       delegate_to: "{{ ptf_host }}"
-  
+
     - name: Verify that exabgp processes for IPv6 are started
       wait_for:
         host: "{{ ptf_host_ip }}"
@@ -125,7 +125,7 @@
       loop_control:
         loop_var: vm_item
       delegate_to: localhost
-  
+
   - name: Announce routes
     announce_routes:
       topo_name: "{{ topo }}"

--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -128,6 +128,5 @@
   announce_routes:
     topo_name: "{{ topo }}"
     ptf_ip: "{{ ptf_host_ip }}"
-    dut_interfaces: "{{ dut_interfaces | default('') }}"
   delegate_to: localhost
   when: exabgp_action == 'start'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In this PR, we added new features to make announce routes script more powerful.
1. Variable ipv6 address pattern, previously, we are hardcoding ipv6 prefix with pattern 20%02X:%02X%02X:0:%02X::/64, now, it can be set in script or topology file.
2. Selectable exabgp setting up and routes generation. now we can add flag in topology file to enable ipv4 or ipv6, or disable ipv4 or ipv6.
3. Aggregated routes on peers. At the VM definition in topology file, we now support define aggregate route on the VM.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
To make route announcement more powerful.
#### How did you do it?
Add routes generation switch, aggregate routes and variable ipv6 address pattern
#### How did you verify/test it?
Verified on 7215 testbed with t0 and t1 topologies.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
