### PR TITLE
refactor: use separate LCs for BFD traffic test

### DIFF
--- a/tests/bfd/test_bfd_traffic.py
+++ b/tests/bfd/test_bfd_traffic.py
@@ -6,7 +6,7 @@ import pytest
 from tests.bfd.bfd_helpers import get_ptf_src_port, get_backend_interface_in_use_by_counter, \
     get_random_bgp_neighbor_ip_of_asic, toggle_port_channel_or_member, get_port_channel_by_member, \
     wait_until_given_bfd_down, assert_traffic_switching, verify_bfd_only, extract_backend_portchannels, \
-    get_src_dst_asic_next_hops
+    get_src_dst_asic_next_hops, get_upstream_and_downstream_dut_pool
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 
 pytestmark = [
@@ -21,127 +21,111 @@ class TestBfdTraffic:
     PACKET_COUNT = 10000
 
     @pytest.fixture(scope="class")
-    def select_dut_and_src_dst_asic_index(self, duthosts):
+    def get_src_dst_asic(self, request, duthosts):
         if not duthosts.frontend_nodes:
             pytest.skip("DUT does not have any frontend nodes")
 
-        dut_index = random.choice(list(range(len(duthosts.frontend_nodes))))
-        asic_namespace_list = duthosts.frontend_nodes[dut_index].get_asic_namespace_list()
-        if len(asic_namespace_list) < 2:
-            pytest.skip("DUT does not have more than one ASICs")
+        src_dut_pool, dst_dut_pool = get_upstream_and_downstream_dut_pool(duthosts.frontend_nodes)
+        if not src_dut_pool or not dst_dut_pool:
+            pytest.skip("No upstream or downstream DUTs found")
 
-        # Random selection of src asic & dst asic on DUT
-        src_asic_namespace, dst_asic_namespace = random.sample(asic_namespace_list, 2)
-        src_asic_index = src_asic_namespace.split("asic")[1]
-        dst_asic_index = dst_asic_namespace.split("asic")[1]
+        src_dut_index = random.choice(list(range(len(src_dut_pool))))
+        dst_dut_index = random.choice(list(range(len(dst_dut_pool))))
+        src_dut = src_dut_pool[src_dut_index]
+        dst_dut = dst_dut_pool[dst_dut_index]
+        src_asic_namespace_list = src_dut.get_asic_namespace_list()
+        dst_asic_namespace_list = dst_dut.get_asic_namespace_list()
+        if not src_asic_namespace_list or not dst_asic_namespace_list:
+            pytest.skip("No asic namespaces found on source or destination DUT")
+
+        src_asic_namespace = random.choice(src_asic_namespace_list)
+        dst_asic_namespace = random.choice(dst_asic_namespace_list)
+        src_asic_index = int(src_asic_namespace.split("asic")[1])
+        dst_asic_index = int(dst_asic_namespace.split("asic")[1])
+        src_asic = src_dut.asics[src_asic_index]
+        dst_asic = dst_dut.asics[dst_asic_index]
 
         yield {
-            "dut_index": dut_index,
-            "src_asic_index": int(src_asic_index),
-            "dst_asic_index": int(dst_asic_index),
-        }
-
-    @pytest.fixture(scope="class")
-    def get_src_dst_asic(self, request, duthosts, select_dut_and_src_dst_asic_index):
-        logger.info("Printing select_dut_and_src_dst_asic_index")
-        logger.info(select_dut_and_src_dst_asic_index)
-
-        logger.info("Printing duthosts.frontend_nodes")
-        logger.info(duthosts.frontend_nodes)
-        dut = duthosts.frontend_nodes[select_dut_and_src_dst_asic_index["dut_index"]]
-
-        logger.info("Printing dut asics")
-        logger.info(dut.asics)
-
-        src_asic = dut.asics[select_dut_and_src_dst_asic_index["src_asic_index"]]
-        dst_asic = dut.asics[select_dut_and_src_dst_asic_index["dst_asic_index"]]
-
-        request.config.src_asic = src_asic
-        request.config.dst_asic = dst_asic
-        request.config.dut = dut
-
-        rtn_dict = {
+            "src_dut": src_dut,
             "src_asic": src_asic,
+            "src_asic_index": src_asic_index,
+            "dst_dut": dst_dut,
             "dst_asic": dst_asic,
-            "dut": dut,
+            "dst_asic_index": dst_asic_index,
         }
-
-        rtn_dict.update(select_dut_and_src_dst_asic_index)
-        yield rtn_dict
 
     @pytest.fixture(scope="class", params=["ipv4", "ipv6"])
     def prepare_traffic_test_variables(self, get_src_dst_asic, request):
         version = request.param
         logger.info("Version: %s", version)
 
-        dut = get_src_dst_asic["dut"]
+        src_dut = get_src_dst_asic["src_dut"]
         src_asic = get_src_dst_asic["src_asic"]
         src_asic_index = get_src_dst_asic["src_asic_index"]
+        dst_dut = get_src_dst_asic["dst_dut"]
         dst_asic = get_src_dst_asic["dst_asic"]
         dst_asic_index = get_src_dst_asic["dst_asic_index"]
         logger.info(
-            "DUT: {}, src_asic_index: {}, dst_asic_index: {}".format(dut.hostname, src_asic_index, dst_asic_index)
+            "src_dut: {}, src_asic_index: {}, dst_dut: {}, dst_asic_index: {}".format(
+                src_dut.hostname,
+                src_asic_index,
+                dst_dut.hostname,
+                dst_asic_index,
+            )
         )
 
-        backend_port_channels = extract_backend_portchannels(dut)
-        src_asic_next_hops, dst_asic_next_hops, src_prefix, dst_prefix = get_src_dst_asic_next_hops(
+        src_backend_port_channels = extract_backend_portchannels(src_dut)
+        dst_backend_port_channels = extract_backend_portchannels(dst_dut)
+        src_asic_next_hops, dst_asic_next_hops = get_src_dst_asic_next_hops(
             version,
-            dut,
+            src_dut,
             src_asic,
+            src_backend_port_channels,
+            dst_dut,
             dst_asic,
-            request,
-            backend_port_channels,
+            dst_backend_port_channels,
         )
 
         src_asic_router_mac = src_asic.get_router_mac()
 
         yield {
-            "dut": dut,
+            "src_dut": src_dut,
             "src_asic": src_asic,
             "src_asic_index": src_asic_index,
+            "dst_dut": dst_dut,
             "dst_asic": dst_asic,
             "dst_asic_index": dst_asic_index,
             "src_asic_next_hops": src_asic_next_hops,
             "dst_asic_next_hops": dst_asic_next_hops,
-            "src_prefix": src_prefix,
-            "dst_prefix": dst_prefix,
             "src_asic_router_mac": src_asic_router_mac,
-            "backend_port_channels": backend_port_channels,
+            "src_backend_port_channels": src_backend_port_channels,
+            "dst_backend_port_channels": dst_backend_port_channels,
             "version": version,
         }
 
-    def test_bfd_traffic_remote_port_channel_shutdown(
-        self,
-        request,
-        tbinfo,
-        ptfadapter,
-        prepare_traffic_test_variables,
-        bfd_cleanup_db,
-    ):
-        dut = prepare_traffic_test_variables["dut"]
+    def test_bfd_traffic_remote_port_channel_shutdown(self, request, tbinfo, ptfadapter,
+                                                      prepare_traffic_test_variables, bfd_cleanup_db):
+        src_dut = prepare_traffic_test_variables["src_dut"]
         src_asic = prepare_traffic_test_variables["src_asic"]
         src_asic_index = prepare_traffic_test_variables["src_asic_index"]
+        dst_dut = prepare_traffic_test_variables["dst_dut"]
         dst_asic = prepare_traffic_test_variables["dst_asic"]
         dst_asic_index = prepare_traffic_test_variables["dst_asic_index"]
         src_asic_next_hops = prepare_traffic_test_variables["src_asic_next_hops"]
         dst_asic_next_hops = prepare_traffic_test_variables["dst_asic_next_hops"]
-        src_prefix = prepare_traffic_test_variables["src_prefix"]
-        dst_prefix = prepare_traffic_test_variables["dst_prefix"]
         src_asic_router_mac = prepare_traffic_test_variables["src_asic_router_mac"]
-        backend_port_channels = prepare_traffic_test_variables["backend_port_channels"]
+        src_backend_port_channels = prepare_traffic_test_variables["src_backend_port_channels"]
+        dst_backend_port_channels = prepare_traffic_test_variables["dst_backend_port_channels"]
         version = prepare_traffic_test_variables["version"]
-        src_dst_context = [
-            ("src", src_asic, src_prefix, src_asic_next_hops),
-            ("dst", dst_asic, dst_prefix, dst_asic_next_hops),
-        ]
 
-        dst_neighbor_ip = get_random_bgp_neighbor_ip_of_asic(dut, dst_asic_index, version)
+        dst_neighbor_ip = get_random_bgp_neighbor_ip_of_asic(dst_dut, dst_asic_index, version)
         if not dst_neighbor_ip:
-            pytest.skip("No BGP neighbor found on asic{} of dut {}".format(dst_asic_index, dut.hostname))
+            pytest.skip("No BGP neighbor found on asic{} of dut {}".format(dst_asic_index, dst_dut.hostname))
 
         ptf_src_port = get_ptf_src_port(src_asic, tbinfo)
         src_bp_iface_before_shutdown, dst_bp_iface_before_shutdown = get_backend_interface_in_use_by_counter(
-            dut,
+            src_dut,
+            dst_dut,
             self.PACKET_COUNT,
             version,
             src_asic_router_mac,
@@ -153,7 +137,7 @@ class TestBfdTraffic:
         )
 
         dst_port_channel_before_shutdown = get_port_channel_by_member(
-            backend_port_channels,
+            dst_backend_port_channels,
             dst_bp_iface_before_shutdown,
         )
 
@@ -162,26 +146,27 @@ class TestBfdTraffic:
 
         toggle_port_channel_or_member(
             dst_port_channel_before_shutdown,
-            dut,
+            dst_dut,
             dst_asic,
             request,
             "shutdown",
         )
 
         src_port_channel_before_shutdown = get_port_channel_by_member(
-            backend_port_channels,
+            src_backend_port_channels,
             src_bp_iface_before_shutdown,
         )
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
-            for next_hops, port_channel, asic_index in [
-                (src_asic_next_hops, dst_port_channel_before_shutdown, src_asic_index),
-                (dst_asic_next_hops, src_port_channel_before_shutdown, dst_asic_index),
+            for next_hops, port_channel, asic_index, dut in [
+                (src_asic_next_hops, dst_port_channel_before_shutdown, src_asic_index, src_dut),
+                (dst_asic_next_hops, src_port_channel_before_shutdown, dst_asic_index, dst_dut),
             ]:
                 executor.submit(wait_until_given_bfd_down, next_hops, port_channel, asic_index, dut)
 
         src_bp_iface_after_shutdown, dst_bp_iface_after_shutdown = get_backend_interface_in_use_by_counter(
-            dut,
+            src_dut,
+            dst_dut,
             self.PACKET_COUNT,
             version,
             src_asic_router_mac,
@@ -193,8 +178,10 @@ class TestBfdTraffic:
         )
 
         assert_traffic_switching(
-            dut,
-            backend_port_channels,
+            src_dut,
+            dst_dut,
+            src_backend_port_channels,
+            dst_backend_port_channels,
             src_asic_index,
             src_bp_iface_before_shutdown,
             src_bp_iface_after_shutdown,
@@ -207,48 +194,42 @@ class TestBfdTraffic:
 
         toggle_port_channel_or_member(
             dst_port_channel_before_shutdown,
-            dut,
+            dst_dut,
             dst_asic,
             request,
             "startup",
         )
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
-            for _, asic, _, next_hops in src_dst_context:
+            for dut, next_hops, asic in [
+                (src_dut, src_asic_next_hops, src_asic),
+                (dst_dut, dst_asic_next_hops, dst_asic),
+            ]:
                 executor.submit(verify_bfd_only, dut, next_hops, asic, "Up")
 
-    def test_bfd_traffic_local_port_channel_shutdown(
-        self,
-        request,
-        tbinfo,
-        ptfadapter,
-        prepare_traffic_test_variables,
-        bfd_cleanup_db,
-    ):
-        dut = prepare_traffic_test_variables["dut"]
+    def test_bfd_traffic_local_port_channel_shutdown(self, request, tbinfo, ptfadapter,
+                                                     prepare_traffic_test_variables, bfd_cleanup_db):
+        src_dut = prepare_traffic_test_variables["src_dut"]
         src_asic = prepare_traffic_test_variables["src_asic"]
         src_asic_index = prepare_traffic_test_variables["src_asic_index"]
+        dst_dut = prepare_traffic_test_variables["dst_dut"]
         dst_asic = prepare_traffic_test_variables["dst_asic"]
         dst_asic_index = prepare_traffic_test_variables["dst_asic_index"]
         src_asic_next_hops = prepare_traffic_test_variables["src_asic_next_hops"]
         dst_asic_next_hops = prepare_traffic_test_variables["dst_asic_next_hops"]
-        src_prefix = prepare_traffic_test_variables["src_prefix"]
-        dst_prefix = prepare_traffic_test_variables["dst_prefix"]
         src_asic_router_mac = prepare_traffic_test_variables["src_asic_router_mac"]
-        backend_port_channels = prepare_traffic_test_variables["backend_port_channels"]
+        src_backend_port_channels = prepare_traffic_test_variables["src_backend_port_channels"]
+        dst_backend_port_channels = prepare_traffic_test_variables["dst_backend_port_channels"]
         version = prepare_traffic_test_variables["version"]
-        src_dst_context = [
-            ("src", src_asic, src_prefix, src_asic_next_hops),
-            ("dst", dst_asic, dst_prefix, dst_asic_next_hops),
-        ]
 
-        dst_neighbor_ip = get_random_bgp_neighbor_ip_of_asic(dut, dst_asic_index, version)
+        dst_neighbor_ip = get_random_bgp_neighbor_ip_of_asic(dst_dut, dst_asic_index, version)
         if not dst_neighbor_ip:
-            pytest.skip("No BGP neighbor found on asic{} of dut {}".format(dst_asic_index, dut.hostname))
+            pytest.skip("No BGP neighbor found on asic{} of dut {}".format(dst_asic_index, dst_dut.hostname))
 
         ptf_src_port = get_ptf_src_port(src_asic, tbinfo)
         src_bp_iface_before_shutdown, dst_bp_iface_before_shutdown = get_backend_interface_in_use_by_counter(
-            dut,
+            src_dut,
+            dst_dut,
             self.PACKET_COUNT,
             version,
             src_asic_router_mac,
@@ -260,7 +241,7 @@ class TestBfdTraffic:
         )
 
         src_port_channel_before_shutdown = get_port_channel_by_member(
-            backend_port_channels,
+            src_backend_port_channels,
             src_bp_iface_before_shutdown,
         )
 
@@ -269,26 +250,27 @@ class TestBfdTraffic:
 
         toggle_port_channel_or_member(
             src_port_channel_before_shutdown,
-            dut,
+            src_dut,
             src_asic,
             request,
             "shutdown",
         )
 
         dst_port_channel_before_shutdown = get_port_channel_by_member(
-            backend_port_channels,
+            dst_backend_port_channels,
             dst_bp_iface_before_shutdown,
         )
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
-            for next_hops, port_channel, asic_index in [
-                (src_asic_next_hops, dst_port_channel_before_shutdown, src_asic_index),
-                (dst_asic_next_hops, src_port_channel_before_shutdown, dst_asic_index),
+            for next_hops, port_channel, asic_index, dut in [
+                (src_asic_next_hops, dst_port_channel_before_shutdown, src_asic_index, src_dut),
+                (dst_asic_next_hops, src_port_channel_before_shutdown, dst_asic_index, dst_dut),
             ]:
                 executor.submit(wait_until_given_bfd_down, next_hops, port_channel, asic_index, dut)
 
         src_bp_iface_after_shutdown, dst_bp_iface_after_shutdown = get_backend_interface_in_use_by_counter(
-            dut,
+            src_dut,
+            dst_dut,
             self.PACKET_COUNT,
             version,
             src_asic_router_mac,
@@ -300,8 +282,10 @@ class TestBfdTraffic:
         )
 
         assert_traffic_switching(
-            dut,
-            backend_port_channels,
+            src_dut,
+            dst_dut,
+            src_backend_port_channels,
+            dst_backend_port_channels,
             src_asic_index,
             src_bp_iface_before_shutdown,
             src_bp_iface_after_shutdown,
@@ -314,48 +298,42 @@ class TestBfdTraffic:
 
         toggle_port_channel_or_member(
             src_port_channel_before_shutdown,
-            dut,
+            src_dut,
             src_asic,
             request,
             "startup",
         )
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
-            for _, asic, _, next_hops in src_dst_context:
+            for dut, next_hops, asic in [
+                (src_dut, src_asic_next_hops, src_asic),
+                (dst_dut, dst_asic_next_hops, dst_asic),
+            ]:
                 executor.submit(verify_bfd_only, dut, next_hops, asic, "Up")
 
-    def test_bfd_traffic_remote_port_channel_member_shutdown(
-        self,
-        request,
-        tbinfo,
-        ptfadapter,
-        prepare_traffic_test_variables,
-        bfd_cleanup_db,
-    ):
-        dut = prepare_traffic_test_variables["dut"]
+    def test_bfd_traffic_remote_port_channel_member_shutdown(self, request, tbinfo, ptfadapter,
+                                                             prepare_traffic_test_variables, bfd_cleanup_db):
+        src_dut = prepare_traffic_test_variables["src_dut"]
         src_asic = prepare_traffic_test_variables["src_asic"]
         src_asic_index = prepare_traffic_test_variables["src_asic_index"]
+        dst_dut = prepare_traffic_test_variables["dst_dut"]
         dst_asic = prepare_traffic_test_variables["dst_asic"]
         dst_asic_index = prepare_traffic_test_variables["dst_asic_index"]
         src_asic_next_hops = prepare_traffic_test_variables["src_asic_next_hops"]
         dst_asic_next_hops = prepare_traffic_test_variables["dst_asic_next_hops"]
-        src_prefix = prepare_traffic_test_variables["src_prefix"]
-        dst_prefix = prepare_traffic_test_variables["dst_prefix"]
         src_asic_router_mac = prepare_traffic_test_variables["src_asic_router_mac"]
-        backend_port_channels = prepare_traffic_test_variables["backend_port_channels"]
+        src_backend_port_channels = prepare_traffic_test_variables["src_backend_port_channels"]
+        dst_backend_port_channels = prepare_traffic_test_variables["dst_backend_port_channels"]
         version = prepare_traffic_test_variables["version"]
-        src_dst_context = [
-            ("src", src_asic, src_prefix, src_asic_next_hops),
-            ("dst", dst_asic, dst_prefix, dst_asic_next_hops),
-        ]
 
-        dst_neighbor_ip = get_random_bgp_neighbor_ip_of_asic(dut, dst_asic_index, version)
+        dst_neighbor_ip = get_random_bgp_neighbor_ip_of_asic(dst_dut, dst_asic_index, version)
         if not dst_neighbor_ip:
-            pytest.skip("No BGP neighbor found on asic{} of dut {}".format(dst_asic_index, dut.hostname))
+            pytest.skip("No BGP neighbor found on asic{} of dut {}".format(dst_asic_index, dst_dut.hostname))
 
         ptf_src_port = get_ptf_src_port(src_asic, tbinfo)
         src_bp_iface_before_shutdown, dst_bp_iface_before_shutdown = get_backend_interface_in_use_by_counter(
-            dut,
+            src_dut,
+            dst_dut,
             self.PACKET_COUNT,
             version,
             src_asic_router_mac,
@@ -366,36 +344,37 @@ class TestBfdTraffic:
             dst_asic_index,
         )
 
-        toggle_port_channel_or_member(
-            dst_bp_iface_before_shutdown,
-            dut,
-            dst_asic,
-            request,
-            "shutdown",
-        )
-
         src_port_channel_before_shutdown = get_port_channel_by_member(
-            backend_port_channels,
+            src_backend_port_channels,
             src_bp_iface_before_shutdown,
         )
 
         dst_port_channel_before_shutdown = get_port_channel_by_member(
-            backend_port_channels,
+            dst_backend_port_channels,
             dst_bp_iface_before_shutdown,
         )
 
         if not src_port_channel_before_shutdown or not dst_port_channel_before_shutdown:
             pytest.fail("No port channel found with interface in use")
 
+        toggle_port_channel_or_member(
+            dst_bp_iface_before_shutdown,
+            dst_dut,
+            dst_asic,
+            request,
+            "shutdown",
+        )
+
         with SafeThreadPoolExecutor(max_workers=8) as executor:
-            for next_hops, port_channel, asic_index in [
-                (src_asic_next_hops, dst_port_channel_before_shutdown, src_asic_index),
-                (dst_asic_next_hops, src_port_channel_before_shutdown, dst_asic_index),
+            for next_hops, port_channel, asic_index, dut in [
+                (src_asic_next_hops, dst_port_channel_before_shutdown, src_asic_index, src_dut),
+                (dst_asic_next_hops, src_port_channel_before_shutdown, dst_asic_index, dst_dut),
             ]:
                 executor.submit(wait_until_given_bfd_down, next_hops, port_channel, asic_index, dut)
 
         src_bp_iface_after_shutdown, dst_bp_iface_after_shutdown = get_backend_interface_in_use_by_counter(
-            dut,
+            src_dut,
+            dst_dut,
             self.PACKET_COUNT,
             version,
             src_asic_router_mac,
@@ -407,8 +386,10 @@ class TestBfdTraffic:
         )
 
         assert_traffic_switching(
-            dut,
-            backend_port_channels,
+            src_dut,
+            dst_dut,
+            src_backend_port_channels,
+            dst_backend_port_channels,
             src_asic_index,
             src_bp_iface_before_shutdown,
             src_bp_iface_after_shutdown,
@@ -421,48 +402,42 @@ class TestBfdTraffic:
 
         toggle_port_channel_or_member(
             dst_bp_iface_before_shutdown,
-            dut,
+            dst_dut,
             dst_asic,
             request,
             "startup",
         )
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
-            for _, asic, _, next_hops in src_dst_context:
+            for dut, next_hops, asic in [
+                (src_dut, src_asic_next_hops, src_asic),
+                (dst_dut, dst_asic_next_hops, dst_asic),
+            ]:
                 executor.submit(verify_bfd_only, dut, next_hops, asic, "Up")
 
-    def test_bfd_traffic_local_port_channel_member_shutdown(
-        self,
-        request,
-        tbinfo,
-        ptfadapter,
-        prepare_traffic_test_variables,
-        bfd_cleanup_db,
-    ):
-        dut = prepare_traffic_test_variables["dut"]
+    def test_bfd_traffic_local_port_channel_member_shutdown(self, request, tbinfo, ptfadapter,
+                                                            prepare_traffic_test_variables, bfd_cleanup_db):
+        src_dut = prepare_traffic_test_variables["src_dut"]
         src_asic = prepare_traffic_test_variables["src_asic"]
         src_asic_index = prepare_traffic_test_variables["src_asic_index"]
+        dst_dut = prepare_traffic_test_variables["dst_dut"]
         dst_asic = prepare_traffic_test_variables["dst_asic"]
         dst_asic_index = prepare_traffic_test_variables["dst_asic_index"]
         src_asic_next_hops = prepare_traffic_test_variables["src_asic_next_hops"]
         dst_asic_next_hops = prepare_traffic_test_variables["dst_asic_next_hops"]
-        src_prefix = prepare_traffic_test_variables["src_prefix"]
-        dst_prefix = prepare_traffic_test_variables["dst_prefix"]
         src_asic_router_mac = prepare_traffic_test_variables["src_asic_router_mac"]
-        backend_port_channels = prepare_traffic_test_variables["backend_port_channels"]
+        src_backend_port_channels = prepare_traffic_test_variables["src_backend_port_channels"]
+        dst_backend_port_channels = prepare_traffic_test_variables["dst_backend_port_channels"]
         version = prepare_traffic_test_variables["version"]
-        src_dst_context = [
-            ("src", src_asic, src_prefix, src_asic_next_hops),
-            ("dst", dst_asic, dst_prefix, dst_asic_next_hops),
-        ]
 
-        dst_neighbor_ip = get_random_bgp_neighbor_ip_of_asic(dut, dst_asic_index, version)
+        dst_neighbor_ip = get_random_bgp_neighbor_ip_of_asic(dst_dut, dst_asic_index, version)
         if not dst_neighbor_ip:
-            pytest.skip("No BGP neighbor found on asic{} of dut {}".format(dst_asic_index, dut.hostname))
+            pytest.skip("No BGP neighbor found on asic{} of dut {}".format(dst_asic_index, dst_dut.hostname))
 
         ptf_src_port = get_ptf_src_port(src_asic, tbinfo)
         src_bp_iface_before_shutdown, dst_bp_iface_before_shutdown = get_backend_interface_in_use_by_counter(
-            dut,
+            src_dut,
+            dst_dut,
             self.PACKET_COUNT,
             version,
             src_asic_router_mac,
@@ -473,36 +448,37 @@ class TestBfdTraffic:
             dst_asic_index,
         )
 
-        toggle_port_channel_or_member(
-            src_bp_iface_before_shutdown,
-            dut,
-            src_asic,
-            request,
-            "shutdown",
-        )
-
         src_port_channel_before_shutdown = get_port_channel_by_member(
-            backend_port_channels,
+            src_backend_port_channels,
             src_bp_iface_before_shutdown,
         )
 
         dst_port_channel_before_shutdown = get_port_channel_by_member(
-            backend_port_channels,
+            dst_backend_port_channels,
             dst_bp_iface_before_shutdown,
         )
 
         if not src_port_channel_before_shutdown or not dst_port_channel_before_shutdown:
             pytest.fail("No port channel found with interface in use")
 
+        toggle_port_channel_or_member(
+            src_bp_iface_before_shutdown,
+            src_dut,
+            src_asic,
+            request,
+            "shutdown",
+        )
+
         with SafeThreadPoolExecutor(max_workers=8) as executor:
-            for next_hops, port_channel, asic_index in [
-                (src_asic_next_hops, dst_port_channel_before_shutdown, src_asic_index),
-                (dst_asic_next_hops, src_port_channel_before_shutdown, dst_asic_index),
+            for next_hops, port_channel, asic_index, dut in [
+                (src_asic_next_hops, dst_port_channel_before_shutdown, src_asic_index, src_dut),
+                (dst_asic_next_hops, src_port_channel_before_shutdown, dst_asic_index, dst_dut),
             ]:
                 executor.submit(wait_until_given_bfd_down, next_hops, port_channel, asic_index, dut)
 
         src_bp_iface_after_shutdown, dst_bp_iface_after_shutdown = get_backend_interface_in_use_by_counter(
-            dut,
+            src_dut,
+            dst_dut,
             self.PACKET_COUNT,
             version,
             src_asic_router_mac,
@@ -514,8 +490,10 @@ class TestBfdTraffic:
         )
 
         assert_traffic_switching(
-            dut,
-            backend_port_channels,
+            src_dut,
+            dst_dut,
+            src_backend_port_channels,
+            dst_backend_port_channels,
             src_asic_index,
             src_bp_iface_before_shutdown,
             src_bp_iface_after_shutdown,
@@ -528,12 +506,15 @@ class TestBfdTraffic:
 
         toggle_port_channel_or_member(
             src_bp_iface_before_shutdown,
-            dut,
+            src_dut,
             src_asic,
             request,
             "startup",
         )
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
-            for _, asic, _, next_hops in src_dst_context:
+            for dut, next_hops, asic in [
+                (src_dut, src_asic_next_hops, src_asic),
+                (dst_dut, dst_asic_next_hops, dst_asic),
+            ]:
                 executor.submit(verify_bfd_only, dut, next_hops, asic, "Up")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Use upstream and downstream LCs for BFD traffic test so it can cover the "port channel down but BFD not down" issue.

Summary:
Fixes # (issue) Microsoft ADO 30112186

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
In `bfd/test_bfd_traffic.py`, we want to pick 2 LCs, where one connected to T1 (downstream LC) and other one connected to T3 (upstream LC), because if we pick only 1 LC or pick 2 LCs but both are downstream LCs (or upstream LCs), we will not cover the issue of "port channel down but BFD not down". 

#### How did you do it?
Randomly pick one upstream LC and one downstream LC.

#### How did you verify/test it?
I ran the updated code and can confirm that it works as expected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
