### PR TITLE
Fix pfcwd flaky pfcwd/test_pfcwd_timer_accuracy.py and test_pfcwd_mmu_change

### DIFF
--- a/tests/common/templates/pfc_storm_eos.j2
+++ b/tests/common/templates/pfc_storm_eos.j2
@@ -3,7 +3,7 @@ cd /mnt/flash
 {% if (pfc_asym  is defined) and (pfc_asym == True) %}
 {% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo python {{pfc_gen_file}} {% if pfc_gen_multiprocess is defined %}-m {% endif %}-p {{pfc_queue_index}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} &
 {% else %}
-{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo python {{pfc_gen_file}} {% if pfc_gen_multiprocess is defined %}-m {% endif %}-p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}} &
+{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo python {{pfc_gen_file}} {% if pfc_gen_multiprocess is defined %}-m {% endif %}-p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}}{% if pfc_send_period is defined %} --sendtime {{pfc_send_period}} {% endif %}-i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}} &
 {% endif %}
 exit
 exit

--- a/tests/common/templates/pfc_storm_stop_eos.j2
+++ b/tests/common/templates/pfc_storm_stop_eos.j2
@@ -3,7 +3,7 @@ cd /mnt/flash
 {% if (pfc_asym  is defined) and (pfc_asym == True) %}
 {% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo pkill -f "python {{pfc_gen_file}} {% if pfc_gen_multiprocess is defined %}-m {% endif %}-p {{pfc_queue_index}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}}" {{'&' if pfc_storm_stop_defer_time is defined else ''}}
 {% else %}
-{% if pfc_storm_stop_defer_time is defined %} sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f "python {{pfc_gen_file}} {% if pfc_gen_multiprocess is defined %}-m {% endif %}-p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}}" {{'&' if pfc_storm_stop_defer_time is defined else ''}}
+{% if pfc_storm_stop_defer_time is defined %} sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f "python {{pfc_gen_file}} {% if pfc_gen_multiprocess is defined %}-m {% endif %}-p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}}{% if pfc_send_period is defined %} --sendtime {{pfc_send_period}} {% endif %}-i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}}" {{'&' if pfc_storm_stop_defer_time is defined else ''}}
 {% endif %}
 exit
 exit

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -469,7 +469,11 @@ class SetupPfcwdFunc(object):
                 pfc_send_time = 240
             else:
                 gen_file = 'pfc_gen.py'
-                pfc_send_time = None
+
+                if self.dut.topo_type == 't2':
+                    pfc_send_time = 240
+                else:
+                    pfc_send_time = None
 
             # get pfc storm handle
             if init and detect:

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -160,15 +160,22 @@ def set_storm_params(dut, fanout_info, fanout, peer_params):
     pfc_queue_index = 4
     pfc_frames_count = 1000000
     peer_device = peer_params['peerdevice']
+
     if dut.topo_type == 't2' and fanout[peer_device].os == 'sonic':
         pfc_gen_file = 'pfc_gen_t2.py'
         pfc_send_time = 8
     else:
         pfc_gen_file = 'pfc_gen.py'
-        pfc_send_time = None
+
+        if dut.topo_type == 't2':
+            pfc_send_time = 8
+        else:
+            pfc_send_time = None
+
     storm_handle = PFCStorm(dut, fanout_info, fanout, pfc_queue_idx=pfc_queue_index,
                             pfc_frames_number=pfc_frames_count, pfc_gen_file=pfc_gen_file,
                             pfc_send_period=pfc_send_time, peer_info=peer_params)
+
     storm_handle.deploy_pfc_gen()
     return storm_handle
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 3035558 and 30115858 MMU case

If the fanout is leaf-fanout and not sonic, we currently don't have the time configuration. 

1. For `test_pfcwd_mmu_change`, this test case requires to manually stop storm for log analytics. However, without specifying the time, we dont guarantee that the storm will be lasting long enough for detection path. So the idea is we need to keep storming and manually stop ourself.

2. For `test_pfcwd_timer_accuracy.py`, this module calculate based on poll time and detect time. If the leaf is not sonic, currently there is no guarantee that it will be stormed poll time + detect time (800ms).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
We add the time configuration for leaf fanout that's not sonic as well so that we make sure to stormed for that amount of time.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
