### PR TITLE
Change the verify_in_flight_buffer_pkts to use ingress duthost's buffer size

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -553,7 +553,8 @@ def verify_basic_test_flow(flow_metrics,
     snappi_extra_params.test_tx_frames = test_tx_frames
 
 
-def verify_in_flight_buffer_pkts(duthost,
+def verify_in_flight_buffer_pkts(egress_duthost,
+                                 ingress_duthost,
                                  flow_metrics,
                                  snappi_extra_params, asic_value=None):
     """
@@ -561,7 +562,8 @@ def verify_in_flight_buffer_pkts(duthost,
     for when test traffic is expected to be paused
 
     Args:
-        duthost (obj): DUT host object
+        egress_duthost  (obj): DUT host object for egress.
+        ingress_duthost (obj): DUT host object for ingress.
         flow_metrics (list): per-flow statistics
         snappi_extra_params (SnappiTestParams obj): additional parameters for Snappi traffic
     Returns:
@@ -570,7 +572,7 @@ def verify_in_flight_buffer_pkts(duthost,
     data_flow_config = snappi_extra_params.traffic_flow_config.data_flow_config
     tx_frames_total = sum(metric.frames_tx for metric in flow_metrics if data_flow_config["flow_name"] in metric.name)
     tx_bytes_total = tx_frames_total * data_flow_config["flow_pkt_size"]
-    dut_buffer_size = get_lossless_buffer_size(host_ans=duthost)
+    dut_buffer_size = get_lossless_buffer_size(host_ans=ingress_duthost)
     headroom_test_params = snappi_extra_params.headroom_test_params
     dut_port_config = snappi_extra_params.base_flow_config["dut_port_config"]
     pytest_assert(dut_port_config is not None, "Flow port config is not provided")
@@ -589,7 +591,7 @@ def verify_in_flight_buffer_pkts(duthost,
 
         for peer_port, prios in dut_port_config[0].items():
             for prio in prios:
-                dropped_packets = get_pg_dropped_packets(duthost, peer_port, prio, asic_value)
+                dropped_packets = get_pg_dropped_packets(egress_duthost, peer_port, prio, asic_value)
                 pytest_assert(dropped_packets > 0,
                               "Total TX dropped packets {} should be more than 0".
                               format(dropped_packets))
@@ -600,7 +602,7 @@ def verify_in_flight_buffer_pkts(duthost,
 
         for peer_port, prios in dut_port_config[0].items():
             for prio in prios:
-                dropped_packets = get_pg_dropped_packets(duthost, peer_port, prio, asic_value)
+                dropped_packets = get_pg_dropped_packets(egress_duthost, peer_port, prio, asic_value)
                 pytest_assert(dropped_packets == 0,
                               "Total TX dropped packets {} should be 0".
                               format(dropped_packets))

--- a/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/multidut_helper.py
@@ -291,7 +291,8 @@ def run_pfc_test(api,
 
     if test_traffic_pause:
         # Verify in flight TX packets count relative to switch buffer size
-        verify_in_flight_buffer_pkts(duthost=egress_duthost,
+        verify_in_flight_buffer_pkts(egress_duthost=egress_duthost,
+                                     ingress_duthost=ingress_duthost,
                                      flow_metrics=in_flight_flow_metrics,
                                      snappi_extra_params=snappi_extra_params,
                                      asic_value=tx_port['asic_value'])

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -290,7 +290,8 @@ def run_pfc_test(api,
 
     if test_traffic_pause:
         # Verify in flight TX packets count relative to switch buffer size
-        verify_in_flight_buffer_pkts(duthost=duthost,
+        verify_in_flight_buffer_pkts(egress_duthost=duthost,
+                                     ingress_duthost=duthost,
                                      flow_metrics=in_flight_flow_metrics,
                                      snappi_extra_params=snappi_extra_params)
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The function: verify_in_flight_buffer_pkts is using the egress duthost's buffer size to verify the amount of packets that are transmitted is below the buffer size. That number is greatly influenced by the ingress buffer size when long links are in use as HBM is used with large XOFF threshold. Update this function to use the ingress DUT's buffer size.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Updated the function to take ingress_duthost and egress_duthost, instead of just duthost.

#### How did you verify/test it?
Ran it in my TB:
```
=========================================================================================================== PASSES ===========================================================================================================
___________________________________________________________________________ test_pfc_pause_single_lossless_prio[multidut_port_info0-yy39top-lc4|3] ___________________________________________________________________________
___________________________________________________________________________ test_pfc_pause_single_lossless_prio[multidut_port_info0-yy39top-lc4|4] ___________________________________________________________________________
___________________________________________________________________________ test_pfc_pause_single_lossless_prio[multidut_port_info1-yy39top-lc4|3] ___________________________________________________________________________
___________________________________________________________________________ test_pfc_pause_single_lossless_prio[multidut_port_info1-yy39top-lc4|4] ___________________________________________________________________________
__________________________________________________________________________________ test_pfc_pause_multi_lossless_prio[multidut_port_info0] ___________________________________________________________________________________
__________________________________________________________________________________ test_pfc_pause_multi_lossless_prio[multidut_port_info1] ___________________________________________________________________________________
_____________________________________________________________________ test_pfc_pause_single_lossless_prio_reboot[multidut_port_info0-cold-yy39top-lc4|3] _____________________________________________________________________
_____________________________________________________________________ test_pfc_pause_single_lossless_prio_reboot[multidut_port_info1-cold-yy39top-lc4|3] _____________________________________________________________________
____________________________________________________________________________ test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info0-cold] _____________________________________________________________________________
____________________________________________________________________________ test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info1-cold] _____________________________________________________________________________
--------------------------------------------------------------- generated xml file: /run_logs/ixia/buffer_size/2024-12-09-23-31-36/tr_2024-12-09-23-31-36.xml ----------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
--------------------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------------------
01:13:18 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================================== short test summary info ===================================================================================================
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info0-yy39top-lc4|3]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info0-yy39top-lc4|4]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info1-yy39top-lc4|3]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info1-yy39top-lc4|4]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio[multidut_port_info0]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio[multidut_port_info1]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[multidut_port_info0-cold-yy39top-lc4|3]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[multidut_port_info1-cold-yy39top-lc4|3]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info0-cold]
PASSED snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info1-cold]
SKIPPED [2] snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py:139: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py:139: Reboot type fast is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py:199: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py:199: Reboot type fast is not supported on cisco-8000 switches
================================================================================== 10 passed, 8 skipped, 14 warnings in 6099.48s (1:41:39) ===================================================================================
sonic@snappi-sonic-mgmt-vanilla-202405-t2:/data/tests$ 
```
#### Any platform specific information?
@sdszhang , @auspham : Pls let me know if this has to be only for cisco-8000, or applicable to all platforms.