### PR TITLE
[202405][deploy-mg] Disable default_pfcwd_status for m0/mx (#15922)

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -34,6 +34,25 @@ class GenerateGoldenConfigDBModule(object):
         self.topo_name = self.module.params['topo_name']
         self.port_index_map = self.module.params['port_index_map']
 
+    def generate_mgfx_golden_config_db(self):
+        rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
+        if rc != 0:
+            self.module.fail_json(msg="Failed to get config from minigraph: {}".format(err))
+
+        # Generate config table from init_cfg.ini
+        ori_config_db = json.loads(out)
+
+        golden_config_db = {}
+        if "DEVICE_METADATA" in ori_config_db:
+            golden_config_db["DEVICE_METADATA"] = ori_config_db["DEVICE_METADATA"]
+            if ("localhost" in golden_config_db["DEVICE_METADATA"] and
+               "default_pfcwd_status" in golden_config_db["DEVICE_METADATA"]["localhost"]):
+                golden_config_db["DEVICE_METADATA"]["localhost"]["default_pfcwd_status"] = "disable"
+
+        if self.topo_name == "mx":
+            golden_config_db.update(self.generate_mx_golden_config_db())
+        return json.dumps(golden_config_db, indent=4)
+
     def generate_mx_golden_config_db(self):
         """
         If FEATURE table in init_cfg.json contains dhcp_server, enable it.
@@ -70,11 +89,11 @@ class GenerateGoldenConfigDBModule(object):
         dhcp_server_config_obj["DHCP_SERVER_IPV4_PORT"] = dhcp_server_port_config
 
         gold_config_db.update(dhcp_server_config_obj)
-        return json.dumps(gold_config_db, indent=4)
+        return gold_config_db
 
     def generate(self):
-        if self.topo_name == "mx":
-            config = self.generate_mx_golden_config_db()
+        if self.topo_name == "mx" or "m0" in self.topo_name:
+            config = self.generate_mgfx_golden_config_db()
         else:
             config = "{}"
 


### PR DESCRIPTION
What is the motivation for this PR?
default_pfcwd_status should be disable for m0 and mx

How did you do it?
In golden config_db, disable pfcwd for m0 and mx

How did you verify/test it?
Deploy topo

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Manually cherry-pick and resolve conflicts of this PR: https://github.com/sonic-net/sonic-mgmt/pull/15922

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
