### PR TITLE
Add populate_mac_table in test_vlan_ping case

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -10,6 +10,7 @@ from ipaddress import ip_address, IPv4Address
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m   # noqa F401
 from tests.common.dualtor.dual_tor_utils import lower_tor_host   # noqa F401
+from tests.vlan.test_vlan import populate_mac_table   # noqa F401
 
 logger = logging.getLogger(__name__)
 
@@ -220,7 +221,7 @@ def verify_icmp_packet(dut_mac, src_port, dst_port, ptfadapter, tbinfo,
 
 
 def test_vlan_ping(vlan_ping_setup, duthosts, rand_one_dut_hostname, ptfadapter, tbinfo,
-                   toggle_all_simulator_ports_to_rand_selected_tor_m):  # noqa F811
+                   toggle_all_simulator_ports_to_rand_selected_tor_m, populate_mac_table):  # noqa F811
     """
     test for checking connectivity of statically added ipv4 and ipv6 arp entries
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add populate_mac_table in test_vlan_ping case
Fixes # Need populate_mac_table before run test_vlan_ping case, otherwise the case may fail due to old mac table info

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
