### PR TITLE
Fix test_pfcwd_function on Mellanox platform

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -568,9 +568,23 @@ def has_neighbor_device(setup_pfc_test):
     return True
 
 
-def check_pfc_storm_state(dut, port, queue, expected_state):
+def check_pfc_storm_state(dut, port, queue):
     """
     Helper function to check if PFC storm is detected/restored on a given queue
+    """
+    pfcwd_stats = dut.show_and_parse("show pfcwd stats")
+    queue_name = str(port) + ":" + str(queue)
+    for entry in pfcwd_stats:
+        if entry["queue"] == queue_name:
+            logger.info("PFCWD status on queue {} stats: {}".format(queue_name, entry))
+            return entry['storm detected/restored']
+    logger.info("PFCWD not triggered on queue {}".format(queue_name))
+    return None
+
+
+def verify_pfc_storm_in_expected_state(dut, port, queue, expected_state):
+    """
+    Helper function to verify if PFC storm on a specific queue is in expected state
     """
     pfcwd_stat = parser_show_pfcwd_stat(dut, port, queue)
     if expected_state == "storm":

--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -12,7 +12,7 @@ from tests.ptf_runner import ptf_runner
 from tests.common import constants
 from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled, dualtor_ports # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m # noqa F401, E501
-from tests.common.helpers.pfcwd_helper import send_background_traffic, check_pfc_storm_state, parser_show_pfcwd_stat
+from tests.common.helpers.pfcwd_helper import send_background_traffic, verify_pfc_storm_in_expected_state, parser_show_pfcwd_stat # noqa E501
 from tests.common.utilities import wait_until
 
 pytestmark = [
@@ -297,7 +297,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
 
         logger.info("Verify if PFC storm is detected on port {}".format(port))
         pytest_assert(
-            wait_until(30, 2, 5, check_pfc_storm_state, dut, port, self.storm_hndle.pfc_queue_idx, "storm"),
+            wait_until(30, 2, 5, verify_pfc_storm_in_expected_state, dut, port, self.storm_hndle.pfc_queue_idx, "storm"), # noqa E501
             "PFC storm state did not change as expected"
         )
 
@@ -316,7 +316,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         # storm restore
         logger.info("Verify if PFC storm is restored on port {}".format(port))
         pytest_assert(
-            wait_until(30, 2, 5, check_pfc_storm_state, dut, port, self.storm_hndle.pfc_queue_idx, "restore"),
+            wait_until(30, 2, 5, verify_pfc_storm_in_expected_state, dut, port, self.storm_hndle.pfc_queue_idx, "restore"), # noqa E501
             "PFC storm state did not change as expected"
         )
 

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -722,6 +722,10 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         test_ports_info = {self.pfc_wd['rx_port'][0]: self.pfc_wd}
         queues = [self.storm_hndle.pfc_queue_idx]
 
+        if dut.facts['asic_type'] == "mellanox":
+            PFC_STORM_TIMEOUT = 30
+            pfcwd_stats_before_test = check_pfc_storm_state(dut, port, self.storm_hndle.pfc_queue_idx)
+
         with send_background_traffic(dut, self.ptf, queues, selected_test_ports, test_ports_info):
             if action != "dontcare":
                 start_wd_on_ports(dut, port, restore_time, detect_time, action)
@@ -741,14 +745,9 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             if dut.facts['asic_type'] == ["mellanox", "cisco-8000"]:
                 # On Mellanox platform, more time is required for PFC storm being triggered
                 # as PFC pause sent from Non-Mellanox leaf fanout is not continuous sometimes.
-                PFC_STORM_TIMEOUT = 30
-                pytest_assert(
-                    wait_until(
-                        PFC_STORM_TIMEOUT, 2, 5,
-                        check_pfc_storm_state, dut, port, self.storm_hndle.pfc_queue_idx, "storm"
-                    ),
-                    "PFC storm state did not change as expected"
-                )
+                pytest_assert(wait_until(PFC_STORM_TIMEOUT, 2, 0,
+                                        lambda: check_pfc_storm_state(dut, port, self.storm_hndle.pfc_queue_idx) != pfcwd_stats_before_test),  # noqa: E501, E128
+                                        "PFC storm state did not change as expected")  # noqa: E127
             else:
                 time.sleep(5)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix test issue caused by PR #14711

The code below is to ensure there is PFCWD triggered on new queues before checking syslog.

https://github.com/sonic-net/sonic-mgmt/blob/15bf90347aa121064884adeacaed8ed5ba084e63/tests/pfcwd/test_pfcwd_function.py#L739-L741

The test is flaky after change in 14711 because the wait time is not enough for PFCWD to be triggered on new queues.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
This PR is to fix test issue caused by PR https://github.com/sonic-net/sonic-mgmt/pull/15946

#### How did you do it?
Change the logic back while maintain compatibility with chassis.

#### How did you verify/test it?
The change is verified on a Mellanox platform.
```
collected 5 items                                                                                                                                                                                     

pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[str2-msn4600c-acs-04]  ^H ^H ^H ^HPASSED                                                                                                    [ 20%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[str2-msn4600c-acs-04]  ^H ^H ^HPASSED                                                                                                 [ 40%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[str2-msn4600c-acs-04]  ^H ^HPASSED                                                                                                 [ 60%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[str2-msn4600c-acs-04]  ^H ^H ^HPASSED                                                                                                [ 80%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[str2-msn4600c-acs-04] SKIPPED (This test is applicable only for cisco-8000 / Pfcwd tests skipped on m0/mx testbed.)          [100%]
```
#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
