### PR TITLE
Apply GCU changes to the appropriate namespace scope for each suite

### DIFF
--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -76,7 +76,8 @@ def add_bbr_config_to_running_config(duthost, status):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to asic namespaces only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -99,7 +100,7 @@ def config_bbr_by_gcu(duthost, status):
             "value": "{}".format(status)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -76,7 +76,6 @@ def add_bbr_config_to_running_config(duthost, status):
             }
         }
     ]
-    # change is applied to asic namespaces only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)

--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -368,7 +368,8 @@ def bgp_peer_range_add_config(
                 }
             ]
 
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to asic namespaces only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
 
@@ -404,7 +405,7 @@ def bgp_peer_range_delete_config(
         {"op": "remove", "path": "/BGP_PEER_RANGE/{}".format(ip_range_name)},
         {"op": "remove", "path": "/BGP_PEER_RANGE/{}".format(ipv6_range_name)},
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -368,7 +368,6 @@ def bgp_peer_range_add_config(
                 }
             ]
 
-    # change is applied to asic namespaces only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -36,8 +36,17 @@ def delete_tmpfile(duthost, tmpfile):
     duthost.file(path=tmpfile, state='absent')
 
 
-def format_json_patch_for_multiasic(duthost, json_data, is_asic_specific=False):
-    if is_asic_specific:
+def format_json_patch_for_multiasic(duthost, json_data, is_asic_specific=False, is_host_specific=False):
+    """
+    Formats a JSON patch for multi-ASIC platforms by adding a path change to be applied
+    simultaneously in all DUT host namespaces (localhost + ASIC namespaces).
+
+    - For changes that are ASIC-specific (applied only in one ASIC namespace), the function
+    returns without any formatting.
+    - For changes that are host-specific (applied only to the localhost namespace and not
+    to ASIC namespaces), the function returns without any formatting.
+    """
+    if is_asic_specific or is_host_specific:
         return json_data
 
     json_patch = []

--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -20,8 +20,8 @@ GCUTIMEOUT = 600
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 FILES_DIR = os.path.join(BASE_DIR, "files")
 TMP_DIR = '/tmp'
-HOST_NAME = "/localhost"
-ASIC_PREFIX = "/asic"
+HOST_NAME = "localhost"
+ASIC_PREFIX = "asic"
 
 
 def generate_tmpfile(duthost):
@@ -36,41 +36,75 @@ def delete_tmpfile(duthost, tmpfile):
     duthost.file(path=tmpfile, state='absent')
 
 
-def format_json_patch_for_multiasic(duthost, json_data, is_asic_specific=False, is_host_specific=False):
+def format_json_patch_for_multiasic(duthost, json_data,
+                                    is_asic_specific=False,
+                                    is_host_specific=False,
+                                    asic_namespaces=None):
     """
-    Formats a JSON patch for multi-ASIC platforms by adding a path change to be applied
-    simultaneously in all DUT host namespaces (localhost + ASIC namespaces).
+    Formats a JSON patch for multi-ASIC platforms based on the specified scope.
 
-    - For changes that are ASIC-specific (applied only in one ASIC namespace), the function
-    returns without any formatting.
-    - For changes that are host-specific (applied only to the localhost namespace and not
-    to ASIC namespaces), the function returns without any formatting.
+    - Case 1: Apply changes only to /localhost namespace.
+      example: format_json_patch_for_multiasic(duthost, json_data, is_host_specific=True)
+
+    - Case 2: Apply changes only to all available ASIC namespaces (e.g., /asic0, /asic1).
+      example: format_json_patch_for_multiasic(duthost, json_data, is_asic_specific=True)
+
+    - Case 3: Apply changes to one specific ASIC namespace (e.g., /asic0).
+      example: format_json_patch_for_multiasic(duthost, json_data, is_asic_specific=True, asic_namespaces='asic0')
+
+    - Case 4: Apply changes to both /localhost and all ASIC namespaces.
+      example: format_json_patch_for_multiasic(duthost, json_data)
+
     """
-    if is_asic_specific or is_host_specific:
-        return json_data
-
     json_patch = []
+    asic_namespaces = asic_namespaces or []
+
     if duthost.is_multi_asic:
         num_asic = duthost.facts.get('num_asic')
 
         for operation in json_data:
             path = operation["path"]
-            if path.startswith(HOST_NAME) and ASIC_PREFIX in path:
-                json_patch.append(operation)
-            else:
-                template = {
-                    "op": operation["op"],
-                    "path": "{}{}".format(HOST_NAME, path)
-                }
 
-                if operation["op"] in ["add", "replace", "test"]:
-                    template["value"] = operation["value"]
-                json_patch.append(template.copy())
+            # Case 1: Apply only to localhost
+            if is_host_specific:
+                if path.startswith(f"/{HOST_NAME}"):
+                    json_patch.append(operation)
+                else:
+                    template = operation.copy()
+                    template["path"] = f"/{HOST_NAME}{path}"
+                    json_patch.append(template)
+
+            # Case 2: Apply only to all ASIC namespaces
+            elif is_asic_specific and not asic_namespaces:
                 for asic_index in range(num_asic):
-                    asic_ns = "{}{}".format(ASIC_PREFIX, asic_index)
-                    template["path"] = "{}{}".format(asic_ns, path)
-                    json_patch.append(template.copy())
+                    asic_ns = f"{ASIC_PREFIX}{asic_index}"
+                    template = operation.copy()
+                    template["path"] = f"/{asic_ns}{path}"
+                    json_patch.append(template)
+
+            # Case 3: Apply to one specific ASIC namespace
+            elif asic_namespaces:
+                for asic_ns in asic_namespaces:
+                    template = operation.copy()
+                    template["path"] = f"/{asic_ns}{path}"
+                    json_patch.append(template)
+
+            # Case 4: Apply to both localhost and all ASIC namespaces
+            else:
+                # Add for localhost
+                template = operation.copy()
+                template["path"] = f"/{HOST_NAME}{path}"
+                json_patch.append(template)
+
+                # Add for all ASIC namespaces
+                for asic_index in range(num_asic):
+                    asic_ns = f"{ASIC_PREFIX}{asic_index}"
+                    template = operation.copy()
+                    template["path"] = f"/{asic_ns}{path}"
+                    json_patch.append(template)
+
         json_data = json_patch
+    logger.debug("format_json_patch_for_multiasic: {}".format(json_data))
 
     return json_data
 

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -295,18 +295,23 @@ def verify_features_state(duthost):
     return True
 
 
-def verify_orchagent_running_or_assert(duthost):
+def verify_orchagent_running_or_assert(duthost, asic_id=None):
     """
     Verifies that orchagent is running, asserts otherwise
 
     Args:
         duthost: Device Under Test (DUT)
+        asic_id: Asic ID to verify. If None verifies for all asics that duthost contains.
     """
 
     def _orchagent_running():
-        cmds = 'docker exec swss supervisorctl status orchagent'
-        output = duthost.shell(cmds, module_ignore_errors=True)
-        pytest_assert(not output['rc'], "Unable to check orchagent status output")
+        asic_ids = duthost.get_asic_ids() if asic_id is None else [asic_id]
+        for asic in asic_ids:
+            cmd = 'docker exec swss supervisorctl status orchagent'
+            if asic is not None:
+                cmd = 'docker exec swss{} supervisorctl status orchagent'.format(asic)
+            output = duthost.shell(cmd, module_ignore_errors=True)
+            pytest_assert(not output['rc'], "Unable to check orchagent status output for asic_id {}".format(asic))
         return 'RUNNING' in output['stdout']
 
     pytest_assert(

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -295,23 +295,27 @@ def verify_features_state(duthost):
     return True
 
 
-def verify_orchagent_running_or_assert(duthost, asic_id=None):
+def verify_orchagent_running_or_assert(duthost):
     """
-    Verifies that orchagent is running, asserts otherwise
+    Verifies that orchagent is running, asserts otherwise.
+    In case of multi-asic platforms verifies orchagent running for all the asic namespaces.
 
     Args:
         duthost: Device Under Test (DUT)
-        asic_id: Asic ID to verify. If None verifies for all asics that duthost contains.
     """
 
     def _orchagent_running():
-        asic_ids = duthost.get_asic_ids() if asic_id is None else [asic_id]
-        for asic in asic_ids:
-            cmd = 'docker exec swss supervisorctl status orchagent'
-            if asic is not None:
-                cmd = 'docker exec swss{} supervisorctl status orchagent'.format(asic)
-            output = duthost.shell(cmd, module_ignore_errors=True)
-            pytest_assert(not output['rc'], "Unable to check orchagent status output for asic_id {}".format(asic))
+        if duthost.is_multi_asic:
+            num_asic = duthost.facts.get('num_asic')
+            for asic_index in range(num_asic):
+                cmd = 'docker exec swss{} supervisorctl status orchagent'.format(asic_index)
+                output = duthost.shell(cmd, module_ignore_errors=True)
+                pytest_assert(not output['rc'], "Unable to check orchagent status output for asic_id {}"
+                              .format(asic_index))
+        else:
+            cmds = 'docker exec swss supervisorctl status orchagent'
+            output = duthost.shell(cmds, module_ignore_errors=True)
+            pytest_assert(not output['rc'], "Unable to check orchagent status output")
         return 'RUNNING' in output['stdout']
 
     pytest_assert(

--- a/tests/generic_config_updater/gu_utils.py
+++ b/tests/generic_config_updater/gu_utils.py
@@ -36,11 +36,13 @@ def format_and_apply_template(duthost, template_name, extra_vars, setup):
     return outputs
 
 
-def load_and_apply_json_patch(duthost, file_name, setup):
+def load_and_apply_json_patch(duthost, file_name, setup, is_asic_specific=False, is_host_specific=False):
     with open(os.path.join(TEMPLATES_DIR, file_name)) as file:
         json_patch = json.load(file)
 
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=is_asic_specific,
+                                                 is_host_specific=is_host_specific)
     duts_to_apply = [duthost]
     outputs = []
     if setup["is_dualtor"]:

--- a/tests/generic_config_updater/test_aaa.py
+++ b/tests/generic_config_updater/test_aaa.py
@@ -169,7 +169,8 @@ def aaa_tc1_add_config(duthost):
             "value": aaa_config
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to localhost namespace only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -208,7 +209,7 @@ def aaa_tc1_replace(duthost):
             "value": "tacacs+"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -246,7 +247,7 @@ def aaa_tc1_add_duplicate(duthost):
             "value": "tacacs+"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -273,7 +274,7 @@ def aaa_tc1_remove(duthost):
             "path": "/AAA"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -318,7 +319,7 @@ def tacacs_global_tc2_add_config(duthost):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
 
@@ -358,7 +359,7 @@ def tacacs_global_tc2_invalid_input(duthost):
                 }
             }
         ]
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
 
@@ -382,7 +383,7 @@ def tacacs_global_tc2_duplicate_input(duthost):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
 
@@ -408,7 +409,7 @@ def tacacs_global_tc2_remove(duthost):
             "path": "/TACPLUS"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
 
@@ -452,7 +453,7 @@ def tacacs_server_tc3_add_init(duthost):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -491,7 +492,7 @@ def tacacs_server_tc3_add_max(duthost):
         }
         json_patch.append(patch)
 
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
 
@@ -532,7 +533,7 @@ def tacacs_server_tc3_replace_invalid(duthost):
                 }
             }
         ]
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
 
@@ -554,7 +555,7 @@ def tacacs_server_tc3_add_duplicate(duthost):
             "value": TACACS_SERVER_OPTION
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -579,7 +580,7 @@ def tacacs_server_tc3_remove(duthost):
             "path": "/TACPLUS_SERVER"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_aaa.py
+++ b/tests/generic_config_updater/test_aaa.py
@@ -169,7 +169,6 @@ def aaa_tc1_add_config(duthost):
             "value": aaa_config
         }
     ]
-    # change is applied to localhost namespace only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)

--- a/tests/generic_config_updater/test_bgp_prefix.py
+++ b/tests/generic_config_updater/test_bgp_prefix.py
@@ -116,7 +116,9 @@ def bgp_prefix_tc1_add_config(duthost, community, community_table):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+
+    # change is applied to asic namespaces only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -157,7 +159,7 @@ def bgp_prefix_tc1_xfail(duthost, community_table):
                 "value": prefixes_v4
             }
         ]
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
@@ -185,7 +187,7 @@ def bgp_prefix_tc1_replace(duthost, community, community_table):
             "value": PREFIXES_V4_DUMMY
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -219,7 +221,7 @@ def bgp_prefix_tc1_remove(duthost, community):
             "path": "/BGP_ALLOWED_PREFIXES"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_bgp_prefix.py
+++ b/tests/generic_config_updater/test_bgp_prefix.py
@@ -117,7 +117,6 @@ def bgp_prefix_tc1_add_config(duthost, community, community_table):
         }
     ]
 
-    # change is applied to asic namespaces only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)

--- a/tests/generic_config_updater/test_bgp_sentinel.py
+++ b/tests/generic_config_updater/test_bgp_sentinel.py
@@ -130,7 +130,6 @@ def bgp_sentinel_tc1_add_config(duthost, lo_intf_ips):
             }
         }
     ]
-    # change is applied to asic namespaces only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)

--- a/tests/generic_config_updater/test_bgp_sentinel.py
+++ b/tests/generic_config_updater/test_bgp_sentinel.py
@@ -130,7 +130,8 @@ def bgp_sentinel_tc1_add_config(duthost, lo_intf_ips):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to asic namespaces only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -170,7 +171,7 @@ def bgp_sentinel_tc1_add_dummy_ip_range(duthost):
             "value": "{}".format(DUMMY_IP_RANGE_V6)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -204,7 +205,7 @@ def bgp_sentinel_tc1_rm_dummy_ip_range(duthost):
             "path": "/BGP_SENTINELS/{}/ip_range/1".format(BGPSENTINEL_V6)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -239,7 +240,7 @@ def bgp_sentinel_tc1_replace_src_address(duthost):
             "value": "{}".format(DUMMY_SRC_ADDRESS_V6)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_bgp_speaker.py
+++ b/tests/generic_config_updater/test_bgp_speaker.py
@@ -125,7 +125,8 @@ def bgp_speaker_tc1_add_config(duthost, lo_intf_ips, vlan_intf_ip_ranges):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to asic namespaces only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -165,7 +166,7 @@ def bgp_speaker_tc1_add_dummy_ip_range(duthost):
             "value": "{}".format(DUMMY_IP_RANGE_V6)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -198,7 +199,7 @@ def bgp_speaker_tc1_rm_dummy_ip_range(duthost):
             "path": "/BGP_PEER_RANGE/{}/ip_range/1".format(BGPSPEAKER_V6)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -233,7 +234,7 @@ def bgp_speaker_tc1_replace_src_address(duthost):
             "value": "{}".format(DUMMY_SRC_ADDRESS_V6)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_bgp_speaker.py
+++ b/tests/generic_config_updater/test_bgp_speaker.py
@@ -125,7 +125,6 @@ def bgp_speaker_tc1_add_config(duthost, lo_intf_ips, vlan_intf_ip_ranges):
             }
         }
     ]
-    # change is applied to asic namespaces only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)

--- a/tests/generic_config_updater/test_bgpl.py
+++ b/tests/generic_config_updater/test_bgpl.py
@@ -114,7 +114,6 @@ def bgpmon_tc1_add_init(duthost, bgpmon_setup_info):
             }
         }
     ]
-    # change is applied to asic namespaces only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)

--- a/tests/generic_config_updater/test_bgpl.py
+++ b/tests/generic_config_updater/test_bgpl.py
@@ -114,7 +114,8 @@ def bgpmon_tc1_add_init(duthost, bgpmon_setup_info):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to asic namespaces only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -148,7 +149,7 @@ def bgpmon_tc1_add_duplicate(duthost, bgpmon_setup_info):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -173,7 +174,7 @@ def bgpmon_tc1_admin_change(duthost, bgpmon_setup_info):
             "value": "down"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -216,7 +217,7 @@ def bgpmon_tc1_ip_change(duthost, bgpmon_setup_info):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -239,7 +240,7 @@ def bgpmon_tc1_remove(duthost):
             "path": "/BGP_MONITORS"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -166,7 +166,8 @@ def cacl_tc1_add_new_table(duthost, protocol):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to asic namespaces only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -202,7 +203,7 @@ def cacl_tc1_add_duplicate_table(duthost, protocol):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -262,7 +263,7 @@ def cacl_tc1_replace_table_variable(duthost, protocol):
             }
         ]
 
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
 
@@ -309,7 +310,7 @@ def cacl_tc1_add_invalid_table(duthost, protocol):
 
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
         try:
             output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
@@ -327,7 +328,7 @@ def cacl_tc1_remove_unexisted_table(duthost):
             "path": "/ACL_RULE/SSH_ONLY_UNEXISTED"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -351,7 +352,7 @@ def cacl_tc1_remove_table(duthost, protocol):
             "path": "/ACL_TABLE/{}".format(table_name)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -413,7 +414,7 @@ def cacl_tc2_add_init_rule(duthost, protocol):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
 
@@ -471,7 +472,7 @@ def cacl_tc2_add_duplicate_rule(duthost, protocol):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -511,7 +512,7 @@ def cacl_tc2_replace_rule(duthost, protocol):
             "value": "8.8.8.8/32"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
 
@@ -554,7 +555,7 @@ def cacl_tc2_add_rule_to_unexisted_table(duthost):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -583,7 +584,7 @@ def cacl_tc2_remove_table_before_rule(duthost, protocol):
             "path": "/ACL_TABLE/{}".format(table)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -612,7 +613,7 @@ def cacl_tc2_remove_unexist_rule(duthost, protocol):
             "path": "/ACL_RULE/{}|TEST_DROP2".format(table)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
     try:
@@ -631,7 +632,7 @@ def cacl_tc2_remove_rule(duthost):
             "path": "/ACL_RULE"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -672,7 +673,7 @@ def cacl_external_client_add_new_table(duthost):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -166,7 +166,6 @@ def cacl_tc1_add_new_table(duthost, protocol):
             }
         }
     ]
-    # change is applied to asic namespaces only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)

--- a/tests/generic_config_updater/test_dhcp_relay.py
+++ b/tests/generic_config_updater/test_dhcp_relay.py
@@ -258,7 +258,10 @@ def test_dhcp_relay_tc1_rm_nonexist(rand_selected_dut, vlan_intfs_list):
             "op": "remove",
             "path": "/VLAN/Vlan" + str(vlan_intfs_list[0]) + "/dhcp_servers/5"
         }]
-    dhcp_rm_nonexist_json = format_json_patch_for_multiasic(duthost=rand_selected_dut, json_data=dhcp_rm_nonexist_json)
+    # change is applied to asic namespaces
+    dhcp_rm_nonexist_json = format_json_patch_for_multiasic(duthost=rand_selected_dut,
+                                                            json_data=dhcp_rm_nonexist_json,
+                                                            is_asic_specific=True)
 
     tmpfile = generate_tmpfile(rand_selected_dut)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_dhcp_relay.py
+++ b/tests/generic_config_updater/test_dhcp_relay.py
@@ -258,7 +258,6 @@ def test_dhcp_relay_tc1_rm_nonexist(rand_selected_dut, vlan_intfs_list):
             "op": "remove",
             "path": "/VLAN/Vlan" + str(vlan_intfs_list[0]) + "/dhcp_servers/5"
         }]
-    # change is applied to asic namespaces
     dhcp_rm_nonexist_json = format_json_patch_for_multiasic(duthost=rand_selected_dut,
                                                             json_data=dhcp_rm_nonexist_json,
                                                             is_asic_specific=True)

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -637,7 +637,8 @@ def build_exp_pkt(input_pkt):
 def dynamic_acl_create_table_type(rand_selected_dut, rand_unselected_dut, setup):
     """Create a new ACL table type that can be used"""
 
-    outputs = load_and_apply_json_patch(rand_selected_dut, CREATE_CUSTOM_TABLE_TYPE_FILE, setup)
+    # change is applied to asic namespaces
+    outputs = load_and_apply_json_patch(rand_selected_dut, CREATE_CUSTOM_TABLE_TYPE_FILE, setup, is_asic_specific=True)
 
     for output in outputs:
         expect_op_success(rand_selected_dut, output)
@@ -793,7 +794,7 @@ def dynamic_acl_create_three_drop_rules(duthost, setup):
 def dynamic_acl_create_arp_forward_rule(duthost, setup):
     """Create an ARP forward rule with the highest priority"""
 
-    outputs = load_and_apply_json_patch(duthost, CREATE_ARP_FORWARD_RULE_FILE, setup)
+    outputs = load_and_apply_json_patch(duthost, CREATE_ARP_FORWARD_RULE_FILE, setup, is_asic_specific=True)
 
     for output in outputs:
         expect_op_success(duthost, output)
@@ -806,7 +807,7 @@ def dynamic_acl_create_arp_forward_rule(duthost, setup):
 def dynamic_acl_create_ndp_forward_rule(duthost, setup):
     "Create an NDP forwarding rule with high priority"
 
-    outputs = load_and_apply_json_patch(duthost, CREATE_NDP_FORWARD_RULE_FILE, setup)
+    outputs = load_and_apply_json_patch(duthost, CREATE_NDP_FORWARD_RULE_FILE, setup, is_asic_specific=True)
 
     for output in outputs:
         expect_op_success(duthost, output)
@@ -819,7 +820,7 @@ def dynamic_acl_create_ndp_forward_rule(duthost, setup):
 def dynamic_acl_create_dhcp_forward_rule(duthost, setup):
     """Create DHCP forwarding rules"""
 
-    outputs = load_and_apply_json_patch(duthost, CREATE_DHCP_FORWARD_RULE_FILE, setup)
+    outputs = load_and_apply_json_patch(duthost, CREATE_DHCP_FORWARD_RULE_FILE, setup, is_asic_specific=True)
 
     for output in outputs:
         expect_op_success(duthost, output)
@@ -886,7 +887,7 @@ def dynamic_acl_remove_third_drop_rule(duthost, setup):
 def dynamic_acl_replace_nonexistent_rule(duthost, setup):
     """Verify that replacing a non-existent rule fails"""
 
-    outputs = load_and_apply_json_patch(duthost, REPLACE_NONEXISTENT_RULE_FILE, setup)
+    outputs = load_and_apply_json_patch(duthost, REPLACE_NONEXISTENT_RULE_FILE, setup, is_asic_specific=True)
 
     for output in outputs:
         expect_op_failure(output)
@@ -1034,7 +1035,7 @@ def dynamic_acl_remove_ip_forward_rule(duthost, ip_type, setup):
 def dynamic_acl_remove_table(duthost, setup):
     """Remove an ACL Table Type from the duthost"""
 
-    outputs = load_and_apply_json_patch(duthost, REMOVE_TABLE_FILE, setup)
+    outputs = load_and_apply_json_patch(duthost, REMOVE_TABLE_FILE, setup, is_asic_specific=True)
 
     for output in outputs:
         expect_op_success(duthost, output)
@@ -1043,7 +1044,7 @@ def dynamic_acl_remove_table(duthost, setup):
 def dynamic_acl_remove_nonexistent_table(duthost, setup):
     """Remove a nonexistent ACL Table from the duthost, verify it fails"""
 
-    outputs = load_and_apply_json_patch(duthost, REMOVE_NONEXISTENT_TABLE_FILE, setup)
+    outputs = load_and_apply_json_patch(duthost, REMOVE_NONEXISTENT_TABLE_FILE, setup, is_asic_specific=True)
 
     for output in outputs:
         expect_op_failure(output)
@@ -1052,7 +1053,7 @@ def dynamic_acl_remove_nonexistent_table(duthost, setup):
 def dynamic_acl_remove_table_type(duthost, setup):
     """Remove an ACL Table definition from the duthost"""
 
-    outputs = load_and_apply_json_patch(duthost, REMOVE_TABLE_TYPE_FILE, setup)
+    outputs = load_and_apply_json_patch(duthost, REMOVE_TABLE_TYPE_FILE, setup, is_asic_specific=True)
 
     for output in outputs:
         expect_op_success(duthost, output)

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -637,7 +637,6 @@ def build_exp_pkt(input_pkt):
 def dynamic_acl_create_table_type(rand_selected_dut, rand_unselected_dut, setup):
     """Create a new ACL table type that can be used"""
 
-    # change is applied to asic namespaces
     outputs = load_and_apply_json_patch(rand_selected_dut, CREATE_CUSTOM_TABLE_TYPE_FILE, setup, is_asic_specific=True)
 
     for output in outputs:

--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -108,7 +108,6 @@ def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, opera
                            "path": "/WRED_PROFILE/AZURE_LOSSLESS/{}".format(field),
                            "value": "{}".format(value)})
 
-    # change is applied to asic namespaces only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)

--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -108,7 +108,8 @@ def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, opera
                            "path": "/WRED_PROFILE/AZURE_LOSSLESS/{}".format(field),
                            "value": "{}".format(value)})
 
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to asic namespaces only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         if is_valid_platform_and_version(duthost, "WRED_PROFILE", "ECN tuning", operation):

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -147,7 +147,8 @@ def test_remove_lanes(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
             "path": "/PORT/Ethernet0/lanes"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to specific asic namespace only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -175,7 +176,7 @@ def test_replace_lanes(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
             "value": "{}".format(update_lanes)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -201,7 +202,7 @@ def test_replace_mtu(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
             "value": "{}".format(target_mtu)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -226,7 +227,7 @@ def test_toggle_pfc_asym(duthosts, rand_one_dut_hostname, ensure_dut_readiness, 
             "value": "{}".format(pfc_asym)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -252,7 +253,7 @@ def test_replace_fec(duthosts, rand_one_dut_hostname, ensure_dut_readiness, fec)
             "value": "{}".format(fec)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
 
@@ -283,7 +284,7 @@ def test_update_invalid_index(duthosts, rand_one_dut_hostname, ensure_dut_readin
             "value": "abc1"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -322,7 +323,7 @@ def test_update_valid_index(duthosts, rand_one_dut_hostname, ensure_dut_readines
             "value": "{}".format(list(interfaces.values())[0])
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -345,7 +346,7 @@ def test_update_speed(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
                 "value": "{}".format(speed)
             }
         ]
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
@@ -373,7 +374,7 @@ def test_update_description(duthosts, rand_one_dut_hostname, ensure_dut_readines
             "value": "Updated description"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -395,7 +396,7 @@ def test_eth_interface_admin_change(duthosts, rand_one_dut_hostname, admin_statu
             "value": "{}".format(admin_status)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -41,8 +41,10 @@ def ensure_dut_readiness(duthosts, rand_one_dut_hostname):
         delete_checkpoint(duthost)
 
 
-def is_valid_fec_state_db(duthost, value):
-    read_supported_fecs_cli = 'sonic-db-cli STATE_DB hget "PORT_TABLE|{}" supported_fecs'.format("Ethernet0")
+def is_valid_fec_state_db(duthost, value, port, namespace=None):
+    namespace_prefix = '' if namespace is None else '-n ' + namespace
+    read_supported_fecs_cli = 'sonic-db-cli {} STATE_DB hget "PORT_TABLE|{}" supported_fecs'.format(
+        namespace_prefix, port)
     supported_fecs_str = duthost.shell(read_supported_fecs_cli)['stdout']
     if supported_fecs_str:
         if supported_fecs_str != 'N/A':
@@ -56,8 +58,29 @@ def is_valid_fec_state_db(duthost, value):
     return True
 
 
-def is_valid_speed_state_db(duthost, value):
-    read_supported_speeds_cli = 'sonic-db-cli STATE_DB hget "PORT_TABLE|{}" supported_speeds'.format("Ethernet0")
+def fec_exists_on_config_db(duthost, port, namespace=None):
+    """
+    Check if FEC (Forward Error Correction) exists on the CONFIG_DB for a given port.
+    Args:
+        duthost (object): The DUT (Device Under Test) host object.
+        port (str): The port for which FEC existence needs to be checked.
+        namespace (str, optional): The namespace in which the port exists. Defaults to None.
+    Returns:
+        bool: True if FEC exists on the CONFIG_DB for the given port, False otherwise.
+    """
+    namespace_prefix = '' if namespace is None else '-n ' + namespace
+    read_fec = 'sonic-db-cli {} CONFIG_DB hget "PORT|{}" fec'.format(namespace_prefix, port)
+    read_fec_str = duthost.shell(read_fec)['stdout']
+    if read_fec_str:
+        return True
+    else:
+        return False
+
+
+def is_valid_speed_state_db(duthost, value, port, namespace=None):
+    namespace_prefix = '' if namespace is None else '-n ' + namespace
+    read_supported_speeds_cli = 'sonic-db-cli {} STATE_DB hget "PORT_TABLE|{}" supported_speeds'.format(
+        namespace_prefix, port)
     supported_speeds_str = duthost.shell(read_supported_speeds_cli)['stdout']
     supported_speeds = [int(s) for s in supported_speeds_str.split(',') if s]
     if supported_speeds and int(value) not in supported_speeds:
@@ -65,9 +88,9 @@ def is_valid_speed_state_db(duthost, value):
     return True
 
 
-def check_interface_status(duthost, field, interface='Ethernet0'):
+def check_interface_status(duthost, field, interface):
     """
-    Returns current status for Ethernet0 of specified field
+    Returns current status for interface of specified field
 
     Args:
         duthost: DUT host object under test
@@ -88,14 +111,20 @@ def check_interface_status(duthost, field, interface='Ethernet0'):
     return status
 
 
-def get_ethernet_port_not_in_portchannel(duthost):
+def get_ethernet_port_not_in_portchannel(duthost, namespace=None):
     """
         Returns the name of an ethernet port which is not a member of a port channel
 
         Args:
             duthost: DUT host object under test
+            namespace: DUT asic namespace
     """
-    config_facts = duthost.get_running_config_facts()
+    config_facts = duthost.config_facts(
+        host=duthost.hostname,
+        source="running",
+        verbose=False,
+        namespace=namespace
+    )['ansible_facts']
     port_name = ""
     ports = list(config_facts['PORT'].keys())
     port_channel_members = []
@@ -109,17 +138,21 @@ def get_ethernet_port_not_in_portchannel(duthost):
             port_channel_members.append(member)
     for port in ports:
         if port not in port_channel_members:
+            port_role = config_facts['PORT'][port].get('role')
+            if port_role and port_role != 'Ext':    # ensure port is front-panel port
+                continue
             port_name = port
             break
     return port_name
 
 
-def get_port_speeds_for_test(duthost):
+def get_port_speeds_for_test(duthost, port):
     """
     Get the speeds parameters for case test_update_speed, including 2 valid speeds and 1 invalid speed
 
     Args:
         duthost: DUT host object
+        port: The port for which speeds need to be tested
     """
     speeds_to_test = []
     invalid_speed_yang = ("20a", False)
@@ -127,7 +160,7 @@ def get_port_speeds_for_test(duthost):
     if duthost.get_facts()['asic_type'] == 'vs':
         valid_speeds = ['20000', '40000']
     else:
-        valid_speeds = duthost.get_supported_speeds('Ethernet0')
+        valid_speeds = duthost.get_supported_speeds(port)
         if valid_speeds:
             invalid_speed_state_db = (str(int(valid_speeds[0]) - 1), False)
     pytest_assert(valid_speeds, "Failed to get any valid port speed to test.")
@@ -139,16 +172,20 @@ def get_port_speeds_for_test(duthost):
     return speeds_to_test
 
 
-def test_remove_lanes(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_remove_lanes(duthosts, rand_one_dut_front_end_hostname,
+                      ensure_dut_readiness, enum_rand_one_frontend_asic_index):
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
+    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
     json_patch = [
         {
             "op": "remove",
-            "path": "/PORT/Ethernet0/lanes"
+            "path": "/PORT/{}/lanes".format(port)
         }
     ]
-    # change is applied to specific asic namespace only
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[asic_namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -161,9 +198,13 @@ def test_remove_lanes(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
 
 
 @pytest.mark.skip(reason="Bypass as it is blocking submodule update")
-def test_replace_lanes(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
-    duthost = duthosts[rand_one_dut_hostname]
-    cur_lanes = check_interface_status(duthost, "Lanes")
+def test_replace_lanes(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
+                       enum_rand_one_frontend_asic_index):
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
+    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
+    cur_lanes = check_interface_status(duthost, "Lanes", port)
     cur_lanes = cur_lanes.split(",")
     cur_lanes.sort()
     update_lanes = cur_lanes
@@ -172,11 +213,12 @@ def test_replace_lanes(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
     json_patch = [
         {
             "op": "replace",
-            "path": "/PORT/Ethernet0/lanes",
+            "path": "/PORT/{}/lanes".format(port),
             "value": "{}".format(update_lanes)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[asic_namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -188,21 +230,25 @@ def test_replace_lanes(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_replace_mtu(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_replace_mtu(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
+                     enum_rand_one_frontend_asic_index):
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
     # Can't directly change mtu of the port channel member
     # So find a ethernet port that are not in a port channel
-    port_name = get_ethernet_port_not_in_portchannel(duthost)
-    pytest_assert(port_name, "No available ethernet ports, all ports are in port channels.")
+    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
+    pytest_assert(port, "No available ethernet ports, all ports are in port channels.")
     target_mtu = "1514"
     json_patch = [
         {
             "op": "replace",
-            "path": "/PORT/{}/mtu".format(port_name),
+            "path": "/PORT/{}/mtu".format(port),
             "value": "{}".format(target_mtu)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[asic_namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -210,7 +256,7 @@ def test_replace_mtu(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         expect_op_success(duthost, output)
-        current_status_mtu = check_interface_status(duthost, "MTU", port_name)
+        current_status_mtu = check_interface_status(duthost, "MTU", port)
         pytest_assert(current_status_mtu == target_mtu,
                       "Failed to properly configure interface MTU to requested value {}".format(target_mtu))
     finally:
@@ -218,16 +264,21 @@ def test_replace_mtu(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
 
 
 @pytest.mark.parametrize("pfc_asym", ["on", "off"])
-def test_toggle_pfc_asym(duthosts, rand_one_dut_hostname, ensure_dut_readiness, pfc_asym):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_toggle_pfc_asym(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness, pfc_asym,
+                         enum_rand_one_frontend_asic_index):
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
+    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
     json_patch = [
         {
             "op": "replace",
-            "path": "/PORT/Ethernet0/pfc_asym",
+            "path": "/PORT/{}/pfc_asym".format(port),
             "value": "{}".format(pfc_asym)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[asic_namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -235,7 +286,7 @@ def test_toggle_pfc_asym(duthosts, rand_one_dut_hostname, ensure_dut_readiness, 
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         expect_op_success(duthost, output)
-        current_status_pfc_asym = check_interface_status(duthost, "Asym")
+        current_status_pfc_asym = check_interface_status(duthost, "Asym", port)
         pytest_assert(current_status_pfc_asym == pfc_asym,
                       "Failed to properly configure interface Asym PFC to requested value off")
     finally:
@@ -244,24 +295,29 @@ def test_toggle_pfc_asym(duthosts, rand_one_dut_hostname, ensure_dut_readiness, 
 
 @pytest.mark.device_type('physical')
 @pytest.mark.parametrize("fec", ["rs", "fc"])
-def test_replace_fec(duthosts, rand_one_dut_hostname, ensure_dut_readiness, fec):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_replace_fec(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness, fec,
+                     enum_rand_one_frontend_asic_index):
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
+    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
     json_patch = [
         {
             "op": "add",
-            "path": "/PORT/Ethernet0/fec",
+            "path": "/PORT/{}/fec".format(port),
             "value": "{}".format(fec)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[asic_namespace])
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
 
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
-        if is_valid_fec_state_db(duthost, fec):
+        if is_valid_fec_state_db(duthost, fec, port, namespace=asic_namespace):
             expect_op_success(duthost, output)
-            current_status_fec = check_interface_status(duthost, "FEC")
+            current_status_fec = check_interface_status(duthost, "FEC", port)
             pytest_assert(current_status_fec == fec,
                           "Failed to properly configure interface FEC to requested value {}".format(fec))
 
@@ -275,16 +331,21 @@ def test_replace_fec(duthosts, rand_one_dut_hostname, ensure_dut_readiness, fec)
 
 
 @pytest.mark.skip(reason="Bypass as this is not a production scenario")
-def test_update_invalid_index(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_update_invalid_index(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
+                              enum_rand_one_frontend_asic_index):
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
+    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
     json_patch = [
         {
             "op": "replace",
-            "path": "/PORT/Ethernet0/index",
+            "path": "/PORT/{}/index".format(port),
             "value": "abc1"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[asic_namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -297,8 +358,11 @@ def test_update_invalid_index(duthosts, rand_one_dut_hostname, ensure_dut_readin
 
 
 @pytest.mark.skip(reason="Bypass as this is not a production scenario")
-def test_update_valid_index(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_update_valid_index(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
+                            enum_rand_one_frontend_asic_index):
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
     output = duthost.shell('sonic-db-cli CONFIG_DB keys "PORT|"\\*')["stdout"]
     interfaces = {}  # to be filled with two interfaces mapped to their indeces
 
@@ -323,7 +387,8 @@ def test_update_valid_index(duthosts, rand_one_dut_hostname, ensure_dut_readines
             "value": "{}".format(list(interfaces.values())[0])
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[asic_namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -335,27 +400,32 @@ def test_update_valid_index(duthosts, rand_one_dut_hostname, ensure_dut_readines
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_update_speed(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
-    duthost = duthosts[rand_one_dut_hostname]
-    speed_params = get_port_speeds_for_test(duthost)
+def test_update_speed(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
+                      enum_rand_one_frontend_asic_index):
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
+    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
+    speed_params = get_port_speeds_for_test(duthost, port)
     for speed, is_valid in speed_params:
         json_patch = [
             {
                 "op": "replace",
-                "path": "/PORT/Ethernet0/speed",
+                "path": "/PORT/{}/speed".format(port),
                 "value": "{}".format(speed)
             }
         ]
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                     is_asic_specific=True, asic_namespaces=[asic_namespace])
 
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
 
         try:
             output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
-            if is_valid and is_valid_speed_state_db(duthost, speed):
+            if is_valid and is_valid_speed_state_db(duthost, speed, port, namespace=asic_namespace):
                 expect_op_success(duthost, output)
-                current_status_speed = check_interface_status(duthost, "Speed").replace("G", "000")
+                current_status_speed = check_interface_status(duthost, "Speed", port).replace("G", "000")
                 current_status_speed = current_status_speed.replace("M", "")
                 pytest_assert(current_status_speed == speed,
                               "Failed to properly configure interface speed to requested value {}".format(speed))
@@ -365,16 +435,21 @@ def test_update_speed(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
             delete_tmpfile(duthost, tmpfile)
 
 
-def test_update_description(duthosts, rand_one_dut_hostname, ensure_dut_readiness):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_update_description(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
+                            enum_rand_one_frontend_asic_index):
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
+    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
     json_patch = [
         {
             "op": "replace",
-            "path": "/PORT/Ethernet0/description",
+            "path": "/PORT/{}/description".format(port),
             "value": "Updated description"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[asic_namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -387,16 +462,21 @@ def test_update_description(duthosts, rand_one_dut_hostname, ensure_dut_readines
 
 
 @pytest.mark.parametrize("admin_status", ["up", "down"])
-def test_eth_interface_admin_change(duthosts, rand_one_dut_hostname, admin_status):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_eth_interface_admin_change(duthosts, rand_one_dut_front_end_hostname, admin_status,
+                                    enum_rand_one_frontend_asic_index):
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
+    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
     json_patch = [
         {
             "op": "add",
-            "path": "/PORT/Ethernet0/admin_status",
+            "path": "/PORT/{}/admin_status".format(port),
             "value": "{}".format(admin_status)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[asic_namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -405,7 +485,7 @@ def test_eth_interface_admin_change(duthosts, rand_one_dut_hostname, admin_statu
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         expect_op_success(duthost, output)
 
-        pytest_assert(wait_until(10, 2, 0, lambda: check_interface_status(duthost, "Admin") == admin_status),
+        pytest_assert(wait_until(10, 2, 0, lambda: check_interface_status(duthost, "Admin", port) == admin_status),
                       "Interface failed to update admin status to {}".format(admin_status))
     finally:
         delete_tmpfile(duthost, tmpfile)

--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -237,7 +237,6 @@ def test_incremental_qos_config_updates(duthost, tbinfo, ensure_dut_readiness, c
             "path": "/BUFFER_POOL/{}".format(configdb_field),
             "value": "{}".format(value)
         }]
-    # change is applied to asic namespaces only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     try:

--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -237,7 +237,8 @@ def test_incremental_qos_config_updates(duthost, tbinfo, ensure_dut_readiness, c
             "path": "/BUFFER_POOL/{}".format(configdb_field),
             "value": "{}".format(value)
         }]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to asic namespaces only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)

--- a/tests/generic_config_updater/test_ip_bgp.py
+++ b/tests/generic_config_updater/test_ip_bgp.py
@@ -37,16 +37,18 @@ def ensure_dut_readiness(duthost):
         delete_checkpoint(duthost)
 
 
-def get_ip_neighbor(duthost, ip_version=6):
+def get_ip_neighbor(duthost, namespace=None, ip_version=6):
     """
     Returns ip BGP neighbor address, properties of BGP neighbor
 
     Args:
         duthost: DUT host object
+        namespace: DUT asic namespace
         ip_version: Ip version of the bgp neighbor
     """
 
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running",
+                                        verbose=False, namespace=namespace)['ansible_facts']
     bgp_neighbors_data = config_facts['BGP_NEIGHBOR']
     for neighbor_address in list(bgp_neighbors_data.keys()):
         if ipaddress.ip_address((neighbor_address.encode().decode())).version == ip_version:
@@ -60,8 +62,8 @@ def check_neighbor_existence(duthost, neighbor_address, ip_version=6):
     return re.search(r'\b{}\b'.format(neighbor_address), ip_bgp_su)
 
 
-def add_deleted_ip_neighbor(duthost, ip_version=6):
-    ip_neighbor_address, ip_neighbor_config = get_ip_neighbor(duthost, ip_version)
+def add_deleted_ip_neighbor(duthost, namespace=None, ip_version=6):
+    ip_neighbor_address, ip_neighbor_config = get_ip_neighbor(duthost, namespace, ip_version)
     neighbor_exists = check_neighbor_existence(duthost, ip_neighbor_address, ip_version)
     pytest_assert(neighbor_exists, "Nonexistent ipv{} BGP neighbor".format(ip_version))
 
@@ -77,8 +79,8 @@ def add_deleted_ip_neighbor(duthost, ip_version=6):
             "value": ip_neighbor_config
         }
     ]
-    # change is applied to specific asic namespace
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -93,8 +95,8 @@ def add_deleted_ip_neighbor(duthost, ip_version=6):
         delete_tmpfile(duthost, tmpfile)
 
 
-def add_duplicate_ip_neighbor(duthost, ip_version=6):
-    ip_neighbor_address, ip_neighbor_config = get_ip_neighbor(duthost, ip_version)
+def add_duplicate_ip_neighbor(duthost, namespace=None, ip_version=6):
+    ip_neighbor_address, ip_neighbor_config = get_ip_neighbor(duthost, namespace, ip_version)
 
     json_patch = [
         {
@@ -103,7 +105,8 @@ def add_duplicate_ip_neighbor(duthost, ip_version=6):
             "value": ip_neighbor_config
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -118,7 +121,7 @@ def add_duplicate_ip_neighbor(duthost, ip_version=6):
         delete_tmpfile(duthost, tmpfile)
 
 
-def invalid_ip_neighbor(duthost, ip_version=6):
+def invalid_ip_neighbor(duthost, namespace=None, ip_version=6):
     xfailv6_input = [
         ("add", "FC00::xyz/126"),
         ("remove", "FC00::01/126")
@@ -136,7 +139,8 @@ def invalid_ip_neighbor(duthost, ip_version=6):
                 "value": {}
             }
         ]
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                     is_asic_specific=True, asic_namespaces=[namespace])
 
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
@@ -148,8 +152,8 @@ def invalid_ip_neighbor(duthost, ip_version=6):
             delete_tmpfile(duthost, tmpfile)
 
 
-def ip_neighbor_admin_change(duthost, ip_version=6):
-    ip_neighbor_address, ip_neighbor_config = get_ip_neighbor(duthost, ip_version)
+def ip_neighbor_admin_change(duthost, namespace=None, ip_version=6):
+    ip_neighbor_address, ip_neighbor_config = get_ip_neighbor(duthost, namespace, ip_version)
     json_patch = [
         {
             "op": "add",
@@ -162,7 +166,8 @@ def ip_neighbor_admin_change(duthost, ip_version=6):
             "value": "down"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -180,8 +185,8 @@ def ip_neighbor_admin_change(duthost, ip_version=6):
         delete_tmpfile(duthost, tmpfile)
 
 
-def delete_ip_neighbor(duthost, ip_version=6):
-    ip_neighbor_address, ip_neighbor_config = get_ip_neighbor(duthost, ip_version)
+def delete_ip_neighbor(duthost, namespace=None, ip_version=6):
+    ip_neighbor_address, ip_neighbor_config = get_ip_neighbor(duthost, namespace, ip_version)
 
     json_patch = [
         {
@@ -189,7 +194,8 @@ def delete_ip_neighbor(duthost, ip_version=6):
             "path": "/BGP_NEIGHBOR/{}".format(ip_neighbor_address)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -205,9 +211,11 @@ def delete_ip_neighbor(duthost, ip_version=6):
 
 
 @pytest.mark.parametrize("ip_version", [6, 4])
-def test_ip_suite(duthost, ensure_dut_readiness, ip_version):
-    add_deleted_ip_neighbor(duthost, ip_version)
-    add_duplicate_ip_neighbor(duthost, ip_version)
-    invalid_ip_neighbor(duthost, ip_version)
-    ip_neighbor_admin_change(duthost, ip_version)
-    delete_ip_neighbor(duthost, ip_version)
+def test_ip_suite(duthost, ensure_dut_readiness, ip_version, enum_rand_one_frontend_asic_index):
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
+    add_deleted_ip_neighbor(duthost, asic_namespace, ip_version)
+    add_duplicate_ip_neighbor(duthost, asic_namespace, ip_version)
+    invalid_ip_neighbor(duthost, asic_namespace, ip_version)
+    ip_neighbor_admin_change(duthost, asic_namespace, ip_version)
+    delete_ip_neighbor(duthost, asic_namespace, ip_version)

--- a/tests/generic_config_updater/test_ip_bgp.py
+++ b/tests/generic_config_updater/test_ip_bgp.py
@@ -77,7 +77,8 @@ def add_deleted_ip_neighbor(duthost, ip_version=6):
             "value": ip_neighbor_config
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to specific asic namespace
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -102,7 +103,7 @@ def add_duplicate_ip_neighbor(duthost, ip_version=6):
             "value": ip_neighbor_config
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -135,7 +136,7 @@ def invalid_ip_neighbor(duthost, ip_version=6):
                 "value": {}
             }
         ]
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
@@ -161,7 +162,7 @@ def ip_neighbor_admin_change(duthost, ip_version=6):
             "value": "down"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -188,7 +189,7 @@ def delete_ip_neighbor(duthost, ip_version=6):
             "path": "/BGP_NEIGHBOR/{}".format(ip_neighbor_address)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_kubernetes_config.py
+++ b/tests/generic_config_updater/test_kubernetes_config.py
@@ -266,7 +266,6 @@ def k8s_config_update(duthost, test_data):
     for num, (json_patch, target_config, target_table, expected_result) in enumerate(test_data):
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
-        # change is applied to localhost namespace only
         json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
         try:

--- a/tests/generic_config_updater/test_kubernetes_config.py
+++ b/tests/generic_config_updater/test_kubernetes_config.py
@@ -266,7 +266,8 @@ def k8s_config_update(duthost, test_data):
     for num, (json_patch, target_config, target_table, expected_result) in enumerate(test_data):
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+        # change is applied to localhost namespace only
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
         try:
             output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)

--- a/tests/generic_config_updater/test_lo_interface.py
+++ b/tests/generic_config_updater/test_lo_interface.py
@@ -112,7 +112,8 @@ def lo_interface_tc1_add_init(duthost, lo_intf):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to localhost namespace only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -158,7 +159,7 @@ def lo_interface_tc1_add_duplicate(duthost, lo_intf):
             "value": {}
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -208,7 +209,7 @@ def lo_interface_tc1_xfail(duthost, lo_intf):
                 "value": {}
             }
         ]
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
@@ -262,7 +263,7 @@ def lo_interface_tc1_replace(duthost, lo_intf):
             "value": {}
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -288,7 +289,7 @@ def lo_interface_tc1_remove(duthost, lo_intf):
             "path": "/LOOPBACK_INTERFACE"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -331,7 +332,7 @@ def setup_vrf_config(duthost, lo_intf):
             "value": "Vrf_01"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -384,7 +385,7 @@ def test_lo_interface_tc2_vrf_change(rand_selected_dut, lo_intf):
             "value": "Vrf_02"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=rand_selected_dut, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=rand_selected_dut, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(rand_selected_dut)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_lo_interface.py
+++ b/tests/generic_config_updater/test_lo_interface.py
@@ -112,7 +112,6 @@ def lo_interface_tc1_add_init(duthost, lo_intf):
             }
         }
     ]
-    # change is applied to localhost namespace only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)

--- a/tests/generic_config_updater/test_mgmt_interface.py
+++ b/tests/generic_config_updater/test_mgmt_interface.py
@@ -57,7 +57,6 @@ def update_forced_mgmt_route(duthost, interface_address, interface_key, routes):
         else:
             json_patch[0]["op"] = "add"
 
-    # change is applied to localhost namespace only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
     tmpfile = generate_tmpfile(duthost)
     try:

--- a/tests/generic_config_updater/test_mgmt_interface.py
+++ b/tests/generic_config_updater/test_mgmt_interface.py
@@ -57,7 +57,8 @@ def update_forced_mgmt_route(duthost, interface_address, interface_key, routes):
         else:
             json_patch[0]["op"] = "add"
 
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to localhost namespace only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
     tmpfile = generate_tmpfile(duthost)
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)

--- a/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
+++ b/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
@@ -123,7 +123,6 @@ def test_dynamic_th_config_updates(duthost, ensure_dut_readiness, operation, ski
         }
         json_patch.append(individual_patch)
 
-    # change is applied to asic namespaces only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {} created for json patch of updating dynamic threshold and operation: {}"

--- a/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
+++ b/tests/generic_config_updater/test_mmu_dynamic_threshold_config_update.py
@@ -123,7 +123,8 @@ def test_dynamic_th_config_updates(duthost, ensure_dut_readiness, operation, ski
         }
         json_patch.append(individual_patch)
 
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to asic namespaces only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {} created for json patch of updating dynamic threshold and operation: {}"
                 .format(tmpfile, operation))

--- a/tests/generic_config_updater/test_monitor_config.py
+++ b/tests/generic_config_updater/test_monitor_config.py
@@ -195,7 +195,8 @@ def monitor_config_add_config(duthost, get_valid_acl_ports):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to asic namespaces only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_monitor_config.py
+++ b/tests/generic_config_updater/test_monitor_config.py
@@ -195,7 +195,6 @@ def monitor_config_add_config(duthost, get_valid_acl_ports):
             }
         }
     ]
-    # change is applied to asic namespaces only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)

--- a/tests/generic_config_updater/test_ntp.py
+++ b/tests/generic_config_updater/test_ntp.py
@@ -116,7 +116,6 @@ def ntp_server_tc1_add_config(duthost):
             }
         }
     ]
-    # change is applied to localhost namespace only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     json_patch_bc = [

--- a/tests/generic_config_updater/test_ntp.py
+++ b/tests/generic_config_updater/test_ntp.py
@@ -116,7 +116,8 @@ def ntp_server_tc1_add_config(duthost):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to localhost namespace only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     json_patch_bc = [
         {
@@ -127,7 +128,7 @@ def ntp_server_tc1_add_config(duthost):
             }
         }
     ]
-    json_patch_bc = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch_bc)
+    json_patch_bc = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch_bc, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -172,7 +173,7 @@ def ntp_server_tc1_xfail(duthost):
                 "value": {}
             }
         ]
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
@@ -203,7 +204,7 @@ def ntp_server_tc1_replace(duthost):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     json_patch_bc = [
         {
@@ -216,7 +217,7 @@ def ntp_server_tc1_replace(duthost):
             "value": {}
         }
     ]
-    json_patch_bc = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch_bc)
+    json_patch_bc = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch_bc, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -251,7 +252,7 @@ def ntp_server_tc1_remove(duthost):
             "path": "/NTP_SERVER"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_pfcwd_interval.py
+++ b/tests/generic_config_updater/test_pfcwd_interval.py
@@ -165,7 +165,8 @@ def test_pfcwd_interval_config_updates(duthost, ensure_dut_readiness, oper,
             "path": "/PFC_WD/GLOBAL/POLL_INTERVAL",
             "value": "{}".format(value)
         }]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to asic namespaces only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)

--- a/tests/generic_config_updater/test_pfcwd_interval.py
+++ b/tests/generic_config_updater/test_pfcwd_interval.py
@@ -165,7 +165,6 @@ def test_pfcwd_interval_config_updates(duthost, ensure_dut_readiness, oper,
             "path": "/PFC_WD/GLOBAL/POLL_INTERVAL",
             "value": "{}".format(value)
         }]
-    # change is applied to asic namespaces only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     try:

--- a/tests/generic_config_updater/test_pfcwd_status.py
+++ b/tests/generic_config_updater/test_pfcwd_status.py
@@ -213,8 +213,8 @@ def test_stop_pfcwd(duthost, extract_pfcwd_config, ensure_dut_readiness, port):
         if port == 'single':
             exp_str = interface
             break
-
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to specific asic namespace
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     try:
         tmpfile = generate_tmpfile(duthost)
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
@@ -257,8 +257,7 @@ def test_start_pfcwd(duthost, extract_pfcwd_config, ensure_dut_readiness, stop_p
         if port == 'single':
             exp_str = interface
             break
-
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     try:
         tmpfile = generate_tmpfile(duthost)
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)

--- a/tests/generic_config_updater/test_pfcwd_status.py
+++ b/tests/generic_config_updater/test_pfcwd_status.py
@@ -59,7 +59,6 @@ def set_default_pfcwd_config(duthost):
     meta_data = json.loads(res["stdout"])
     pfc_status = meta_data["DEVICE_METADATA|localhost"]["value"].get("default_pfcwd_status", "")
     if pfc_status == 'disable':
-        duthost.shell('sonic-db-cli CONFIG_DB hset \"DEVICE_METADATA|localhost\" default_pfcwd_status enable')
         cmd = 'sonic-db-cli CONFIG_DB hset \"DEVICE_METADATA|localhost\" default_pfcwd_status enable'
         for asic_id in duthost.get_asic_ids():
             if asic_id:
@@ -72,7 +71,6 @@ def set_default_pfcwd_config(duthost):
     # Restore default config
     duthost.shell('config pfcwd stop')
     if pfc_status == 'disable':
-        duthost.shell('sonic-db-cli CONFIG_DB hset \"DEVICE_METADATA|localhost\" default_pfcwd_status disable')
         cmd = 'sonic-db-cli CONFIG_DB hset \"DEVICE_METADATA|localhost\" default_pfcwd_status disable'
         for asic_id in duthost.get_asic_ids():
             if asic_id:

--- a/tests/generic_config_updater/test_pfcwd_status.py
+++ b/tests/generic_config_updater/test_pfcwd_status.py
@@ -9,7 +9,6 @@ from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import verify_orchagent_running_or_assert
 from tests.common.gu_utils import apply_patch, expect_op_success, expect_op_failure
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
-from tests.common.gu_utils import format_json_patch_for_multiasic
 from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
 from tests.common.gu_utils import is_valid_platform_and_version
 
@@ -61,6 +60,12 @@ def set_default_pfcwd_config(duthost):
     pfc_status = meta_data["DEVICE_METADATA|localhost"]["value"].get("default_pfcwd_status", "")
     if pfc_status == 'disable':
         duthost.shell('sonic-db-cli CONFIG_DB hset \"DEVICE_METADATA|localhost\" default_pfcwd_status enable')
+        cmd = 'sonic-db-cli CONFIG_DB hset \"DEVICE_METADATA|localhost\" default_pfcwd_status enable'
+        for asic_id in duthost.get_asic_ids():
+            if asic_id:
+                duthost.asic_instance(asic_id).command(cmd)
+            else:
+                duthost.shell(cmd)
 
     yield
 
@@ -68,6 +73,12 @@ def set_default_pfcwd_config(duthost):
     duthost.shell('config pfcwd stop')
     if pfc_status == 'disable':
         duthost.shell('sonic-db-cli CONFIG_DB hset \"DEVICE_METADATA|localhost\" default_pfcwd_status disable')
+        cmd = 'sonic-db-cli CONFIG_DB hset \"DEVICE_METADATA|localhost\" default_pfcwd_status disable'
+        for asic_id in duthost.get_asic_ids():
+            if asic_id:
+                duthost.asic_instance(asic_id).command(cmd)
+            else:
+                duthost.shell(cmd)
     else:
         start_pfcwd = duthost.shell('config pfcwd start_default')
         pytest_assert(not start_pfcwd['rc'], "Failed to start default pfcwd config")
@@ -106,7 +117,12 @@ def stop_pfcwd(duthost):
     Args:
         duthost: DUT host object
     """
-    duthost.shell('config pfcwd stop')
+    cmd = 'config pfcwd stop'
+    for asic_id in duthost.get_asic_ids():
+        if asic_id:
+            duthost.asic_instance(asic_id).command(cmd)
+        else:
+            duthost.shell(cmd)
     yield
 
 
@@ -118,7 +134,12 @@ def start_pfcwd(duthost):
     Args:
         duthost: DUT host object
     """
-    duthost.shell('config pfcwd start_default')
+    cmd = 'config pfcwd start_default'
+    for asic_id in duthost.get_asic_ids():
+        if asic_id:
+            duthost.asic_instance(asic_id).command(cmd)
+        else:
+            duthost.shell(cmd)
     yield
 
 
@@ -148,17 +169,20 @@ def extract_pfcwd_config(duthost, start_pfcwd):
     yield pfcwd_config
 
 
-def get_flex_db_count(duthost):
+def get_flex_db_count(duthost, namespace=None):
     """
     Get the count of the number of pfcwd entries seen in flex db
     For every port, there will be 3 entries - 1 for the port, 1 for queue 3 and 1 for queue 4
     Args:
         duthost: DUT host object
+        namespace: DUT asic namespace
 
     Returns:
         Number of PFCWD related flex db entries
     """
-    db_entries = duthost.shell('sonic-db-cli FLEX_COUNTER_DB keys *FLEX_COUNTER_TABLE:PFC_WD*')["stdout"]
+    ns_flag_prefix = '' if namespace is None else '-n ' + namespace
+    cmd = 'sonic-db-cli {} FLEX_COUNTER_DB keys *FLEX_COUNTER_TABLE:PFC_WD*'.format(ns_flag_prefix)
+    db_entries = duthost.shell(cmd)["stdout"]
     if db_entries == '':
         return 0
     else:
@@ -173,17 +197,25 @@ def check_config_update(duthost, expected_count):
         duthost: DUT host object
         expected_count: number of pfcwd entries expected in the updated config
     """
-    def _confirm_value_in_flex_db(duthost, expected_count):
-        pfcwd_entries_count = get_flex_db_count(duthost)
-        logger.info("Actual number of entries: {}".format(pfcwd_entries_count))
+    def _confirm_value_in_flex_db():
+        if duthost.is_multi_asic:
+            pfcwd_entries_count = 0
+            num_asics = duthost.facts.get('num_asic', 0)
+            for asic_index in range(num_asics):
+                asic_ns = f"/asic{asic_index}"
+                pfcwd_entries_count += get_flex_db_count(duthost, asic_ns)
+        else:
+            pfcwd_entries_count = get_flex_db_count(duthost)
         return pfcwd_entries_count == expected_count
 
     logger.info("Validating in FLEX COUNTER DB...")
     pytest_assert(
-        wait_until(READ_FLEXDB_TIMEOUT, READ_FLEXDB_INTERVAL, 0, _confirm_value_in_flex_db, duthost, expected_count),
-        "FLEX DB does not properly reflect Pfcwd status: Expected number of entries {}"
-        .format(expected_count)
-    )
+        wait_until(
+            READ_FLEXDB_TIMEOUT,
+            READ_FLEXDB_INTERVAL,
+            0,
+            _confirm_value_in_flex_db
+            ), "FLEX DB does not properly reflect Pfcwd status: Expected number of entries {}".format(expected_count))
 
 
 @pytest.mark.parametrize('port', ['single', 'all'])
@@ -205,16 +237,23 @@ def test_stop_pfcwd(duthost, extract_pfcwd_config, ensure_dut_readiness, port):
     json_patch = list()
     exp_str = 'Ethernet'
     for interface in pfcwd_config:
+        asic_index = None
+        json_namespace = ''
+        if duthost.is_multi_asic:
+            asic_index = duthost.get_port_asic_instance(interface).asic_index
+            ns = duthost.get_namespace_from_asic_id(asic_index)
+            json_namespace = '/' + ns
         json_patch.extend([
                             {
                               'op': 'remove',
-                              'path': '/PFC_WD/{}'.format(interface)
+                              'path': '{}/PFC_WD/{}'.format(json_namespace, interface)
                             }])
         if port == 'single':
             exp_str = interface
             break
-    # change is applied to specific asic namespace
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    # Removing the JSON patch formatting because the above patch includes interfaces
+    # that may belong to multiple ASICs, and the formatting has already been handled per interface.
+    # json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     try:
         tmpfile = generate_tmpfile(duthost)
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
@@ -247,17 +286,25 @@ def test_start_pfcwd(duthost, extract_pfcwd_config, ensure_dut_readiness, stop_p
     exp_str = 'Ethernet'
     op = 'add'
     for interface, value in pfcwd_config.items():
+        asic_index = None
+        json_namespace = ''
+        if duthost.is_multi_asic:
+            asic_index = duthost.get_port_asic_instance(interface).asic_index
+            ns = duthost.get_namespace_from_asic_id(asic_index)
+            json_namespace = '/' + ns
         json_patch.extend([
                             {
                               'op': op,
-                              'path': '/PFC_WD/{}'.format(interface),
+                              'path': '{}/PFC_WD/{}'.format(json_namespace, interface),
                               'value': {'action': value['action'],
                                         'detection_time': value['detect_time'],
                                         'restoration_time': value['restore_time']}}])
         if port == 'single':
             exp_str = interface
             break
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    # Removing the JSON patch formatting because the above patch includes interfaces
+    # that may belong to multiple ASICs, and the formatting has already been handled per interface.
+    # json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     try:
         tmpfile = generate_tmpfile(duthost)
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)

--- a/tests/generic_config_updater/test_pg_headroom_update.py
+++ b/tests/generic_config_updater/test_pg_headroom_update.py
@@ -103,7 +103,6 @@ def test_pg_headroom_update(duthost, ensure_dut_readiness, operation, skip_when_
                           {"op": "{}".format(operation),
                            "path": "/BUFFER_PROFILE/{}/xoff".format(profile_name),
                            "value": "{}".format(value)})
-    # change is applied to asic namespaces only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)

--- a/tests/generic_config_updater/test_pg_headroom_update.py
+++ b/tests/generic_config_updater/test_pg_headroom_update.py
@@ -103,8 +103,8 @@ def test_pg_headroom_update(duthost, ensure_dut_readiness, operation, skip_when_
                           {"op": "{}".format(operation),
                            "path": "/BUFFER_PROFILE/{}/xoff".format(profile_name),
                            "value": "{}".format(value)})
-
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to asic namespaces only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         if is_valid_platform_and_version(duthost, "BUFFER_PROFILE", "PG headroom modification", operation):

--- a/tests/generic_config_updater/test_portchannel_interface.py
+++ b/tests/generic_config_updater/test_portchannel_interface.py
@@ -34,6 +34,14 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
+def rand_portchannel_name(cfg_facts):
+    portchannel_dict = cfg_facts.get('PORTCHANNEL', {})
+    pytest_require(portchannel_dict, "Portchannel table is empty")
+    for portchannel_key in portchannel_dict:
+        return portchannel_key
+
+
+@pytest.fixture(scope="module")
 def portchannel_table(cfg_facts):
     def _is_ipv4_address(ip_addr):
         return ipaddress.ip_address(ip_addr).version == 4
@@ -61,14 +69,14 @@ def check_portchannel_table(duthost, portchannel_table):
 
 
 @pytest.fixture(autouse=True)
-def setup_env(duthosts, rand_one_dut_hostname, portchannel_table):
+def setup_env(duthosts, rand_one_dut_front_end_hostname, portchannel_table):
     """
     Setup/teardown fixture for portchannel interface config
     Args:
         duthosts: list of DUTs.
-        rand_selected_dut: The fixture returns a randomly selected DuT.
+        rand_one_dut_front_end_hostname: The fixture returns a randomly selected frontend DuT.
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     create_checkpoint(duthost)
 
     yield
@@ -81,27 +89,30 @@ def setup_env(duthosts, rand_one_dut_hostname, portchannel_table):
         delete_checkpoint(duthost)
 
 
-def portchannel_interface_tc1_add_duplicate(duthost, portchannel_table):
+def portchannel_interface_tc1_add_duplicate(duthost, portchannel_table, enum_rand_one_frontend_asic_index,
+                                            rand_portchannel_name):
     """ Test adding duplicate portchannel interface
     """
-    dup_ip = portchannel_table["PortChannel101"]["ip"]
-    dup_ipv6 = portchannel_table["PortChannel101"]["ipv6"]
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
+    dup_ip = portchannel_table[rand_portchannel_name]["ip"]
+    dup_ipv6 = portchannel_table[rand_portchannel_name]["ipv6"]
     json_patch = [
         {
             "op": "add",
             "path": create_path(["PORTCHANNEL_INTERFACE",
-                                 "PortChannel101|{}".format(dup_ip)]),
+                                 "{}|{}".format(rand_portchannel_name, dup_ip)]),
             "value": {}
         },
         {
             "op": "add",
             "path": create_path(["PORTCHANNEL_INTERFACE",
-                                 "PortChannel101|{}".format(dup_ipv6.upper())]),
+                                 "{}|{}".format(rand_portchannel_name, dup_ipv6.upper())]),
             "value": {}
         }
     ]
-    # change is applied to specific asic namespace
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[asic_namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -110,13 +121,13 @@ def portchannel_interface_tc1_add_duplicate(duthost, portchannel_table):
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         expect_op_success(duthost, output)
 
-        check_show_ip_intf(duthost, "PortChannel101", [dup_ip], [], is_ipv4=True)
-        check_show_ip_intf(duthost, "PortChannel101", [dup_ipv6], [], is_ipv4=False)
+        check_show_ip_intf(duthost, rand_portchannel_name, [dup_ip], [], is_ipv4=True)
+        check_show_ip_intf(duthost, rand_portchannel_name, [dup_ipv6], [], is_ipv4=False)
     finally:
         delete_tmpfile(duthost, tmpfile)
 
 
-def portchannel_interface_tc1_xfail(duthost):
+def portchannel_interface_tc1_xfail(duthost, enum_rand_one_frontend_asic_index, rand_portchannel_name):
     """ Test invalid ip address and remove unexited interface
 
     ("add", "PortChannel101", "10.0.0.256/31", "FC00::71/126"), ADD Invalid IPv4 address
@@ -124,11 +135,13 @@ def portchannel_interface_tc1_xfail(duthost):
     ("remove", "PortChannel101", "10.0.0.57/31", "FC00::71/126"), REMOVE Unexist IPv4 address
     ("remove", "PortChannel101", "10.0.0.56/31", "FC00::72/126"), REMOVE Unexist IPv6 address
     """
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
     xfail_input = [
-        ("add", "PortChannel101", "10.0.0.256/31", "FC00::71/126"),
-        ("add", "PortChannel101", "10.0.0.56/31", "FC00::xyz/126"),
-        ("remove", "PortChannel101", "10.0.0.57/31", "FC00::71/126"),
-        ("remove", "PortChannel101", "10.0.0.56/31", "FC00::72/126")
+        ("add", rand_portchannel_name, "10.0.0.256/31", "FC00::71/126"),
+        ("add", rand_portchannel_name, "10.0.0.56/31", "FC00::xyz/126"),
+        ("remove", rand_portchannel_name, "10.0.0.57/31", "FC00::71/126"),
+        ("remove", rand_portchannel_name, "10.0.0.56/31", "FC00::72/126")
     ]
 
     for op, po_name, ip, ipv6 in xfail_input:
@@ -146,7 +159,8 @@ def portchannel_interface_tc1_xfail(duthost):
                 "value": {}
             }
         ]
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                     is_asic_specific=True, asic_namespaces=[asic_namespace])
 
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
@@ -158,38 +172,43 @@ def portchannel_interface_tc1_xfail(duthost):
             delete_tmpfile(duthost, tmpfile)
 
 
-def portchannel_interface_tc1_add_and_rm(duthost, portchannel_table):
+def portchannel_interface_tc1_add_and_rm(duthost, portchannel_table,
+                                         enum_rand_one_frontend_asic_index,
+                                         rand_portchannel_name):
     """ Test portchannel interface replace ip address
     """
-    org_ip = portchannel_table["PortChannel101"]["ip"]
-    org_ipv6 = portchannel_table["PortChannel101"]["ipv6"]
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
+    org_ip = portchannel_table[rand_portchannel_name]["ip"]
+    org_ipv6 = portchannel_table[rand_portchannel_name]["ipv6"]
     rep_ip = "10.0.0.156/31"
     rep_ipv6 = "fc00::171/126"
     json_patch = [
         {
             "op": "remove",
             "path": create_path(["PORTCHANNEL_INTERFACE",
-                                 "PortChannel101|{}".format(org_ip)])
+                                 "{}|{}".format(rand_portchannel_name, org_ip)])
         },
         {
             "op": "remove",
             "path": create_path(["PORTCHANNEL_INTERFACE",
-                                 "PortChannel101|{}".format(org_ipv6.upper())])
+                                 "{}|{}".format(rand_portchannel_name, org_ipv6.upper())])
         },
         {
             "op": "add",
             "path": create_path(["PORTCHANNEL_INTERFACE",
-                                 "PortChannel101|{}".format(rep_ip)]),
+                                 "{}|{}".format(rand_portchannel_name, rep_ip)]),
             "value": {}
         },
         {
             "op": "add",
             "path": create_path(["PORTCHANNEL_INTERFACE",
-                                 "PortChannel101|{}".format(rep_ipv6)]),
+                                 "{}|{}".format(rand_portchannel_name, rep_ipv6)]),
             "value": {}
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[asic_namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -198,16 +217,20 @@ def portchannel_interface_tc1_add_and_rm(duthost, portchannel_table):
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         expect_op_success(duthost, output)
 
-        check_show_ip_intf(duthost, "PortChannel101", [rep_ip], [org_ip], is_ipv4=True)
-        check_show_ip_intf(duthost, "PortChannel101", [rep_ipv6], [org_ipv6], is_ipv4=False)
+        check_show_ip_intf(duthost, rand_portchannel_name, [rep_ip], [org_ip], is_ipv4=True)
+        check_show_ip_intf(duthost, rand_portchannel_name, [rep_ipv6], [org_ipv6], is_ipv4=False)
     finally:
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_portchannel_interface_tc1_suite(rand_selected_dut, portchannel_table):
-    portchannel_interface_tc1_add_duplicate(rand_selected_dut, portchannel_table)
-    portchannel_interface_tc1_xfail(rand_selected_dut)
-    portchannel_interface_tc1_add_and_rm(rand_selected_dut, portchannel_table)
+def test_portchannel_interface_tc1_suite(rand_selected_front_end_dut, portchannel_table,
+                                         enum_rand_one_frontend_asic_index, rand_portchannel_name):
+    portchannel_interface_tc1_add_duplicate(rand_selected_front_end_dut, portchannel_table,
+                                            enum_rand_one_frontend_asic_index, rand_portchannel_name)
+    portchannel_interface_tc1_xfail(rand_selected_front_end_dut,
+                                    enum_rand_one_frontend_asic_index, rand_portchannel_name)
+    portchannel_interface_tc1_add_and_rm(rand_selected_front_end_dut, portchannel_table,
+                                         enum_rand_one_frontend_asic_index, rand_portchannel_name)
 
 
 def verify_po_running(duthost, portchannel_table):
@@ -250,9 +273,13 @@ def verify_attr_change(duthost, po_name, attr, value):
         pytest_assert(output['stdout'].startswith(value), "{} {} change failed".format(po_name, attr))
 
 
-def portchannel_interface_tc2_replace(duthost):
+def portchannel_interface_tc2_replace(duthost,
+                                      enum_rand_one_frontend_asic_index,
+                                      rand_portchannel_name):
     """Test PortChannelXXXX attribute change
     """
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
     attributes = [
         ("mtu", "3324"),
         ("min_links", "2"),
@@ -263,12 +290,13 @@ def portchannel_interface_tc2_replace(duthost):
     for attr, value in attributes:
         patch = {
             "op": "replace",
-            "path": "/PORTCHANNEL/PortChannel101/{}".format(attr),
+            "path": "/PORTCHANNEL/{}/{}".format(rand_portchannel_name, attr),
             "value": value
         }
         json_patch.append(patch)
 
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[asic_namespace])
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
 
@@ -276,24 +304,29 @@ def portchannel_interface_tc2_replace(duthost):
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         expect_op_success(duthost, output)
 
-        verify_po_running(duthost, ["PortChannel101"])
+        verify_po_running(duthost, [rand_portchannel_name])
         for attr, value in attributes:
-            verify_attr_change(duthost, "PortChannel101", attr, value)
+            verify_attr_change(duthost, rand_portchannel_name, attr, value)
     finally:
         delete_tmpfile(duthost, tmpfile)
 
 
-def portchannel_interface_tc2_incremental(duthost):
+def portchannel_interface_tc2_incremental(duthost,
+                                          enum_rand_one_frontend_asic_index,
+                                          rand_portchannel_name):
     """Test PortChannelXXXX incremental change
     """
+    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
+        '/asic{}'.format(enum_rand_one_frontend_asic_index)
     json_patch = [
         {
          "op": "add",
-         "path": "/PORTCHANNEL/PortChannel101/description",
-         "value": "Description for PortChannel101"
+         "path": "/PORTCHANNEL/{}/description".format(rand_portchannel_name),
+         "value": "Description for {}".format(rand_portchannel_name)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[asic_namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -305,6 +338,12 @@ def portchannel_interface_tc2_incremental(duthost):
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_portchannel_interface_tc2_attributes(rand_selected_dut):
-    portchannel_interface_tc2_replace(rand_selected_dut)
-    portchannel_interface_tc2_incremental(rand_selected_dut)
+def test_portchannel_interface_tc2_attributes(rand_selected_front_end_dut,
+                                              enum_rand_one_frontend_asic_index,
+                                              rand_portchannel_name):
+    portchannel_interface_tc2_replace(rand_selected_front_end_dut,
+                                      enum_rand_one_frontend_asic_index,
+                                      rand_portchannel_name)
+    portchannel_interface_tc2_incremental(rand_selected_front_end_dut,
+                                          enum_rand_one_frontend_asic_index,
+                                          rand_portchannel_name)

--- a/tests/generic_config_updater/test_portchannel_interface.py
+++ b/tests/generic_config_updater/test_portchannel_interface.py
@@ -100,7 +100,8 @@ def portchannel_interface_tc1_add_duplicate(duthost, portchannel_table):
             "value": {}
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to specific asic namespace
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -145,7 +146,7 @@ def portchannel_interface_tc1_xfail(duthost):
                 "value": {}
             }
         ]
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
@@ -188,7 +189,7 @@ def portchannel_interface_tc1_add_and_rm(duthost, portchannel_table):
             "value": {}
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -267,7 +268,7 @@ def portchannel_interface_tc2_replace(duthost):
         }
         json_patch.append(patch)
 
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
 
@@ -292,7 +293,7 @@ def portchannel_interface_tc2_incremental(duthost):
          "value": "Description for PortChannel101"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_syslog.py
+++ b/tests/generic_config_updater/test_syslog.py
@@ -126,7 +126,6 @@ def syslog_server_tc1_add_init(duthost):
             }
         }
     ]
-    # change is applied to localhost namespace only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)

--- a/tests/generic_config_updater/test_syslog.py
+++ b/tests/generic_config_updater/test_syslog.py
@@ -126,7 +126,8 @@ def syslog_server_tc1_add_init(duthost):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to localhost namespace only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -164,7 +165,7 @@ def syslog_server_tc1_add_duplicate(duthost):
             "value": {}
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -208,7 +209,7 @@ def syslog_server_tc1_xfail(duthost):
                 "value": {}
             }
         ]
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
 
@@ -249,7 +250,7 @@ def syslog_server_tc1_replace(duthost):
             "value": {}
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -281,7 +282,7 @@ def syslog_server_tc1_remove(duthost):
             "path": "/SYSLOG_SERVER"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_vlan_interface.py
+++ b/tests/generic_config_updater/test_vlan_interface.py
@@ -149,7 +149,8 @@ def vlan_interface_tc1_add_duplicate(duthost, vlan_info):
             "value": {}
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    # change is applied to asic namespaces only
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     logger.info("json patch {}".format(json_patch))
 
@@ -235,7 +236,7 @@ def vlan_interface_tc1_xfail(duthost, vlan_info):
                 "value": {}
             }
         ]
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
@@ -307,7 +308,7 @@ def vlan_interface_tc1_add_new(duthost):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -366,7 +367,7 @@ def vlan_interface_tc1_replace(duthost, vlan_info):
             "value": {}
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -392,7 +393,7 @@ def vlan_interface_tc1_remove(duthost, vlan_info):
             "path": "/VLAN_INTERFACE"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -436,7 +437,7 @@ def test_vlan_interface_tc2_incremental_change(rand_selected_dut):
             "value": "incremental test for Vlan{}".format(EXIST_VLAN_ID)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=rand_selected_dut, json_data=json_patch)
+    json_patch = format_json_patch_for_multiasic(duthost=rand_selected_dut, json_data=json_patch, is_asic_specific=True)
 
     tmpfile = generate_tmpfile(rand_selected_dut)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_vlan_interface.py
+++ b/tests/generic_config_updater/test_vlan_interface.py
@@ -149,7 +149,6 @@ def vlan_interface_tc1_add_duplicate(duthost, vlan_info):
             "value": {}
         }
     ]
-    # change is applied to asic namespaces only
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
 
     logger.info("json patch {}".format(json_patch))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
For GCU test suites, configuration changes applied via patches sometimes target a specific ASIC namespace or apply globally to the card (localhost), depending on the feature functionality.

With the recent merged PR https://github.com/sonic-net/sonic-mgmt/pull/14098, configuration changes are now applied to both localhost and all ASIC namespaces for all multi-ASIC platforms by default, which is incorrect.

Examples:

Configuration paths like /BGP_NEIGHBOR/ should apply only to the ASIC namespace.
Paths like /SYSLOG_SERVER/ should apply only to the localhost namespace.
This PR addresses the issue by introducing a missing flag for "asic_specific" configurations. It adapts the calls appropriately in each test suite based on the targeted configuration scope (ASIC namespace or localhost).

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Ran vs-kvm tests.

Attaching sample results for test_portchannel.py and test_eth_interface.py: 

![image](https://github.com/user-attachments/assets/7fe04e70-bd35-4542-b8ac-2cbb62dbba4e)
![image](https://github.com/user-attachments/assets/0cf64885-d523-4a73-ac3e-01b6d844f7af)



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
