### PR TITLE
[GCU] Reload after lo test to recover default route

### DIFF
--- a/tests/generic_config_updater/test_lo_interface.py
+++ b/tests/generic_config_updater/test_lo_interface.py
@@ -78,7 +78,7 @@ def setup_env(duthosts, rand_one_dut_hostname, lo_intf):
 
         # Loopback interface removal will impact default route. Restart bgp to recover routes.
         duthost.shell("sudo systemctl restart bgp")
-        if not wait_until(240, 10, 0, duthost.check_default_route()):
+        if not wait_until(240, 10, 0, duthost.check_default_route):
             logger.warning(
                 "Default routes not recovered after restart bgp, restoring with `config_reload`"
             )

--- a/tests/generic_config_updater/test_lo_interface.py
+++ b/tests/generic_config_updater/test_lo_interface.py
@@ -3,6 +3,7 @@ import pytest
 import ipaddress
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.config_reload import config_reload
 from tests.common.gu_utils import apply_patch, expect_op_success, expect_op_failure
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import format_json_patch_for_multiasic
@@ -74,6 +75,8 @@ def setup_env(duthosts, rand_one_dut_hostname, lo_intf):
             duthost, DEFAULT_LOOPBACK,
             [lo_intf["ipv6"].lower()], ["Vrf"], is_ipv4=False)
 
+        # Loopback interface removal will impact default route. Reload to recover routes.
+        config_reload(duthost)
         pytest_assert(duthost.check_default_route(), "Default route check failed.")
     finally:
         delete_checkpoint(duthost)

--- a/tests/generic_config_updater/test_lo_interface.py
+++ b/tests/generic_config_updater/test_lo_interface.py
@@ -73,6 +73,8 @@ def setup_env(duthosts, rand_one_dut_hostname, lo_intf):
         check_show_ip_intf(
             duthost, DEFAULT_LOOPBACK,
             [lo_intf["ipv6"].lower()], ["Vrf"], is_ipv4=False)
+
+        pytest_assert(duthost.check_default_route(), "Default route check failed.")
     finally:
         delete_checkpoint(duthost)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Reload after lo test to recover default route
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
default route test would fail after lo test
#### How did you do it?
Recover default route after test
#### How did you verify/test it?
E2E test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
