### PR TITLE
Porting 14827 to 202405: Enabling bfd scale and associated fixes.

### DIFF
--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -107,24 +107,21 @@ def get_neighbors_scale(duthost, tbinfo, ipv6=False, scale_count=1):
     neighbor_devs = []
     ptf_devs = []
     index = 0
-    # The arrays: neighbor_intfs and ptf_intfs are filled only upto 128.
-    # Beyond that we need to re-use the same addresses. We do this by
-    # using the modulus(% operation) instead of the actual index intself.
     for idx in range(1, scale_count):
         if idx != 0 and idx % 127 == 0:
             index += 1
         if ipv6:
             local_addrs.append(t1_ipv6_pattern.format(idx * 2))
             neighbor_addrs.append(t1_ipv6_pattern.format(idx * 2 + 1))
-            neighbor_devs.append(neighbor_intfs[index % len(neighbor_intfs)])
-            ptf_devs.append(ptf_intfs[index % len(ptf_intfs)])
+            neighbor_devs.append(neighbor_intfs[index])
+            ptf_devs.append(ptf_intfs[index])
         else:
             rolloveridx = idx % 125
             idx2 = idx // 125
             local_addrs.append(t1_ipv4_pattern.format(idx2, rolloveridx * 2))
             neighbor_addrs.append(t1_ipv4_pattern.format(idx2, rolloveridx * 2 + 1))
-            neighbor_devs.append(neighbor_intfs[index % len(neighbor_intfs)])
-            ptf_devs.append(ptf_intfs[index % len(ptf_intfs)])
+            neighbor_devs.append(neighbor_intfs[index])
+            ptf_devs.append(ptf_intfs[index])
     prefix = 127 if ipv6 else 31
     return local_addrs, prefix, neighbor_addrs, neighbor_devs, ptf_devs
 

--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -107,21 +107,24 @@ def get_neighbors_scale(duthost, tbinfo, ipv6=False, scale_count=1):
     neighbor_devs = []
     ptf_devs = []
     index = 0
+    # The arrays: neighbor_intfs and ptf_intfs are filled only upto 128.
+    # Beyond that we need to re-use the same addresses. We do this by
+    # using the modulus(% operation) instead of the actual index intself.
     for idx in range(1, scale_count):
         if idx != 0 and idx % 127 == 0:
             index += 1
         if ipv6:
             local_addrs.append(t1_ipv6_pattern.format(idx * 2))
             neighbor_addrs.append(t1_ipv6_pattern.format(idx * 2 + 1))
-            neighbor_devs.append(neighbor_intfs[index])
-            ptf_devs.append(ptf_intfs[index])
+            neighbor_devs.append(neighbor_intfs[index % len(neighbor_intfs)])
+            ptf_devs.append(ptf_intfs[index % len(ptf_intfs)])
         else:
             rolloveridx = idx % 125
             idx2 = idx // 125
             local_addrs.append(t1_ipv4_pattern.format(idx2, rolloveridx * 2))
             neighbor_addrs.append(t1_ipv4_pattern.format(idx2, rolloveridx * 2 + 1))
-            neighbor_devs.append(neighbor_intfs[index])
-            ptf_devs.append(ptf_intfs[index])
+            neighbor_devs.append(neighbor_intfs[index % len(neighbor_intfs)])
+            ptf_devs.append(ptf_intfs[index % len(ptf_intfs)])
     prefix = 127 if ipv6 else 31
     return local_addrs, prefix, neighbor_addrs, neighbor_devs, ptf_devs
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -92,11 +92,11 @@ bfd/test_bfd.py::test_bfd_echo_mode:
 
 bfd/test_bfd.py::test_bfd_scale:
   skip:
-    reason: "Test is not verified for cisco-8111 and cisco-8122 yet.
+    reason: "Test not supported for cisco as it doesnt support single hop BFD.
              and not supported for platforms other than Nvidia 4600c/4700/5600 and cisco-8102. Skipping the test"
     conditions_logical_operator: or
     conditions:
-      - "platform in ['x86_64-8111_32eh_o-r0', 'x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
+      - "platform in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-8111_32eh_o-r0', 'x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
       - "platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0']"
       - "release in ['201811', '201911']"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -92,11 +92,11 @@ bfd/test_bfd.py::test_bfd_echo_mode:
 
 bfd/test_bfd.py::test_bfd_scale:
   skip:
-    reason: "Test not supported for cisco as it doesnt support single hop BFD.
+    reason: "Test is not verified for cisco-8111 and cisco-8122 yet.
              and not supported for platforms other than Nvidia 4600c/4700/5600 and cisco-8102. Skipping the test"
     conditions_logical_operator: or
     conditions:
-      - "platform in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-8111_32eh_o-r0', 'x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
+      - "platform in ['x86_64-8111_32eh_o-r0', 'x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
       - "platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0']"
       - "release in ['201811', '201911']"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
bfd_scale test was skipped for cisco-8000 till now. This PR addresses the gap, and enables it. The default is still 128. If we need to run bigger numbers, we need to pass "-e --num_sessions_scale=400" argument.

Caveat:
The ptf container is unable to handle more than ~700 sessions. This is not a limitation on the DUT. When running with 1024 sessions, the PTF pretty much hangs, and the script errors out with the error below. This needs to be seperately fixed.

```
        # Raise exception if host(s) unreachable
        # FIXME - if multiple hosts were involved, should an exception be raised?
        if callback.unreachable:
>           raise AnsibleConnectionFailure(
                "Host unreachable in the inventory",
                dark=callback.unreachable,
                contacted=callback.contacted,
            )
E           pytest_ansible.errors.AnsibleConnectionFailure: Host unreachable in the inventory

arg_value  = ['/data/ansible/library']
args       = ['pytest-ansible', 'ptf_ucs-m5-2', '--connection=smart', '--become', '--become-method=sudo', '--become-user=root', ...]
argument   = 'module-path'
callback   = <pytest_ansible.module_dispatcher.v213.ResultAccumulator object at 0x7fdbdc90c790>
complex_args = {'_raw_params': 'bfdd-control stop'}
extra_hosts = []
hosts      = [ptf_ucs-m5-2]
kwargs     = {'inventory': <ansible.inventory.manager.InventoryManager object at 0x7fdbdc10c820>, 'loader': <ansible.parsing.datalo...ss': None}, 'stdout_callback': <pytest_ansible.module_dispatcher.v213.ResultAccumulator object at 0x7fdbdc90c790>, ...}
kwargs_extra = {}
module_args = ('bfdd-control stop',)
no_hosts   = False
play       = pytest-ansible
play_ds    = {'become': True, 'become_user': 'root', 'gather_facts': 'no', 'hosts': 'ptf_ucs-m5-2', ...}
play_extra = None
self       = <pytest_ansible.module_dispatcher.v213.ModuleDispatcherV213 object at 0x7fdbdc10c670>
tqm        = <ansible.executor.task_queue_manager.TaskQueueManager object at 0x7fdbdc9755b0>
verbosity  = None
verbosity_syntax = '-vvvvv'
```

Summary:
Enable bfd_scale test for cisco-8000.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [X] 202305
- [X] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Need to enable bfd scale test for cisco-8000.

#### How did you do it?
Removed the skip condition, and fixed some issues while running bigger numbers than 128.
#### How did you verify/test it?
Ran it on my TB.