### PR TITLE
chore: fix test_iface_naming_mode skip

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -858,13 +858,11 @@ class TestConfigInterface():
         speed = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} {}'.format(ifmode, db_cmd))['stdout']
         hwsku = duthost.facts['hwsku']
         if hwsku in ["Cisco-88-LC0-36FH-M-O36", "Cisco-88-LC0-36FH-O36"]:
-            if (int(speed) == 400000 and int(configure_speed) <= 100000) or \
-               (int(speed) == 100000 and int(configure_speed) > 200000):
-                pytest.skip(
-                    "Cisco-88-LC0-36FH-M-O36 and Cisco-88-LC0-36FH-O36 \
-                     currently does not support\
-                     speed change from 100G to 400G and vice versa on runtime"
-                )
+            pytest.skip(
+                "Cisco-88-LC0-36FH-M-O36 and Cisco-88-LC0-36FH-O36 \
+                    currently does not support\
+                    speed change from 100G to 400G and vice versa on runtime"
+            )
 
         out = dutHostGuest.shell(
             'SONIC_CLI_IFACE_MODE={} sudo config interface {} speed {} {}'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 30112203

Previous PR #15761 still failing in one of the LC. I suspect the situation was failing if changing speed from `400000` to `400000`

This PR will always skip this test

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

Always skip regardless of the speed

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
