### PR TITLE
[test_snmp_queue_counters.py]: queuestat command output change fix for multi-asic

### DIFF
--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -24,6 +24,15 @@ def get_queue_ctrs(duthost, cmd):
     return len(duthost.shell(cmd)["stdout_lines"])
 
 
+def get_queuestat_ctrs(duthost, cmd):
+    cmd_output = duthost.shell(cmd)["stdout_lines"]
+    queue_cnt = 0
+    for line in cmd_output:
+        if "UC" in line or "MC" in line:
+            queue_cnt = queue_cnt + 1
+    return queue_cnt
+
+
 def check_snmp_cmd_output(duthost, cmd):
     out_len = len(duthost.shell(cmd)["stdout_lines"])
     if out_len > 1:
@@ -124,7 +133,7 @@ def test_snmp_queue_counters(duthosts,
     data['DEVICE_METADATA']["localhost"]["create_only_config_db_buffers"] \
         = "true"
     load_new_cfg(duthost, data)
-    stat_queue_counters_cnt_pre = (get_queue_ctrs(duthost, get_queue_stat_cmd) - 2) * UNICAST_CTRS
+    stat_queue_counters_cnt_pre = get_queuestat_ctrs(duthost, get_queue_stat_cmd) * UNICAST_CTRS
     wait_until(60, 20, 0, check_snmp_cmd_output, duthost, get_bfr_queue_cntrs_cmd)
     queue_counters_cnt_pre = get_queue_ctrs(duthost, get_bfr_queue_cntrs_cmd)
 
@@ -136,7 +145,7 @@ def test_snmp_queue_counters(duthosts,
     # Remove buffer queue and reload and get number of queue counters of selected interface
     del data['BUFFER_QUEUE'][buffer_queue_to_del]
     load_new_cfg(duthost, data)
-    stat_queue_counters_cnt_post = (get_queue_ctrs(duthost, get_queue_stat_cmd) - 2) * UNICAST_CTRS
+    stat_queue_counters_cnt_post = get_queuestat_ctrs(duthost, get_queue_stat_cmd) * UNICAST_CTRS
     wait_until(60, 20, 0, check_snmp_cmd_output, duthost, get_bfr_queue_cntrs_cmd)
     queue_counters_cnt_post = get_queue_ctrs(duthost, get_bfr_queue_cntrs_cmd)
     pytest_assert((queue_counters_cnt_post == stat_queue_counters_cnt_post),


### PR DESCRIPTION
queuestat command output change fix for multi-asic
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

A new fix in queuestat script add extra line for multi-asic system
e.g "For namespace asic0"

Added logic to look for UC or MC string in each line and calculate counters accordingly


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
A new fix in queuestat script add extra line for multi-asic system
e.g "For namespace asic0"

#### How did you do it?
Added logic to look for UC or MC string in each line and calculate counters accordingly

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
