### PR TITLE
[sonic-mgmt] Fix snmp/test_snmp_queue_counters.py teardown failure

### DIFF
--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -167,7 +167,8 @@ def test_snmp_queue_counters(duthosts,
 def teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Teardown procedure for all test function
-    :param duthost: DUT host object
+    :param duthosts: List of DUT hosts
+    :param enum_rand_one_per_hwsku_frontend_hostname: hostname of a randomly selected DUT
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     yield

--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -164,11 +164,12 @@ def test_snmp_queue_counters(duthosts,
 
 
 @pytest.fixture(scope="module")
-def teardown(duthost):
+def teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     Teardown procedure for all test function
     :param duthost: DUT host object
     """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     yield
     # Cleanup
     duthost.copy(src=ORIG_CFG_DB, dest=CFG_DB_PATH, remote_src=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [sonic-mgmt][dualtor] Fix snmp/test_snmp_queue_counters.py teardown failure
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/340

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
`teardown` fixture is trying to replace config_db.json file with the original config_db.json file on the duthost (saved by the `test_snmp_queue_counters` method before performing any config changes). But the teardown is happening on incorrect duthost (different from duthost used by the test method) and leading to `Source /etc/sonic/orig_config_db.json not found` error

#### How did you do it?
Use `enum_rand_one_per_hwsku_frontend_hostname` fixture in the `teardown` fixture to derive the duthost name (similar to `test_snmp_queue_counters` method). This fixes the issue of teardown/cleanup happening in the incorrect dut.

#### How did you verify/test it?
Verified that test is passing with the fix on `Arista-7260CX3-D108C8`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
