### PR TITLE
Run dhclient before sending dhcp packets

### DIFF
--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -74,3 +74,15 @@ def test_eventd_healthy(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, ptf
     module.test_event(duthost, gnxi_path, ptfhost, ptfadapter, DATA_DIR, None)
 
     logger.info("Completed test file: {}".format("eventd_events test completed."))
+
+
+@pytest.fixture(scope="module")
+def setup_ptfhost_eventd_testing(ptfhost, creds):
+    http_proxy = creds.get("proxy_env", {}).get("http_proxy", "")
+    http_param = "-o Acquire::http::proxy='{}'".format(http_proxy) if http_proxy != "" else ""
+    ptfhost.shell("apt-get {} update".format(http_param), module_ignore_errors=True)
+    ptfhost.shell("apt-get {} install isc-dhcp-client -y".format(http_param))
+
+    yield
+
+    ptfhost.shell("apt-get remove isc-dhcp-client -y", module_ignore_errors=True)

--- a/tests/telemetry/events/run_events_test.py
+++ b/tests/telemetry/events/run_events_test.py
@@ -17,7 +17,7 @@ def run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, trigger, json
         if ptfadapter is None:
             trigger(duthost)  # add events to cache
         else:
-            trigger(duthost, ptfadapter)
+            trigger(duthost, ptfhost, ptfadapter)
     listen_for_events(duthost, gnxi_path, ptfhost, filter_event_regex, op_file,
                       timeout)  # listen from cache
     data = {}

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -34,8 +34,8 @@ def validate_yang(duthost, op_file="", yang_file=""):
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 @pytest.mark.disable_loganalyzer
-def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, ptfadapter, setup_streaming_telemetry, gnxi_path,
-                test_eventd_healthy):
+def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, ptfadapter, creds, setup_streaming_telemetry,
+                gnxi_path, test_eventd_healthy, setup_ptfhost_eventd_testing):
     """ Run series of events inside duthost and validate that output is correct
     and conforms to YANG schema"""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 30372797

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

Ensure dhcp packets are being sent to port so that proper syslog/events are generated.

#### How did you do it?

Run dhclient before sending dhcp packets.

#### How did you verify/test it?

Manual test/pipeline

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
