### PR TITLE
Fix different format mgmt ip for eth0 in test_lldp_syncd

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -179,10 +179,21 @@ def assert_lldp_entry_content(interface, entry_content, lldpctl_interface):
                 chassis_info.get("mgmt-ip", ""),
             ),
         )
+
+    if interface == "eth0":
+        expected_sys_cap_supported_result = (
+            entry_content["lldp_rem_sys_cap_supported"] == "28 00"
+            or entry_content["lldp_rem_sys_cap_supported"] == "20 00",
+        )
+    else:
+        expected_sys_cap_supported_result = (
+            entry_content["lldp_rem_sys_cap_supported"] == "28 00"
+        )
     pytest_assert(
-        entry_content["lldp_rem_sys_cap_supported"] == "28 00",
+        expected_sys_cap_supported_result,
         "lldp_rem_sys_cap_supported does not match for {}".format(interface),
     )
+
     if interface == "eth0":
         expected_sys_cap_enable_result = (
             entry_content["lldp_rem_sys_cap_enabled"] == "28 00"


### PR DESCRIPTION
Fix case failure of Failed: lldp_rem_sys_cap_supported does not match for eth0

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
For the mgmt port, the lldp_rem_sys_cap_supported could be 20 00.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
