### PR TITLE
[Draft] Add debug check in lo_interfacet test to address default route missing issue

### DIFF
--- a/tests/generic_config_updater/test_lo_interface.py
+++ b/tests/generic_config_updater/test_lo_interface.py
@@ -356,10 +356,7 @@ def setup_vrf_config(duthost, lo_intf):
 
 
 def check_default_route_status(rand_selected_dut):
-    asichost = rand_selected_dut.asic_instance(0 if rand_selected_dut.is_multi_asic else None)
-    rtinfo = asichost.get_ip_route_info(ipaddress.ip_network("0.0.0.0/0"))
-    pytest_assert(rtinfo['set_src'],
-                  "default route do not have set src. {}".format(rtinfo))
+    pytest_assert(rand_selected_dut.check_default_route(), "Default route check failed.")
 
 
 def test_lo_interface_tc1_suite(rand_selected_dut, cfg_facts, lo_intf):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
`test_default_route.py` is flaky in KVM PR test, when I check the details, I found the default route was missing, and each time it fails, `test_lo_interface.py` was running before in the same testbed, and I found some sonic_yang loading error, it may cause default route missing.
#### How did you do it?
Create the draft PR to check default route in `test_lo_interface.py`, and run batches of tests to verify.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
