### PR TITLE
skip chassis supervisor in check_interface_status_of_up_ports

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -44,7 +44,7 @@ def parse_intf_status(lines):
 
 
 def check_interface_status_of_up_ports(duthost):
-    if duthost.is_supervisor_node():
+    if duthost.facts['asic_type'] == 'vs' and duthost.is_supervisor_node():
         return True
     
     if duthost.is_multi_asic:

--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -44,6 +44,9 @@ def parse_intf_status(lines):
 
 
 def check_interface_status_of_up_ports(duthost):
+    if duthost.is_supervisor_node():
+        return True
+    
     if duthost.is_multi_asic:
         up_ports = []
         for asic in duthost.frontend_asics:

--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -46,7 +46,7 @@ def parse_intf_status(lines):
 def check_interface_status_of_up_ports(duthost):
     if duthost.facts['asic_type'] == 'vs' and duthost.is_supervisor_node():
         return True
-    
+
     if duthost.is_multi_asic:
         up_ports = []
         for asic in duthost.frontend_asics:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: skip virtual chassis supervisor in check_interface_status_of_up_ports. Virtual T2 chassis supervisor does not have any front-end interface and neither 'PORT' configuration, so we should not run this check on virtual chassis SUP.
Fixes # (issue)

Microsoft ADO number: 30553232

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [x] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

Make the sanity check on T2 chassis smoother

#### How did you do it?

Add code to skip chassis supervisor in check_interface_status_of_up_ports

#### How did you verify/test it?

Run the sanity check with such a change on a virtual chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
