### PR TITLE
Change the batch shutdown call to individual call on 201911

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1154,9 +1154,10 @@ class SonicHost(AnsibleHostBase):
                 ifnames (list): the interface names to bring up
         """
         image_info = self.get_image_info()
-        # 201811 image does not support multiple interfaces startup
+        # 201811 & 201911 images do not support multiple interface startup
         # Change the batch startup call to individual call here
-        if "201811" in image_info.get("current"):
+        current_image = image_info.get("current")
+        if "201811" in current_image or "201911" in current_image:
             for ifname in ifnames:
                 self.no_shutdown(ifname)
             return

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1125,9 +1125,10 @@ class SonicHost(AnsibleHostBase):
                 ifnames (list): the interface names to shutdown
         """
         image_info = self.get_image_info()
-        # 201811 image does not support multiple interfaces shutdown
+        # 201811 & 201911 images do not support multiple interface shutdown
         # Change the batch shutdown call to individual call here
-        if "201811" in image_info.get("current"):
+        current_image = image_info.get("current")
+        if "201811" in current_image or "201911" in current_image:
             for ifname in ifnames:
                 self.shutdown(ifname)
             return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The bulk interface shutdown command is unsupported on 201911 and results in the following when sad path testing:

{
    "changed": true,
    "cmd": [
        "sudo",
        "config",
        "interface",
        "shutdown",
        "Ethernet0,Ethernet10,Ethernet104,Ethernet106"
    ],
    "delta": "0:00:01.058308",
    "end": "2024-10-31 02:40:10.394406",
    "failed": true,
    "msg": "non-zero return code",
    "rc": 2,
    "start": "2024-10-31 02:40:09.336098",
    "stderr": "Usage: config interface shutdown [OPTIONS] <interface_name>\n\nError: Interface name is invalid. Please enter a valid interface name!!",
    "stderr_lines": [
        "Usage: config interface shutdown [OPTIONS] <interface_name>",
        "",
        "Error: Interface name is invalid. Please enter a valid interface name!!"
    ],
    "stdout": "",
    "stdout_lines": []
}

This changes it to use the individual calls same as for 201811.

ADO: 30499903

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix a bug to get reboot sad path testing working on 201911

#### How did you do it?
Switched the bulk command to individual commands + for-loop in python

#### How did you verify/test it?
Tested the command on a device running 201911 as well as ran the test.

#### Any platform specific information?
All 201911

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
