### PR TITLE
Handle KeyError in get_pending_entries

### DIFF
--- a/tests/syslog/test_logrotate.py
+++ b/tests/syslog/test_logrotate.py
@@ -243,6 +243,8 @@ def get_pending_entries(duthost, ignore_list=None):
                 pending_entries.remove(entry)
             except ValueError:
                 continue
+            except KeyError:
+                continue
     pending_entries = list(pending_entries)
     logger.info('Pending entries in APPL_DB: {}'.format(pending_entries))
     return pending_entries


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to handle `KeyError` in `get_pending_entries`.
The error message is
```
File "/var/src/sonic-mgmt_vms21-t0-2700_646f1402735219c3e5444094/tests/syslog/test_logrotate.py", line 243, in get_pending_entries
    pending_entries.remove(entry)
KeyError: '_ROUTE_TABLE:192.220.128.128/25'
, error:'_ROUTE_TABLE:192.220.128.128/25'
```
Before this change, only `ValueError` was handled.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to handle `KeyError` in `get_pending_entries`.

#### How did you do it?
Catch `KeyError` and ignore it.

#### How did you verify/test it?
The change is verified on a physical testbed.
```
collected 5 items                                                                                                                                                                                     

syslog/test_logrotate.py::test_orchagent_logrotate[bjw2-can-4600c-6-None-1-5] PASSED                                                                                                            [ 20%]
syslog/test_logrotate.py::test_orchagent_logrotate[bjw2-can-4600c-6-None-2-5] PASSED                                                                                                            [ 40%]
syslog/test_logrotate.py::test_orchagent_logrotate[bjw2-can-4600c-6-None-3-5] PASSED                                                                                                            [ 60%]
syslog/test_logrotate.py::test_orchagent_logrotate[bjw2-can-4600c-6-None-4-5] PASSED                                                                                                            [ 80%]
syslog/test_logrotate.py::test_orchagent_logrotate[bjw2-can-4600c-6-None-5-5] PASSED                                                                                                            [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
