### PR TITLE
Fixed issue with neigbour lag not going down with sonic neighbors

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -485,7 +485,9 @@ class ReloadTest(BaseTest):
                 for vm_key in self.vm_dut_map.keys():
                     if member in self.vm_dut_map[vm_key]['dut_ports']:
                         self.vm_dut_map[vm_key]['dut_portchannel'] = str(key)
-                        self.vm_dut_map[vm_key]['neigh_portchannel'] = 'Port-Channel1'
+                        neigh_portchannel = "PortChannel1" if self.test_params['neighbor_type'] == "sonic" \
+                                            else "Port-Channel1"
+                        self.vm_dut_map[vm_key]['neigh_portchannel'] = neigh_portchannel
                         if self.is_dualtor:
                             self.peer_vm_dut_map[vm_key]['dut_portchannel'] = str(key)
                         break

--- a/ansible/roles/test/files/ptftests/sonic.py
+++ b/ansible/roles/test/files/ptftests/sonic.py
@@ -469,9 +469,12 @@ class Sonic(host_device.HostDevice):
 
     def change_neigh_lag_state(self, intf, is_up=True):
         state = ['shutdown', 'startup']
-        is_match = re.match(r'(Port-Channel|Ethernet)\d+', intf)
+        pattern = r'(PortChannel|Ethernet)\d+'
+        is_match = re.match(pattern, intf)
         if is_match:
             self.do_cmd('sudo config interface %s intf' % state[is_up])
+        else:
+            self.log("Failed to match interface '%s' with pattern '%s'" % (intf, pattern))
 
     def change_neigh_intfs_state(self, intfs, is_up=True):
         for intf in intfs:

--- a/ansible/roles/test/files/ptftests/sonic.py
+++ b/ansible/roles/test/files/ptftests/sonic.py
@@ -472,7 +472,7 @@ class Sonic(host_device.HostDevice):
         pattern = r'(PortChannel|Ethernet)\d+'
         is_match = re.match(pattern, intf)
         if is_match:
-            self.do_cmd('sudo config interface %s intf' % state[is_up])
+            self.do_cmd('sudo config interface %s %s' % (state[is_up], intf))
         else:
             self.log("Failed to match interface '%s' with pattern '%s'" % (intf, pattern))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

This error was observed in the ptf output when running sad sub case 'neigh_lag_down:3' with sonic neighbors:

2024-11-04 01:06:10 : --------------------------------------------------
2024-11-04 01:06:10 : Fails:
2024-11-04 01:06:10 : --------------------------------------------------
2024-11-04 01:06:10 : FAILED:dut:Preboot: Lag state is not down on the DUT for PortChannel107
2024-11-04 01:06:10 : FAILED:dut:DUT is not ready for test
2024-11-04 01:06:10 : FAILED:dut:Preboot: Obtained:   107  PortChannel107  LACP(A)(Up)  Ethernet96(S)

2024-11-04 01:06:10 : FAILED:dut:Traceback (most recent call last):
  File \"ptftests/py3/advanced-reboot.py\", line 1335, in runTest
    self.wait_dut_to_warm_up()
  File \"ptftests/py3/advanced-reboot.py\", line 2185, in wait_dut_to_warm_up
    \"Actual warm up time {}\".format(ctrlplane, dataplane, elapsed))
Exception: IO didn't come up within warm up timeout. Control plane: up, Data plane: down.Actual warm up time 300.39338

2024-11-04 01:06:10 : FAILED:dut:BGP state not down on DUT
2024-11-04 01:06:10 : FAILED:dut:Preboot: Lag state is not down on the DUT for PortChannel105
2024-11-04 01:06:10 : FAILED:dut:Preboot: Obtained:   105  PortChannel105  LACP(A)(Up)  Ethernet88(S)

2024-11-04 01:06:10 : FAILED:dut:Preboot: Lag state is not down on the DUT for PortChannel106
2024-11-04 01:06:10 : FAILED:dut:Preboot: Obtained:   106  PortChannel106  LACP(A)(Up)  Ethernet92(S)

2024-11-04 01:06:10 : FAILED:172.16.141.68:BGP state not down for 172.16.141.68
2024-11-04 01:06:10 : FAILED:172.16.141.68:Preboot: LAG state not down for 172.16.141.68
2024-11-04 01:06:10 : FAILED:172.16.141.69:BGP state not down for 172.16.141.69
2024-11-04 01:06:10 : FAILED:172.16.141.69:Preboot: LAG state not down for 172.16.141.69
2024-11-04 01:06:10 : FAILED:172.16.141.70:Preboot: LAG state not down for 172.16.141.70
2024-11-04 01:06:10 : FAILED:172.16.141.70:BGP state not down for 172.16.141.70
2024-11-04 01:06:10 : ==================================================
2024-11-04 01:06:10 : Disabling arp_responder

The problem is it was looking for the ceos neighbor name 'Port-Channel1' as opposed to the sonic one 'PortChannel1' when running with sonic neighbors and attempting to change interface state.

ADO: 30500449

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix a bug

#### How did you do it?
Changed the hardcoded logic to check if neighbor type is sonic. Also added additional logging to help debug future issues in this area.

#### How did you verify/test it?
Ran the test on the internal pipeline.

#### Any platform specific information?
All sad sonic neighbor advanced-reboot tests 

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
