### PR TITLE
Add debug function for bfd responder start process

### DIFF
--- a/ansible/roles/test/files/helpers/bfd_responder.py
+++ b/ansible/roles/test/files/helpers/bfd_responder.py
@@ -124,7 +124,7 @@ class BFDResponder(object):
         ip_version = str(ether.payload.version)
         ip_priority_field = 'tos' if ip_version == IPv4 else 'tc'
         ip_priority = getattr(ether.payload, ip_priority_field)
-        bfdpkt = BFD(ether.payload.payload.payload.load)
+        bfdpkt = BFD(bytes(ether.payload.payload.payload.load))
         bfd_remote_disc = bfdpkt.my_discriminator
         bfd_state = bfdpkt.sta
         bfd_flags = bfdpkt.flags
@@ -135,7 +135,7 @@ class BFDResponder(object):
 
     def craft_bfd_packet(self, session, data, mac_src, mac_dst, ip_src, ip_dst, bfd_remote_disc, bfd_state):
         ethpart = scapy2.Ether(data)
-        bfdpart = BFD(ethpart.payload.payload.payload.load)
+        bfdpart = BFD(bytes(ethpart.payload.payload.payload.load))
         bfdpart.my_discriminator = session["my_disc"]
         bfdpart.your_discriminator = bfd_remote_disc
         bfdpart.sta = bfd_state


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
1.Log the error log of bfd responder when it failed to start 
2.Transfer bfd data to bytes type

Change-Id: Idef5a8fba1ef8544f410a7399b263bccf94e5926

Summary:
Fixes # (issue)
When bfd responder receive some bfd packet data with non-bytes values, it could lead to bfd responder start failure:
bfd_responder: ERROR (spawn error)
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Bfd responder start failure:
bfd_responder: ERROR (spawn error)
#### How did you do it?
1.Log the error log of bfd responder when it failed to start 
2.Transfer bfd data to bytes type
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
