### PR TITLE
chore: bump BFD toggle wait timeout

### DIFF
--- a/tests/bfd/bfd_helpers.py
+++ b/tests/bfd/bfd_helpers.py
@@ -31,7 +31,7 @@ def prepare_bfd_state(dut, flag, expected_bfd_state):
 def verify_bfd_only(dut, nexthops, asic, expected_bfd_state):
     logger.info("BFD verifications")
     assert wait_until(
-        300,
+        450,
         10,
         0,
         lambda: verify_bfd_state(dut, nexthops.values(), asic, expected_bfd_state),
@@ -730,7 +730,7 @@ def verify_given_bfd_state(asic_next_hops, port_channel, asic_index, dut, expect
 
 def wait_until_given_bfd_down(next_hops, port_channel, asic_index, dut):
     assert wait_until(
-        300,
+        450,
         10,
         0,
         lambda: verify_given_bfd_state(next_hops, port_channel, asic_index, dut, "Down"),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Bump the BFD toggle wait timeout to 450 seconds to give BFD session enough time to go up/down.

Summary:
Fixes # (issue) Microsoft ADO 30112171

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
We noticed that 300 seconds is not enough for BFD session to go up/down, so Cisco suggested us to bump it to 450 seconds.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
