### PR TITLE
[Bugfix] Fix missing imports for `platform_api_conn` in `tests/platform_tests/api`

### DIFF
--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -5,6 +5,7 @@ import pytest
 
 from tests.common.helpers.platform_api import chassis, fan
 from .platform_api_test_base import PlatformApiTestBase
+from tests.common.platform.device_utils import platform_api_conn    # noqa F401
 from tests.common.helpers.thermal_control_test_helper import start_thermal_control_daemon, stop_thermal_control_daemon
 
 ###################################################
@@ -45,7 +46,7 @@ class TestChassisFans(PlatformApiTestBase):
     # level, so we must do the same here to prevent a scope mismatch.
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, platform_api_conn, duthost):
+    def setup(self, platform_api_conn, duthost):    # noqa F811
         if self.num_fans is None:
             try:
                 self.num_fans = int(chassis.get_num_fans(platform_api_conn))
@@ -92,7 +93,7 @@ class TestChassisFans(PlatformApiTestBase):
     #
     # Functions to test methods inherited from DeviceBase class
     #
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for i in range(self.num_fans):
             name = fan.get_name(platform_api_conn, i)
@@ -103,7 +104,7 @@ class TestChassisFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for i in range(self.num_fans):
             presence = fan.get_presence(platform_api_conn, i)
 
@@ -113,7 +114,7 @@ class TestChassisFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):     # noqa F811
         for i in range(self.num_fans):
             model = fan.get_model(platform_api_conn, i)
 
@@ -122,7 +123,7 @@ class TestChassisFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         for i in range(self.num_fans):
             serial = fan.get_serial(platform_api_conn, i)
 
@@ -131,7 +132,7 @@ class TestChassisFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         for i in range(self.num_fans):
             status = fan.get_status(platform_api_conn, i)
 
@@ -140,14 +141,14 @@ class TestChassisFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_position_in_parent(self, platform_api_conn):
+    def test_get_position_in_parent(self, platform_api_conn):   # noqa F811
         for i in range(self.num_fans):
             position = fan.get_position_in_parent(platform_api_conn, i)
             if self.expect(position is not None, "Failed to perform get_position_in_parent for fan {}".format(i)):
                 self.expect(isinstance(position, int), "Position value must be an integer value for fan {}".format(i))
         self.assert_expectations()
 
-    def test_is_replaceable(self, platform_api_conn):
+    def test_is_replaceable(self, platform_api_conn):       # noqa F811
         for i in range(self.num_fans):
             replaceable = fan.is_replaceable(platform_api_conn, i)
             if self.expect(replaceable is not None, "Failed to perform is_replaceable for fan {}".format(i)):
@@ -159,7 +160,7 @@ class TestChassisFans(PlatformApiTestBase):
     # Functions to test methods defined in FanBase class
     #
 
-    def test_get_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn): # noqa F811
         # Ensure the fan speed is sane
         for i in range(self.num_fans):
             speed = fan.get_speed(platform_api_conn, i)
@@ -170,7 +171,7 @@ class TestChassisFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_direction(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_direction(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn): # noqa F811
         # Ensure the fan speed is sane
         FAN_DIRECTION_LIST = [
             "intake",
@@ -186,7 +187,7 @@ class TestChassisFans(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_fans_target_speed(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                   localhost, platform_api_conn):
+                                   localhost, platform_api_conn):   # noqa F811
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         fans_skipped = 0
@@ -218,7 +219,7 @@ class TestChassisFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_set_fans_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_set_fans_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn): # noqa F811
 
         fans_skipped = 0
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -258,7 +259,7 @@ class TestChassisFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_set_fans_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_set_fans_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         LED_COLOR_LIST = [
             "off",
             "red",

--- a/tests/platform_tests/api/test_fan_drawer_fans.py
+++ b/tests/platform_tests/api/test_fan_drawer_fans.py
@@ -6,6 +6,7 @@ import pytest
 
 from tests.common.helpers.platform_api import chassis, fan_drawer, fan_drawer_fan
 from tests.common.helpers.thermal_control_test_helper import start_thermal_control_daemon, stop_thermal_control_daemon
+from tests.common.platform.device_utils import platform_api_conn    # noqa F401
 from .platform_api_test_base import PlatformApiTestBase
 
 ###################################################
@@ -46,7 +47,7 @@ class TestFanDrawerFans(PlatformApiTestBase):
     # level, so we must do the same here to prevent a scope mismatch.
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn):
+    def setup(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn): # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         if self.num_fan_drawers is None:
             try:
@@ -102,7 +103,7 @@ class TestFanDrawerFans(PlatformApiTestBase):
     #
     # Functions to test methods inherited from DeviceBase class
     #
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for j in range(self.num_fan_drawers):
             num_fans = fan_drawer.get_num_fans(platform_api_conn, j)
@@ -117,7 +118,7 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
 
         for j in range(self.num_fan_drawers):
             num_fans = fan_drawer.get_num_fans(platform_api_conn, j)
@@ -134,7 +135,7 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn): # noqa F811
 
         for j in range(self.num_fan_drawers):
             num_fans = fan_drawer.get_num_fans(platform_api_conn, j)
@@ -148,7 +149,7 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
 
         for j in range(self.num_fan_drawers):
             num_fans = fan_drawer.get_num_fans(platform_api_conn, j)
@@ -163,7 +164,7 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
 
         for j in range(self.num_fan_drawers):
             num_fans = fan_drawer.get_num_fans(platform_api_conn, j)
@@ -176,7 +177,7 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_position_in_parent(self, platform_api_conn):
+    def test_get_position_in_parent(self, platform_api_conn):   # noqa F811
         for j in range(self.num_fan_drawers):
             num_fans = fan_drawer.get_num_fans(platform_api_conn, j)
             for i in range(num_fans):
@@ -187,7 +188,7 @@ class TestFanDrawerFans(PlatformApiTestBase):
                                 "Position value must be an integer value for drawer {} fan {}".format(j, i))
         self.assert_expectations()
 
-    def test_is_replaceable(self, platform_api_conn):
+    def test_is_replaceable(self, platform_api_conn):       # noqa F811
         for j in range(self.num_fan_drawers):
             num_fans = fan_drawer.get_num_fans(platform_api_conn, j)
             for i in range(num_fans):
@@ -203,7 +204,7 @@ class TestFanDrawerFans(PlatformApiTestBase):
     # Functions to test methods defined in FanBase class
     #
 
-    def test_get_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):     # noqa F811
 
         for j in range(self.num_fan_drawers):
             num_fans = fan_drawer.get_num_fans(platform_api_conn, j)
@@ -219,7 +220,7 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_direction(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_direction(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn): # noqa F811
         # Ensure the fan speed is sane
         FAN_DIRECTION_LIST = [
             "intake",
@@ -239,8 +240,8 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_fans_target_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn,
-                                   suspend_and_resume_hw_tc_on_mellanox_device):
+    def test_get_fans_target_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                   platform_api_conn, suspend_and_resume_hw_tc_on_mellanox_device):        # noqa F811
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         fan_drawers_skipped = 0
@@ -282,7 +283,7 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_set_fans_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_set_fans_speed(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn): # noqa F811
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         fan_drawers_skipped = 0
@@ -327,7 +328,7 @@ class TestFanDrawerFans(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_set_fans_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_set_fans_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         FAULT_LED_COLOR_LIST = [
             STATUS_LED_COLOR_AMBER,

--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -8,6 +8,7 @@ from tests.platform_tests.cli.util import get_skip_mod_list
 from .platform_api_test_base import PlatformApiTestBase
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs
+from tests.common.platform.device_utils import platform_api_conn    # noqa F401
 
 ###################################################
 # TODO: Remove this after we transition to Python 3
@@ -67,7 +68,7 @@ class TestModuleApi(PlatformApiTestBase):
     # it relies on the platform_api_conn_per_supervisor fixture, which is scoped at the function
     # level, so we must do the same here to prevent a scope mismatch.
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, platform_api_conn):
+    def setup(self, platform_api_conn): # noqa F811
         if self.num_modules is None:
             try:
                 self.num_modules = int(chassis.get_num_modules(platform_api_conn))
@@ -85,14 +86,14 @@ class TestModuleApi(PlatformApiTestBase):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         self.skip_mod_list = get_skip_mod_list(duthost)
 
-    def skip_absent_module(self, module_num, platform_api_conn):
+    def skip_absent_module(self, module_num, platform_api_conn):    # noqa F811
         name = module.get_name(platform_api_conn, module_num)
         if name in self.skip_mod_list:
             logger.info("Skipping module {} since it is part of skip_mod_list".format(name))
             return True
         return False
 
-    def skip_module_other_than_myself(self, module_num, platform_api_conn):
+    def skip_module_other_than_myself(self, module_num, platform_api_conn): # noqa F811
         if chassis.is_modular_chassis(platform_api_conn):
             name = module.get_name(platform_api_conn, module_num)
             module_slot = module.get_slot(platform_api_conn, module_num)
@@ -103,7 +104,7 @@ class TestModuleApi(PlatformApiTestBase):
             return False
         return False
 
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
 
         for i in range(self.num_modules):
             if self.skip_absent_module(i, platform_api_conn):
@@ -113,7 +114,7 @@ class TestModuleApi(PlatformApiTestBase):
                 self.expect(isinstance(name, STRING_TYPE), "Module {} name appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
 
         for i in range(self.num_modules):
             presence = module.get_presence(platform_api_conn, i)
@@ -126,7 +127,7 @@ class TestModuleApi(PlatformApiTestBase):
                         logger.info("Skipping module {} since it is part of skip_mod_list".format(name))
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn): # noqa F811
 
         for i in range(self.num_modules):
             if self.skip_absent_module(i, platform_api_conn):
@@ -138,7 +139,7 @@ class TestModuleApi(PlatformApiTestBase):
                 self.expect(isinstance(model, STRING_TYPE), "Module {} model appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
 
         for i in range(self.num_modules):
             if self.skip_absent_module(i, platform_api_conn):
@@ -150,7 +151,7 @@ class TestModuleApi(PlatformApiTestBase):
                 self.expect(isinstance(serial, STRING_TYPE), "Module {} serial number appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
 
         for i in range(self.num_modules):
             if self.skip_absent_module(i, platform_api_conn):
@@ -160,7 +161,7 @@ class TestModuleApi(PlatformApiTestBase):
                 self.expect(isinstance(status, bool), "Module {} status appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_position_in_parent(self, platform_api_conn):
+    def test_get_position_in_parent(self, platform_api_conn):   # noqa F811
         for i in range(self.num_modules):
             if self.skip_absent_module(i, platform_api_conn):
                 continue
@@ -170,7 +171,7 @@ class TestModuleApi(PlatformApiTestBase):
                             "Position value must be an integer value for module {}".format(i))
         self.assert_expectations()
 
-    def test_is_replaceable(self, platform_api_conn):
+    def test_is_replaceable(self, platform_api_conn):   # noqa F811
         for i in range(self.num_modules):
             if self.skip_absent_module(i, platform_api_conn):
                 continue
@@ -185,7 +186,7 @@ class TestModuleApi(PlatformApiTestBase):
     # Functions to test methods defined in ModuleBase class
     #
 
-    def test_get_base_mac(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_base_mac(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
 
         # Ensure the base MAC address of each module is sane
         # TODO: Add expected base MAC address for each module to inventory file and compare against it
@@ -206,7 +207,8 @@ class TestModuleApi(PlatformApiTestBase):
                         "Module {}: Base MAC address appears to be incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_system_eeprom_info(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_system_eeprom_info(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                    platform_api_conn):     # noqa F811
         """
         Test that we can retrieve sane system EEPROM info from each module of the DUT via the platform API
         """
@@ -286,7 +288,7 @@ class TestModuleApi(PlatformApiTestBase):
                         "Module {}: Serial number appears to be incorrect".format(i))
         self.assert_expectations()
 
-    def test_components(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_components(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
 
         # TODO: Ensure the number of components and that the returned list is correct for this platform
         for mod_idx in range(self.num_modules):
@@ -308,7 +310,7 @@ class TestModuleApi(PlatformApiTestBase):
                             "Module {}: Component {} is incorrect".format(mod_idx, comp_idx))
         self.assert_expectations()
 
-    def test_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_fans(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
 
         # TODO: Ensure the number of fans and that the returned list is correct for this platform
         for mod_idx in range(self.num_modules):
@@ -330,7 +332,7 @@ class TestModuleApi(PlatformApiTestBase):
                             "Module {}: Fan {} is incorrect".format(mod_idx, fan_idx))
         self.assert_expectations()
 
-    def test_psus(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_psus(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):      # noqa F811
 
         # TODO: Ensure the number of PSUs and that the returned list is correct for this platform
         for mod_idx in range(self.num_modules):
@@ -352,7 +354,7 @@ class TestModuleApi(PlatformApiTestBase):
                             "Module {}: PSU {} is incorrect".format(mod_idx, psu_idx))
         self.assert_expectations()
 
-    def test_thermals(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_thermals(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):      # noqa F811
 
         # TODO: Ensure the number of thermals and that the returned list is correct for this platform
         for mod_idx in range(self.num_modules):
@@ -374,7 +376,7 @@ class TestModuleApi(PlatformApiTestBase):
                             "Thermal {} is incorrect".format(therm_idx))
         self.assert_expectations()
 
-    def test_sfps(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_sfps(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):      # noqa F811
 
         # TODO: Ensure the number of SFPs and that the returned list is correct for this platform
         for mod_idx in range(self.num_modules):
@@ -396,7 +398,8 @@ class TestModuleApi(PlatformApiTestBase):
                             "Module {}: SFP {} is incorrect".format(mod_idx, sfp_idx))
         self.assert_expectations()
 
-    def test_get_description(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_description(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                             platform_api_conn):   # noqa F811
 
         for i in range(self.num_modules):
             if self.skip_absent_module(i, platform_api_conn):
@@ -407,7 +410,7 @@ class TestModuleApi(PlatformApiTestBase):
                             "Module {} description appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_slot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_slot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
 
         for i in range(self.num_modules):
             if self.skip_absent_module(i, platform_api_conn):
@@ -418,7 +421,7 @@ class TestModuleApi(PlatformApiTestBase):
                             "Module {} slot id is not correct ".format(i))
         self.assert_expectations()
 
-    def test_get_type(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_type(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
 
         for i in range(self.num_modules):
             if self.skip_absent_module(i, platform_api_conn):
@@ -430,7 +433,7 @@ class TestModuleApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_maximum_consumed_power(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                        localhost, platform_api_conn):
+                                        localhost, platform_api_conn):  # noqa F811
 
         for i in range(self.num_modules):
             if self.skip_absent_module(i, platform_api_conn):
@@ -441,7 +444,8 @@ class TestModuleApi(PlatformApiTestBase):
                             "Module {} max consumed power format appears incorrect ".format(i))
         self.assert_expectations()
 
-    def test_get_midplane_ip(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_midplane_ip(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                             platform_api_conn):   # noqa F811
 
         for i in range(self.num_modules):
             if self.skip_absent_module(i, platform_api_conn):
@@ -454,7 +458,8 @@ class TestModuleApi(PlatformApiTestBase):
                                 "Module {} midplane ip appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_is_midplane_reachable(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_is_midplane_reachable(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                   platform_api_conn):      # noqa F811
 
         for i in range(self.num_modules):
             if self.skip_absent_module(i, platform_api_conn):
@@ -468,7 +473,8 @@ class TestModuleApi(PlatformApiTestBase):
                                 "Module {} midplabe reachability appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_oper_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_oper_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                             platform_api_conn):   # noqa F811
 
         for i in range(self.num_modules):
             if self.skip_absent_module(i, platform_api_conn):
@@ -479,7 +485,7 @@ class TestModuleApi(PlatformApiTestBase):
                 self.expect(status in MODULE_STATUS, "Module {}  status {} is invalid value".format(i, status))
         self.assert_expectations()
 
-    def test_reboot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_reboot(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         reboot_type = 'default'
         reboot_timeout = 300
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -10,6 +10,7 @@ from tests.common.platform.interface_utils import get_physical_port_indices
 from tests.common.utilities import wait_until
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F401
 from tests.common.fixtures.duthost_utils import shutdown_ebgp           # noqa F401
+from tests.common.platform.device_utils import platform_api_conn    # noqa F401
 
 from .platform_api_test_base import PlatformApiTestBase
 
@@ -322,7 +323,7 @@ class TestSfpApi(PlatformApiTestBase):
     # Functions to test methods inherited from DeviceBase class
     #
 
-    def test_get_name(self,  duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_name(self,  duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn): # noqa F811
         expected_sfp_names = self.sfp_setup["sfp_fact_names"]
         for i in self.sfp_setup["sfp_test_port_indices"]:
             name = sfp.get_name(platform_api_conn, i)
@@ -332,7 +333,7 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver name '{}' for PORT{} NOT found in platform.json".format(name, i))
         self.assert_expectations()
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for i in self.sfp_setup["sfp_test_port_indices"]:
             presence = sfp.get_presence(platform_api_conn, i)
             if self.expect(presence is not None, "Unable to retrieve transceiver {} presence".format(i)):
@@ -340,7 +341,7 @@ class TestSfpApi(PlatformApiTestBase):
                     self.expect(presence is True, "Transceiver {} is not present".format(i))
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn): # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
 
@@ -350,7 +351,7 @@ class TestSfpApi(PlatformApiTestBase):
                 self.expect(isinstance(model, STRING_TYPE), "Transceiver {} model appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
 
@@ -361,7 +362,7 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} serial number appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_is_replaceable(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn):
+    def test_is_replaceable(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn):   # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
         for sfp_id in self.sfp_setup["sfp_test_port_indices"]:
@@ -375,7 +376,8 @@ class TestSfpApi(PlatformApiTestBase):
     # Functions to test methods defined in SfpBase class
     #
 
-    def test_get_transceiver_info(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_transceiver_info(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                  platform_api_conn):   # noqa F811
         # TODO: Do more sanity checking on transceiver info values
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
@@ -430,7 +432,7 @@ class TestSfpApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_transceiver_bulk_status(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                         localhost, platform_api_conn, port_list_with_flat_memory):
+                                         localhost, platform_api_conn, port_list_with_flat_memory): # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
 
@@ -454,7 +456,7 @@ class TestSfpApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_transceiver_threshold_info(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                            localhost, platform_api_conn):
+                                            localhost, platform_api_conn):      # noqa F811
         # TODO: Do more sanity checking on transceiver threshold info values
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
@@ -495,7 +497,8 @@ class TestSfpApi(PlatformApiTestBase):
                             False, "Transceiver {} threshold info contains unexpected field '{}'".format(i, key))
         self.assert_expectations()
 
-    def test_get_reset_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_reset_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                              platform_api_conn):  # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
 
@@ -507,7 +510,7 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} reset status appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_rx_los(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_rx_los(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         # TODO: Do more sanity checking on the data we retrieve
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
@@ -528,7 +531,7 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} RX loss-of-signal data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_tx_fault(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_tx_fault(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         # TODO: Do more sanity checking on the data we retrieve
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
@@ -548,7 +551,8 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} TX fault data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                             platform_api_conn):   # noqa F811
         # TODO: Do more sanity checking on the data we retrieve
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
@@ -567,7 +571,7 @@ class TestSfpApi(PlatformApiTestBase):
                 self.expect(isinstance(temp, float), "Transceiver {} temperature appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_voltage(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_voltage(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa F811
         # TODO: Do more sanity checking on the data we retrieve
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
@@ -586,7 +590,7 @@ class TestSfpApi(PlatformApiTestBase):
                 self.expect(isinstance(voltage, float), "Transceiver {} voltage appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_tx_bias(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_tx_bias(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):   # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
 
@@ -605,7 +609,7 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} TX bias data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_rx_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_rx_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
 
@@ -630,7 +634,7 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} RX power data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_tx_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_tx_power(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         # TODO: Do more sanity checking on the data we retrieve
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
@@ -661,7 +665,7 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} TX power data appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_reset(self, request, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_reset(self, request, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn): # noqa F811
         # TODO: Verify that the transceiver was actually reset
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
@@ -678,7 +682,7 @@ class TestSfpApi(PlatformApiTestBase):
                 self.expect(ret is False, "Resetting transceiver {} succeeded but should have failed".format(i))
         self.assert_expectations()
 
-    def test_tx_disable(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_tx_disable(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         """This function tests both the get_tx_disable() and tx_disable() APIs"""
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
@@ -705,7 +709,8 @@ class TestSfpApi(PlatformApiTestBase):
                                     "Transceiver {} TX disable data is incorrect".format(i))
         self.assert_expectations()
 
-    def test_tx_disable_channel(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_tx_disable_channel(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                platform_api_conn):     # noqa F811
         """This function tests both the get_tx_disable_channel() and tx_disable_channel() APIs"""
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx", "nokia"])
@@ -758,10 +763,10 @@ class TestSfpApi(PlatformApiTestBase):
                     expected_mask = expected_mask >> 1
         self.assert_expectations()
 
-    def _check_lpmode_status(self, sfp, platform_api_conn, i, state):
+    def _check_lpmode_status(self, sfp, platform_api_conn, i, state):   # noqa F811
         return state == sfp.get_lpmode(platform_api_conn, i)
 
-    def test_lpmode(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_lpmode(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         """This function tests both the get_lpmode() and set_lpmode() APIs"""
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
@@ -800,7 +805,8 @@ class TestSfpApi(PlatformApiTestBase):
                             .format(i, "enable" if state is True else "disable"))
         self.assert_expectations()
 
-    def test_power_override(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_power_override(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                            platform_api_conn):    # noqa F811
         """This function tests both the get_power_override() and set_power_override() APIs"""
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx", "nokia"])
@@ -846,7 +852,8 @@ class TestSfpApi(PlatformApiTestBase):
                             "Transceiver {} power override data is incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_error_description(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_error_description(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                   platform_api_conn):      # noqa F811
         """This function tests get_error_description() API (supported on 202106 and above)"""
         skip_release(duthosts[enum_rand_one_per_hwsku_hostname], ["201811", "201911", "202012"])
 
@@ -865,7 +872,7 @@ class TestSfpApi(PlatformApiTestBase):
                     self.expect(error_description == "OK", "Transceiver {} is not present".format(i))
         self.assert_expectations()
 
-    def test_thermals(self, platform_api_conn):
+    def test_thermals(self, platform_api_conn):     # noqa F811
         for sfp_id in self.sfp_setup["sfp_test_port_indices"]:
             try:
                 num_thermals = int(sfp.get_num_thermals(platform_api_conn, sfp_id))

--- a/tests/platform_tests/api/test_thermal.py
+++ b/tests/platform_tests/api/test_thermal.py
@@ -3,6 +3,7 @@ import pytest
 
 from tests.common.helpers.platform_api import chassis, thermal
 from tests.common.utilities import skip_release_for_platform
+from tests.common.platform.device_utils import platform_api_conn    # noqa F401
 
 from .platform_api_test_base import PlatformApiTestBase
 
@@ -35,7 +36,7 @@ class TestThermalApi(PlatformApiTestBase):
     # level, so we must do the same here to prevent a scope mismatch.
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, platform_api_conn):
+    def setup(self, platform_api_conn):     # noqa F811
         if self.num_thermals is None:
             try:
                 self.num_thermals = int(chassis.get_num_thermals(platform_api_conn))
@@ -93,7 +94,7 @@ class TestThermalApi(PlatformApiTestBase):
     # Functions to test methods inherited from DeviceBase class
     #
 
-    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_name(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         for i in range(self.num_thermals):
             name = thermal.get_name(platform_api_conn, i)
@@ -104,7 +105,7 @@ class TestThermalApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_presence(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for i in range(self.num_thermals):
             presence = thermal.get_presence(platform_api_conn, i)
 
@@ -114,7 +115,7 @@ class TestThermalApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):     # noqa F811
         for i in range(self.num_thermals):
             model = thermal.get_model(platform_api_conn, i)
 
@@ -123,7 +124,7 @@ class TestThermalApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa F811
         for i in range(self.num_thermals):
             serial = thermal.get_serial(platform_api_conn, i)
 
@@ -132,7 +133,7 @@ class TestThermalApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811
         for i in range(self.num_thermals):
             status = thermal.get_status(platform_api_conn, i)
 
@@ -141,7 +142,7 @@ class TestThermalApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_position_in_parent(self, platform_api_conn):
+    def test_get_position_in_parent(self, platform_api_conn):       # noqa F811
         for i in range(self.num_thermals):
             position = thermal.get_position_in_parent(platform_api_conn, i)
             if self.expect(position is not None, "Failed to perform get_position_in_parent for thermal {}".format(i)):
@@ -149,7 +150,7 @@ class TestThermalApi(PlatformApiTestBase):
                             "Position value must be an integer value for thermal {}".format(i))
         self.assert_expectations()
 
-    def test_is_replaceable(self, platform_api_conn):
+    def test_is_replaceable(self, platform_api_conn):       # noqa F811
         for i in range(self.num_thermals):
             replaceable = thermal.is_replaceable(platform_api_conn, i)
             if self.expect(replaceable is not None, "Failed to perform is_replaceable for thermal {}".format(i)):
@@ -161,7 +162,8 @@ class TestThermalApi(PlatformApiTestBase):
     # Functions to test methods defined in ThermalBase class
     #
 
-    def test_get_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_temperature(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                             platform_api_conn):   # noqa F811
         for i in range(self.num_thermals):
             temperature = thermal.get_temperature(platform_api_conn, i)
 
@@ -169,7 +171,8 @@ class TestThermalApi(PlatformApiTestBase):
                 self.expect(isinstance(temperature, float), "Thermal {} temperature appears incorrect".format(i))
         self.assert_expectations()
 
-    def test_get_minimum_recorded(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_minimum_recorded(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                  platform_api_conn):       # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         thermals_skipped = 0
 
@@ -195,7 +198,8 @@ class TestThermalApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_maximum_recorded(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_maximum_recorded(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                  platform_api_conn):       # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         thermals_skipped = 0
 
@@ -221,7 +225,8 @@ class TestThermalApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_low_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_low_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                               platform_api_conn):      # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         thermals_skipped = 0
 
@@ -244,7 +249,8 @@ class TestThermalApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_get_high_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_high_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                platform_api_conn):     # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         thermals_skipped = 0
 
@@ -268,7 +274,7 @@ class TestThermalApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_low_critical_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                        localhost, platform_api_conn):
+                                        localhost, platform_api_conn):      # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         thermals_skipped = 0
 
@@ -292,7 +298,7 @@ class TestThermalApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_high_critical_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname,
-                                         localhost, platform_api_conn):
+                                         localhost, platform_api_conn):     # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         thermals_skipped = 0
 
@@ -316,7 +322,8 @@ class TestThermalApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_set_low_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_set_low_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                               platform_api_conn):      # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         thermals_skipped = 0
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
@@ -349,7 +356,8 @@ class TestThermalApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
-    def test_set_high_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_set_high_threshold(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                                platform_api_conn):     # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         thermals_skipped = 0
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #15605, the `platform_api_conn` fixture was relocated to a common location. However, some imports were overlooked in the scripts within the tests/platform_tests/api folder, leading to test failures. This PR addresses the issue by adding the missing imports to resolve the errors.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In PR #15605, the `platform_api_conn` fixture was relocated to a common location. However, some imports were overlooked in the scripts within the tests/platform_tests/api folder, leading to test failures. This PR addresses the issue by adding the missing imports to resolve the errors.

#### How did you do it?
This PR addresses the issue by adding the missing imports to resolve the errors.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
