### PR TITLE
[Manual] [PR:15136] [202405] New testcase PO & PO Member flap status sync across all DBs scenario

### DIFF
--- a/tests/common/helpers/voq_lag.py
+++ b/tests/common/helpers/voq_lag.py
@@ -2,7 +2,6 @@ import pytest
 import logging
 import re
 
-from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.sonic_db import AsicDbCli, AppDbCli, VoqDbCli
 
@@ -11,14 +10,13 @@ TMP_PC = 'PortChannel999'
 
 def get_lag_ids_from_chassis_db(duthosts):
     """
-    Get lag_ids from CHASSIS_DB
-    cmd = 'redis-dump -H 10.0.5.16 -p 6380 -d 12 -y -k "*SYSTEM_LAG_TABLE*PortChannel0016"'
-      Args:
-          duthosts: The duthost fixture.
+    Get all LAG IDs from CHASSIS_DB
 
-      Returns:
-          lag_ids<list>: lag id
+    Args:
+        duthosts: duthosts to probe
 
+    Returns:
+        lag_ids: List of LAG ids in CHASSIS_DB
     """
     lag_ids = list()
     for sup in duthosts.supervisor_nodes:
@@ -27,29 +25,30 @@ def get_lag_ids_from_chassis_db(duthosts):
         for lag in lag_list:
             lag_ids.append(voqdb.hget_key_value(lag, "lag_id"))
 
-    logging.info("LAG id's preset in CHASSIS_DB are {}".format(lag_ids))
+    logging.info("LAG IDs present in CHASSIS_DB are {}".format(lag_ids))
     return lag_ids
 
 
-def get_lag_id_from_chassis_db(duthosts):
+def get_lag_id_from_chassis_db(duthosts, pc=TMP_PC):
     """
-    Get LAG id for a lag form CHASSIS_DB
+    Get LAG ID for a LAG from CHASSIS_DB
+
     Args:
-        duthosts: The duthost fixture.
+        duthosts: duthosts to probe
 
     Returns:
-        lag_ids <int>: lag id
+        lag_id: LAG ID of LAG
     """
     for sup in duthosts.supervisor_nodes:
         voqdb = VoqDbCli(sup)
         lag_list = voqdb.get_lag_list()
         for lag in lag_list:
-            if TMP_PC in lag:
+            if pc in lag:
                 lag_id = voqdb.hget_key_value(lag, "lag_id")
-                logging.info("LAG id for lag {} is {}".format(TMP_PC, lag_id))
+                logging.info("LAG ID for LAG {} is {}".format(pc, lag_id))
                 return lag_id
 
-        pytest.fail("LAG id for lag {} is not preset in CHASSIS_DB".format(TMP_PC))
+        pytest.fail("LAG ID for LAG {} is not present in CHASSIS_DB".format(pc))
 
 
 def verify_lag_interface(duthost, asic, portchannel, expected=True):
@@ -60,311 +59,200 @@ def verify_lag_interface(duthost, asic, portchannel, expected=True):
     return False
 
 
-def add_lag(duthost, asic, portchannel_members=None, portchannel_ip=None,
-            portchannel=TMP_PC, add=True):
-    """
-    Add LAG to an ASIC
-    runs command e.g. 'sudo config portchannel -n asic0 add PortChannel99'
-    Args:
-        duthost<object>: duthost
-        asic<object>: asic object
-        portchannel_members<list> : portchannel members
-        portchannel_ip<str>: portchannel ip
-        portchannel<str> : portchannel
-        add<bool> : True adds portchannel
-    """
-    if add:
-        config_cmd = "config portchannel {}"\
-            .format(asic.cli_ns_option if asic.cli_ns_option else "")
-        duthost.shell("{} add {}".format(config_cmd, portchannel))
-        int_facts = duthost.interface_facts(namespace=asic.namespace)['ansible_facts']
-        pytest_assert(int_facts['ansible_interface_facts'][portchannel])
-
-    if portchannel_members:
-        for member in portchannel_members:
-            duthost.shell("config portchannel {} member add {} {}"
-                          .format(asic.cli_ns_option, portchannel, member))
-
-    if portchannel_ip:
-        duthost.shell("config interface {} ip add {} {}"
-                      .format(asic.cli_ns_option, portchannel, portchannel_ip))
-        int_facts = duthost.interface_facts(namespace=asic.namespace)['ansible_facts']
-        pytest_assert(int_facts['ansible_interface_facts']
-                      [portchannel]['ipv4']['address'] == portchannel_ip.split('/')[0])
-
-        pytest_assert(wait_until(30, 5, 0, verify_lag_interface, duthost, asic, portchannel),
-                      'For added Portchannel {} link is not up'.format(portchannel))
-
-
-def verify_lag_id_is_unique_in_chassis_db(duthosts, duthost, asic):
-    """
-    Verifies lag id is unique for a newly added LAG in CHASSIS_DB
-    args:
-        duthosts <list>: duthost
-        duthost <obj>: duthost
-        asic <obje>: asic
-
-    """
-    logging.info("Verifying on duthost {} asic {} that lag id is unique"
-                 .format(duthost.hostname, asic.asic_index))
-    lag_id_list = get_lag_ids_from_chassis_db(duthosts)
-    add_lag(duthost, asic)
-    added_pc_lag_id = get_lag_id_from_chassis_db(duthosts)
-    if added_pc_lag_id in lag_id_list:
-        pytest.fail('LAG id {} for newly added LAG {} already exist in lag_id_list {}'
-                    .format(added_pc_lag_id, TMP_PC, lag_id_list))
-
-    logging.info('LAG id {} for newly added LAG {} is unique.'
-                 .format(added_pc_lag_id, TMP_PC))
-
-
-def verify_lag_in_app_db(asic, deleted=False):
-    """
-    Verifies lag in ASIC APP DB.
-    It runs the command e.g. 'sonic-db-cli APPL_DB keys "*LAG_TABLE*"'
-    Args:
-        asic<obj>: asic
-        deleted<bool>: False if lag is not deleted
-    """
+def is_lag_in_app_db(asic, pc=TMP_PC):
+    """Returns True if LAG in given ASIC APP DB else False"""
     appdb = AppDbCli(asic)
     app_db_lag_list = appdb.get_app_db_lag_list()
-    if deleted:
-        for lag in app_db_lag_list:
-            if TMP_PC in lag:
-                pytest.fail('LAG {} still exist in ASIC app db,'
-                            ' Expected was should be deleted from asic app db.'.format(TMP_PC))
+    for lag in app_db_lag_list:
+        if pc in lag:
+            return True
 
-        logging.info('LAG {} is deleted in ASIC app db'.format(TMP_PC))
-        return
+    return False
 
+
+def verify_lag_in_app_db(asic, pc=TMP_PC, expected=True):
+    """Verifies if LAG exists or not in given ASIC APP DB"""
+    exists = is_lag_in_app_db(asic, pc)
+    lag_exists_msg = "LAG {} exists in {} asic{} APPL_DB".format(pc, asic.sonichost.hostname, asic.asic_index)
+    lag_missing_msg = "LAG {} doesn't exist in {} asic{} APPL_DB".format(pc, asic.sonichost.hostname, asic.asic_index)
+    lag_msg = lag_exists_msg if exists else lag_missing_msg
+    if exists == expected:
+        logging.info(lag_msg)
     else:
-        for lag in app_db_lag_list:
-            if TMP_PC in lag:
-                logging.info('LAG {} exist in ASIC app db'.format(TMP_PC))
-                return
-        pytest.fail('LAG {} does not exist in ASIC app db,'
-                    ' Expected was should should exist in asic app db. '.format(TMP_PC))
+        pytest.fail(lag_msg)
 
 
-def verify_lag_in_asic_db(asics, lag_id, deleted=False):
-    """
-    Verifies LAG in ASIC DB
-    Args:
-        asics<list>: asic
-        lag_id<int>: lag id
-        deleted<bool>: True if lag is deleted
-    """
+def verify_lag_in_chassis_db(duthosts, pc=TMP_PC, expected=True):
+    """Verifies if LAG exists or not in CHASSIS DB"""
+    for sup in duthosts.supervisor_nodes:
+        voqdb = VoqDbCli(sup)
+        lag_list = voqdb.get_lag_list()
+        exists = False
+        for lag in lag_list:
+            if pc in lag:
+                exists = True
+                break
+
+        lag_exists_msg = "LAG {} exists CHASSIS_APP_DB on {}".format(pc, sup)
+        lag_missing_msg = "LAG {} doesn't exist in CHASSIS_APP_DB on {}".format(pc, sup)
+        lag_msg = lag_exists_msg if exists else lag_missing_msg
+        if exists == expected:
+            logging.info(lag_msg)
+        else:
+            pytest.fail(lag_msg)
+
+
+def verify_lag_id_in_asic_dbs(asics, lag_id, expected=True):
+    """Verifies if LAG exists or not in given ASIC DBs"""
     for asic in asics:
         asicdb = AsicDbCli(asic)
         asic_db_lag_list = asicdb.get_asic_db_lag_list()
-        if deleted:
-            for lag in asic_db_lag_list:
-                if asicdb.hget_key_value(lag, "SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID") == lag_id:
-                    pytest.fail('LAG id {} for LAG {} exist in ASIC DB,'
-                                ' Expected was should not be present'.format(lag_id, TMP_PC))
+        exists = False
+        for lag in asic_db_lag_list:
+            if asicdb.hget_key_value(lag, "SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID") == lag_id:
+                exists = True
+                break
 
-            logging.info('LAG id {} for LAG {} does not exist in ASIC DB'.format(lag_id, TMP_PC))
-
+        lag_id_exists_msg = "LAG ID {} exists in {} asic{} ASIC_DB"\
+                            .format(lag_id, asic.sonichost.hostname, asic.asic_index)
+        lag_id_missing_msg = "LAG ID {} doesn't exist in {} asic{} ASIC_DB"\
+                             .format(lag_id, asic.sonichost.hostname, asic.asic_index)
+        lag_msg = lag_id_exists_msg if exists else lag_id_missing_msg
+        if exists == expected:
+            logging.info(lag_msg)
         else:
-            for lag in asic_db_lag_list:
-                if asicdb.hget_key_value(lag, "SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID") == lag_id:
-                    logging.info('LAG id {} for LAG {} exist in ASIC DB'.format(lag_id, TMP_PC))
-                    return
-            pytest.fail('LAG id {} for LAG {} does not exist in ASIC DB'.format(lag_id, TMP_PC))
+            pytest.fail(lag_msg)
 
 
-def verify_lag_in_remote_asic_db(remote_duthosts, lag_id, deleted=False):
-    """
-    Verifies lag in remote asic db
-    Args:
-        remote_duthosts<list>: list of remote dut
-        lag_id<int>: lag id of added/deleted lag
-        deleted<bool>: True if lag is deleted
-    """
-    for dut in remote_duthosts:
-        logging.info("Verifing lag in remote {} asic db ".format(dut.hostname))
-        verify_lag_in_asic_db(dut.asics, lag_id, deleted)
-
-
-def delete_lag(duthost, asic, portchannel=TMP_PC):
-    """
-    Deletes a LAG
-
-    """
-    logging.info("Deleting lag from {}".format(duthost.hostname))
-    duthost.shell("config portchannel {} del {}".format(asic.cli_ns_option, portchannel))
-
-
-def delete_lag_members_ip(duthost, asic, portchannel_members,
-                          portchannel_ip=None, portchannel=TMP_PC):
-    """
-    deletes lag members and ip
-    """
-    if portchannel_ip:
-        duthost.shell("config interface {} ip remove {} {}"
-                      .format(asic.cli_ns_option, portchannel, portchannel_ip))
-
-    logging.info('Deleting lag members {} from lag {} on dut {}'
-                 .format(portchannel_members, portchannel, duthost.hostname))
-    for member in portchannel_members:
-        duthost.shell("config portchannel {} member del {} {}"
-                      .format(asic.cli_ns_option, portchannel, member))
-
-    if portchannel_ip:
-        pytest_assert(wait_until(30, 5, 0, verify_lag_interface, duthost, asic, portchannel, expected=False),
-                      'For deleted Portchannel {} ip link is not down'.format(portchannel))
-
-
-def verify_lag_id_deleted_in_chassis_db(duthosts, duthost, asic, lag_id):
-    """
-    Verifies lag id is deletes in CHASSIS_DB
-    """
-    delete_lag(duthost, asic)
-    lag_id_list = get_lag_ids_from_chassis_db(duthosts)
-    if lag_id in lag_id_list:
-        pytest.fail('LAG id {} for lag {} still exist in chassis db lag_id_list {}, '
-                    'Expected was should be deleted. '.format(lag_id, TMP_PC, lag_id_list))
-
-    logging.info('LAG id {} for lag {} is deleted in chassis db.'.format(lag_id, TMP_PC))
-
-
-def verify_lag_member_in_app_db(asic, pc_members, deleted=False):
-    """"
-    Verifies lag member in asic app db
-    cmd = sonic-db-cli APPL_DB KEYS "*LAG_MEMBER_TABLE*"
-    """
+def verify_lag_member_in_app_db(asic, pc_member, pc=TMP_PC, expected=True):
+    """"Verifies if LAG member exists or not in given ASICs APP DB"""
     appdb = AppDbCli(asic)
     app_db_lag_member_list = appdb.get_app_db_lag_member_list()
-    if deleted:
-        for member in pc_members:
-            pattern = "{}:{}".format(TMP_PC, member)
-            exist = False
-            for lag_member in app_db_lag_member_list:
-                if pattern in lag_member:
-                    exist = True
-                    break
+    exists = False
+    pattern = "{}:{}".format(pc, pc_member)
+    for lag_member in app_db_lag_member_list:
+        if pattern in lag_member:
+            exists = True
+            break
 
-            if exist:
-                pytest.fail('LAG {} still exist in ASIC app db, '
-                            'Expected was should be deleted from asic app db.'.format(TMP_PC))
-
-        logging.info('For lag {} lag members {} are deleted in ASIC app db'.format(TMP_PC, pc_members))
+    lag_member_exists_msg = "LAG {} member {} exists in {} asic{} APPL_DB".\
+                            format(pc, pc_member, asic.sonichost.hostname, asic.asic_index)
+    lag_member_missing_msg = "LAG {} member {} doesn't exist in {} asic{} APPL_DB".\
+                             format(pc, pc_member, asic.sonichost.hostname, asic.asic_index)
+    lag_member_msg = lag_member_exists_msg if exists else lag_member_missing_msg
+    if exists == expected:
+        logging.info(lag_member_msg)
     else:
-        for member in pc_members:
-            pattern = "{}:{}".format(TMP_PC, member)
-            exist = False
-            for lag in app_db_lag_member_list:
-                if pattern in lag:
-                    exist = True
-                    break
-
-            if not exist:
-                pytest.fail('LAG {} does not exist in ASIC app db,'
-                            ' Expected was should should exist in asic app db. '.format(TMP_PC))
-
-        logging.info('For lag {} lag members {} are present in ASIC app db'.format(TMP_PC, pc_members))
+        pytest.fail(lag_member_msg)
 
 
-def verify_lag_member_in_asic_db(asics, lag_id, pc_members, deleted=False):
-    """
-       Verifies lag member in ASIC DB
-       It runs the command e.g.
-    """
+def verify_lag_member_in_chassis_db(duthosts, pc_member, pc=TMP_PC, expected=True):
+    """Verifies if LAG member exists or not in CHASSIS DB"""
+    for sup in duthosts.supervisor_nodes:
+        voqdb = VoqDbCli(sup)
+        lag_member_list = voqdb.get_lag_member_list()
+        exists = False
+        pattern = "{}.*{}".format(pc, pc_member)
+        for lag_member in lag_member_list:
+            if re.search(pattern, lag_member):
+                exists = True
+                break
+
+        lag_member_exists_msg = "LAG {} member {} exists in {} CHASSIS_APP_DB".format(pc, pc_member, sup)
+        lag_member_missing_msg = "LAG {} member {} doesn't exist in {} CHASSIS_APP_DB".format(pc, pc_member, sup)
+        lag_member_msg = lag_member_exists_msg if exists else lag_member_missing_msg
+        if exists == expected:
+            logging.info(lag_member_msg)
+        else:
+            pytest.fail(lag_member_msg)
+
+
+def verify_lag_member_in_asic_db(asics, lag_id, expected=0):
+    """Verifies if expected amount of LAG members exist in given ASIC DBs"""
     for asic in asics:
         asicdb = AsicDbCli(asic)
         asic_lag_list = asicdb.get_asic_db_lag_list()
         asic_db_lag_member_list = asicdb.get_asic_db_lag_member_list()
         lag_oid = None
-        if deleted:
-            for lag in asic_lag_list:
-                if asicdb.hget_key_value(lag,
-                                         "SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID") == lag_id:
-                    lag_oid = ":".join(lag for lag in lag.split(':')[-1:-3:-1])
 
-            for lag_member in asic_db_lag_member_list:
-                if asicdb.hget_key_value(lag_member, "SAI_LAG_MEMBER_ATTR_LAG_ID") == lag_oid:
-                    pytest.fail("lag members {} still exist in lag member table on {},"
-                                " Expected was should be deleted"
-                                .format(pc_members, asic.sonichost.hostname))
-            logging.info('Lag members are deleted from {} on {}'.format(asic.asic_index,
-                                                                        asic.sonichost.hostname))
+        for lag in asic_lag_list:
+            if asicdb.hget_key_value(lag, "SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID") == lag_id:
+                lag_oid = ":".join(lag for lag in lag.split(':')[-2::1])
 
-        else:
-            for lag in asic_lag_list:
-                if asicdb.hget_key_value(lag, "SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID") == lag_id:
-                    lag_oid = ":".join(lag for lag in lag.split(':')[-2::1])
-                    break
+        count = 0
+        for lag_member in asic_db_lag_member_list:
+            if asicdb.hget_key_value(lag_member, "SAI_LAG_MEMBER_ATTR_LAG_ID") == lag_oid:
+                count += 1
 
-            for lag_member in asic_db_lag_member_list:
-                if asicdb.hget_key_value(lag_member, "SAI_LAG_MEMBER_ATTR_LAG_ID") == lag_oid:
-                    logging.info('Lag members exist in {} on {}'
-                                 .format(asic.asic_index, asic.sonichost.hostname))
-                    return
-
-            pytest.fail('Lag members {} does not exist in {} on {}'
-                        .format(pc_members, asic.asic_index, asic.sonichost.hostname))
+        logging.info("Found {} members of LAG in {} asic {} ASIC_DB"
+                     .format(count, asic.sonichost.hostname, asic.asic_index))
+        pytest_assert(count == expected, "Found {} LAG members in {} asic{} ASIC_DB, expected {}"
+                                         .format(count, asic.sonichost.hostname, asic.asic_index, expected))
 
 
-def verify_lag_member_in_remote_asic_db(remote_dut, lag_id, pc_members, deleted=False):
-    """
-      Verifies lag member in remote ASIC DB
+def verify_lag_member_status_in_app_db(asic, pc_member, enabled=True):
+    """Verifies if the status of a LAG member is enabled or disabled in given ASIC APP DB"""
+    appdb = AppDbCli(asic)
+    app_db_lag_member_list = appdb.get_app_db_lag_member_list()
 
-    """
-    for dut in remote_dut:
-        logging.info('Verifying lag members {} on dut {}'.format(pc_members, dut.hostname))
-        verify_lag_member_in_asic_db(dut.asics, lag_id, pc_members, deleted)
+    pattern = "{}:{}".format(TMP_PC, pc_member)
+    for lag in app_db_lag_member_list:
+        if pattern in lag:
+            status = appdb.hget_key_value(lag, "status")
+            logging.info("LAG member {} is {} in ASIC APPL_DB".format(pc_member, status))
+            fail_msg = "LAG member {} is {} in ASIC APPL_DB when it shouldn't be".format(pc_member, status)
+            status = True if status == "enabled" else False
+            pytest_assert(status == enabled, fail_msg)
+            return
+
+    pytest.fail('LAG member {} does not exist in ASIC APPL_DB'.format(TMP_PC))
 
 
-def verify_lag_member_in_chassis_db(duthosts, members, deleted=False):
-    """
-    verifies lag members for a lag exist in chassis db
-    cmd = 'sonic-db-cli CHASSIS_APP_DB KEYS "*SYSTEM_LAG_MEMBER_TABLE*|PortChannel0051*|Ethernet*"'
-    """
+def verify_lag_member_status_in_chassis_db(duthosts, pc_member, enabled=False):
+    """Verifies if the status of a LAG member is enabled or disabled in CHASSIS DB"""
     for sup in duthosts.supervisor_nodes:
         voqdb = VoqDbCli(sup)
         lag_member_list = voqdb.get_lag_member_list()
-        if deleted:
-            for member in members:
-                exist = False
-                pattern = "{}.*{}".format(TMP_PC, member)
-                for lag_member in lag_member_list:
-                    if re.search(pattern, lag_member):
-                        exist = True
-                        break
-                if exist:
-                    pytest.fail('lag member {} not found in system lag member table {}'
-                                .format(member, lag_member_list))
+        pattern = "{}.*{}".format(TMP_PC, pc_member)
+        for lag_member in lag_member_list:
+            if re.search(pattern, lag_member):
+                status = voqdb.hget_key_value(lag_member, "status")
+                logging.info("LAG member {} is {} in CHASSIS_APP_DB".format(pc_member, status))
+                fail_msg = "LAG member {} is {} in CHASSIS_APP_DB when it shouldn't be".format(pc_member, status)
+                status = True if status == "enabled" else False
+                pytest_assert(status == enabled, fail_msg)
+                return
 
-            logging.info('lag members {} found in system lag member table {}'
-                         .format(members, lag_member_list))
-
-        else:
-            for member in members:
-                exist = False
-                pattern = "{}.*{}".format(TMP_PC, member)
-                for lag_member in lag_member_list:
-                    if re.search(pattern, lag_member):
-                        exist = True
-                        logging.info('lag member {} found in system lag member table {}'
-                                     .format(member, lag_member))
-                        break
-
-                if not exist:
-                    pytest.fail('lag member {} not found in system lag member table {}'
-                                .format(member, lag_member_list))
+        pytest.fail('LAG member {} does not exist in CHASSIS_APP_DB'.format(TMP_PC))
 
 
-def is_lag_in_app_db(asic):
-    """
-    Returnes True if lag in app db else False
-    It runs the command e.g. 'sonic-db-cli APPL_DB keys "*LAG_TABLE*"'
-    Args:
-        asic<obj>: asic
-    """
-    appdb = AppDbCli(asic)
-    app_db_lag_list = appdb.get_app_db_lag_list()
-    for lag in app_db_lag_list:
-        if TMP_PC in lag:
-            return True
+def verify_lag_member_status_in_asic_db(asics, lag_id, exp_disabled=0):
+    """Verifies if expected amount of LAG members are disabled in given ASIC DBs"""
+    for asic in asics:
+        asicdb = AsicDbCli(asic)
+        asic_lag_list = asicdb.get_asic_db_lag_list()
+        asic_db_lag_member_list = asicdb.get_asic_db_lag_member_list()
+        lag_oid = None
+        count = 0
+        disabled = 0
+        # Find LAG members OIDs from lag id
+        for lag in asic_lag_list:
+            if asicdb.hget_key_value(lag, "SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID") == lag_id:
+                lag_oid = ":".join(lag for lag in lag.split(':')[-2::1])
+                break
 
-    return False
+        # Find LAG members of LAG by OID, one should have disabled status
+        for lag_member in asic_db_lag_member_list:
+            if asicdb.hget_key_value(lag_member, "SAI_LAG_MEMBER_ATTR_LAG_ID") == lag_oid:
+                status = asicdb.hget_key_value(lag_member, "SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE")
+                count += 1
+                if status == "true":
+                    disabled += 1
+
+        logging.info("Found {} members of LAG in {} asic {} ASIC_DB, {} are disabled"
+                     .format(count, asic.sonichost.hostname, asic.asic_index, disabled))
+        pytest_assert(count != 0, "No members matching LAG exist in {} asic {} ASIC_DB"
+                                  .format(asic.sonichost.hostname, asic.asic_index))
+        pytest_assert(disabled == exp_disabled,
+                      "Found {} disabled members of LAG in {} asic {} ASIC_DB, expected {}"
+                      .format(disabled, asic.sonichost.hostname, asic.asic_index, exp_disabled))

--- a/tests/pc/test_po_voq.py
+++ b/tests/pc/test_po_voq.py
@@ -1,6 +1,10 @@
 import pytest
+import random
 import tests.common.helpers.voq_lag as voq_lag
 from tests.voq.voq_helpers import verify_no_routes_from_nexthop
+from tests.common.platform.device_utils import fanout_switch_port_lookup
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 import logging
 logger = logging.getLogger(__name__)
 
@@ -9,47 +13,52 @@ pytestmark = [
 ]
 
 
-def get_asic_with_pc(duthost):
-    """
-    Returns Asic with portchannel
+def _get_random_asic_with_pc(duthost):
+    """Returns a random ASIC with portchannel from given duthost
 
     Args:
-        duthost <obj>: The duthost object
+        duthost: A duthost object to probe ASICs
 
     Returns:
-        asic <obj> : Asic object
-
+        asic: Random ASIC with PC from the duthost
     """
+    asics_with_pc = []
     for asic in duthost.asics:
         config_facts = duthost.config_facts(source='persistent',
                                             asic_index=asic.asic_index)['ansible_facts']
         if 'PORTCHANNEL' in config_facts:
-            return asic
+            asics_with_pc.append(asic)
+
+    if asics_with_pc:
+        return random.choice(asics_with_pc)
+    else:
+        pytest.fail("{} has no ASICs with portchannels".format(duthost))
 
 
 @pytest.fixture(scope='module')
 def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
-     Prepares dut for the testcase by deleting the existing port channel members and ip,
-     adds a new portchannel and assignes port channel members and ip
-      from the previous port channel
+    Setup:
+    Create a temporary test portchannel, moves members and IP from an existing portchannel
+    to the temporary test portchannel
 
-     Args:
-         duthosts <list>: The duthosts object
-         enum_rand_one_per_hwsku_frontend_hostname <int>:
-          random per fromtend per hwsku duthost
+    Teardown:
+    Moves members from temporary test portchannel back to the original portchannel,
+    deletes temporary test portchannel
 
-    Returns:
-        portchannel_ip <str> : portchannel ip address
-        portchannle_members <list> : portchannel members
-
+    Yields:
+        (asic: ASIC that hosts the portchannel,
+        portchannel_ip: portchannel ip address,
+        portchannel_members: portchannel members)
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    asic = get_asic_with_pc(duthost)
+
+    # Choose a random portchannel and corresponding ASIC
+    asic = _get_random_asic_with_pc(duthost)
     config_facts = duthost.config_facts(source='persistent',
                                         asic_index=asic.asic_index)['ansible_facts']
 
-    portchannel = list(config_facts['PORTCHANNEL'].keys())[0]
+    portchannel = random.choice(list(config_facts['PORTCHANNEL'].keys()))
     portchannel_members = config_facts['PORTCHANNEL'][portchannel].get('members')
 
     portchannel_ip = None
@@ -63,66 +72,218 @@ def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         if portchannel_ip.split('/')[0] == config_facts['BGP_NEIGHBOR'][addr]['local_addr']:
             nbr_addr = addr
 
-    voq_lag.delete_lag_members_ip(duthost, asic, portchannel_members, portchannel_ip, portchannel)
+    # Move members and IP from original lag to newly created temporary lag
+    logging.info("Moving LAG members {} and IP {} from LAG {} to temporary LAG {}"
+                 .format(portchannel_members, portchannel_ip, portchannel, voq_lag.TMP_PC))
+    asic.config_ip_intf(portchannel, portchannel_ip, "remove")
+    for portchannel_member in portchannel_members:
+        asic.config_portchannel_member(portchannel, portchannel_member, "del")
+
     verify_no_routes_from_nexthop(duthosts, nbr_addr)
-    voq_lag.add_lag(duthost, asic, portchannel_members, portchannel_ip)
+
+    asic.config_portchannel(voq_lag.TMP_PC, "add")
+    asic.config_ip_intf(voq_lag.TMP_PC, portchannel_ip, "add")
+    for portchannel_member in portchannel_members:
+        asic.config_portchannel_member(voq_lag.TMP_PC, portchannel_member, "add")
 
     yield asic, portchannel_ip, portchannel_members
 
-    voq_lag.delete_lag_members_ip(duthost, asic, portchannel_members, portchannel_ip)
-    # remove tmp portchannel
-    voq_lag.delete_lag(duthost, asic)
+    # Move members and IP from new temporary LAG back to original lag, delete old LAG
+    logging.info("Moving LAG members {} and IP {} from temporary LAG {} back to LAG {}"
+                 .format(portchannel_members, portchannel_ip, portchannel, voq_lag.TMP_PC))
+    asic.config_ip_intf(voq_lag.TMP_PC, portchannel_ip, "remove")
+    for portchannel_member in portchannel_members:
+        asic.config_portchannel_member(voq_lag.TMP_PC, portchannel_member, "del")
+    asic.config_portchannel(voq_lag.TMP_PC, "del")
+
     verify_no_routes_from_nexthop(duthosts, nbr_addr)
-    # add only lag members and ip since lag already exist
-    voq_lag.add_lag(duthost, asic, portchannel_members, portchannel_ip, portchannel, add=False)
+
+    asic.config_ip_intf(portchannel, portchannel_ip, "add")
+    for portchannel_member in portchannel_members:
+        asic.config_portchannel_member(portchannel, portchannel_member, "add")
 
 
 def test_voq_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
-    """
-    test to verify when a LAG is added/deleted via CLI on an ASIC,
-     It is populated in remote ASIC_DB.
-    Steps:
-        1. On any ASIC, add a new LAG
-        2. verify added lag gets a unique lag id in chassis app db
-        3. verify added lag exist in app db
-        4. verify lag exist in asic db on remote and local asic db
-        5. delete the added lag
+    """Test to verify when a LAG is added/deleted via CLI, it is synced across all DBs
+
+    All DBs = local app db, chassis app db, local & remote asic db
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    asic = get_asic_with_pc(duthost)
+    remote_duthosts = [dut_host for dut_host in duthosts.frontend_nodes if dut_host != duthost]
+    asic = _get_random_asic_with_pc(duthost)
+    prev_lag_id_list = voq_lag.get_lag_ids_from_chassis_db(duthosts)
     try:
-        voq_lag.verify_lag_id_is_unique_in_chassis_db(duthosts, duthost, asic)
-        voq_lag.verify_lag_in_app_db(asic)
+        # Add LAG and verify LAG creation is synced across all DBs
+        logging.info("Add temporary LAG {}".format(voq_lag.TMP_PC))
+        asic.config_portchannel(voq_lag.TMP_PC, "add")
+
+        # Verify LAG is created with unique LAG ID in chassis db
         tmp_lag_id = voq_lag.get_lag_id_from_chassis_db(duthosts)
-        voq_lag.verify_lag_in_asic_db(duthost.asics, tmp_lag_id)
-        # to verify lag in remote asic db
-        remote_duthosts = [dut_host for dut_host in duthosts.frontend_nodes if dut_host != duthost]
-        voq_lag.verify_lag_in_remote_asic_db(remote_duthosts, tmp_lag_id)
-        voq_lag.verify_lag_id_deleted_in_chassis_db(duthosts, duthost, asic, tmp_lag_id)
-        voq_lag.verify_lag_in_app_db(asic, deleted=True)
-        voq_lag.verify_lag_in_asic_db(duthost.asics, tmp_lag_id, deleted=True)
-        remote_duthosts = [dut_host for dut_host in duthosts.frontend_nodes if dut_host != duthost]
-        voq_lag.verify_lag_in_remote_asic_db(remote_duthosts, tmp_lag_id, deleted=True)
+        pytest_assert(tmp_lag_id not in prev_lag_id_list, "Temporary PC LAG ID {} is not unique")
+
+        voq_lag.verify_lag_in_app_db(asic)
+        voq_lag.verify_lag_in_chassis_db(duthosts)
+        voq_lag.verify_lag_id_in_asic_dbs(duthost.asics, tmp_lag_id)
+        for remote_duthost in remote_duthosts:
+            voq_lag.verify_lag_id_in_asic_dbs(remote_duthost.asics, tmp_lag_id)
+
+        # Delete LAG and verify LAG deletion is synced across all DBs
+        logging.info("Deleting temporary LAG {}".format(voq_lag.TMP_PC))
+        asic.config_portchannel(voq_lag.TMP_PC, "del")
+
+        voq_lag.verify_lag_in_app_db(asic, expected=False)
+        voq_lag.verify_lag_in_chassis_db(duthosts, expected=False)
+        voq_lag.verify_lag_id_in_asic_dbs(duthost.asics, tmp_lag_id, expected=False)
+        for remote_duthost in remote_duthosts:
+            voq_lag.verify_lag_id_in_asic_dbs(remote_duthost.asics, tmp_lag_id, expected=False)
     finally:
         if voq_lag.is_lag_in_app_db(asic):
-            voq_lag.delete_lag(duthost, asic)
+            logging.info("Deleting temporary LAG {}".format(voq_lag.TMP_PC))
+            asic.config_portchannel(voq_lag.TMP_PC, "del")
 
 
 def test_voq_po_member_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup_teardown):
-    """
-    Test to verify when a LAG members is added/deleted via CLI on an ASIC,
-     It is synced to remote ASIC_DB.
-    Steps:
-        1. On any ASIC, add LAG members to a lag
-        2. verify lag members exist in local asic app db
-        3. verify lag members exist in chassis app db
-        4. verify lag members exist in local and remote asic db
+    """Test to verify when LAG members are added/deleted via CLI, it is synced across all DBs
+
+    All DBs = local app db, chassis app db, local & remote asic db
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    remote_duthosts = [dut_host for dut_host in duthosts.frontend_nodes if dut_host != duthost]
     asic, portchannel_ip, portchannel_members = setup_teardown
     tmp_lag_id = voq_lag.get_lag_id_from_chassis_db(duthosts)
-    voq_lag.verify_lag_member_in_app_db(asic, portchannel_members)
-    voq_lag.verify_lag_member_in_chassis_db(duthosts, portchannel_members)
-    voq_lag.verify_lag_member_in_asic_db(duthost.asics, tmp_lag_id, portchannel_members)
+
+    # Check that members added to LAG in setup is synced across all DBs
+    for portchannel_member in portchannel_members:
+        voq_lag.verify_lag_member_in_app_db(asic, portchannel_member)
+        voq_lag.verify_lag_member_in_chassis_db(duthosts, portchannel_member)
+    # For checking LAG member added/deleted in ASIC_DB,
+    # we check how many members exist in a LAG since we can't identify individual members
+    voq_lag.verify_lag_member_in_asic_db(duthost.asics, tmp_lag_id, expected=len(portchannel_members))
+    for remote_duthost in remote_duthosts:
+        voq_lag.verify_lag_member_in_asic_db(remote_duthost.asics, tmp_lag_id, expected=len(portchannel_members))
+
+    # Choose a random LAG member to delete, verify deletion is synced across all DBs
+    del_pc_member = random.choice(portchannel_members)
+    remaining_pc_members = [pc_member for pc_member in portchannel_members if pc_member != del_pc_member]
+    try:
+        logging.info("Deleting LAG member {} from {}".format(del_pc_member, voq_lag.TMP_PC))
+        asic.config_portchannel_member(voq_lag.TMP_PC, del_pc_member, "del")
+
+        # Verify other LAG members are still up
+        for remaining_pc_member in remaining_pc_members:
+            voq_lag.verify_lag_member_in_app_db(asic, remaining_pc_member)
+            voq_lag.verify_lag_member_in_chassis_db(duthosts, remaining_pc_member)
+
+        voq_lag.verify_lag_member_in_app_db(asic, del_pc_member, expected=False)
+        voq_lag.verify_lag_member_in_chassis_db(duthosts, del_pc_member, expected=False)
+        voq_lag.verify_lag_member_in_asic_db(duthost.asics, tmp_lag_id, expected=len(remaining_pc_members))
+        for remote_duthost in remote_duthosts:
+            voq_lag.verify_lag_member_in_asic_db(remote_duthost.asics, tmp_lag_id, expected=len(remaining_pc_members))
+    finally:
+        logging.info("Adding LAG member {} back to {}".format(del_pc_member, voq_lag.TMP_PC))
+        asic.config_portchannel_member(voq_lag.TMP_PC, del_pc_member, "add")
+
+
+def test_voq_po_down_via_cli_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup_teardown):
+    """Test to verify when a LAG goes down on an ASIC via CLI, it is synced across all DBs
+
+    All DBs = local app db, chassis app db, local & remote asic db
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     remote_duthosts = [dut_host for dut_host in duthosts.frontend_nodes if dut_host != duthost]
-    voq_lag.verify_lag_member_in_remote_asic_db(remote_duthosts, tmp_lag_id, portchannel_members, deleted=True)
+    asic, portchannel_ip, portchannel_members = setup_teardown
+    tmp_lag_id = voq_lag.get_lag_id_from_chassis_db(duthosts)
+    num_portchannels = len(portchannel_members)
+
+    # Make sure LAG is up across all DBs (all PC members are up across all DBs)
+    for portchannel_member in portchannel_members:
+        voq_lag.verify_lag_member_status_in_app_db(asic, portchannel_member, enabled=True)
+        voq_lag.verify_lag_member_status_in_chassis_db(duthosts, portchannel_member, enabled=True)
+    # For checking LAG member status in ASIC_DB,
+    # we check how many members are disabled in a LAG since we can't identify individual members
+    voq_lag.verify_lag_member_status_in_asic_db(duthost.asics, tmp_lag_id, exp_disabled=0)
+    for remote_duthost in remote_duthosts:
+        voq_lag.verify_lag_member_status_in_asic_db(remote_duthost.asics, tmp_lag_id, exp_disabled=0)
+
+    try:
+        # Bring down LAG, check that LAG down is synced across all DBs (all PC members are down across all DBs)
+        logging.info("Disabling {}".format(voq_lag.TMP_PC))
+        duthost.shell("config interface {} shutdown {}".format(asic.cli_ns_option, voq_lag.TMP_PC))
+        pytest_assert(wait_until(30, 5, 0, lambda: not duthost.check_intf_link_state(voq_lag.TMP_PC)),
+                      "{} is not disabled".format(voq_lag.TMP_PC))
+
+        for portchannel_member in portchannel_members:
+            voq_lag.verify_lag_member_status_in_app_db(asic, portchannel_member, enabled=False)
+            voq_lag.verify_lag_member_status_in_chassis_db(duthosts, portchannel_member, enabled=False)
+        voq_lag.verify_lag_member_status_in_asic_db(duthost.asics, tmp_lag_id, exp_disabled=num_portchannels)
+        for remote_duthost in remote_duthosts:
+            voq_lag.verify_lag_member_status_in_asic_db(remote_duthost.asics, tmp_lag_id, exp_disabled=num_portchannels)
+    finally:
+        # Bring LAG back up
+        logging.info("Enabling {}".format(voq_lag.TMP_PC))
+        duthost.shell("config interface {} startup {}".format(asic.cli_ns_option, voq_lag.TMP_PC))
+        pytest_assert(wait_until(30, 5, 0, lambda: duthost.check_intf_link_state(voq_lag.TMP_PC)),
+                      "{} is not enabled".format(voq_lag.TMP_PC))
+
+
+@pytest.mark.parametrize("flap_method", ["local", "remote"])
+def test_voq_po_member_down_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                   setup_teardown, fanouthosts, flap_method):
+    """
+    Test to verify when a LAG member goes down on an ASIC, it is synced across all DBs
+
+    All DBs = local app db, chassis app db, local & remote asic db
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    remote_duthosts = [dut_host for dut_host in duthosts.frontend_nodes if dut_host != duthost]
+    asic, portchannel_ip, portchannel_members = setup_teardown
+    tmp_lag_id = voq_lag.get_lag_id_from_chassis_db(duthosts)
+
+    # Make sure LAG is up across all DBs (all PC members are up across all DBs)
+    for portchannel_member in portchannel_members:
+        voq_lag.verify_lag_member_status_in_app_db(asic, portchannel_member, enabled=True)
+        voq_lag.verify_lag_member_status_in_chassis_db(duthosts, portchannel_member, enabled=True)
+    # For checking LAG member status in ASIC_DB,
+    # we check how many members are disabled in a LAG since we can't identify individual members
+    voq_lag.verify_lag_member_status_in_asic_db(duthost.asics, tmp_lag_id, exp_disabled=0)
+    for remote_duthost in remote_duthosts:
+        voq_lag.verify_lag_member_status_in_asic_db(remote_duthost.asics, tmp_lag_id, exp_disabled=0)
+
+    # Choose a random LAG member to bring down, check that LAG member down is synced across all DBs
+    down_pc_member = random.choice(portchannel_members)
+    fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, duthost.hostname, down_pc_member)
+    up_pc_members = [pc_member for pc_member in portchannel_members if pc_member != down_pc_member]
+    try:
+        if flap_method == "local":
+            logging.info("Disabling {} via CLI".format(down_pc_member))
+            duthost.shell("config interface {} shutdown {}".format(asic.cli_ns_option, down_pc_member))
+        else:
+            logging.info("Disabling {} via fanout to simulate external flapping".format(down_pc_member))
+            logging.info("Disabling {} on {}".format(fanout_port, fanout.hostname))
+            fanout.shutdown(fanout_port)
+
+        pytest_assert(wait_until(30, 5, 0, lambda: not duthost.check_intf_link_state(down_pc_member)),
+                      "{} is not disabled".format(down_pc_member))
+
+        # Verify other LAG members are still up
+        for up_pc_member in up_pc_members:
+            voq_lag.verify_lag_member_status_in_app_db(asic, up_pc_member, enabled=True)
+            voq_lag.verify_lag_member_status_in_chassis_db(duthosts, up_pc_member, enabled=True)
+
+        voq_lag.verify_lag_member_status_in_app_db(asic, down_pc_member, enabled=False)
+        voq_lag.verify_lag_member_status_in_chassis_db(duthosts, down_pc_member, enabled=False)
+        voq_lag.verify_lag_member_status_in_asic_db(duthost.asics, tmp_lag_id, exp_disabled=1)
+        for remote_duthost in remote_duthosts:
+            voq_lag.verify_lag_member_status_in_asic_db(remote_duthost.asics, tmp_lag_id, exp_disabled=1)
+    finally:
+        # Bring LAG member back up
+        if flap_method == "local":
+            logging.info("Enabling {} via CLI".format(down_pc_member))
+            duthost.shell("config interface {} startup {}".format(asic.cli_ns_option, down_pc_member))
+        else:
+            logging.info("Enabling {} via fanout".format(down_pc_member))
+            logging.info("Enabling {} on {}".format(fanout_port, fanout.hostname))
+            fanout.no_shutdown(fanout_port)
+
+        pytest_assert(wait_until(30, 5, 0, lambda: duthost.check_intf_link_state(down_pc_member)),
+                      "{} is not enabled".format(down_pc_member))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #14984 and cleanup similar tests in file

I suggest looking at individual commits to have an easier time navigating changes

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Test gap for DB states across local & remote linecards updating for PO member state changes
#### How did you do it?
Added 2 testcases, one where PO went down, one where individual member went down
#### How did you verify/test it?
Tested on T2 testbed
#### Any platform specific information?
T2 VoQ only
#### Supported testbed topology if it's a new test case?
T2 VoQ only
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
