### PR TITLE
Disable LogAnalyzer in test_bbr_status_consistent_after_reload

### DIFF
--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -441,6 +441,7 @@ def test_bbr_disabled_dut_asn_in_aspath(duthosts, rand_one_dut_hostname, nbrhost
 
 
 @pytest.mark.parametrize('bbr_status', ['enabled', 'disabled'])
+@pytest.mark.disable_loganalyzer
 def test_bbr_status_consistent_after_reload(duthosts, rand_one_dut_hostname, setup,
                                             bbr_status, restore_bbr_default_state):
     duthost = duthosts[rand_one_dut_hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to disable LogAnalyzer in `test_bbr_status_consistent_after_reload`.
Due to the reload operation in `test_bbr_status_consistent_after_reload`, some error log shows up and causes the test to error.
These error logs can be ignored safely.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to disable LogAnalyzer in `test_bbr_status_consistent_after_reload`.

#### How did you do it?
Set pytest marker for this single test.

#### How did you verify/test it?
The change is verified on a physical testbed.
```
collected 2 items                                                                                                                                                                                     

bgp/test_bgp_bbr.py::test_bbr_status_consistent_after_reload[enabled]  ^HPASSED                                                                                                                    [ 50%]
bgp/test_bgp_bbr.py::test_bbr_status_consistent_after_reload[disabled] PASSED                                                                                                                   [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
