### PR TITLE
TypeError in test_multidut_pfc_pause_lossy_with_snappi.py

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -4,6 +4,7 @@ This module allows various snappi based tests to generate various traffic config
 import time
 import logging
 import random
+import re
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi_tests.common_helpers import get_egress_queue_count, pfc_class_enable_vector, \
     get_lossless_buffer_size, get_pg_dropped_packets, \
@@ -530,15 +531,20 @@ def verify_basic_test_flow(flow_metrics,
         else:
             pytest_assert(tx_frames == rx_frames,
                           "{} should not have any dropped packet".format(metric.name))
+
             # Check if flow_rate_percent is a dictionary
             if isinstance(data_flow_config["flow_rate_percent"], dict):
-                # Sum all the flow rate percentages
-                total_flow_rate_percent = sum(data_flow_config["flow_rate_percent"].values())
+                # Extract the priority number from metric.name
+                match = re.search(r'Prio (\d+)', metric.name)
+                prio = int(match.group(1)) if match else None
+                flow_rate_percent = data_flow_config["flow_rate_percent"].get(prio, 0)
             else:
                 # Use the flow rate percent as is
-                total_flow_rate_percent = data_flow_config["flow_rate_percent"]
-            exp_test_flow_rx_pkts = total_flow_rate_percent / 100.0 * speed_gbps \
+                flow_rate_percent = data_flow_config["flow_rate_percent"]
+
+            exp_test_flow_rx_pkts = flow_rate_percent / 100.0 * speed_gbps \
                 * 1e9 * data_flow_config["flow_dur_sec"] / 8.0 / data_flow_config["flow_pkt_size"]
+
             deviation = (rx_frames - exp_test_flow_rx_pkts) / float(exp_test_flow_rx_pkts)
             pytest_assert(abs(deviation) < tolerance,
                           "{} should receive {} packets (actual {})".

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -529,8 +529,14 @@ def verify_basic_test_flow(flow_metrics,
         else:
             pytest_assert(tx_frames == rx_frames,
                           "{} should not have any dropped packet".format(metric.name))
-
-            exp_test_flow_rx_pkts = data_flow_config["flow_rate_percent"] / 100.0 * speed_gbps \
+            # Check if flow_rate_percent is a dictionary
+            if isinstance(data_flow_config["flow_rate_percent"], dict):
+                # Sum all the flow rate percentages
+                total_flow_rate_percent = sum(data_flow_config["flow_rate_percent"].values())
+            else:
+                # Use the flow rate percent as is
+                total_flow_rate_percent = data_flow_config["flow_rate_percent"]
+            exp_test_flow_rx_pkts = total_flow_rate_percent / 100.0 * speed_gbps \
                 * 1e9 * data_flow_config["flow_dur_sec"] / 8.0 / data_flow_config["flow_pkt_size"]
             deviation = (rx_frames - exp_test_flow_rx_pkts) / float(exp_test_flow_rx_pkts)
             pytest_assert(abs(deviation) < tolerance,

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -351,9 +351,10 @@ def run_traffic(duthost,
         cs.state = cs.START
         api.set_capture_state(cs)
 
-    clear_dut_interface_counters(duthost)
-
-    clear_dut_que_counters(duthost)
+    for host in set([*snappi_extra_params.multi_dut_params.ingress_duthosts,
+                     *snappi_extra_params.multi_dut_params.egress_duthosts, duthost]):
+        clear_dut_interface_counters(host)
+        clear_dut_que_counters(host)
 
     logger.info("Starting transmit on all flows ...")
     ts = api.transmit_state()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

Issue #15799 

#### How did you do it?

Made code changes

#### How did you verify/test it?

Verified on a Ixia run

```
------------------------------------------------------------------------------------------------------------------------------------ live log sessionfinish -------------------------------------------------------------------------------------------------------------------------------------
22:33:44 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
==================================================================================================================================== short test summary info ====================================================================================================================================
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info0-aaa14-ixia-m64|0]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info0-aaa14-ixia-m64|1]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info0-aaa14-ixia-m64|2]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info0-aaa14-ixia-m64|5]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info0-aaa14-ixia-m64|6]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info1-aaa14-ixia-m64|0]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info1-aaa14-ixia-m64|1]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info1-aaa14-ixia-m64|2]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info1-aaa14-ixia-m64|5]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info1-aaa14-ixia-m64|6]
========================================================================================================================= 10 passed, 13 warnings in 1932.91s (0:32:12) ==========================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
