### PR TITLE
[dhcp_relay] Increase wait time for default route check in dhcp_relay test

### DIFF
--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -146,7 +146,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
 def validate_dut_routes_exist(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data):
     """Fixture to valid a route to each DHCP server exist
     """
-    py_assert(wait_until(120, 5, 0, check_routes_to_dhcp_server, duthosts[rand_one_dut_hostname],
+    py_assert(wait_until(360, 5, 0, check_routes_to_dhcp_server, duthosts[rand_one_dut_hostname],
                          dut_dhcp_relay_data),
               "Packets relayed to DHCP server should go through default route via upstream neighbor, but now it's" +
               " going through mgmt interface, which means device is in an unhealthy status")

--- a/tests/dhcp_relay/dhcp_relay_utils.py
+++ b/tests/dhcp_relay/dhcp_relay_utils.py
@@ -9,6 +9,8 @@ logger = logging.getLogger(__name__)
 def check_routes_to_dhcp_server(duthost, dut_dhcp_relay_data):
     """Validate there is route on DUT to each DHCP server
     """
+    output = duthost.shell("show ip bgp sum", module_ignore_errors=True)
+    logger.info("bgp state: {}".format(output["stdout"]))
     default_gw_ip = dut_dhcp_relay_data[0]['default_gw_ip']
     dhcp_servers = set()
     for dhcp_relay in dut_dhcp_relay_data:

--- a/tests/dhcp_relay/dhcp_relay_utils.py
+++ b/tests/dhcp_relay/dhcp_relay_utils.py
@@ -11,6 +11,8 @@ def check_routes_to_dhcp_server(duthost, dut_dhcp_relay_data):
     """
     output = duthost.shell("show ip bgp sum", module_ignore_errors=True)
     logger.info("bgp state: {}".format(output["stdout"]))
+    output = duthost.shell("show int po", module_ignore_errors=True)
+    logger.info("portchannel state: {}".format(output["stdout"]))
     default_gw_ip = dut_dhcp_relay_data[0]['default_gw_ip']
     dhcp_servers = set()
     for dhcp_relay in dut_dhcp_relay_data:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
There is flaky failure in this case because default route missing

#### How did you do it?
1. Increase wait time for it.
2. Add log for triage

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
