### PR TITLE
[Mellanox] Update telemetry event test cpu threshold

### DIFF
--- a/tests/telemetry/events/host_events.py
+++ b/tests/telemetry/events/host_events.py
@@ -25,7 +25,7 @@ def test_event(duthost, gnxi_path, ptfhost, ptfadapter, data_dir, validate_yang)
         duthost,
         [
             "> 90% for 10 times within 20 cycles then alert repeat every 1 cycles",
-            "> 2% for 1 times within 5 cycles then alert repeat every 1 cycles"
+            "> 1% for 1 times within 5 cycles then alert repeat every 1 cycles"
         ]
     )
     try:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Use 1 percent as cpu threshold for all the platforms.
It covers the sn4280, it has more cpu cores, and the threshold should be lower than 2 percent.

Summary:
Fixes # (issue)
telemetry.test_events#test_events failure 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
telemetry.test_events#test_events failure due to gRPC error at sn4280, it has more cpu cores, so the cpu threshold should be lower.
#### How did you do it?
Use lower cpu threshold for Nvidia platforms once it is clear that the new threshold is OK for all Nvidia platforms.
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?
run the test on multiple Nvidia platforms.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
