### PR TITLE
Adding support to get safe_reload and check_intf_up_ports

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -254,6 +254,8 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
             # get 'wait' and 'timeout' from inventory if they are specified, otherwise use current values
             wait = plt_reboot_ctrl.get('wait', wait)
             timeout = plt_reboot_ctrl.get('timeout', timeout)
+            safe_reboot = plt_reboot_ctrl.get('safe_reboot', safe_reboot)
+            check_intf_up_ports = plt_reboot_ctrl.get('check_intf_up_ports', check_intf_up_ports)
         if warmboot_finalizer_timeout == 0 and 'warmboot_finalizer_timeout' in reboot_ctrl:
             warmboot_finalizer_timeout = reboot_ctrl['warmboot_finalizer_timeout']
         if duthost.get_facts().get("modular_chassis") and safe_reboot:


### PR DESCRIPTION
### Description of PR
We had support for time and wait in plt_reboot_dict, Adding support to fetch safe reload and check_intf_up_status. With these parameters we can provide knobs in lab file for which tests vendors want to check critical process status and interface status. This will be particular to their profile and devices, instead of being global to all

For e.g.

plt_reboot_dict:
        cold:
          timeout: 450
          wait: 360
          safe_reboot: True
          check_intf_up_ports: True
        watchdog:
          timeout: 300
          wait: 360
          safe_reboot: True
          check_intf_up_ports: True
        acl/test_acl.py::TestAclWithReboot:
          timeout: 300
          wait: 600
          safe_reboot: True
          check_intf_up_ports: True
        platform_tests/test_reload_config.py::test_reload_configuration_checks:
          timeout: 300
          wait: 60
        platform_tests/test_kdump.py::TestKernelPanic::test_kernel_panic:
          timeout: 300
          wait: 360
          safe_reboot: True
          check_intf_up_ports: True

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
In some testcases we want to have a provision to check container  status and interface status after a reboot.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
