### PR TITLE
Reg: TC test_voq_chassis_app_db_consistency.py Modification Due to Lag ID Set Changes

### DIFF
--- a/tests/voq/test_voq_chassis_app_db_consistency.py
+++ b/tests/voq/test_voq_chassis_app_db_consistency.py
@@ -40,11 +40,6 @@ def verify_data_in_db(post_change_db_dump, tmp_pc, pc_members, duthosts, pc_nbr_
     key = "SYSTEM_INTERFACE|{}*{}".format(duthost.sonichost.hostname, tmp_pc)
     pytest_assert(voqdb.get_keys(key),
                   "SYSTEM_INTERFACE in Chasiss_APP_DB is missing for portchannel {}".format(tmp_pc))
-    # Verfication on SYSTEM_LAG_ID_SET
-    if lag_id not in post_change_db_dump["SYSTEM_LAG_ID_SET"]:
-        pytest.fail(
-            "Portchannel Lag id {} is not allocatioed to tmp portchannel {} in SYSTEM_LAG_ID_SET".format(pc_nbr_ip,
-                                                                                                         tmp_pc))
 
 
 @pytest.mark.parametrize("test_case", ["dut_reboot", "config_reload_with_config_save", "config_reload_no_config_save"])
@@ -252,11 +247,34 @@ def get_db_dump(duthosts, duthost):
     """
 
     chassis_app_db_sysparams = {}
+    system_lag_id = {}
     key = "*SYSTEM*|*" + duthost.sonichost.hostname + "*"
     chassis_app_db_result = redis_get_keys(duthosts.supervisor_nodes[0], "CHASSIS_APP_DB", key)
     if chassis_app_db_result is not None:
         chassis_app_db_sysparams["CHASSIS_APP_DB"] = chassis_app_db_result
     voqdb = VoqDbCli(duthosts.supervisor_nodes[0])
-    chassis_app_db_sysparams["SYSTEM_LAG_ID_TABLE"] = voqdb.dump("SYSTEM_LAG_ID_TABLE")["SYSTEM_LAG_ID_TABLE"]['value']
-    chassis_app_db_sysparams["SYSTEM_LAG_ID_SET"] = voqdb.dump("SYSTEM_LAG_ID_SET")["SYSTEM_LAG_ID_SET"]['value']
+    system_lag_id["SYSTEM_LAG_ID_TABLE"] = voqdb.dump("SYSTEM_LAG_ID_TABLE")["SYSTEM_LAG_ID_TABLE"]['value']
+    SYSTEM_LAG_ID_SET = voqdb.dump("SYSTEM_LAG_ID_SET")["SYSTEM_LAG_ID_SET"]['value']
+    end = int(voqdb.dump("SYSTEM_LAG_ID_END")["SYSTEM_LAG_ID_END"]['value'])
+    start = int(voqdb.dump("SYSTEM_LAG_ID_START")["SYSTEM_LAG_ID_START"]['value'])
+    LAG_IDS_FREE_LIST = voqdb.dump("SYSTEM_LAG_IDS_FREE_LIST")["SYSTEM_LAG_IDS_FREE_LIST"]['value']
+
+    def verify_system_lag_sanity():
+        seen = set(LAG_IDS_FREE_LIST + SYSTEM_LAG_ID_SET)
+        if len(seen) != (end - start + 1):
+            logging.error(
+                "Missing or extra values are found in SYSTEM_LAG_IDS_FREE_LIST:{} or SYSTEM_LAG_ID_SET:{}".
+                format(LAG_IDS_FREE_LIST, SYSTEM_LAG_ID_SET))
+            return False
+        if any(LAG_IDS_FREE_LIST.count(x) > 1 or SYSTEM_LAG_ID_SET.count(
+                x) > 1 or x in LAG_IDS_FREE_LIST and x in SYSTEM_LAG_ID_SET for x in seen):
+            logging.error(
+                "Duplicate values found in SYSTEM_LAG_IDS_FREE_LIST:{} or SYSTEM_LAG_ID_SET:{}".
+                format(LAG_IDS_FREE_LIST, SYSTEM_LAG_ID_SET))
+            return False
+
+        return True
+
+    pytest_assert(wait_until(220, 10, 0, verify_system_lag_sanity))
+
     return {k: sorted(v) for k, v in chassis_app_db_sysparams.items()}

--- a/tests/voq/test_voq_chassis_app_db_consistency.py
+++ b/tests/voq/test_voq_chassis_app_db_consistency.py
@@ -267,7 +267,7 @@ def get_db_dump(duthosts, duthost):
                 format(LAG_IDS_FREE_LIST, SYSTEM_LAG_ID_SET))
             return False
         if any(LAG_IDS_FREE_LIST.count(x) > 1 or SYSTEM_LAG_ID_SET.count(
-                x) > 1 or x in LAG_IDS_FREE_LIST and x in SYSTEM_LAG_ID_SET for x in seen):
+                x) > 1 or (x in LAG_IDS_FREE_LIST and x in SYSTEM_LAG_ID_SET) for x in seen):
             logging.error(
                 "Duplicate values found in SYSTEM_LAG_IDS_FREE_LIST:{} or SYSTEM_LAG_ID_SET:{}".
                 format(LAG_IDS_FREE_LIST, SYSTEM_LAG_ID_SET))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Due to LAG ID SET Changes https://github.com/sonic-net/sonic-buildimage/pull/20369.
The Test Case Expectation and Assertion need to be changed.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Changes by the Functionality https://github.com/sonic-net/sonic-buildimage/pull/20369 of Lag ID assignment.
The TC Expectation and assertion is changed

#### How did you do it?
Ignoring the SYSTEM_LAG_ID_SET to be same as in case pre-dump.
But rather be assigned from `SYSTEM_LAG_IDS_FREE_LIST` in order.
Added a sanity of lag_id_set to ensure the functionality of PR https://github.com/sonic-net/sonic-buildimage/pull/20369.

#### How did you verify/test it?
Tested and Verified on a T2 VOQ Chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
