### PR TITLE
Restrict Permissions on SSH Host Key Files to fix "Permissions 0644 for '/etc/ssh/ssh_host_*_key' are too open"

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -346,6 +346,10 @@ function start_local_container() {
         exit_failure "failed to start a container: ${CONTAINER_NAME}"
     fi
 
+    # Restrict Permissions on SSH Host Key Files to fix "Permissions 0644 for '/etc/ssh/ssh_host_*_key' are too open"
+    # 600 indicates that the keys are readable and writable only by the owner.
+    chmod 600 ~/.ssh/id_rsa
+
     eval "docker exec --user root \"${CONTAINER_NAME}\" \
     bash -c \"service ssh restart\" ${SILENT_HOOK}" || \
     exit_failure "failed to start SSH service"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Restrict Permissions on SSH Host Key Files to fix "Permissions 0644 for '/etc/ssh/ssh_host_*_key' are too open".
![image](https://github.com/user-attachments/assets/3c9ed6b4-b4f0-432d-b6ef-7a29b81a43b4)


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
