### PR TITLE
Add SAI_OBJECT_TYPE_ROUTE_ENTRY:.*doesn't exist ERR to ignore list

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -309,3 +309,6 @@ r, ".* ERR sshd\[\d*\]: auth fail.*"
 r, ".* ERR auditd\[\d*\]: Error receiving audit netlink packet \(No buffer space available\)"
 r, ".* ERR audisp-tacplus: tac_connect_single: connection failed with.*Interrupted system call"
 r, ".* ERR audisp-tacplus: tac_connect_single: connection failed with.*Transport endpoint is not connected"
+
+# Ignore meta_sai_validate_route_entry ROUTE_ENTRY doesn't exist
+r, ".* ERR swss#orchagent: :- meta_sai_validate_route_entry: object key SAI_OBJECT_TYPE_ROUTE_ENTRY:.*doesn't exist.*"


### PR DESCRIPTION
Error can appear when dualtor systems remove a tunnel route but that route had already been processed. It does not affect functionality since the route had already been removed.

### Description of PR

Summary: Adding ignore regex for SAI_OBJECT_TYPE_ROUTE_ENTRY:.*doesn't exist error, which is sometimes failing dualtor tests. The error isn't harmful since it is often caused by tunnel route already being removed shortly before.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Dualtor tests are sometimes failing because of loganalyzer catching this error. However, test cases pass so the error itself should not fail the test.

#### How did you do it?
```
# Ignore meta_sai_validate_route_entry ROUTE_ENTRY doesn't exist
r, ".* ERR swss#orchagent: :- meta_sai_validate_route_entry: object key SAI_OBJECT_TYPE_ROUTE_ENTRY:.*doesn't exist.*"
```
Added to ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt

#### How did you verify/test it?
Run locally on dualtor testbed

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A

ADOs:
29870594
30294047