### PR TITLE
Skip ip-proto `255` in `hash_test.py`

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -242,7 +242,8 @@ class HashTest(BaseTest):
         # ip_proto 60 is redirected to ip_proto 4 as encapsulation protocol, ip payload will be malformat
         # ip_proto 254 is experimental
         # MLNX ASIC can't forward ip_proto 254, BRCM is OK, skip for all for simplicity
-        skip_protos = [2, 253, 4, 41, 60, 254]
+        # ip_proto 255 is reserved
+        skip_protos = [2, 253, 4, 41, 60, 254, 255]
 
         if self.is_active_active_dualtor:
             # Skip ICMP for active-active dualtor as it is duplicated to both ToRs

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -242,8 +242,7 @@ class HashTest(BaseTest):
         # ip_proto 60 is redirected to ip_proto 4 as encapsulation protocol, ip payload will be malformat
         # ip_proto 254 is experimental
         # MLNX ASIC can't forward ip_proto 254, BRCM is OK, skip for all for simplicity
-        # ip_proto 255 is reserved
-        skip_protos = [2, 253, 4, 41, 60, 254, 255]
+        skip_protos = [2, 253, 4, 41, 60, 254]
 
         if self.is_active_active_dualtor:
             # Skip ICMP for active-active dualtor as it is duplicated to both ToRs
@@ -254,6 +253,8 @@ class HashTest(BaseTest):
             skip_protos.append(0)
             # Skip IPv6-ICMP for active-active dualtor as it is duplicated to both ToRs
             skip_protos.append(58)
+            # next-header 255 on BRCM causes 4 bytes to be stripped (CS00012366805)
+            skip_protos.append(255)
 
         while True:
             ip_proto = random.randint(0, 255)


### PR DESCRIPTION
When `255` is selected as the ip-protocol(v4) or next-header(v6) field I see the TCP src-port and TCP dst-port are removed from the packet causing the `fib/test_fib.py` to fail

RX packet:
```
16:39:46.124644 52:67:2c:8e:a0:09 (oui Unknown) > 94:8e:d3:1f:b0:fd (oui Unknown), ethertype IPv6 (0x86dd), length 100: 20d0:a800:: > 20d0:a800:0:1::: ip-proto-255 46
        0x0000:  948e d31f b0fd 5267 2c8e a009 86dd 6000
        0x0010:  0000 002e ff40 20d0 a800 0000 0000 0000
        0x0020:  0000 0000 0000 20d0 a800 0000 0001 0000
        0x0030:  0000 0000 0000 04d2 0050 0000 0000 0000
        0x0040:  0000 5002 2000 818d 0000 4444 4444 4444
        0x0050:  4444 4444 4444 4444 4444 4444 4444 4444
        0x0060:  4444 4444
```

TX packet:
```
16:38:00.797992 94:8e:d3:5e:af:13 (oui Unknown) > 1e:bf:59:4c:90:6f (oui Unknown), ethertype IPv6 (0x86dd), length 96: truncated-ip6 - 4 bytes missing!20d0:a800:: > 20d0:a800:0:1::: ip-proto-255 46
        0x0000:  1ebf 594c 906f 948e d35e af13 86dd 6000
        0x0010:  0000 002e ff3f 20d0 a800 0000 0000 0000
        0x0020:  0000 0000 0000 20d0 a800 0000 0001 0000
        0x0030:  0000 0000 0000 0000 0000 0000 0000 5002
        0x0040:  2000 818d 0000 4444 4444 4444 4444 4444
        0x0050:  4444 4444 4444 4444 4444 4444 4444 4444
```

Summary:
Fixes #15838 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405