### PR TITLE
Move some stable test scripts to standard PR checkers.

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -225,6 +225,9 @@ t0:
   - fdb/test_fdb_mac_learning.py
   - ip/test_mgmt_ipv6_only.py
   - zmq/test_gnmi_zmq.py
+  - bgp/test_bgp_route_neigh_learning.py
+  - l2/test_l2_configure.py
+  - srv6/test_srv6_basic_sanity.py
 
 t0-2vlans:
   - dhcp_relay/test_dhcp_relay.py
@@ -434,6 +437,8 @@ t1-lag:
   - vxlan/test_vxlan_route_advertisement.py
   - lldp/test_lldp_syncd.py
   - ipfwd/test_nhop_group.py
+  - restapi/test_restapi_vxlan_ecmp.py
+  - srv6/test_srv6_basic_sanity.py
 
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py
@@ -475,15 +480,10 @@ onboarding_t0:
   - lldp/test_lldp_syncd.py
   # Flaky, we will triage and fix it later, move to onboarding to unblock pr check
   - dhcp_relay/test_dhcp_relay_stress.py
-  - bgp/test_bgp_route_neigh_learning.py
-  - l2/test_l2_configure.py
   - pc/test_lag_member_forwarding.py
-  - srv6/test_srv6_basic_sanity.py
 
 onboarding_t1:
   - pc/test_lag_member_forwarding.py
-  - restapi/test_restapi_vxlan_ecmp.py
-  - srv6/test_srv6_basic_sanity.py
   - pfcwd/test_pfcwd_all_port_storm.py
   - pfcwd/test_pfcwd_function.py
   - pfcwd/test_pfcwd_timer_accuracy.py

--- a/tests/restapi/test_restapi_vxlan_ecmp.py
+++ b/tests/restapi/test_restapi_vxlan_ecmp.py
@@ -9,7 +9,7 @@ from restapi_operations import Restapi
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t1'),
+    pytest.mark.topology('t0', 't1'),
     pytest.mark.disable_loganalyzer
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #15907, we initially added several test scripts to the onboarding PR checkers. After monitoring their performance over a few days, some of these scripts have proven to be stable. In this PR, we promote these stable scripts from the onboarding PR checkers to the standard PR checkers.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In PR #15907, we initially added several test scripts to the onboarding PR checkers. After monitoring their performance over a few days, some of these scripts have proven to be stable. In this PR, we promote these stable scripts from the onboarding PR checkers to the standard PR checkers.

#### How did you do it?
In this PR, we promote these stable scripts from the onboarding PR checkers to the standard PR checkers.

#### How did you verify/test it?

TestbedName | FilePath | RunDate | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-t0 | bgp/test_bgp_route_neigh_learning.py | 2024-12-12 00:00:00.0000000 | 5 | 0 | 5 | 1
vms-kvm-t0 | l2/test_l2_configure.py | 2024-12-12 00:00:00.0000000 | 5 | 0 | 5 | 1
vms-kvm-t0 | srv6/test_srv6_basic_sanity.py | 2024-12-12 00:00:00.0000000 | 35 | 0 | 35 | 1
vms-kvm-t0 | bgp/test_bgp_route_neigh_learning.py | 2024-12-11 00:00:00.0000000 | 42 | 0 | 42 | 1
vms-kvm-t0 | l2/test_l2_configure.py | 2024-12-11 00:00:00.0000000 | 42 | 0 | 42 | 1
vms-kvm-t0 | srv6/test_srv6_basic_sanity.py | 2024-12-11 00:00:00.0000000 | 294 | 0 | 294 | 1
vms-kvm-t0 | bgp/test_bgp_route_neigh_learning.py | 2024-12-10 00:00:00.0000000 | 55 | 0 | 55 | 1
vms-kvm-t0 | l2/test_l2_configure.py | 2024-12-10 00:00:00.0000000 | 55 | 0 | 55 | 1
vms-kvm-t0 | srv6/test_srv6_basic_sanity.py | 2024-12-10 00:00:00.0000000 | 385 | 0 | 385 | 1
vms-kvm-t0 | bgp/test_bgp_route_neigh_learning.py | 2024-12-09 00:00:00.0000000 | 26 | 0 | 26 | 1
vms-kvm-t0 | l2/test_l2_configure.py | 2024-12-09 00:00:00.0000000 | 25 | 0 | 25 | 1
vms-kvm-t0 | srv6/test_srv6_basic_sanity.py | 2024-12-09 00:00:00.0000000 | 175 | 0 | 175 | 1


TestbedName | FilePath | RunDate | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-t0 | srv6/test_srv6_basic_sanity.py | 2024-12-12 00:00:00.0000000 | 35 | 0 | 35 | 1
vms-kvm-t0 | srv6/test_srv6_basic_sanity.py | 2024-12-11 00:00:00.0000000 | 294 | 0 | 294 | 1
vms-kvm-t0 | srv6/test_srv6_basic_sanity.py | 2024-12-10 00:00:00.0000000 | 385 | 0 | 385 | 1
vms-kvm-t0 | srv6/test_srv6_basic_sanity.py | 2024-12-09 00:00:00.0000000 | 175 | 0 | 175 | 1


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
