### PR TITLE
Move stable onboarding t1 tests to PR test job

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -431,6 +431,8 @@ t1-lag:
   - snmp/test_snmp_link_local.py
   - mpls/test_mpls.py
   - vxlan/test_vxlan_route_advertisement.py
+  - lldp/test_lldp_syncd.py
+  - ipfwd/test_nhop_group.py
 
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py
@@ -474,8 +476,7 @@ onboarding_t0:
   - dhcp_relay/test_dhcp_relay_stress.py
 
 onboarding_t1:
-  - lldp/test_lldp_syncd.py
-  - ipfwd/test_nhop_group.py
+  -
 
 specific_param:
   t0-sonic:

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -476,7 +476,9 @@ onboarding_t0:
   - dhcp_relay/test_dhcp_relay_stress.py
 
 onboarding_t1:
-  -
+  - pfcwd/test_pfcwd_all_port_storm.py
+  - pfcwd/test_pfcwd_function.py
+  - pfcwd/test_pfcwd_timer_accuracy.py
 
 specific_param:
   t0-sonic:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Some dataplane test scripts have been added to PR test and put into optional onboarding job to test case performance, I calculated the success rate of test scripts in recent 3 days, I think I can move high success rate test scripts to t0/t1 job now
TestbedName | FilePath | TestCase | RunDate | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | -- | --
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_member_count | 2024-11-22 00:00:00.0000000 | 17 | 0 | 17 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_member_order_capability[vlab-03-None] | 2024-11-22 00:00:00.0000000 | 17 | 0 | 17 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_interface_flap[vlab-03-None] | 2024-11-22 00:00:00.0000000 | 17 | 0 | 17 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_keys[vlab-03] | 2024-11-22 00:00:00.0000000 | 17 | 0 | 17 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_content[vlab-03] | 2024-11-22 00:00:00.0000000 | 17 | 0 | 17 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_flap[vlab-03] | 2024-11-22 00:00:00.0000000 | 17 | 0 | 17 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_lldp_restart[vlab-03] | 2024-11-22 00:00:00.0000000 | 17 | 0 | 17 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_reboot[vlab-03] | 2024-11-22 00:00:00.0000000 | 17 | 0 | 17 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_member_count | 2024-11-23 00:00:00.0000000 | 19 | 0 | 19 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_member_order_capability[vlab-03-None] | 2024-11-23 00:00:00.0000000 | 17 | 2 | 19 | 0.8947
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_interface_flap[vlab-03-None] | 2024-11-23 00:00:00.0000000 | 17 | 0 | 17 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_keys[vlab-03] | 2024-11-23 00:00:00.0000000 | 19 | 0 | 19 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_content[vlab-03] | 2024-11-23 00:00:00.0000000 | 19 | 0 | 19 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_flap[vlab-03] | 2024-11-23 00:00:00.0000000 | 19 | 0 | 19 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_lldp_restart[vlab-03] | 2024-11-23 00:00:00.0000000 | 19 | 0 | 19 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_reboot[vlab-03] | 2024-11-23 00:00:00.0000000 | 19 | 0 | 19 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_member_count | 2024-11-24 00:00:00.0000000 | 10 | 0 | 10 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_member_order_capability[vlab-03-None] | 2024-11-24 00:00:00.0000000 | 10 | 0 | 10 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_interface_flap[vlab-03-None] | 2024-11-24 00:00:00.0000000 | 10 | 0 | 10 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_keys[vlab-03] | 2024-11-24 00:00:00.0000000 | 10 | 0 | 10 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_content[vlab-03] | 2024-11-24 00:00:00.0000000 | 10 | 0 | 10 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_flap[vlab-03] | 2024-11-24 00:00:00.0000000 | 10 | 0 | 10 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_lldp_restart[vlab-03] | 2024-11-24 00:00:00.0000000 | 10 | 0 | 10 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_reboot[vlab-03] | 2024-11-24 00:00:00.0000000 | 10 | 0 | 10 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_member_count | 2024-11-25 00:00:00.0000000 | 55 | 0 | 55 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_member_order_capability[vlab-03-None] | 2024-11-25 00:00:00.0000000 | 55 | 0 | 55 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_interface_flap[vlab-03-None] | 2024-11-25 00:00:00.0000000 | 55 | 0 | 55 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_keys[vlab-03] | 2024-11-25 00:00:00.0000000 | 55 | 0 | 55 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_content[vlab-03] | 2024-11-25 00:00:00.0000000 | 55 | 0 | 55 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_flap[vlab-03] | 2024-11-25 00:00:00.0000000 | 55 | 0 | 55 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_lldp_restart[vlab-03] | 2024-11-25 00:00:00.0000000 | 55 | 0 | 55 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_reboot[vlab-03] | 2024-11-25 00:00:00.0000000 | 55 | 0 | 55 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_keys[vlab-03] | 2024-11-26 00:00:00.0000000 | 31 | 0 | 31 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_content[vlab-03] | 2024-11-26 00:00:00.0000000 | 31 | 0 | 31 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_flap[vlab-03] | 2024-11-26 00:00:00.0000000 | 31 | 0 | 31 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_lldp_restart[vlab-03] | 2024-11-26 00:00:00.0000000 | 31 | 0 | 31 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_reboot[vlab-03] | 2024-11-26 00:00:00.0000000 | 31 | 0 | 31 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_member_count | 2024-11-26 00:00:00.0000000 | 31 | 0 | 31 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_member_order_capability[vlab-03-None] | 2024-11-26 00:00:00.0000000 | 31 | 0 | 31 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_interface_flap[vlab-03-None] | 2024-11-26 00:00:00.0000000 | 31 | 0 | 31 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_member_count | 2024-11-27 00:00:00.0000000 | 20 | 0 | 20 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_member_order_capability[vlab-03-None] | 2024-11-27 00:00:00.0000000 | 20 | 0 | 20 | 1
vms-kvm-t1-lag | ipfwd/test_nhop_group.py | test_nhop_group_interface_flap[vlab-03-None] | 2024-11-27 00:00:00.0000000 | 20 | 0 | 20 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_keys[vlab-03] | 2024-11-27 00:00:00.0000000 | 20 | 0 | 20 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_content[vlab-03] | 2024-11-27 00:00:00.0000000 | 20 | 0 | 20 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_flap[vlab-03] | 2024-11-27 00:00:00.0000000 | 20 | 0 | 20 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_lldp_restart[vlab-03] | 2024-11-27 00:00:00.0000000 | 20 | 0 | 20 | 1
vms-kvm-t1-lag | lldp/test_lldp_syncd.py | test_lldp_entry_table_after_reboot[vlab-03] | 2024-11-27 00:00:00.0000000 | 20 | 0 | 20 | 1
#### How did you do it?
Move test from onboarding job to t1 job
Add pfcwd test to onborading t1 job
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
