### PR TITLE
Remove supervisorAsicBase offset from test_fabric_reach.py test

### DIFF
--- a/tests/voq/fabric_data/Arista-7804R3-FM.yaml
+++ b/tests/voq/fabric_data/Arista-7804R3-FM.yaml
@@ -1,3 +1,2 @@
 ---
-moduleIdBase: '300'
 asicPerSlot: '2'

--- a/tests/voq/fabric_data/Arista-7808R3A-FM.yaml
+++ b/tests/voq/fabric_data/Arista-7808R3A-FM.yaml
@@ -1,3 +1,2 @@
 ---
-moduleIdBase: '300'
 asicPerSlot: '2'

--- a/tests/voq/fabric_data/Nokia-IXR7250E-SUP-10.yaml
+++ b/tests/voq/fabric_data/Nokia-IXR7250E-SUP-10.yaml
@@ -1,3 +1,2 @@
 ---
-moduleIdBase: '0'
 asicPerSlot: '2'

--- a/tests/voq/test_fabric_reach.py
+++ b/tests/voq/test_fabric_reach.py
@@ -10,7 +10,6 @@ pytestmark = [
 ]
 
 localModule = 0
-supervisorAsicBase = 1
 supReferenceData = {}
 linecardModule = []
 
@@ -86,7 +85,6 @@ def test_fabric_reach_linecards(duthosts, enum_frontend_dut_hostname,
                                 refData, supData):
     """compare the CLI output with the reference data"""
     global localModule
-    global supervisorAsicBase
     global supReferenceData
     global linecardModule
 
@@ -105,8 +103,6 @@ def test_fabric_reach_linecards(duthosts, enum_frontend_dut_hostname,
     slot = duthost.facts['slot_num']
     referenceData = refData[slot]
 
-    # base module Id for asics on supervisor
-    supervisorAsicBase = int(supData['moduleIdBase'])
     # the number of ASICs on each fabric card of a supervisor
     asicPerSlot = int(supData['asicPerSlot'])
 
@@ -138,7 +134,7 @@ def test_fabric_reach_linecards(duthosts, enum_frontend_dut_hostname,
 
             remoteSlot = int(referencePortData['peer slot'])
             remoteAsic = int(referencePortData['peer asic'])
-            remoteMod = supervisorAsicBase + (remoteSlot - 1)*2 + remoteAsic
+            remoteMod = (remoteSlot - 1)*2 + remoteAsic
             referenceRemoteModule = str(remoteMod)
             referenceRemotePort = referencePortData['peer lk']
             pytest_assert(remoteModule == referenceRemoteModule,
@@ -149,7 +145,7 @@ def test_fabric_reach_linecards(duthosts, enum_frontend_dut_hostname,
                           .format(localPortName))
 
             # build reference data for sup: supReferenceData
-            fabricAsic = 'asic' + str(remoteMod - supervisorAsicBase)
+            fabricAsic = 'asic' + str(remoteMod)
             lkData = {'peer slot': slot, 'peer lk': localPortName, 'peer asic': asic, 'peer mod': localModule}
             if localModule not in linecardModule:
                 linecardModule.append(localModule)

--- a/tests/voq/test_fabric_reach.py
+++ b/tests/voq/test_fabric_reach.py
@@ -94,8 +94,8 @@ def test_fabric_reach_linecards(duthosts, enum_frontend_dut_hostname,
     if len(duthosts.supervisor_nodes) == 0:
         logger.info("Please run the test on modular systems")
         return
-    duthost = duthosts.supervisor_nodes[0]
-    logger.info("duthost: {}".format(duthost.hostname))
+    supervisor = duthosts.supervisor_nodes[0]
+    logger.info("duthost: {}".format(supervisor.hostname))
 
     # Load the reference data file.
     duthost = duthosts[enum_frontend_dut_hostname]
@@ -135,7 +135,10 @@ def test_fabric_reach_linecards(duthosts, enum_frontend_dut_hostname,
             remoteSlot = int(referencePortData['peer slot'])
             remoteAsic = int(referencePortData['peer asic'])
             remoteMod = (remoteSlot - 1)*2 + remoteAsic
-            referenceRemoteModule = str(remoteMod)
+            # Get the fabric switch ID from config DB
+            referenceRemoteModule = supervisor.shell(
+                'sonic-db-cli -n asic{} CONFIG_DB HGET "DEVICE_METADATA|localhost" "switch_id"'
+                .format(remoteMod))["stdout"]
             referenceRemotePort = referencePortData['peer lk']
             pytest_assert(remoteModule == referenceRemoteModule,
                           "Remote module mismatch for port {}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #15753 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The original test used a base moduleID offset for Arista devices, however, this offset created mismatch in the moduleID and led the test to fail.

#### How did you do it?
Remove the base module ID offset variable: `supervisorAsicBase`

#### How did you verify/test it?
I ran the test successfully on a T2 testbed to verify the change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
