### PR TITLE
Optimise pfc_gen scripts to use multiprocessing

### DIFF
--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -47,6 +47,7 @@ class PFCStorm(object):
         self.send_pfc_frame_interval = kwargs.pop('send_pfc_frame_interval', 0)
         self.pfc_send_period = kwargs.pop('pfc_send_period', None)
         self.peer_info = kwargs.pop('peer_info')
+        self.pfc_send_parallel = kwargs.pop('pfc_send_parallel', False)
         self._validate_params(expected_args=['pfc_fanout_interface', 'peerdevice'])
         if 'hwsku' not in self.peer_info:
             self._populate_peer_hwsku()
@@ -171,7 +172,8 @@ class PFCStorm(object):
             "ansible_eth0_ipv4_addr": self.ip_addr,
             "peer_hwsku": self.peer_info['hwsku'],
             "send_pfc_frame_interval": self.send_pfc_frame_interval,
-            "pfc_send_period": self.pfc_send_period
+            "pfc_send_period": self.pfc_send_period,
+            "pfc_send_parallel": self.pfc_send_parallel,
             }
         if self.peer_device.os in self._PFC_GEN_DIR:
             self.extra_vars['pfc_gen_dir'] = \
@@ -338,7 +340,8 @@ class PFCMultiStorm(object):
                                                    pfc_frames_number=frames_cnt,
                                                    pfc_gen_file=gen_file,
                                                    pfc_send_period=pfc_send_time,
-                                                   peer_info=peer_info)
+                                                   peer_info=peer_info,
+                                                   pfc_send_parallel=True)
 
             self.storm_handle[peer_dev].deploy_pfc_gen()
 

--- a/tests/common/templates/pfc_storm_eos.j2
+++ b/tests/common/templates/pfc_storm_eos.j2
@@ -3,7 +3,7 @@ cd /mnt/flash
 {% if (pfc_asym  is defined) and (pfc_asym == True) %}
 {% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo python {{pfc_gen_file}} {% if pfc_gen_multiprocess is defined %}-m {% endif %}-p {{pfc_queue_index}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} &
 {% else %}
-{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo python {{pfc_gen_file}} {% if pfc_gen_multiprocess is defined %}-m {% endif %}-p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}} &
+{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo python {{pfc_gen_file}} {% if pfc_gen_multiprocess is defined %}-m {% endif %}-p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}}{% if pfc_send_parallel is defined %} --parallel-send {% endif %}&
 {% endif %}
 exit
 exit

--- a/tests/common/templates/pfc_storm_stop_eos.j2
+++ b/tests/common/templates/pfc_storm_stop_eos.j2
@@ -3,7 +3,7 @@ cd /mnt/flash
 {% if (pfc_asym  is defined) and (pfc_asym == True) %}
 {% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo pkill -f "python {{pfc_gen_file}} {% if pfc_gen_multiprocess is defined %}-m {% endif %}-p {{pfc_queue_index}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}}" {{'&' if pfc_storm_stop_defer_time is defined else ''}}
 {% else %}
-{% if pfc_storm_stop_defer_time is defined %} sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f "python {{pfc_gen_file}} {% if pfc_gen_multiprocess is defined %}-m {% endif %}-p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}}" {{'&' if pfc_storm_stop_defer_time is defined else ''}}
+{% if pfc_storm_stop_defer_time is defined %} sleep {{pfc_storm_stop_defer_time}} &&{% endif %} sudo pkill -f "python {{pfc_gen_file}} {% if pfc_gen_multiprocess is defined %}-m {% endif %}-p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}}{% if pfc_send_parallel is defined %} --parallel-send{% endif %}" {{'&' if pfc_storm_stop_defer_time is defined else ''}}
 {% endif %}
 exit
 exit

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -478,6 +478,7 @@ class SetupPfcwdFunc(object):
                                             pfc_frames_number=self.pfc_wd['frames_number'],
                                             pfc_send_period=pfc_send_time,
                                             pfc_gen_file=gen_file,
+                                            pfc_send_parallel=True,
                                             peer_info=peer_info)
             self.storm_hndle.update_queue_index(self.pfc_wd['queue_index'])
             self.storm_hndle.update_peer_info(peer_info)

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -168,7 +168,9 @@ def set_storm_params(dut, fanout_info, fanout, peer_params):
         pfc_send_time = None
     storm_handle = PFCStorm(dut, fanout_info, fanout, pfc_queue_idx=pfc_queue_index,
                             pfc_frames_number=pfc_frames_count, pfc_gen_file=pfc_gen_file,
-                            pfc_send_period=pfc_send_time, peer_info=peer_params)
+                            pfc_send_period=pfc_send_time,
+                            pfc_send_parallel=True,
+                            peer_info=peer_params)
     storm_handle.deploy_pfc_gen()
     return storm_handle
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 30445057

Currently pfc_gen on non-sonic devices are not fast enough can affect trigger time of pfcwd storm detection. This will also affect 100G line card.

The reason for slowing down is we storm each socket at a time and iterate through 10000000 times.

We can leverage multi-processing to storm all socket in the same time with each one iterate 10000000 times

This is the result

```
With multiprocessing

real    4m59.814s
user    1m22.296s
sys     3m35.872s


Without multiprocessing

real    6m22.204s
user    2m32.916s
sys     3m47.376s
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
1. Add support for `--parallel-send` for non-sonic devices.
2. Uplift current pfc_gen script 


#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
