### PR TITLE
[lag_member] add necessary missed imports to test

### DIFF
--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -10,7 +10,7 @@ from collections import Counter
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_until
-from tests.common.fixtures.ptfhost_utils import copy_acstests_directory # noqa F401
+from tests.common.fixtures.ptfhost_utils import copy_acstests_directory, copy_ptftests_directory, copy_arp_responder_py # noqa F401
 from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
During movement test to Python 3 (#14944), were deleted necessary imports of fixtures with "autouse=True":
`copy_ptftests_directory`
`copy_arp_responder_py`


**copy_arp_responder_py**:
The fixture copied required configuration files. The arp responder configurations used in the test by method `setup_arp_responder`
Error from test without this fixture:
```Failed: Setup failed with error: run module shell failed, Ansible Results =>
failed = True
changed = True
end = 2024-12-11 05:18:59.588230
cmd = supervisorctl restart arp_responder
delta = 0:00:02.249219
rc = 7
invocation = {'module_args': {'creates': None, 'executable': None, '_uses_shell': True, 'strip_empty_ends': True, '_raw_params': 'supervisorctl restart arp_responder', 'removes': None, 'argv': None, 'warn': False, 'chdir': None, 'stdin_add_newline': True, 'stdin': None}}
start = 2024-12-11 05:18:57.339011
msg = non-zero return code
_ansible_no_log = None
stdout =
arp_responder: ERROR (not running)
arp_responder: ERROR (spawn error)stderr =
```
cmd `supervisorctl restart arp_responder` called in sonic-mgmt/tests/pc/test_lag_member.py: line 225

**copy_ptftests_directory**:
Error from test without this fixture:
```
cmd = /root/env-python3/bin/ptf --test-dir acstests/py3 lag_test.LagMemberTrafficTest --platform-dir /root/ptftests --platform remote -t 'dut_mac='"'"'9c:05:91:99:26:00'"'"';dut_vlan={'"'"'id'"'"': 109, '"'"'ip'"'"': '"'"'192.168.9.1/24'"'"'};ptf_lag={'"'"'port_list'"'"': ['"'"'eth1'"'"', '"'"'eth2'"'"', '"'"'eth3'"'"', '"'"'eth8'"'"', '"'"'eth9'"'"', '"'"'eth10'"'"', '"'"'eth11'"'"', '"'"'eth56'"'"'], '"'"'ip'"'"': '"'"'192.168.9.2/24'"'"'};port_not_behind_lag={'"'"'port_id'"'"': 16, '"'"'port_name'"'"': '"'"'eth16'"'"', '"'"'ip'"'"': '"'"'192.168.9.3/24'"'"'};kvm_support=True' --relax --debug info
delta = 0:00:00.433834
rc = 1
invocation = {'module_args': {'creates': None, 'executable': None, 'chdir': '/root', 'strip_empty_ends': True, '_raw_params': '/root/env-python3/bin/ptf --test-dir acstests/py3 lag_test.LagMemberTrafficTest --platform-dir /root/ptftests --platform remote -t \'dut_mac=\'"\'"\'9c:05:91:99:26:00\'"\......}
start = 2024-12-11 14:33:11.478026
msg = non-zero return code
_ansible_no_log = None
stdout =
Using packet manipulation module: ptf.packet_scapystderr =
Traceback (most recent call last):
  File "/root/env-python3/bin/ptf", line 820, in <module>
    platform_mod = import_module(config["platform_dir"], platform_name)
  File "/root/env-python3/bin/ptf", line 112, in import_module
    return module_specs.loader.load_module()
AttributeError: 'NoneType' object has no attribute 'loader'
```

Only when the test is executed with these imports does it pass.



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Stabilaze lag_member test

#### How did you do it?
Added removed imports

#### How did you verify/test it?
Executed on setup

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
