### PR TITLE
Choose ARP scale based on available NH entries for CISCO 8000 platforms

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -104,6 +104,11 @@ def test_ipv4_arp(duthost, garp_enabled, ip_and_intf_info, intfs_for_test,
     pytest_assert(ipv4_available > 0 and fdb_available > 0, "Entries have been filled")
 
     arp_available = min(min(ipv4_available, fdb_available), ENTRIES_NUMBERS)
+    # Neighbor support is dependant on NH scale  for some cisco platforms.
+    # Limit ARP scale based on available NH entries
+    if 'cisco-8000' in asic_type:
+        ipv4_nh_available = get_crm_resources(duthost, "ipv4_nexthop", "available")
+        arp_available = min(arp_available, ipv4_nh_available)
 
     pytest_require(garp_enabled, 'Gratuitous ARP not enabled for this device')
     ptf_intf_ipv4_hosts = genrate_ipv4_ip()
@@ -196,6 +201,9 @@ def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
 
     nd_available = min(min(ipv6_available, fdb_available), ENTRIES_NUMBERS)
 
+    if 'cisco-8000' in asic_type:
+        ipv6_nh_available = get_crm_resources(duthost, "ipv6_nexthop", "available")
+        nd_available = min(nd_available, ipv6_nh_available)
     while loop_times > 0:
         loop_times -= 1
         try:

--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -106,6 +106,7 @@ def test_ipv4_arp(duthost, garp_enabled, ip_and_intf_info, intfs_for_test,
     arp_available = min(min(ipv4_available, fdb_available), ENTRIES_NUMBERS)
     # Neighbor support is dependant on NH scale  for some cisco platforms.
     # Limit ARP scale based on available NH entries
+    asic_type = duthost.facts["asic_type"]
     if 'cisco-8000' in asic_type:
         ipv4_nh_available = get_crm_resources(duthost, "ipv4_nexthop", "available")
         arp_available = min(arp_available, ipv4_nh_available)
@@ -200,7 +201,7 @@ def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
     pytest_assert(ipv6_available > 0 and fdb_available > 0, "Entries have been filled")
 
     nd_available = min(min(ipv6_available, fdb_available), ENTRIES_NUMBERS)
-
+    asic_type = duthost.facts["asic_type"]
     if 'cisco-8000' in asic_type:
         ipv6_nh_available = get_crm_resources(duthost, "ipv6_nexthop", "available")
         nd_available = min(nd_available, ipv6_nh_available)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- 
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
ARP stress test is failing for certain CISCO 8000 platforms as the tested scale exceeds the HW availablity

Fixes # (issue)
Choose ARP scale based on available NH entries for CISCO 8000 platforms
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Pass all sonic mgmt tests on CISCO 8000  platforms


#### How did you do it?
ARP scale depends on NH Scale. Earlier NH scale is not considered while pushing ARP entries. Now NH scale is also used.

#### How did you verify/test it?
Make sure all learnt ARP's are installed by comparing the neighbor entries installed in HW with ARP requests sent .
Ran it on T0 setup of Cisco-8122-O64 and Cisco-8111-O32 platforms

#### Any platform specific information?
In certain CISCO platforms, Each Neighbor needs one NH entry. As a general fix,  we limit the number of Neighbor entries tested to the available NH entry on the platform

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
