### PR TITLE
Some of the Line cards does not support speed change during runtime

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1057,6 +1057,12 @@ iface_namingmode/test_iface_namingmode.py::TestConfigInterface:
     conditions:
       - "platform in ['x86_64-8111_32eh_o-r0']"
 
+iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_speed:
+  skip:
+    reason: "Cisco-88-LC0-36FH-M-O36 & Cisco-88-LC0-36FH-O36 does not support speed change during runtime"
+    conditions:
+      - "hwsku in ['Cisco-88-LC0-36FH-M-O36','Cisco-88-LC0-36FH-O36']"
+
 iface_namingmode/test_iface_namingmode.py::TestShowPriorityGroup:
   xfail:
     reason: "Platform specific issue"


### PR DESCRIPTION
### Description of PR

Cisco-88-LC0-36FH-M-O36 & Cisco-88-LC0-36FH-O36 does not support speed change during runtime

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Test case errors out due to LA error stating that the operation is unsupported

#### How did you do it?
Skipping the test, since it is not supported on the two HWSKU

#### How did you verify/test it?
On Cisco Chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
