### PR TITLE
Fix config_db.json backup in `test_counterpoll_watermark.py`

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -48,7 +48,7 @@ def _backup_and_restore_config_db(duts, scope='function'):
 
         # Backup the per-asic config_db.json files
         for asicId in duthost.get_asic_ids():
-            if asicId == None:
+            if asicId is None:
                 break
             cfg_str = CONFIG_DB.format(asicId)
             cfg_bak_str = CONFIG_DB_BAK.format(asicId)
@@ -66,7 +66,7 @@ def _backup_and_restore_config_db(duts, scope='function'):
 
         # Restore the per-asic config_db.json files
         for asicId in duthost.get_asic_ids():
-            if asicId == None:
+            if asicId is None:
                 break
             cfg_str = CONFIG_DB.format(asicId)
             cfg_bak_str = CONFIG_DB_BAK.format(asicId)

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -31,8 +31,8 @@ def _backup_and_restore_config_db(duts, scope='function'):
     to be recovered aftet reboot. In such a case we need to backup config_db.json before
     the test starts and then restore it after the test ends.
     """
-    CONFIG_DB = "/etc/sonic/config_db{}.json"
-    CONFIG_DB_BAK = "/host/config_db{{}}.json.before_test_{}".format(scope)
+    CONFIG_DB = "/etc/sonic/config_db.json"
+    CONFIG_DB_BAK = "/host/config_db.json.before_test_{}".format(scope)
 
     if type(duts) is not list:
         duthosts = [duts]
@@ -40,38 +40,14 @@ def _backup_and_restore_config_db(duts, scope='function'):
         duthosts = duts
 
     for duthost in duthosts:
-        # Backup the default config_db.json
-        cfg_str = CONFIG_DB.format('')
-        cfg_bak_str = CONFIG_DB_BAK.format('')
-        logger.info("Backup {} to {} on {}".format(cfg_str, cfg_bak_str, duthost.hostname))
-        duthost.shell("cp {} {}".format(cfg_str, cfg_bak_str))
-
-        # Backup the per-asic config_db.json files
-        for asicId in duthost.get_asic_ids():
-            if asicId is None:
-                break
-            cfg_str = CONFIG_DB.format(asicId)
-            cfg_bak_str = CONFIG_DB_BAK.format(asicId)
-            logger.info("Backup {} to {} on {}".format(cfg_str, cfg_bak_str, duthost.hostname))
-            duthost.shell("cp {} {}".format(cfg_str, cfg_bak_str))
+        logger.info("Backup {} to {} on {}".format(CONFIG_DB, CONFIG_DB_BAK, duthost.hostname))
+        duthost.shell("cp {} {}".format(CONFIG_DB, CONFIG_DB_BAK))
 
     yield
 
     for duthost in duthosts:
-        # Restore the default config_db.json
-        cfg_str = CONFIG_DB.format('')
-        cfg_bak_str = CONFIG_DB_BAK.format('')
-        logger.info("Restore {} with {} on {}".format(cfg_str, cfg_bak_str, duthost.hostname))
-        duthost.shell("mv {} {}".format(cfg_bak_str, cfg_str))
-
-        # Restore the per-asic config_db.json files
-        for asicId in duthost.get_asic_ids():
-            if asicId is None:
-                break
-            cfg_str = CONFIG_DB.format(asicId)
-            cfg_bak_str = CONFIG_DB_BAK.format(asicId)
-            logger.info("Restore {} with {} on {}".format(cfg_str, cfg_bak_str, duthost.hostname))
-            duthost.shell("mv {} {}".format(cfg_bak_str, cfg_str))
+        logger.info("Restore {} with {} on {}".format(CONFIG_DB, CONFIG_DB_BAK, duthost.hostname))
+        duthost.shell("mv {} {}".format(CONFIG_DB_BAK, CONFIG_DB))
 
 
 @pytest.fixture(scope="module")
@@ -87,15 +63,6 @@ def backup_and_restore_config_db_on_duts(duthosts):
 def backup_and_restore_config_db(duthosts, rand_one_dut_hostname):
     """Back up and restore config DB at the function level."""
     duthost = duthosts[rand_one_dut_hostname]
-    # TODO: Use the neater "yield from _function" syntax when we move to python3
-    for func in _backup_and_restore_config_db(duthost, "function"):
-        yield func
-
-
-@pytest.fixture
-def backup_and_restore_config_db_frontend(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
-    """Back up and restore config DB at the function level."""
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     # TODO: Use the neater "yield from _function" syntax when we move to python3
     for func in _backup_and_restore_config_db(duthost, "function"):
         yield func

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -31,8 +31,8 @@ def _backup_and_restore_config_db(duts, scope='function'):
     to be recovered aftet reboot. In such a case we need to backup config_db.json before
     the test starts and then restore it after the test ends.
     """
-    CONFIG_DB = "/etc/sonic/config_db.json"
-    CONFIG_DB_BAK = "/host/config_db.json.before_test_{}".format(scope)
+    CONFIG_DB = "/etc/sonic/config_db{}.json"
+    CONFIG_DB_BAK = "/host/config_db{{}}.json.before_test_{}".format(scope)
 
     if type(duts) is not list:
         duthosts = [duts]
@@ -40,14 +40,38 @@ def _backup_and_restore_config_db(duts, scope='function'):
         duthosts = duts
 
     for duthost in duthosts:
-        logger.info("Backup {} to {} on {}".format(CONFIG_DB, CONFIG_DB_BAK, duthost.hostname))
-        duthost.shell("cp {} {}".format(CONFIG_DB, CONFIG_DB_BAK))
+        # Backup the default config_db.json
+        cfg_str = CONFIG_DB.format('')
+        cfg_bak_str = CONFIG_DB_BAK.format('')
+        logger.info("Backup {} to {} on {}".format(cfg_str, cfg_bak_str, duthost.hostname))
+        duthost.shell("cp {} {}".format(cfg_str, cfg_bak_str))
+
+        # Backup the per-asic config_db.json files
+        for asicId in duthost.get_asic_ids():
+            if asicId == None:
+                break
+            cfg_str = CONFIG_DB.format(asicId)
+            cfg_bak_str = CONFIG_DB_BAK.format(asicId)
+            logger.info("Backup {} to {} on {}".format(cfg_str, cfg_bak_str, duthost.hostname))
+            duthost.shell("cp {} {}".format(cfg_str, cfg_bak_str))
 
     yield
 
     for duthost in duthosts:
-        logger.info("Restore {} with {} on {}".format(CONFIG_DB, CONFIG_DB_BAK, duthost.hostname))
-        duthost.shell("mv {} {}".format(CONFIG_DB_BAK, CONFIG_DB))
+        # Restore the default config_db.json
+        cfg_str = CONFIG_DB.format('')
+        cfg_bak_str = CONFIG_DB_BAK.format('')
+        logger.info("Restore {} with {} on {}".format(cfg_str, cfg_bak_str, duthost.hostname))
+        duthost.shell("mv {} {}".format(cfg_bak_str, cfg_str))
+
+        # Restore the per-asic config_db.json files
+        for asicId in duthost.get_asic_ids():
+            if asicId == None:
+                break
+            cfg_str = CONFIG_DB.format(asicId)
+            cfg_bak_str = CONFIG_DB_BAK.format(asicId)
+            logger.info("Restore {} with {} on {}".format(cfg_str, cfg_bak_str, duthost.hostname))
+            duthost.shell("mv {} {}".format(cfg_bak_str, cfg_str))
 
 
 @pytest.fixture(scope="module")
@@ -63,6 +87,15 @@ def backup_and_restore_config_db_on_duts(duthosts):
 def backup_and_restore_config_db(duthosts, rand_one_dut_hostname):
     """Back up and restore config DB at the function level."""
     duthost = duthosts[rand_one_dut_hostname]
+    # TODO: Use the neater "yield from _function" syntax when we move to python3
+    for func in _backup_and_restore_config_db(duthost, "function"):
+        yield func
+
+
+@pytest.fixture
+def backup_and_restore_config_db_frontend(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    """Back up and restore config DB at the function level."""
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     # TODO: Use the neater "yield from _function" syntax when we move to python3
     for func in _backup_and_restore_config_db(duthost, "function"):
         yield func

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,7 @@ from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.helpers.inventory_utils import trim_inventory
 from tests.common.utilities import InterruptableThread
 from tests.common.plugins.ptfadapter.dummy_testutils import DummyTestUtils
+from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 
 try:
     from tests.common.macsec import MacsecPluginT2, MacsecPluginT0
@@ -2355,26 +2356,27 @@ def collect_db_dump(request, duthosts):
     if request.config.getoption("--collect_db_data"):
         collect_db_dump_on_duts(request, duthosts)
 
+def restore_config_db_and_config_reload(duts_data, duthosts):
+    # First copy the pre_running_config to the config_db.json files
+    for duthost in duthosts:
+        logger.info("dut reload called on {}".format(duthost.hostname))
+        duthost.copy(content=json.dumps(duts_data[duthost.hostname]["pre_running_config"][None], indent=4),
+                     dest='/etc/sonic/config_db.json', verbose=False)
 
-def __dut_reload(duts_data, node=None, results=None):
-    if node is None or results is None:
-        logger.error('Missing kwarg "node" or "results"')
-        return
-    logger.info("dut reload called on {}".format(node.hostname))
-    node.copy(content=json.dumps(duts_data[node.hostname]["pre_running_config"][None], indent=4),
-              dest='/etc/sonic/config_db.json', verbose=False)
+        if duthost.is_multi_asic:
+            for asic_index in range(0, duthost.facts.get('num_asic')):
+                asic_ns = "asic{}".format(asic_index)
+                asic_cfg_file = "/tmp/{}_config_db{}.json".format(duthost.hostname, asic_index)
+                with open(asic_cfg_file, "w") as outfile:
+                    outfile.write(json.dumps(duts_data[duthost.hostname]['pre_running_config'][asic_ns], indent=4))
+                duthost.copy(src=asic_cfg_file, dest='/etc/sonic/config_db{}.json'.format(asic_index), verbose=False)
+                os.remove(asic_cfg_file)
 
-    if node.is_multi_asic:
-        for asic_index in range(0, node.facts.get('num_asic')):
-            asic_ns = "asic{}".format(asic_index)
-            asic_cfg_file = "/tmp/{}_config_db{}.json".format(node.hostname, asic_index)
-            with open(asic_cfg_file, "w") as outfile:
-                outfile.write(json.dumps(duts_data[node.hostname]['pre_running_config'][asic_ns], indent=4))
-            node.copy(src=asic_cfg_file, dest='/etc/sonic/config_db{}.json'.format(asic_index), verbose=False)
-            os.remove(asic_cfg_file)
-
-    config_reload(node, wait_before_force_reload=300, safe_reload=True, check_intf_up_ports=True)
-
+    # Second execute config reload on all duthosts
+    with SafeThreadPoolExecutor(max_workers=8) as executor:
+        for duthost in duthosts:
+            executor.submit(config_reload, duthost, wait_before_force_reload=300, safe_reload=True,
+                            check_intf_up_ports=True, wait_for_bgp=True)
 
 def compare_running_config(pre_running_config, cur_running_config):
     if type(pre_running_config) != type(cur_running_config):
@@ -2669,12 +2671,7 @@ def core_dump_and_config_check(duthosts, tbinfo, request,
                 logger.warning("Core dump or config check failed for {}, results: {}"
                                .format(module_name, json.dumps(check_result)))
 
-                is_modular_chassis = duthosts[0].get_facts().get("modular_chassis")
-                if is_modular_chassis:
-                    recover_chassis(duthosts)
-                else:
-                    results = parallel_run(__dut_reload, (), {"duts_data": duts_data}, duthosts, timeout=360)
-                    logger.debug('Results of dut reload: {}'.format(json.dumps(dict(results))))
+                restore_config_db_and_config_reload(duts_data, duthosts)
             else:
                 logger.info("Core dump and config check passed for {}".format(module_name))
         if check_result:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2354,6 +2354,7 @@ def collect_db_dump(request, duthosts):
     if request.config.getoption("--collect_db_data"):
         collect_db_dump_on_duts(request, duthosts)
 
+
 def restore_config_db_and_config_reload(duts_data, duthosts):
     # First copy the pre_running_config to the config_db.json files
     for duthost in duthosts:
@@ -2375,6 +2376,7 @@ def restore_config_db_and_config_reload(duts_data, duthosts):
         for duthost in duthosts:
             executor.submit(config_reload, duthost, wait_before_force_reload=300, safe_reload=True,
                             check_intf_up_ports=True, wait_for_bgp=True)
+
 
 def compare_running_config(pre_running_config, cur_running_config):
     if type(pre_running_config) != type(cur_running_config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,6 @@ from tests.common.devices.duthosts import DutHosts
 from tests.common.devices.vmhost import VMHost
 from tests.common.devices.base import NeighborDevice
 from tests.common.devices.cisco import CiscoHost
-from tests.common.helpers.parallel import parallel_run
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_session    # noqa F401
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file                        # noqa F401
 from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active         # noqa F401
@@ -49,7 +48,6 @@ from tests.common.helpers.custom_msg_utils import add_custom_msg
 from tests.common.helpers.dut_ports import encode_dut_port_name
 from tests.common.helpers.dut_utils import encode_dut_and_container_name
 from tests.common.helpers.parallel_utils import InitialCheckState, InitialCheckStatus
-from tests.common.plugins.sanity_check import recover_chassis
 from tests.common.system_utils import docker
 from tests.common.testbed import TestbedInfo
 from tests.common.utilities import get_inventory_files

--- a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
+++ b/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
@@ -9,7 +9,7 @@ import time
 import pytest
 
 from tests.common.config_reload import config_reload
-from tests.common.fixtures.duthost_utils import backup_and_restore_config_db    # noqa F401
+from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_frontend    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.sonic_db import SonicDbCli, SonicDbKeyNotFound
 from tests.common.utilities import get_inventory_files, get_host_visible_vars
@@ -75,7 +75,7 @@ def check_counters_populated(duthost, key):
 
 
 def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname, dut_vars,
-                                             backup_and_restore_config_db):     # noqa F811
+                                             backup_and_restore_config_db_frontend):     # noqa F811
     """
     @summary: Verify FLEXCOUNTERS_DB and COUNTERS_DB content after `counterpoll queue/watermark/queue enable`
 

--- a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
+++ b/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
@@ -9,7 +9,6 @@ import time
 import pytest
 
 from tests.common.config_reload import config_reload
-from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_frontend    # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.sonic_db import SonicDbCli, SonicDbKeyNotFound
 from tests.common.utilities import get_inventory_files, get_host_visible_vars
@@ -74,8 +73,7 @@ def check_counters_populated(duthost, key):
         return False
 
 
-def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname, dut_vars,
-                                             backup_and_restore_config_db_frontend):     # noqa F811
+def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname, dut_vars):
     """
     @summary: Verify FLEXCOUNTERS_DB and COUNTERS_DB content after `counterpoll queue/watermark/queue enable`
 


### PR DESCRIPTION
Details of failure described in more detail in https://github.com/sonic-net/sonic-mgmt/issues/15991

Created a new fixture `backup_and_restore_config_db_frontend` which uses `enum_rand_one_per_hwsku_frontend_hostname` so `test_counterpoll_watermark.py` can run it.

Updated `_backup_and_restore_config_db` to work on multi-asic LCs

Summary:
Fixes #15991 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405