### PR TITLE
Add log ignore to account for FDB flush race condition

### DIFF
--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
 
     ignore_errors = [
+        r".*ERR swss#orchagent: :- update: Failed to get port by bridge port ID.*",
         r".* ERR swss#tunnel_packet_handler.py: All portchannels failed to come up within \d+ minutes, exiting.*"
         ]
     if loganalyzer:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
During fdb/test_fdb_mac_learning.py::testARPCompleted, syslog will output the following error log:

```
ERR swss#orchagent: :- update: Failed to get port by bridge port ID 0x3a00000000155c.
```

This is not an actual error, but a minor race condition - it is caused by Broadcom SAI sending a FDB AGED event after the FDB entry has been flushed, causing orchagent to check on a bridge port that does not exist. Fix by extending log ignore to the test.

Same issue as the one reoslved in
https://github.com/sonic-net/sonic-mgmt/pull/9818

Separate PR created for 202405: https://github.com/sonic-net/sonic-mgmt/pull/15798

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Test no longer fails with log analyzer on Broadcom platforms.

#### Any platform specific information?
Broadcom platforms only.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
