### PR TITLE
[Chassis] Remove the useless LC reboot during upgrade image

### DIFF
--- a/ansible/devutil/devices/sonic.py
+++ b/ansible/devutil/devices/sonic.py
@@ -41,25 +41,10 @@ def upgrade_by_sonic(sonichosts, localhost, image_url, disk_used_percent):
             # Chassis DUT need to firstly upgrade and reboot supervisor cards.
             # Until supervisor cards back online, then upgrade and reboot line cards.
             rp_hostnames = get_chassis_hostnames(sonichosts, ChassisCardType.SUPERVISOR_CARD)
-            lc_hostnames = get_chassis_hostnames(sonichosts, ChassisCardType.LINE_CARD)
             sonichosts.shell("reboot", target_hosts=rp_hostnames,
                              module_attrs={"become": True, "async": 300, "poll": 0})
             logger.info("Sleep 900s to wait for supervisor card to be ready...")
             time.sleep(900)
-            for i in range(len(sonichosts.ips)):
-                localhost.wait_for(
-                    host=sonichosts.ips[i],
-                    port=22,
-                    state="started",
-                    search_regex="OpenSSH",
-                    delay=0,
-                    timeout=600,
-                    module_attrs={"changed_when": False}
-                )
-            sonichosts.shell("reboot", target_hosts=lc_hostnames,
-                             module_attrs={"become": True, "async": 300, "poll": 0})
-            logger.info("Sleep 300s to wait for line cards to be ready...")
-            time.sleep(300)
         else:
             sonichosts.shell("reboot", module_attrs={"become": True, "async": 300, "poll": 0})
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes MSFT PBI#28727277

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
During the code logic, we install the image on all the devices at the same time.
Then reboot the RP and wait, then reboot the LC and wait.
But on chassis, after RP rebooted, the LC rebooted automatically.

Hence remove the useless LC reboot to save the time.

About the production image upgrade, we will have upgrade path test covering it.
#### How did you do it?
Remove useless LC reboot.
#### How did you verify/test it?
Tested on physical chassis and it works well.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
