### PR TITLE
Update all port pfcwd storm test to make it more stable

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -489,12 +489,13 @@ numprocs=1
 
 
 @contextlib.contextmanager
-def send_background_traffic(duthost, ptfhost, storm_hndle, selected_test_ports, test_ports_info):
+def send_background_traffic(duthost, ptfhost, storm_hndle, selected_test_ports, test_ports_info, pkt_count=100000):
     """Send background traffic, stop the background traffic when the context finish """
     if is_mellanox_device(duthost) or is_cisco_device(duthost):
         background_traffic_params = _prepare_background_traffic_params(duthost, storm_hndle,
                                                                        selected_test_ports,
-                                                                       test_ports_info)
+                                                                       test_ports_info,
+                                                                       pkt_count)
         background_traffic_log = _send_background_traffic(ptfhost, background_traffic_params)
         # Ensure the background traffic is running before moving on
         time.sleep(1)
@@ -503,7 +504,7 @@ def send_background_traffic(duthost, ptfhost, storm_hndle, selected_test_ports, 
         _stop_background_traffic(ptfhost, background_traffic_log)
 
 
-def _prepare_background_traffic_params(duthost, queues, selected_test_ports, test_ports_info):
+def _prepare_background_traffic_params(duthost, queues, selected_test_ports, test_ports_info, pkt_count):
     src_ports = []
     dst_ports = []
     src_ips = []
@@ -519,8 +520,6 @@ def _prepare_background_traffic_params(duthost, queues, selected_test_ports, tes
         src_ips.append(selected_test_port_info["rx_neighbor_addr"])
 
     router_mac = duthost.get_dut_iface_mac(selected_test_ports[0])
-    # Send enough packets to make sure the background traffic is running during the test
-    pkt_count = 100000
 
     ptf_params = {'router_mac': router_mac,
                   'src_ports': src_ports,

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -244,3 +244,18 @@ def pfcwd_pause_service(ptfhost):
         needs_resume["garp_service"] = False
 
     logger.debug("pause_service needs_resume {}".format(needs_resume))
+
+
+@pytest.fixture(scope='module', autouse=True)
+def clear_ptf_ip_addr(duthosts, ptfhost, enum_rand_one_per_hwsku_frontend_hostname):
+    """
+    Fixture that remove ip address of ethX interface at ptf and clear arp at dut
+    :param duthosts: dut instance
+    :param ptfhost: ptf instance
+    :return: None
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    yield
+    logger.info("Remove ip address of ethX interface at PTF")
+    ptfhost.script("./scripts/remove_ip.sh")
+    duthost.command("sonic-clear arp")

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -172,6 +172,23 @@ def set_storm_params(duthost, fanout_graph, fanouthosts, peer_params):
     return storm_hndle
 
 
+def resolve_arp(duthost, ptfhost, test_ports_info):
+    """
+    Populate ARP info for the DUT vlan port
+
+    Args:
+        ptfhost: ptf host instance
+        test_ports_info: test ports information
+    """
+    for port, port_info in test_ports_info.items():
+        if port_info['test_port_type'] == 'vlan':
+            neighbor_ip = port_info['test_neighbor_addr']
+            ptf_port = f"eth{port_info['test_port_id']}"
+            ptfhost.command(f"ifconfig {ptf_port} {neighbor_ip}")
+            duthost.command(f"docker exec -i swss arping {neighbor_ip} -c 5")
+            break
+
+
 @pytest.mark.usefixtures('degrade_pfcwd_detection', 'stop_pfcwd', 'storm_test_setup_restore', 'start_background_traffic') # noqa E501
 class TestPfcwdAllPortStorm(object):
     """ PFC storm test class """
@@ -229,8 +246,9 @@ class TestPfcwdAllPortStorm(object):
             test_port = device_conn[intf]['peerport']
             if test_port in setup_pfc_test['test_ports']:
                 selected_test_ports.append(test_port)
-
-        with send_background_traffic(duthost, ptfhost, queues, selected_test_ports, setup_pfc_test['test_ports']):
+        resolve_arp(duthost, ptfhost, setup_pfc_test['test_ports'])
+        with send_background_traffic(duthost, ptfhost, queues, selected_test_ports, setup_pfc_test['test_ports'],
+                                     pkt_count=500):
             self.run_test(duthost,
                           storm_hndle,
                           expect_regex=[EXPECT_PFC_WD_DETECT_RE + fetch_vendor_specific_diagnosis_re(duthost)],


### PR DESCRIPTION

### Description of PR
Update all port pfcwd storm test to make it more stable
1. Optimize background traffic
2. Fix arp resolve issue
3. Remove ptf leftovers added in pfcwd test

Change-Id: I5e0a5f4157bd0e22f5bc2f28df977bfccb679603

Summary:
Fixes # (issue)
All port pfcwd storm test not stable enough.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Update all port pfcwd storm test is not stable engough. 
#### How did you do it?
Optimize background traffic and arp resolvation.
#### How did you verify/test it?
Run it in internal regression.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
