### PR TITLE
[default-route-bgp-flap]: Fix for 9052 - test failure

### DIFF
--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -36,7 +36,7 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
     return None
 
 
-def get_upstream_neigh(tb, device_neigh_metadata):
+def get_upstream_neigh(tb, device_neigh_metadata, af, nexthops):
     """
     Get the information for upstream neighbors present in the testbed
 
@@ -54,21 +54,19 @@ def get_upstream_neigh(tb, device_neigh_metadata):
     for neigh_name, neigh_cfg in list(topo_cfg_facts.items()):
         if neigh_type not in neigh_name:
             continue
-        if neigh_type == 'T3' and device_neigh_metadata[neigh_name]['type'] == 'AZNGHub':
-            continue
         interfaces = neigh_cfg.get('interfaces', {})
         ipv4_addr = None
         ipv6_addr = None
         for intf, intf_cfg in list(interfaces.items()):
             if 'Port-Channel' in intf:
-                if 'ipv4' in intf_cfg:
+                if 'ipv4' in intf_cfg and af in intf_cfg and interfaces[intf]['ipv4'].split('/')[0] in nexthops:
                     ipv4_addr = interfaces[intf]['ipv4'].split('/')[0]
-                if 'ipv6' in intf_cfg:
+                if 'ipv6' in intf_cfg and af in intf_cfg and interfaces[intf]['ipv6'].split('/')[0].lower() in nexthops:
                     ipv6_addr = interfaces[intf]['ipv6'].split('/')[0]
             elif 'Ethernet' in intf:
-                if 'ipv4' in intf_cfg:
+                if 'ipv4' in intf_cfg and af in intf_cfg and interfaces[intf]['ipv4'].split('/')[0] in nexthops:
                     ipv4_addr = interfaces[intf]['ipv4']
-                if 'ipv6' in intf_cfg:
+                if 'ipv6' in intf_cfg and af in intf_cfg and interfaces[intf]['ipv6'].split('/')[0].lower() in nexthops:
                     ipv6_addr = interfaces[intf]['ipv6']
             else:
                 continue
@@ -113,7 +111,7 @@ def verify_default_route_in_app_db(duthost, tbinfo, af, uplink_ns, device_neigh_
     pytest_assert(nexthops is not None, "Default route has not nexthops")
     logging.info("nexthops in app_db {}".format(nexthops))
 
-    upstream_neigh = get_upstream_neigh(tbinfo, device_neigh_metadata)
+    upstream_neigh = get_upstream_neigh(tbinfo, device_neigh_metadata, af, nexthops)
     pytest_assert(upstream_neigh is not None,
                   "No upstream neighbors in the testbed")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR fixes issue #9052, where '_test_default_route_with_bgp_flap_' fails with "_Default route nexthops doesn't match the testbed topology_" issue.

The count of the next hops is not matching with the upstream neighbor as per the topology (reading data from config facts).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
-  '_test_default_route_with_bgp_flap_' fails with "_Default route nexthops doesn't match the testbed topology_" issue.
- The count of the next hops is not matching with the upstream neighbor as per the topology.

#### How did you do it?
- Instead of skipping T3 neighbors of AZNGHub, use the address family and next hops information to find out the list of upstream neighbors.

#### How did you verify/test it?
- Ran the above-mentioned test case on a T2 chassis and made sure the test passed without any issues.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/user-attachments/assets/03516f51-63f0-41bb-be9e-eb9ae2c18d92)


![image](https://github.com/user-attachments/assets/0932f1fb-0754-4949-b50d-33a8007d878d)
