### PR TITLE
[T2] Updated JR2 tuning values for T2 systems

### DIFF
--- a/tests/qos/files/qos_params.jr2.yaml
+++ b/tests/qos/files/qos_params.jr2.yaml
@@ -114,15 +114,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 415271
-                    pkts_num_trig_ingr_drp: 418781
+                    pkts_num_trig_pfc: 369873
+                    pkts_num_trig_ingr_drp: 373383
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 415271
-                    pkts_num_trig_ingr_drp: 418781
+                    pkts_num_trig_pfc: 369873
+                    pkts_num_trig_ingr_drp: 373383
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -131,29 +131,29 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_pfc: 369873
                     pkts_num_hdrm_full: 362
                     pkts_num_hdrm_partial: 182
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 415271
-                    pkts_num_trig_ingr_drp: 418781
+                    pkts_num_trig_pfc: 369873
+                    pkts_num_trig_ingr_drp: 373383
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_pfc: 369873
                     pkts_num_dismiss_pfc: 3243
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_pfc: 369873
                     pkts_num_dismiss_pfc: 3243
                     pkts_num_margin: 150
                 lossy_queue_1:
@@ -167,7 +167,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_pfc: 369873
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -185,7 +185,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 418781
+                    pkts_num_trig_ingr_drp: 373383
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -220,15 +220,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 415271
-                    pkts_num_trig_ingr_drp: 593885
+                    pkts_num_trig_pfc: 369873
+                    pkts_num_trig_ingr_drp: 548487
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 415271
-                    pkts_num_trig_ingr_drp: 593885
+                    pkts_num_trig_pfc: 369873
+                    pkts_num_trig_ingr_drp: 548487
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [ 3, 4 ]
@@ -237,29 +237,29 @@ qos_params:
                     src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_pfc: 369873
                     pkts_num_hdrm_full: 362
                     pkts_num_hdrm_partial: 182
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 415271
-                    pkts_num_trig_ingr_drp: 593885
+                    pkts_num_trig_pfc: 369873
+                    pkts_num_trig_ingr_drp: 548487
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_pfc: 369873
                     pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_pfc: 369873
                     pkts_num_dismiss_pfc: 3245
                     pkts_num_margin: 150
                 lossy_queue_1:
@@ -273,7 +273,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 415271
+                    pkts_num_trig_pfc: 369873
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -291,7 +291,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 593885
+                    pkts_num_trig_ingr_drp: 548487
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3


### PR DESCRIPTION
The JR2 tuning values were copied over from the J2c+ tuning values here: https://github.com/sonic-net/sonic-mgmt/pull/13660

But the JR2 tunings are slightly different as the shared buffer pool is different on JR2 vs J2c+.
J2c+:
```
root@cmp206-4:~# bcmcmd -n 0 "tm ing vsq resources"
tm ing vsq resources
==========================================================================================
|                               Core 0 Resource Allocation                               |
==========================================================================================
| Parameter        | Bytes                   | OCB Buffers      | OCB Packet Descriptors |
==========================================================================================
| Nominal Headroom | 198048000               | 0                | 0                      |
| (Max Headroom)   | 198048000               | 0                | 0                      |
| Pool 0           | 3022756608              | 131040           | 262112                 |
| Pool 1           | 0                       | 0                | 0                      |
| Reserved         | 0                       | 0                | 0                      |
| Maximal          | 4294967295 (0xffffffff) | 131071 (0x1ffff) | 262143 (0x3ffff)       |
| Unused           | 1074162688              | 32               | 32                     |
==========================================================================================
```
JR2:
```
root@nfc407-5:~# bcmcmd "tm ing vsq resources"
tm ing vsq resources
========================================================================================
|                              Core 0 Resource Allocation                              |
========================================================================================
| Parameter        | Bytes                   | OCB Buffers    | OCB Packet Descriptors |
========================================================================================
| Nominal Headroom | 528128256               | 0              | 0                      |
| (Max Headroom)   | 528128256               | 0              | 0                      |
| Pool 0           | 2692676352              | 65504          | 131040                 |
| Pool 1           | 0                       | 0              | 0                      |
| Reserved         | 256000                  | 16             | 16                     |
| Maximal          | 4294967295 (0xffffffff) | 65535 (0xffff) | 131071 (0x1ffff)       |
| Unused           | 1073906688              | 0              | 0                      |
========================================================================================
```

For example to calculate `pkts_num_trig_pfc`:
`pkts_num_trig_pfc = pool0-bytes / ((2^dyn_threshold)+1) / pkt_size`

J2c+:
`pkts_num_trig_pfc = 3022756608 / 65 / 112 = 415213`

JR2:
`pkts_num_trig_pfc = 2692676352 / 65 / 112 = 369873`

This change also requires https://github.com/sonic-net/sonic-buildimage/pull/20926 to be present before Arista CW2 SKUs will start passing QOS sonic-mgmt tests.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
