### PR TITLE
Skip test scripts in PR testing using pytest markers. 

### DIFF
--- a/tests/cacl/test_ebtables_application.py
+++ b/tests/cacl/test_ebtables_application.py
@@ -3,7 +3,8 @@ from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer globally
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -32,7 +32,8 @@ from tests.common import config_reload
 
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 PACKET_COUNT = 1000

--- a/tests/dualtor/test_orchagent_slb.py
+++ b/tests/dualtor/test_orchagent_slb.py
@@ -24,7 +24,8 @@ from tests.common.utilities import is_ipv4_address
 
 
 pytestmark = [
-    pytest.mark.topology("dualtor")
+    pytest.mark.topology("dualtor"),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/dualtor_io/test_grpc_server_failure.py
+++ b/tests/dualtor_io/test_grpc_server_failure.py
@@ -17,7 +17,8 @@ from tests.common.dualtor.nic_simulator_control import restart_nic_simulator    
 
 
 pytestmark = [
-    pytest.mark.topology("dualtor")
+    pytest.mark.topology("dualtor"),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -20,7 +20,8 @@ from tests.common.helpers.assertions import pytest_assert
 
 
 pytestmark = [
-    pytest.mark.topology("dualtor")
+    pytest.mark.topology("dualtor"),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -25,7 +25,8 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("dualtor")
+    pytest.mark.topology("dualtor"),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/dualtor_mgmt/test_egress_drop_nvidia.py
+++ b/tests/dualtor_mgmt/test_egress_drop_nvidia.py
@@ -17,7 +17,8 @@ from ptf.testutils import simple_tcp_packet, simple_ipv4ip_packet
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 
 pytestmark = [
-    pytest.mark.topology('dualtor')
+    pytest.mark.topology('dualtor'),
+    pytest.mark.device_type('physical')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.asic('broadcom'),
     pytest.mark.topology('t0', 't1'),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.device_type('physical')
 ]
 
 seed_cmd = [

--- a/tests/ecmp/test_fgnhg.py
+++ b/tests/ecmp/test_fgnhg.py
@@ -35,7 +35,8 @@ DUT_VXLAN_PORT_JSON_FILE = '/tmp/vxlan.switch.json'
 pytestmark = [
     pytest.mark.topology('t0'),
     pytest.mark.asic('mellanox'),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.device_type('physical')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/generic_config_updater/test_pfcwd_interval.py
+++ b/tests/generic_config_updater/test_pfcwd_interval.py
@@ -13,6 +13,7 @@ from tests.common.gu_utils import is_valid_platform_and_version
 pytestmark = [
     pytest.mark.asic('mellanox'),
     pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/ixia/ecn/test_dequeue_ecn.py
+++ b/tests/ixia/ecn/test_dequeue_ecn.py
@@ -10,7 +10,10 @@ from files.helper import run_ecn_test, is_ecn_marked
 from tests.common.cisco_data import get_markings_dut, setup_markings_dut
 from tests.ixia.ptf_utils import get_sai_attributes
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_dequeue_ecn(request, ixia_api, ixia_testbed_config, conn_graph_facts,                  # noqa F811

--- a/tests/ixia/ecn/test_red_accuracy.py
+++ b/tests/ixia/ecn/test_red_accuracy.py
@@ -10,7 +10,10 @@ from tests.common.ixia.qos_fixtures import prio_dscp_map, lossless_prio_list    
 from files.helper import run_ecn_test, is_ecn_marked
 from tests.common.cisco_data import get_markings_dut, setup_markings_dut
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_red_accuracy(request, ixia_api, ixia_testbed_config, conn_graph_facts,             # noqa F811

--- a/tests/ixia/ixanvl/test_bgp_conformance.py
+++ b/tests/ixia/ixanvl/test_bgp_conformance.py
@@ -7,7 +7,8 @@ from scp import SCPClient
 
 pytestmark = [
     pytest.mark.topology('tgen'),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/ixia/pfc/test_global_pause.py
+++ b/tests/ixia/pfc/test_global_pause.py
@@ -9,7 +9,10 @@ from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list, lossles
 
 from .files.helper import run_pfc_test
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_global_pause(ixia_api, ixia_testbed_config, conn_graph_facts, fanout_graph_facts,      # noqa F811

--- a/tests/ixia/pfc/test_pfc_congestion.py
+++ b/tests/ixia/pfc/test_pfc_congestion.py
@@ -18,7 +18,10 @@ from tests.common.ixia.qos_fixtures import (    # noqa: F401
     all_prio_list,
     lossless_prio_list)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_pfc_congestion(ixia_api,     # noqa: F811

--- a/tests/ixia/pfc/test_pfc_pause_lossless.py
+++ b/tests/ixia/pfc/test_pfc_pause_lossless.py
@@ -10,7 +10,10 @@ from tests.ixia.files.helper import skip_warm_reboot
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_pfc_pause_single_lossless_prio(ixia_api,

--- a/tests/ixia/pfc/test_pfc_pause_lossy.py
+++ b/tests/ixia/pfc/test_pfc_pause_lossy.py
@@ -14,7 +14,10 @@ from tests.ixia.files.helper import skip_warm_reboot
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_pfc_pause_single_lossy_prio(ixia_api, ixia_testbed_config, conn_graph_facts,           # noqa F811

--- a/tests/ixia/pfcwd/test_pfcwd_a2a.py
+++ b/tests/ixia/pfcwd/test_pfcwd_a2a.py
@@ -10,7 +10,10 @@ from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list,\
 from .files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 from .files.helper import skip_pfcwd_test
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])

--- a/tests/ixia/pfcwd/test_pfcwd_basic.py
+++ b/tests/ixia/pfcwd/test_pfcwd_basic.py
@@ -14,7 +14,10 @@ from .files.helper import skip_pfcwd_test
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 DEPENDENT_SERVICES = ['teamd', 'snmp', 'dhcp_relay', 'radv']
 

--- a/tests/ixia/pfcwd/test_pfcwd_burst_storm.py
+++ b/tests/ixia/pfcwd/test_pfcwd_burst_storm.py
@@ -10,7 +10,10 @@ from .files.pfcwd_burst_storm_helper import run_pfcwd_burst_storm_test
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_pfcwd_burst_storm_single_lossless_prio(ixia_api, ixia_testbed_config, conn_graph_facts,        # noqa F811

--- a/tests/ixia/pfcwd/test_pfcwd_m2o.py
+++ b/tests/ixia/pfcwd/test_pfcwd_m2o.py
@@ -10,7 +10,10 @@ from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list,\
 from .files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 from .files.helper import skip_pfcwd_test
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])

--- a/tests/ixia/pfcwd/test_pfcwd_runtime_traffic.py
+++ b/tests/ixia/pfcwd/test_pfcwd_runtime_traffic.py
@@ -8,7 +8,10 @@ from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list         
 
 from .files.pfcwd_runtime_traffic_helper import run_pfcwd_runtime_traffic_test
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_pfcwd_runtime_traffic(ixia_api, ixia_testbed_config, conn_graph_facts, fanout_graph_facts,     # noqa F811

--- a/tests/ixia/test_ixia_traffic.py
+++ b/tests/ixia/test_ixia_traffic.py
@@ -28,7 +28,8 @@ from tests.common.ixia.common_helpers import get_vlan_subnet, get_addrs_in_subne
 
 pytestmark = [
     pytest.mark.topology('tgen'),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/ixia/test_tgen.py
+++ b/tests/ixia/test_tgen.py
@@ -21,7 +21,8 @@ from abstract_open_traffic_generator.result import FlowRequest
 
 pytestmark = [
     pytest.mark.topology('tgen'),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/k8s/test_config_reload.py
+++ b/tests/k8s/test_config_reload.py
@@ -6,7 +6,8 @@ from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.config_reload import config_reload
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/k8s/test_disable_flag.py
+++ b/tests/k8s/test_disable_flag.py
@@ -4,7 +4,8 @@ import k8s_test_utilities as ku
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/k8s/test_join_available_master.py
+++ b/tests/k8s/test_join_available_master.py
@@ -7,7 +7,8 @@ from tests.common.helpers.assertions import pytest_assert
 WAIT_FOR_SYNC = 60
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/macsec/test_interop_wan_isis.py
+++ b/tests/macsec/test_interop_wan_isis.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.macsec_required,
     pytest.mark.topology("wan-pub-isis"),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/mclag/test_mclag_l3.py
+++ b/tests/mclag/test_mclag_l3.py
@@ -23,7 +23,8 @@ from mclag_helpers import CONFIG_DB_TEMP, CONFIG_DB_BACKUP, PTF_SCRIPT_TEMP, REN
 from mclag_helpers import DEFAULT_SESSION_TIMEOUT, NEW_SESSION_TIMEOUT
 
 pytestmark = [
-    pytest.mark.topology('t0-mclag')
+    pytest.mark.topology('t0-mclag'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -12,7 +12,8 @@ from pkg_resources import parse_version
 from tests.common.devices.ptf import PTFHost
 
 pytestmark = [
-    pytest.mark.topology("any")
+    pytest.mark.topology("any"),
+    pytest.mark.device_type('physical')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/nat/test_dynamic_nat.py
+++ b/tests/nat/test_dynamic_nat.py
@@ -41,7 +41,8 @@ import ptf.testutils as testutils
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/nat/test_static_nat.py
+++ b/tests/nat/test_static_nat.py
@@ -44,7 +44,8 @@ from tests.nat.conftest import nat_global_config
 
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/ospf/test_ospf.py
+++ b/tests/ospf/test_ospf.py
@@ -6,7 +6,8 @@ import re
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/ospf/test_ospf_bfd.py
+++ b/tests/ospf/test_ospf_bfd.py
@@ -5,7 +5,8 @@ import time
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1')
+    pytest.mark.topology('t0', 't1'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/pfc_asym/test_pfc_asym.py
+++ b/tests/pfc_asym/test_pfc_asym.py
@@ -3,7 +3,8 @@ from tests.common.fixtures.pfc_asym import setup    # noqa F401
 import pytest
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
@@ -7,7 +7,8 @@ from tests.common.platform.transceiver_utils import parse_sfp_eeprom_infos
 
 pytestmark = [
     pytest.mark.asic('mellanox', 'nvidia-bluefield'),
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 SHOW_EEPOMR_CMDS = ["show interface transceiver eeprom -d",

--- a/tests/platform_tests/mellanox/test_check_sfp_presence.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_presence.py
@@ -9,7 +9,8 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F
 
 pytestmark = [
     pytest.mark.asic('mellanox', 'nvidia-bluefield'),
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_using_ethtool.py
@@ -13,7 +13,8 @@ from .check_hw_mgmt_service import check_hw_management_service
 
 pytestmark = [
     pytest.mark.asic('mellanox'),
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/platform_tests/mellanox/test_check_sysfs.py
+++ b/tests/platform_tests/mellanox/test_check_sysfs.py
@@ -10,7 +10,8 @@ from .check_sysfs import check_sysfs
 
 pytestmark = [
     pytest.mark.asic('mellanox'),
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/platform_tests/mellanox/test_hw_management_service.py
+++ b/tests/platform_tests/mellanox/test_hw_management_service.py
@@ -9,7 +9,8 @@ from .check_hw_mgmt_service import check_hw_management_service
 
 pytestmark = [
     pytest.mark.asic('mellanox'),
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/platform_tests/mellanox/test_psu_power_threshold.py
+++ b/tests/platform_tests/mellanox/test_psu_power_threshold.py
@@ -11,7 +11,8 @@ from tests.common.helpers.mellanox_thermal_control_test_helper import MockerHelp
 
 pytestmark = [
     pytest.mark.asic('mellanox'),
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/platform_tests/mellanox/test_reboot_cause.py
+++ b/tests/platform_tests/mellanox/test_reboot_cause.py
@@ -6,7 +6,8 @@ from tests.common.helpers.thermal_control_test_helper import mocker_factory  # n
 
 pytestmark = [
     pytest.mark.asic('mellanox'),
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -5,7 +5,8 @@ from tests.common.utilities import skip_release, wait_until
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 SUPPORTED_PLATFORMS = [

--- a/tests/read_mac/test_read_mac_metadata.py
+++ b/tests/read_mac/test_read_mac_metadata.py
@@ -14,7 +14,8 @@ BINARY_FILE_ON_LOCALHOST_2 = "/tmp/sonic_image_on_localhost_2.bin"
 BINARY_FILE_ON_DUTHOST = "/tmp/sonic_image_on_duthost.bin"
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('t0'),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.device_type('physical')
 ]
 
 CLIENT_CERT = 'restapiclient.crt'

--- a/tests/sai_qualify/test_brcm_t0.py
+++ b/tests/sai_qualify/test_brcm_t0.py
@@ -14,7 +14,8 @@ pytestmark = [
     pytest.mark.topology("ptf"),
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
-    pytest.mark.skip_check_dut_health
+    pytest.mark.skip_check_dut_health,
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/sai_qualify/test_community.py
+++ b/tests/sai_qualify/test_community.py
@@ -20,7 +20,8 @@ pytestmark = [
     pytest.mark.topology("ptf"),
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
-    pytest.mark.skip_check_dut_health
+    pytest.mark.skip_check_dut_health,
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/sai_qualify/test_sai_ptf.py
+++ b/tests/sai_qualify/test_sai_ptf.py
@@ -14,7 +14,8 @@ pytestmark = [
     pytest.mark.topology("ptf"),
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
-    pytest.mark.skip_check_dut_health
+    pytest.mark.skip_check_dut_health,
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/sai_qualify/test_sai_ptf_warm_reboot.py
+++ b/tests/sai_qualify/test_sai_ptf_warm_reboot.py
@@ -17,7 +17,8 @@ pytestmark = [
     pytest.mark.topology("ptf"),
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
-    pytest.mark.skip_check_dut_health
+    pytest.mark.skip_check_dut_health,
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/sai_qualify/test_sai_t0_warm_reboot.py
+++ b/tests/sai_qualify/test_sai_t0_warm_reboot.py
@@ -17,7 +17,8 @@ pytestmark = [
     pytest.mark.topology("ptf"),
     pytest.mark.sanity_check(skip_sanity=True),
     pytest.mark.disable_loganalyzer,
-    pytest.mark.skip_check_dut_health
+    pytest.mark.skip_check_dut_health,
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -21,7 +21,8 @@ from tests.common.utilities import wait_until
 SFLOW_RATE_DEFAULT = 512
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0', 'mx')
+    pytest.mark.topology('t0', 'm0', 'mx'),
+    pytest.mark.device_type('physical')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/snappi_tests/bgp/test_bgp_convergence_performance.py
+++ b/tests/snappi_tests/bgp/test_bgp_convergence_performance.py
@@ -5,7 +5,10 @@ from tests.common.fixtures.conn_graph_facts import (                        # no
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize('multipath', [2])

--- a/tests/snappi_tests/bgp/test_bgp_local_link_failover.py
+++ b/tests/snappi_tests/bgp/test_bgp_local_link_failover.py
@@ -5,7 +5,10 @@ from tests.common.fixtures.conn_graph_facts import (                        # no
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize('multipath', [2])

--- a/tests/snappi_tests/bgp/test_bgp_remote_link_failover.py
+++ b/tests/snappi_tests/bgp/test_bgp_remote_link_failover.py
@@ -5,7 +5,10 @@ from tests.common.fixtures.conn_graph_facts import (                        # no
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize('multipath', [2])

--- a/tests/snappi_tests/bgp/test_bgp_rib_in_capacity.py
+++ b/tests/snappi_tests/bgp/test_bgp_rib_in_capacity.py
@@ -5,7 +5,10 @@ from tests.common.fixtures.conn_graph_facts import (                        # no
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize('multipath', [2])

--- a/tests/snappi_tests/bgp/test_bgp_rib_in_convergence.py
+++ b/tests/snappi_tests/bgp/test_bgp_rib_in_convergence.py
@@ -5,7 +5,10 @@ from tests.common.fixtures.conn_graph_facts import (                        # no
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize('multipath', [2])

--- a/tests/snappi_tests/bgp/test_bgp_scalability.py
+++ b/tests/snappi_tests/bgp/test_bgp_scalability.py
@@ -6,7 +6,10 @@ from tests.common.fixtures.conn_graph_facts import (                        # no
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize('multipath', [1])

--- a/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
@@ -16,7 +16,10 @@ from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_dequeue_ecn(request,

--- a/tests/snappi_tests/ecn/test_ecn_marking_cisco8000.py
+++ b/tests/snappi_tests/ecn/test_ecn_marking_cisco8000.py
@@ -12,7 +12,10 @@ from tests.common.cisco_data import is_cisco_device
 
 
 logger = logging.getLogger(__name__)
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 # ecn counter is per TC
 # Two streams are started for the indicated line rate.

--- a/tests/snappi_tests/ecn/test_red_accuracy_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_red_accuracy_with_snappi.py
@@ -18,7 +18,10 @@ from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_red_accuracy(request,

--- a/tests/snappi_tests/lacp/test_add_remove_link_from_dut.py
+++ b/tests/snappi_tests/lacp/test_add_remove_link_from_dut.py
@@ -6,7 +6,10 @@ from tests.common.fixtures.conn_graph_facts import (                    # noqa F
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize('port_count', [4])

--- a/tests/snappi_tests/lacp/test_add_remove_link_physically.py
+++ b/tests/snappi_tests/lacp/test_add_remove_link_physically.py
@@ -6,7 +6,10 @@ from tests.common.fixtures.conn_graph_facts import (                # noqa F401
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize('port_count', [4])

--- a/tests/snappi_tests/lacp/test_lacp_timers_effect.py
+++ b/tests/snappi_tests/lacp/test_lacp_timers_effect.py
@@ -6,7 +6,10 @@ from tests.common.fixtures.conn_graph_facts import (            # noqa F401
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize('port_count', [4])

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_port_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_port_flap.py
@@ -12,7 +12,10 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams       
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('multidut-tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen'),
+    pytest.mark.device_type('physical')
+]
 
 FLAP_DETAILS = {
         'device_name': t1_t2_device_hostnames[0],

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_process_crash.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_process_crash.py
@@ -12,7 +12,10 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams       
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('multidut-tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen'),
+    pytest.mark.device_type('physical')
+]
 
 ITERATION = 1
 ROUTE_RANGES = [{

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_tsa.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_tsa.py
@@ -12,7 +12,10 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams       
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('multidut-tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen'),
+    pytest.mark.device_type('physical')
+]
 
 ITERATION = 1
 ROUTE_RANGES = [{

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_multi_po_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_multi_po_flap.py
@@ -12,7 +12,10 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams       
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('multidut-tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen'),
+    pytest.mark.device_type('physical')
+]
 
 ITERATION = 1
 ROUTE_RANGES = [{

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_member_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_member_flap.py
@@ -12,7 +12,10 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams       
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('multidut-tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen'),
+    pytest.mark.device_type('physical')
+]
 
 FLAP_DETAILS = {
         'device_name': 'Ixia',

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_process_crash.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_process_crash.py
@@ -12,7 +12,10 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams       
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('multidut-tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen'),
+    pytest.mark.device_type('physical')
+]
 
 ITERATION = 1
 ROUTE_RANGES = [{

--- a/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
@@ -18,7 +18,10 @@ from tests.snappi_tests.files.helper import skip_ecn_tests
 from tests.common.snappi_tests.common_helpers import packet_capture
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])

--- a/tests/snappi_tests/multidut/ecn/test_multidut_red_accuracy_with_snappi.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_red_accuracy_with_snappi.py
@@ -19,7 +19,10 @@ from tests.snappi_tests.multidut.ecn.files.multidut_helper import run_ecn_test
 from tests.common.snappi_tests.common_helpers import packet_capture # noqa F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])

--- a/tests/snappi_tests/multidut/pfc/test_lossless_response_to_external_pause_storms.py
+++ b/tests/snappi_tests/multidut/pfc/test_lossless_response_to_external_pause_storms.py
@@ -15,7 +15,10 @@ from tests.snappi_tests.multidut.pfc.files.lossless_response_to_external_pause_s
     )
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])

--- a/tests/snappi_tests/multidut/pfc/test_lossless_response_to_throttling_pause_storms.py
+++ b/tests/snappi_tests/multidut/pfc/test_lossless_response_to_throttling_pause_storms.py
@@ -15,7 +15,10 @@ from tests.snappi_tests.multidut.pfc.files.lossless_response_to_throttling_pause
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict     # noqa: F401
 logger = logging.getLogger(__name__)
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])

--- a/tests/snappi_tests/multidut/pfc/test_m2o_fluctuating_lossless.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_fluctuating_lossless.py
@@ -13,7 +13,10 @@ from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.multidut.pfc.files.m2o_fluctuating_lossless_helper import run_m2o_fluctuating_lossless_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])

--- a/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless.py
@@ -15,7 +15,10 @@ from tests.snappi_tests.multidut.pfc.files.m2o_oversubscribe_lossless_helper imp
     )
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])

--- a/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless_lossy.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossless_lossy.py
@@ -16,7 +16,10 @@ from tests.snappi_tests.multidut.pfc.files.m2o_oversubscribe_lossless_lossy_help
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams            # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict        # noqa: F401
 logger = logging.getLogger(__name__)
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])

--- a/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossy.py
+++ b/tests/snappi_tests/multidut/pfc/test_m2o_oversubscribe_lossy.py
@@ -13,7 +13,10 @@ from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.multidut.pfc.files.m2o_oversubscribe_lossy_helper import run_pfc_m2o_oversubscribe_lossy_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])

--- a/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
@@ -14,7 +14,10 @@ from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -16,7 +16,10 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -16,7 +16,10 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import reboot_duts, setup_ports_and_dut, multidut_port_info  # noqa: F401
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_a2a_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_a2a_with_snappi.py
@@ -14,7 +14,10 @@ from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.multidut.pfcwd.files.pfcwd_multidut_multi_node_helper import run_pfcwd_multi_node_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("trigger_pfcwd", [False])

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
@@ -21,7 +21,10 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import skip_pfcwd_test, reboot_duts, \
     setup_ports_and_dut, multidut_port_info   # noqa: F401
 logger = logging.getLogger(__name__)
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 WAIT_TIME = 600
 INTERVAL = 40
@@ -33,7 +36,7 @@ def number_of_tx_rx_ports():
 
 
 @pytest.fixture(autouse=False)
-def save_restore_config(setup_ports_and_dut):
+def save_restore_config(setup_ports_and_dut):   # noqa F811
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
     timestamp = time.time()
     dest = f'~/{timestamp}'

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_burst_storm_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_burst_storm_with_snappi.py
@@ -14,7 +14,10 @@ from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.multidut.pfcwd.files.pfcwd_multidut_burst_storm_helper import run_pfcwd_burst_storm_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_m2o_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_m2o_with_snappi.py
@@ -14,7 +14,10 @@ from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.multidut.pfcwd.files.pfcwd_multidut_multi_node_helper import run_pfcwd_multi_node_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("trigger_pfcwd", [True])

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_runtime_traffic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_runtime_traffic_with_snappi.py
@@ -14,7 +14,10 @@ from tests.snappi_tests.multidut.pfcwd.files.\
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen', 'tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])

--- a/tests/snappi_tests/pfc/test_global_pause_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_global_pause_with_snappi.py
@@ -10,7 +10,10 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,
 
 from tests.snappi_tests.pfc.files.helper import run_pfc_test
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_global_pause(snappi_api,                   # noqa F811

--- a/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
@@ -17,7 +17,10 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_pfc_pause_single_lossless_prio(snappi_api,                 # noqa F811

--- a/tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
@@ -15,7 +15,10 @@ from tests.snappi_tests.files.helper import skip_warm_reboot
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa F811

--- a/tests/snappi_tests/pfc/test_pfc_pause_response_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_response_with_snappi.py
@@ -13,7 +13,10 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_pfc_single_lossless_headroom(snappi_api,                       # noqa F811

--- a/tests/snappi_tests/pfc/test_pfc_pause_unset_bit_enable_vector.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_unset_bit_enable_vector.py
@@ -13,7 +13,10 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_pfc_unset_cev_single_prio(snappi_api, # noqa F811

--- a/tests/snappi_tests/pfc/test_pfc_pause_zero_mac.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_zero_mac.py
@@ -13,7 +13,10 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_pfc_zero_src_mac_single_lossless_prio(snappi_api, # noqa F811

--- a/tests/snappi_tests/pfc/test_valid_pfc_frame_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_valid_pfc_frame_with_snappi.py
@@ -14,7 +14,10 @@ from tests.common.snappi_tests.common_helpers import packet_capture
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 def test_valid_pfc_frame(snappi_api, # noqa F811
                          snappi_testbed_config, # noqa F811

--- a/tests/snappi_tests/pfc/test_valid_src_mac_pfc_frame.py
+++ b/tests/snappi_tests/pfc/test_valid_src_mac_pfc_frame.py
@@ -16,7 +16,10 @@ from tests.common.cisco_data import is_cisco_device
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_valid_pfc_frame_src_mac(

--- a/tests/snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py
@@ -11,7 +11,10 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,
 from tests.snappi_tests.pfcwd.files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])

--- a/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
@@ -15,7 +15,10 @@ from tests.snappi_tests.files.helper import skip_warm_reboot
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])

--- a/tests/snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py
@@ -11,7 +11,10 @@ from tests.snappi_tests.pfcwd.files.pfcwd_burst_storm_helper import run_pfcwd_bu
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 def test_pfcwd_burst_storm_single_lossless_prio(snappi_api,                 # noqa F811
                                                 snappi_testbed_config,      # noqa F811

--- a/tests/snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py
@@ -10,7 +10,10 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,
 
 from tests.snappi_tests.pfcwd.files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])

--- a/tests/snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py
@@ -9,7 +9,10 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list 
 
 from tests.snappi_tests.pfcwd.files.pfcwd_runtime_traffic_helper import run_pfcwd_runtime_traffic_test
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 def test_pfcwd_runtime_traffic(snappi_api,                  # noqa F811
                                snappi_testbed_config,       # noqa F811

--- a/tests/snappi_tests/qos/test_ipip_packet_reorder_with_snappi.py
+++ b/tests/snappi_tests/qos/test_ipip_packet_reorder_with_snappi.py
@@ -11,7 +11,10 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map # noqa F401
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology('tgen')]
+pytestmark = [
+    pytest.mark.topology('tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 def test_ip_in_ip_packet_reorder(snappi_api, # noqa F811

--- a/tests/snappi_tests/reboot/test_cold_reboot.py
+++ b/tests/snappi_tests/reboot/test_cold_reboot.py
@@ -7,7 +7,10 @@ from tests.common.fixtures.conn_graph_facts import (        # noqa F401
 import pytest
 
 
-pytestmark = [pytest.mark.topology('snappi')]
+pytestmark = [
+    pytest.mark.topology('snappi'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/snappi_tests/reboot/test_fast_reboot.py
+++ b/tests/snappi_tests/reboot/test_fast_reboot.py
@@ -7,7 +7,10 @@ from tests.common.fixtures.conn_graph_facts import (        # noqa F401
 import pytest
 
 
-pytestmark = [pytest.mark.topology('snappi')]
+pytestmark = [
+    pytest.mark.topology('snappi'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/snappi_tests/reboot/test_soft_reboot.py
+++ b/tests/snappi_tests/reboot/test_soft_reboot.py
@@ -7,7 +7,10 @@ from tests.common.fixtures.conn_graph_facts import (        # noqa F401
 import pytest
 
 
-pytestmark = [pytest.mark.topology('snappi')]
+pytestmark = [
+    pytest.mark.topology('snappi'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/snappi_tests/reboot/test_warm_reboot.py
+++ b/tests/snappi_tests/reboot/test_warm_reboot.py
@@ -6,7 +6,10 @@ from tests.common.fixtures.conn_graph_facts import (        # noqa F401
     conn_graph_facts, fanout_graph_facts)
 import pytest
 
-pytestmark = [pytest.mark.topology('snappi')]
+pytestmark = [
+    pytest.mark.topology('snappi'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/snappi_tests/test_multidut_snappi.py
+++ b/tests/snappi_tests/test_multidut_snappi.py
@@ -14,7 +14,10 @@ from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_
 logger = logging.getLogger(__name__)
 SNAPPI_POLL_DELAY_SEC = 2
 
-pytestmark = [pytest.mark.topology('multidut-tgen')]
+pytestmark = [
+    pytest.mark.topology('multidut-tgen'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/snappi_tests/test_snappi.py
+++ b/tests/snappi_tests/test_snappi.py
@@ -12,7 +12,10 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map  # noqa F401
 
 SNAPPI_POLL_DELAY_SEC = 2
 
-pytestmark = [pytest.mark.topology('snappi')]
+pytestmark = [
+    pytest.mark.topology('snappi'),
+    pytest.mark.device_type('physical')
+]
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/system_health/test_watchdog.py
+++ b/tests/system_health/test_watchdog.py
@@ -6,7 +6,8 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('physical')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/test_vs_chassis_setup.py
+++ b/tests/test_vs_chassis_setup.py
@@ -11,7 +11,8 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology("t2"),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/voq/test_fabric_cli_and_db.py
+++ b/tests/voq/test_fabric_cli_and_db.py
@@ -5,7 +5,8 @@ import random
 logger = logging.getLogger(__name__)
 # This test only runs on t2 systems.
 pytestmark = [
-    pytest.mark.topology('t2')
+    pytest.mark.topology('t2'),
+    pytest.mark.device_type('physical')
 ]
 
 # There are 12 asic on Supervisor now.

--- a/tests/voq/test_fabric_reach.py
+++ b/tests/voq/test_fabric_reach.py
@@ -6,7 +6,8 @@ import yaml
 logger = logging.getLogger(__name__)
 # This test only runs on t2 systems.
 pytestmark = [
-    pytest.mark.topology('t2')
+    pytest.mark.topology('t2'),
+    pytest.mark.device_type('physical')
 ]
 
 localModule = 0

--- a/tests/voq/test_voq_chassis_app_db_consistency.py
+++ b/tests/voq/test_voq_chassis_app_db_consistency.py
@@ -13,7 +13,8 @@ import tests.common.helpers.voq_lag as voq_lag
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t2')
+    pytest.mark.topology('t2'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/voq/test_voq_disrupts.py
+++ b/tests/voq/test_voq_disrupts.py
@@ -22,7 +22,8 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t2')
+    pytest.mark.topology('t2'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/voq/test_voq_fabric_isolation.py
+++ b/tests/voq/test_voq_fabric_isolation.py
@@ -8,7 +8,8 @@ logger = logging.getLogger(__name__)
 
 # This test only runs on t2 systems.
 pytestmark = [
-    pytest.mark.topology('t2')
+    pytest.mark.topology('t2'),
+    pytest.mark.device_type('physical')
 ]
 
 # This test checks if fabric link monitoring algorithm works as expected.

--- a/tests/voq/test_voq_fabric_status_all.py
+++ b/tests/voq/test_voq_fabric_status_all.py
@@ -7,7 +7,8 @@ logger = logging.getLogger(__name__)
 
 # This test only runs on t2 systems.
 pytestmark = [
-    pytest.mark.topology('t2')
+    pytest.mark.topology('t2'),
+    pytest.mark.device_type('physical')
 ]
 
 # This test checks the fabric link status.

--- a/tests/voq/test_voq_init.py
+++ b/tests/voq/test_voq_init.py
@@ -13,7 +13,8 @@ from tests.common.helpers.voq_helpers import dump_and_verify_neighbors_on_asic
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t2')
+    pytest.mark.topology('t2'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/voq/test_voq_intfs.py
+++ b/tests/voq/test_voq_intfs.py
@@ -14,7 +14,8 @@ from .test_voq_disrupts import check_bgp_neighbors
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t2')
+    pytest.mark.topology('t2'),
+    pytest.mark.device_type('physical')
 ]
 
 ADDR = ipaddress.IPv4Interface(u"50.1.1.1/24")

--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -34,7 +34,8 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.topology('t2'),
     pytest.mark.sanity_check(check_items=["-monit"], allow_recover=False),
-    pytest.mark.disable_loganalyzer
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.device_type('physical')
 ]
 
 LOG_PING = True

--- a/tests/voq/test_voq_nbr.py
+++ b/tests/voq/test_voq_nbr.py
@@ -31,7 +31,8 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory  # noqa 
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t2')
+    pytest.mark.topology('t2'),
+    pytest.mark.device_type('physical')
 ]
 
 NEW_MAC = "00:01:94:00:00:01"

--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -36,7 +36,8 @@ from tests.common.helpers.assertions import pytest_assert
 """
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0'),
+    pytest.mark.device_type('physical')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/vrf/test_vrf_attr.py
+++ b/tests/vrf/test_vrf_attr.py
@@ -16,7 +16,8 @@ from tests.common.storage_backend.backend_utils import skip_test_module_over_bac
 
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0'),
+    pytest.mark.device_type('physical')
 ]
 
 # tests

--- a/tests/wan/isis/test_isis_authentication.py
+++ b/tests/wan/isis/test_isis_authentication.py
@@ -22,6 +22,7 @@ description:
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 ITF_AUTH_PASSWRD = 'itf_auth'

--- a/tests/wan/isis/test_isis_csnp_interval.py
+++ b/tests/wan/isis/test_isis_csnp_interval.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_database.py
+++ b/tests/wan/isis/test_isis_database.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-2dut'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_dynamic_hostname.py
+++ b/tests/wan/isis/test_isis_dynamic_hostname.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_ecmp.py
+++ b/tests/wan/isis/test_isis_ecmp.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-ecmp'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_hello_interval.py
+++ b/tests/wan/isis/test_isis_hello_interval.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_hello_pad.py
+++ b/tests/wan/isis/test_isis_hello_pad.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_holdtime.py
+++ b/tests/wan/isis/test_isis_holdtime.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_intf_passive.py
+++ b/tests/wan/isis/test_isis_intf_passive.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_level_capacity.py
+++ b/tests/wan/isis/test_isis_level_capacity.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_log_adjacency_change.py
+++ b/tests/wan/isis/test_isis_log_adjacency_change.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_lsp_fragment.py
+++ b/tests/wan/isis/test_isis_lsp_fragment.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_lsp_gen_interval.py
+++ b/tests/wan/isis/test_isis_lsp_gen_interval.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_lsp_lifetime.py
+++ b/tests/wan/isis/test_isis_lsp_lifetime.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_lsp_refresh.py
+++ b/tests/wan/isis/test_isis_lsp_refresh.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_metric_wide.py
+++ b/tests/wan/isis/test_isis_metric_wide.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_neighbor.py
+++ b/tests/wan/isis/test_isis_neighbor.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_overload_bit.py
+++ b/tests/wan/isis/test_isis_overload_bit.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_redistribute.py
+++ b/tests/wan/isis/test_isis_redistribute.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 

--- a/tests/wan/isis/test_isis_spf_default_interval.py
+++ b/tests/wan/isis/test_isis_spf_default_interval.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 SPF_INTERVAL = 20

--- a/tests/wan/isis/test_isis_spf_ietf_interval.py
+++ b/tests/wan/isis/test_isis_spf_ietf_interval.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-com'),
+    pytest.mark.device_type('physical')
 ]
 
 QUIET = 'QUIET'

--- a/tests/wan/lacp/test_wan_lacp.py
+++ b/tests/wan/lacp/test_wan_lacp.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('wan-pub', 'wan-pub-cisco'),
+    pytest.mark.device_type('physical')
 ]
 
 # The dir will be deleted from host, so be sure not to use system dir


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Previously, we used the `.azure-pipelines/pr_test_skip_scripts.yaml` file to manually specify test scripts to skip during PR testing. However, in our new PR testing model proposed in #15666, test scripts are collected automatically, eliminating the need for this hardcoded file.

To handle skipped scripts in the new model, we now identify them directly within the test scripts. Specifically, we use the `pytest.mark.device_type('physical')` marker to indicate scripts that can only run on physical testbeds and should be skipped in PR testing. This PR adds the necessary markers to the relevant scripts to align with the new approach.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Previously, we used the `.azure-pipelines/pr_test_skip_scripts.yaml` file to manually specify test scripts to skip during PR testing. However, in our new PR testing model proposed in #15666, test scripts are collected automatically, eliminating the need for this hardcoded file.

To handle skipped scripts in the new model, we now identify them directly within the test scripts. Specifically, we use the `pytest.mark.device_type('physical')` marker to indicate scripts that can only run on physical testbeds and should be skipped in PR testing. This PR adds the necessary markers to the relevant scripts to align with the new approach.

#### How did you do it?
This PR adds the necessary markers to the relevant scripts to align with the new approach.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
