### PR TITLE
Fix PC test_lag_2 failure issue

### DIFF
--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -40,7 +40,7 @@ def common_setup_teardown(copy_acstests_directory, copy_ptftests_directory, ptfh
                 duthost, config_source='running_golden_config', safe_reload=True
             ) for _ in duthosts
         ],
-        timeout=300,
+        timeout=600,
         thread_count=len(duthosts)
     )
 

--- a/tests/pc/test_lag_2.py
+++ b/tests/pc/test_lag_2.py
@@ -37,10 +37,11 @@ def common_setup_teardown(copy_acstests_directory, copy_ptftests_directory, ptfh
     parallel_run_threaded(
         target_functions=[
             lambda duthost=_: config_reload(
-                duthost, config_source='running_golden_config'
+                duthost, config_source='running_golden_config', safe_reload=True
             ) for _ in duthosts
         ],
-        timeout=300
+        timeout=300,
+        thread_count=len(duthosts)
     )
 
 


### PR DESCRIPTION
### Description of PR
It's found that the PC test_lag_2 tests could fail on common_setup_teardown. This routine is using parallel thread to do config_reload. The parallel thread is by default has pool of 2 threads. The config_reload() has some changes to wait 900 seconds if  safe_reload flag is not set. This has 2 issues here. 
1) With 2 threads pool and we have 4 cards on testing bed, will have 2 cards doing config_reload and after that's done another 2 will have change to run. This could make total wait time have to be set to > 30 min. Currently wait time is 10m. 
2) Set config_reload to be true will save many times to check if all critical services are back on line than config_reload  to be false which will make API wait 15m before quit

Fix is for PC common_setup_teardown to use thread pool and set number of hosts as number of threads. Thus all cards will execute config_reload at the same time. 
Also when calling config_reload() set safe_reload to be true. 

Summary:
Fixes # (issue)

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

#### How did you verify/test it?
Verified on OC test bed with the fix. Test passed. 
