### PR TITLE
fix: half all traffic for lossy

### DIFF
--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -50,7 +50,8 @@ def run_pfc_test(api,
                  prio_dscp_map,
                  test_traffic_pause,
                  test_flow_is_lossless=True,
-                 snappi_extra_params=None):
+                 snappi_extra_params=None,
+                 flow_factor=1):
     """
     Run a multidut PFC test
     Args:
@@ -99,8 +100,8 @@ def run_pfc_test(api,
     port_id = 0
 
     # Rate percent must be an integer
-    bg_flow_rate_percent = int(BG_FLOW_AGGR_RATE_PERCENT / len(bg_prio_list))
-    test_flow_rate_percent = int(TEST_FLOW_AGGR_RATE_PERCENT / len(test_prio_list))
+    bg_flow_rate_percent = int((BG_FLOW_AGGR_RATE_PERCENT / flow_factor) / len(bg_prio_list))
+    test_flow_rate_percent = int((TEST_FLOW_AGGR_RATE_PERCENT / flow_factor) / len(test_prio_list))
 
     # Generate base traffic config
     snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -69,8 +69,8 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
 
     flow_factor = 1
 
-    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and snappi_ports[0]['speed'] == '400000':
-        flow_factor = 2
+    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and int(snappi_ports[0]['speed']) > 200000:
+        flow_factor = int(snappi_ports[0]['speed']) / 200000
 
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
@@ -125,8 +125,8 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
 
     flow_factor = 1
 
-    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and snappi_ports[0]['speed'] == '400000':
-        flow_factor = 2
+    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and int(snappi_ports[0]['speed']) > 200000:
+        flow_factor = int(snappi_ports[0]['speed']) / 200000
 
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
@@ -192,8 +192,8 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
 
     flow_factor = 1
 
-    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and snappi_ports[0]['speed'] == '400000':
-        flow_factor = 2
+    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and int(snappi_ports[0]['speed']) > 200000:
+        flow_factor = int(snappi_ports[0]['speed']) / 200000
 
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
@@ -254,8 +254,8 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
 
     flow_factor = 1
 
-    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and snappi_ports[0]['speed'] == '400000':
-        flow_factor = 2
+    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and int(snappi_ports[0]['speed']) > 200000:
+        flow_factor = int(snappi_ports[0]['speed']) / 200000
 
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -69,7 +69,7 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
 
     flow_factor = 1
 
-    if snappi_extra_params.multi_dut_params.multi_dut_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800':
+    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and snappi_ports[0]['speed'] == '400000':
         flow_factor = 2
 
     run_pfc_test(api=snappi_api,
@@ -125,7 +125,7 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
 
     flow_factor = 1
 
-    if snappi_extra_params.multi_dut_params.multi_dut_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800':
+    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and snappi_ports[0]['speed'] == '400000':
         flow_factor = 2
 
     run_pfc_test(api=snappi_api,
@@ -192,7 +192,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
 
     flow_factor = 1
 
-    if snappi_extra_params.multi_dut_params.multi_dut_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800':
+    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and snappi_ports[0]['speed'] == '400000':
         flow_factor = 2
 
     run_pfc_test(api=snappi_api,
@@ -254,7 +254,7 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
 
     flow_factor = 1
 
-    if snappi_extra_params.multi_dut_params.multi_dut_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800':
+    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and snappi_ports[0]['speed'] == '400000':
         flow_factor = 2
 
     run_pfc_test(api=snappi_api,

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -67,6 +67,11 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
+    flow_factor = 1
+
+    if snappi_extra_params.multi_dut_params.multi_dut_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800':
+        flow_factor = 2
+
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
                  port_config_list=port_config_list,
@@ -79,7 +84,8 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
                  test_flow_is_lossless=False,
-                 snappi_extra_params=snappi_extra_params)
+                 snappi_extra_params=snappi_extra_params,
+                 flow_factor=flow_factor)
 
 
 def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
@@ -117,6 +123,11 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
+    flow_factor = 1
+
+    if snappi_extra_params.multi_dut_params.multi_dut_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800':
+        flow_factor = 2
+
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
                  port_config_list=port_config_list,
@@ -129,7 +140,8 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
                  test_flow_is_lossless=False,
-                 snappi_extra_params=snappi_extra_params)
+                 snappi_extra_params=snappi_extra_params,
+                 flow_factor=flow_factor)
 
 
 @pytest.mark.disable_loganalyzer
@@ -178,6 +190,11 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
+    flow_factor = 1
+
+    if snappi_extra_params.multi_dut_params.multi_dut_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800':
+        flow_factor = 2
+
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
                  port_config_list=port_config_list,
@@ -190,7 +207,8 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
                  test_flow_is_lossless=False,
-                 snappi_extra_params=snappi_extra_params)
+                 snappi_extra_params=snappi_extra_params,
+                 flow_factor=flow_factor)
 
 
 @pytest.mark.disable_loganalyzer
@@ -234,6 +252,11 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
+    flow_factor = 1
+
+    if snappi_extra_params.multi_dut_params.multi_dut_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800':
+        flow_factor = 2
+
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
                  port_config_list=port_config_list,
@@ -246,4 +269,5 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
                  prio_dscp_map=prio_dscp_map,
                  test_traffic_pause=False,
                  test_flow_is_lossless=False,
-                 snappi_extra_params=snappi_extra_params)
+                 snappi_extra_params=snappi_extra_params,
+                 flow_factor=flow_factor)

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -69,7 +69,7 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
 
     flow_factor = 1
 
-    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and int(snappi_ports[0]['speed']) > 200000:
+    if snappi_ports[0]['asic_type'] == 'cisco-8800' and int(snappi_ports[0]['speed']) > 200000:
         flow_factor = int(snappi_ports[0]['speed']) / 200000
 
     run_pfc_test(api=snappi_api,
@@ -125,7 +125,7 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
 
     flow_factor = 1
 
-    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and int(snappi_ports[0]['speed']) > 200000:
+    if snappi_ports[0]['asic_type'] == 'cisco-8800' and int(snappi_ports[0]['speed']) > 200000:
         flow_factor = int(snappi_ports[0]['speed']) / 200000
 
     run_pfc_test(api=snappi_api,
@@ -192,7 +192,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
 
     flow_factor = 1
 
-    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and int(snappi_ports[0]['speed']) > 200000:
+    if snappi_ports[0]['asic_type'] == 'cisco-8800' and int(snappi_ports[0]['speed']) > 200000:
         flow_factor = int(snappi_ports[0]['speed']) / 200000
 
     run_pfc_test(api=snappi_api,
@@ -254,7 +254,7 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
 
     flow_factor = 1
 
-    if snappi_ports[0]['duthost'].facts()['asic_type'] == 'cisco-8800' and int(snappi_ports[0]['speed']) > 200000:
+    if snappi_ports[0]['asic_type'] == 'cisco-8800' and int(snappi_ports[0]['speed']) > 200000:
         flow_factor = int(snappi_ports[0]['speed']) / 200000
 
     run_pfc_test(api=snappi_api,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Halving the traffic on test and background flow for compatibility between 400g and 200g for lossy

Summary:
Fixes # (issue) 30112807

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
