### PR TITLE
Wait BGP sessions after changing mgmt IP

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -619,6 +619,17 @@ def check_bgp_router_id(duthost, mgFacts):
         logger.error("Error loading BGP routerID - {}".format(e))
 
 
+def wait_bgp_sessions(duthost, timeout=120):
+    """
+    A helper function to wait bgp sessions on DUT
+    """
+    bgp_neighbors = duthost.get_bgp_neighbors_per_asic(state="all")
+    pytest_assert(
+        wait_until(timeout, 10, 0, duthost.check_bgp_session_state_all_asics, bgp_neighbors),
+        "Not all bgp sessions are established after config reload",
+    )
+
+
 @pytest.fixture(scope="module")
 def convert_and_restore_config_db_to_ipv6_only(duthosts):
     """Convert the DUT's mgmt-ip to IPv6 only
@@ -767,6 +778,7 @@ def convert_and_restore_config_db_to_ipv6_only(duthosts):
             # Wait until all critical processes are up,
             # especially snmpd as it needs to be up for SNMP status verification
             wait_critical_processes(duthost)
+            wait_bgp_sessions(duthost)
 
     # Verify mgmt-interface status
     mgmt_intf_name = "eth0"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to add another fix BGP not established issue in test `test_bgp_facts_ipv6_only`.
The fix submitted earlier in https://github.com/sonic-net/sonic-mgmt/pull/15570 didn't address the issue completely as an Exception is thrown from `config_reload` fixture, which breaks the wait and check.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
This PR is to add another fix BGP not established issue in test `test_bgp_facts_ipv6_only`.

#### How did you do it?
Add a function to wait BGP sessions up.

#### How did you verify/test it?
The change is verified on a physical testbed.
```
collected 1 item                                                                                                                                                                                      

ip/test_mgmt_ipv6_only.py::test_bgp_facts_ipv6_only[bjw2-can-4600c-5-None] 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
21:34:57 duthost_utils.convert_and_restore_config L0762 WARNING| Exception after config reload: Host unreachable
PASSED
```
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
Not a new test case.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
