### PR TITLE
[202311] Ignore GNMI setup and test cname authorization feature on old image

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -64,6 +64,14 @@ def del_gnmi_client_common_name(duthost, cname):
     duthost.shell('sudo sonic-db-cli CONFIG_DB del "GNMI_CLIENT_CERT|{}"'.format(cname), module_ignore_errors=True)
 
 
+def support_cname_auth(duthost):
+    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
+    dut_command = "docker exec {} bash -c '{} -h'".format(env.gnmi_container, env.gnmi_process)
+    supported_parameters = duthost.shell(dut_command, module_ignore_errors=True)['stderr']
+    logger.warning("GNMI supported parameters: {}".format(supported_parameters))
+    return '  -config_table_name string' in supported_parameters
+
+
 def apply_cert_config(duthost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     # Stop all running program
@@ -83,8 +91,10 @@ def apply_cert_config(duthost):
     dut_command = "docker exec %s bash -c " % env.gnmi_container
     dut_command += "\"/usr/bin/nohup /usr/sbin/%s -logtostderr --port %s " % (env.gnmi_process, env.gnmi_port)
     dut_command += "--server_crt /etc/sonic/telemetry/gnmiserver.crt --server_key /etc/sonic/telemetry/gnmiserver.key "
-    dut_command += "--config_table_name GNMI_CLIENT_CERT "
-    dut_command += "--client_auth cert "
+    # Old image does not support cname authorization feature
+    if support_cname_auth(duthost):
+        dut_command += "--config_table_name GNMI_CLIENT_CERT "
+        dut_command += "--client_auth cert "
     dut_command += "--ca_crt /etc/sonic/telemetry/gnmiCA.pem -gnmi_native_write=true -v=10 >/root/gnmi.log 2>&1 &\""
     duthost.shell(dut_command)
 

--- a/tests/gnmi/test_gnmi.py
+++ b/tests/gnmi/test_gnmi.py
@@ -1,7 +1,8 @@
 import pytest
 import logging
 
-from .helper import gnmi_capabilities, gnmi_set, add_gnmi_client_common_name, del_gnmi_client_common_name, support_cname_auth
+from .helper import gnmi_capabilities, gnmi_set, add_gnmi_client_common_name, del_gnmi_client_common_name, \
+    support_cname_auth
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ def test_gnmi_authorize_failed_with_invalid_cname(duthosts,
 
     # Old image does not support cname authorization feature
     if not support_cname_auth(duthost):
-        logger.info("This image does not support cname authorization, ignore test_gnmi_authorize_failed_with_invalid_cname test.")
+        logger.info("This image does not support cname authorization, ignore test.")
         return
 
     file_name = "vnet.txt"

--- a/tests/gnmi/test_gnmi.py
+++ b/tests/gnmi/test_gnmi.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 
-from .helper import gnmi_capabilities, gnmi_set, add_gnmi_client_common_name, del_gnmi_client_common_name
+from .helper import gnmi_capabilities, gnmi_set, add_gnmi_client_common_name, del_gnmi_client_common_name, support_cname_auth
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +46,11 @@ def test_gnmi_authorize_failed_with_invalid_cname(duthosts,
     GNMI set request with invalid path
     '''
     duthost = duthosts[rand_one_dut_hostname]
+
+    # Old image does not support cname authorization feature
+    if not support_cname_auth(duthost):
+        logger.info("This image does not support cname authorization, ignore test_gnmi_authorize_failed_with_invalid_cname test.")
+        return
 
     file_name = "vnet.txt"
     text = "{\"Vnet1\": {\"vni\": \"1000\", \"guid\": \"559c6ce8-26ab-4193-b946-ccc6e8f930b2\"}}"


### PR DESCRIPTION
Ignore GNMI setup and test cname authorization feature on old image.

#### Why I did it
GNMI cname authorization feature been cherry-pick to 202311 branch.
Recently some test failed on old image which does not support this feature.

##### Work item tracking
- Microsoft ADO: 30343954

#### How I did it
Ignore GNMI setup and test cname authorization feature on old image.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Ignore GNMI setup and test cname authorization feature on old image.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

