### PR TITLE
Disable pfcwd for pfc_lossless.

### DIFF
--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -93,6 +93,7 @@ def test_pfc_pause_multi_lossless_prio(snappi_api,                   # noqa: F81
                                        lossless_prio_list,           # noqa: F811
                                        get_snappi_ports,             # noqa: F811
                                        tbinfo,
+                                       disable_pfcwd,                # noqa: F811
                                        setup_ports_and_dut):         # noqa: F811
 
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The pfc lossless test assume pfcwd is disabled. But this test: test_pfc_pause_multi_lossless_prio is not provided the fixture: "disable_pfcwd" which is used by all other tests in the same script. This causes this test to fail since the pfcwd is triggered and packets are dropped.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
this test is failing with this error:
```Failed: Total TX bytes   841563217920 should be smaller than DUT buffer size 67108864```
#### How did you do it?
Disable pfcwd during the test using the fixture, that is already used by other tests in the same script.

#### How did you verify/test it?
Ran it on my TB:

@sdszhang , @auspham : FYI.