### PR TITLE
Ensure correct testing telemetry config after config reload (#15071)

### DIFF
--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -115,19 +115,6 @@ def _context_for_setup_streaming_telemetry(request, duthosts, enum_rand_one_per_
         env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
         default_client_auth = setup_telemetry_forpyclient(duthost)
 
-        if default_client_auth == "true":
-            duthost.shell('sonic-db-cli CONFIG_DB HSET "%s|gnmi" "client_auth" "false"' % (env.gnmi_config_table),
-                          module_ignore_errors=False)
-            duthost.shell("systemctl reset-failed %s" % (env.gnmi_container))
-            duthost.service(name=env.gnmi_container, state="restarted")
-        else:
-            logger.info('client auth is false. No need to restart telemetry')
-
-        # Wait until telemetry was restarted
-        py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, env.gnmi_container),
-                  "%s not started." % (env.gnmi_container))
-        logger.info("telemetry process restarted. Now run pyclient on ptfdocker")
-
         # Wait until the TCP port was opened
         dut_ip = duthost.mgmt_ip
         if is_ipv6:

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -5,7 +5,7 @@ import sys
 
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.errors import RunAnsibleModuleFail
-from tests.common.utilities import wait_until, wait_tcp_connection, get_mgmt_ipv6
+from tests.common.utilities import wait_tcp_connection, get_mgmt_ipv6
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from tests.telemetry.telemetry_utils import get_list_stdout, setup_telemetry_forpyclient, restore_telemetry_forpyclient
 from contextlib import contextmanager

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -69,7 +69,7 @@ def setup_telemetry_forpyclient(duthost):
         duthost.service(name=env.gnmi_container, state="restarted")
         # Wait until telemetry was restarted
         pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, env.gnmi_container),
-                  "%s not started." % (env.gnmi_container))
+                      "%s not started." % (env.gnmi_container))
         logger.info("telemetry process restarted")
     else:
         logger.info('client auth is false. No need to restart telemetry')

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -60,6 +60,19 @@ def setup_telemetry_forpyclient(duthost):
     client_auth_out = duthost.shell('sonic-db-cli CONFIG_DB HGET "%s|gnmi" "client_auth"' % (env.gnmi_config_table),
                                     module_ignore_errors=False)['stdout_lines']
     client_auth = str(client_auth_out[0])
+
+    if client_auth == "true":
+        duthost.shell('sonic-db-cli CONFIG_DB HSET "%s|gnmi" "client_auth" "false"' % (env.gnmi_config_table),
+                      module_ignore_errors=False)
+        duthost.shell("systemctl reset-failed %s" % (env.gnmi_container))
+        duthost.service(name=env.gnmi_container, state="restarted")
+        # Wait until telemetry was restarted
+        py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, env.gnmi_container),
+                  "%s not started." % (env.gnmi_container))
+        logger.info("telemetry process restarted")
+    else:
+        logger.info('client auth is false. No need to restart telemetry')
+
     return client_auth
 
 

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -6,6 +6,7 @@ import re
 from pkg_resources import parse_version
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +68,7 @@ def setup_telemetry_forpyclient(duthost):
         duthost.shell("systemctl reset-failed %s" % (env.gnmi_container))
         duthost.service(name=env.gnmi_container, state="restarted")
         # Wait until telemetry was restarted
-        py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, env.gnmi_container),
+        pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started, env.gnmi_container),
                   "%s not started." % (env.gnmi_container))
         logger.info("telemetry process restarted")
     else:

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -8,6 +8,7 @@ import json
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
+from telemetry_utils import setup_telemetry_forpyclient
 from telemetry_utils import assert_equal, get_list_stdout, get_dict_stdout, skip_201911_and_older
 from telemetry_utils import generate_client_cli, parse_gnmi_output, check_gnmi_cli_running
 from tests.common import config_reload
@@ -30,7 +31,9 @@ MAX_UC_CNT = 7
 
 def load_new_cfg(duthost, data):
     duthost.copy(content=json.dumps(data, indent=4), dest=CFG_DB_PATH)
-    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+    config_reload(duthost, config_source='config_db', safe_reload=True)
+    # config reload overrides testing telemetry config, ensure testing config exists
+    setup_telemetry_forpyclient(duthost)
 
 
 def get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, iface, gnmi_port):
@@ -137,6 +140,7 @@ def test_telemetry_ouput(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
+@pytest.mark.disable_loganalyzer
 def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
                                     setup_streaming_telemetry, gnxi_path):
     """


### PR DESCRIPTION
What is the motivation for this PR?

Backport PR of #15071 

After config reload, other telemetry cases fail since testing telemetry config is no longer present. This causes that telemetry config will not have client_auth set to false which results in cert errors when running telemetry query.

Added disable_loganalyzer to test_telemetry_queue_buffer_cnt since we see teardown loganalyzer errors complaining about non telemetry related syncd SAI_API logs

How did you do it?
Ensure that telemetry present after each config reload call.

How did you verify/test it?
Manual/Pipeline

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
