### PR TITLE
Fix a couple issues in `change_lag_lacp_timer`

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2588,7 +2588,6 @@ class QosSaiBase(QosBase):
 
         if ('platform_asic' in dutTestParams["basicParams"] and
                 dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx"):
-            src_dut = get_src_dst_asic_and_duts['src_dut']
             dst_dut = get_src_dst_asic_and_duts['dst_dut']
             dst_mgfacts = dst_dut.get_extended_minigraph_facts(tbinfo)
             dst_interfaces = []
@@ -2599,7 +2598,7 @@ class QosSaiBase(QosBase):
             for port_ch, port_intf in dst_mgfacts['minigraph_portchannels'].items():
                 for member in port_intf['members']:
                     if member in dst_interfaces:
-                        lag_names.append( port_ch )
+                        lag_names.append(port_ch)
                         break
             if len(lag_names) == 0:
                 yield

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2627,5 +2627,5 @@ class QosSaiBase(QosBase):
             for vm_host, neighbor_lag_intfs in vm_host_neighbor_lag_members.items():
                 for neighbor_lag_member in neighbor_lag_intfs:
                     logger.info(
-                        "Changing lacp timer multiplier to default for %s in %s" % (neighbor_lag_member, peer_device))
+                        "Changing lacp timer multiplier to default for %s in %s" % (neighbor_lag_member, vm_host))
                     vm_host.no_lacp_time_multiplier(neighbor_lag_member)

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -590,7 +590,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2", "xon_3", "xon_4"])
     def testQosSaiPfcXonLimit(
         self, get_src_dst_asic_and_duts, xonProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile
+        ingressLosslessProfile, change_lag_lacp_timer
     ):
         # NOTE: cisco 8800 will skip this test if it's not xon_1 or xon_2
         """


### PR DESCRIPTION
https://github.com/sonic-net/sonic-mgmt/pull/14469 was introduced to increase the LACP timeout of EOS neighbors during QOS tests.
This was required because the QOS tests would disable TX credits on the test's dest ports, without TX credits LACP packets won't egress and eventually the LAG will be brought down by the EOS neighbor due to LACP timeout.

This change adds a couple improvements to that existing PR:
-Updated to work with single-asic LCs
-Updated to change the LACP timeout multiplier for all 3 dst_port_id neighbors.

Also made testQosSaiPfcXonLimit use fixture change_lag_lacp_timer

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405