### PR TITLE
[dhcp_relay][telemetry] Fix incorrect client mac in dhcp_relay related telemetry test

### DIFF
--- a/tests/telemetry/events/dhcp-relay_events.py
+++ b/tests/telemetry/events/dhcp-relay_events.py
@@ -8,7 +8,7 @@ import ptf.testutils as testutils
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.utilities import wait_until
 from run_events_test import run_test
-from event_utils import find_test_vlan, find_test_port_and_mac, create_dhcp_discover_packet
+from event_utils import find_test_vlan, find_test_client_port_and_mac, create_dhcp_discover_packet
 
 logger = logging.getLogger(__name__)
 tag = "sonic-events-dhcp-relay"
@@ -96,7 +96,7 @@ def send_dhcp_discover_packets(duthost, ptfadapter, packets_to_send=5, interval=
         # Send packets
 
         # results contains up to 5 tuples of member interfaces from vlan (port, mac address)
-        results = find_test_port_and_mac(duthost, member_interfaces, 5)
+        results = find_test_client_port_and_mac(ptfadapter, duthost, member_interfaces, 5)
 
         for i in range(packets_to_send):
             result = results[i % len(results)]

--- a/tests/telemetry/events/event_utils.py
+++ b/tests/telemetry/events/event_utils.py
@@ -144,19 +144,18 @@ def find_test_vlan(duthost):
     return {}
 
 
-def find_test_port_and_mac(duthost, members, count):
-    # Will return up to count many up ports with their port index and mac address
+def find_test_client_port_and_mac(ptfadapter, duthost, members, count):
+    # Will return up to count many up ports with their port index and mac address of ptf
     results = []
     interf_status = duthost.show_interface(command="status")['ansible_facts']['int_status']
     for member_interface in members:
         if len(results) == count:
             return results
         if interf_status[member_interface]['admin_state'] == "up":
-            mac = duthost.get_dut_iface_mac(member_interface)
             minigraph_info = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
             port_index = minigraph_info['minigraph_port_indices'][member_interface]
-            if mac != "" and port_index != "":
-                results.append([int(port_index), mac])
+            if port_index != "":
+                results.append([int(port_index), ptfadapter.dataplane.get_mac(0, port_index).decode()])
     return results
 
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Client mac of DHCP packets should be ptf interface mac rather than DUT interface mac

#### How did you do it?
Modify test case to use ptf interface mac

#### How did you verify/test it?
Run tests in m0/t0 topo

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
