### PR TITLE
fix for voq fabric related tests

### DIFF
--- a/tests/voq/test_fabric_cli_and_db.py
+++ b/tests/voq/test_fabric_cli_and_db.py
@@ -77,81 +77,82 @@ def test_fabric_cli_isolate_linecards(duthosts, enum_frontend_dut_hostname):
             pytest_assert(
                 originalIsolateStatus == "True" or originalIsolateStatus == "False",
                 "Port {} CONFIG_DB initial isolateStatus is True, expected False".format(localPort))
+            try:
+                # If the port is isolated then temporarily unisolate it
+                if originalIsolateStatus == "True":
+                    cmd = "sudo config fabric port unisolate {} {}".format(localPort, asicNamespaceOption)
+                    cmd_output = duthost.shell(cmd, module_ignore_errors=True)
+                    stderr_output = cmd_output["stderr"]
+                    pytest_assert(
+                          len(stderr_output) <= 0, "command: {} failed, error: {}".format(cmd, stderr_output))
 
-            # If the port is isolated then temporarily unisolate it
-            if originalIsolateStatus == "True":
-                cmd = "sudo config fabric port unisolate {} {}".format(localPort, asicNamespaceOption)
+                # Check the isolateStatus in CONFIG_DB
+                cmd = "sonic-db-cli {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicNamespaceOption,
+                                                                                                   localPort)
+                cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
+                tokens = cmd_output[0].split()
+                pytest_assert(
+                      len(tokens) > 0,
+                      "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB".format(localPort))
+                isolateStatus = tokens[0]
+                pytest_assert(
+                      isolateStatus == "False",
+                      "Port {} CONFIG_DB initial isolateStatus is True, expected False".format(localPort))
+
+                # Check the isolateStatus in APPL_DB
+                cmd = "sonic-db-cli {} APPL_DB hget 'FABRIC_PORT_TABLE:Fabric{}' isolateStatus".format(asicNamespaceOption,
+                                                                                                       localPort)
+                cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
+                tokens = cmd_output[0].split()
+                pytest_assert(
+                      len(tokens) > 0, "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB".format(localPort))
+                isolateStatus = tokens[0]
+                pytest_assert(
+                      isolateStatus == "False",
+                      "Port {} APPL_DB initial isolateStatus is True, expected False".format(localPort))
+
+                # Isolate the port
+                cmd = "sudo config fabric port isolate {} {}".format(localPort, asicNamespaceOption)
                 cmd_output = duthost.shell(cmd, module_ignore_errors=True)
                 stderr_output = cmd_output["stderr"]
                 pytest_assert(
                       len(stderr_output) <= 0, "command: {} failed, error: {}".format(cmd, stderr_output))
 
-            # Check the isolateStatus in CONFIG_DB
-            cmd = "sonic-db-cli {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicNamespaceOption,
-                                                                                               localPort)
-            cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
-            tokens = cmd_output[0].split()
-            pytest_assert(
-                  len(tokens) > 0,
-                  "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB".format(localPort))
-            isolateStatus = tokens[0]
-            pytest_assert(
-                  isolateStatus == "False",
-                  "Port {} CONFIG_DB initial isolateStatus is True, expected False".format(localPort))
-
-            # Check the isolateStatus in APPL_DB
-            cmd = "sonic-db-cli {} APPL_DB hget 'FABRIC_PORT_TABLE:Fabric{}' isolateStatus".format(asicNamespaceOption,
+                # Check the isolateStatus in CONFIG_DB
+                cmd = "sonic-db-cli {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicNamespaceOption,
                                                                                                    localPort)
-            cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
-            tokens = cmd_output[0].split()
-            pytest_assert(
-                  len(tokens) > 0, "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB".format(localPort))
-            isolateStatus = tokens[0]
-            pytest_assert(
-                  isolateStatus == "False",
-                  "Port {} APPL_DB initial isolateStatus is True, expected False".format(localPort))
-
-            # Isolate the port
-            cmd = "sudo config fabric port isolate {} {}".format(localPort, asicNamespaceOption)
-            cmd_output = duthost.shell(cmd, module_ignore_errors=True)
-            stderr_output = cmd_output["stderr"]
-            pytest_assert(
-                  len(stderr_output) <= 0, "command: {} failed, error: {}".format(cmd, stderr_output))
-
-            # Check the isolateStatus in CONFIG_DB
-            cmd = "sonic-db-cli {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicNamespaceOption,
-                                                                                               localPort)
-            cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
-            tokens = cmd_output[0].split()
-            pytest_assert(
-                  len(tokens) > 0,
-                  "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB".format(localPort))
-            isolateStatus = tokens[0]
-            pytest_assert(
-                  isolateStatus == "True",
-                  "Port {} CONFIG_DB initial isolateStatus is True, expected False".format(localPort))
-
-            # Check the isolateStatus in APPL_DB
-            cmd = "sonic-db-cli {} APPL_DB hget 'FABRIC_PORT_TABLE:Fabric{}' isolateStatus".format(asicNamespaceOption,
-                                                                                                   localPort)
-            cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
-            tokens = cmd_output[0].split()
-            pytest_assert(
-                  len(tokens) > 0,
-                  "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB".format(localPort))
-            isolateStatus = tokens[0]
-            pytest_assert(
-                  isolateStatus == "True",
-                  "Port {} APPL_DB initial isolateStatus is True, expected False".format(localPort))
-
-            # If the port was originally not isolsated then restore it
-            if originalIsolateStatus == "False":
-                cmd = "sudo config fabric port unisolate {} {}".format(localPort, asicNamespaceOption)
-                cmd_output = duthost.shell(cmd, module_ignore_errors=True)
-                stderr_output = cmd_output["stderr"]
+                cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
+                tokens = cmd_output[0].split()
                 pytest_assert(
-                      len(stderr_output) <= 0,
-                      "command: {} failed, error: {}".format(cmd, stderr_output))
+                      len(tokens) > 0,
+                      "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB".format(localPort))
+                isolateStatus = tokens[0]
+                pytest_assert(
+                      isolateStatus == "True",
+                      "Port {} CONFIG_DB initial isolateStatus is True, expected False".format(localPort))
+
+                # Check the isolateStatus in APPL_DB
+                cmd = "sonic-db-cli {} APPL_DB hget 'FABRIC_PORT_TABLE:Fabric{}' isolateStatus".format(asicNamespaceOption,
+                                                                                                       localPort)
+                cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
+                tokens = cmd_output[0].split()
+                pytest_assert(
+                      len(tokens) > 0,
+                      "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB".format(localPort))
+                isolateStatus = tokens[0]
+                pytest_assert(
+                      isolateStatus == "True",
+                      "Port {} APPL_DB initial isolateStatus is True, expected False".format(localPort))
+
+            finally:
+                # If the port was originally not isolsated then restore it
+                if originalIsolateStatus == "False":
+                    cmd = "sudo config fabric port unisolate {} {}".format(localPort, asicNamespaceOption)
+                    cmd_output = duthost.shell(cmd, module_ignore_errors=True)
+                    stderr_output = cmd_output["stderr"]
+                    pytest_assert(
+                          len(stderr_output) <= 0,
+                          "command: {} failed, error: {}".format(cmd, stderr_output))
 
 
 # This test iterates over the fabric links on each asic
@@ -172,122 +173,120 @@ def test_fabric_cli_isolate_supervisor(duthosts, enum_supervisor_dut_hostname):
     num_asics = duthost.num_asics()
     logger.info("num_asics: {}".format(num_asics))
     for asic in range(num_asics):
-        allPortsList = []
-        portList = []
-        asicName = "asic{}".format(asic)
-        logger.info(asicName)
+        if asic in duthost.facts['asics_present']:
+            allPortsList = []
+            portList = []
+            asicName = "asic{}".format(asic)
+            logger.info(asicName)
 
-        # Create list of ports
-        cmd = "show fabric reachability -n asic{}".format(asic)
-        cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
-        for line in cmd_output:
-            if not line:
-                continue
-            tokens = line.split()
-            # (localPort,  remoteModule, remotePort, status)
-            if not tokens[0].isdigit():
-                continue
-            localPort = tokens[0]
-            allPortsList.append(localPort)
-
-        # To test a few of the links
-        portList = []
-        while len(portList) < num_links_to_test:
-            randomPort = random.choice(allPortsList)
-            if randomPort not in portList:
-                portList.append(randomPort)
-
-        # Test each fabric link
-        for localPort in portList:
-            logger.info("local port {}".format(localPort))
-            # continue
-
-            # Get the current isolation status of the port
-            cmd = "sonic-db-cli -n {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicName, localPort)
+            # Create list of ports
+            cmd = "show fabric reachability -n asic{}".format(asic)
             cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
-            tokens = cmd_output[0].split()
-            originalIsolateStatus = tokens[0]
-            pytest_assert(
-                  originalIsolateStatus == "True" or originalIsolateStatus == "False",
-                  "Port {} CONFIG_DB initial isolateStatus is True, expected False".format(localPort))
-            logger.debug("originalIsolateStatus: {}".format(originalIsolateStatus))
+            for line in cmd_output:
+                if not line:
+                    continue
+                tokens = line.split()
+                # (localPort,  remoteModule, remotePort, status)
+                if not tokens[0].isdigit():
+                    continue
+                localPort = tokens[0]
+                allPortsList.append(localPort)
 
-            # If the port is isolated then temporarily unisolate it
-            if originalIsolateStatus == "True":
-                cmd = "sudo config fabric port unisolate {} -n {}".format(localPort, asicName)
-                cmd_output = duthost.shell(cmd, module_ignore_errors=True)
-                stderr_output = cmd_output["stderr"]
-                pytest_assert(
-                      len(stderr_output) <= 0,
-                      "command: {} failed, error: {}".format(cmd, stderr_output))
+            # To test a few of the links
+            portList = []
+            while len(portList) < num_links_to_test:
+                randomPort = random.choice(allPortsList)
+                if randomPort not in portList:
+                    portList.append(randomPort)
 
-            # Check the isolateStatus in CONFIG_DB
-            cmd = "sonic-db-cli -n {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicName, localPort)
-            cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
-            tokens = cmd_output[0].split()
-            originalIsolateStatus = tokens[0]
-            pytest_assert(
-                  len(tokens) > 0,
-                  "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB, {} ".format(localPort, asicName))
-            isolateStatus = tokens[0]
-            pytest_assert(
-                  isolateStatus == "False",
-                  "Port {} CONFIG_DB initial isolateStatus is '{}', expected False".format(localPort, isolateStatus))
+            # Test each fabric link
+            for localPort in portList:
+                logger.info("local port {}".format(localPort))
+                # continue
 
-            # Check the isolateStatus in APPL_DB
-            cmd = "sonic-db-cli -n {} APPL_DB hget 'FABRIC_PORT_TABLE:Fabric{}' isolateStatus".format(asicName,
+                # Get the current isolation status of the port
+                cmd = "sonic-db-cli -n {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicName,
                                                                                                       localPort)
-            cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
-            tokens = cmd_output[0].split()
-            originalIsolateStatus = tokens[0]
-            pytest_assert(
-                  len(tokens) > 0,
-                  "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB, {} ".format(localPort, asicName))
-            isolateStatus = tokens[0]
-            pytest_assert(
-                  isolateStatus == "False",
-                  "Port {} APPL_DB initial isolateStatus is '{}', expected False".format(localPort, isolateStatus))
-
-            # Isolate the port
-            cmd = "sudo config fabric port isolate {} -n {}".format(localPort, asicName)
-            cmd_output = duthost.shell(cmd, module_ignore_errors=True)
-            stderr_output = cmd_output["stderr"]
-            pytest_assert(
-                  len(stderr_output) <= 0,
-                  "command: {} failed, error: {}".format(cmd, stderr_output))
-
-            # Check the isolateStatus in CONFIG_DB
-            cmd = "sonic-db-cli -n {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicName, localPort)
-            cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
-            tokens = cmd_output[0].split()
-            originalIsolateStatus = tokens[0]
-            pytest_assert(
-                  len(tokens) > 0,
-                  "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB, {} ".format(localPort, asicName))
-            isolateStatus = tokens[0]
-            pytest_assert(
-                  isolateStatus == "True",
-                  "Port {} CONFIG_DB initial isolateStatus is '{}', expected False".format(localPort, isolateStatus))
-
-            # Check the isolateStatus in APPL_DB
-            cmd = "sonic-db-cli -n {} APPL_DB hget 'FABRIC_PORT_TABLE:Fabric{}' isolateStatus".format(asicName,
-                                                                                                      localPort)
-            cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
-            tokens = cmd_output[0].split()
-            originalIsolateStatus = tokens[0]
-            pytest_assert(
-                  len(tokens) > 0,
-                  "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB, {} ".format(localPort, asicName))
-            isolateStatus = tokens[0]
-            pytest_assert(
-                  isolateStatus == "True",
-                  "Port {} APPL_DB initial isolateStatus is '{}', expected False".format(localPort, isolateStatus))
-
-            # If the port was originally not isolsated then restore it
-            if originalIsolateStatus == "False":
-                cmd = "sudo config fabric port unisolate {} -n {}".format(localPort, asicName)
-                cmd_output = duthost.shell(cmd, module_ignore_errors=True)
-                stderr_output = cmd_output["stderr"]
+                cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
+                tokens = cmd_output[0].split()
+                originalIsolateStatus = tokens[0]
                 pytest_assert(
-                      len(stderr_output) <= 0,
-                      "command: {} failed, error: {}".format(cmd, stderr_output))
+                    originalIsolateStatus == "True" or originalIsolateStatus == "False",
+                    "Port {} CONFIG_DB initial isolateStatus is True, expected False".format(localPort))
+                logger.debug("originalIsolateStatus: {}".format(originalIsolateStatus))
+                try:
+                    # If the port is isolated then temporarily unisolate it
+                    if originalIsolateStatus == "True":
+                        cmd = "sudo config fabric port unisolate {} -n {}".format(localPort, asicName)
+                        cmd_output = duthost.shell(cmd, module_ignore_errors=True)
+                        stderr_output = cmd_output["stderr"]
+                        pytest_assert(
+                              len(stderr_output) <= 0,
+                              "command: {} failed, error: {}".format(cmd, stderr_output))
+
+                    # Check the isolateStatus in CONFIG_DB
+                    cmd = "sonic-db-cli -n {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicName, localPort)
+                    cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
+                    tokens = cmd_output[0].split()
+                    isolateStatus = tokens[0]
+                    pytest_assert(
+                          len(tokens) > 0,
+                          "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB, {} ".format(localPort, asicName))
+                    pytest_assert(
+                          isolateStatus == "False",
+                          "Port {} CONFIG_DB initial isolateStatus is '{}', expected False".format(localPort, isolateStatus))
+
+                    # Check the isolateStatus in APPL_DB
+                    cmd = "sonic-db-cli -n {} APPL_DB hget 'FABRIC_PORT_TABLE:Fabric{}' isolateStatus".format(asicName,
+                                                                                                              localPort)
+                    cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
+                    tokens = cmd_output[0].split()
+                    isolateStatus = tokens[0]
+                    pytest_assert(
+                          len(tokens) > 0,
+                          "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB, {} ".format(localPort, asicName))
+                    pytest_assert(
+                          isolateStatus == "False",
+                          "Port {} APPL_DB initial isolateStatus is '{}', expected False".format(localPort, isolateStatus))
+
+                    # Isolate the port
+                    cmd = "sudo config fabric port isolate {} -n {}".format(localPort, asicName)
+                    cmd_output = duthost.shell(cmd, module_ignore_errors=True)
+                    stderr_output = cmd_output["stderr"]
+                    pytest_assert(
+                          len(stderr_output) <= 0,
+                          "command: {} failed, error: {}".format(cmd, stderr_output))
+
+                    # Check the isolateStatus in CONFIG_DB
+                    cmd = "sonic-db-cli -n {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicName, localPort)
+                    cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
+                    tokens = cmd_output[0].split()
+                    isolateStatus = tokens[0]
+                    pytest_assert(
+                          len(tokens) > 0,
+                          "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB, {} ".format(localPort, asicName))
+                    pytest_assert(
+                          isolateStatus == "True",
+                          "Port {} CONFIG_DB initial isolateStatus is '{}', expected True".format(localPort, isolateStatus))
+
+                    # Check the isolateStatus in APPL_DB
+                    cmd = "sonic-db-cli -n {} APPL_DB hget 'FABRIC_PORT_TABLE:Fabric{}' isolateStatus".format(asicName,
+                                                                                                              localPort)
+                    cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
+                    tokens = cmd_output[0].split()
+                    isolateStatus = tokens[0]
+                    pytest_assert(
+                          len(tokens) > 0,
+                          "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB, {} ".format(localPort, asicName))
+                    pytest_assert(
+                          isolateStatus == "True",
+                          "Port {} APPL_DB initial isolateStatus is '{}', expected True".format(localPort, isolateStatus))
+                finally:
+                    # If the port was originally not isolsated then restore it
+                    if originalIsolateStatus == "False":
+                        cmd = "sudo config fabric port unisolate {} -n {}".format(localPort, asicName)
+                        cmd_output = duthost.shell(cmd, module_ignore_errors=True)
+                        stderr_output = cmd_output["stderr"]
+                        pytest_assert(
+                              len(stderr_output) <= 0,
+                              "command: {} failed, error: {}".format(cmd, stderr_output))

--- a/tests/voq/test_fabric_cli_and_db.py
+++ b/tests/voq/test_fabric_cli_and_db.py
@@ -233,10 +233,10 @@ def test_fabric_cli_isolate_supervisor(duthosts, enum_supervisor_dut_hostname):
                                                                                                           localPort)
                     cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
                     tokens = cmd_output[0].split()
-                    isolateStatus = tokens[0]
                     pytest_assert(
                         len(tokens) > 0,
                         "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB, {} ".format(localPort, asicName))
+                    isolateStatus = tokens[0]
                     pytest_assert(
                         isolateStatus == "False",
                         "Port {} CONFIG_DB initial isolateStatus is '{}', expected False".format(localPort,
@@ -247,11 +247,11 @@ def test_fabric_cli_isolate_supervisor(duthosts, enum_supervisor_dut_hostname):
                                                                                                               localPort)
                     cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
                     tokens = cmd_output[0].split()
-                    isolateStatus = tokens[0]
                     pytest_assert(
                         len(tokens) > 0,
                         "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB, {} ".format(localPort,
                                                                                                     asicName))
+                    isolateStatus = tokens[0]
                     pytest_assert(
                         isolateStatus == "False",
                         "Port {} APPL_DB initial isolateStatus is '{}', expected False".format(localPort,
@@ -270,10 +270,10 @@ def test_fabric_cli_isolate_supervisor(duthosts, enum_supervisor_dut_hostname):
                                                                                                           localPort)
                     cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
                     tokens = cmd_output[0].split()
-                    isolateStatus = tokens[0]
                     pytest_assert(len(tokens) > 0,
                                   "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB, {} ".format(localPort,
                                                                                                           asicName))
+                    isolateStatus = tokens[0]
                     pytest_assert(
                         isolateStatus == "True",
                         "Port {} CONFIG_DB initial isolateStatus is '{}', expected True".format(localPort,
@@ -284,11 +284,11 @@ def test_fabric_cli_isolate_supervisor(duthosts, enum_supervisor_dut_hostname):
                                                                                                               localPort)
                     cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
                     tokens = cmd_output[0].split()
-                    isolateStatus = tokens[0]
                     pytest_assert(
                         len(tokens) > 0,
                         "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB, {} ".format(localPort,
                                                                                                     asicName))
+                    isolateStatus = tokens[0]
                     pytest_assert(isolateStatus == "True",
                                   "Port {} APPL_DB initial isolateStatus is '{}', expected True".format(localPort,
                                                                                                         isolateStatus))

--- a/tests/voq/test_fabric_cli_and_db.py
+++ b/tests/voq/test_fabric_cli_and_db.py
@@ -2,6 +2,7 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 import logging
 import random
+
 logger = logging.getLogger(__name__)
 # This test only runs on t2 systems.
 pytestmark = [
@@ -15,6 +16,7 @@ num_asics = 12
 # Set the number of links to test for each test. If all
 # links are tested these tests can take almost an hour!
 num_links_to_test = 6
+
 
 # This test iterates over the fabric links on a linecard
 # It isolates and unisolates each fabric link. Each time the
@@ -84,7 +86,7 @@ def test_fabric_cli_isolate_linecards(duthosts, enum_frontend_dut_hostname):
                     cmd_output = duthost.shell(cmd, module_ignore_errors=True)
                     stderr_output = cmd_output["stderr"]
                     pytest_assert(
-                          len(stderr_output) <= 0, "command: {} failed, error: {}".format(cmd, stderr_output))
+                        len(stderr_output) <= 0, "command: {} failed, error: {}".format(cmd, stderr_output))
 
                 # Check the isolateStatus in CONFIG_DB
                 cmd = "sonic-db-cli {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicNamespaceOption,
@@ -92,31 +94,32 @@ def test_fabric_cli_isolate_linecards(duthosts, enum_frontend_dut_hostname):
                 cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
                 tokens = cmd_output[0].split()
                 pytest_assert(
-                      len(tokens) > 0,
-                      "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB".format(localPort))
+                    len(tokens) > 0,
+                    "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB".format(localPort))
                 isolateStatus = tokens[0]
                 pytest_assert(
-                      isolateStatus == "False",
-                      "Port {} CONFIG_DB initial isolateStatus is True, expected False".format(localPort))
+                    isolateStatus == "False",
+                    "Port {} CONFIG_DB initial isolateStatus is True, expected False".format(localPort))
 
                 # Check the isolateStatus in APPL_DB
-                cmd = "sonic-db-cli {} APPL_DB hget 'FABRIC_PORT_TABLE:Fabric{}' isolateStatus".format(asicNamespaceOption,
-                                                                                                       localPort)
+                cmd = "sonic-db-cli {} APPL_DB hget 'FABRIC_PORT_TABLE:Fabric{}' isolateStatus".format(
+                    asicNamespaceOption,
+                    localPort)
                 cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
                 tokens = cmd_output[0].split()
                 pytest_assert(
-                      len(tokens) > 0, "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB".format(localPort))
+                    len(tokens) > 0, "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB".format(localPort))
                 isolateStatus = tokens[0]
                 pytest_assert(
-                      isolateStatus == "False",
-                      "Port {} APPL_DB initial isolateStatus is True, expected False".format(localPort))
+                    isolateStatus == "False",
+                    "Port {} APPL_DB initial isolateStatus is True, expected False".format(localPort))
 
                 # Isolate the port
                 cmd = "sudo config fabric port isolate {} {}".format(localPort, asicNamespaceOption)
                 cmd_output = duthost.shell(cmd, module_ignore_errors=True)
                 stderr_output = cmd_output["stderr"]
                 pytest_assert(
-                      len(stderr_output) <= 0, "command: {} failed, error: {}".format(cmd, stderr_output))
+                    len(stderr_output) <= 0, "command: {} failed, error: {}".format(cmd, stderr_output))
 
                 # Check the isolateStatus in CONFIG_DB
                 cmd = "sonic-db-cli {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicNamespaceOption,
@@ -124,25 +127,26 @@ def test_fabric_cli_isolate_linecards(duthosts, enum_frontend_dut_hostname):
                 cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
                 tokens = cmd_output[0].split()
                 pytest_assert(
-                      len(tokens) > 0,
-                      "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB".format(localPort))
+                    len(tokens) > 0,
+                    "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB".format(localPort))
                 isolateStatus = tokens[0]
                 pytest_assert(
-                      isolateStatus == "True",
-                      "Port {} CONFIG_DB initial isolateStatus is True, expected False".format(localPort))
+                    isolateStatus == "True",
+                    "Port {} CONFIG_DB initial isolateStatus is True, expected False".format(localPort))
 
                 # Check the isolateStatus in APPL_DB
-                cmd = "sonic-db-cli {} APPL_DB hget 'FABRIC_PORT_TABLE:Fabric{}' isolateStatus".format(asicNamespaceOption,
-                                                                                                       localPort)
+                cmd = "sonic-db-cli {} APPL_DB hget 'FABRIC_PORT_TABLE:Fabric{}' isolateStatus".format(
+                    asicNamespaceOption,
+                    localPort)
                 cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
                 tokens = cmd_output[0].split()
                 pytest_assert(
-                      len(tokens) > 0,
-                      "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB".format(localPort))
+                    len(tokens) > 0,
+                    "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB".format(localPort))
                 isolateStatus = tokens[0]
                 pytest_assert(
-                      isolateStatus == "True",
-                      "Port {} APPL_DB initial isolateStatus is True, expected False".format(localPort))
+                    isolateStatus == "True",
+                    "Port {} APPL_DB initial isolateStatus is True, expected False".format(localPort))
 
             finally:
                 # If the port was originally not isolsated then restore it
@@ -151,8 +155,8 @@ def test_fabric_cli_isolate_linecards(duthosts, enum_frontend_dut_hostname):
                     cmd_output = duthost.shell(cmd, module_ignore_errors=True)
                     stderr_output = cmd_output["stderr"]
                     pytest_assert(
-                          len(stderr_output) <= 0,
-                          "command: {} failed, error: {}".format(cmd, stderr_output))
+                        len(stderr_output) <= 0,
+                        "command: {} failed, error: {}".format(cmd, stderr_output))
 
 
 # This test iterates over the fabric links on each asic
@@ -221,20 +225,22 @@ def test_fabric_cli_isolate_supervisor(duthosts, enum_supervisor_dut_hostname):
                         cmd_output = duthost.shell(cmd, module_ignore_errors=True)
                         stderr_output = cmd_output["stderr"]
                         pytest_assert(
-                              len(stderr_output) <= 0,
-                              "command: {} failed, error: {}".format(cmd, stderr_output))
+                            len(stderr_output) <= 0,
+                            "command: {} failed, error: {}".format(cmd, stderr_output))
 
                     # Check the isolateStatus in CONFIG_DB
-                    cmd = "sonic-db-cli -n {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicName, localPort)
+                    cmd = "sonic-db-cli -n {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicName,
+                                                                                                          localPort)
                     cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
                     tokens = cmd_output[0].split()
                     isolateStatus = tokens[0]
                     pytest_assert(
-                          len(tokens) > 0,
-                          "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB, {} ".format(localPort, asicName))
+                        len(tokens) > 0,
+                        "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB, {} ".format(localPort, asicName))
                     pytest_assert(
-                          isolateStatus == "False",
-                          "Port {} CONFIG_DB initial isolateStatus is '{}', expected False".format(localPort, isolateStatus))
+                        isolateStatus == "False",
+                        "Port {} CONFIG_DB initial isolateStatus is '{}', expected False".format(localPort,
+                                                                                                 isolateStatus))
 
                     # Check the isolateStatus in APPL_DB
                     cmd = "sonic-db-cli -n {} APPL_DB hget 'FABRIC_PORT_TABLE:Fabric{}' isolateStatus".format(asicName,
@@ -243,31 +249,35 @@ def test_fabric_cli_isolate_supervisor(duthosts, enum_supervisor_dut_hostname):
                     tokens = cmd_output[0].split()
                     isolateStatus = tokens[0]
                     pytest_assert(
-                          len(tokens) > 0,
-                          "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB, {} ".format(localPort, asicName))
+                        len(tokens) > 0,
+                        "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB, {} ".format(localPort,
+                                                                                                    asicName))
                     pytest_assert(
-                          isolateStatus == "False",
-                          "Port {} APPL_DB initial isolateStatus is '{}', expected False".format(localPort, isolateStatus))
+                        isolateStatus == "False",
+                        "Port {} APPL_DB initial isolateStatus is '{}', expected False".format(localPort,
+                                                                                               isolateStatus))
 
                     # Isolate the port
                     cmd = "sudo config fabric port isolate {} -n {}".format(localPort, asicName)
                     cmd_output = duthost.shell(cmd, module_ignore_errors=True)
                     stderr_output = cmd_output["stderr"]
                     pytest_assert(
-                          len(stderr_output) <= 0,
-                          "command: {} failed, error: {}".format(cmd, stderr_output))
+                        len(stderr_output) <= 0,
+                        "command: {} failed, error: {}".format(cmd, stderr_output))
 
                     # Check the isolateStatus in CONFIG_DB
-                    cmd = "sonic-db-cli -n {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicName, localPort)
+                    cmd = "sonic-db-cli -n {} CONFIG_DB hget 'FABRIC_PORT|Fabric{}' isolateStatus".format(asicName,
+                                                                                                          localPort)
                     cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
                     tokens = cmd_output[0].split()
                     isolateStatus = tokens[0]
+                    pytest_assert(len(tokens) > 0,
+                                  "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB, {} ".format(localPort,
+                                                                                                          asicName))
                     pytest_assert(
-                          len(tokens) > 0,
-                          "FABRIC_PORT|Fabric{} isolateStatus not found in CONFIG_DB, {} ".format(localPort, asicName))
-                    pytest_assert(
-                          isolateStatus == "True",
-                          "Port {} CONFIG_DB initial isolateStatus is '{}', expected True".format(localPort, isolateStatus))
+                        isolateStatus == "True",
+                        "Port {} CONFIG_DB initial isolateStatus is '{}', expected True".format(localPort,
+                                                                                                isolateStatus))
 
                     # Check the isolateStatus in APPL_DB
                     cmd = "sonic-db-cli -n {} APPL_DB hget 'FABRIC_PORT_TABLE:Fabric{}' isolateStatus".format(asicName,
@@ -276,11 +286,12 @@ def test_fabric_cli_isolate_supervisor(duthosts, enum_supervisor_dut_hostname):
                     tokens = cmd_output[0].split()
                     isolateStatus = tokens[0]
                     pytest_assert(
-                          len(tokens) > 0,
-                          "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB, {} ".format(localPort, asicName))
-                    pytest_assert(
-                          isolateStatus == "True",
-                          "Port {} APPL_DB initial isolateStatus is '{}', expected True".format(localPort, isolateStatus))
+                        len(tokens) > 0,
+                        "FABRIC_PORT_TABLE:Fabric{} isolateStatus not found in APPL_DB, {} ".format(localPort,
+                                                                                                    asicName))
+                    pytest_assert(isolateStatus == "True",
+                                  "Port {} APPL_DB initial isolateStatus is '{}', expected True".format(localPort,
+                                                                                                        isolateStatus))
                 finally:
                     # If the port was originally not isolsated then restore it
                     if originalIsolateStatus == "False":
@@ -288,5 +299,5 @@ def test_fabric_cli_isolate_supervisor(duthosts, enum_supervisor_dut_hostname):
                         cmd_output = duthost.shell(cmd, module_ignore_errors=True)
                         stderr_output = cmd_output["stderr"]
                         pytest_assert(
-                              len(stderr_output) <= 0,
-                              "command: {} failed, error: {}".format(cmd, stderr_output))
+                            len(stderr_output) <= 0,
+                            "command: {} failed, error: {}".format(cmd, stderr_output))

--- a/tests/voq/test_fabric_reach.py
+++ b/tests/voq/test_fabric_reach.py
@@ -178,31 +178,32 @@ def test_fabric_reach_supervisor(duthosts, enum_supervisor_dut_hostname, refData
     num_asics = duthost.num_asics()
     logger.info("num_asics: {}".format(num_asics))
     for asic in range(num_asics):
-        asicName = "asic{}".format(asic)
-        logger.info(asicName)
-        cmd = "show fabric reachability -n asic{}".format(asic)
-        cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
-        asicReferenceData = supReferenceData[asicName]
-        for line in cmd_output:
-            if not line:
-                continue
-            tokens = line.split()
-            if not tokens[0].isdigit():
-                continue
-            localPortName = tokens[0]
-            remoteModule = int(tokens[1])
-            remotePort = int(tokens[2])
-            if remoteModule not in linecardModule:
-                logger.info("The linecard is not inserted or down.")
-                continue
-            pytest_assert(localPortName in asicReferenceData,
-                          "Reference port data for {} not found!".format(localPortName))
-            referencePortData = asicReferenceData[localPortName]
-            referenceRemoteModule = referencePortData['peer mod']
-            referenceRemotePort = referencePortData['peer lk']
-            pytest_assert(remoteModule == referenceRemoteModule,
-                          "Remote module mismatch for asic {}, port {}"
-                          .format(asicName, localPortName))
-            pytest_assert(remotePort == referenceRemotePort,
-                          "Remote port mismatch for asic {}, port {}"
-                          .format(asicName, localPortName))
+        if asic in duthost.facts['asics_present']:
+            asicName = "asic{}".format(asic)
+            logger.info(asicName)
+            cmd = "show fabric reachability -n asic{}".format(asic)
+            cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
+            asicReferenceData = supReferenceData[asicName]
+            for line in cmd_output:
+                if not line:
+                    continue
+                tokens = line.split()
+                if not tokens[0].isdigit():
+                    continue
+                localPortName = tokens[0]
+                remoteModule = int(tokens[1])
+                remotePort = int(tokens[2])
+                if remoteModule not in linecardModule:
+                    logger.info("The linecard is not inserted or down.")
+                    continue
+                pytest_assert(localPortName in asicReferenceData,
+                              "Reference port data for {} not found!".format(localPortName))
+                referencePortData = asicReferenceData[localPortName]
+                referenceRemoteModule = referencePortData['peer mod']
+                referenceRemotePort = referencePortData['peer lk']
+                pytest_assert(remoteModule == referenceRemoteModule,
+                              "Remote module mismatch for asic {}, port {}"
+                              .format(asicName, localPortName))
+                pytest_assert(remotePort == referenceRemotePort,
+                              "Remote port mismatch for asic {}, port {}"
+                              .format(asicName, localPortName))

--- a/tests/voq/test_fabric_reach.py
+++ b/tests/voq/test_fabric_reach.py
@@ -175,6 +175,8 @@ def test_fabric_reach_supervisor(duthosts, enum_supervisor_dut_hostname, refData
     # supReferenceData has the expected data
     duthost = duthosts[enum_supervisor_dut_hostname]
     logger.info("duthost: {}".format(duthost.hostname))
+    if not supReferenceData:
+        supRefData(duthosts)
     num_asics = duthost.num_asics()
     logger.info("num_asics: {}".format(num_asics))
     for asic in range(num_asics):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # 16067 
https://github.com/sonic-net/sonic-mgmt/issues/16067

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X ] 202405

### Approach
#### What is the motivation for this PR?
Fixing issue 16067. 
#### How did you do it?
Changed to not re-write originalIsolateStatus but instead write to isolateStatus.
Also added try/catch block to both tests as today if the test fails it exits without restoring the state of the port.

I also added check  to tests/voq/test_fabric_reach.py::test_fabric_reach_supervisor to run against only if asic is present. Right not the tests get the max asics for the platform and assumes they are all present.
#### How did you verify/test it?
Ran against t2 Nokia chassis
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
