### PR TITLE
Adding skip for any test that uses pfc_gen or pfc_gen_t2 for > 100Gbps

### DIFF
--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -204,7 +204,8 @@ class TestPfcwdAllPortStorm(object):
             time.sleep(5)
 
     def test_all_port_storm_restore(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                    storm_test_setup_restore, setup_pfc_test, ptfhost):
+                                    storm_test_setup_restore, setup_pfc_test, ptfhost,
+                                    skip_pfcwd_higher_speeds):
         """
         Tests PFC storm/restore on all ports
 

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -855,7 +855,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_actions(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
                            ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
                            setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,         # noqa F811
-                           toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m): # noqa F811
+                           toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,                      # noqa F811
+                           skip_pfcwd_higher_speeds):
         """
         PFCwd functional test
 
@@ -933,7 +934,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_multi_port(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
                               ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
                               setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,         # noqa F811
-                              toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m): # noqa F811
+                              toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,                      # noqa F811
+                              skip_pfcwd_higher_speeds):
         """
         Tests pfcwd behavior when 2 ports are under pfc storm one after the other
 
@@ -1014,7 +1016,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_mmu_change(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,   # noqa F811
                               ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, dualtor_ports, # noqa F811
                               setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,       # noqa F811
-                              toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m): # noqa F811
+                              toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,                    # noqa F811
+                              skip_pfcwd_higher_speeds):
         """
         Tests if mmu changes impact Pfcwd functionality
 
@@ -1108,7 +1111,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_port_toggle(self, request, fake_storm, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
                                tbinfo, ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
                                setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,         # noqa F811
-                               toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m): # noqa F811
+                               toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,                      # noqa F811
+                               skip_pfcwd_higher_speeds):
         """
         Test PfCWD functionality after toggling port
 
@@ -1213,7 +1217,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
 
     def test_pfcwd_no_traffic(
             self, request, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
-            ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
+            ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
+            skip_pfcwd_higher_speeds):
         """
         Verify the pfcwd is not triggered when no traffic is sent, even when pfc storm is active.
         Args:

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -322,7 +322,7 @@ class TestPfcwdAllTimer(object):
         return int(timestamp_ms)
 
     def test_pfcwd_timer_accuracy(self, duthosts, ptfhost, enum_rand_one_per_hwsku_frontend_hostname,
-                                  pfcwd_timer_setup_restore, fanouthosts):
+                                  pfcwd_timer_setup_restore, fanouthosts, skip_pfcwd_higher_speeds):
         """
         Tests PFCwd timer accuracy
 

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -594,7 +594,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
 
     def test_pfcwd_wb(self, fake_storm, testcase_action, setup_pfc_test, enum_fanout_graph_facts,   # noqa F811
                       ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                      localhost, fanouthosts, two_queues):
+                      localhost, fanouthosts, two_queues, skip_pfcwd_higher_speeds):
         """
         Tests PFCwd warm reboot with various testcase actions
 


### PR DESCRIPTION


Continuation of #16023

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR


### Type of change

Marking the failed tests as xfail for cisco 8000 and t2

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently we depend on pfc_gen and pfc_gen_t2 for generating pfc storm from fanout to the DUT. This works ok until 100G data link speeds. However at 400G speeds, the fanout and the pfc_gen programs are not able to maintain the required flow of pfc packets continuously, and the DUT ends up either pushing out the data packet in the gaps, or not triggering watchdog. This PR proposes to skip the testcases that depend on pfc_gen or pfc_gen_t2 for any speed higher than 100G. The same tests will be covered or partially already covered in tests/snappi_tests testcases as listed in #16023 


#### How did you do it?

Conditionally add mark xfail

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
