### PR TITLE
Ignore trap messages that should be warnings instead of error messages

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -287,6 +287,7 @@ r, ".* INFO healthd.*Key 'TEMPERATURE_INFO|ASIC' field 'temperature' unavailable
 r, ".* ERR kernel:.*cisco-fpga-p2pm-m-slot p2pm-m-slot\.\d+: cisco_fpga_select_new_acpi_companion: searching for child status\d+ 0x[0-9a-f]+; fpga_id 0x[0-9a-f]+.*"
 r, ".* ERR kernel:.*cisco-fpga-pci \d+:\d+:\d+\.\d+: cisco_fpga_select_new_acpi_companion: searching for child status\d+ 0x[0-9a-f]+; fpga_id 0x[0-9a-f]+.*"
 r, ".* WARNING kernel:.*pcieport.*device.*error.*status/mask=.*"
+r, ".* ERR syncd\d*#syncd:.* -E-HLD-0- Trap.* is not supported.*"
 
 
 # Ignore rsyslog librelp error if rsyslogd on host or container is down or going down


### PR DESCRIPTION
### Description of PR
In Cisco platforms these error messages should be warning instead of error messages. We will be making the change but in the meanwhile, I am adding an ignore in log analyzer ignore files to avoid causing testcase failures

2024 Nov  4 10:29:37.967901 sfd-lt2-lc0 ERR syncd0#syncd: 04-11-2024 10:29:37.967 -E-HLD-0- Trap 'ETHERNET_EGRESS_EVPN_DF_BLOCK' is not supported

2024 Nov  4 10:29:37.972258 sfd-lt2-lc0 ERR syncd0#syncd: 04-11-2024 10:29:37.972 -E-HLD-0- Trap 'ETHERNET_EGRESS_EVPN_ESI_ETREE_DROP' is not supported

2024 Nov  4 10:29:37.994537 sfd-lt2-lc0 ERR syncd0#syncd: 04-11-2024 10:29:37.994 -E-HLD-0- Trap 'ETHERNET_INGRESS_EVPN_ETREE_DROP' is not supported

2024 Nov  4 10:29:38.022655 sfd-lt2-lc0 ERR syncd0#syncd: 04-11-2024 10:29:38.022 -E-HLD-0- Trap 'ETHERNET_ETM_DSP_MISMATCH' is not supported

2024 Nov  4 10:29:38.163310 sfd-lt2-lc0 ERR syncd1#syncd: 04-11-2024 10:29:38.163 -E-HLD-0- Trap 'ETHERNET_EGRESS_EVPN_DF_BLOCK' is not supported

2024 Nov  4 10:29:38.167415 sfd-lt2-lc0 ERR syncd1#syncd: 04-11-2024 10:29:38.167 -E-HLD-0- Trap 'ETHERNET_EGRESS_EVPN_ESI_ETREE_DROP' is not supported

2024 Nov  4 10:29:38.197054 sfd-lt2-lc0 ERR syncd1#syncd: 04-11-2024 10:29:38.196 -E-HLD-0- Trap 'ETHERNET_INGRESS_EVPN_ETREE_DROP' is not supported

2024 Nov  4 10:29:38.205383 sfd-lt2-lc0 ERR syncd1#syncd: 04-11-2024 10:29:38.205 -E-HLD-0- Trap 'ETHERNET_ETM_DSP_MISMATCH' is not supported

2024 Nov  4 10:29:38.366179 sfd-lt2-lc0 ERR syncd2#syncd: 04-11-2024 10:29:38.365 -E-HLD-0- Trap 'ETHERNET_EGRESS_EVPN_DF_BLOCK' is not supported

2024 Nov  4 10:29:38.370530 sfd-lt2-lc0 ERR syncd2#syncd: 04-11-2024 10:29:38.370 -E-HLD-0- Trap 'ETHERNET_EGRESS_EVPN_ESI_ETREE_DROP' is not supported

2024 Nov  4 10:29:38.383009 sfd-lt2-lc0 ERR syncd1#syncd: 04-11-2024 10:29:38.382 -E-HLD-0- Trap 'ETHERNET_TEST_OAM_AC_MIP' is not supported

2024 Nov  4 10:29:38.407172 sfd-lt2-lc0 ERR syncd0#syncd: 04-11-2024 10:29:38.406 -E-HLD-0- Trap 'ETHERNET_TEST_OAM_AC_MIP' is not supported

2024 Nov  4 10:29:38.410782 sfd-lt2-lc0 ERR syncd2#syncd: 04-11-2024 10:29:38.410 -E-HLD-0- Trap 'ETHERNET_INGRESS_EVPN_ETREE_DROP' is not supported

2024 Nov  4 10:29:38.419797 sfd-lt2-lc0 ERR syncd2#syncd: 04-11-2024 10:29:38.419 -E-HLD-0- Trap 'ETHERNET_ETM_DSP_MISMATCH' is not supported

2024 Nov  4 10:29:38.624297 sfd-lt2-lc0 ERR syncd2#syncd: 04-11-2024 10:29:38.623 -E-HLD-0- Trap 'ETHERNET_TEST_OAM_AC_MIP' is not supported

2024 Nov  4 10:29:38.676893 sfd-lt2-lc0 ERR syncd0#syncd: 04-11-2024 10:29:38.676 -E-HLD-0- Trap 'MPLS_MISSING_FWD_LABEL_AFTER_POP' is not supported

2024 Nov  4 10:29:38.692243 sfd-lt2-lc0 ERR syncd0#syncd: 04-11-2024 10:29:38.692 -E-HLD-0- Trap 'MPLS_MPLS_TP_OVER_PWE' is not supported

2024 Nov  4 10:29:38.719584 sfd-lt2-lc0 ERR syncd1#syncd: 04-11-2024 10:29:38.719 -E-HLD-0- Trap 'MPLS_MISSING_FWD_LABEL_AFTER_POP' is not supported

2024 Nov  4 10:29:38.736103 sfd-lt2-lc0 ERR syncd1#syncd: 04-11-2024 10:29:38.735 -E-HLD-0- Trap 'MPLS_MPLS_TP_OVER_PWE' is not supported

2024 Nov  4 10:29:38.880861 sfd-lt2-lc0 ERR syncd2#syncd: 04-11-2024 10:29:38.880 -E-HLD-0- Trap 'MPLS_MISSING_FWD_LABEL_AFTER_POP' is not supported

2024 Nov  4 10:29:38.901931 sfd-lt2-lc0 ERR syncd2#syncd: 04-11-2024 10:29:38.901 -E-HLD-0- Trap 'MPLS_MPLS_TP_OVER_PWE' is not supported

2024 Nov  4 10:29:38.933522 sfd-lt2-lc0 ERR syncd0#syncd: 04-11-2024 10:29:38.933 -E-HLD-0- Trap 'L3_LPM_INCOMPLETE0' is not supported

2024 Nov  4 10:29:38.938166 sfd-lt2-lc0 ERR syncd0#syncd: 04-11-2024 10:29:38.937 -E-HLD-0- Trap 'L3_LPM_INCOMPLETE2' is not supported

2024 Nov  4 10:29:38.947298 sfd-lt2-lc0 ERR syncd1#syncd: 04-11-2024 10:29:38.946 -E-HLD-0- Trap 'L3_LPM_INCOMPLETE0' is not supported

2024 Nov  4 10:29:38.950833 sfd-lt2-lc0 ERR syncd1#syncd: 04-11-2024 10:29:38.950 -E-HLD-0- Trap 'L3_LPM_INCOMPLETE2' is not supported

2024 Nov  4 10:29:39.040628 sfd-lt2-lc0 ERR syncd0#syncd: 04-11-2024 10:29:39.040 -E-HLD-0- Trap 'L3_NAT' is not supported

2024 Nov  4 10:29:39.087678 sfd-lt2-lc0 ERR syncd1#syncd: 04-11-2024 10:29:39.087 -E-HLD-0- Trap 'L3_NAT' is not supported

2024 Nov  4 10:29:39.228651 sfd-lt2-lc0 ERR syncd2#syncd: 04-11-2024 10:29:39.228 -E-HLD-0- Trap 'L3_LPM_INCOMPLETE0' is not supported

2024 Nov  4 10:29:39.238835 sfd-lt2-lc0 ERR syncd2#syncd: 04-11-2024 10:29:39.238 -E-HLD-0- Trap 'L3_LPM_INCOMPLETE2' is not supported

2024 Nov  4 10:29:39.239133 sfd-lt2-lc0 ERR syncd1#syncd: 04-11-2024 10:29:39.238 -E-HLD-0- Trap 'APP_NON_INJECT_UP' is not supported

2024 Nov  4 10:29:39.248208 sfd-lt2-lc0 ERR syncd0#syncd: 04-11-2024 10:29:39.247 -E-HLD-0- Trap 'APP_NON_INJECT_UP' is not supported

2024 Nov  4 10:29:39.328303 sfd-lt2-lc0 ERR syncd2#syncd: 04-11-2024 10:29:39.328 -E-HLD-0- Trap 'L3_NAT' is not supported

2024 Nov  4 10:29:39.471959 sfd-lt2-lc0 ERR syncd2#syncd: 04-11-2024 10:29:39.471 -E-HLD-0- Trap 'APP_NON_INJECT_UP' is not supported

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
These trap messages are causing testcase failures

#### How did you do it?
Added an ignore statement in LA ignore file

#### How did you verify/test it?
On Cisco Chassis with T2 profile.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
