### PR TITLE
Disable loganalyzer for voq_disrupts test

### DIFF
--- a/tests/voq/test_voq_disrupts.py
+++ b/tests/voq/test_voq_disrupts.py
@@ -22,6 +22,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 pytestmark = [
+    pytest.mark.disable_loganalyzer,
     pytest.mark.topology('t2')
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #15916 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
When an LC or a supervisor is rebooted it produces a lot of logs irrelevant to the individual testcases. This is one of the drawbacks faced by the voq disrupts tests that reboots the device and fails because of these unaccounted error logs. Following the theme seen in the below tests that call reboots, I have disabled the log analyzer in voq disrupt to make sure the test focuses more on catching the voq related failures.

- https://github.com/sonic-net/sonic-mgmt/blob/7e7dded7e51fa08e4fcff2efe1e0b0d412a3c230/tests/pfcwd/test_pfcwd_warm_reboot.py#L37
- https://github.com/sonic-net/sonic-mgmt/blob/7e7dded7e51fa08e4fcff2efe1e0b0d412a3c230/tests/platform_tests/test_power_off_reboot.py#L12
- https://github.com/sonic-net/sonic-mgmt/blob/7e7dded7e51fa08e4fcff2efe1e0b0d412a3c230/tests/platform_tests/test_cont_warm_reboot.py#L23

#### How did you do it?
By adding the `pytest.mark.disable_loganalyzer` pytest mark

#### How did you verify/test it?
I have run the test on a T2 topology and verified that we no longer hit the loganalyzer errors

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
