### PR TITLE
Handle AUTO_ISOLATED attribute missing from table

### DIFF
--- a/tests/voq/test_voq_fabric_isolation.py
+++ b/tests/voq/test_voq_fabric_isolation.py
@@ -110,7 +110,8 @@ def check_fabric_link_status(host, asicName, port, state):
     if auto_isolated == state:
         return True
     elif auto_isolated == '' and state == '0':
-        # AUTO_ISOLATED attribute may be missing from the table if it's the first time it's been isolated, missing means not isolated
+        # AUTO_ISOLATED attribute may be missing from the table if it's the first time it's been isolated,
+        # missing means the port is not isolated
         return True
     else:
         return False

--- a/tests/voq/test_voq_fabric_isolation.py
+++ b/tests/voq/test_voq_fabric_isolation.py
@@ -109,5 +109,8 @@ def check_fabric_link_status(host, asicName, port, state):
     auto_isolated = cmd_output[0]
     if auto_isolated == state:
         return True
+    elif auto_isolated == '' and state == '0':
+        # AUTO_ISOLATED attribute may be missing from the table if it's the first time it's been isolated, missing means not isolated
+        return True
     else:
         return False


### PR DESCRIPTION
AUTO_ISOLATED is only added to the FABRIC_PORT_TABLE once the fabric port has been isolated once, so we should treat this attribute missing from this table the same as AUTO_ISOLATED=0

Summary:
Fixes #15858 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
