### PR TITLE
[PR:15758] Cherry - Add container length check

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -323,6 +323,12 @@ function start_local_container() {
 function parse_arguments() {
     if [[ -z "${CONTAINER_NAME}" ]]; then
         exit_failure "container name is not set"
+    else
+        # If container name is over 64 characters, container will not be able to start due to hostname limitation
+        container_name_len=${#CONTAINER_NAME}
+        if [ "$container_name_len" -gt "64" ]; then
+            exit_failure "Length of supplied container name exceeds 64 characters (currently $container_name_len chars)"
+        fi
     fi
 
     if [[ -z "${LINK_DIR}" ]]; then


### PR DESCRIPTION
Cherry #15758
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adds a check to enhance clarity of error thrown when a container created with a name that is of a length greater than 64 characters will fail to start after creation:

```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: sethostname: invalid argument: unknown.
```

This is due to the internal hostname of the container being set to the container's name, which has an additional 64 character limit, causing the container to fail to start consistently.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/*improvement*)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

To enhance error messaging for this particular edge case, as it was previously difficult to discern why the container would be created successfully, but then consistently fail to start.

#### How did you do it?

Adds a check to prevent containers from being created with name lengths greater than 64 characters, as these containers will not be able to start.

#### How did you verify/test it?

Ran the setup script, with both a valid name and an invalid name (valid is on the left, invalid is on the right):
<img width="1199" alt="image" src="https://github.com/user-attachments/assets/1ed3c16f-d3ca-4ae4-9303-d16a7e03de5d">


#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A