### PR TITLE
Add 7 nodes SRv6 testbed configuration based on Force 10 hwsku

### DIFF
--- a/ansible/lab
+++ b/ansible/lab
@@ -234,3 +234,13 @@ sonic_cisco_vs:
       hwsku: cisco-8101-p4-32x100-vs
       ansible_host: 10.250.0.125
       ansible_hostv6: fec0::ffff:afa:13
+    vlab-c-02:
+      ansible_host: 10.250.0.125
+      ansible_hostv6: fec0::ffff:afb:8
+      type: kvm
+      hwsku: Force10-S6000
+      serial_port: 9025
+      ansible_password: password
+      ansible_user: admin
+      ansible_ssh_user: admin
+      ansible_altpassword: admin

--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -1,8 +1,3 @@
-- name: Add docker official GPG key
-  apt_key: url=https://download.docker.com/linux/ubuntu/gpg state=present
-  become: yes
-  environment: "{{ proxy_env | default({}) }}"
-
 - name: Check docker repository
   find:
     paths: /etc/apt/sources.list.d/
@@ -17,6 +12,12 @@
 - name: Report docker repository not exists
   debug:
     msg: "Docker repository does not exist"
+  when: docker_repo.matched == 0
+
+- name: Add docker official GPG key
+  apt_key: url=https://download.docker.com/linux/ubuntu/gpg state=present
+  become: yes
+  environment: "{{ proxy_env | default({}) }}"
   when: docker_repo.matched == 0
 
 - name: Add docker repository for 16.04

--- a/ansible/vars/configdb_jsons/7nodes_force10/P1.json
+++ b/ansible/vars/configdb_jsons/7nodes_force10/P1.json
@@ -1,0 +1,450 @@
+{
+    "BGP_GLOBALS": {
+        "default": {
+            "local_asn": "65100",
+            "router_id": "100.1.0.35",
+            "log_nbr_state_changes": "true",
+            "load_balance_mp_relax": "true",
+            "keepalive": "10",
+            "holdtime": "30"
+        }
+    },
+    "ROUTE_MAP": {
+        "pass_all|1": {
+            "route_operation": "permit"
+        },
+        "pass_all_in|1": {
+            "route_operation": "permit",
+            "set_ipv6_next_hop_prefer_global": "true"
+        }
+    },
+    "BGP_GLOBALS_AF": {
+        "default|ipv6_unicast": {
+            "max_ebgp_paths": 64,
+            "redistribute_connected": "true",
+            "redistribute_static_rmap": "pass_all"
+        }
+    },
+    "BGP_NEIGHBOR_AF": {
+        "default|fc00::72|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc00::76|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc00::7e|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc00::81|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc01::85|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        }
+    },
+    "BGP_NEIGHBOR": {
+        "default|fc00::72": {
+            "admin_status": "true",
+            "local_asn": "65100",
+            "min_adv_interval": "0",
+            "local_addr": "fc00::71",
+            "asn": "64600",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "PE1"
+        },
+        "default|fc00::76": {
+            "admin_status": "true",
+            "local_asn": "65100",
+            "min_adv_interval": "0",
+            "local_addr": "fc00::75",
+            "asn": "64601",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "PE2"
+        },
+        "default|fc00::7e": {
+            "admin_status": "true",
+            "local_asn": "65100",
+            "min_adv_interval": "0",
+            "local_addr": "fc00::7d",
+            "asn": "65101",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "P3"
+        },
+        "default|fc00::81": {
+            "admin_status": "true",
+            "local_asn": "65100",
+            "min_adv_interval": "0",
+            "local_addr": "fc00::82",
+            "asn": "65102",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "P2"
+        },
+        "default|fc01::85": {
+            "admin_status": "true",
+            "local_asn": "65100",
+            "min_adv_interval": "0",
+            "local_addr": "fc01::86",
+            "asn": "65103",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "P4"
+        }
+    },
+    "DEVICE_METADATA": {
+        "localhost": {
+            "asic": "vs",
+            "bgp_asn": "65100",
+            "hostname": "P1",
+            "mac": "52:54:00:00:00:4e",
+            "platform": "x86_64-kvm_x86_64-r0",
+            "synchronous_mode": "enable",
+            "hwsku": "Force10-S6000",
+            "nexthop_group": "enabled",
+            "frr_mgmt_framework_config": "true",
+            "docker_routing_config_mode": "unified",
+            "type": "LeafRouter"
+        }
+    },
+    "INTERFACE": {
+        "Ethernet112": {},
+        "Ethernet112|fc00::71/126 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet116": {},
+        "Ethernet116|fc00::75/126 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet124": {},
+        "Ethernet124|fc00::7d/126": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet64": {},
+        "Ethernet64|fc00::82/126 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet68": {},
+        "Ethernet68|fc01::86/126 ": {
+            "family": "IPv6",
+            "scope": "global"
+        }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "lanes": "25,26,27,28",
+            "alias": "Ethernet0",
+            "index": "0",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet4": {
+            "lanes": "29,30,31,32",
+            "alias": "Ethernet4",
+            "index": "1",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet8": {
+            "lanes": "33,34,35,36",
+            "alias": "Ethernet8",
+            "index": "2",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet12": {
+            "lanes": "37,38,39,40",
+            "alias": "Ethernet12",
+            "index": "3",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet16": {
+            "lanes": "45,46,47,48",
+            "alias": "Ethernet16",
+            "index": "4",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet20": {
+            "lanes": "41,42,43,44",
+            "alias": "Ethernet20",
+            "index": "5",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet24": {
+            "lanes": "1,2,3,4",
+            "alias": "Ethernet24",
+            "index": "6",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet28": {
+            "lanes": "5,6,7,8",
+            "alias": "Ethernet28",
+            "index": "7",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet32": {
+            "lanes": "13,14,15,16",
+            "alias": "Ethernet32",
+            "index": "8",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet36": {
+            "lanes": "9,10,11,12",
+            "alias": "Ethernet36",
+            "index": "9",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet40": {
+            "lanes": "17,18,19,20",
+            "alias": "Ethernet40",
+            "index": "10",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet44": {
+            "lanes": "21,22,23,24",
+            "alias": "Ethernet44",
+            "index": "11",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet48": {
+            "lanes": "53,54,55,56",
+            "alias": "Ethernet48",
+            "index": "12",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet52": {
+            "lanes": "49,50,51,52",
+            "alias": "Ethernet52",
+            "index": "13",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet56": {
+            "lanes": "57,58,59,60",
+            "alias": "Ethernet56",
+            "index": "14",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet60": {
+            "lanes": "61,62,63,64",
+            "alias": "Ethernet60",
+            "index": "15",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet64": {
+            "lanes": "69,70,71,72",
+            "alias": "Ethernet64",
+            "index": "16",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet68": {
+            "lanes": "65,66,67,68",
+            "alias": "Ethernet68",
+            "index": "17",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet72": {
+            "lanes": "73,74,75,76",
+            "alias": "Ethernet72",
+            "index": "18",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet76": {
+            "lanes": "77,78,79,80",
+            "alias": "Ethernet76",
+            "index": "19",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet80": {
+            "lanes": "109,110,111,112",
+            "alias": "Ethernet80",
+            "index": "20",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet84": {
+            "lanes": "105,106,107,108",
+            "alias": "Ethernet84",
+            "index": "21",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet88": {
+            "lanes": "113,114,115,116",
+            "alias": "Ethernet88",
+            "index": "22",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet92": {
+            "lanes": "117,118,119,120",
+            "alias": "Ethernet92",
+            "index": "23",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet96": {
+            "lanes": "125,126,127,128",
+            "alias": "Ethernet96",
+            "index": "24",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet100": {
+            "lanes": "121,122,123,124",
+            "alias": "Ethernet100",
+            "index": "25",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet104": {
+            "lanes": "81,82,83,84",
+            "alias": "Ethernet104",
+            "index": "26",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet108": {
+            "lanes": "85,86,87,88",
+            "alias": "Ethernet108",
+            "index": "27",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet112": {
+            "lanes": "93,94,95,96",
+            "alias": "Ethernet112",
+            "index": "28",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet116": {
+            "lanes": "89,90,91,92",
+            "alias": "Ethernet116",
+            "index": "29",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet120": {
+            "lanes": "101,102,103,104",
+            "alias": "Ethernet120",
+            "index": "30",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet124": {
+            "lanes": "97,98,99,100",
+            "alias": "Ethernet124",
+            "index": "31",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0": {},
+        "Loopback0|100.1.0.35/32": {},
+        "Loopback0|2064:700::23/128": {}
+    },
+    "MGMT_INTERFACE": {
+        "eth0|10.250.0.125/24": {
+            "gwaddr": "10.250.0.1"
+        }
+    },
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0"
+        }
+    },
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable",
+            "FLEX_COUNTER_DELAY_STATUS": "true",
+            "POLL_INTERVAL": "10000"
+        }
+    }
+}

--- a/ansible/vars/configdb_jsons/7nodes_force10/P2.json
+++ b/ansible/vars/configdb_jsons/7nodes_force10/P2.json
@@ -1,0 +1,431 @@
+{
+    "BGP_GLOBALS": {
+        "default": {
+            "local_asn": "65102",
+            "router_id": "100.1.0.33",
+            "log_nbr_state_changes": "true",
+            "load_balance_mp_relax": "true",
+            "keepalive": "10",
+            "holdtime": "30"
+        }
+    },
+    "ROUTE_MAP": {
+        "pass_all|1": {
+            "route_operation": "permit"
+        },
+        "pass_all_in|1": {
+            "route_operation": "permit",
+            "set_ipv6_next_hop_prefer_global": "true"
+        }
+    },
+    "BGP_GLOBALS_AF": {
+        "default|ipv6_unicast": {
+            "max_ebgp_paths": 64,
+            "redistribute_connected": "true",
+            "redistribute_static_rmap": "pass_all"
+        }
+    },
+    "BGP_NEIGHBOR_AF": {
+        "default|fc00::82|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc09::2|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc08::1|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc07::1|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        }
+    },
+    "BGP_NEIGHBOR": {
+        "default|fc00::82": {
+            "admin_status": "true",
+            "local_asn": "65102",
+            "min_adv_interval": "0",
+            "local_addr": "fc00::81",
+            "asn": "65100",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "P1"
+        },
+        "default|fc09::2": {
+            "admin_status": "true",
+            "local_asn": "65102",
+            "min_adv_interval": "0",
+            "local_addr": "fc09::1",
+            "asn": "65101",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "P3"
+        },
+        "default|fc08::1": {
+            "admin_status": "true",
+            "local_asn": "65102",
+            "min_adv_interval": "0",
+            "local_addr": "fc08::2",
+            "asn": "64602",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "PE3"
+        },
+        "default|fc07::1": {
+            "admin_status": "true",
+            "local_asn": "65102",
+            "min_adv_interval": "0",
+            "local_addr": "fc07::2",
+            "asn": "65103",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "P4"
+        }
+    },
+    "DEVICE_METADATA": {
+        "localhost": {
+            "asic": "vs",
+            "bgp_asn": "65102",
+            "hostname": "P2",
+            "mac": "52:54:00:df:3c:6e",
+            "platform": "x86_64-kvm_x86_64-r0",
+            "synchronous_mode": "enable",
+            "hwsku": "Force10-S6000",
+            "nexthop_group": "enabled",
+            "frr_mgmt_framework_config": "true",
+            "docker_routing_config_mode": "unified",
+            "type": "LeafRouter"
+        }
+    },
+    "INTERFACE": {
+        "Ethernet0": {},
+        "Ethernet0|fc00::81/126 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet4": {},
+        "Ethernet4|fc09::1/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet8": {},
+        "Ethernet8|fc07::2/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet12": {},
+        "Ethernet12|fc08::2/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet124": {},
+        "Ethernet124|fc0a::33/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "lanes": "25,26,27,28",
+            "alias": "Ethernet0",
+            "index": "0",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet4": {
+            "lanes": "29,30,31,32",
+            "alias": "Ethernet4",
+            "index": "1",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet8": {
+            "lanes": "33,34,35,36",
+            "alias": "Ethernet8",
+            "index": "2",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet12": {
+            "lanes": "37,38,39,40",
+            "alias": "Ethernet12",
+            "index": "3",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet16": {
+            "lanes": "45,46,47,48",
+            "alias": "Ethernet16",
+            "index": "4",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet20": {
+            "lanes": "41,42,43,44",
+            "alias": "Ethernet20",
+            "index": "5",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet24": {
+            "lanes": "1,2,3,4",
+            "alias": "Ethernet24",
+            "index": "6",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet28": {
+            "lanes": "5,6,7,8",
+            "alias": "Ethernet28",
+            "index": "7",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet32": {
+            "lanes": "13,14,15,16",
+            "alias": "Ethernet32",
+            "index": "8",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet36": {
+            "lanes": "9,10,11,12",
+            "alias": "Ethernet36",
+            "index": "9",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet40": {
+            "lanes": "17,18,19,20",
+            "alias": "Ethernet40",
+            "index": "10",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet44": {
+            "lanes": "21,22,23,24",
+            "alias": "Ethernet44",
+            "index": "11",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet48": {
+            "lanes": "53,54,55,56",
+            "alias": "Ethernet48",
+            "index": "12",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet52": {
+            "lanes": "49,50,51,52",
+            "alias": "Ethernet52",
+            "index": "13",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet56": {
+            "lanes": "57,58,59,60",
+            "alias": "Ethernet56",
+            "index": "14",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet60": {
+            "lanes": "61,62,63,64",
+            "alias": "Ethernet60",
+            "index": "15",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet64": {
+            "lanes": "69,70,71,72",
+            "alias": "Ethernet64",
+            "index": "16",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet68": {
+            "lanes": "65,66,67,68",
+            "alias": "Ethernet68",
+            "index": "17",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet72": {
+            "lanes": "73,74,75,76",
+            "alias": "Ethernet72",
+            "index": "18",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet76": {
+            "lanes": "77,78,79,80",
+            "alias": "Ethernet76",
+            "index": "19",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet80": {
+            "lanes": "109,110,111,112",
+            "alias": "Ethernet80",
+            "index": "20",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet84": {
+            "lanes": "105,106,107,108",
+            "alias": "Ethernet84",
+            "index": "21",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet88": {
+            "lanes": "113,114,115,116",
+            "alias": "Ethernet88",
+            "index": "22",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet92": {
+            "lanes": "117,118,119,120",
+            "alias": "Ethernet92",
+            "index": "23",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet96": {
+            "lanes": "125,126,127,128",
+            "alias": "Ethernet96",
+            "index": "24",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet100": {
+            "lanes": "121,122,123,124",
+            "alias": "Ethernet100",
+            "index": "25",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet104": {
+            "lanes": "81,82,83,84",
+            "alias": "Ethernet104",
+            "index": "26",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet108": {
+            "lanes": "85,86,87,88",
+            "alias": "Ethernet108",
+            "index": "27",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet112": {
+            "lanes": "93,94,95,96",
+            "alias": "Ethernet112",
+            "index": "28",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet116": {
+            "lanes": "89,90,91,92",
+            "alias": "Ethernet116",
+            "index": "29",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet120": {
+            "lanes": "101,102,103,104",
+            "alias": "Ethernet120",
+            "index": "30",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet124": {
+            "lanes": "97,98,99,100",
+            "alias": "Ethernet124",
+            "index": "31",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0": {},
+        "Loopback0|100.1.0.33/32": {},
+        "Loopback0|2064:500::21/128": {}
+    },
+    "MGMT_INTERFACE": {
+        "eth0|10.250.0.55/24": {
+            "gwaddr": "10.250.0.1"
+        }
+    },
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0"
+        }
+    },
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable",
+            "FLEX_COUNTER_DELAY_STATUS": "true",
+            "POLL_INTERVAL": "10000"
+        }
+    }
+}

--- a/ansible/vars/configdb_jsons/7nodes_force10/P3.json
+++ b/ansible/vars/configdb_jsons/7nodes_force10/P3.json
@@ -1,0 +1,455 @@
+{
+    "BGP_GLOBALS": {
+        "default": {
+            "local_asn": "65101",
+            "router_id": "100.1.0.33",
+            "log_nbr_state_changes": "true",
+            "load_balance_mp_relax": "true",
+            "keepalive": "10",
+            "holdtime": "30"
+        }
+    },
+    "ROUTE_MAP": {
+        "pass_all|1": {
+            "route_operation": "permit"
+        },
+        "pass_all_in|1": {
+            "route_operation": "permit",
+            "set_ipv6_next_hop_prefer_global": "true"
+        }
+    },
+    "BGP_GLOBALS_AF": {
+        "default|ipv6_unicast": {
+            "max_ebgp_paths": 64,
+            "redistribute_connected": "true",
+            "redistribute_static_rmap": "pass_all"
+        }
+    },
+    "BGP_NEIGHBOR_AF": {
+        "default|fc00::7d|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc02::1|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc03::1|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc04::1|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc09::1|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        }
+    },
+    "BGP_NEIGHBOR": {
+        "default|fc00::7d": {
+            "admin_status": "true",
+            "local_asn": "65101",
+            "min_adv_interval": "0",
+            "local_addr": "fc00::7e",
+            "asn": "65100",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "P1"
+        },
+        "default|fc02::1": {
+            "admin_status": "true",
+            "local_asn": "65101",
+            "min_adv_interval": "0",
+            "local_addr": "fc02::2",
+            "asn": "64600",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "PE1"
+        },
+        "default|fc03::1": {
+            "admin_status": "true",
+            "local_asn": "65101",
+            "min_adv_interval": "0",
+            "local_addr": "fc03::2",
+            "asn": "64601",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "PE2"
+        },
+        "default|fc04::1": {
+            "admin_status": "true",
+            "local_asn": "65101",
+            "min_adv_interval": "0",
+            "local_addr": "fc04::2",
+            "asn": "65103",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "P4"
+        },
+        "default|fc09::1": {
+            "admin_status": "true",
+            "local_asn": "65101",
+            "min_adv_interval": "0",
+            "local_addr": "fc09::2",
+            "asn": "65102",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "P2"
+        }
+    },
+    "DEVICE_METADATA": {
+        "localhost": {
+            "asic": "vs",
+            "bgp_asn": "65101",
+            "hostname": "P3",
+            "mac": "52:54:00:df:2c:6e",
+            "platform": "x86_64-kvm_x86_64-r0",
+            "synchronous_mode": "enable",
+            "hwsku": "Force10-S6000",
+            "nexthop_group": "enabled",
+            "frr_mgmt_framework_config": "true",
+            "docker_routing_config_mode": "unified",
+            "type": "LeafRouter"
+        }
+    },
+    "INTERFACE": {
+        "Ethernet124": {},
+        "Ethernet124|fc0a::32/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet0": {},
+        "Ethernet0|fc00::7e/126": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet4": {},
+        "Ethernet4|fc02::2/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet8": {},
+        "Ethernet8|fc03::2/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet12": {},
+        "Ethernet12|fc09::2/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet16": {},
+        "Ethernet16|fc04::2/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "lanes": "25,26,27,28",
+            "alias": "Ethernet0",
+            "index": "0",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet4": {
+            "lanes": "29,30,31,32",
+            "alias": "Ethernet4",
+            "index": "1",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet8": {
+            "lanes": "33,34,35,36",
+            "alias": "Ethernet8",
+            "index": "2",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet12": {
+            "lanes": "37,38,39,40",
+            "alias": "Ethernet12",
+            "index": "3",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet16": {
+            "lanes": "45,46,47,48",
+            "alias": "Ethernet16",
+            "index": "4",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet20": {
+            "lanes": "41,42,43,44",
+            "alias": "Ethernet20",
+            "index": "5",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet24": {
+            "lanes": "1,2,3,4",
+            "alias": "Ethernet24",
+            "index": "6",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet28": {
+            "lanes": "5,6,7,8",
+            "alias": "Ethernet28",
+            "index": "7",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet32": {
+            "lanes": "13,14,15,16",
+            "alias": "Ethernet32",
+            "index": "8",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet36": {
+            "lanes": "9,10,11,12",
+            "alias": "Ethernet36",
+            "index": "9",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet40": {
+            "lanes": "17,18,19,20",
+            "alias": "Ethernet40",
+            "index": "10",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet44": {
+            "lanes": "21,22,23,24",
+            "alias": "Ethernet44",
+            "index": "11",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet48": {
+            "lanes": "53,54,55,56",
+            "alias": "Ethernet48",
+            "index": "12",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet52": {
+            "lanes": "49,50,51,52",
+            "alias": "Ethernet52",
+            "index": "13",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet56": {
+            "lanes": "57,58,59,60",
+            "alias": "Ethernet56",
+            "index": "14",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet60": {
+            "lanes": "61,62,63,64",
+            "alias": "Ethernet60",
+            "index": "15",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet64": {
+            "lanes": "69,70,71,72",
+            "alias": "Ethernet64",
+            "index": "16",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet68": {
+            "lanes": "65,66,67,68",
+            "alias": "Ethernet68",
+            "index": "17",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet72": {
+            "lanes": "73,74,75,76",
+            "alias": "Ethernet72",
+            "index": "18",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet76": {
+            "lanes": "77,78,79,80",
+            "alias": "Ethernet76",
+            "index": "19",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet80": {
+            "lanes": "109,110,111,112",
+            "alias": "Ethernet80",
+            "index": "20",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet84": {
+            "lanes": "105,106,107,108",
+            "alias": "Ethernet84",
+            "index": "21",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet88": {
+            "lanes": "113,114,115,116",
+            "alias": "Ethernet88",
+            "index": "22",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet92": {
+            "lanes": "117,118,119,120",
+            "alias": "Ethernet92",
+            "index": "23",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet96": {
+            "lanes": "125,126,127,128",
+            "alias": "Ethernet96",
+            "index": "24",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet100": {
+            "lanes": "121,122,123,124",
+            "alias": "Ethernet100",
+            "index": "25",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet104": {
+            "lanes": "81,82,83,84",
+            "alias": "Ethernet104",
+            "index": "26",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet108": {
+            "lanes": "85,86,87,88",
+            "alias": "Ethernet108",
+            "index": "27",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet112": {
+            "lanes": "93,94,95,96",
+            "alias": "Ethernet112",
+            "index": "28",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet116": {
+            "lanes": "89,90,91,92",
+            "alias": "Ethernet116",
+            "index": "29",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet120": {
+            "lanes": "101,102,103,104",
+            "alias": "Ethernet120",
+            "index": "30",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet124": {
+            "lanes": "97,98,99,100",
+            "alias": "Ethernet124",
+            "index": "31",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0": {},
+        "Loopback0|100.1.0.32/32": {},
+        "Loopback0|2064:400::20/128": {}
+    },
+    "MGMT_INTERFACE": {
+        "eth0|10.250.0.54/24": {
+            "gwaddr": "10.250.0.1"
+        }
+    },
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0"
+        }
+    },
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable",
+            "FLEX_COUNTER_DELAY_STATUS": "true",
+            "POLL_INTERVAL": "10000"
+        }
+    }
+}

--- a/ansible/vars/configdb_jsons/7nodes_force10/P4.json
+++ b/ansible/vars/configdb_jsons/7nodes_force10/P4.json
@@ -1,0 +1,431 @@
+{
+    "BGP_GLOBALS": {
+        "default": {
+            "local_asn": "65103",
+            "router_id": "100.1.0.34",
+            "log_nbr_state_changes": "true",
+            "load_balance_mp_relax": "true",
+            "keepalive": "10",
+            "holdtime": "30"
+        }
+    },
+    "ROUTE_MAP": {
+        "pass_all|1": {
+            "route_operation": "permit"
+        },
+        "pass_all_in|1": {
+            "route_operation": "permit",
+            "set_ipv6_next_hop_prefer_global": "true"
+        }
+    },
+    "BGP_GLOBALS_AF": {
+        "default|ipv6_unicast": {
+            "max_ebgp_paths": 64,
+            "redistribute_connected": "true",
+            "redistribute_static_rmap": "pass_all"
+        }
+    },
+    "BGP_NEIGHBOR_AF": {
+        "default|fc01::86|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc07::02|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc06::01|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc04::02|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        }
+    },
+    "BGP_NEIGHBOR": {
+        "default|fc01::86": {
+            "admin_status": "true",
+            "local_asn": "65103",
+            "min_adv_interval": "0",
+            "local_addr": "fc01::85",
+            "asn": "65100",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "P1"
+        },
+        "default|fc07::2": {
+            "admin_status": "true",
+            "local_asn": "65103",
+            "min_adv_interval": "0",
+            "local_addr": "fc07::1",
+            "asn": "65102",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "P2"
+        },
+        "default|fc06::1": {
+            "admin_status": "true",
+            "local_asn": "65103",
+            "min_adv_interval": "0",
+            "local_addr": "fc06::2",
+            "asn": "64602",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "PE3"
+        },
+        "default|fc04::2": {
+            "admin_status": "true",
+            "local_asn": "65103",
+            "min_adv_interval": "0",
+            "local_addr": "fc04::1",
+            "asn": "65101",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "name": "P3"
+        }
+    },
+    "DEVICE_METADATA": {
+        "localhost": {
+            "asic": "vs",
+            "bgp_asn": "65103",
+            "hostname": "P4",
+            "mac": "52:54:00:df:5c:6e",
+            "platform": "x86_64-kvm_x86_64-r0",
+            "synchronous_mode": "enable",
+            "hwsku": "Force10-S6000",
+            "nexthop_group": "enabled",
+            "frr_mgmt_framework_config": "true",
+            "docker_routing_config_mode": "unified",
+            "type": "LeafRouter"
+        }
+    },
+    "INTERFACE": {
+        "Ethernet0": {},
+        "Ethernet0|fc01::85/126 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet4": {},
+        "Ethernet4|fc04::1/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet8": {},
+        "Ethernet8|fc07::1/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet12": {},
+        "Ethernet12|fc06::2/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet124": {},
+        "Ethernet124|fc0a::34/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "lanes": "25,26,27,28",
+            "alias": "Ethernet0",
+            "index": "0",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet4": {
+            "lanes": "29,30,31,32",
+            "alias": "Ethernet4",
+            "index": "1",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet8": {
+            "lanes": "33,34,35,36",
+            "alias": "Ethernet8",
+            "index": "2",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet12": {
+            "lanes": "37,38,39,40",
+            "alias": "Ethernet12",
+            "index": "3",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet16": {
+            "lanes": "45,46,47,48",
+            "alias": "Ethernet16",
+            "index": "4",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet20": {
+            "lanes": "41,42,43,44",
+            "alias": "Ethernet20",
+            "index": "5",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet24": {
+            "lanes": "1,2,3,4",
+            "alias": "Ethernet24",
+            "index": "6",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet28": {
+            "lanes": "5,6,7,8",
+            "alias": "Ethernet28",
+            "index": "7",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet32": {
+            "lanes": "13,14,15,16",
+            "alias": "Ethernet32",
+            "index": "8",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet36": {
+            "lanes": "9,10,11,12",
+            "alias": "Ethernet36",
+            "index": "9",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet40": {
+            "lanes": "17,18,19,20",
+            "alias": "Ethernet40",
+            "index": "10",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet44": {
+            "lanes": "21,22,23,24",
+            "alias": "Ethernet44",
+            "index": "11",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet48": {
+            "lanes": "53,54,55,56",
+            "alias": "Ethernet48",
+            "index": "12",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet52": {
+            "lanes": "49,50,51,52",
+            "alias": "Ethernet52",
+            "index": "13",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet56": {
+            "lanes": "57,58,59,60",
+            "alias": "Ethernet56",
+            "index": "14",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet60": {
+            "lanes": "61,62,63,64",
+            "alias": "Ethernet60",
+            "index": "15",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet64": {
+            "lanes": "69,70,71,72",
+            "alias": "Ethernet64",
+            "index": "16",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet68": {
+            "lanes": "65,66,67,68",
+            "alias": "Ethernet68",
+            "index": "17",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet72": {
+            "lanes": "73,74,75,76",
+            "alias": "Ethernet72",
+            "index": "18",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet76": {
+            "lanes": "77,78,79,80",
+            "alias": "Ethernet76",
+            "index": "19",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet80": {
+            "lanes": "109,110,111,112",
+            "alias": "Ethernet80",
+            "index": "20",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet84": {
+            "lanes": "105,106,107,108",
+            "alias": "Ethernet84",
+            "index": "21",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet88": {
+            "lanes": "113,114,115,116",
+            "alias": "Ethernet88",
+            "index": "22",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet92": {
+            "lanes": "117,118,119,120",
+            "alias": "Ethernet92",
+            "index": "23",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet96": {
+            "lanes": "125,126,127,128",
+            "alias": "Ethernet96",
+            "index": "24",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet100": {
+            "lanes": "121,122,123,124",
+            "alias": "Ethernet100",
+            "index": "25",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet104": {
+            "lanes": "81,82,83,84",
+            "alias": "Ethernet104",
+            "index": "26",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet108": {
+            "lanes": "85,86,87,88",
+            "alias": "Ethernet108",
+            "index": "27",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet112": {
+            "lanes": "93,94,95,96",
+            "alias": "Ethernet112",
+            "index": "28",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet116": {
+            "lanes": "89,90,91,92",
+            "alias": "Ethernet116",
+            "index": "29",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet120": {
+            "lanes": "101,102,103,104",
+            "alias": "Ethernet120",
+            "index": "30",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet124": {
+            "lanes": "97,98,99,100",
+            "alias": "Ethernet124",
+            "index": "31",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0": {},
+        "Loopback0|100.1.0.34/32": {},
+        "Loopback0|2064:600::22/128": {}
+    },
+    "MGMT_INTERFACE": {
+        "eth0|10.250.0.56/24": {
+            "gwaddr": "10.250.0.1"
+        }
+    },
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0"
+        }
+    },
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable",
+            "FLEX_COUNTER_DELAY_STATUS": "true",
+            "POLL_INTERVAL": "10000"
+        }
+    }
+}

--- a/ansible/vars/configdb_jsons/7nodes_force10/PE1.json
+++ b/ansible/vars/configdb_jsons/7nodes_force10/PE1.json
@@ -1,0 +1,486 @@
+{
+    "BGP_GLOBALS": {
+        "Vrf1": {
+            "local_asn": "64600",
+            "router_id": "100.1.0.29 ",
+            "log_nbr_state_changes": "true",
+            "load_balance_mp_relax": "true",
+            "srv6_locator": "lsid1",
+            "keepalive": "10",
+            "holdtime": "30"
+        },
+        "default": {
+            "local_asn": "64600",
+            "router_id": "100.1.0.29",
+            "log_nbr_state_changes": "true",
+            "load_balance_mp_relax": "true",
+            "keepalive": "10",
+            "holdtime": "30"
+        }
+    },
+    "ROUTE_MAP": {
+        "pass_all|1": {
+            "route_operation": "permit"
+        },
+        "s1|1": {
+            "route_operation": "permit"
+        },
+        "pass_all_in|1": {
+            "route_operation": "permit",
+            "set_ipv6_next_hop_prefer_global": "true"
+        }
+    },
+    "BGP_GLOBALS_AF": {
+        "default|ipv6_unicast": {
+            "max_ebgp_paths": 64,
+            "redistribute_connected": "true",
+            "redistribute_static_rmap": "pass_all"
+        },
+        "default|ipv4_vpn": {
+            "max_ebgp_paths": 64
+        },
+        "Vrf1|ipv4_unicast": {
+            "max_ebgp_paths": 64,
+            "rd_vpn_export": "2:2",
+            "rt_vpn_both": "1:1",
+            "rmap_vpn_export": "s1",
+            "export_vpn": "true",
+            "import_vpn": "true"
+        }
+    },
+    "BGP_NEIGHBOR_AF": {
+        "Vrf1|10.10.246.254|ipv4_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|2064:200::1e|ipv4_vpn": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|2064:300::1f|ipv4_vpn": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|FC00::71|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc02::2|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        }
+    },
+    "BGP_NEIGHBOR": {
+        "Vrf1|10.10.246.254": {
+            "admin_status": "true",
+            "local_asn": "64600",
+            "local_addr": "10.10.246.29",
+            "asn": "64600",
+            "name": "exabgp_v4"
+        },
+        "default|2064:200::1e": {
+            "admin_status": "true",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "capability_ext_nexthop": "true",
+            "local_addr": "2064:100::1d",
+            "local_asn": "64600",
+            "asn": "64601",
+            "name": "PE2"
+        },
+        "default|2064:300::1f": {
+            "admin_status": "true",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "capability_ext_nexthop": "true",
+            "local_addr": "2064:100::1d",
+            "local_asn": "64600",
+            "asn": "64602",
+            "name": "PE3"
+        },
+        "default|FC00::71": {
+            "admin_status": "true",
+            "local_asn": "64600",
+            "local_addr": "FC00::71",
+            "asn": "65100",
+            "name": "P1"
+        },
+        "default|fc02::2": {
+            "admin_status": "true",
+            "local_asn": "64600",
+            "local_addr": "FC02::01",
+            "asn": "65101",
+            "name": "P3"
+        }
+    },
+    "DEVICE_METADATA": {
+        "localhost": {
+            "asic": "vs",
+            "bgp_asn": "64600",
+            "hostname": "PE1",
+            "mac": "52:54:00:df:0c:4e",
+            "platform": "x86_64-kvm_x86_64-r0",
+            "synchronous_mode": "enable",
+            "hwsku": "Force10-S6000",
+            "nexthop_group": "enabled",
+            "frr_mgmt_framework_config": "true",
+            "docker_routing_config_mode": "unified",
+            "type": "LeafRouter"
+        }
+    },
+    "INTERFACE": {
+        "Ethernet0": {},
+        "Ethernet4": {},
+        "Ethernet24": {
+            "vrf_name": "Vrf1"
+        },
+        "Ethernet24|10.10.246.29/24 ": {
+            "family": "IPv4",
+            "vrf_name": "PUBLIC-TC11",
+            "scope": "global"
+        },
+        "Ethernet24|fc0a::29/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet0|fc00::72/126 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet4|fc02::1/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "lanes": "25,26,27,28",
+            "alias": "Ethernet0",
+            "index": "0",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet4": {
+            "lanes": "29,30,31,32",
+            "alias": "Ethernet4",
+            "index": "1",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet8": {
+            "lanes": "33,34,35,36",
+            "alias": "Ethernet8",
+            "index": "2",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet12": {
+            "lanes": "37,38,39,40",
+            "alias": "Ethernet12",
+            "index": "3",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet16": {
+            "lanes": "45,46,47,48",
+            "alias": "Ethernet16",
+            "index": "4",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet20": {
+            "lanes": "41,42,43,44",
+            "alias": "Ethernet20",
+            "index": "5",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet24": {
+            "lanes": "1,2,3,4",
+            "alias": "Ethernet24",
+            "index": "6",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet28": {
+            "lanes": "5,6,7,8",
+            "alias": "Ethernet28",
+            "index": "7",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet32": {
+            "lanes": "13,14,15,16",
+            "alias": "Ethernet32",
+            "index": "8",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet36": {
+            "lanes": "9,10,11,12",
+            "alias": "Ethernet36",
+            "index": "9",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet40": {
+            "lanes": "17,18,19,20",
+            "alias": "Ethernet40",
+            "index": "10",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet44": {
+            "lanes": "21,22,23,24",
+            "alias": "Ethernet44",
+            "index": "11",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet48": {
+            "lanes": "53,54,55,56",
+            "alias": "Ethernet48",
+            "index": "12",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet52": {
+            "lanes": "49,50,51,52",
+            "alias": "Ethernet52",
+            "index": "13",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet56": {
+            "lanes": "57,58,59,60",
+            "alias": "Ethernet56",
+            "index": "14",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet60": {
+            "lanes": "61,62,63,64",
+            "alias": "Ethernet60",
+            "index": "15",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet64": {
+            "lanes": "69,70,71,72",
+            "alias": "Ethernet64",
+            "index": "16",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet68": {
+            "lanes": "65,66,67,68",
+            "alias": "Ethernet68",
+            "index": "17",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet72": {
+            "lanes": "73,74,75,76",
+            "alias": "Ethernet72",
+            "index": "18",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet76": {
+            "lanes": "77,78,79,80",
+            "alias": "Ethernet76",
+            "index": "19",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet80": {
+            "lanes": "109,110,111,112",
+            "alias": "Ethernet80",
+            "index": "20",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet84": {
+            "lanes": "105,106,107,108",
+            "alias": "Ethernet84",
+            "index": "21",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet88": {
+            "lanes": "113,114,115,116",
+            "alias": "Ethernet88",
+            "index": "22",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet92": {
+            "lanes": "117,118,119,120",
+            "alias": "Ethernet92",
+            "index": "23",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet96": {
+            "lanes": "125,126,127,128",
+            "alias": "Ethernet96",
+            "index": "24",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet100": {
+            "lanes": "121,122,123,124",
+            "alias": "Ethernet100",
+            "index": "25",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet104": {
+            "lanes": "81,82,83,84",
+            "alias": "Ethernet104",
+            "index": "26",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet108": {
+            "lanes": "85,86,87,88",
+            "alias": "Ethernet108",
+            "index": "27",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet112": {
+            "lanes": "93,94,95,96",
+            "alias": "Ethernet112",
+            "index": "28",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet116": {
+            "lanes": "89,90,91,92",
+            "alias": "Ethernet116",
+            "index": "29",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet120": {
+            "lanes": "101,102,103,104",
+            "alias": "Ethernet120",
+            "index": "30",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet124": {
+            "lanes": "97,98,99,100",
+            "alias": "Ethernet124",
+            "index": "31",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0": {},
+        "Loopback0|100.1.0.29/32": {},
+        "Loopback0|2064:100::1d/128": {}
+    },
+    "MGMT_INTERFACE": {
+        "eth0|10.250.0.51/24": {
+            "gwaddr": "10.250.0.1"
+        }
+    },
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0"
+        }
+    },
+    "VRF": {
+        "Vrf1": {},
+        "Vrf2": {}
+    },
+    "SRV6_LOCATOR": {
+        "lsid1": {
+            "argu_len": "48",
+            "block_len": "32",
+            "func_len": "32",
+            "node_len": "16",
+            "opcode_prefix": [
+                "::fff1:1:0:0:0",
+                "::fff1:11:0:0:0"
+            ],
+            "opcode_act": [
+                "end-dt46",
+                "end-dt46"
+            ],
+            "opcode_data": [
+                "vrf Vrf1",
+                "vrf Vrf2"
+            ],
+            "prefix": "fd00:201:201::/48"
+        }
+    },
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable",
+            "FLEX_COUNTER_DELAY_STATUS": "true",
+            "POLL_INTERVAL": "10000"
+        }
+    }
+}

--- a/ansible/vars/configdb_jsons/7nodes_force10/PE2.json
+++ b/ansible/vars/configdb_jsons/7nodes_force10/PE2.json
@@ -1,0 +1,486 @@
+{
+    "BGP_GLOBALS": {
+        "Vrf1": {
+            "local_asn": "64601",
+            "router_id": "100.1.0.30 ",
+            "log_nbr_state_changes": "true",
+            "load_balance_mp_relax": "true",
+            "srv6_locator": "lsid1",
+            "keepalive": "10",
+            "holdtime": "30"
+        },
+        "default": {
+            "local_asn": "64601",
+            "router_id": "100.1.0.30",
+            "log_nbr_state_changes": "true",
+            "load_balance_mp_relax": "true",
+            "keepalive": "10",
+            "holdtime": "30"
+        }
+    },
+    "ROUTE_MAP": {
+        "pass_all|1": {
+            "route_operation": "permit"
+        },
+        "s1|1": {
+            "route_operation": "permit"
+        },
+        "pass_all_in|1": {
+            "route_operation": "permit",
+            "set_ipv6_next_hop_prefer_global": "true"
+        }
+    },
+    "BGP_GLOBALS_AF": {
+        "default|ipv6_unicast": {
+            "max_ebgp_paths": 64,
+            "redistribute_connected": "true",
+            "redistribute_static_rmap": "pass_all"
+        },
+        "default|ipv4_vpn": {
+            "max_ebgp_paths": 64
+        },
+        "Vrf1|ipv4_unicast": {
+            "max_ebgp_paths": 64,
+            "rd_vpn_export": "2:2",
+            "rt_vpn_both": "1:1",
+            "rmap_vpn_export": "s1",
+            "export_vpn": "true",
+            "import_vpn": "true"
+        }
+    },
+    "BGP_NEIGHBOR_AF": {
+        "Vrf1|10.10.246.254|ipv4_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|2064:100::1d|ipv4_vpn": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|2064:300::1f|ipv4_vpn": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|FC00::75|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc03::2|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        }
+    },
+    "BGP_NEIGHBOR": {
+        "Vrf1|10.10.246.254": {
+            "admin_status": "up",
+            "local_asn": "64601",
+            "local_addr": "10.10.246.30",
+            "asn": "64601",
+            "name": "exabgp_v4"
+        },
+        "default|2064:100::1d": {
+            "admin_status": "up",
+            "local_addr": "2064:200::1e",
+            "local_asn": "64601",
+            "asn": "64600",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "capability_ext_nexthop": "true",
+            "name": "PE1"
+        },
+        "default|2064:300::1f": {
+            "admin_status": "up",
+            "local_addr": "2064:200::1e",
+            "local_asn": "64601",
+            "asn": "64602",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "capability_ext_nexthop": "true",
+            "name": "PE3"
+        },
+        "default|FC00::75": {
+            "admin_status": "up",
+            "local_addr": "FC00::76",
+            "local_asn": "64601",
+            "asn": "65100",
+            "name": "P1"
+        },
+        "default|fc03::2": {
+            "admin_status": "up",
+            "local_addr": "FC03::1",
+            "local_asn": "64601",
+            "asn": "65101",
+            "name": "P3"
+        }
+    },
+    "DEVICE_METADATA": {
+        "localhost": {
+            "asic": "vs",
+            "bgp_asn": "64601",
+            "hostname": "PE2",
+            "mac": "52:54:00:96:90:d5",
+            "platform": "x86_64-kvm_x86_64-r0",
+            "synchronous_mode": "enable",
+            "hwsku": "Force10-S6000",
+            "nexthop_group": "enabled",
+            "frr_mgmt_framework_config": "true",
+            "docker_routing_config_mode": "unified",
+            "type": "LeafRouter"
+        }
+    },
+    "INTERFACE": {
+        "Ethernet0": {},
+        "Ethernet8": {},
+        "Ethernet24": {
+            "vrf_name": "Vrf1"
+        },
+        "Ethernet24|10.10.246.30/24 ": {
+            "family": "IPv4",
+            "vrf_name": "PUBLIC-TC11",
+            "scope": "global"
+        },
+        "Ethernet24|fc0a::30/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet0|fc00::76/126 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet8|fc03::1/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "lanes": "25,26,27,28",
+            "alias": "Ethernet0",
+            "index": "0",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet4": {
+            "lanes": "29,30,31,32",
+            "alias": "Ethernet4",
+            "index": "1",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet8": {
+            "lanes": "33,34,35,36",
+            "alias": "Ethernet8",
+            "index": "2",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet12": {
+            "lanes": "37,38,39,40",
+            "alias": "Ethernet12",
+            "index": "3",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet16": {
+            "lanes": "45,46,47,48",
+            "alias": "Ethernet16",
+            "index": "4",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet20": {
+            "lanes": "41,42,43,44",
+            "alias": "Ethernet20",
+            "index": "5",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet24": {
+            "lanes": "1,2,3,4",
+            "alias": "Ethernet24",
+            "index": "6",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet28": {
+            "lanes": "5,6,7,8",
+            "alias": "Ethernet28",
+            "index": "7",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet32": {
+            "lanes": "13,14,15,16",
+            "alias": "Ethernet32",
+            "index": "8",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet36": {
+            "lanes": "9,10,11,12",
+            "alias": "Ethernet36",
+            "index": "9",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet40": {
+            "lanes": "17,18,19,20",
+            "alias": "Ethernet40",
+            "index": "10",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet44": {
+            "lanes": "21,22,23,24",
+            "alias": "Ethernet44",
+            "index": "11",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet48": {
+            "lanes": "53,54,55,56",
+            "alias": "Ethernet48",
+            "index": "12",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet52": {
+            "lanes": "49,50,51,52",
+            "alias": "Ethernet52",
+            "index": "13",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet56": {
+            "lanes": "57,58,59,60",
+            "alias": "Ethernet56",
+            "index": "14",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet60": {
+            "lanes": "61,62,63,64",
+            "alias": "Ethernet60",
+            "index": "15",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet64": {
+            "lanes": "69,70,71,72",
+            "alias": "Ethernet64",
+            "index": "16",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet68": {
+            "lanes": "65,66,67,68",
+            "alias": "Ethernet68",
+            "index": "17",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet72": {
+            "lanes": "73,74,75,76",
+            "alias": "Ethernet72",
+            "index": "18",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet76": {
+            "lanes": "77,78,79,80",
+            "alias": "Ethernet76",
+            "index": "19",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet80": {
+            "lanes": "109,110,111,112",
+            "alias": "Ethernet80",
+            "index": "20",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet84": {
+            "lanes": "105,106,107,108",
+            "alias": "Ethernet84",
+            "index": "21",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet88": {
+            "lanes": "113,114,115,116",
+            "alias": "Ethernet88",
+            "index": "22",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet92": {
+            "lanes": "117,118,119,120",
+            "alias": "Ethernet92",
+            "index": "23",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet96": {
+            "lanes": "125,126,127,128",
+            "alias": "Ethernet96",
+            "index": "24",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet100": {
+            "lanes": "121,122,123,124",
+            "alias": "Ethernet100",
+            "index": "25",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet104": {
+            "lanes": "81,82,83,84",
+            "alias": "Ethernet104",
+            "index": "26",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet108": {
+            "lanes": "85,86,87,88",
+            "alias": "Ethernet108",
+            "index": "27",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet112": {
+            "lanes": "93,94,95,96",
+            "alias": "Ethernet112",
+            "index": "28",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet116": {
+            "lanes": "89,90,91,92",
+            "alias": "Ethernet116",
+            "index": "29",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet120": {
+            "lanes": "101,102,103,104",
+            "alias": "Ethernet120",
+            "index": "30",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet124": {
+            "lanes": "97,98,99,100",
+            "alias": "Ethernet124",
+            "index": "31",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0": {},
+        "Loopback0|100.1.0.30/32": {},
+        "Loopback0|2064:200::1e/128": {}
+    },
+    "VRF": {
+        "Vrf1": {},
+        "Vrf2": {}
+    },
+    "MGMT_INTERFACE": {
+        "eth0|10.250.0.52/24": {
+            "gwaddr": "10.250.0.1"
+        }
+    },
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0"
+        }
+    },
+    "SRV6_LOCATOR": {
+        "lsid1": {
+            "argu_len": "48",
+            "block_len": "32",
+            "func_len": "32",
+            "node_len": "16",
+            "opcode_prefix": [
+                "::fff2:2:0:0:0",
+                "::fff2:22:0:0:0"
+            ],
+            "opcode_act": [
+                "end-dt46",
+                "end-dt46"
+            ],
+            "opcode_data": [
+                "vrf Vrf1",
+                "vrf Vrf2"
+            ],
+            "prefix": "fd00:202:202::/48"
+        }
+    },
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable",
+            "FLEX_COUNTER_DELAY_STATUS": "true",
+            "POLL_INTERVAL": "10000"
+        }
+    }
+}

--- a/ansible/vars/configdb_jsons/7nodes_force10/PE3.json
+++ b/ansible/vars/configdb_jsons/7nodes_force10/PE3.json
@@ -1,0 +1,485 @@
+{
+    "BGP_GLOBALS": {
+        "Vrf1": {
+            "local_asn": "64602",
+            "router_id": "100.1.0.31 ",
+            "log_nbr_state_changes": "true",
+            "load_balance_mp_relax": "true",
+            "srv6_locator": "lsid1",
+            "keepalive": "10",
+            "holdtime": "30"
+        },
+        "default": {
+            "local_asn": "64602",
+            "router_id": "100.1.0.31",
+            "log_nbr_state_changes": "true",
+            "load_balance_mp_relax": "true",
+            "keepalive": "10",
+            "holdtime": "30"
+        }
+    },
+    "ROUTE_MAP": {
+        "pass_all|1": {
+            "route_operation": "permit"
+        },
+        "s1|1": {
+            "route_operation": "permit"
+        },
+        "pass_all_in|1": {
+            "route_operation": "permit",
+            "set_ipv6_next_hop_prefer_global": "true"
+        }
+    },
+    "BGP_GLOBALS_AF": {
+        "default|ipv6_unicast": {
+            "max_ebgp_paths": 64,
+            "redistribute_connected": "true",
+            "redistribute_static_rmap": "pass_all"
+        },
+        "default|ipv4_vpn": {
+            "max_ebgp_paths": 64
+        },
+        "Vrf1|ipv4_unicast": {
+            "max_ebgp_paths": 64,
+            "rd_vpn_export": "2:2",
+            "rt_vpn_both": "1:1",
+            "rmap_vpn_export": "s1",
+            "export_vpn": "true",
+            "import_vpn": "true"
+        }
+    },
+    "BGP_NEIGHBOR_AF": {
+        "Vrf1|10.10.246.254|ipv4_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|2064:100::1d|ipv4_vpn": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|2064:200::1e|ipv4_vpn": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|FC08::02|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        },
+        "default|fc06::2|ipv6_unicast": {
+            "admin_status": "true",
+            "route_map_in": [
+                "pass_all_in"
+            ],
+            "route_map_out": [
+                "pass_all"
+            ]
+        }
+    },
+    "BGP_NEIGHBOR": {
+        "Vrf1|10.10.246.254": {
+            "admin_status": "true",
+            "local_asn": "64602",
+            "local_addr": "10.10.246.31",
+            "asn": "64602",
+            "name": "exabgp_v4"
+        },
+        "default|2064:200::1e": {
+            "admin_status": "true",
+            "local_addr": "2064:300::1f",
+            "local_asn": "64602",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "capability_ext_nexthop": "true",
+            "asn": "64601",
+            "name": "PE2"
+        },
+        "default|2064:100::1d": {
+            "admin_status": "true",
+            "local_addr": "2064:300::1f",
+            "local_asn": "64602",
+            "ebgp_multihop": "true",
+            "ebgp_multihop_ttl": "255",
+            "capability_ext_nexthop": "true",
+            "asn": "64600",
+            "name": "PE1"
+        },
+        "default|FC08::02": {
+            "admin_status": "true",
+            "local_asn": "64602",
+            "local_addr": "FC08::01",
+            "asn": "65102",
+            "name": "P2"
+        },
+        "default|fc06::2": {
+            "admin_status": "true",
+            "local_asn": "64602",
+            "local_addr": "FC06::01",
+            "asn": "65103",
+            "name": "P4"
+        }
+    },
+    "DEVICE_METADATA": {
+        "localhost": {
+            "asic": "vs",
+            "bgp_asn": "64602",
+            "hostname": "PE3",
+            "mac": "52:54:00:df:1c:5e",
+            "platform": "x86_64-kvm_x86_64-r0",
+            "synchronous_mode": "enable",
+            "hwsku": "Force10-S6000",
+            "nexthop_group": "enabled",
+            "frr_mgmt_framework_config": "true",
+            "docker_routing_config_mode": "unified",
+            "type": "LeafRouter"
+        }
+    },
+    "INTERFACE": {
+        "Ethernet24": {
+            "vrf_name": "Vrf1"
+        },
+        "Ethernet24|10.10.246.31/24 ": {
+            "family": "IPv4",
+            "scope": "global"
+        },
+        "Ethernet24|fc0a::31/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet4": {},
+        "Ethernet4|fc08::1/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        },
+        "Ethernet12": {},
+        "Ethernet12|fc06::1/120 ": {
+            "family": "IPv6",
+            "scope": "global"
+        }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "lanes": "25,26,27,28",
+            "alias": "Ethernet0",
+            "index": "0",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet4": {
+            "lanes": "29,30,31,32",
+            "alias": "Ethernet4",
+            "index": "1",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet8": {
+            "lanes": "33,34,35,36",
+            "alias": "Ethernet8",
+            "index": "2",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet12": {
+            "lanes": "37,38,39,40",
+            "alias": "Ethernet12",
+            "index": "3",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet16": {
+            "lanes": "45,46,47,48",
+            "alias": "Ethernet16",
+            "index": "4",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet20": {
+            "lanes": "41,42,43,44",
+            "alias": "Ethernet20",
+            "index": "5",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet24": {
+            "lanes": "1,2,3,4",
+            "alias": "Ethernet24",
+            "index": "6",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet28": {
+            "lanes": "5,6,7,8",
+            "alias": "Ethernet28",
+            "index": "7",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet32": {
+            "lanes": "13,14,15,16",
+            "alias": "Ethernet32",
+            "index": "8",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet36": {
+            "lanes": "9,10,11,12",
+            "alias": "Ethernet36",
+            "index": "9",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet40": {
+            "lanes": "17,18,19,20",
+            "alias": "Ethernet40",
+            "index": "10",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet44": {
+            "lanes": "21,22,23,24",
+            "alias": "Ethernet44",
+            "index": "11",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet48": {
+            "lanes": "53,54,55,56",
+            "alias": "Ethernet48",
+            "index": "12",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet52": {
+            "lanes": "49,50,51,52",
+            "alias": "Ethernet52",
+            "index": "13",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet56": {
+            "lanes": "57,58,59,60",
+            "alias": "Ethernet56",
+            "index": "14",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet60": {
+            "lanes": "61,62,63,64",
+            "alias": "Ethernet60",
+            "index": "15",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet64": {
+            "lanes": "69,70,71,72",
+            "alias": "Ethernet64",
+            "index": "16",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet68": {
+            "lanes": "65,66,67,68",
+            "alias": "Ethernet68",
+            "index": "17",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet72": {
+            "lanes": "73,74,75,76",
+            "alias": "Ethernet72",
+            "index": "18",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet76": {
+            "lanes": "77,78,79,80",
+            "alias": "Ethernet76",
+            "index": "19",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet80": {
+            "lanes": "109,110,111,112",
+            "alias": "Ethernet80",
+            "index": "20",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet84": {
+            "lanes": "105,106,107,108",
+            "alias": "Ethernet84",
+            "index": "21",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet88": {
+            "lanes": "113,114,115,116",
+            "alias": "Ethernet88",
+            "index": "22",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet92": {
+            "lanes": "117,118,119,120",
+            "alias": "Ethernet92",
+            "index": "23",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet96": {
+            "lanes": "125,126,127,128",
+            "alias": "Ethernet96",
+            "index": "24",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet100": {
+            "lanes": "121,122,123,124",
+            "alias": "Ethernet100",
+            "index": "25",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet104": {
+            "lanes": "81,82,83,84",
+            "alias": "Ethernet104",
+            "index": "26",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet108": {
+            "lanes": "85,86,87,88",
+            "alias": "Ethernet108",
+            "index": "27",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet112": {
+            "lanes": "93,94,95,96",
+            "alias": "Ethernet112",
+            "index": "28",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet116": {
+            "lanes": "89,90,91,92",
+            "alias": "Ethernet116",
+            "index": "29",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet120": {
+            "lanes": "101,102,103,104",
+            "alias": "Ethernet120",
+            "index": "30",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        },
+        "Ethernet124": {
+            "lanes": "97,98,99,100",
+            "alias": "Ethernet124",
+            "index": "31",
+            "speed": "100000",
+            "admin_status": "up",
+            "mtu": "9100"
+        }
+    },
+    "VRF": {
+        "Vrf1": {},
+        "Vrf2": {}
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0": {},
+        "Loopback0|100.1.0.31/32": {},
+        "Loopback0|2064:300::1f/128": {}
+    },
+    "MGMT_INTERFACE": {
+        "eth0|10.250.0.53/24": {
+            "gwaddr": "10.250.0.1"
+        }
+    },
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0"
+        }
+    },
+    "SRV6_LOCATOR": {
+        "lsid1": {
+            "argu_len": "48",
+            "block_len": "32",
+            "func_len": "32",
+            "node_len": "16",
+            "opcode_prefix": [
+                "::fff3:3:0:0:0",
+                "::fff3:33:0:0:0"
+            ],
+            "opcode_act": [
+                "end-dt46",
+                "end-dt46"
+            ],
+            "opcode_data": [
+                "vrf Vrf1",
+                "vrf Vrf2"
+            ],
+            "prefix": "fd00:203:203::/48"
+        }
+    },
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable",
+            "FLEX_COUNTER_DELAY_STATUS": "true",
+            "POLL_INTERVAL": "10000"
+        }
+    }
+}

--- a/ansible/vars/init_cfg_profiles.yml
+++ b/ansible/vars/init_cfg_profiles.yml
@@ -5,3 +5,11 @@
 7nodes_cisco_P2: vars/configdb_jsons/7nodes_cisco/P2.json
 7nodes_cisco_P3: vars/configdb_jsons/7nodes_cisco/P3.json
 7nodes_cisco_P4: vars/configdb_jsons/7nodes_cisco/P4.json
+
+7nodes_force10_P1: vars/configdb_jsons/7nodes_force10/P1.json
+7nodes_force10_P2: vars/configdb_jsons/7nodes_force10/P2.json
+7nodes_force10_P3: vars/configdb_jsons/7nodes_force10/P3.json
+7nodes_force10_P4: vars/configdb_jsons/7nodes_force10/P4.json
+7nodes_force10_PE1: vars/configdb_jsons/7nodes_force10/PE1.json
+7nodes_force10_PE2: vars/configdb_jsons/7nodes_force10/PE2.json
+7nodes_force10_PE3: vars/configdb_jsons/7nodes_force10/PE3.json

--- a/ansible/vars/topo_force10-7nodes.yml
+++ b/ansible/vars/topo_force10-7nodes.yml
@@ -1,0 +1,220 @@
+topology:
+  host_interfaces:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
+    - 15
+    - 21
+    - 22
+    - 23
+    - 24
+    - 25
+    - 26
+    - 27
+  disabled_host_interfaces:
+    - 0
+    - 25
+    - 26
+    - 27
+  VMs:
+    PE1:
+      vlans:
+        - 28
+      vm_offset: 0
+    PE2:
+      vlans:
+        - 29
+      vm_offset: 1
+    PE3:
+      vlans:
+        - 30
+      vm_offset: 2
+    P3:
+      vlans:
+        - 31
+      vm_offset: 3
+    P2:
+      vlans:
+        - 16
+      vm_offset: 4
+    P4:
+      vlans:
+        - 17
+      vm_offset: 5
+  VM_LINKs: # the port index should to be multipled to 4 to match the EthernetXXX in the port config.
+    PE1P3:
+      start_vm_offset: 0
+      start_vm_port_idx: 1
+      end_vm_offset: 3
+      end_vm_port_idx: 1
+    PE2P3:
+      start_vm_offset: 1
+      start_vm_port_idx: 2
+      end_vm_offset: 3
+      end_vm_port_idx: 2
+    P3P2:
+      start_vm_offset: 3
+      start_vm_port_idx: 3
+      end_vm_offset: 4
+      end_vm_port_idx: 1
+    P3P4:
+      start_vm_offset: 3
+      start_vm_port_idx: 4
+      end_vm_offset: 5
+      end_vm_port_idx: 1
+    P2P4:
+      start_vm_offset: 4
+      start_vm_port_idx: 2
+      end_vm_offset: 5
+      end_vm_port_idx: 2
+  OVS_LINKs:
+    P2PE3:
+      vlans:
+        - 39
+      start_vm_offset: 4
+      start_vm_port_idx: 3
+      end_vm_offset: 2
+      end_vm_port_idx: 1
+    P4PE3:
+      vlans:
+        - 40
+      start_vm_offset: 5
+      start_vm_port_idx: 3
+      end_vm_offset: 2
+      end_vm_port_idx: 3
+  DUT:
+    vlan_configs:
+      default_vlan_config: one_vlan_a
+      one_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 21, 22, 23, 24]
+          prefix: 192.168.0.1/21
+          prefix_v6: fc02:1000::1/64
+          tag: 1000
+      two_vlan_a:
+        Vlan100:
+          id: 100
+          intfs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+          prefix: 192.168.0.1/22
+          prefix_v6: fc02:100::1/64
+          tag: 100
+        Vlan200:
+          id: 200
+          intfs: [13, 14, 15, 21, 22, 23, 24]
+          prefix: 192.168.4.1/22
+          prefix_v6: fc02:200::1/64
+          tag: 200
+      four_vlan_a:
+        Vlan1000:
+          id: 1000
+          intfs: [1, 2, 3, 4, 5, 6]
+          prefix: 192.168.0.1/23
+          prefix_v6: fc02:400::1/64
+          tag: 1000
+        Vlan2000:
+          id: 2000
+          intfs: [7, 8, 9, 10, 11, 12]
+          prefix: 192.168.2.1/23
+          prefix_v6: fc02:401::1/64
+          tag: 2000
+        Vlan3000:
+          id: 3000
+          intfs: [13, 14, 15]
+          prefix: 192.168.4.1/23
+          prefix_v6: fc02:402::1/64
+          tag: 3000
+        Vlan4000:
+          id: 4000
+          intfs: [21, 22, 23, 24]
+          prefix: 192.168.6.1/23
+          prefix_v6: fc02:403::1/64
+          tag: 4000
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: ToRRouter
+    swrole: leaf
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 16
+    tor_subnet_number: 2
+    max_tor_subnet_number: 16
+    tor_subnet_size: 128
+    spine_asn: 65534
+    leaf_asn_start: 64600
+    tor_asn_start: 65500
+    failure_rate: 0
+
+init_cfg_profile: 7nodes_force10_P1
+
+max_fp_num_provided : 6
+
+configuration:
+  PE1:
+    init_cfg_profile: 7nodes_force10_PE1
+    hwsku: Force10-S6000
+    bgp:
+      asn: 64600
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::29/64
+
+  PE2:
+    init_cfg_profile: 7nodes_force10_PE2
+    hwsku: Force10-S6000
+    bgp:
+      asn: 64601
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::30/64
+
+  PE3:
+    init_cfg_profile: 7nodes_force10_PE3
+    hwsku: Force10-S6000
+    bgp:
+      asn: 64602
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::31/64
+
+  P3:
+    init_cfg_profile: 7nodes_force10_P3
+    hwsku: Force10-S6000
+    bgp:
+      asn: 65101
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::20/64
+
+  P2:
+    init_cfg_profile: 7nodes_force10_P2
+    hwsku: Force10-S6000
+    bgp:
+      asn: 65102
+    bp_interface:
+      ipv4: 10.10.246.33/24
+      ipv6: fc0a::21/64
+
+  P4:
+    init_cfg_profile: 7nodes_force10_P4
+    hwsku: Force10-S6000
+    bgp:
+      asn: 65103
+    bp_interface:
+      ipv4: 10.10.246.34/24
+      ipv6: fc0a::22/64

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -54,6 +54,7 @@ all:
           - dpu-1
           - ciscovs-7nodes
           - ciscovs-5nodes
+          - force10-7nodes
       children:
         server_1:
     lab:
@@ -75,6 +76,7 @@ all:
         vlab-t2-02:
         vlab-t2-sup:
         vlab-c-01:
+        vlab-c-02:
     ptf:
       hosts:
         ptf-01:
@@ -274,6 +276,16 @@ all:
           hwsku: cisco-8101-p4-32x100-vs
           serial_port: 9025
           ansible_password: admin
+          ansible_user: admin
+          ansible_ssh_user: admin
+          ansible_altpassword: admin
+        vlab-c-02:
+          ansible_host: 10.250.0.125
+          ansible_hostv6: fec0::ffff:afb:8
+          type: kvm
+          hwsku: Force10-S6000
+          serial_port: 9025
+          ansible_password: password
           ansible_user: admin
           ansible_ssh_user: admin
           ansible_altpassword: admin

--- a/ansible/vtestbed.yaml
+++ b/ansible/vtestbed.yaml
@@ -412,3 +412,18 @@
   inv_name: veos_vtb
   auto_recover: False
   comment: Tests t1-smartswitch-ha topo deployment with VMs
+
+- conf-name: vms-kvm-force10-7nodes
+  group-name: vms9-2
+  topo: force10-7nodes
+  ptf_image_name: docker-ptf
+  ptf: ptf-01
+  ptf_ip: 10.250.0.102/24
+  ptf_ipv6: fec0::ffff:afa:2/64
+  server: server_1
+  vm_base: VM0100
+  dut:
+    - vlab-c-02
+  inv_name: veos_vtb
+  auto_recover: 'False'
+  comment: Tests virtual force vs vm with 7 nodes

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2172,7 +2172,13 @@ span/test_port_mirroring.py:
 #######################################
 srv6/test_srv6_basic_sanity.py:
   skip:
-    reason: "It's a new test case, skip it for other topologies except cisco vs nodes."
+    reason: "It's a new test case, skip it for other topologies except cisco vs nodes and force nodes."
+    conditions:
+      - topo_name not in ["ciscovs-7nodes", "ciscovs-5nodes", "force10-7nodes"]
+
+srv6/test_srv6_basic_sanity.py::test_traffic_check:
+  skip:
+    reason: "It's a new test case, skip it for other topologies except cisco vs nodes (SRv6 data plane required)."
     conditions:
       - topo_name not in ["ciscovs-7nodes", "ciscovs-5nodes"]
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2176,7 +2176,7 @@ srv6/test_srv6_basic_sanity.py:
     conditions:
       - topo_name not in ["ciscovs-7nodes", "ciscovs-5nodes", "force10-7nodes"]
 
-srv6/test_srv6_basic_sanity.py::test_traffic_check:
+srv6/test_srv6_basic_sanity.py::test_traffic_check_normal:
   skip:
     reason: "It's a new test case, skip it for other topologies except cisco vs nodes (SRv6 data plane required)."
     conditions:

--- a/tests/srv6/test_srv6_basic_sanity.py
+++ b/tests/srv6/test_srv6_basic_sanity.py
@@ -212,7 +212,7 @@ def test_check_routes(duthosts, rand_one_dut_hostname, nbrhosts):
 #
 # Test Case : Traffic check in Normal Case
 #
-def test_traffic_check(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, ptfadapter):
+def test_traffic_check_normal(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, ptfadapter):
     #
     # Create a packet sending to 192.100.0.1
     #


### PR DESCRIPTION
### Description of PR

In #15349 and #15723 , the 7-nodes testbed for SRv6 based on Cisco VS hwsku was added with the corresponding tests. In this PR, a testbed with similar config to the cisco one, but based on Force 10 hwsku, is introduced.

The cisco vs testbed requires specific SONiC image and data plane emulation toolset from Cisco to work. Therefore, for the sake of testing the control plane only using SONiC images with the `vs` hwsku, this testbed is added.

Additionally, tests for SRv6 that don't require data plane (i.e. non-traffic-check cases) are enabled for the new Force 10 testbed. 

Summary:
~Fixes # (issue)~ (Not appliciable)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

Enable the control plane test for SRv6 with a `vs` hwsku, without any specific emulation software.

#### How did you do it?

Duplicate the configuration from the cisco vs testbed, and modify it for Force 10 VS hwsku.

#### How did you verify/test it?

SRv6 functionality was tested manually first: IPv4 routes were injected from the PTF mimicing CE devices into one of the PE devices, and SRv6 encapsulation enabled routes were observed on other PE devices. Therefore, those routes were successfully propagated via BGP.

The test cases introduced from #15723 passed, except the ones that require the data plane which isn't available currently with a `vs` hwsku.

#### Any platform specific information?

The DUT and cEOS images were built from https://github.com/eddieruan-alibaba/sonic-buildimage , not from sonic-net/sonic-sonic-buildimage .

#### Supported testbed topology if it's a new test case?

Not applicable.

### Documentation

https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/srv6/SRv6-phoenixwing-ptf-testplan.md

### Test result

<img width="1092" alt="0363719f32afa4725e747d25554ca3fb" src="https://github.com/user-attachments/assets/a6e9794e-f2cc-467b-9e23-a2f486a5ddcc">
