### PR TITLE
[loganalyzer] Get the modular_chassis fact only when the duthosts[0] is available

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -53,7 +53,7 @@ def log_rotate_modular_chassis(duthosts, request):
     if request.config.getoption("--disable_loganalyzer") or "disable_loganalyzer" in request.keywords:
         return
 
-    is_modular_chassis = duthosts[0].get_facts().get("modular_chassis")
+    is_modular_chassis = duthosts[0].get_facts().get("modular_chassis") if duthosts else False
 
     if not is_modular_chassis:
         return
@@ -73,7 +73,7 @@ def loganalyzer(duthosts, request, log_rotate_modular_chassis):
     store_la_logs = request.config.getoption("--store_la_logs")
     analyzers = {}
     should_rotate_log = request.config.getoption("--loganalyzer_rotate_logs")
-    is_modular_chassis = duthosts[0].get_facts().get("modular_chassis")
+    is_modular_chassis = duthosts[0].get_facts().get("modular_chassis") if duthosts else False
 
     # We make sure only run logrotate as "function" scope for non-modular chassis for optimisation purpose.
     # For modular chassis please refer to "log_rotate_modular_chassis" fixture


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The duthosts could be a empty list with some special testbed, get the modular_chassis fact only when the duthosts[0] is available, otherwise it's not a modular chassis.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
See the summary.
#### How did you do it?
See the summary.
#### How did you verify/test it?
Run regression with this change, no issues observed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
