### PR TITLE
chore: skip PSU check for chassis LC

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -241,13 +241,16 @@ def check_all_psu_on(dut, psu_test_results):
 
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize('ignore_particular_error_log', [SKIP_ERROR_LOG_PSU_ABSENCE], indirect=True)
-def test_turn_on_off_psu_and_check_psustatus(duthosts,
+def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_hostname,
                                              get_pdu_controller, ignore_particular_error_log, tbinfo):
     """
     @summary: Turn off/on PSU and check PSU status using 'show platform psustatus'
     """
-    duthost = get_sup_node_or_random_node(duthosts)
+    is_modular_chassis = duthosts[0].get_facts().get("modular_chassis")
+    if is_modular_chassis and not duthosts[enum_rand_one_per_hwsku_hostname].is_supervisor_node():
+        pytest.skip("Skip the PSU check test on Line card on modular chassis")
 
+    duthost = get_sup_node_or_random_node(duthosts)
     psu_line_pattern = get_dut_psu_line_pattern(duthost)
 
     psu_num = get_healthy_psu_num(duthost)
@@ -277,7 +280,6 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts,
 
     # Increase pdu_wait_time for modular chassis
     pdu_wait_time = PDU_WAIT_TIME
-    is_modular_chassis = duthosts[0].get_facts().get("modular_chassis")
     if is_modular_chassis:
         pdu_wait_time = MODULAR_CHASSIS_PDU_WAIT_TIME
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Skip `platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_psustatus` for chassis LC

Summary:
Fixes # (issue) Microsoft ADO 30114143

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Due to the module-level enumerate fixture `psu_test_setup_teardown` that has `enum_rand_one_per_hwsku_hostname` in this test module, we will run `platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_psustatus` multiple times when it's a T2 chassis. However, we don't need to run it multiple times because we are just toggling the PDU/PSU on the supervisor card in this test case. Therefore, we should skip the runs when the parametrization is on LCs.

#### How did you do it?

#### How did you verify/test it?
Ran it on T2 and I can confirm it's only run for supervisor parametrization.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
