### PR TITLE
MIGSMSFT-765 & MIGSMSFT-778 Sequential udp ports for different priorities

### DIFF
--- a/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -1,5 +1,4 @@
 import logging                                                                          # noqa: F401
-import random
 from math import ceil
 from tests.common.helpers.assertions import pytest_assert, pytest_require               # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts  # noqa: F401
@@ -322,10 +321,6 @@ def __gen_data_flow(testbed_config,
     flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
     eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-    src_port = random.randint(5000, 6000)
-    udp.src_port.increment.start = src_port
-    udp.src_port.increment.step = 1
-    udp.src_port.increment.count = 1
 
     eth.src.value = tx_mac
     eth.dst.value = rx_mac
@@ -344,6 +339,11 @@ def __gen_data_flow(testbed_config,
             eth.pfc_queue.value = pfcQueueValueDict[flow_prio[0]]
         elif 'Test Flow 2 -> 0' in flow.name:
             eth.pfc_queue.value = pfcQueueValueDict[flow_prio[1]]
+
+    src_port = 5000 + eth.pfc_queue.value * 1000
+    udp.src_port.increment.start = src_port
+    udp.src_port.increment.step = 1
+    udp.src_port.increment.count = 1
 
     ipv4.src.value = tx_port_config.ip
     ipv4.dst.value = rx_port_config.ip

--- a/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -21,6 +21,7 @@ DATA_PKT_SIZE = 1024
 DATA_FLOW_DURATION_SEC = 10
 DATA_FLOW_DELAY_SEC = 5
 SNAPPI_POLL_DELAY_SEC = 2
+UDP_PORT_START = 5000
 
 
 def run_m2o_fluctuating_lossless_test(api,
@@ -340,7 +341,7 @@ def __gen_data_flow(testbed_config,
         elif 'Test Flow 2 -> 0' in flow.name:
             eth.pfc_queue.value = pfcQueueValueDict[flow_prio[1]]
 
-    src_port = 5000 + eth.pfc_queue.value * 1000
+    src_port = UDP_PORT_START + eth.pfc_queue.value
     udp.src_port.increment.start = src_port
     udp.src_port.increment.step = 1
     udp.src_port.increment.count = 1

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_runtime_traffic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_runtime_traffic_helper.py
@@ -1,6 +1,5 @@
 import time
 import logging
-import random
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id          # noqa: F401
@@ -146,10 +145,6 @@ def __gen_traffic(testbed_config,
         data_flow.tx_rx.port.rx_name = rx_port_name
 
         eth, ipv4, udp = data_flow.packet.ethernet().ipv4().udp()
-        src_port = random.randint(5000, 6000)
-        udp.src_port.increment.start = src_port
-        udp.src_port.increment.step = 1
-        udp.src_port.increment.count = 1
 
         eth.src.value = tx_mac
         eth.dst.value = rx_mac
@@ -157,6 +152,11 @@ def __gen_traffic(testbed_config,
             eth.pfc_queue.value = prio
         else:
             eth.pfc_queue.value = pfcQueueValueDict[prio]
+
+        src_port = 5000 + eth.pfc_queue.value * 1000
+        udp.src_port.increment.start = src_port
+        udp.src_port.increment.step = 1
+        udp.src_port.increment.count = 1
 
         ipv4.src.value = tx_port_config.ip
         ipv4.dst.value = rx_port_config.ip

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_runtime_traffic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_runtime_traffic_helper.py
@@ -15,6 +15,7 @@ DATA_FLOW_DURATION_SEC = 15
 PFCWD_START_DELAY_SEC = 3
 SNAPPI_POLL_DELAY_SEC = 2
 TOLERANCE_THRESHOLD = 0.05
+UDP_PORT_START = 5000
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +154,7 @@ def __gen_traffic(testbed_config,
         else:
             eth.pfc_queue.value = pfcQueueValueDict[prio]
 
-        src_port = 5000 + eth.pfc_queue.value * 1000
+        src_port = UDP_PORT_START + eth.pfc_queue.value
         udp.src_port.increment.start = src_port
         udp.src_port.increment.step = 1
         udp.src_port.increment.count = 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://migsonic.atlassian.net/browse/MIGSMSFT-765
https://migsonic.atlassian.net/browse/MIGSMSFT-778

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fixed udp ports selection, make test result stable.

#### How did you do it?
Remove random.

#### How did you verify/test it?
Verified it on T2 ixia testbed.
```
=============================================================== PASSES ================================================================
_________________________________________ test_m2o_fluctuating_lossless[multidut_port_info0] __________________________________________
----------------------- generated xml file: /run_logs/ixia/18470/2024-11-27-01-04-55/tr_2024-11-27-01-04-55.xml -----------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------- live log sessionfinish --------------------------------------------------------
01:14:00 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
======================================================= short test summary info =======================================================
PASSED snappi_tests/multidut/pfc/test_m2o_fluctuating_lossless.py::test_m2o_fluctuating_lossless[multidut_port_info0]
============================================== 1 passed, 4 warnings in 542.83s (0:09:02) ==============================================
sonic@snappi-sonic-mgmt-vanilla-202405-t2:/data/tests$ 

=============================================================== PASSES ================================================================
___________________________________________ test_pfcwd_runtime_traffic[multidut_port_info0] ___________________________________________
----------------------- generated xml file: /run_logs/ixia/18470/2024-11-27-01-19-10/tr_2024-11-27-01-19-10.xml -----------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------- live log sessionfinish --------------------------------------------------------
01:28:10 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
======================================================= short test summary info =======================================================
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_runtime_traffic_with_snappi.py::test_pfcwd_runtime_traffic[multidut_port_info0]
============================================== 1 passed, 4 warnings in 538.55s (0:08:58) ==============================================
sonic@snappi-sonic-mgmt-vanilla-202405-t2:/data/tests$ 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
