### PR TITLE
Add newly added snappi tests to PR test skip yaml

### DIFF
--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -232,6 +232,7 @@ tgen:
   - snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_member_flap.py
   - snappi_tests/multidut/bgp/test_bgp_outbound_uplink_process_crash.py
   - snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
+  - snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py
   - snappi_tests/multidut/ecn/test_multidut_red_accuracy_with_snappi.py
   - snappi_tests/multidut/pfc/test_lossless_response_to_external_pause_storms.py
   - snappi_tests/multidut/pfc/test_lossless_response_to_throttling_pause_storms.py
@@ -242,6 +243,7 @@ tgen:
   - snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
   - snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
   - snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+  - snappi_tests/multidut/pfc/test_tx_drop_counter_with_snappi.py
   - snappi_tests/multidut/pfcwd/test_multidut_pfcwd_a2a_with_snappi.py
   - snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
   - snappi_tests/multidut/pfcwd/test_multidut_pfcwd_burst_storm_with_snappi.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
Meanwhile, we are using .azure-pipelines/testscripts_analyse/ to static test scripts have been added or not, if a test script need to skip in KVM test, need to add it to .azure-pipelines/pr_test_skip_scripts.yaml and we would mark it as checked/covered.
Based on that, snappi test could not run on KVM platform, so need to add these tests to .azure-pipelines/pr_test_skip_scripts.yaml
#### How did you do it?
Add snappi test scripts to .azure-pipelines/pr_test_skip_scripts.yaml
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
