### PR TITLE
Correct log analyzer for the location of logrotate script

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
@@ -98,7 +98,7 @@
 
 - block:
     - name: Disable logrotate cron task
-      shell: sed -i 's/^/#/g' /etc/cron.d/logrotate
+      shell: sed -i 's/^/#/g' /etc/cron.daily/logrotate
       become: yes
 
     - name: Wait for logrotate from previous cron task run to finish
@@ -119,7 +119,7 @@
 
   always:
     - name: Enable logrotate cron task back
-      shell: sed -i 's/^#//g' /etc/cron.d/logrotate
+      shell: sed -i 's/^#//g' /etc/cron.daily/logrotate
       become: yes
 
 - set_fact: cmd="python {{ run_dir }}/loganalyzer.py --action analyze --logs {{ tmp_log_file }} --run_id {{ testname_unique }} {% if start_marker is defined %}--start_marker '{{ start_marker }}'{% endif %} --out_dir {{ test_out_dir }} {{ match_file_option }} {{ ignore_file_option }} {{ expect_file_option }} -v"

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -37,7 +37,7 @@ class DisableLogrotateCronContext:
         # available in older version like 201911.
         self.ansible_host.command("systemctl stop logrotate.timer", module_ignore_errors=True)
         # Disable logrotate cron task. Bullseye-based images will not have this file, so ignore any errors.
-        self.ansible_host.command("sed -i 's/^/#/g' /etc/cron.d/logrotate", module_ignore_errors=True)
+        self.ansible_host.command("sed -i 's/^/#/g' /etc/cron.daily/logrotate", module_ignore_errors=True)
         logging.debug("Waiting for logrotate from previous cron task or systemd timer run to finish")
         # Wait for logrotate from previous cron task run to finish
         end = time.time() + 60
@@ -59,7 +59,7 @@ class DisableLogrotateCronContext:
         Restore logrotate cron task and systemd timer.
         """
         # Enable logrotate cron task back. Bullseye-based images will not have this file, so ignore any errors.
-        self.ansible_host.command("sed -i 's/^#//g' /etc/cron.d/logrotate", module_ignore_errors=True)
+        self.ansible_host.command("sed -i 's/^#//g' /etc/cron.daily/logrotate", module_ignore_errors=True)
         # Enable logrotate systemd timer by best effort. The reason is that logrotate.timer service is not
         # available in older version like 201911.
         self.ansible_host.command("systemctl start logrotate.timer", module_ignore_errors=True)


### PR DESCRIPTION
### Description of PR
Log analyzer will try to stop the logrotate timer and also modify the cron script for logrotate. Which with the new Linux version its location has changed to /etc/cron.daily/logrotate. Loy analyzer is trying yo modify /etc/cron/logrotate which does not exist. 

Without this fix logrotate could still be triggered from crond which could cause unexpected behavior if logrotate and log analyzer is working simultaneously for the same file. Though the chance is very rare. 

We had a /var/log file system corrupted issue during the OC test for 2-3 times in the past year. Suspect this could possibly be the cause. 

Fix this issue to have logrotate completely disabled during one test module to avoid any possible race condition.  

Summary:
Fixes # (issue)

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Fix the issue found for log analyzer

#### How did you verify/test it?
Run some OC tests and did not see any side effect.
