### PR TITLE
Skip test_max_limit[core] test for images where "/tmp" is on tmpfs

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -410,6 +410,12 @@ class TestAutoTechSupport:
         with allure.step('Get used space in mount point: {}'.format(validation_folder)):
             total, used, avail, used_percent = get_partition_usage_info(self.duthost, validation_folder)
 
+        with allure.step('Get /tmp Filesystem Type'):
+            tmp_fstype = is_tmp_on_tmpfs(self.duthost)
+
+        if test_mode == 'core' and tmp_fstype == 'tmpfs':
+            pytest.skip('Test skipped due to known sonic-buildimage issues #20950 and #15101')
+
         if used_percent > 50:
             pytest.skip('System uses more than 50% of space. '
                         'Test required at least 50% of free space in {}'.format(validation_folder))
@@ -1089,6 +1095,11 @@ def trigger_auto_techsupport(duthost, docker):
         core_file_name = create_core_file(duthost, docker)
 
     return core_file_name
+
+
+def is_tmp_on_tmpfs(duthost):
+    out = duthost.command("df -h /tmp --output='fstype'")['stdout_lines']
+    return out[1].strip() if len(out) == 2 else None
 
 
 def get_partition_usage_info(duthost, partition='/'):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

This PR mitigates sonic-buildimage issue [20950](https://github.com/sonic-net/sonic-buildimage/issues/20950)

Summary:
Fixes # (issue)

The `show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_max_limit[core]` test creates huge core files. 
When `/tmp` is on tmpfs and available memory is low (as is often the case with KVMs), it crashes the device. This leads to a test failure with following signature:

```
27/11/2024 06:24:39 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 1788, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/var/src/sonic-mgmt/tests/show_techsupport/test_auto_techsupport.py", line 440, in test_max_limit
    validate_techsupport_generation(self.duthost, self.dut_cli, is_techsupport_expected=True,
  File "/var/src/sonic-mgmt/tests/show_techsupport/test_auto_techsupport.py", line 928, in validate_techsupport_generation
    techsupport_folder_path = extract_techsupport_tarball_file(duthost, tech_support_file_path)
  File "/var/src/sonic-mgmt/tests/show_techsupport/test_auto_techsupport.py", line 799, in extract_techsupport_tarball_file
    duthost.shell('tar -xf {} -C {}'.format(tarball_name, dst_folder))
  File "/var/src/sonic-mgmt/tests/common/devices/multi_asic.py", line 135, in _run_on_asics
    return getattr(self.sonichost, self.multi_asic_attr)(*module_args, **complex_args)
  File "/var/src/sonic-mgmt/tests/common/devices/base.py", line 105, in _run
    res = self.module(*module_args, **complex_args)[self.hostname]
  File "/usr/local/lib/python3.8/dist-packages/pytest_ansible/module_dispatcher/v213.py", line 232, in _run
    raise AnsibleConnectionFailure(
pytest_ansible.errors.AnsibleConnectionFailure: Host unreachable in the inventory
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Added a pytest skip fixture when `/tmp` is on tmpfs.


#### How did you verify/test it?
Ran the test on a DUT where `/tmp` is on tmpfs and verified that the test_max_limit[core] test was skipped:
[test_max_limit_logs.txt](https://github.com/user-attachments/files/17941427/test_max_limit_logs.txt)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
