### PR TITLE
Update BGPMON_V6 tests for both passive and active bgpmon_v6

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -178,6 +178,10 @@ bgp/test_bgpmon.py:
     conditions:
       - "'backend' in topo_name or 't2' in topo_name"
 
+bgp/test_bgpmon_v6.py::test_bgpmon_no_ipv6_resolve_via_default:
+  skip:
+    reason: "Known issue with no ipv6 nht resolve-via-default not preventing connection to BGP neighbor"
+
 bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away:
   skip:
     reason: "Test is flaky and causing PR test to fail unnecessarily"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -180,7 +180,7 @@ bgp/test_bgpmon.py:
 
 bgp/test_bgpmon_v6.py::test_bgpmon_no_ipv6_resolve_via_default:
   skip:
-    reason: "Known issue with no ipv6 nht resolve-via-default not preventing connection to BGP neighbor"
+    reason: "Not applicable for passive bgpmon_v6"
 
 bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
- Generalises BGPMON_V6 test to work with both active and pasive implementation of BGPMON_V6
- Add skip for known issue

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Prevent failures where in bgp/test_bgpmon_v6.py where bgpmon_v6 may be passive
#### How did you do it?
Removed check for SYN packet sent from DUT and use of information from that SYN packet following
#### How did you verify/test it?
Tested with passive bgpmon_v6 version on physical T2 device
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
