### PR TITLE
fix: temporarily disable parallel run for config test

### DIFF
--- a/tests/test_parallel_modes.json
+++ b/tests/test_parallel_modes.json
@@ -8,7 +8,6 @@
     "iface_namingmode/test_iface_namingmode.py": "FULL_PARALLEL",
     "lldp/test_lldp.py": "FULL_PARALLEL",
     "memory_checker/test_memory_checker.py": "FULL_PARALLEL",
-    "override_config_table/test_override_config_table_masic.py": "FULL_PARALLEL",
     "passw_hardening/test_passw_hardening.py": "FULL_PARALLEL",
     "pc/test_po_cleanup.py": "FULL_PARALLEL",
     "platform_tests/api/test_chassis.py": "FULL_PARALLEL",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Disable parallel run for the `override_config_table/test_override_config_table_masic.py` test as it's not compatible with parallel run anymore. We will refactor this test to re-enable parallel run for it later.

Summary:
Fixes # (issue) Microsoft ADO 30459127

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The `override_config_table/test_override_config_table_masic.py` test will not be able run in parallel after #14713 anymore because it only enumerates the upstream LC now, which is not compatible with the current parallel run implementation.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
