### PR TITLE
Don't exit warmboot-finalizer loop early due to SSH connection issue

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1061,7 +1061,7 @@ class ReloadTest(BaseTest):
         self.finalizer_state = self.get_warmboot_finalizer_state()
         self.log('warmboot finalizer service state {}'.format(self.finalizer_state))
         count = 0
-        while self.finalizer_state == 'activating':
+        while self.finalizer_state == 'activating' or self.finalizer_state == '':
             self.finalizer_state = self.get_warmboot_finalizer_state()
             self.log('warmboot finalizer service state {}'.format(self.finalizer_state))
             time.sleep(10)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

In some cases, connecting to the device may fail for whatever reason. If this happens, the current code returns an empty string as the warmboot-finalizer state. There's a for-loop that exits when the warmboot-finalizer state is no longer active. An empty string being returned here breaks that.

#### How did you do it?

To avoid that, don't exit this loop if we get an empty string.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
