### PR TITLE
`ip/test_ip_packet.py` Increase `tx_ok` tolerance from `200` to `400` on T2

### DIFF
--- a/tests/ip/test_ip_packet.py
+++ b/tests/ip/test_ip_packet.py
@@ -401,12 +401,12 @@ class TestIPPacket(object):
         tx_drp = TestIPPacket.sum_ifaces_counts(portstat_out, out_ifaces, "tx_drp")
         tx_err = TestIPPacket.sum_ifaces_counts(rif_counter_out, out_rif_ifaces, "tx_err") if rif_support else 0
 
-        # For t2 max topology, increase the tolerance value from 0.1 to 0.2
-        # Set the tolerance value to 0.2 if the topology is T2 max, PKT_NUM_ZERO would be set to 200
+        # For t2 max topology, increase the tolerance value from 0.1 to 0.4
+        # Set the tolerance value to 0.4 if the topology is T2 max, PKT_NUM_ZERO would be set to 400
         vms_num = len(tbinfo['topo']['properties']['topology']['VMs'])
         if tbinfo['topo']['type'] == "t2" and vms_num > 8:
             logger.info("Setting PKT_NUM_ZERO for t2 max topology with 0.2 tolerance")
-            self.PKT_NUM_ZERO = self.PKT_NUM * 0.2
+            self.PKT_NUM_ZERO = self.PKT_NUM * 0.4
 
         if asic_type == "vs":
             logger.info("Skipping packet count check on VS platform")


### PR DESCRIPTION
https://github.com/sonic-net/sonic-mgmt/issues/7954 described an issue we saw on T2 platforms where `test_ip_packet.py::test_forward_ip_packet_with_0xffff_chksum_drop` would fail sporadically if sufficient control/background traffic egressed the `out_ifaces`.

https://github.com/sonic-net/sonic-mgmt/pull/8414 was created to fix this by increasing the tolerance from `100` to `200` packets. However, it seems like this wasn't sufficient tolerance as we're seeing failures on T2 devices:
```
Failed: Forwarded 276 packets in tx, not in expected range
Failed: Forwarded 275 packets in tx, not in expected range
Failed: Forwarded 264 packets in tx, not in expected range
Failed: Forwarded 295 packets in tx, not in expected range
Failed: Forwarded 316 packets in tx, not in expected range
Failed: Forwarded 301 packets in tx, not in expected range
Failed: Forwarded 264 packets in tx, not in expected range
```

But if we look at the RX_DROP counters we see all 1000 packets were dropped on RX:
```
root@cmp235-3:~# show interfaces counters
Last cached time was 2024-12-10T22:16:35.704269
      IFACE    STATE    RX_OK      RX_BPS    RX_UTIL    RX_ERR    RX_DRP
-----------  -------  -------  ----------  ---------  --------  --------
Ethernet144        U   15,399  141.74 B/s      0.00%         0     1,000
```

So the packets captured on TX was background traffic.

Summary:
Fixes #7954 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
