### PR TITLE
[T2 IXIA] Update show queue counters api to use -n

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -990,8 +990,8 @@ def get_egress_queue_count(duthost, port, priority):
     # If DUT is multi-asic, asic will be used.
     if duthost.is_multi_asic:
         asic = duthost.get_port_asic_instance(port).get_asic_namespace()
-        raw_out = duthost.shell("sudo ip netns exec {} show queue counters {} | sed -n '/UC{}/p'".
-                                format(asic, port, priority))['stdout']
+        raw_out = duthost.shell("show queue counters {} -n {} | sed -n '/UC{}/p'".
+                                format(port, asic, priority))['stdout']
         total_pkts = "0" if raw_out.split()[2] == "N/A" else raw_out.split()[2]
         total_bytes = "0" if raw_out.split()[3] == "N/A" else raw_out.split()[3]
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Previously we're using `sudo ip netns exec asic0 show queue counter` for showing the queue counter in multi-asic. However with the new apis, `-n` is supported natively in `show queue counter -n asic0`

This PR updates so that in get_egress_queue_count will use the new queue counters.

The queue counter support was added in the original PR:
- https://github.com/sonic-net/sonic-utilities/pull/2439

Cherry-pick to 202205:
- https://github.com/sonic-net/sonic-utilities/pull/2647

Summary:
Fixes # (issue) #15856 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Adjust the command to use the new format `show queue counter -n asic0`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
