### PR TITLE
Everflow - Test for recycle port queue counter

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1224,6 +1224,30 @@ everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_eve
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/17034 and 't2' not in topo_name"
 
+everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_fwd_recircle_port_queue_check:
+    skip:
+      reason: "Test not supported on non broadcom-dnx and non voq platforms"
+      conditions_logical_operator: "OR"
+      conditions:
+        - "(asic_subtype not in ['broadcom-dnx'])"
+        - "('voq' not in switch_type)"
+
+everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_fwd_recircle_port_queue_check:
+  skip:
+    reason: "Test not supported on non broadcom-dnx and non voq platforms"
+    conditions_logical_operator: "OR"
+    conditions:
+      - "(asic_subtype not in ['broadcom-dnx'])"
+      - "('voq' not in switch_type)"
+
+everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_fwd_recircle_port_queue_check:
+  skip:
+    reason: "Test not supported on non broadcom-dnx and non voq platforms"
+    conditions_logical_operator: "OR"
+    conditions:
+      - "(asic_subtype not in ['broadcom-dnx'])"
+      - "('voq' not in switch_type)"
+
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_basic_forwarding[erspan_ipv6-cli-downstream-default]:
   skip:
     reason: "SAI_STATUS_NOT_SUPPORTED for everflow over IPv6 on Arista-7260CX3"
@@ -1253,6 +1277,14 @@ everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_e
     reason: "Test is not ready for dualtor and not stable on Non-T2 platform."
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/17034 and 't2' not in topo_name"
+
+everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_fwd_recircle_port_queue_check:
+  skip:
+    reason: "Test not supported on non broadcom-dnx and non voq platforms"
+    conditions_logical_operator: "OR"
+    conditions:
+      - "(asic_subtype not in ['broadcom-dnx'])"
+      - "('voq' not in switch_type)"
 
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_neighbor_mac_change[erspan_ipv6-cli-downstream-default]:
   skip:

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -343,6 +343,35 @@ def erspan_ip_ver(request):
     return request.param
 
 
+def clear_queue_counters(asichost):
+    """
+    @summary: Clear the queue counters for the asichost
+    """
+    asichost.command("sonic-clear queuecounters")
+
+
+def check_queue_counters(dut, asic_ns, port, queue):
+    """
+    @summary: Determine whether queue counter value increased or not
+    """
+    output = get_queue_counters(dut, asic_ns, port, queue)
+    return output != 0
+
+
+def get_queue_counters(dut, asic_ns, port, queue):
+    """
+    @summary: Return the counter for a given queue in given port
+    """
+    cmd = "show queue counters -n {} {}".format(asic_ns, port)
+    output = dut.command(cmd)['stdout_lines']
+    txq = "UC{}".format(queue)
+    for line in output:
+        fields = line.split()
+        if fields[1] == txq:
+            return int(fields[2].replace(',', ''))
+    return -1
+
+
 @pytest.fixture(scope="module")
 def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

- A new test case has been added to make sure mirrored packets are sent on the recycle port via the specific queue configured under mirror session config.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

- To make sure specific queue configuration under mirror session config is verified.
- And to make sure the mirrored packets are sent on the recycle port via the specific queue configured.

#### How did you do it?

- Added a new test case to verify mirrored packets are sent via the specific queue configured under mirror session config.

#### How did you verify/test it?

- Ran the test on T2 VOQ chassis and made sure the tests are passing.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/user-attachments/assets/9c301ce7-9d3f-4e80-bbfe-aede2a916cf9)
