### PR TITLE
Adding skip for any test that uses pfc_gen or pfc_gen_t2, for any speeds higher than 100Gbps

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1364,10 +1364,6 @@ pfcwd/test_pfcwd_all_port_storm.py:
       - "hwsku in ['Arista-7060X6-64PE-256x200G']"
       - "topo_type in ['m0', 'mx']"
       - "asic_type in ['vs']"
-   xfail:
-     reason: "The fanout and pfc_gen_t2.py cannont produce xOffs at consistent rates."
-     conditions:
-      - "asic_type in ['cisco-8000']"
 
 pfcwd/test_pfcwd_cli.py:
    skip:
@@ -1380,10 +1376,6 @@ pfcwd/test_pfcwd_function.py:
      reason: "Temporarily skip in PR testing"
      conditions:
         - "asic_type in ['vs']"
-   xfail:
-     reason: "The fanout and pfc_gen_t2.py cannont produce xOffs at consistent rates."
-     conditions:
-       - "asic_type in ['cisco-8000']"
 
 pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic:
    skip:
@@ -1399,10 +1391,6 @@ pfcwd/test_pfcwd_timer_accuracy.py:
     reason: "Temporarily skip in PR testing"
     conditions:
       - "asic_type in ['vs']"
-  xfail:
-    reason: "The fanout and pfc_gen_t2.py cannont produce xOffs at consistent rates."
-    conditions:
-      - "asic_type in ['cisco-8000']"
 
 pfcwd/test_pfcwd_warm_reboot.py:
    skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1364,6 +1364,10 @@ pfcwd/test_pfcwd_all_port_storm.py:
       - "hwsku in ['Arista-7060X6-64PE-256x200G']"
       - "topo_type in ['m0', 'mx']"
       - "asic_type in ['vs']"
+   xfail:
+     reason: "The fanout and pfc_gen_t2.py cannont produce xOffs at consistent rates."
+     conditions:
+      - "asic_type in ['cisco-8000']"
 
 pfcwd/test_pfcwd_cli.py:
    skip:
@@ -1376,6 +1380,10 @@ pfcwd/test_pfcwd_function.py:
      reason: "Temporarily skip in PR testing"
      conditions:
         - "asic_type in ['vs']"
+   xfail:
+     reason: "The fanout and pfc_gen_t2.py cannont produce xOffs at consistent rates."
+     conditions:
+       - "asic_type in ['cisco-8000']"
 
 pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic:
    skip:
@@ -1391,6 +1399,10 @@ pfcwd/test_pfcwd_timer_accuracy.py:
     reason: "Temporarily skip in PR testing"
     conditions:
       - "asic_type in ['vs']"
+  xfail:
+    reason: "The fanout and pfc_gen_t2.py cannont produce xOffs at consistent rates."
+    conditions:
+      - "asic_type in ['cisco-8000']"
 
 pfcwd/test_pfcwd_warm_reboot.py:
    skip:

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -252,8 +252,7 @@ def skip_pfcwd_higher_speeds(
         enum_rand_one_per_hwsku_frontend_hostname,
         setup_pfc_test):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    if duthost.facts["asic_type"] != "cisco-8000" and \
-            not duthost.get_facts().get("modular_chassis", None):
+    if duthost.facts["asic_type"] != "cisco-8000":
         yield
         return
 
@@ -263,7 +262,7 @@ def skip_pfcwd_higher_speeds(
             "show interfaces status {}".format(test_port))[0]['speed']
         speed_int = speed.split("G")[0]
         if int(speed_int) > 100:
-            pytest.skip(
+            pytest.xfail(
                 "The tests using pfc_gen or pfc_gen_t2 can be run " +
                 "only for speeds less than " +
                 f"100Gbps(for:{enum_rand_one_per_hwsku_frontend_hostname})")

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -259,8 +259,9 @@ def skip_pfcwd_higher_speeds(
         speed_int = speed.split("G")[0]
         if int(speed_int) > 100:
             pytest.skip(
-                "The tests using pfc_gen or pfc_gen_t2 can be run "
-                "only for speeds less than 100Gbps.")
+                "The tests using pfc_gen or pfc_gen_t2 can be run " +
+                "only for speeds less than " +
+                f"100Gbps(for:{enum_rand_one_per_hwsku_frontend_hostname})")
 
     yield
     pass

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -244,3 +244,23 @@ def pfcwd_pause_service(ptfhost):
         needs_resume["garp_service"] = False
 
     logger.debug("pause_service needs_resume {}".format(needs_resume))
+
+
+@pytest.fixture(scope="function", autouse=False)
+def skip_pfcwd_higher_speeds(
+        duthosts,
+        enum_rand_one_per_hwsku_frontend_hostname,
+        setup_pfc_test):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    test_ports = setup_pfc_test['test_ports']
+    for test_port in test_ports:
+        speed = duthost.show_and_parse(
+            "show interfaces status {}".format(test_port))[0]['speed']
+        speed_int = speed.split("G")[0]
+        if int(speed_int) > 100:
+            pytest.skip(
+                "The tests using pfc_gen or pfc_gen_t2 can be run "
+                "only for speeds less than 100Gbps.")
+
+    yield
+    pass

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -252,6 +252,10 @@ def skip_pfcwd_higher_speeds(
         enum_rand_one_per_hwsku_frontend_hostname,
         setup_pfc_test):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    if duthost.facts["asic_type"] != "cisco-8000":
+        yield
+        return
+
     test_ports = setup_pfc_test['test_ports']
     for test_port in test_ports:
         speed = duthost.show_and_parse(

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -252,7 +252,8 @@ def skip_pfcwd_higher_speeds(
         enum_rand_one_per_hwsku_frontend_hostname,
         setup_pfc_test):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    if duthost.facts["asic_type"] != "cisco-8000":
+    if duthost.facts["asic_type"] != "cisco-8000" and \
+            not duthost.get_facts().get("modular_chassis", None):
         yield
         return
 

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -204,7 +204,8 @@ class TestPfcwdAllPortStorm(object):
             time.sleep(5)
 
     def test_all_port_storm_restore(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                    storm_test_setup_restore, setup_pfc_test, ptfhost):
+                                    storm_test_setup_restore, setup_pfc_test, ptfhost,
+                                    skip_pfcwd_higher_speeds):
         """
         Tests PFC storm/restore on all ports
 

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -855,7 +855,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_actions(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
                            ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
                            setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,         # noqa F811
-                           toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m): # noqa F811
+                           toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,                      # noqa F811
+                           skip_pfcwd_higher_speeds):
         """
         PFCwd functional test
 
@@ -933,7 +934,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_multi_port(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
                               ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
                               setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,         # noqa F811
-                              toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m): # noqa F811
+                              toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,                      # noqa F811
+                              skip_pfcwd_higher_speeds):
         """
         Tests pfcwd behavior when 2 ports are under pfc storm one after the other
 
@@ -1014,7 +1016,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_mmu_change(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,   # noqa F811
                               ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, dualtor_ports, # noqa F811
                               setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,       # noqa F811
-                              toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m): # noqa F811
+                              toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,                    # noqa F811
+                              skip_pfcwd_higher_speeds):
         """
         Tests if mmu changes impact Pfcwd functionality
 
@@ -1108,7 +1111,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_port_toggle(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
                                tbinfo, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
                                setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,         # noqa F811
-                               toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m): # noqa F811
+                               toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,                      # noqa F811
+                               skip_pfcwd_higher_speeds):
         """
         Test PfCWD functionality after toggling port
 
@@ -1213,7 +1217,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
 
     def test_pfcwd_no_traffic(
             self, request, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
-            ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+            ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
+            skip_pfcwd_higher_speeds):
         """
         Verify the pfcwd is not triggered when no traffic is sent, even when pfc storm is active.
         Args:

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -322,7 +322,7 @@ class TestPfcwdAllTimer(object):
         return int(timestamp_ms)
 
     def test_pfcwd_timer_accuracy(self, duthosts, ptfhost, enum_rand_one_per_hwsku_frontend_hostname,
-                                  pfcwd_timer_setup_restore, fanouthosts):
+                                  pfcwd_timer_setup_restore, fanouthosts, skip_pfcwd_higher_speeds):
         """
         Tests PFCwd timer accuracy
 

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -594,7 +594,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
 
     def test_pfcwd_wb(self, fake_storm, testcase_action, setup_pfc_test, enum_fanout_graph_facts,   # noqa F811
                       ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                      localhost, fanouthosts, two_queues):
+                      localhost, fanouthosts, two_queues, skip_pfcwd_higher_speeds):
         """
         Tests PFCwd warm reboot with various testcase actions
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Currently we depend on pfc_gen and pfc_gen_t2 for generating pfc storm from fanout to the DUT. This works ok until 100G data link speeds. However at 400G speeds, the fanout and the pfc_gen programs are not able to maintain the required flow of pfc packets continuously, and the DUT ends up either pushing out the data packet in the gaps, or not triggering watchdog. This PR proposes to skip the testcases that depend on pfc_gen or pfc_gen_t2 for any speed higher than 100G. The same tests will be covered or partially already covered in tests/snappi_tests testcases listed below:
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/rraghav/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/rraghav/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{font-weight:700;
	font-family:"Aptos Narrow";
	mso-generic-font-family:auto;
	mso-font-charset:0;}
-->
</style>
</head>

<body link="#467886" vlink="#96607D">


Skipped   sonic-mgmt TC | Snappi TC
-- | --
test_pfcwd_function.py::test_pfcwd_actions | test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio
test_pfcwd_function.py::test_pfcwd_multi_port | test_pfcwd_a2a_with_snappi.py
test_pfcwd_function.py::test_pfcwd_mmu_change | NA
test_pfcwd_function.py::test_pfcwd_port_toggle | NA
test_pfcwd_function.py::test_pfcwd_no_traffic | NA
  |  
test_pfcwd_all_port_storm.py::test_all_port_storm_restore | NA
  |  
test_pfcwd_warm_reboot.py::test_pfcwd_wb | test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_reboot



</body>

</html>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Flakiness in tests that use the pfc_gen or pfc_gen_t2 programs.

#### How did you do it?
Skip the tests for higher speeds.

#### How did you verify/test it?
Ran it on my TB. In my TB, there is a problem with the fanouts, which can't produce enough pfc storm even at 100G, so we see these failures. They are not related to the PR. lc1 and lc7 are 100G. lc0 is 400G. The PR basically skips the tests for LC0-400G links:
```
================================================================================================== short test summary info ===================================================================================================
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_invalid_action_cfg[xx37-lc0]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_invalid_detect_time_cfg[xx37-lc0]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_low_detect_time_cfg[xx37-lc0]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_high_detect_time_cfg[xx37-lc0]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_invalid_restore_time_cfg[xx37-lc0]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_low_restore_time_cfg[xx37-lc0]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_high_restore_time_cfg[xx37-lc0]
PASSED pfcwd/test_pfc_config.py::TestDefaultPfcConfig::test_default_cfg_after_load_mg[xx37-lc0]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_invalid_action_cfg[xx37-lc1]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_invalid_detect_time_cfg[xx37-lc1]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_low_detect_time_cfg[xx37-lc1]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_high_detect_time_cfg[xx37-lc1]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_invalid_restore_time_cfg[xx37-lc1]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_low_restore_time_cfg[xx37-lc1]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_high_restore_time_cfg[xx37-lc1]
PASSED pfcwd/test_pfc_config.py::TestDefaultPfcConfig::test_default_cfg_after_load_mg[xx37-lc1]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_invalid_action_cfg[xx37-lc7]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_invalid_detect_time_cfg[xx37-lc7]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_low_detect_time_cfg[xx37-lc7]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_high_detect_time_cfg[xx37-lc7]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_invalid_restore_time_cfg[xx37-lc7]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_low_restore_time_cfg[xx37-lc7]
PASSED pfcwd/test_pfc_config.py::TestPfcConfig::test_high_restore_time_cfg[xx37-lc7]
PASSED pfcwd/test_pfc_config.py::TestDefaultPfcConfig::test_default_cfg_after_load_mg[xx37-lc7]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[xx37-lc1]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[xx37-lc7]
SKIPPED [3] pfcwd/test_pfc_config.py: Forward action not supported in cisco-8000 / Pfcwd tests skipped on m0/mx testbed.
SKIPPED [1] pfcwd/test_pfcwd_all_port_storm.py:205: The tests using pfc_gen or pfc_gen_t2 can be run only for speeds less than 100Gbps(for:xx37-lc0)
SKIPPED [1] pfcwd/test_pfcwd_function.py:853: The tests using pfc_gen or pfc_gen_t2 can be run only for speeds less than 100Gbps(for:xx37-lc0)
SKIPPED [1] pfcwd/test_pfcwd_function.py:932: The tests using pfc_gen or pfc_gen_t2 can be run only for speeds less than 100Gbps(for:xx37-lc0)
SKIPPED [1] pfcwd/test_pfcwd_function.py:1014: The tests using pfc_gen or pfc_gen_t2 can be run only for speeds less than 100Gbps(for:xx37-lc0)
SKIPPED [1] pfcwd/test_pfcwd_function.py:1109: The tests using pfc_gen or pfc_gen_t2 can be run only for speeds less than 100Gbps(for:xx37-lc0)
SKIPPED [1] pfcwd/test_pfcwd_function.py:1216: The tests using pfc_gen or pfc_gen_t2 can be run only for speeds less than 100Gbps(for:xx37-lc0)
SKIPPED [1] pfcwd/test_pfcwd_timer_accuracy.py:324: The tests using pfc_gen or pfc_gen_t2 can be run only for speeds less than 100Gbps(for:xx37-lc0)
SKIPPED [9] pfcwd/test_pfcwd_warm_reboot.py: Warm Reboot is not supported in T2 or in standalone topos. / Pfcwd tests skipped on m0/mx testbed.
FAILED pfcwd/test_pfcwd_all_port_storm.py::TestPfcwdAllPortStorm::test_all_port_storm_restore[xx37-lc1] - tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 0
FAILED pfcwd/test_pfcwd_all_port_storm.py::TestPfcwdAllPortStorm::test_all_port_storm_restore[xx37-lc7] - tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 0
FAILED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[xx37-lc1] - tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 0
FAILED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[xx37-lc1] - tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 0
FAILED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[xx37-lc1] - tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 0
FAILED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[xx37-lc1] - tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 0
FAILED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[xx37-lc7] - tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 0
FAILED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[xx37-lc7] - tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 0
FAILED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[xx37-lc7] - tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 0
FAILED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[xx37-lc7] - tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 0
FAILED pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy[xx37-lc1] - Failed: run module shell failed, Ansible Results =>
FAILED pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy[xx37-lc7] - Failed: run module shell failed, Ansible Results =>
============================================================================= 12 failed, 26 passed, 19 skipped, 1 warning in 6114.21s (1:41:54) ==============================================================================
```
#### Any platform specific information?
Unless a new platform comes up for fanout that can really maintain the pfc packets at very high speeds, this is applicable to all platforms.