### PR TITLE
Fix acl/test_stress_acl.py invalid interface name

### DIFF
--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -99,7 +99,7 @@ def prepare_test_port(rand_selected_dut, tbinfo):
     dut_port = ports[0] if ports else None
 
     if not dut_port:
-        pytest.skip('No portchannels available in dualtor topo')
+        pytest.skip('No portchannels available in dualtor topo or no interfaces found on DUT')
     if "Ethernet" in dut_port:
         dut_eth_port = dut_port
     elif "PortChannel" in dut_port:

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -91,12 +91,15 @@ def prepare_test_file(rand_selected_dut):
 @pytest.fixture(scope='module')
 def prepare_test_port(rand_selected_dut, tbinfo):
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
-    if tbinfo["topo"]["type"] == "mx":
-        dut_port = mg_facts["minigraph_acls"]["DataAcl"][0]
-    else:
-        dut_port = list(mg_facts['minigraph_portchannels'].keys())[0]
+
+    ports = list(mg_facts['minigraph_portchannels'])
+    if tbinfo["topo"]["type"] != "dualtor" and not ports:
+        ports = mg_facts["minigraph_acls"]["DataAcl"]
+
+    dut_port = ports[0] if ports else None
+
     if not dut_port:
-        pytest.skip('No portchannels found')
+        pytest.skip('No portchannels available in dualtor topo')
     if "Ethernet" in dut_port:
         dut_eth_port = dut_port
     elif "PortChannel" in dut_port:

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -93,13 +93,13 @@ def prepare_test_port(rand_selected_dut, tbinfo):
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
 
     ports = list(mg_facts['minigraph_portchannels'])
-    if tbinfo["topo"]["type"] != "dualtor" and not ports:
+    if not ports:
         ports = mg_facts["minigraph_acls"]["DataAcl"]
 
     dut_port = ports[0] if ports else None
 
     if not dut_port:
-        pytest.skip('No portchannels available in dualtor topo or no interfaces found on DUT')
+        pytest.skip('No portchannels nor dataacl ports found')
     if "Ethernet" in dut_port:
         dut_eth_port = dut_port
     elif "PortChannel" in dut_port:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fix acl/test_stress_acl.py using bad interface name for ACL table creation
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In `acl/test_stress_acl.py`, it attempts to retrieve an interface that can be used to create a ACL table. DUTs with and without PortChannels require different methods respectively.

Currently, it checks by filtering with topo. However, some topology flags can have configurations that have or not have PortChannels, making topos no longer a sufficient check - in some topos the test will fail with:
```
Error: Failed to parse ACL table config: exception=Cannot bind ACL to specified port Ethernet136
```

Reproducible by manually running the following on the DUT:
```
config acl add table DATAACL L3 -s ingress -p Ethernet0
^FAILS
config acl add table DATAACL L3 -s ingress -p PortChannel101
^WORKS
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Fix by checking if a PortChannel exists. If it does - use it. If it does not - fallback on the secondary method to retrieve a normal interface name if its a not a dualtor topo (due to
https://github.com/sonic-net/sonic-mgmt/pull/6960).

#### How did you verify/test it?
Test no longer fails creating an ACL table on a t1 topo with PortChannels.
Tested with Arista HwSkus on t0, t1, t2, and mx topologies.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
