### PR TITLE
[Chassis] Reduce wait/timeout time for chassis

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -192,7 +192,7 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
         sonic_host.shell(cmd, executable="/bin/bash")
 
     modular_chassis = sonic_host.get_facts().get("modular_chassis")
-    wait = max(wait, 900) if modular_chassis else wait
+    wait = max(wait, 600) if modular_chassis else wait
 
     if safe_reload:
         # The wait time passed in might not be guaranteed to cover the actual

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -104,7 +104,7 @@ def check_interfaces(duthosts):
         networking_uptime = dut.get_networking_uptime().seconds
         timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 0)
         if dut.get_facts().get("modular_chassis"):
-            timeout = max(timeout, 900)
+            timeout = max(timeout, 600)
         interval = 20
         logger.info("networking_uptime=%d seconds, timeout=%d seconds, interval=%d seconds" %
                     (networking_uptime, timeout, interval))
@@ -232,7 +232,7 @@ def check_bgp(duthosts, tbinfo):
         else:
             max_timeout = SYSTEM_STABILIZE_MAX_TIME - networking_uptime + 480
         if dut.get_facts().get("modular_chassis"):
-            max_timeout = max(max_timeout, 900)
+            max_timeout = max(max_timeout, 600)
         timeout = max(max_timeout, 1)
         interval = 20
         wait_until(timeout, interval, 0, _check_bgp_status_helper)

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -258,8 +258,8 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         if warmboot_finalizer_timeout == 0 and 'warmboot_finalizer_timeout' in reboot_ctrl:
             warmboot_finalizer_timeout = reboot_ctrl['warmboot_finalizer_timeout']
         if duthost.get_facts().get("modular_chassis") and safe_reboot:
-            wait = max(wait, 900)
-            timeout = max(timeout, 600)
+            wait = max(wait, 600)
+            timeout = max(timeout, 420)
     except KeyError:
         raise ValueError('invalid reboot type: "{} for {}"'.format(reboot_type, hostname))
     logger.info('Reboot {}: wait[{}], timeout[{}]'.format(hostname, wait, timeout))

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -104,8 +104,8 @@ def do_reboot(duthost, localhost, duthosts):
 def post_reboot_healthcheck(duthost, localhost, duthosts, wait_time):
     timeout = 300
     if duthost.get_facts().get("modular_chassis"):
-        wait_time = max(wait_time, 900)
-        timeout = max(timeout, 600)
+        wait_time = max(wait_time, 600)
+        timeout = max(timeout, 420)
         localhost.wait_for(host=duthost.mgmt_ip, port=22, state="started", delay=10, timeout=timeout)
     else:
         localhost.wait_for(host=duthost.mgmt_ip, port=22, state="started", delay=10, timeout=timeout)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Cisco chassis used to be unstable months ago, so updated the wait time of sshd ready to 600s, and service ready to 900s.
After the image became stable, we can reduce the time to:
sshd ready: 420s
service ready: 600s

Will keep monitoring and see whether we can reduce the wait time to align with t0/t1 in the future.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Cisco chassis used to be unstable months ago, so updated the wait time of sshd ready to 600s, and service ready to 900s.
After the image became stable, we can reduce the time to:
sshd ready: 420s
service ready: 600s

Will keep monitoring and see whether we can reduce the wait time to align with t0/t1 in the future.
#### How did you do it?

#### How did you verify/test it?
In the nightly test, the configuration works well.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
