### PR TITLE
Cisco-8000 test pfcwd function background traffic revision

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -9,6 +9,7 @@ import logging
 
 from tests.ptf_runner import ptf_runner
 from tests.common import constants
+from tests.common.cisco_data import is_cisco_device
 from tests.common.mellanox_data import is_mellanox_device
 
 # If the version of the Python interpreter is greater or equal to 3, set the unicode variable to the str class.
@@ -490,7 +491,7 @@ numprocs=1
 @contextlib.contextmanager
 def send_background_traffic(duthost, ptfhost, storm_hndle, selected_test_ports, test_ports_info):
     """Send background traffic, stop the background traffic when the context finish """
-    if is_mellanox_device(duthost):
+    if is_mellanox_device(duthost) or is_cisco_device(duthost):
         background_traffic_params = _prepare_background_traffic_params(duthost, storm_hndle,
                                                                        selected_test_ports,
                                                                        test_ports_info)
@@ -498,7 +499,7 @@ def send_background_traffic(duthost, ptfhost, storm_hndle, selected_test_ports, 
         # Ensure the background traffic is running before moving on
         time.sleep(1)
     yield
-    if is_mellanox_device(duthost):
+    if is_mellanox_device(duthost) or is_cisco_device(duthost):
         _stop_background_traffic(ptfhost, background_traffic_log)
 
 

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -738,7 +738,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             if self.pfc_wd['fake_storm']:
                 PfcCmd.set_storm_status(dut, self.queue_oid, "enabled")
 
-            if dut.facts['asic_type'] == "mellanox":
+            if dut.facts['asic_type'] == ["mellanox", "cisco-8000"]:
                 # On Mellanox platform, more time is required for PFC storm being triggered
                 # as PFC pause sent from Non-Mellanox leaf fanout is not continuous sometimes.
                 PFC_STORM_TIMEOUT = 30
@@ -754,11 +754,6 @@ class TestPfcwdFunc(SetupPfcwdFunc):
 
         # storm detect
         logger.info("Verify if PFC storm is detected on port {}".format(port))
-        if dut.facts['asic_type'] == "cisco-8000":
-            # The function get_pkt_cnts() works only if pfcwd is triggered.
-            # When the WD is not triggered, this redis-cli command returns
-            # (nil), so this function call fails.
-            self.traffic_inst.verify_tx_egress(self.tx_action)
         loganalyzer.analyze(marker)
 
         self.stats.get_pkt_cnts(self.queue_oid, begin=True)
@@ -924,8 +919,6 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                     logger.info("{} on port {}: Tx traffic action {}, Rx traffic action {} ".
                                 format(WD_ACTION_MSG_PFX[action], port, self.tx_action, self.rx_action))
                     self.run_test(self.dut, port, action)
-                except Exception as e:
-                    pytest.fail(str(e))
 
                 finally:
                     if self.storm_hndle:
@@ -1013,9 +1006,6 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                     logger.info("--- Testing on {} ---".format(port))
                     self.setup_test_params(port, setup_info['vlan'], init=not idx, detect=False, toggle=idx and count)
                     self.run_test(self.dut, port, "drop", detect=False)
-
-            except Exception as e:
-                pytest.fail(str(e))
 
             finally:
                 logger.info("--- Stop PFC WD ---")
@@ -1105,9 +1095,6 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                     self.is_dualtor)
                 self.run_test(self.dut, port, "drop", mmu_action=mmu_action)
                 self.dut.command("pfcwd stop")
-
-        except Exception as e:
-            pytest.fail(str(e))
 
         finally:
             if self.storm_hndle:
@@ -1213,9 +1200,6 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                 result = loganalyzer.analyze(marker, fail=False)
                 if result["total"]["expected_missing_match"] == 0:
                     pytest.fail(result)
-
-            except Exception as e:
-                pytest.fail(str(e))
 
             finally:
                 if self.storm_hndle:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
- Revise Cisco-8000's current method of sending background traffic from an extra "verify_tx_egress" call to use the pre-existing background traffic support. The verify tx egress operation could fail if some packets leakout due to slow pfc_gen.py frames from fanout. 
- Remove the test failure catcher, as it simply rethrows an exception that is more difficult to debug. Using a simple "try-finally" pattern allows the "finally" clause to always execute even with an exception, but also continues to throw the exception without catching it, resulting in the required test failure in that case. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405


### Related PRs
#14711 is not in 202405, but is requested for the branch. Without that PR in 202405, the double commit of this PR will have a either have a merge conflict or possibly fail if it happens to not conflict. Possible to get that PR in 202405?

### Approach
#### What is the motivation for this PR?
Fix flaky test on Cisco-8000.
Clarify exceptions that do occur for all vendors. 

#### How did you do it?

#### How did you verify/test it?
Verified pass 10 times on Cisco-8122 T0 on 202405 branch. But master/202405 aren't in sync yet due to missing 14711 PR. 

#### Any platform specific information?
The verify_tx_egress change is cisco-only.
The exception catcher removal should improve exception readability for all vendors. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
