### PR TITLE
[snmp]Skipping enable_queue_counterpoll_type fixture for Nokia 7215 armhf platforms

### DIFF
--- a/tests/snmp/conftest.py
+++ b/tests/snmp/conftest.py
@@ -95,7 +95,8 @@ def check_redis_output(duthost, key):
 @pytest.fixture(scope="module", autouse=True)
 def enable_queue_counterpoll_type(duthosts):
     for duthost in duthosts:
-        duthost.command('counterpoll queue enable')
+        if duthost.facts['platform'] not in ['armhf-nokia_ixs7215_52x-r0']:
+            duthost.command('counterpoll queue enable')
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fixture enable_queue_counterpoll_type in snmp is enabling queue counterpolls. But for Nokia 7215 armhf platforms, as queue statistics are not supported, there is an error while executing this command : "SAI_OBJECT_TYPE_QUEUE is not Supported".
So, added a skip condition inside the fixture for Nokia 7215 armhf platforms
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes error: "SAI_OBJECT_TYPE_QUEUE is not Supported" in Nokia 7215 armhf platforms

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Added condition inside fixture to skip for Nokia 7215 armhf platform
#### How did you verify/test it?
Run snmp test suite and verify fixture is not executed on Nokia-7215 armhf platforms
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
