### PR TITLE
Add check to see if bgp sessions are up before proceeding with the tests

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1314,19 +1314,11 @@ class TestAclWithReboot(TestBasicAcl):
 
         """
         dut.command("config save -y")
+        up_bgp_neighbors = dut.get_bgp_neighbors_per_asic("established")
         reboot(dut, localhost, safe_reboot=True, check_intf_up_ports=True)
         # We need some additional delay on e1031
         if dut.facts["platform"] == "x86_64-cel_e1031-r0":
             time.sleep(240)
-        if 't1' in tbinfo["topo"]["name"] or 'm0' in tbinfo["topo"]["name"]:
-            # Wait BGP sessions up on T1 as we saw BGP sessions to T0
-            # established later than T2
-            bgp_neighbors = dut.get_bgp_neighbors()
-            pytest_assert(
-                wait_until(120, 10, 0, dut.check_bgp_session_state, list(bgp_neighbors.keys())),
-                "Not all bgp sessions are established after reboot")
-            # Delay 10 seconds for route convergence
-            time.sleep(10)
         # We need additional delay and make sure ports are up for Nokia-IXR7250E-36x400G
         if dut.facts["hwsku"] == "Nokia-IXR7250E-36x400G":
             interfaces = conn_graph_facts["device_conn"][dut.hostname]
@@ -1338,6 +1330,12 @@ class TestAclWithReboot(TestBasicAcl):
                                 xcvr_skip_list)
             assert result, "Not all transceivers are detected or interfaces are up in {} seconds".format(
                 MAX_WAIT_TIME_FOR_INTERFACES)
+
+        pytest_assert(
+            wait_until(300, 10, 0, dut.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
+            "All BGP sessions are not up after reboot, no point in continuing the test")
+        # Delay 10 seconds for route convergence
+        time.sleep(10)
 
         populate_vlan_arp_entries()
 


### PR DESCRIPTION
### Description of PR
After acl reboot, we check for critical process status and interface status but do not check to see if all BGP sessions are up or not. Sometimes testcases fail because packet is not received, this is because BGP sessions are not yet up and fail the ACL tests for the wrong reasons. 

This check will make sure that BGP sessions are up before continuing with the ACL tests

Instead of checking only for T1 and M0 profile, checking it for all profiles

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
After acl reboot, we check for critical process status and interface status but do not check to see if all BGP sessions are up or not. Sometimes testcases fail because packet is not received, this is because BGP sessions are not yet up and fail the ACL tests for the wrong reasons. 

#### How did you do it?
This check will make sure that BGP sessions are up before continuing with the ACL tests

#### How did you verify/test it?
On T2 profile for Cisco 8808 chassis

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
