### PR TITLE
Fix unexpected exception in wait_for while executing reboot

### DIFF
--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -158,14 +158,14 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     if not config_force_option_supported(duthost):
         return
 
-    timeout = None
     if duthost.get_facts().get("modular_chassis"):
         timeout = 420
-
-    reboot(duthost, localhost, reboot_type="cold", wait=5,
-           timeout=timeout,
-           plt_reboot_ctrl_overwrite=False)
-
+        reboot(duthost, localhost, reboot_type="cold", wait=5,
+               timeout=timeout,
+               plt_reboot_ctrl_overwrite=False)
+    else:
+        reboot(duthost, localhost, reboot_type="cold", wait=5,
+               plt_reboot_ctrl_overwrite=False)
     # Check if all database containers have started
     # Some device after reboot may take some longer time to have database container started up
     # we must give it a little longer or else it may falsely fail the test.

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -158,14 +158,14 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     if not config_force_option_supported(duthost):
         return
 
+    timeout = 0
     if duthost.get_facts().get("modular_chassis"):
         timeout = 420
-        reboot(duthost, localhost, reboot_type="cold", wait=5,
-               timeout=timeout,
-               plt_reboot_ctrl_overwrite=False)
-    else:
-        reboot(duthost, localhost, reboot_type="cold", wait=5,
-               plt_reboot_ctrl_overwrite=False)
+
+    reboot(duthost, localhost, reboot_type="cold", wait=5,
+           timeout=timeout,
+           plt_reboot_ctrl_overwrite=False)
+
     # Check if all database containers have started
     # Some device after reboot may take some longer time to have database container started up
     # we must give it a little longer or else it may falsely fail the test.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
`platform_tests/test_reload_config.py::test_reload_configuration_checks` failed due to the following error:

`TypeError: unsupported type for timedelta seconds component: NoneType`

in the following error test log:
```
Traceback (most recent call last):
  File \"/tmp/.ansible-AzDevOps/ansible-tmp-1734119665.955616-147727-226449133302882/AnsiballZ_wait_for.py\", line 107, in <module>
    _ansiballz_main()
  File \"/tmp/.ansible-AzDevOps/ansible-tmp-1734119665.955616-147727-226449133302882/AnsiballZ_wait_for.py\", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File \"/tmp/.ansible-AzDevOps/ansible-tmp-1734119665.955616-147727-226449133302882/AnsiballZ_wait_for.py\", line 47, in invoke_module
    runpy.run_module(mod_name='ansible.modules.wait_for', init_globals=dict(_module_fqn='ansible.modules.wait_for', _modlib_path=modlib_path),
  File \"/usr/lib/python3.8/runpy.py\", line 207, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File \"/usr/lib/python3.8/runpy.py\", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File \"/usr/lib/python3.8/runpy.py\", line 87, in _run_code
    exec(code, run_globals)
  File \"/tmp/ansible_wait_for_payload_9brlx4xp/ansible_wait_for_payload.zip/ansible/modules/wait_for.py\", line 689, in <module>
  File \"/tmp/ansible_wait_for_payload_9brlx4xp/ansible_wait_for_payload.zip/ansible/modules/wait_for.py\", line 544, in main
TypeError: unsupported type for timedelta seconds component: NoneType
",
  "msg": "MODULE FAILURE
See stdout/stderr for the exact error",
```
That because `timeout` parameter is set to None for `localhost.wait_for `function.
 
The change was made in https://github.com/sonic-net/sonic-mgmt/pull/15951



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Fix the `TypeError: unsupported type for timedelta seconds component: NoneType` for localhost.wait_for.

#### How did you do it?
Don't pass in timeout if it's not module chassis

#### How did you verify/test it?
Run `platform_tests/test_reload_config.py::test_reload_configuration_checks` on non T2 testbed.

#### Any platform specific information?
T0/T1/M0/Mx

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
