### PR TITLE
Adjust t2 timing in tests/platform_tests/test_reload_config.py

### DIFF
--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -70,7 +70,7 @@ def test_reload_configuration(duthosts, enum_rand_one_per_hwsku_hostname,
 
     logging.info("Wait some time for all the transceivers to be detected")
     max_wait_time_for_transceivers = 300
-    if duthost.facts["platform"] == "x86_64-cel_e1031-r0":
+    if duthost.facts["platform"] in ["x86_64-cel_e1031-r0", "x86_64-88_lc0_36fh_m-r0"]:
         max_wait_time_for_transceivers = 900
     assert wait_until(max_wait_time_for_transceivers, 20, 0, check_all_interface_information,
                       duthost, interfaces, xcvr_skip_list), "Not all transceivers are detected \
@@ -158,7 +158,12 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     if not config_force_option_supported(duthost):
         return
 
+    timeout = None
+    if duthost.get_facts().get("modular_chassis"):
+        timeout = 420
+
     reboot(duthost, localhost, reboot_type="cold", wait=5,
+           timeout=timeout,
            plt_reboot_ctrl_overwrite=False)
 
     # Check if all database containers have started


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 3045798

The decision was to enable this test gap in #13476 however we mentioned that we need to increase the time.

By default, the reboot time will be decided from constant variable `reboot_ctrl_dict` which will set the `REBOOT_TYPE_COLD` = 300

https://github.com/sonic-net/sonic-mgmt/blob/master/tests/common/reboot.py#L133

For T2, this time is not sufficient enough and lead to failure. We will adjust the time accordingly.

This PR will fix that

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Enable plt_reboot_ctrl_overwrite if platform is T2

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
