### PR TITLE
Add default route check in sanity check

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1349,11 +1349,13 @@ default nhid 224 proto bgp src fc00:1::32 metric 20 pref medium
         if ipv4:
             rtinfo_v4 = self.get_ip_route_info(ipaddress.ip_network('0.0.0.0/0'))
             if len(rtinfo_v4['nexthops']) == 0:
+                logger.info("Check IPv4 default route failed with no nexthop")
                 return False
 
         if ipv6:
             rtinfo_v6 = self.get_ip_route_info(ipaddress.ip_network('::/0'))
             if len(rtinfo_v6['nexthops']) == 0:
+                logger.info("Check IPv6 default route failed with no nexthop")
                 return False
 
         return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Sometimes device may be unhealthy with missing default route, but sanity check didn't cover this scenario. Adding this check is better for us to filter some failure caused by test env.
#### How did you do it?
Add default route check in sanity check.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
