### PR TITLE
Skip crm check for KVM testbed in `dualtor/test_orch_stress.py` test

### DIFF
--- a/tests/dualtor/test_orch_stress.py
+++ b/tests/dualtor/test_orch_stress.py
@@ -225,6 +225,7 @@ def test_flap_neighbor_entry_active(
         mock_server_ip_mac_map):
 
     dut = rand_selected_dut
+    asic_type = dut.facts['asic_type']
 
     vlan_interface_name = list(dut.get_extended_minigraph_facts(tbinfo)['minigraph_vlans'].keys())[0]
 
@@ -246,8 +247,9 @@ def test_flap_neighbor_entry_active(
     logger.info(json.dumps(crm_facts2, indent=4))
 
     unmatched_crm_facts = compare_crm_facts(crm_facts1, crm_facts2)
-    pytest_assert(len(unmatched_crm_facts) == 0, 'Unmatched CRM facts: {}'
-                  .format(json.dumps(unmatched_crm_facts, indent=4)))
+    if asic_type != 'vs':
+        pytest_assert(len(unmatched_crm_facts) == 0, 'Unmatched CRM facts: {}'
+                      .format(json.dumps(unmatched_crm_facts, indent=4)))
 
 
 def test_flap_neighbor_entry_standby(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
`dualtor/test_orch_stress.py::test_flap_neighbor_entry_active` test would compare crm facts which do not completely supported in KVM testbed
#### How did you do it?
Skip crm facts check in `dualtor/test_orch_stress.py::test_flap_neighbor_entry_active` test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
