### PR TITLE
Add gnmi test for smartswitch

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -96,6 +96,7 @@ def apply_cert_config(duthost):
     dut_command += "--config_table_name GNMI_CLIENT_CERT "
     dut_command += "--client_auth cert "
     dut_command += "--enable_crl=true "
+    dut_command += "--zmq_address=tcp://127.0.0.1:8100 "
     dut_command += "--ca_crt /etc/sonic/telemetry/gnmiCA.pem -gnmi_native_write=true -v=10 >/root/gnmi.log 2>&1 &\""
     duthost.shell(dut_command)
 

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -76,6 +76,10 @@ def del_gnmi_client_common_name(duthost, cname):
 
 def apply_cert_config(duthost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
+    # Get subtype
+    cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    metadata = cfg_facts["DEVICE_METADATA"]["localhost"]
+    subtype = metadata.get('subtype', None)
     # Stop all running program
     dut_command = "docker exec %s supervisorctl status" % (env.gnmi_container)
     output = duthost.shell(dut_command, module_ignore_errors=True)
@@ -96,7 +100,8 @@ def apply_cert_config(duthost):
     dut_command += "--config_table_name GNMI_CLIENT_CERT "
     dut_command += "--client_auth cert "
     dut_command += "--enable_crl=true "
-    dut_command += "--zmq_address=tcp://127.0.0.1:8100 "
+    if subtype == 'SmartSwitch':
+        dut_command += "--zmq_address=tcp://127.0.0.1:8100 "
     dut_command += "--ca_crt /etc/sonic/telemetry/gnmiCA.pem -gnmi_native_write=true -v=10 >/root/gnmi.log 2>&1 &\""
     duthost.shell(dut_command)
 

--- a/tests/gnmi/test_gnmi_smartswitch.py
+++ b/tests/gnmi/test_gnmi_smartswitch.py
@@ -34,13 +34,21 @@ def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
     if type != "LeafRouter" or subtype != 'SmartSwitch':
         pytest.skip("This test is supported only on smartswitch platforms")
     # Locate the first online DPU
+    # Name    Description    Physical-Slot    Oper-Status    Admin-Status    Serial
+    # ------  -------------  ---------------  -------------  --------------  --------
     # DPU0            N/A              N/A         Online              up       N/A
     target = None
     result = duthost.shell("show chassis module status")
+    headers = result['stdout_lines'][0].split()
+    for i, header in enumerate(headers):
+        if header == "Name":
+            name_idx = i
+        if header == "Oper-Status":
+            oper_status_idx = i
     for line in result['stdout_lines']:
         module_status = line.split()
-        if "Online" in module_status:
-            target = module_status[0].lower()
+        if module_status[oper_status_idx] == "Online":
+            target = module_status[name_idx].lower()
             logger.info("target is {}".format(target))
             break
     assert target is not None, "Can't locate online DPU"
@@ -50,7 +58,7 @@ def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
     redis_port = data['INSTANCES']['redis']['port']
     file_name = "vnet.txt"
     vni = "1000"
-    guid = "559c6ce8-26ab-4193-b946-ccc6e8f930b2"
+    guid = str(uuid.uuid4())
     proto = get_vnet_proto(vni, guid)
     with open(file_name, 'wb') as file:
         file.write(proto)

--- a/tests/gnmi/test_gnmi_smartswitch.py
+++ b/tests/gnmi/test_gnmi_smartswitch.py
@@ -1,0 +1,76 @@
+import json
+import logging
+import pytest
+import uuid
+from .helper import gnmi_set
+from dash_api.vnet_pb2 import Vnet
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.disable_loganalyzer
+]
+
+
+def get_vnet_proto(vni, guid):
+    pb = Vnet()
+    pb.vni = int(vni)
+    pb.guid.value = bytes.fromhex(uuid.UUID(guid).hex)
+    return pb.SerializeToString()
+
+
+def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
+    '''
+    Verify GNMI native write with ApplDB
+    Update DASH_VNET_TABLE
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    metadata = cfg_facts["DEVICE_METADATA"]["localhost"]
+    subtype = metadata.get('subtype', None)
+    type = metadata.get('type', None)
+    logger.info("type {}, subtype {}".format(type, subtype))
+    if type != "LeafRouter" or subtype != 'SmartSwitch':
+        pytest.skip("This test is supported only on smartswitch platforms")
+    # Locate the first online DPU
+    # DPU0            N/A              N/A         Online              up       N/A
+    target = None
+    result = duthost.shell("show chassis module status")
+    for line in result['stdout_lines']:
+        module_status = line.split()
+        if "Online" in module_status:
+            target = module_status[0].lower()
+            logger.info("target is {}".format(target))
+            break
+    assert target is not None, "Can't locate online DPU"
+    # Get redis port
+    result = duthost.shell("cat /var/run/redis%s/sonic-db/database_config.json" % target)
+    data = json.loads(result['stdout'])
+    redis_port = data['INSTANCES']['redis']['port']
+    file_name = "vnet.txt"
+    vni = "1000"
+    guid = "559c6ce8-26ab-4193-b946-ccc6e8f930b2"
+    proto = get_vnet_proto(vni, guid)
+    with open(file_name, 'wb') as file:
+        file.write(proto)
+    ptfhost.copy(src=file_name, dest='/root')
+    # Add DASH_VNET_TABLE
+    update_list = ["/sonic-db:APPL_DB/%s/DASH_VNET_TABLE/Vnet1:$/root/%s" % (target, file_name)]
+    gnmi_set(duthost, ptfhost, [], update_list, [])
+    # Verify APPL_DB
+    int_cmd = "redis-cli --raw -p %s -n 0 hget \"DASH_VNET_TABLE:Vnet1\" pb" % redis_port
+    int_cmd += " | dash_api_utils --table_name DASH_VNET_TABLE"
+    result = duthost.shell('docker exec database bash -c "%s"' % int_cmd)
+    vnet_config = json.loads(result["stdout"])
+    assert str(vnet_config["vni"]) == vni, "DASH_VNET_TABLE is wrong: " + result["stdout"]
+    logger.info("DASH_VNET_TABLE is updated: {}".format(result["stdout"]))
+    # Remove DASH_VNET_TABLE
+    delete_list = ["/sonic-db:APPL_DB/%s/DASH_VNET_TABLE/Vnet1" % target]
+    gnmi_set(duthost, ptfhost, delete_list, [], [])
+    # Verify APPL_DB
+    int_cmd = "redis-cli --raw -p %s -n 0 hgetall \"DASH_VNET_TABLE:Vnet1\"" % redis_port
+    result = duthost.shell('docker exec database bash -c "%s"' % int_cmd)
+    assert "pb" not in result["stdout"], "DASH_VNET_TABLE is wrong: " + result["stdout"]
+    logger.info("DASH_VNET_TABLE is removed: {}".format(result["stdout"]))
+

--- a/tests/gnmi/test_gnmi_smartswitch.py
+++ b/tests/gnmi/test_gnmi_smartswitch.py
@@ -40,11 +40,15 @@ def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
     target = None
     result = duthost.shell("show chassis module status")
     headers = result['stdout_lines'][0].split()
+    name_idx = None
+    oper_status_idx = None
     for i, header in enumerate(headers):
         if header == "Name":
             name_idx = i
         if header == "Oper-Status":
             oper_status_idx = i
+    assert name_idx is not None, "Can't locate Name in the headers"
+    assert oper_status_idx is not None, "Can't locate Oper-Status in the headers"
     for line in result['stdout_lines']:
         module_status = line.split()
         if module_status[oper_status_idx] == "Online":

--- a/tests/gnmi/test_gnmi_smartswitch.py
+++ b/tests/gnmi/test_gnmi_smartswitch.py
@@ -74,3 +74,4 @@ def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
     assert "pb" not in result["stdout"], "DASH_VNET_TABLE is wrong: " + result["stdout"]
     logger.info("DASH_VNET_TABLE is removed: {}".format(result["stdout"]))
 
+

--- a/tests/gnmi/test_gnmi_smartswitch.py
+++ b/tests/gnmi/test_gnmi_smartswitch.py
@@ -73,5 +73,3 @@ def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
     result = duthost.shell('docker exec database bash -c "%s"' % int_cmd)
     assert "pb" not in result["stdout"], "DASH_VNET_TABLE is wrong: " + result["stdout"]
     logger.info("DASH_VNET_TABLE is removed: {}".format(result["stdout"]))
-
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Microsoft ADO: 28940620

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Add gnmi end to end test for smartswitch

#### How did you do it?
Use GNMI to update the DASH_VNET_TABLE, and use redis cli to verify the DASH_VNET_TABLE in APPL_DB.
Only run test for smartswitch device.

#### How did you verify/test it?
Run gnmi end to end test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
