### PR TITLE
Temporary skip `dualtor_mgmt/test_toggle_mux.py` for low passing rate in KVM

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -622,7 +622,7 @@ dualtor_mgmt/test_server_failure.py::test_server_reboot:
     conditions:
       - "asic_type in ['vs']"
 
-dualtor_mgmt/test_toggle_mux.py::test_toggle_mux_from_simulator:
+dualtor_mgmt/test_toggle_mux.py:
   skip:
     reason: "This testcase has low passing rate in KVM PR test, skip with issue to unblock PR test."
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -622,6 +622,12 @@ dualtor_mgmt/test_server_failure.py::test_server_reboot:
     conditions:
       - "asic_type in ['vs']"
 
+dualtor_mgmt/test_toggle_mux.py::test_toggle_mux_from_simulator:
+  skip:
+    reason: "This testcase has low passing rate in KVM PR test, skip with issue to unblock PR test."
+    conditions:
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/15958"
+
 #######################################
 #####         dut_console         #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Testcase `dualtor_mgmt/test_toggle_mux.py` has low passing rate in KVM, which may block some PR tests.
![image](https://github.com/user-attachments/assets/b7beff3d-110f-4493-8444-334a81937c74)

Error message:
```
>           pytest.fail('Toggle mux from simulator test failed')
E           Failed: Toggle mux from simulator test failed

check_result = False
duthosts   = [<MultiAsicSonicHost vlab-05>, <MultiAsicSonicHost vlab-06>]
get_mux_status = <function get_mux_status.<locals>._get_mux_status at 0x7baf5e6b0550>
simulator_muxstatus = {'mbr-vms6-4-0': {'active_port': 'vlab-06-1', 'active_side': 'lower_tor', 'bridge': 'mbr-vms6-4-0', 'flap_counter': 1,...11': {'active_port': 'vlab-06-12', 'active_side': 'lower_tor', 'bridge': 'mbr-vms6-4-11', 'flap_counter': 3, ...}, ...}
```
#### How did you do it?
Temporary skip with issue https://github.com/sonic-net/sonic-mgmt/issues/15958 in KVM
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
