### PR TITLE
T2/Snappi: Move global definitions of test and background flow rates to be local to the function they are used.

### DIFF
--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_multi_node_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_multi_node_helper.py
@@ -19,9 +19,7 @@ logger = logging.getLogger(__name__)
 PAUSE_FLOW_NAME = 'Pause Storm'
 WARM_UP_TRAFFIC_NAME = "Warm Up Traffic"
 TEST_FLOW_NAME = 'Test Flow'
-TEST_FLOW_AGGR_RATE_PERCENT = 45
 BG_FLOW_NAME = 'Background Flow'
-BG_FLOW_AGGR_RATE_PERCENT = 45
 WARM_UP_TRAFFIC_DUR = 1
 DATA_PKT_SIZE = 1024
 SNAPPI_POLL_DELAY_SEC = 2
@@ -112,10 +110,10 @@ def run_pfcwd_multi_node_test(api,
 
     speed_str = testbed_config.layer1[0].speed
     speed_gbps = int(speed_str.split('_')[1])
+    TEST_FLOW_AGGR_RATE_PERCENT = 45
+    BG_FLOW_AGGR_RATE_PERCENT = 45
     # Backplane is 200G in Cisco platforms.
     if speed_gbps > 200 and cisco_platform:
-        global TEST_FLOW_AGGR_RATE_PERCENT
-        global BG_FLOW_AGGR_RATE_PERCENT
         TEST_FLOW_AGGR_RATE_PERCENT = TEST_FLOW_AGGR_RATE_PERCENT * 200 / speed_gbps
         BG_FLOW_AGGR_RATE_PERCENT = BG_FLOW_AGGR_RATE_PERCENT * 200 / speed_gbps
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes this problem:
```
                    * 1e9 * data_flow_dur_sec / 8.0 / data_pkt_size
&gt;               deviation = (rx_frames - exp_bg_flow_rx_pkts) / float(exp_bg_flow_rx_pkts)
E               ZeroDivisionError: float division by zero

bg_flow_name = 'Background Flow'
bg_flow_rate_percent = 0
data_flow_dur_sec = 2
data_pkt_size = 1024
dst_port_id = 0
exp_bg_flow_rx_pkts = 0.0
exp_test_flow_rx_pkts = 1953125.0
flow_name  = 'Background Flow 1 -&gt; 0 Prio 1'
pause_flow_name = 'Pause Storm'
pause_port_id = 0
row        = &lt;snappi.snappi.FlowMetric object at 0x7ff2ccffa980&gt;
rows       = &lt;snappi.snappi.FlowMetricIter object at 0x7ff2cd3df880&gt;
rx_frames  = 1
speed_gbps = 400
src_port_id = 2
test_flow_name = 'Test Flow'
test_flow_rate_percent = 2
tolerance  = 0.05
trigger_pfcwd = True
tx_frames  = 1

snappi_tests/multidut/pfcwd/files/pfcwd_multidut_multi_node_helper.py:633: ZeroDivisionError
```
This issue happens since the initialization for TEST_FLOW_AGGR_RATE_PERCENT and BG_FLOW_AGGR_RATE_PERCENT are global, and everytime the function run_pfcwd_multi_node_test() is called, their value is halved. After 4-5 times of halving, the int() value of the above variables is zero. This results in the above traceback at the 4th or 5th call.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Fixing the ZeroDivision problem.

#### How did you do it?
Moved the global definition to the function scope.

#### How did you verify/test it?
Ran it on my TB:
```
=========================================================================================================================== PASSES ===========================================================================================================================
______________________________________________________________________________________________________ test_pfcwd_many_to_one[multidut_port_info0-True] ______________________________________________________________________________________________________
______________________________________________________________________________________________________ test_pfcwd_many_to_one[multidut_port_info1-True] ______________________________________________________________________________________________________
_________________________________________________________________________________________________ test_multidut_pfcwd_all_to_all[multidut_port_info0-False] __________________________________________________________________________________________________
_________________________________________________________________________________________________ test_multidut_pfcwd_all_to_all[multidut_port_info1-False] __________________________________________________________________________________________________
------------------------------------------------------------------------------ generated xml file: /run_logs/ixia/zero-division/2024-12-09-02-43-06/tr_2024-12-09-02-43-06.xml -------------------------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------------------------------
02:55:06 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================================================== short test summary info ===================================================================================================================
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_m2o_with_snappi.py::test_pfcwd_many_to_one[multidut_port_info0-True]
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_m2o_with_snappi.py::test_pfcwd_many_to_one[multidut_port_info1-True]
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all[multidut_port_info0-False]
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all[multidut_port_info1-False]
========================================================================================================= 4 passed, 8 warnings in 717.52s (0:11:57) ==========================================================================================================
```
#### Any platform specific information?
The issue is specific to cisco-8000.