### PR TITLE
[202311] Fix test_gnmi_authorize_failed_with_invalid_cname backport issue because gnmi_set method changed on 202311.

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -29,6 +29,9 @@ t0:
   - generic_config_updater/test_vlan_interface.py
   - generic_config_updater/test_mmu_dynamic_threshold_config_update.py
   - generic_config_updater/test_ecn_config_update.py
+  - gnmi/test_gnmi.py
+  - gnmi/test_gnmi_appldb.py
+  - gnmi/test_gnmi_configdb.py
   - iface_namingmode/test_iface_namingmode.py
   - lldp/test_lldp.py
   - memory_checker/test_memory_checker.py

--- a/tests/gnmi/test_gnmi.py
+++ b/tests/gnmi/test_gnmi.py
@@ -37,7 +37,6 @@ def setup_invalid_client_cert_cname(duthosts, rand_one_dut_hostname):
     add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
 
 
-
 def test_gnmi_authorize_failed_with_invalid_cname(duthosts,
                                                   rand_one_dut_hostname,
                                                   localhost,

--- a/tests/gnmi/test_gnmi.py
+++ b/tests/gnmi/test_gnmi.py
@@ -37,6 +37,7 @@ def setup_invalid_client_cert_cname(duthosts, rand_one_dut_hostname):
     add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
 
 
+
 def test_gnmi_authorize_failed_with_invalid_cname(duthosts,
                                                   rand_one_dut_hostname,
                                                   localhost,
@@ -46,13 +47,12 @@ def test_gnmi_authorize_failed_with_invalid_cname(duthosts,
     GNMI set request with invalid path
     '''
     duthost = duthosts[rand_one_dut_hostname]
-
     file_name = "vnet.txt"
     text = "{\"Vnet1\": {\"vni\": \"1000\", \"guid\": \"559c6ce8-26ab-4193-b946-ccc6e8f930b2\"}}"
     with open(file_name, 'w') as file:
         file.write(text)
     # Add DASH_VNET_TABLE
-    update_list = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE:@/root/%s" % (file_name)]
+    update_list = ["/sonic-db:APPL_DB/DASH_VNET_TABLE:@./%s" % (file_name)]
     ret, msg = gnmi_set(duthost, localhost, [], update_list, [])
 
     assert "Unauthenticated" in msg

--- a/tests/gnmi/test_gnmi.py
+++ b/tests/gnmi/test_gnmi.py
@@ -39,7 +39,7 @@ def setup_invalid_client_cert_cname(duthosts, rand_one_dut_hostname):
 
 def test_gnmi_authorize_failed_with_invalid_cname(duthosts,
                                                   rand_one_dut_hostname,
-                                                  ptfhost,
+                                                  localhost,
                                                   setup_invalid_client_cert_cname):
     '''
     Verify GNMI native write, incremental config for configDB
@@ -51,14 +51,8 @@ def test_gnmi_authorize_failed_with_invalid_cname(duthosts,
     text = "{\"Vnet1\": {\"vni\": \"1000\", \"guid\": \"559c6ce8-26ab-4193-b946-ccc6e8f930b2\"}}"
     with open(file_name, 'w') as file:
         file.write(text)
-    ptfhost.copy(src=file_name, dest='/root')
     # Add DASH_VNET_TABLE
     update_list = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE:@/root/%s" % (file_name)]
-    msg = ""
-    try:
-        gnmi_set(duthost, ptfhost, [], update_list, [])
-    except Exception as e:
-        logger.info("Failed to set: " + str(e))
-        msg = str(e)
+    ret, msg = gnmi_set(duthost, localhost, [], update_list, [])
 
     assert "Unauthenticated" in msg


### PR DESCRIPTION
Fix test_gnmi_authorize_failed_with_invalid_cname backport issue because gnmi_set method changed 202311.

#### Why I did it
test_gnmi_authorize_failed_with_invalid_cname  test case failed on 202311 because gnmi_set method on 202311 have different parameter and behavior.

The original cherry-pick PR to 202311 not found this issue: https://github.com/sonic-net/sonic-mgmt/pull/15678 , because he GNMI test no run enable on 202311 branch sonic-mgmt repo merge validation: https://github.com/sonic-net/sonic-mgmt/blob/202311/.azure-pipelines/pr_test_scripts.yaml


##### Work item tracking
- Microsoft ADO: 30343954

#### How I did it
Change code to pass correct parameter.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Fix test_gnmi_authorize_failed_with_invalid_cname backport issue because gnmi_set method changed on 202311.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

