### PR TITLE
[T2] [chassis] change default wait time for links to come up for T2

### DIFF
--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -12,7 +12,7 @@ from tests.common.utilities import wait_until, get_plt_reboot_ctrl
 logger = logging.getLogger(__name__)
 
 
-def reset_timeout(duthost):
+def reset_timeout(duthost, reset_timeout):
     """
     return: if timeout is specified in inventory file for this dut, return new timeout
             if not specified, return 300 sec as default timeout
@@ -21,11 +21,9 @@ def reset_timeout(duthost):
           timeout: 400
           wait: 60
     """
-    reset_timeout = 300
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'processes_utils.py', 'cold')
     if plt_reboot_ctrl:
         reset_timeout = plt_reboot_ctrl.get('timeout', 300)
-    return reset_timeout
 
 
 def get_critical_processes_status(dut):
@@ -63,12 +61,13 @@ def check_critical_processes(dut, watch_secs=0):
         watch_secs = watch_secs - 5
 
 
-def wait_critical_processes(dut):
+def wait_critical_processes(dut, timeout=300):
     """
     @summary: wait until all critical processes are healthy.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
+    timeout: we give it default 300sec as usual, also give the option to pass a timeout value
     """
-    timeout = reset_timeout(dut)
+    reset_timeout(dut, timeout)
     # No matter what we set in inventory file, we always set sup timeout to 900
     # because most SUPs have 10+ dockers that need to come up
     if dut.is_supervisor_node():

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -206,6 +206,7 @@ def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku
                                     conn_graph_facts,
                                     fanouthosts, xcvr_skip_list):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    wait_time = 300
     set_max_to_reboot(duthost)
     hostname = duthost.hostname
 
@@ -238,8 +239,10 @@ def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku
     assert rebooted, "Device {} did not reboot".format(hostname)
 
     # After test, check all interfaces and services are up
+    if len(duthosts.nodes) > 1:
+        wait_time = 400
     check_interfaces_and_services(
-        duthost, conn_graph_facts.get("device_conn", {}).get("hostname", {}), xcvr_skip_list, interfaces_wait_time=400)
+        duthost, conn_graph_facts.get("device_conn", {}).get("hostname", {}), xcvr_skip_list, interfaces_wait_time=wait_time)
 
     # Also make sure fanout hosts' links are up
     link_status_on_host(fanouts_and_ports)

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -143,7 +143,7 @@ def link_status_on_all_fanouts(fanouts_and_ports, up=True):
 def check_interfaces_and_services_all_LCs(duthosts, conn_graph_facts, xcvr_skip_list):
     for LC in duthosts.frontend_nodes:
         check_interfaces_and_services(
-            LC, conn_graph_facts["device_conn"][LC.hostname], xcvr_skip_list)
+            LC, conn_graph_facts["device_conn"][LC.hostname], xcvr_skip_list, interfaces_wait_time=400)
 
 
 def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostname,
@@ -239,7 +239,7 @@ def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku
 
     # After test, check all interfaces and services are up
     check_interfaces_and_services(
-        duthost, conn_graph_facts.get("device_conn", {}).get("hostname", {}), xcvr_skip_list)
+        duthost, conn_graph_facts.get("device_conn", {}).get("hostname", {}), xcvr_skip_list, interfaces_wait_time=400)
 
     # Also make sure fanout hosts' links are up
     link_status_on_host(fanouts_and_ports)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
some T2 testbed do not define timeout in inventory files, thus they are still taking default 300sec that was made for T0/T1.
for T2 linecards, make the default wait time to be 400sec
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
