### PR TITLE
Update test_turn_on_off_psu_and_check_psustatus to handle PSUs with multiple PDUs

### DIFF
--- a/tests/common/helpers/psu_helpers.py
+++ b/tests/common/helpers/psu_helpers.py
@@ -1,0 +1,60 @@
+import logging
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+
+
+def turn_on_all_outlets(pdu_controller):
+    """Turns on all outlets through SNMP and confirms they are turned on successfully
+
+    Args:
+        pdu_controller (BasePduController): Instance of PDU controller
+
+    Returns:
+        None
+    """
+    logging.info("Turning on all outlets/PDUs")
+    outlet_status = pdu_controller.get_outlet_status()
+    for outlet in outlet_status:
+        if not outlet['outlet_on']:
+            pdu_controller.turn_on_outlet(outlet)
+
+    for outlet in outlet_status:
+        pytest_assert(wait_until(60, 5, 0, check_outlet_status,
+                      pdu_controller, outlet, True),
+                      "Outlet {} did not turn on".format(outlet['pdu_name']))
+
+
+def check_outlet_status(pdu_controller, outlet, expect_status=True):
+    """Check if a given PDU matches the expected status
+
+    Args:
+        pdu_controller (BasePduController): Instance of PDU controller
+        outlet (RPS outlet): Outlet whose status is to be checked
+        expect_status (boolean): Expected status in True/False (On/Off)
+
+    Returns:
+        boolean: True if the outlet matches expected status, False otherwise
+    """
+    status = pdu_controller.get_outlet_status(outlet)
+    return 'outlet_on' in status[0] and status[0]['outlet_on'] == expect_status
+
+
+def get_grouped_pdus_by_psu(pdu_controller):
+    """Returns a grouping of PDUs associated with a PSU in dictionary form
+
+    Args:
+        pdu_controller (BasePduController): Instance of PDU controller
+
+    Returns:
+        dict: {PSU: array of PDUs} where PDUs are associated with PSU
+    """
+    # Group outlets/PDUs by PSU
+    outlet_status = pdu_controller.get_outlet_status()
+    psu_to_pdus = {}
+    for outlet in outlet_status:
+        if outlet['psu_name'] not in psu_to_pdus:
+            psu_to_pdus[outlet['psu_name']] = [outlet]
+        else:
+            psu_to_pdus[outlet['psu_name']].append(outlet)
+
+    return psu_to_pdus

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -11,6 +11,7 @@ import pytest
 
 from retry.api import retry_call
 from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.psu_helpers import turn_on_all_outlets, get_grouped_pdus_by_psu
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import wait_until, get_sup_node_or_random_node
 from tests.common.platform.device_utils import get_dut_psu_line_pattern
@@ -27,7 +28,7 @@ CMD_PLATFORM_PSUSTATUS_JSON = "{} --json".format(CMD_PLATFORM_PSUSTATUS)
 CMD_PLATFORM_FANSTATUS = "show platform fan"
 CMD_PLATFORM_TEMPER = "show platform temperature"
 
-PDU_WAIT_TIME = 20
+PDU_WAIT_TIME = 60
 
 THERMAL_CONTROL_TEST_WAIT_TIME = 65
 THERMAL_CONTROL_TEST_CHECK_INTERVAL = 5
@@ -205,17 +206,6 @@ def check_vendor_specific_psustatus(dut, psu_status_line, psu_line_pattern):
         check_psu_sysfs(dut, psu_id, psu_status)
 
 
-def turn_all_outlets_on(pdu_ctrl):
-    all_outlet_status = pdu_ctrl.get_outlet_status()
-    pytest_require(all_outlet_status and len(all_outlet_status) >= 2,
-                   'Skip the test, cannot to get at least 2 outlet status: {}'.format(all_outlet_status))
-    for outlet in all_outlet_status:
-        if not outlet["outlet_on"]:
-            pdu_ctrl.turn_on_outlet(outlet)
-            time.sleep(5)
-    time.sleep(5)
-
-
 def check_all_psu_on(dut, psu_test_results):
     """
         @summary: check all PSUs are in 'OK' status.
@@ -273,7 +263,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
 
     logging.info(
         "To avoid DUT being shutdown, need to turn on PSUs that are not powered")
-    turn_all_outlets_on(pdu_ctrl)
+    turn_on_all_outlets(pdu_ctrl)
 
     logging.info("Initialize test results")
     psu_test_results = {}
@@ -282,7 +272,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
 
     pytest_assert(
         len(list(psu_test_results.keys())) == psu_num,
-        "In consistent PSU number output by '%s' and '%s'" % (CMD_PLATFORM_PSUSTATUS, "sudo psuutil numpsus"))
+        "Inconsistent PSU number output by '%s' and '%s'" % (CMD_PLATFORM_PSUSTATUS, "sudo psuutil numpsus"))
 
     logging.info("Start testing turn off/on PSUs")
     all_outlet_status = pdu_ctrl.get_outlet_status()
@@ -292,39 +282,49 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
         all_outlet_status = all_outlet_status[0:-2]
         logging.info(
             "DUT is MgmtTsToR, the last 2 outlets are reserved for Console Switch and are not visible from DUT.")
-    for outlet in all_outlet_status:
-        psu_under_test = None
-        if outlet['outlet_on'] is False:
-            continue
 
-        logging.info("Turn off outlet {}".format(outlet))
-        pdu_ctrl.turn_off_outlet(outlet)
-        time.sleep(PDU_WAIT_TIME)
+    # Group outlets/PDUs by PSU and toggle PDUs by PSU
+    psu_to_pdus = get_grouped_pdus_by_psu(pdu_ctrl)
 
-        cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
-        for line in cli_psu_status["stdout_lines"][2:]:
-            psu_match = psu_line_pattern.match(line)
-            pytest_assert(psu_match, "Unexpected PSU status output")
-            # also make sure psustatus is not 'NOT PRESENT', which cannot be turned on/off
-            if psu_match.group(2) != "OK" and psu_match.group(2) != "NOT PRESENT":
-                psu_under_test = psu_match.group(1)
-            check_vendor_specific_psustatus(duthost, line, psu_line_pattern)
-        pytest_assert(psu_under_test is not None, "No PSU is turned off")
+    try:
+        for psu in psu_to_pdus.keys():
+            outlets = psu_to_pdus[psu]
+            psu_under_test = None
 
-        logging.info("Turn on outlet {}".format(outlet))
-        pdu_ctrl.turn_on_outlet(outlet)
-        time.sleep(PDU_WAIT_TIME)
+            logging.info("Turning off {} PDUs connected to {}".format(len(outlets), psu))
+            for outlet in outlets:
+                pdu_ctrl.turn_off_outlet(outlet)
+            time.sleep(PDU_WAIT_TIME)
 
-        cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
-        for line in cli_psu_status["stdout_lines"][2:]:
-            psu_match = psu_line_pattern.match(line)
-            pytest_assert(psu_match, "Unexpected PSU status output")
-            if psu_match.group(1) == psu_under_test:
-                pytest_assert(psu_match.group(2) == "OK",
-                              "Unexpected PSU status after turned it on")
-            check_vendor_specific_psustatus(duthost, line, psu_line_pattern)
+            # Check that PSU is turned off
+            cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
+            breakpoint()
+            for line in cli_psu_status["stdout_lines"][2:]:
+                psu_match = psu_line_pattern.match(line)
+                pytest_assert(psu_match, "Unexpected PSU status output")
+                # also make sure psustatus is not 'NOT PRESENT', which cannot be turned on/off
+                if psu_match.group(2) != "OK" and psu_match.group(2) != "NOT PRESENT":
+                    psu_under_test = psu_match.group(1)
+                check_vendor_specific_psustatus(duthost, line, psu_line_pattern)
+            pytest_assert(psu_under_test is not None, "No PSU is turned off")
 
-        psu_test_results[psu_under_test] = True
+            for outlet in outlets:
+                logging.info("Turn on outlet {}".format(outlet))
+                pdu_ctrl.turn_on_outlet(outlet)
+            time.sleep(PDU_WAIT_TIME)
+
+            cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
+            for line in cli_psu_status["stdout_lines"][2:]:
+                psu_match = psu_line_pattern.match(line)
+                pytest_assert(psu_match, "Unexpected PSU status output")
+                if psu_match.group(1) == psu_under_test:
+                    pytest_assert(psu_match.group(2) == "OK",
+                                  "Unexpected PSU status after turned it on")
+                check_vendor_specific_psustatus(duthost, line, psu_line_pattern)
+
+            psu_test_results[psu_under_test] = True
+    finally:
+        turn_on_all_outlets(pdu_ctrl)
 
     for psu in psu_test_results:
         pytest_assert(psu_test_results[psu],

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -298,7 +298,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
 
             # Check that PSU is turned off
             cli_psu_status = duthost.command(CMD_PLATFORM_PSUSTATUS)
-            breakpoint()
+
             for line in cli_psu_status["stdout_lines"][2:]:
                 psu_match = psu_line_pattern.match(line)
                 pytest_assert(psu_match, "Unexpected PSU status output")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update test_turn_on_off_psu_and_check_psustatus to handle PSUs with multiple PDUs correctly
Related: #15972

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
* Instead of toggling one outlet/PDU, toggle a set at a time connected to one PSU
* Move common PSU helpers function to new psu_helpers.py in tests/common/helpers folder
* Add try / catch block to ensure all PSUs are turned back on after the test
#### What is the motivation for this PR?
Prevent test from failing when toggling a PDU connected to a PSU that will stay on due to other redundant PDUs that were not toggled.
#### How did you do it?
Break PDUs into sets based on PSU, make sure to toggle whole sets at once.
#### How did you verify/test it?
TBC
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
