### PR TITLE
Update test_turn_off_psu_and_check_psu_info to handle PSUs with multiple PDUs

### DIFF
--- a/tests/common/helpers/psu_helpers.py
+++ b/tests/common/helpers/psu_helpers.py
@@ -39,7 +39,7 @@ def check_outlet_status(pdu_controller, outlet, expect_status=True):
     return 'outlet_on' in status[0] and status[0]['outlet_on'] == expect_status
 
 
-def get_grouped_PDUs_by_PSU(pdu_controller):
+def get_grouped_pdus_by_psu(pdu_controller):
     """Returns a grouping of PDUs associated with a PSU in dictionary form
 
     Args:

--- a/tests/common/helpers/psu_helpers.py
+++ b/tests/common/helpers/psu_helpers.py
@@ -50,11 +50,11 @@ def get_grouped_pdus_by_psu(pdu_controller):
     """
     # Group outlets/PDUs by PSU
     outlet_status = pdu_controller.get_outlet_status()
-    PSU_to_PDUs = {}
+    psu_to_pdus = {}
     for outlet in outlet_status:
-        if outlet['psu_name'] not in PSU_to_PDUs:
-            PSU_to_PDUs[outlet['psu_name']] = [outlet]
+        if outlet['psu_name'] not in psu_to_pdus:
+            psu_to_pdus[outlet['psu_name']] = [outlet]
         else:
-            PSU_to_PDUs[outlet['psu_name']].append(outlet)
+            psu_to_pdus[outlet['psu_name']].append(outlet)
 
-    return PSU_to_PDUs
+    return psu_to_pdus

--- a/tests/common/helpers/psu_helpers.py
+++ b/tests/common/helpers/psu_helpers.py
@@ -1,0 +1,60 @@
+import logging
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+
+
+def turn_on_all_outlets(pdu_controller):
+    """Turns on all outlets through SNMP and confirms they are turned on successfully
+
+    Args:
+        pdu_controller (BasePduController): Instance of PDU controller
+
+    Returns:
+        None
+    """
+    logging.info("Turning on all outlets/PDUs")
+    outlet_status = pdu_controller.get_outlet_status()
+    for outlet in outlet_status:
+        if not outlet['outlet_on']:
+            pdu_controller.turn_on_outlet(outlet)
+
+    for outlet in outlet_status:
+        pytest_assert(wait_until(60, 5, 0, check_outlet_status,
+                      pdu_controller, outlet, True),
+                      "Outlet {} did not turn on".format(outlet['pdu_name']))
+
+
+def check_outlet_status(pdu_controller, outlet, expect_status=True):
+    """Check if a given PDU matches the expected status
+
+    Args:
+        pdu_controller (BasePduController): Instance of PDU controller
+        outlet (RPS outlet): Outlet whose status is to be checked
+        expect_status (boolean): Expected status in True/False (On/Off)
+
+    Returns:
+        boolean: True if the outlet matches expected status, False otherwise
+    """
+    status = pdu_controller.get_outlet_status(outlet)
+    return 'outlet_on' in status[0] and status[0]['outlet_on'] == expect_status
+
+
+def get_grouped_PDUs_by_PSU(pdu_controller):
+    """Returns a grouping of PDUs associated with a PSU in dictionary form
+
+    Args:
+        pdu_controller (BasePduController): Instance of PDU controller
+
+    Returns:
+        dict: {PSU: array of PDUs} where PDUs are associated with PSU
+    """
+    # Group outlets/PDUs by PSU
+    outlet_status = pdu_controller.get_outlet_status()
+    PSU_to_PDUs = {}
+    for outlet in outlet_status:
+        if outlet['psu_name'] not in PSU_to_PDUs:
+            PSU_to_PDUs[outlet['psu_name']] = [outlet]
+        else:
+            PSU_to_PDUs[outlet['psu_name']].append(outlet)
+
+    return PSU_to_PDUs

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -277,7 +277,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
 
     # Increase pdu_wait_time for modular chassis
     pdu_wait_time = PDU_WAIT_TIME
-    is_modular_chassis = duthosts[0].get_facts().get("module_chassis")
+    is_modular_chassis = duthosts[0].get_facts().get("modular_chassis")
     if is_modular_chassis:
         pdu_wait_time = MODULAR_CHASSIS_PDU_WAIT_TIME
 

--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -3,11 +3,14 @@ import logging
 import pytest
 import re
 import time
+import random
 from enum import Enum, unique
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.snmp_helpers import get_snmp_facts
-from tests.common.helpers.thermal_control_test_helper import mocker_factory     # noqa F401
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.psu_helpers import turn_on_all_outlets, check_outlet_status, get_grouped_PDUs_by_PSU
+from tests.platform_tests.thermal_control_test_helper import mocker_factory     # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -634,31 +637,36 @@ def test_turn_off_psu_and_check_psu_info(duthosts, enum_supervisor_dut_hostname,
     pdu_controller = get_pdu_controller(duthost)
     if not pdu_controller:
         pytest.skip('psu_controller is None, skipping this test')
+
     outlet_status = pdu_controller.get_outlet_status()
     if len(outlet_status) < 2:
         pytest.skip(
             'At least 2 PSUs required for rest of the testing in this case')
 
-    # turn on all PSU
-    for outlet in outlet_status:
-        if not outlet['outlet_on']:
-            pdu_controller.turn_on_outlet(outlet)
-    time.sleep(5)
+    # Turn on all PDUs
+    logging.info("Turning all outlets on before test")
+    turn_on_all_outlets(pdu_controller)
 
-    outlet_status = pdu_controller.get_outlet_status()
-    for outlet in outlet_status:
-        if not outlet['outlet_on']:
-            pytest.skip(
-                'Not all outlet are powered on, skip rest of the testing in this case')
+    PSU_to_PDUs = get_grouped_PDUs_by_PSU(pdu_controller)
+    try:
+        logging.info("Turning off PDUs connected to a random PSU")
+        # Get a random PSU's related PDUs to turn off
+        off_psu = random.choice(list(PSU_to_PDUs.keys()))
+        outlets = PSU_to_PDUs[off_psu]
+        logging.info("Toggling {} PDUs".format(off_psu))
+        for outlet in outlets:
+            pdu_controller.turn_off_outlet(outlet)
+            pytest_assert(wait_until(30, 5, 0, check_outlet_status,
+                          pdu_controller, outlet, False),
+                          "Outlet {} did not turn off".format(outlet['pdu_name']))
 
-    # turn off the first PSU
-    first_outlet = outlet_status[0]
-    pdu_controller.turn_off_outlet(first_outlet)
-    assert wait_until(30, 5, 0, check_outlet_status,
-                      pdu_controller, first_outlet, False)
-    # wait for psud update the database
-    assert wait_until(180, 20, 5, _check_psu_status_after_power_off,
-                      duthost, localhost, creds_all_duts)
+        logging.info("Checking that turning off these outlets affects PSUs")
+        # wait for psud update the database
+        pytest_assert(wait_until(180, 20, 5, _check_psu_status_after_power_off,
+                      duthost, localhost, creds_all_duts),
+                      "No PSUs turned off")
+    finally:
+        turn_on_all_outlets(pdu_controller)
 
 
 def _check_psu_status_after_power_off(duthost, localhost, creds_all_duts):
@@ -844,15 +852,3 @@ def is_null_str(value):
     :return: True if a string is None or 'None' or 'N/A'
     """
     return not value or value == str(None) or value == 'N/A'
-
-
-def check_outlet_status(pdu_controller, outlet, expect_status):
-    """
-    Check if a given PSU is at expect status
-    :param pdu_controller: PDU controller
-    :param outlet: PDU outlet
-    :param expect_status: Expect bool status, True means on, False means off
-    :return: True if a given PSU is at expect status
-    """
-    status = pdu_controller.get_outlet_status(outlet)
-    return 'outlet_on' in status[0] and status[0]['outlet_on'] == expect_status

--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -9,7 +9,7 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.psu_helpers import turn_on_all_outlets, check_outlet_status, get_grouped_PDUs_by_PSU
+from tests.common.helpers.psu_helpers import turn_on_all_outlets, check_outlet_status, get_grouped_pdus_by_psu
 from tests.platform_tests.thermal_control_test_helper import mocker_factory     # noqa F401
 
 pytestmark = [
@@ -647,13 +647,13 @@ def test_turn_off_psu_and_check_psu_info(duthosts, enum_supervisor_dut_hostname,
     logging.info("Turning all outlets on before test")
     turn_on_all_outlets(pdu_controller)
 
-    PSU_to_PDUs = get_grouped_PDUs_by_PSU(pdu_controller)
+    psu_to_pdus = get_grouped_pdus_by_psu(pdu_controller)
     try:
         logging.info("Turning off PDUs connected to a random PSU")
         # Get a random PSU's related PDUs to turn off
-        off_psu = random.choice(list(PSU_to_PDUs.keys()))
-        outlets = PSU_to_PDUs[off_psu]
-        logging.info("Toggling {} PDUs".format(off_psu))
+        off_psu = random.choice(list(psu_to_pdus.keys()))
+        outlets = psu_to_pdus[off_psu]
+        logging.info("Toggling {} PDUs connected to {}".format(len(outlets), off_psu))
         for outlet in outlets:
             pdu_controller.turn_off_outlet(outlet)
             pytest_assert(wait_until(30, 5, 0, check_outlet_status,
@@ -662,7 +662,7 @@ def test_turn_off_psu_and_check_psu_info(duthosts, enum_supervisor_dut_hostname,
 
         logging.info("Checking that turning off these outlets affects PSUs")
         # wait for psud update the database
-        pytest_assert(wait_until(180, 20, 5, _check_psu_status_after_power_off,
+        pytest_assert(wait_until(900, 20, 5, _check_psu_status_after_power_off,
                       duthost, localhost, creds_all_duts),
                       "No PSUs turned off")
     finally:

--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -10,7 +10,7 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.psu_helpers import turn_on_all_outlets, check_outlet_status, get_grouped_pdus_by_psu
-from tests.platform_tests.thermal_control_test_helper import mocker_factory     # noqa F401
+from tests.common.helpers.thermal_control_test_helper import mocker_factory     # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any'),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update test_turn_off_psu_and_check_psu_info to ensure that it handles PSUs with multilpe PDUs correctly
Update test_turn_on_off_psu_and_check_psustatus to handle PSUs with multiple PDUs correctly

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
* Instead of toggling one outlet/PDU, toggle a full set of PDUs connected to one PSU
* Move common PSU helpers function to new psu_helpers.py in tests/common/helpers folder
* Add try / catch block to ensure all PSUs are turned back on after the test

#### What is the motivation for this PR?
Prevent test from failing when toggling a PDU connected to a PSU that will stay on due to other redundant PDUs that were not toggled.
#### How did you do it?
Break PDUs into sets based on PSU, make sure to toggle whole sets at once.
#### How did you verify/test it?
https://elastictest.org/scheduler/testplan/675919214fa1c38a7e20b96c <- T0/T1 regression test
Tested on T2 testbed as well (bar known issues with certain testbed types)
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A