### PR TITLE
Fix PTF TACACS always use default password issue

### DIFF
--- a/ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
+++ b/ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
@@ -80,6 +80,7 @@
     - name: Encrypt TACACS password from secret_group_vars
       shell: python3 -c "import crypt; print(crypt.crypt('{{secret_group_vars['str']['altpasswords'][0]}}', 'abc'))"
       register: encrypted_sonic_password_secret_group_vars
+      no_log: True
       delegate_to: "{{ ptf_host }}"
 
     - name: Set TACACS password from encrypted password from secret_group_vars
@@ -99,6 +100,7 @@
     - name: Encrypt TACACS password from sonicadmin_password
       shell: python3 -c "import crypt; print(crypt.crypt('{{sonicadmin_password}}', 'abc'))"
       register: encrypted_sonic_password_sonicadmin_password
+      no_log: True
       delegate_to: "{{ ptf_host }}"
 
     - name: Set TACACS password from encrypted sonicadmin_password
@@ -108,7 +110,7 @@
     when:
       - tacacs_user_passwd is not defined
 
-- debug: msg="tacacs_user_passwd {{ tacacs_user_passwd }}"
+- debug: msg="encrypted tacacs_user_passwd {{ tacacs_user_passwd }}"
 
 - block:
     - name: Generate tacacs daily daemon config file

--- a/ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
+++ b/ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
@@ -79,12 +79,12 @@
 
     - name: Encrypt TACACS password from secret_group_vars
       shell: python3 -c "import crypt; print(crypt.crypt('{{secret_group_vars['str']['altpasswords'][0]}}', 'abc'))"
-      register: encrypted_sonic_password
+      register: encrypted_sonic_password_secret_group_vars
       delegate_to: "{{ ptf_host }}"
 
-    - name: Set TACACS password from encrypted_sonic_password
+    - name: Set TACACS password from encrypted password from secret_group_vars
       set_fact:
-        tacacs_user_passwd: '{{ encrypted_sonic_password.stdout }}'
+        tacacs_user_passwd: '{{ encrypted_sonic_password_secret_group_vars.stdout }}'
 
     when:
       - secret_group_vars is defined
@@ -98,15 +98,15 @@
 
     - name: Encrypt TACACS password from sonicadmin_password
       shell: python3 -c "import crypt; print(crypt.crypt('{{sonicadmin_password}}', 'abc'))"
-      register: encrypted_sonic_password
+      register: encrypted_sonic_password_sonicadmin_password
       delegate_to: "{{ ptf_host }}"
+
+    - name: Set TACACS password from encrypted sonicadmin_password
+      set_fact:
+        tacacs_user_passwd: '{{ encrypted_sonic_password_sonicadmin_password.stdout }}'
 
     when:
       - tacacs_user_passwd is not defined
-
-  - name: Set TACACS password from encrypted_sonic_password
-    set_fact:
-      tacacs_user_passwd: '{{ encrypted_sonic_password.stdout }}'
 
 - debug: msg="tacacs_user_passwd {{ tacacs_user_passwd }}"
 

--- a/ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
+++ b/ansible/roles/vm_set/tasks/start_tacacs_daily_daemon.yml
@@ -82,6 +82,10 @@
       register: encrypted_sonic_password
       delegate_to: "{{ ptf_host }}"
 
+    - name: Set TACACS password from encrypted_sonic_password
+      set_fact:
+        tacacs_user_passwd: '{{ encrypted_sonic_password.stdout }}'
+
     when:
       - secret_group_vars is defined
       - secret_group_vars['str'] is defined


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
The code for setting up TACACS on PTF host has an issue of always using default password.

#### How did you do it?
The original intention is to get an alternate password. If the alternate password cannot be found, then use default password.

However, the step of using default password always override the alternate password.

This change added code to store  the alternate password in variable `tacacs_user_passwd`. Then the override logic won't happen if alternate password is found.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
