### PR TITLE
Update the conditional mark skip logic to support regular expression

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -420,7 +420,18 @@ def find_all_matches(nodeid, conditions):
 
     for condition in conditions:
         # condition is a dict which has only one item, so we use condition.keys()[0] to get its key.
-        if nodeid.startswith(list(condition.keys())[0]):
+        condition_entry = list(condition.keys())[0]
+        condition_items = condition[condition_entry]
+        if "regex" in condition_items.keys():
+            assert isinstance(condition_items["regex"], bool), \
+                "The value of 'regex' in the mark conditions yaml should be bool type."
+            if condition_items["regex"] is True:
+                match = re.search(condition_entry, nodeid)
+            else:
+                match = None
+        else:
+            match = nodeid.startswith(condition_entry)
+        if match:
             all_matches.append(condition)
 
     for match in all_matches:
@@ -616,6 +627,8 @@ def pytest_collection_modifyitems(session, config, items):
             for match in all_matches:
                 # match is a dict which has only one item, so we use match.values()[0] to get its value.
                 for mark_name, mark_details in list(list(match.values())[0].items()):
+                    if mark_name == "regex":
+                        continue
                     conditions_logical_operator = mark_details.get('conditions_logical_operator', 'AND').upper()
                     add_mark = False
                     if not mark_details:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This change is to support matching the test by regular expression in the conditional mark logic.
Sometimes we need to skip a test by a pytest parameter in the testcase name, which is not supported by the current longest match logic.
For example:
autorestart/test_container_autorestart.py::test_containers_autorestart[dut01-None-**teamd**]
If we only want to skip the **teamd** test case in the test test_container_autorestart.py, we are not able to do that because the first parameter is the dut name and it is different with different testbeds.
With this change, we are able to match the test case name by using a regex pattern, so that the teamd test case can be easily skipped.
The example of the skip condition is like this:
```
autorestart/test_container_autorestart.py::test_containers_autorestart.*teamd:               #regex pattern
  regex: True             #key "regex" with a bool type value
  skip:
    reason: "Testcase ignored due to issue: https://github.com/sonic-net/sonic-buildimage/issues/xxxxx"
    conditions:
      - https://github.com/sonic-net/sonic-buildimage/issues/xxxxx
```

This change is totally backward compatible, we need to add a "regex: True" in the condition to enable the regex match. For the existing conditions, the logic is the same as before.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Update the conditional mark skip logic to support regular expression
#### How did you do it?
Please see the summary
#### How did you verify/test it?
Run regression with this change and skipped conditions with the regex key, no issues observed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
