### PR TITLE
T2 Snappi Based route convergence: Code changes to support multiple platforms

### DIFF
--- a/tests/common/snappi_tests/multi_dut_params.py
+++ b/tests/common/snappi_tests/multi_dut_params.py
@@ -16,5 +16,7 @@ class MultiDUTParams():
         self.duthost1 = None
         self.duthost2 = None
         self.multi_dut_ports = None
+        self.hw_platform = None
         self.ingress_duthosts = []
         self.egress_duthosts = []
+        self.flap_details = None

--- a/tests/snappi_tests/multidut/bgp/files/bgp_outbound_helper.py
+++ b/tests/snappi_tests/multidut/bgp/files/bgp_outbound_helper.py
@@ -15,7 +15,7 @@ from tests.common.helpers.assertions import pytest_assert  # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import create_ip_list  # noqa: F401
 from tests.snappi_tests.variables import T1_SNAPPI_AS_NUM, T2_SNAPPI_AS_NUM, T1_DUT_AS_NUM, T2_DUT_AS_NUM, t1_ports, \
      t2_uplink_portchannel_members, t1_t2_dut_ipv4_list, v4_prefix_length, \
-     t1_t2_dut_ipv6_list, t1_t2_snappi_ipv4_list, portchannel_count, \
+     t1_t2_dut_ipv6_list, t1_t2_snappi_ipv4_list, t1_t2_device_hostnames, portchannel_count, \
      t1_t2_snappi_ipv6_list, t2_dut_portchannel_ipv4_list, t2_dut_portchannel_ipv6_list, \
      snappi_portchannel_ipv4_list, snappi_portchannel_ipv6_list, AS_PATHS, \
      BGP_TYPE, t1_side_interconnected_port, t2_side_interconnected_port, router_ids, \
@@ -28,6 +28,27 @@ total_routes = 0
 fanout_uplink_snappi_info = []
 
 
+def get_hw_platform(hostnames):
+    """
+    Get the hardware platform of the DUT
+
+    Args:
+        hostnames (list): List of DUT hostnames
+
+    Returns:
+        hw_platform (str): Hardware platform of the T2 DUT from the variables file
+    """
+    hw_platform = None
+    t2_dut = hostnames[1]
+    for hw_pltfm in t1_t2_device_hostnames:
+        devices = t1_t2_device_hostnames[hw_pltfm]
+        if t2_dut in devices:
+            hw_platform = hw_pltfm
+            break
+
+    return hw_platform
+
+
 def run_dut_configuration(snappi_extra_params):
     """
     Configures the dut for the test
@@ -38,10 +59,12 @@ def run_dut_configuration(snappi_extra_params):
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
     duthost3 = snappi_extra_params.multi_dut_params.duthost3
     duthosts = [duthost1, duthost2, duthost3]
+    hw_platform = snappi_extra_params.multi_dut_params.hw_platform
     test_name = snappi_extra_params.test_name
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
 
     duthost_bgp_config(duthosts,
+                       hw_platform,
                        snappi_ports,
                        test_name)
 
@@ -64,6 +87,7 @@ def run_bgp_outbound_uplink_blackout_test(api,
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
     duthost3 = snappi_extra_params.multi_dut_params.duthost3
     duthosts = [duthost1, duthost2, duthost3]
+    hw_platform = snappi_extra_params.multi_dut_params.hw_platform
     route_ranges = snappi_extra_params.ROUTE_RANGES
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
     blackout_percentage = snappi_extra_params.multi_dut_params.BLACKOUT_PERCENTAGE
@@ -77,11 +101,13 @@ def run_bgp_outbound_uplink_blackout_test(api,
             traffic_type.append(key)
         snappi_bgp_config = __snappi_bgp_config(api,
                                                 duthosts,
+                                                hw_platform,
                                                 snappi_ports,
                                                 traffic_type,
                                                 route_range)
 
         get_convergence_for_blackout(duthosts,
+                                     hw_platform,
                                      api,
                                      snappi_bgp_config,
                                      traffic_type,
@@ -111,6 +137,7 @@ def run_bgp_outbound_tsa_tsb_test(api,
     duthost3 = snappi_extra_params.multi_dut_params.duthost3
     duthost4 = snappi_extra_params.multi_dut_params.duthost4
     duthosts = [duthost1, duthost2, duthost3, duthost4]
+    hw_platform = snappi_extra_params.multi_dut_params.hw_platform
     route_ranges = snappi_extra_params.ROUTE_RANGES
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
     device_name = snappi_extra_params.device_name
@@ -124,6 +151,7 @@ def run_bgp_outbound_tsa_tsb_test(api,
             traffic_type.append(key)
         snappi_bgp_config = __snappi_bgp_config(api,
                                                 duthosts,
+                                                hw_platform,
                                                 snappi_ports,
                                                 traffic_type,
                                                 route_range)
@@ -159,6 +187,7 @@ def run_bgp_outbound_process_restart_test(api,
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
     duthost3 = snappi_extra_params.multi_dut_params.duthost3
     duthosts = [duthost1, duthost2, duthost3]
+    hw_platform = snappi_extra_params.multi_dut_params.hw_platform
     route_ranges = snappi_extra_params.ROUTE_RANGES
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
     process_names = snappi_extra_params.multi_dut_params.process_names
@@ -168,6 +197,7 @@ def run_bgp_outbound_process_restart_test(api,
 
     """ Create bgp config on dut """
     duthost_bgp_config(duthosts,
+                       hw_platform,
                        snappi_ports,
                        test_name)
 
@@ -178,6 +208,7 @@ def run_bgp_outbound_process_restart_test(api,
             traffic_type.append(key)
         snappi_bgp_config = __snappi_bgp_config(api,
                                                 duthosts,
+                                                hw_platform,
                                                 snappi_ports,
                                                 traffic_type,
                                                 route_range)
@@ -212,6 +243,7 @@ def run_bgp_outbound_link_flap_test(api,
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
     duthost3 = snappi_extra_params.multi_dut_params.duthost3
     duthosts = [duthost1, duthost2, duthost3]
+    hw_platform = snappi_extra_params.multi_dut_params.hw_platform
     route_ranges = snappi_extra_params.ROUTE_RANGES
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
     iteration = snappi_extra_params.iteration
@@ -220,6 +252,7 @@ def run_bgp_outbound_link_flap_test(api,
 
     """ Create bgp config on dut """
     duthost_bgp_config(duthosts,
+                       hw_platform,
                        snappi_ports,
                        test_name)
 
@@ -230,11 +263,13 @@ def run_bgp_outbound_link_flap_test(api,
             traffic_type.append(key)
         snappi_bgp_config = __snappi_bgp_config(api,
                                                 duthosts,
+                                                hw_platform,
                                                 snappi_ports,
                                                 traffic_type,
                                                 route_range)
 
         get_convergence_for_link_flap(duthosts,
+                                      hw_platform,
                                       api,
                                       snappi_bgp_config,
                                       flap_details,
@@ -246,6 +281,7 @@ def run_bgp_outbound_link_flap_test(api,
 
 
 def duthost_bgp_config(duthosts,
+                       hw_platform,
                        snappi_ports,
                        test_name):
     """
@@ -265,7 +301,7 @@ def duthost_bgp_config(duthosts,
     loopback_interfaces.update({"Loopback0": {}})
     loopback_interfaces.update({"Loopback0|1.1.1.1/32": {}})
     loopback_interfaces.update({"Loopback0|1::1/128": {}})
-    for index, custom_port in enumerate(t1_ports[duthosts[0].hostname]):
+    for index, custom_port in enumerate(t1_ports[hw_platform][duthosts[0].hostname]):
         interface_name = {custom_port: {}}
         v4_interface = {f"{custom_port}|{t1_t2_dut_ipv4_list[index]}/{v4_prefix_length}": {}}
         v6_interface = {f"{custom_port}|{t1_t2_dut_ipv6_list[index]}/{v6_prefix_length}": {}}
@@ -279,7 +315,7 @@ def duthost_bgp_config(duthosts,
     bgp_neighbors = dict()
     device_neighbors = dict()
     device_neighbor_metadatas = dict()
-    for index, custom_port in enumerate(t1_ports[duthosts[0].hostname]):
+    for index, custom_port in enumerate(t1_ports[hw_platform][duthosts[0].hostname]):
         for snappi_port in snappi_ports:
             if custom_port == snappi_port['peer_port'] and snappi_port['peer_device'] == duthosts[0].hostname:
                 bgp_neighbor = \
@@ -330,16 +366,16 @@ def duthost_bgp_config(duthosts,
     logger.info('\n')
     logger.info('---------------T1 Inter-Connectivity Section --------------------')
     logger.info('\n')
-    index = len(t1_ports[duthosts[0].hostname])
-    interface_name = {t1_side_interconnected_port: {}}
-    v4_interface = {f"{t1_side_interconnected_port}|{t1_t2_dut_ipv4_list[index]}/{v4_prefix_length}": {}}
-    v6_interface = {f"{t1_side_interconnected_port}|{t1_t2_dut_ipv6_list[index]}/{v6_prefix_length}": {}}
+    index = len(t1_ports[hw_platform][duthosts[0].hostname])
+    interface_name = {t1_side_interconnected_port[hw_platform]: {}}
+    v4_interface = {f"{t1_side_interconnected_port[hw_platform]}|{t1_t2_dut_ipv4_list[index]}/{v4_prefix_length}": {}}
+    v6_interface = {f"{t1_side_interconnected_port[hw_platform]}|{t1_t2_dut_ipv6_list[index]}/{v6_prefix_length}": {}}
     interfaces.update(interface_name)
     interfaces.update(v4_interface)
     interfaces.update(v6_interface)
     logger.info('Configuring IP {}/{} , {}/{} on {} in {} for the T1 interconnectivity'.
                 format(t1_t2_dut_ipv4_list[index], v4_prefix_length,
-                       t1_t2_dut_ipv6_list[index], v6_prefix_length, t1_side_interconnected_port,
+                       t1_t2_dut_ipv6_list[index], v6_prefix_length, t1_side_interconnected_port[hw_platform],
                        duthosts[0].hostname))
 
     logger.info('Configuring BGP in T1 by writing into config_db')
@@ -369,7 +405,7 @@ def duthost_bgp_config(duthosts,
                     }
     bgp_neighbors.update(bgp_neighbor)
     device_neighbor = {
-                                t1_side_interconnected_port:
+                                t1_side_interconnected_port[hw_platform]:
                                 {
                                     "name": "T2",
                                     "port": "Ethernet1"
@@ -430,19 +466,21 @@ def duthost_bgp_config(duthosts,
     loopback_interfaces.update({"Loopback0": {}})
     loopback_interfaces.update({"Loopback0|2.2.2.2/32": {}})
     loopback_interfaces.update({"Loopback0|2::2/128": {}})
-    index = len(t1_ports[duthosts[0].hostname])
-    interface_name = {t2_side_interconnected_port['port_name']: {}}
+    index = len(t1_ports[hw_platform][duthosts[0].hostname])
+    interface_name = {t2_side_interconnected_port[hw_platform]['port_name']: {}}
     v4_interface = {
-                    f"{t2_side_interconnected_port['port_name']}|{t1_t2_snappi_ipv4_list[index]}/{v4_prefix_length}": {}
+                    f"{t2_side_interconnected_port[hw_platform]['port_name']}|"
+                    f"{t1_t2_snappi_ipv4_list[index]}/{v4_prefix_length}": {}
                 }
     v6_interface = {
-                    f"{t2_side_interconnected_port['port_name']}|{t1_t2_snappi_ipv6_list[index]}/{v6_prefix_length}": {}
+                    f"{t2_side_interconnected_port[hw_platform]['port_name']}|"
+                    f"{t1_t2_snappi_ipv6_list[index]}/{v6_prefix_length}": {}
                 }
     interfaces.update(interface_name)
     interfaces.update(v4_interface)
     interfaces.update(v6_interface)
     device_neighbor = {
-                            t2_side_interconnected_port['port_name']:
+                            t2_side_interconnected_port[hw_platform]['port_name']:
                             {
                                 "name": "T1",
                                 "port": "Ethernet1"
@@ -482,10 +520,10 @@ def duthost_bgp_config(duthosts,
                         },
                     }
 
-    if t2_side_interconnected_port['asic_value'] is not None:
-        config_db = 'config_db'+list(t2_side_interconnected_port['asic_value'])[-1]+'.json'
+    if t2_side_interconnected_port[hw_platform]['asic_value'] is not None:
+        config_db = 'config_db'+list(t2_side_interconnected_port[hw_platform]['asic_value'])[-1]+'.json'
         t2_config_db = json.loads(duthosts[2].shell("sonic-cfggen -d -n {} --print-data".
-                                  format(t2_side_interconnected_port['asic_value']))['stdout'])
+                                  format(t2_side_interconnected_port[hw_platform]['asic_value']))['stdout'])
     else:
         config_db = 'config_db.json'
         t2_config_db = json.loads(duthosts[2].shell("sonic-cfggen -d --print-data")['stdout'])
@@ -497,7 +535,7 @@ def duthost_bgp_config(duthosts,
     logger.info('Configuring IP {}/{} , {}/{} on {} in {} for the T1 interconnectivity'.
                 format(t1_t2_snappi_ipv4_list[index], v4_prefix_length,
                        t1_t2_snappi_ipv6_list[index], v6_prefix_length,
-                       t2_side_interconnected_port['port_name'], duthosts[2].hostname))
+                       t2_side_interconnected_port[hw_platform]['port_name'], duthosts[2].hostname))
     if "LOOPBACK_INTERFACE" not in t2_config_db.keys():
         t2_config_db["LOOPBACK_INTERFACE"] = loopback_interfaces
     else:
@@ -538,7 +576,7 @@ def duthost_bgp_config(duthosts,
     loopback_interfaces.update({"Loopback0|3::3/128": {}})
     index = 0
     index_2 = 0
-    for asic_value, portchannel_info in t2_uplink_portchannel_members[duthosts[1].hostname].items():
+    for asic_value, portchannel_info in t2_uplink_portchannel_members[hw_platform][duthosts[1].hostname].items():
         bgp_neighbors = dict()
         device_neighbors = dict()
         device_neighbor_metadatas = dict()
@@ -679,6 +717,7 @@ def generate_mac_address():
 
 def __snappi_bgp_config(api,
                         duthosts,
+                        hw_platform,
                         snappi_ports,
                         traffic_type,
                         route_range):
@@ -699,10 +738,10 @@ def __snappi_bgp_config(api,
     total_routes = 0
     config = api.config()
     # get all the t1 and uplink ports from variables
-    t1_variable_ports = t1_ports[duthosts[0].hostname]
+    t1_variable_ports = t1_ports[hw_platform][duthosts[0].hostname]
     t2_variable_ports = []
     port_tuple = []
-    for asic_value, portchannel_info in t2_uplink_portchannel_members[duthosts[1].hostname].items():
+    for asic_value, portchannel_info in t2_uplink_portchannel_members[hw_platform][duthosts[1].hostname].items():
         for portchannel, ports in portchannel_info.items():
             port_tuple.append(ports)
             for port in ports:
@@ -727,7 +766,7 @@ def __snappi_bgp_config(api,
 
     for _, snappi_test_port in enumerate(snappi_t2_ports):
         po = 1
-        for asic_value, portchannel_info in t2_uplink_portchannel_members[duthosts[1].hostname].items():
+        for asic_value, portchannel_info in t2_uplink_portchannel_members[hw_platform][duthosts[1].hostname].items():
             for portchannel, portchannel_members in portchannel_info.items():
                 for index, mem_port in enumerate(portchannel_members, 1):
                     if snappi_test_port['peer_port'] == mem_port and \
@@ -986,6 +1025,7 @@ def flap_single_fanout_port(fanout_ip, creds, port_name, state):
 
 
 def get_convergence_for_link_flap(duthosts,
+                                  hw_platform,
                                   api,
                                   bgp_config,
                                   flap_details,
@@ -1076,7 +1116,7 @@ def get_convergence_for_link_flap(duthosts,
                 for port in fanout_uplink_snappi_info:
                     if flap_details['port_name'] == port['name']:
                         uplink_port = port['peer_port']
-                for fanout_info in t2_uplink_fanout_info:
+                for fanout_info in t2_uplink_fanout_info[hw_platform]:
                     for port_mapping in fanout_info['port_mapping']:
                         if uplink_port == port_mapping['uplink_port']:
                             fanout_port = port_mapping['fanout_port']
@@ -1601,6 +1641,7 @@ def add_value_to_key(dictionary, key, value):
 
 
 def get_convergence_for_blackout(duthosts,
+                                 hw_platform,
                                  api,
                                  snappi_bgp_config,
                                  traffic_type,
@@ -1676,7 +1717,7 @@ def get_convergence_for_blackout(duthosts,
 
         # Link Down
         portchannel_dict = {}
-        for asic_value, portchannel_info in t2_uplink_portchannel_members[duthosts[1].hostname].items():
+        for asic_value, portchannel_info in t2_uplink_portchannel_members[hw_platform][duthosts[1].hostname].items():
             portchannel_dict.update(portchannel_info)
         number_of_po = math.ceil(blackout_percentage * len(portchannel_dict)/100)
         snappi_port_names = []
@@ -1697,7 +1738,7 @@ def get_convergence_for_blackout(duthosts,
         else:
             required_fanout_mapping = {}
             for uplink_port in uplink_ports:
-                for fanout_info in t2_uplink_fanout_info:
+                for fanout_info in t2_uplink_fanout_info[hw_platform]:
                     for port_mapping in fanout_info['port_mapping']:
                         if uplink_port == port_mapping['uplink_port']:
                             fanout_ip = fanout_info['fanout_ip']

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_port_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_port_flap.py
@@ -5,19 +5,14 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
      fanout_graph_facts_multidut                                                                   # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
      snappi_api, multidut_snappi_ports_for_bgp                                                     # noqa: F401
-from tests.snappi_tests.variables import t1_t2_device_hostnames                                     # noqa: F401
+from tests.snappi_tests.variables import t1_side_interconnected_port, t1_t2_device_hostnames       # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
-     run_bgp_outbound_link_flap_test)                                                               # noqa: F401
+     get_hw_platform, run_bgp_outbound_link_flap_test)                                              # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
 
 logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.topology('multidut-tgen')]
-
-FLAP_DETAILS = {
-        'device_name': t1_t2_device_hostnames[0],
-        'port_name': 'Ethernet120'
-    }
 
 ITERATION = 1
 ROUTE_RANGES = [{
@@ -65,32 +60,40 @@ def test_bgp_outbound_downlink_port_flap(snappi_api,                            
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.ROUTE_RANGES = ROUTE_RANGES
     snappi_extra_params.iteration = ITERATION
-    snappi_extra_params.multi_dut_params.flap_details = FLAP_DETAILS
     snappi_extra_params.test_name = "T1 Interconnectivity flap"
-    if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
 
     ansible_dut_hostnames = []
     for duthost in duthosts:
         ansible_dut_hostnames.append(duthost.hostname)
 
-    for device_hostname in t1_t2_device_hostnames:
+    hw_platform = get_hw_platform(ansible_dut_hostnames)
+    if hw_platform is None:
+        pytest_require(False, "Unknown HW Platform")
+    logger.info("HW Platform: {}".format(hw_platform))
+
+    for device_hostname in t1_t2_device_hostnames[hw_platform]:
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
             pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
-        if t1_t2_device_hostnames[0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[1] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost2 = duthost
-        elif t1_t2_device_hostnames[2] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost3 = duthost
         else:
             continue
 
+    snappi_extra_params.multi_dut_params.flap_details = {
+        'device_name': t1_t2_device_hostnames[hw_platform][0],
+        'port_name': t1_side_interconnected_port[hw_platform]
+    }
+
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     run_bgp_outbound_link_flap_test(api=snappi_api,
                                     creds=creds,
                                     snappi_extra_params=snappi_extra_params)

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_process_crash.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_process_crash.py
@@ -7,7 +7,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
      snappi_api, multidut_snappi_ports_for_bgp                                                      # noqa: F401
 from tests.snappi_tests.variables import t1_t2_device_hostnames                                     # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
-     run_bgp_outbound_process_restart_test)                                                          # noqa: F401
+     get_hw_platform, run_bgp_outbound_process_restart_test)                                        # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -64,31 +64,34 @@ def test_bgp_outbound_downlink_process_crash(snappi_api,                        
                                                             'swss': "/usr/bin/orchagent",
                                                             'syncd': "/usr/bin/syncd",
                                                         }
-    snappi_extra_params.multi_dut_params.host_name = t1_t2_device_hostnames[2]
-    if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
-
     ansible_dut_hostnames = []
     for duthost in duthosts:
         ansible_dut_hostnames.append(duthost.hostname)
 
-    for device_hostname in t1_t2_device_hostnames:
+    hw_platform = get_hw_platform(ansible_dut_hostnames)
+    if hw_platform is None:
+        pytest_require(False, "Unknown HW Platform")
+    logger.info("HW Platform: {}".format(hw_platform))
+
+    for device_hostname in t1_t2_device_hostnames[hw_platform]:
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
             pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
-        if t1_t2_device_hostnames[0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[1] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost2 = duthost
-        elif t1_t2_device_hostnames[2] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost3 = duthost
         else:
             continue
 
+    snappi_extra_params.multi_dut_params.host_name = t1_t2_device_hostnames[hw_platform][2]
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     run_bgp_outbound_process_restart_test(api=snappi_api,
                                           creds=creds,
                                           snappi_extra_params=snappi_extra_params)

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_multi_po_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_multi_po_flap.py
@@ -7,7 +7,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
      snappi_api, multidut_snappi_ports_for_bgp                                                       # noqa: F401
 from tests.snappi_tests.variables import t1_t2_device_hostnames                                     # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
-     run_bgp_outbound_uplink_blackout_test, run_dut_configuration)                                  # noqa: F401
+     run_bgp_outbound_uplink_blackout_test, run_dut_configuration, get_hw_platform)                 # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -58,22 +58,30 @@ def test_dut_configuration(multidut_snappi_ports_for_bgp,                  # noq
     ansible_dut_hostnames = []
     for duthost in duthosts:
         ansible_dut_hostnames.append(duthost.hostname)
-    for device_hostname in t1_t2_device_hostnames:
+
+    hw_platform = get_hw_platform(ansible_dut_hostnames)
+    if hw_platform is None:
+        pytest_require(False, "Unknown HW Platform")
+    logger.info("HW Platform: {}".format(hw_platform))
+
+    for device_hostname in t1_t2_device_hostnames[hw_platform]:
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
             pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
-        if t1_t2_device_hostnames[0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[1] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost2 = duthost
-        elif t1_t2_device_hostnames[2] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost3 = duthost
         else:
             continue
+
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     run_dut_configuration(snappi_extra_params)
 
 
@@ -102,28 +110,32 @@ def test_bgp_outbound_uplink_complete_blackout(snappi_api,                      
     snappi_extra_params.test_name = "T2 Uplink Complete Blackout"
     snappi_extra_params.multi_dut_params.BLACKOUT_PERCENTAGE = 100
 
-    if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
-
     ansible_dut_hostnames = []
     for duthost in duthosts:
         ansible_dut_hostnames.append(duthost.hostname)
-    for device_hostname in t1_t2_device_hostnames:
+
+    hw_platform = get_hw_platform(ansible_dut_hostnames)
+    if hw_platform is None:
+        pytest_require(False, "Unknown HW Platform")
+    logger.info("HW Platform: {}".format(hw_platform))
+
+    for device_hostname in t1_t2_device_hostnames[hw_platform]:
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
             pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
-        if t1_t2_device_hostnames[0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[1] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost2 = duthost
-        elif t1_t2_device_hostnames[2] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost3 = duthost
         else:
             continue
 
+    snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
     run_bgp_outbound_uplink_blackout_test(api=snappi_api,
                                           creds=creds,
@@ -155,28 +167,32 @@ def test_bgp_outbound_uplink_partial_blackout(snappi_api,                       
     snappi_extra_params.test_name = "T2 Uplink Partial Blackout"
     snappi_extra_params.multi_dut_params.BLACKOUT_PERCENTAGE = 50
 
-    if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
-
     ansible_dut_hostnames = []
     for duthost in duthosts:
         ansible_dut_hostnames.append(duthost.hostname)
-    for device_hostname in t1_t2_device_hostnames:
+
+    hw_platform = get_hw_platform(ansible_dut_hostnames)
+    if hw_platform is None:
+        pytest_require(False, "Unknown HW Platform")
+    logger.info("HW Platform: {}".format(hw_platform))
+
+    for device_hostname in t1_t2_device_hostnames[hw_platform]:
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
             pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
-        if t1_t2_device_hostnames[0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[1] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost2 = duthost
-        elif t1_t2_device_hostnames[2] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost3 = duthost
         else:
             continue
 
+    snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
     run_bgp_outbound_uplink_blackout_test(api=snappi_api,
                                           creds=creds,

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_flap.py
@@ -7,7 +7,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
      snappi_api, multidut_snappi_ports_for_bgp                                                       # noqa: F401
 from tests.snappi_tests.variables import t1_t2_device_hostnames                        # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
-     run_bgp_outbound_link_flap_test)                                                               # noqa: F401
+     get_hw_platform, run_bgp_outbound_link_flap_test)                                              # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -67,29 +67,33 @@ def test_bgp_outbound_uplink_po_flap(snappi_api,                                
     snappi_extra_params.test_name = "T2 Uplink Portchannel Flap"
     snappi_extra_params.multi_dut_params.flap_details = FLAP_DETAILS
 
-    if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
-
     ansible_dut_hostnames = []
     for duthost in duthosts:
         ansible_dut_hostnames.append(duthost.hostname)
-    for device_hostname in t1_t2_device_hostnames:
+
+    hw_platform = get_hw_platform(ansible_dut_hostnames)
+    if hw_platform is None:
+        pytest_require(False, "Unknown HW Platform")
+    logger.info("HW Platform: {}".format(hw_platform))
+
+    for device_hostname in t1_t2_device_hostnames[hw_platform]:
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
             pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
-        if t1_t2_device_hostnames[0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[1] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost2 = duthost
-        elif t1_t2_device_hostnames[2] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost3 = duthost
         else:
             continue
 
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     run_bgp_outbound_link_flap_test(api=snappi_api,
                                     creds=creds,
                                     snappi_extra_params=snappi_extra_params)

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_member_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_member_flap.py
@@ -5,9 +5,9 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
      fanout_graph_facts_multidut                                                                     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
      snappi_api, multidut_snappi_ports_for_bgp                                                       # noqa: F401
-from tests.snappi_tests.variables import t1_t2_device_hostnames                         # noqa: F401
+from tests.snappi_tests.variables import t1_t2_device_hostnames                                      # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
-     run_bgp_outbound_link_flap_test)                                                               # noqa: F401
+     get_hw_platform, run_bgp_outbound_link_flap_test)                                              # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -67,28 +67,32 @@ def test_bgp_outbound_uplink_po_member_flap(snappi_api,                         
     snappi_extra_params.test_name = "T2 Uplink Portchannel Member Flap"
     snappi_extra_params.multi_dut_params.flap_details = FLAP_DETAILS
 
-    if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
-
     ansible_dut_hostnames = []
     for duthost in duthosts:
         ansible_dut_hostnames.append(duthost.hostname)
-    for device_hostname in t1_t2_device_hostnames:
+
+    hw_platform = get_hw_platform(ansible_dut_hostnames)
+    if hw_platform is None:
+        pytest_require(False, "Failed to get the hardware platform")
+    logger.info("HW Platform: {}".format(hw_platform))
+
+    for device_hostname in t1_t2_device_hostnames[hw_platform]:
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
             pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
-        if t1_t2_device_hostnames[0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[1] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost2 = duthost
-        elif t1_t2_device_hostnames[2] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost3 = duthost
         else:
             continue
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     run_bgp_outbound_link_flap_test(api=snappi_api,
                                     creds=creds,
                                     snappi_extra_params=snappi_extra_params)

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_process_crash.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_process_crash.py
@@ -7,7 +7,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
      snappi_api, multidut_snappi_ports_for_bgp                                                       # noqa: F401
 from tests.snappi_tests.variables import t1_t2_device_hostnames                                     # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
-     run_bgp_outbound_process_restart_test)                                                          # noqa: F401
+     get_hw_platform, run_bgp_outbound_process_restart_test)                                        # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -64,31 +64,35 @@ def test_bgp_outbound_uplink_process_crash(snappi_api,                          
                                                             'swss': "/usr/bin/orchagent",
                                                             'syncd': "/usr/bin/syncd",
                                                         }
-    snappi_extra_params.multi_dut_params.host_name = t1_t2_device_hostnames[1]
-    if (len(t1_t2_device_hostnames) < 3) or (len(duthosts) < 3):
-        pytest_require(False, "Need minimum of 3 devices : One T1 and Two T2 line cards")
 
     ansible_dut_hostnames = []
     for duthost in duthosts:
         ansible_dut_hostnames.append(duthost.hostname)
 
-    for device_hostname in t1_t2_device_hostnames:
+    hw_platform = get_hw_platform(ansible_dut_hostnames)
+    if hw_platform is None:
+        pytest_require(False, "Unable to get the hardware platform")
+    logger.info("HW Platform: {}".format(hw_platform))
+
+    for device_hostname in t1_t2_device_hostnames[hw_platform]:
         if device_hostname not in ansible_dut_hostnames:
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
             pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
 
     for duthost in duthosts:
-        if t1_t2_device_hostnames[0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[1] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost2 = duthost
-        elif t1_t2_device_hostnames[2] in duthost.hostname:
+        elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost3 = duthost
         else:
             continue
 
+    snappi_extra_params.multi_dut_params.host_name = t1_t2_device_hostnames[hw_platform][1]
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     run_bgp_outbound_process_restart_test(api=snappi_api,
                                           creds=creds,
                                           snappi_extra_params=snappi_extra_params)

--- a/tests/snappi_tests/variables.py
+++ b/tests/snappi_tests/variables.py
@@ -135,7 +135,6 @@ peer_ipv6 = []
 T2_SNAPPI_AS_NUM = 65400
 T2_DUT_AS_NUM = 65100
 BGP_TYPE = 'ebgp'
-t1_t2_device_hostnames = ["sonic-t1", "sonic-t2-uplink", "sonic-t2-downlink"]
 SNAPPI_TRIGGER = 60  # timeout value for snappi operation
 DUT_TRIGGER = 180    # timeout value for dut operation
 
@@ -144,18 +143,6 @@ ipv6_subnet = '2000:1:1:1::1/126'
 v4_prefix_length = int(ipv4_subnet.split('/')[1])
 v6_prefix_length = int(ipv6_subnet.split('/')[1])
 
-# *********** Performance case variables ****************
-# asic_value is None if it's non-chassis based or single line card
-PERFORMANCE_PORTS = {
-                        'Traffic_Tx_Ports': [
-                            {'port_name': 'Ethernet0', 'hostname': t1_t2_device_hostnames[1], 'asic_value': 'asic0'},
-                            {'port_name': 'Ethernet88', 'hostname': t1_t2_device_hostnames[1], 'asic_value': 'asic0'},
-                        ],
-                        'Uplink BGP Session': [
-                            {'port_name': 'Ethernet192', 'hostname': t1_t2_device_hostnames[1], 'asic_value': 'asic1'},
-                            {'port_name': 'Ethernet144', 'hostname': t1_t2_device_hostnames[1], 'asic_value': 'asic1'},
-                        ]
-                    }
 # *********** Outbound case variables ****************
 # Expect the T1 and T2 ports to be routed ports and not part of any portchannel.
 T1_SNAPPI_AS_NUM = 65300
@@ -166,53 +153,75 @@ snappi_community_for_t1 = ["8075:54000"]
 snappi_community_for_t2 = ["8075:316", "8075:10400"]
 fanout_presence = True
 # Note: Increase the MaxSessions in /etc/ssh/sshd_config if the number of fanout ports used is more than 10
-t2_uplink_fanout_info = [
-                            {
-                                 'fanout_ip': '152.148.150.143',
-                                 'port_mapping': [{'fanout_port': 'Ethernet0', 'uplink_port': 'Ethernet0'},
-                                                  {'fanout_port': 'Ethernet88', 'uplink_port': 'Ethernet88'},
-                                                  {'fanout_port': 'Ethernet192', 'uplink_port': 'Ethernet192'},
-                                                  {'fanout_port': 'Ethernet144', 'uplink_port': 'Ethernet144'}]
-                            },
-                            {
-                                'fanout_ip': '152.148.150.142',
-                                'port_mapping': [{'fanout_port': 'Ethernet2', 'uplink_port': 'Ethernet2'},
-                                                 {'fanout_port': 'Ethernet3', 'uplink_port': 'Ethernet3'},
-                                                 {'fanout_port': 'Ethernet4', 'uplink_port': 'Ethernet4'},
-                                                 {'fanout_port': 'Ethernet5', 'uplink_port': 'Ethernet5'}]
-                            }
-                        ]
+t2_uplink_fanout_info = {
+    'HW_PLATFORM1': {
+        'fanout_ip': '10.3.146.9',
+        'port_mapping': [
+            {'fanout_port': 'Ethernet64', 'uplink_port': 'Ethernet0'},
+            {'fanout_port': 'Ethernet68', 'uplink_port': 'Ethernet8'},
+            {'fanout_port': 'Ethernet72', 'uplink_port': 'Ethernet16'},
+            {'fanout_port': 'Ethernet76', 'uplink_port': 'Ethernet24'}
+        ]
+    },
+    'HW_PLATFORM2': {}
+}
+
 # The order of hostname is very important for the outbound test (T1, T2 Uplink, T2 Downlink and Supervisor)
-t1_t2_device_hostnames = ["sonic-t1", "sonic-t2-uplink", "sonic-t2-downlink", "sonic-t2-supervisor"]
+t1_t2_device_hostnames = {
+    'HW_PLATFORM1': [
+        "sonic-t1", "sonic-t2-uplink", "sonic-t2-downlink", "sonic-t2-supervisor"
+    ],
+    'HW_PLATFORM2': [
+    ]
+}
+
 t1_ports = {
-                t1_t2_device_hostnames[0]:
-                [
-                    'Ethernet8',
-                    'Ethernet16'
-                ]
-            }
+     'HW_PLATFORM1': {
+         t1_t2_device_hostnames['HW_PLATFORM1'][0]:
+         [
+            'Ethernet24',
+            'Ethernet28'
+         ]
+     },
+     'HW_PLATFORM2': {
+     }
+}
 
 # asic_value is None if it's non-chassis based or single line card
 t2_uplink_portchannel_members = {
-                                    t1_t2_device_hostnames[1]:
-                                    {
-                                        'asic0':
-                                            {
-                                                'PortChannel0': ['Ethernet0', 'Ethernet88']
-                                            },
-                                        'asic1':
-                                            {
-                                                'PortChannel1': ['Ethernet192', 'Ethernet144']
-                                            }
-                                    }
-                                }
-# TODO: Multiple interconnected ports scenario
-t1_side_interconnected_port = 'Ethernet120'
-t2_side_interconnected_port = {'port_name': 'Ethernet272', 'asic_value': 'asic1'}
+    'HW_PLATFORM1': {
+          t1_t2_device_hostnames['HW_PLATFORM1'][1]: {
+              'asic0': {
+                  'PortChannel0': ['Ethernet0'],
+                  'PortChannel1': ['Ethernet8'],
+                  'PortChannel2': ['Ethernet16'],
+                  'PortChannel3': ['Ethernet24'],
+              },
+              'asic1': {
+              }
+          }
+    },
+    'HW_PLATFORM2': {
 
-routed_port_count = 1+len(t1_ports[t1_t2_device_hostnames[0]])
+    }
+}
+
+# TODO: Multiple interconnected ports scenario
+t1_side_interconnected_port = {
+    'HW_PLATFORM1': 'Ethernet0',
+    'HW_PLATFORM2': None
+}
+
+t2_side_interconnected_port = {
+    'HW_PLATFORM1': {'port_name': 'Ethernet272', 'asic_value': 'asic1'},
+    'HW_PLATFORM2': {}
+}
+
+routed_port_count = 1+len(t1_ports[list(t1_ports.keys())[0]][
+                          t1_t2_device_hostnames[list(t1_t2_device_hostnames.keys())[0]][0]])
 portchannel_count = sum([len(portchannel_info) for _, portchannel_info in
-                        t2_uplink_portchannel_members[t1_t2_device_hostnames[1]].items()])
+                        t2_uplink_portchannel_members[list(t2_uplink_portchannel_members.keys())[0]][
+                        t1_t2_device_hostnames[list(t1_t2_device_hostnames.keys())[0]][1]].items()])
 
 
 def generate_ips_for_bgp_case(ipv4_subnet, ipv6_subnet):
@@ -242,10 +251,5 @@ t1_t2_snappi_ipv6_list = peer_ipv6[:routed_port_count]
 
 t2_dut_portchannel_ipv6_list = ipv6[routed_port_count:]
 snappi_portchannel_ipv6_list = peer_ipv6[routed_port_count:]
-
-t2_dut_ipv4_list = ip[:len(PERFORMANCE_PORTS['Traffic_Tx_Ports'] + PERFORMANCE_PORTS['Uplink BGP Session'])]
-t2_dut_ipv6_list = ipv6[:len(PERFORMANCE_PORTS['Traffic_Tx_Ports'] + PERFORMANCE_PORTS['Uplink BGP Session'])]
-t2_snappi_ipv4_list = peer_ip[:len(PERFORMANCE_PORTS['Traffic_Tx_Ports'] + PERFORMANCE_PORTS['Uplink BGP Session'])]
-t2_snappi_ipv6_list = peer_ipv6[:len(PERFORMANCE_PORTS['Traffic_Tx_Ports'] + PERFORMANCE_PORTS['Uplink BGP Session'])]
 
 # END ---------------------   T2 BGP Case -------------------


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Code changes to support multiple platforms for T2 Snappi Based route convergence tests

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Currently the Snappi based T2 route convergence tests can only be used with single set of duts (hardcoded in variables.py). 
Enhanced the testcases/Infra to provide support for more than one platforms. The platform is fetched at runtime based on testbed parameters.

#### How did you do it?
Fetch the platform info first by comparing the DUTs passed in testcase and duts defined in variables.py.
Use this platform info through out the tests to fetch various other parameters

#### How did you verify/test it?
Ran the T2 snappi route convergance tests

#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
