### PR TITLE
Fix issue "createEntry: Invalid port interface"

### DIFF
--- a/tests/common/snappi_tests/qos_fixtures.py
+++ b/tests/common/snappi_tests/qos_fixtures.py
@@ -125,7 +125,8 @@ def get_pfcwd_config(duthost):
         all_configs = []
         output = duthost.shell("ip netns | awk '{print $1}'")['stdout']
         all_asic_list = output.split("\n")
-        all_asic_list.append(None)
+        all_asic_list.sort()
+        all_asic_list.insert(0, None)
         for space in all_asic_list:
             config = get_running_config(duthost, space)
             if "PFC_WD" in config.keys():
@@ -144,7 +145,8 @@ def reapply_pfcwd(duthost, pfcwd_config):
     elif type(pfcwd_config) is list:
         output = duthost.shell("ip netns | awk '{print $1}'")['stdout']
         all_asic_list = output.split("\n")
-        all_asic_list.append(None)
+        all_asic_list.sort()
+        all_asic_list.insert(0, None)
 
         all_files = []
         for index, config in enumerate(pfcwd_config):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://miggbo.atlassian.net/browse/MIGSOFTWAR-19536
2024 Nov 25 20:11:42.889000 yy39top-lc4 ERR swss0#orchagent: :- createEntry: Invalid port interface Ethernet-BP384
2024 Nov 25 20:11:42.889000 yy39top-lc4 ERR swss0#orchagent: :- doTask: Failed to process PFC watchdog SET task, invalid entry

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Fix issue of "createEntry: Invalid port interface" when running script snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py.

#### How did you do it?
Fix the sequence of config files when doing config load.

#### How did you verify/test it?
Verified the case on T2 ixia testbed.
```
----------------------- generated xml file: /run_logs/ixia/18470/2024-12-04-00-38-12/tr_2024-12-04-00-38-12.xml -----------------------
INFO:root:Can not get Allure report URL. Please check logs
======================================================= short test summary info =======================================================
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_info0]
============================================== 1 passed, 4 warnings in 698.79s (0:11:38) ==============================================
sonic@snappi-sonic-mgmt-vanilla-202405-t2:/data/tests$ 
```
```
cisco@yy39top-lc4:~$ sudo cat /var/log/syslog | grep "start-LogAnalyzer"
2024 Dec  4 00:35:43.561644 yy39top-lc4 INFO start-LogAnalyzer-test_ecn_marking_port_toggle[multidut_port_info0].2024-12-04-00:39:16
2024 Dec  4 00:40:54.158423 yy39top-lc4 INFO python[176673]: ansible-extract_log Invoked with directory=/var/log file_prefix=syslog start_string=start-LogAnalyzer-test_ecn_marking_port_toggle[multidut_port_info0].2024-12-04-00:39:16 target_filename=/tmp/syslog
cisco@yy39top-lc4:~$ sudo cat /var/log/syslog | grep "Invalid port interface"
cisco@yy39top-lc4:~$ sudo cat /var/log/syslog | grep "_raw_params=config load"
2024 Dec  4 00:40:39.667553 yy39top-lc4 INFO python[175350]: ansible-ansible.legacy.command Invoked with _raw_params=config load 1733273048.975233_pfcwd_None.json,1733273048.975233_pfcwd_asic0.json,1733273048.975233_pfcwd_asic1.json,1733273048.975233_pfcwd_asic2.json -y _uses_shell=True warn=False stdin_add_newline=True strip_empty_ends=True argv=None chdir=None executable=None creates=None removes=None stdin=None
cisco@yy39top-lc4:~$ 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
