### PR TITLE
[testbed] ptf data plane connection for multi-servers testbed

### DIFF
--- a/ansible/module_utils/multi_servers_utils.py
+++ b/ansible/module_utils/multi_servers_utils.py
@@ -1,0 +1,63 @@
+class MultiServersUtils:
+    @staticmethod
+    def filter_by_dut_interfaces_util(values, dut_interfaces):
+        if isinstance(dut_interfaces, str) or isinstance(dut_interfaces, unicode):  # noqa F821
+            dut_interfaces = MultiServersUtils.parse_multi_servers_interface(dut_interfaces)
+
+        if isinstance(values, dict):
+            return {k: v for k, v in values.items() if int(k) in dut_interfaces}
+        elif isinstance(values, list):
+            return [v for v in values if int(v) in dut_interfaces]
+        else:
+            raise ValueError('Unsupported type "{}"'.format(type(values)))
+
+    @staticmethod
+    def parse_multi_servers_interface(intf_pattern):
+        intf_pattern = str(intf_pattern)
+        intfs = []
+        for intf in iter(map(str.strip, intf_pattern.split(','))):
+            if intf.isdigit():
+                intfs.append(int(intf))
+            elif '-' in intf:
+                intf_range = list(map(int, map(str.strip, intf.split('-'))))
+                assert len(intf_range) == 2, 'Invalid interface range "{}"'.format(intf)
+                intfs.extend(list(range(intf_range[0], intf_range[1]+1)))
+            else:
+                raise ValueError('Unsupported format "{}"'.format(intf_pattern))
+        if len(intfs) != len(set(intfs)):
+            raise ValueError('There are interface duplication/overlap in "{}"'.format(intf_pattern))
+        return intfs
+
+    @staticmethod
+    def parse_topology_vms(VMs, dut_interfaces):
+        if not dut_interfaces:
+            return VMs
+
+        if isinstance(dut_interfaces, str) or isinstance(dut_interfaces, unicode):  # noqa F821
+            dut_interfaces = MultiServersUtils.parse_multi_servers_interface(dut_interfaces)
+
+        result = {}
+        offset = 0
+        for hostname, attr in VMs.items():
+            if dut_interfaces and attr['vlans'][0] not in dut_interfaces:
+                continue
+            result[hostname] = attr
+            result[hostname]['vm_offset'] = offset
+            offset += 1
+        return result
+
+    @staticmethod
+    def generate_vm_name_mapping(servers_info, topo_vms):
+        _m = {}
+
+        for server_attr in servers_info.values():
+            if 'dut_interfaces' in server_attr:
+                filtered_vms = MultiServersUtils.parse_topology_vms(topo_vms, server_attr['dut_interfaces'])
+                vm_base = server_attr['vm_base']
+                vm_start_index = int(vm_base[2:])
+                vm_name_fmt = 'VM%0{}d'.format(len(vm_base) - 2)
+
+                for hostname, host_attr in filtered_vms.items():
+                    vm_name = vm_name_fmt % (vm_start_index + host_attr['vm_offset'])
+                    _m[hostname] = vm_name
+        return _m

--- a/tests/common/multi_servers_utils.py
+++ b/tests/common/multi_servers_utils.py
@@ -1,0 +1,1 @@
+../../ansible/module_utils/multi_servers_utils.py

--- a/tests/common/plugins/ptfadapter/__init__.py
+++ b/tests/common/plugins/ptfadapter/__init__.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import time
 
-from .ptfadapter import PtfTestAdapter
+from .ptfadapter import PtfTestAdapter, PtfAgent
 import ptf.testutils
 
 from tests.common import constants
@@ -98,7 +98,7 @@ def get_ifaces_map(ifaces, ptf_port_mapping_mode):
 
 
 @pytest.fixture(scope='module')
-def ptfadapter(ptfhost, tbinfo, request, duthost):
+def ptfadapter(ptfhosts, tbinfo, request, duthost):
     """return ptf test adapter object.
     The fixture is module scope, because usually there is not need to
     restart PTF nn agent and reinitialize data plane thread on every
@@ -113,18 +113,13 @@ def ptfadapter(ptfhost, tbinfo, request, duthost):
     else:
         ptf_port_mapping_mode = 'use_orig_interface'
 
-    # get the eth interfaces from PTF and initialize ifaces_map
-    res = ptfhost.command('cat /proc/net/dev')
-    ifaces = get_ifaces(res['stdout'])
-    ifaces_map = get_ifaces_map(ifaces, ptf_port_mapping_mode)
-
-    def start_ptf_nn_agent():
+    def start_ptf_nn_agent(device_num):
         for i in range(MAX_RETRY_TIME):
             ptf_nn_port = random.randint(*DEFAULT_PTF_NN_PORT_RANGE)
 
             # generate supervisor configuration for ptf_nn_agent
             ptfhost.host.options['variable_manager'].extra_vars.update({
-                'device_num': DEFAULT_DEVICE_NUM,
+                'device_num': device_num,
                 'ptf_nn_port': ptf_nn_port,
                 'ifaces_map': ifaces_map,
             })
@@ -145,10 +140,16 @@ def ptfadapter(ptfhost, tbinfo, request, duthost):
                 return ptf_nn_port
         return None
 
-    ptf_nn_agent_port = start_ptf_nn_agent()
-    assert ptf_nn_agent_port is not None
+    ptfagents = []
+    for seq, ptfhost in enumerate(ptfhosts):
+        res = ptfhost.command('cat /proc/net/dev')
+        ifaces = get_ifaces(res['stdout'])
+        ifaces_map = get_ifaces_map(ifaces, ptf_port_mapping_mode)
+        ptf_nn_agent_port = start_ptf_nn_agent(seq)
+        ptfagents.append(PtfAgent(ptfhost.mgmt_ip, ptf_nn_agent_port, seq, ifaces_map))
+        assert ptf_nn_agent_port is not None
 
-    with PtfTestAdapter(tbinfo['ptf_ip'], ptf_nn_agent_port, 0, list(ifaces_map.keys()), ptfhost) as adapter:
+    with PtfTestAdapter(ptfagents, ptfhosts) as adapter:
         if not request.config.option.keep_payload:
             override_ptf_functions()
             node_id = request.module.__name__
@@ -161,12 +162,12 @@ def ptfadapter(ptfhost, tbinfo, request, duthost):
 
 
 @pytest.fixture(scope='module')
-def nbr_device_numbers(nbrhosts):
+def nbr_device_numbers(nbrhosts, ptfhosts):
     """return the mapping of neighbor devices name to ptf device number.
     """
     numbers = sorted(nbrhosts.keys())
     device_numbers = {
-        nbr_name: numbers.index(nbr_name) + DEFAULT_DEVICE_NUM + 1
+        nbr_name: numbers.index(nbr_name) + len(ptfhosts)
         for nbr_name in list(nbrhosts.keys())}
     return device_numbers
 

--- a/tests/common/plugins/ptfadapter/ptfadapter.py
+++ b/tests/common/plugins/ptfadapter/ptfadapter.py
@@ -11,6 +11,14 @@ from tests.common.utilities import wait_until
 import logging
 
 
+class PtfAgent:
+    def __init__(self, ptf_ip, ptf_nn_port, device_num, ptf_port_set):
+        self.ptf_ip = ptf_ip
+        self.ptf_nn_port = ptf_nn_port
+        self.device_num = device_num
+        self.ptf_port_set = ptf_port_set
+
+
 class PtfAdapterNNConnectionError(Exception):
 
     def __init__(self, remote_sock_addr):
@@ -30,20 +38,16 @@ class PtfTestAdapter(BaseTest):
     # the number of currently established connections
     NN_STAT_CURRENT_CONNECTIONS = 201
 
-    def __init__(self, ptf_ip, ptf_nn_port, device_num, ptf_port_set, ptfhost):
+    def __init__(self, ptfagents, ptfhosts):
         """ initialize PtfTestAdapter
-        :param ptf_ip: PTF host IP
-        :param ptf_nn_port: PTF nanomessage agent port
-        :param device_num: device number
-        :param ptf_port_set: PTF ports
-        :return:
         """
         self.runTest = lambda: None    # set a no op runTest attribute to satisfy BaseTest interface
         super(PtfTestAdapter, self).__init__()
         self.payload_pattern = ""
         self.connected = False
-        self.ptfhost = ptfhost
-        self._init_ptf_dataplane(ptf_ip, ptf_nn_port, device_num, ptf_port_set)
+        self.ptfhosts = ptfhosts
+        self.ptfagents = ptfagents
+        self._init_ptf_dataplane()
 
     def __enter__(self):
         """ enter in 'with' block """
@@ -64,40 +68,33 @@ class PtfTestAdapter(BaseTest):
         finally:
             sock.close()
 
-    def _init_ptf_dataplane(self, ptf_ip, ptf_nn_port, device_num, ptf_port_set, ptf_config=None):
+    def _init_ptf_dataplane(self, ptf_config=None):
         """
         initialize ptf framework and establish connection to ptf_nn_agent
         running on PTF host
-        :param ptf_ip: PTF host IP
-        :param ptf_nn_port: PTF nanomessage agent port
-        :param device_num: device number
-        :param ptf_port_set: PTF ports
         :return:
         """
-        self.ptf_ip = ptf_ip
-        self.ptf_nn_port = ptf_nn_port
-        self.device_num = device_num
-        self.ptf_port_set = ptf_port_set
         self.connected = False
 
         ptfutils.default_timeout = self.DEFAULT_PTF_TIMEOUT
         ptfutils.default_negative_timeout = self.DEFAULT_PTF_NEG_TIMEOUT
 
-        ptf_nn_sock_addr = 'tcp://{}:{}'.format(ptf_ip, ptf_nn_port)
-
         ptf.config.update({
             'platform': 'nn',
-            'device_sockets': [
-                (device_num, ptf_port_set, ptf_nn_sock_addr)
-            ],
+            'device_sockets': [],
             'qlen': self.DEFAULT_PTF_QUEUE_LEN,
             'relax': True,
         })
+
         if ptf_config is not None:
             ptf.config.update(ptf_config)
 
-        if not self._check_ptf_nn_agent_availability(ptf_nn_sock_addr):
-            raise PtfAdapterNNConnectionError(ptf_nn_sock_addr)
+        for ptfagent in self.ptfagents:
+            ptf_nn_sock_addr = 'tcp://{}:{}'.format(ptfagent.ptf_ip, ptfagent.ptf_nn_port)
+            ptf.config['device_sockets'].append((ptfagent.device_num, ptfagent.ptf_port_set, ptf_nn_sock_addr))
+
+            if not self._check_ptf_nn_agent_availability(ptf_nn_sock_addr):
+                raise PtfAdapterNNConnectionError(ptf_nn_sock_addr)
 
         # update ptf.config based on NN platform and create dataplane instance
         nn.platform_config_update(ptf.config)
@@ -109,6 +106,9 @@ class PtfTestAdapter(BaseTest):
             device_id, port_id = id
             ptf.dataplane_instance.port_add(ifname, device_id, port_id)
         self.connected = True
+        ptf.dataplane_instance.port_device_map = {p: d for d, p in ptf.dataplane_instance.ports.keys()}
+        ptf.dataplane_instance.port_to_device = lambda port: ptf.dataplane_instance.port_device_map[port]
+        ptf.dataplane_instance.port_to_tuple = lambda port: (ptf.dataplane_instance.port_device_map[port], port)
         self.dataplane = ptf.dataplane_instance
 
     def kill(self):
@@ -133,11 +133,12 @@ class PtfTestAdapter(BaseTest):
 
         # Restart ptf_nn_agent to close any TCP connection from the server side
         logging.info("Restarting ptf_nn_agent")
-        self.ptfhost.command('supervisorctl reread')
-        self.ptfhost.command('supervisorctl update')
-        self.ptfhost.command('supervisorctl restart ptf_nn_agent')
+        for ptfhost in self.ptfhosts:
+            ptfhost.command('supervisorctl reread')
+            ptfhost.command('supervisorctl update')
+            ptfhost.command('supervisorctl restart ptf_nn_agent')
 
-        self._init_ptf_dataplane(self.ptf_ip, self.ptf_nn_port, self.device_num, self.ptf_port_set, ptf_config)
+        self._init_ptf_dataplane(ptf_config)
 
     def update_payload(self, pkt):
         """Update the payload of packet to the default pattern when certain conditions are met.

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -107,10 +107,10 @@ class TestbedInfo(object):
         with open(self.testbed_filename) as f:
             tb_info = yaml.safe_load(f)
             for tb in tb_info:
-                if tb["ptf_ip"]:
+                if "ptf_ip" in tb and tb["ptf_ip"]:
                     tb["ptf_ip"], tb["ptf_netmask"] = \
                         self._cidr_to_ip_mask(tb["ptf_ip"])
-                if tb["ptf_ipv6"]:
+                if "ptf_ipv6" in tb and tb["ptf_ipv6"]:
                     tb["ptf_ipv6"], tb["ptf_netmask_v6"] = \
                         self._cidr_to_ip_mask(tb["ptf_ipv6"])
                 tb["duts"] = tb.pop("dut")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ from tests.common.connections.base_console_conn import (
     CONSOLE_SSH_DIGI_CONFIG,
     CONSOLE_SSH_SONIC_CONFIG
 )
+from tests.common.multi_servers_utils import MultiServersUtils
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F401
 from tests.common.devices.local import Localhost
 from tests.common.devices.ptf import PTFHost
@@ -602,19 +603,35 @@ def localhost(ansible_adhoc):
 
 
 @pytest.fixture(scope="session")
-def ptfhost(enhance_inventory, ansible_adhoc, tbinfo, duthost, request):
+def ptfhost(ptfhosts):
+    if not ptfhosts:
+        return ptfhosts
+    return ptfhosts[0]  # For backward compatibility, this is for single ptfhost testbed.
+
+
+@pytest.fixture(scope="session")
+def ptfhosts(enhance_inventory, ansible_adhoc, tbinfo, duthost, request):
+    _hosts = []
     if 'ptp' in tbinfo['topo']['name']:
         return None
     if "ptf_image_name" in tbinfo and "docker-keysight-api-server" in tbinfo["ptf_image_name"]:
         return None
     if "ptf" in tbinfo:
-        return PTFHost(ansible_adhoc, tbinfo["ptf"], duthost, tbinfo,
-                       macsec_enabled=request.config.option.enable_macsec)
+        _hosts.append(PTFHost(ansible_adhoc, tbinfo["ptf"], duthost, tbinfo,
+                              macsec_enabled=request.config.option.enable_macsec))
+    elif "servers" in tbinfo:
+        for server in tbinfo["servers"].values():
+            if "ptf" in server and server["ptf"]:
+                _host = PTFHost(ansible_adhoc, server["ptf"], duthost, tbinfo,
+                                macsec_enabled=request.config.option.enable_macsec)
+                _hosts.append(_host)
     else:
         # when no ptf defined in testbed.csv
         # try to parse it from inventory
         ptf_host = duthost.host.options["inventory_manager"].get_host(duthost.hostname).get_vars()["ptf_host"]
-        return PTFHost(ansible_adhoc, ptf_host, duthost, tbinfo, macsec_enabled=request.config.option.enable_macsec)
+        _hosts.apend(PTFHost(ansible_adhoc, ptf_host, duthost, tbinfo,
+                             macsec_enabled=request.config.option.enable_macsec))
+    return _hosts
 
 
 @pytest.fixture(scope="module")
@@ -657,14 +674,12 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
     """
     logger.info("Fixture nbrhosts started")
     devices = {}
-    if (not tbinfo['vm_base'] and 'tgen' in tbinfo['topo']['name']) or 'ptf' in tbinfo['topo']['name']:
+    if (('vm_base' in tbinfo and not tbinfo['vm_base']) and 'tgen' in tbinfo['topo']['name']) \
+            or 'ptf' in tbinfo['topo']['name']:
         logger.info("No VMs exist for this topology: {}".format(tbinfo['topo']['name']))
         return devices
 
-    vm_base = int(tbinfo['vm_base'][2:])
-    vm_name_fmt = 'VM%0{}d'.format(len(tbinfo['vm_base']) - 2)
     neighbor_type = request.config.getoption("--neighbor_type")
-
     if 'VMs' not in tbinfo['topo']['properties']['topology']:
         logger.info("No VMs exist for this topology: {}".format(tbinfo['topo']['properties']['topology']))
         return devices
@@ -716,9 +731,23 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
 
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=8)
     futures = []
-    for neighbor_name, neighbor in list(tbinfo['topo']['properties']['topology']['VMs'].items()):
-        vm_name = vm_name_fmt % (vm_base + neighbor['vm_offset'])
-        futures.append(executor.submit(initial_neighbor, neighbor_name, vm_name))
+    servers = []
+    if 'servers' in tbinfo:
+        servers.extend(tbinfo['servers'].values())
+    elif 'server' in tbinfo:
+        servers.append(tbinfo)
+    else:
+        logger.warning("Unknown testbed schema for setup nbrhosts")
+    for server in servers:
+        vm_base = int(server['vm_base'][2:])
+        vm_name_fmt = 'VM%0{}d'.format(len(server['vm_base']) - 2)
+        vms = MultiServersUtils.parse_topology_vms(
+                tbinfo['topo']['properties']['topology']['VMs'],
+                server['dut_interfaces']
+            ) if 'dut_interfaces' in server else tbinfo['topo']['properties']['topology']['VMs']
+        for neighbor_name, neighbor in vms.items():
+            vm_name = vm_name_fmt % (vm_base + neighbor['vm_offset'])
+            futures.append(executor.submit(initial_neighbor, neighbor_name, vm_name))
 
     for future in as_completed(futures):
         # if exception caught in the sub-thread, .result() will raise it in the main thread
@@ -819,13 +848,29 @@ def fanouthosts(enhance_inventory, ansible_adhoc, conn_graph_facts, creds, dutho
 
 
 @pytest.fixture(scope="session")
-def vmhost(enhance_inventory, ansible_adhoc, request, tbinfo):
+def vmhost(vmhosts):
+    if not vmhosts:
+        return vmhosts
+    return vmhosts[0]  # For backward compatibility, this is for single vmhost testbed.
+
+
+@pytest.fixture(scope="session")
+def vmhosts(enhance_inventory, ansible_adhoc, request, tbinfo):
+    hosts = []
+    inv_files = get_inventory_files(request)
     if 'ptp' in tbinfo['topo']['name']:
         return None
-    server = tbinfo["server"]
-    inv_files = get_inventory_files(request)
-    vmhost = get_test_server_host(inv_files, server)
-    return VMHost(ansible_adhoc, vmhost.name)
+    elif "servers" in tbinfo:
+        for server in tbinfo["servers"].keys():
+            vmhost = get_test_server_host(inv_files, server)
+            hosts.append(VMHost(ansible_adhoc, vmhost.name))
+    elif "server" in tbinfo:
+        server = tbinfo["server"]
+        vmhost = get_test_server_host(inv_files, server)
+        hosts.append(VMHost(ansible_adhoc, vmhost.name))
+    else:
+        logger.info("No VM host exist for this topology: {}".format(tbinfo['topo']['name']))
+    return hosts
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
For testbed with multi-servers (HLD: #15395 
We need to make sure ptf data plane connectivity.
In this PR, we make sure ptf data plane works when running tests.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
We need to make sure ptf data plane connectivity during tests running.
#### How did you do it?
Start ptf_nn_agent on every ptf container and connect them with ptf dataplane.
#### How did you verify/test it?
Run test case with ptf dataplane on single server testbed and multi-servers testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
