### PR TITLE
Cisco specific: Check debug shell status before ecn marking test

### DIFF
--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -151,3 +151,38 @@ def reboot_duts(setup_ports_and_dut, localhost, request):
     # parallel_run(revert_config_and_reload, {}, {}, list(args), timeout=900)
     for duthost in args:
         revert_config_and_reload(node=duthost)
+
+
+@pytest.fixture(autouse=True)
+def enable_debug_shell(setup_ports_and_dut):  # noqa: F811
+    _, _, snappi_ports = setup_ports_and_dut
+    rx_duthost = snappi_ports[0]['duthost']
+
+    if is_cisco_device(rx_duthost):
+        dutport = snappi_ports[0]['peer_port']
+        asic_namespace_string = ""
+        syncd_string = "syncd"
+        if rx_duthost.is_multi_asic:
+            asic = rx_duthost.get_port_asic_instance(dutport)
+            asic_namespace_string = " -n " + asic.namespace
+            asic_id = rx_duthost.get_asic_id_from_namespace(asic.namespace)
+            syncd_string += asic_id
+
+        dshell_status = "".join(rx_duthost.shell("docker exec {} supervisorctl status dshell_client | \
+                                                 grep \"dshell_client.*RUNNING\"".format(syncd_string),
+                                                 module_ignore_errors=True)["stdout_lines"])
+        if 'RUNNING' not in dshell_status:
+            debug_shell_enable = rx_duthost.command("docker exec {} supervisorctl start dshell_client".
+                                                    format(syncd_string))
+            logging.info(debug_shell_enable)
+
+            def is_debug_shell_enabled():
+                output = "".join(rx_duthost.shell("sudo show platform npu voq voq_globals -i {}{}".format(
+                                                    dutport, asic_namespace_string))["stdout_lines"])
+                if "cisco sdk-debug enable" in output:
+                    return False
+                return True
+
+            wait_until(360, 5, 0, is_debug_shell_enabled)
+        yield
+        pass

--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -176,13 +176,13 @@ def enable_debug_shell(setup_ports_and_dut):  # noqa: F811
                                                     format(syncd_string))
             logging.info(debug_shell_enable)
 
-            def is_debug_shell_enabled():
-                output = "".join(rx_duthost.shell("sudo show platform npu voq voq_globals -i {}{}".format(
-                                                    dutport, asic_namespace_string))["stdout_lines"])
-                if "cisco sdk-debug enable" in output:
-                    return False
-                return True
+        def is_debug_shell_enabled():
+            output = "".join(rx_duthost.shell("sudo show platform npu voq voq_globals -i {}{}".format(
+                                                dutport, asic_namespace_string))["stdout_lines"])
+            if "cisco sdk-debug enable" in output:
+                return False
+            return True
 
-            wait_until(360, 5, 0, is_debug_shell_enabled)
+        wait_until(360, 5, 0, is_debug_shell_enabled)
         yield
         pass

--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -166,7 +166,7 @@ def enable_debug_shell(setup_ports_and_dut):  # noqa: F811
             asic = rx_duthost.get_port_asic_instance(dutport)
             asic_namespace_string = " -n " + asic.namespace
             asic_id = rx_duthost.get_asic_id_from_namespace(asic.namespace)
-            syncd_string += asic_id
+            syncd_string += str(asic_id)
 
         dshell_status = "".join(rx_duthost.shell("docker exec {} supervisorctl status dshell_client | \
                                                  grep \"dshell_client.*RUNNING\"".format(syncd_string),

--- a/tests/snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py
@@ -8,7 +8,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     is_snappi_multidut, get_snappi_ports_multi_dut   # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
     lossless_prio_list, disable_pfcwd   # noqa F401
-from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut  # noqa: F401
+from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut, enable_debug_shell  # noqa: F401
 from tests.snappi_tests.multidut.ecn.files.multidut_helper import run_ecn_marking_test, run_ecn_marking_port_toggle_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.cisco_data import is_cisco_device

--- a/tests/snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 from tabulate import tabulate # noqa F401
-from tests.common.helpers.assertions import pytest_assert     # noqa: F401
+from tests.common.helpers.assertions import pytest_assert, pytest_require     # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut         # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config, \
@@ -146,7 +146,7 @@ def test_ecn_marking_lossless_prio(
 
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
-    pytest_assert(validate_snappi_ports(snappi_ports), "Invalid combination of duthosts or ASICs in snappi_ports")
+    pytest_require(validate_snappi_ports(snappi_ports), "Invalid combination of duthosts or ASICs in snappi_ports")
 
     logger.info("Snappi Ports : {}".format(snappi_ports))
     snappi_extra_params = SnappiTestParams()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

Testcase execution might fail if a previous test did a config reload
which results in delay of dshell init which is expected.

#### How did you do it?

Added a pytest fixture to run along with testcase.

#### How did you verify/test it?

on Snappi based run

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
