### PR TITLE
[advanced-reboot] Test VLAN gateway address resolvability during upgrade

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1742,7 +1742,7 @@ class ReloadTest(BaseTest):
             #  2. during warm neighbor restoration DUT will send a lot of ARP requests which we are not interested in
             # This is essential to get stable results
             self.apply_filter_all_ports(
-                'not (arp and ether src {}) and not tcp'.format(self.test_params['dut_mac']))
+                'not (arp and ether src {} and ether dst ff:ff:ff:ff:ff:ff) and not tcp'.format(self.test_params['dut_mac']))
             sender_start = datetime.datetime.now()
             self.log("Sender started at %s" % str(sender_start))
 

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -942,7 +942,7 @@ class ReloadTest(BaseTest):
                                    arp_op=2,
                                    ip_snd="192.168.0.1",
                                    hw_snd=self.vlan_mac)
-        self.arp_vlan_gw_ping_exp_packet = Mask(exp_packet)
+        self.arp_vlan_gw_ping_exp_packet = Mask(exp_packet, ignore_extra_bytes=True)
         self.arp_vlan_gw_ping_exp_packet.set_do_not_care_scapy(scapy.Ether, 'dst')
         # PTF's field size calculation is broken for dynamic length fields, do it ourselves
         self.arp_vlan_gw_ping_exp_packet.set_do_not_care(*self.calc_offset_and_size(exp_packet, scapy.ARP, "pdst"))

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -922,7 +922,6 @@ class ReloadTest(BaseTest):
         self.arp_resp.set_do_not_care(*self.calc_offset_and_size(expect, scapy.ARP, "hwsrc"))
         self.arp_src_port = src_port
 
-
     def generate_arp_vlan_gw_packets(self):
         self.arp_vlan_gw_ping_packets = []
 
@@ -933,15 +932,15 @@ class ReloadTest(BaseTest):
             packet = simple_arp_packet(eth_src=src_mac,
                                        arp_op=1,
                                        ip_snd=src_addr,
-                                       ip_tgt="192.168.0.1", # TODO: make this dynamic
+                                       ip_tgt="192.168.0.1",  # TODO: make this dynamic
                                        hw_snd=src_mac)
 
             self.arp_vlan_gw_ping_packets.append((src_port, bytes(packet)))
 
         exp_packet = simple_arp_packet(pktlen=42, eth_src=self.vlan_mac,
-                                   arp_op=2,
-                                   ip_snd="192.168.0.1",
-                                   hw_snd=self.vlan_mac)
+                                       arp_op=2,
+                                       ip_snd="192.168.0.1",
+                                       hw_snd=self.vlan_mac)
         self.arp_vlan_gw_ping_exp_packet = Mask(exp_packet, ignore_extra_bytes=True)
         self.arp_vlan_gw_ping_exp_packet.set_do_not_care_scapy(scapy.Ether, 'dst')
         # PTF's field size calculation is broken for dynamic length fields, do it ourselves
@@ -949,9 +948,9 @@ class ReloadTest(BaseTest):
         self.arp_vlan_gw_ping_exp_packet.set_do_not_care(*self.calc_offset_and_size(exp_packet, scapy.ARP, "hwdst"))
 
         exp_packet = simple_arp_packet(pktlen=42, eth_src=self.vlan_mac,
-                                   arp_op=2,
-                                   ip_snd="192.168.0.1",
-                                   hw_snd=self.vlan_mac)
+                                       arp_op=2,
+                                       ip_snd="192.168.0.1",
+                                       hw_snd=self.vlan_mac)
         exp_packet = exp_packet / ("fe11e1" * 6)
         self.arp_vlan_gw_ferret_exp_packet = Mask(exp_packet)
         self.arp_vlan_gw_ferret_exp_packet.set_do_not_care_scapy(scapy.Ether, 'dst')
@@ -1742,7 +1741,8 @@ class ReloadTest(BaseTest):
             #  2. during warm neighbor restoration DUT will send a lot of ARP requests which we are not interested in
             # This is essential to get stable results
             self.apply_filter_all_ports(
-                'not (arp and ether src {} and ether dst ff:ff:ff:ff:ff:ff) and not tcp'.format(self.test_params['dut_mac']))
+                'not (arp and ether src {} and ether dst ff:ff:ff:ff:ff:ff) and not tcp'.format(
+                    self.test_params['dut_mac']))
             sender_start = datetime.datetime.now()
             self.log("Sender started at %s" % str(sender_start))
 

--- a/tests/arp/files/ferret.py
+++ b/tests/arp/files/ferret.py
@@ -174,7 +174,7 @@ class Responder(object):
     def __init__(self, db, vxlan_port):
         # defines a part of the packet for ARP Reply
         self.arp_chunk = binascii.unhexlify('08060001080006040002')
-        self.arp_pad = binascii.unhexlify('00' * 18)
+        self.arp_pad = binascii.unhexlify('fe11e1' * 6)
         self.db = db
         self.vxlan_port = vxlan_port
 

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -538,12 +538,13 @@ class AdvancedReboot:
             if log_file.endswith('reboot.log'):
                 with open(os.path.join(log_dir, log_file)) as reboot_log:
                     reboot_text_log_file = reboot_log.read()
-                    reboot_summary = re.search(r"Summary:(\n|.)*?=========", reboot_text_log_file).group()
-                    if reboot_summary.find('Fails') == -1:
-                        # if no fails detected - the test passed, print the summary only
-                        logger.info('\n'+reboot_summary)
-                    else:
-                        logger.info(reboot_text_log_file)
+                    reboot_summary = re.search(r"Summary:(\n|.)*?=========", reboot_text_log_file)
+                    if reboot_summary:
+                        if reboot_summary.group().find('Fails') == -1:
+                            # if no fails detected - the test passed, print the summary only
+                            logger.info('\n'+reboot_summary.group())
+                        else:
+                            logger.info(reboot_text_log_file)
 
     def acl_manager_checker(self, error_list):
         """

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -735,6 +735,7 @@ class AdvancedReboot:
             "service_list": None if self.rebootType != 'service-warm-restart' else self.service_list,
             "service_data": None if self.rebootType != 'service-warm-restart' else self.service_data,
             "neighbor_type": self.neighborType,
+            "kvm_support": True,
         }
 
         if self.dual_tor_mode:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

During an upgrade, test to see if the VLAN gateway can be resolved with an ARP request. When CPA is enabled, we expect the VLAN gateway to be always resolvable (even when control plane of the device is down). This is done through the use of a Ferret server running on the PTF container.

#### How did you do it?

Add a basic check for the functionality of that Ferret server by crafting and sending ARP requests, and report the number of ARP responses received. As of right now, this doesn't affect the final result of the warm/fast upgrade test; that will be done later.

Also mark the advanced-reboot tests as functional on KVM. Without this, the warm upgrade test will not run on PR checkers.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
