### PR TITLE
[dhcp_relay] Update error log for dhcp server route incorrect

### DIFF
--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -147,7 +147,9 @@ def validate_dut_routes_exist(duthosts, rand_one_dut_hostname, dut_dhcp_relay_da
     """Fixture to valid a route to each DHCP server exist
     """
     py_assert(wait_until(120, 5, 0, check_routes_to_dhcp_server, duthosts[rand_one_dut_hostname],
-                         dut_dhcp_relay_data), "Failed to find route for DHCP server")
+                         dut_dhcp_relay_data),
+              "Packets relayed to DHCP server should go through default route via upstream neighbor, but now it's" +
+              " going through mgmt interface, which means device is in a unhealthy status")
 
 
 @pytest.fixture(scope="module")

--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -149,7 +149,7 @@ def validate_dut_routes_exist(duthosts, rand_one_dut_hostname, dut_dhcp_relay_da
     py_assert(wait_until(120, 5, 0, check_routes_to_dhcp_server, duthosts[rand_one_dut_hostname],
                          dut_dhcp_relay_data),
               "Packets relayed to DHCP server should go through default route via upstream neighbor, but now it's" +
-              " going through mgmt interface, which means device is in a unhealthy status")
+              " going through mgmt interface, which means device is in an unhealthy status")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Error log for default route incorrect is ambiguous

#### How did you do it?
Update the log

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
