### PR TITLE
MIGSMSFT-767 test_pfcwd_basic_single_lossless_prio_reboot: Loss rate of Data Flow 2 (0.1140553129761207) should be in [0, 0]

### DIFF
--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
@@ -1,7 +1,6 @@
 import time
 from math import ceil
 import logging
-import random
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
@@ -24,6 +23,7 @@ WARM_UP_TRAFFIC_DUR = 1
 DATA_PKT_SIZE = 1024
 SNAPPI_POLL_DELAY_SEC = 2
 DEVIATION = 0.3
+UDP_PORT_START = 5000
 
 
 def run_pfcwd_basic_test(api,
@@ -102,8 +102,8 @@ def run_pfcwd_basic_test(api,
         """ Large enough to trigger PFC watchdog """
         pfc_storm_dur_sec = ceil(detect_time_sec + poll_interval_sec + 0.1)
 
-        flow1_delay_sec = restore_time_sec / 2 + WARM_UP_TRAFFIC_DUR
-        flow1_dur_sec = pfc_storm_dur_sec
+        flow1_delay_sec = detect_time_sec + poll_interval_sec
+        flow1_dur_sec = pfc_storm_dur_sec - flow1_delay_sec + restore_time_sec
 
         """ Start data traffic 2 after PFC is restored """
         flow2_delay_sec = pfc_storm_dur_sec + restore_time_sec + \
@@ -143,8 +143,8 @@ def run_pfcwd_basic_test(api,
                   data_pkt_size=DATA_PKT_SIZE,
                   prio_list=prio_list,
                   prio_dscp_map=prio_dscp_map,
-                  traffic_rate=99.98 if cisco_platform else 100.0,
-                  number_of_streams=2 if cisco_platform else 1)
+                  traffic_rate=49.99 if cisco_platform else 100.0,
+                  number_of_streams=1)
 
     flows = testbed_config.flows
 
@@ -313,10 +313,6 @@ def __gen_traffic(testbed_config,
             data_flow.tx_rx.port.rx_name = rx_port_name
 
             eth, ipv4, udp = data_flow.packet.ethernet().ipv4().udp()
-            src_port = random.randint(5000, 6000)
-            udp.src_port.increment.start = src_port
-            udp.src_port.increment.step = 1
-            udp.src_port.increment.count = number_of_streams
 
             eth.src.value = tx_mac
             eth.dst.value = rx_mac
@@ -324,6 +320,11 @@ def __gen_traffic(testbed_config,
                 eth.pfc_queue.value = prio
             else:
                 eth.pfc_queue.value = pfcQueueValueDict[prio]
+
+            src_port = UDP_PORT_START + eth.pfc_queue.value * number_of_streams
+            udp.src_port.increment.start = src_port
+            udp.src_port.increment.step = 1
+            udp.src_port.increment.count = number_of_streams
 
             ipv4.src.value = tx_port_config.ip
             ipv4.dst.value = rx_port_config.ip

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_basic_helper.py
@@ -102,8 +102,8 @@ def run_pfcwd_basic_test(api,
         """ Large enough to trigger PFC watchdog """
         pfc_storm_dur_sec = ceil(detect_time_sec + poll_interval_sec + 0.1)
 
-        flow1_delay_sec = detect_time_sec + poll_interval_sec
-        flow1_dur_sec = pfc_storm_dur_sec - flow1_delay_sec + restore_time_sec
+        flow1_delay_sec = restore_time_sec / 2 + WARM_UP_TRAFFIC_DUR
+        flow1_dur_sec = pfc_storm_dur_sec
 
         """ Start data traffic 2 after PFC is restored """
         flow2_delay_sec = pfc_storm_dur_sec + restore_time_sec + \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://migsonic.atlassian.net/browse/MIGSMSFT-767 [T2 IXIA] failures in test_pfcwd_basic_single_lossless_prio_reboot: Loss rate of Data Flow 2 (0.1140553129761207) should be in [0, 0]

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fix the failures of test_multidut_pfcwd_basic_with_snappi.py

#### How did you do it?
Data flow 2 dropped packets. 
2 flows in default-voq used single voq, which caused tail drop before pfc pause was triggered. Decrease flow number from 2 to 1. Since backplane port's bandwidth is 200G, also decrease the traffic rate from 99.98% to 49.99%

#### How did you verify/test it?
Verified on T2 ixia testbed.
```
----------------------- generated xml file: /run_logs/ixia/18470/2024-11-28-06-00-02/tr_2024-11-28-06-00-02.xml -----------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------- live log sessionfinish --------------------------------------------------------
08:42:08 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
======================================================= short test summary info =======================================================
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info0-True]
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info0-False]
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-True]
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-False]
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_reboot[multidut_port_info0-cold-yy39top-lc4|3-True]
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_reboot[multidut_port_info0-cold-yy39top-lc4|3-False]
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_reboot[multidut_port_info0-cold-True]
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_reboot[multidut_port_info0-cold-False]
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_service_restart[multidut_port_info0-True-swss]
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_service_restart[multidut_port_info0-False-swss]
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info0-True-swss]
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info0-False-swss]
SKIPPED [2] snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py:142: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py:142: Reboot type fast is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py:190: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py:190: Reboot type fast is not supported on cisco-8000 switches
======================================= 12 passed, 8 skipped, 15 warnings in 9723.32s (2:42:03) =======================================
sonic@snappi-sonic-mgmt-vanilla-202405-t2:/data/tests$ 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
