### PR TITLE
fix: fix port does not exist error test_bgp_queue

### DIFF
--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -19,7 +19,8 @@ def get_queue_counters(asichost, port, queue):
     Return the counter for a given queue in given port
     """
     cmd = "show queue counters {}".format(port)
-    output = asichost.command(cmd)['stdout_lines']
+    output = asichost.command(cmd, new_format=True)['stdout_lines']
+
     txq = "UC{}".format(queue)
     for line in output:
         fields = line.split()

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -407,9 +407,11 @@ class SonicAsic(object):
              " -L *:{}:{}:{} localhost").format(self.get_rpc_port_ssh_tunnel(), ns_docker_if_ipv4,
                                                 self._RPC_PORT_FOR_SSH_TUNNEL))
 
-    def command(self, cmdstr):
+    def command(self, cmdstr, new_format=False):
         """
             Prepend 'ip netns' option for commands meant for this ASIC
+
+            If new format is provided (new_format=True) we use the syntax "{cmd} -n asic{index}" instead.
 
             Args:
                 cmdstr
@@ -419,7 +421,10 @@ class SonicAsic(object):
         if not self.sonichost.is_multi_asic or self.namespace == DEFAULT_NAMESPACE:
             return self.sonichost.command(cmdstr)
 
-        cmdstr = "sudo ip netns exec {} {}".format(self.namespace, cmdstr)
+        if new_format:
+            cmdstr = "sudo {} {}".format(cmdstr, self.cli_ns_option)
+        else:
+            cmdstr = "sudo ip netns exec {} {}".format(self.namespace, cmdstr)
 
         return self.sonichost.command(cmdstr)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 30457143

Currently this is using the old method of capturing queue counters:

```
sudo ip netns exec asic1 show queue counters Ethernet128
```

This will throw an issue with some testbed and says Ethernet128 does not exists. (haven't had chance to confirm why)

However since we have new support for -n https://github.com/sonic-net/sonic-utilities/pull/2439 we should be using this instead

Tested by running manual commands

```
admin@str3-8800-lc4-1:~$ sudo ip netns exec asic1 show queue counters Ethernet128
Port doesn't exist! Ethernet128
```

```
admin@str3-8800-lc4-1:~$ show queue counters Ethernet128 -n asic1
For namespace asic1:
       Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
-----------  -----  --------------  ---------------  -----------  ------------
Ethernet128    UC0               0                0            0             0
...
```


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Update the test to use new APIs that support `-n`

#### How did you verify/test it?
Manually run, needs to verify with available testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
