### PR TITLE
[test_genric_hash.py]: cisco platform checks fix

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/generic_hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/generic_hash_test.py
@@ -467,38 +467,25 @@ class GenericHashTest(BaseTest):
                 logging.info('There are multi-member portchannels, check no hash over the members')
                 for port_group in self.expected_port_groups:
                     hit_port_number = len(set(port_group).intersection(set(hit_count_map.keys())))
-                    if hit_port_number == len(self.expected_port_groups[0]):
-                        logging.info('Check if all ports in a portchannel received traffic')
-                    elif hit_port_number > 0:
-                        logging.info('Check only if few ports in a portchannel received traffic')
-                        assert False, 'The traffic is not balanced over portchannel members.'
+                    if hit_port_number > 1:
+                        logging.info('Check only one port in a portchannel received traffic')
+                        assert False, 'The traffic is balanced over portchannel members.'
                     if hit_port_number == 0:
                         logging.info('Check the traffic is balanced over all the portchannels')
                         assert False, 'Traffic is not balanced over all nexthops.'
             # Check the balance
-            expected_hit_cnt_per_port = expected_total_hit_cnt / (
-                len(self.expected_port_groups) * len(self.expected_port_groups[0]))
+            expected_hit_cnt_per_port = expected_total_hit_cnt / len(self.expected_port_groups)
             assert _calculate_balance(expected_hit_cnt_per_port), "The balancing result is beyond the range."
 
         def _check_only_lag_hash_balancing():
-            miss_list = []
             logging.info('Checking there is only lag hash')
             hit_ports = sorted(hit_count_map.keys())
-            logging.info("Expected ports {} ".format(self.expected_port_groups))
-            logging.info("Hit ports {} ".format(hit_ports))
-            list_expected_ports = [element for innerList in self.expected_port_groups for element in innerList]
-            for hit_port in hit_ports:
-                if hit_port not in list_expected_ports:
-                    logging.info("it dose not hit {} ".format(hit_port))
-                    miss_list.append(hit_port)
-            if miss_list:
-                assert False, "Traffic is not received by all lag members in 1 nexthop."
+            assert hit_ports in self.expected_port_groups, "Traffic is not received by all lag members in 1 nexthop."
             # Check the traffic is balanced over the members
-            expected_hit_cnt_per_port = lag_expected_total_hit_cnt / len(self.expected_port_groups[0])
+            expected_hit_cnt_per_port = expected_total_hit_cnt / len(self.expected_port_groups[0])
             assert _calculate_balance(expected_hit_cnt_per_port), "The balancing result is beyond the range."
 
         expected_total_hit_cnt = self.balancing_test_times * len(self.expected_port_list)
-        lag_expected_total_hit_cnt = self.balancing_test_times * len(self.expected_port_groups[0])
         # If check ecmp hash and lag hash, traffic should be balanced through all expected ports
         if self.ecmp_hash and self.lag_hash:
             _check_ecmp_and_lag_hash_balancing()

--- a/ansible/roles/test/files/ptftests/py3/generic_hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/generic_hash_test.py
@@ -476,7 +476,8 @@ class GenericHashTest(BaseTest):
                         logging.info('Check the traffic is balanced over all the portchannels')
                         assert False, 'Traffic is not balanced over all nexthops.'
             # Check the balance
-            expected_hit_cnt_per_port = expected_total_hit_cnt / (len(self.expected_port_groups) * len(self.expected_port_groups[0]))
+            expected_hit_cnt_per_port = expected_total_hit_cnt /
+                (len(self.expected_port_groups) * len(self.expected_port_groups[0]))
             assert _calculate_balance(expected_hit_cnt_per_port), "The balancing result is beyond the range."
 
         def _check_only_lag_hash_balancing():
@@ -492,7 +493,7 @@ class GenericHashTest(BaseTest):
                     miss_list.append(hit_port)
             if miss_list:
                 assert False, "Traffic is not received by all lag members in 1 nexthop."
-             # Check the traffic is balanced over the members
+            # Check the traffic is balanced over the members
             expected_hit_cnt_per_port = lag_expected_total_hit_cnt / len(self.expected_port_groups[0])
             assert _calculate_balance(expected_hit_cnt_per_port), "The balancing result is beyond the range."
 

--- a/ansible/roles/test/files/ptftests/py3/generic_hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/generic_hash_test.py
@@ -476,8 +476,8 @@ class GenericHashTest(BaseTest):
                         logging.info('Check the traffic is balanced over all the portchannels')
                         assert False, 'Traffic is not balanced over all nexthops.'
             # Check the balance
-            expected_hit_cnt_per_port = expected_total_hit_cnt /
-                (len(self.expected_port_groups) * len(self.expected_port_groups[0]))
+            expected_hit_cnt_per_port = expected_total_hit_cnt / (
+                len(self.expected_port_groups) * len(self.expected_port_groups[0]))
             assert _calculate_balance(expected_hit_cnt_per_port), "The balancing result is beyond the range."
 
         def _check_only_lag_hash_balancing():

--- a/tests/hash/generic_hash_helper.py
+++ b/tests/hash/generic_hash_helper.py
@@ -59,7 +59,7 @@ HASH_CAPABILITIES = {'mellanox': {'ecmp': MELLANOX_ECMP_HASH_FIELDS,
                      'default': {'ecmp': DEFAULT_ECMP_HASH_FIELDS,
                                  'lag': DEFAULT_LAG_HASH_FIELDS},
                      'cisco-8000': {'ecmp': CISCO_ECMP_HASH_FIELDS,
-+                                   'lag': CISCO_LAG_HASH_FIELDS}}
+                                    'lag': CISCO_LAG_HASH_FIELDS}}
 
 logger = logging.getLogger(__name__)
 vlan_member_to_restore = {}

--- a/tests/hash/generic_hash_helper.py
+++ b/tests/hash/generic_hash_helper.py
@@ -25,6 +25,7 @@ VLAN_RANGE = [1032, 1060]
 ETHERTYPE_RANGE = [0x0801, 0x0900]
 ENCAPSULATION = ['ipinip', 'vxlan', 'nvgre']
 MELLANOX_SUPPORTED_HASH_ALGORITHM = ['CRC', 'CRC_CCITT']
+CISCO_SUPPORTED_HASH_ALGORITHM = ['CRC', 'CRC_CCITT']
 DEFAULT_SUPPORTED_HASH_ALGORITHM = ['CRC', 'CRC_CCITT', 'RANDOM', 'XOR']
 
 MELLANOX_ECMP_HASH_FIELDS = [
@@ -36,6 +37,12 @@ MELLANOX_LAG_HASH_FIELDS = [
     'IN_PORT', 'SRC_MAC', 'DST_MAC', 'ETHERTYPE', 'VLAN_ID', 'IP_PROTOCOL', 'SRC_IP', 'DST_IP', 'L4_SRC_PORT',
     'L4_DST_PORT', 'INNER_SRC_IP', 'INNER_DST_IP', 'INNER_IP_PROTOCOL', 'INNER_ETHERTYPE', 'INNER_L4_SRC_PORT',
     'INNER_L4_DST_PORT', 'INNER_SRC_MAC', 'INNER_DST_MAC'
+]
+CISCO_ECMP_HASH_FIELDS = [
+    'SRC_MAC', 'DST_MAC', 'VLAN_ID', 'IP_PROTOCOL', 'SRC_IP', 'DST_IP', 'L4_SRC_PORT', 'L4_DST_PORT'
+]
+CISCO_LAG_HASH_FIELDS = [
+    'SRC_MAC', 'DST_MAC', 'VLAN_ID', 'IP_PROTOCOL', 'SRC_IP', 'DST_IP', 'L4_SRC_PORT', 'L4_DST_PORT'
 ]
 DEFAULT_ECMP_HASH_FIELDS = [
     'IN_PORT', 'SRC_MAC', 'DST_MAC', 'ETHERTYPE', 'VLAN_ID', 'IP_PROTOCOL', 'SRC_IP', 'DST_IP', 'L4_SRC_PORT',
@@ -50,7 +57,9 @@ DEFAULT_LAG_HASH_FIELDS = [
 HASH_CAPABILITIES = {'mellanox': {'ecmp': MELLANOX_ECMP_HASH_FIELDS,
                                   'lag': MELLANOX_LAG_HASH_FIELDS},
                      'default': {'ecmp': DEFAULT_ECMP_HASH_FIELDS,
-                                 'lag': DEFAULT_LAG_HASH_FIELDS}}
+                                 'lag': DEFAULT_LAG_HASH_FIELDS},
+                     'cisco-8000': {'ecmp': CISCO_ECMP_HASH_FIELDS,
++                                   'lag': CISCO_LAG_HASH_FIELDS}}
 
 logger = logging.getLogger(__name__)
 vlan_member_to_restore = {}
@@ -71,6 +80,8 @@ def get_supported_hash_algorithms(request):
     asic_type = get_asic_type(request)
     if asic_type in 'mellanox':
         supported_hash_algorithm_list = MELLANOX_SUPPORTED_HASH_ALGORITHM[:]
+    elif asic_type in 'cisco-8000':
+        supported_hash_algorithm_list = CISCO_SUPPORTED_HASH_ALGORITHM[:]
     else:
         supported_hash_algorithm_list = DEFAULT_SUPPORTED_HASH_ALGORITHM[:]
     return supported_hash_algorithm_list
@@ -477,6 +488,8 @@ def get_hash_algorithm_from_option(request, hash_algorithm_identifier):
     asic_type = get_asic_type(request)
     if asic_type in 'mellanox':
         supported_hash_algorithm_list = MELLANOX_SUPPORTED_HASH_ALGORITHM[:]
+    elif asic_type in 'cisco-8000':
+        supported_hash_algorithm_list = CISCO_SUPPORTED_HASH_ALGORITHM[:]
     else:
         supported_hash_algorithm_list = DEFAULT_SUPPORTED_HASH_ALGORITHM[:]
     if hash_algorithm_identifier == 'all':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Cisco support different HASH algorithms and fields as of now than default

**Some issues were because CISCO was not supporting certain hash algorithms and Fields which led to issues like below** 
```
/12/2024 03:58:04 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 1788, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/data/tests/hash/test_generic_hash.py", line 151, in test_ecmp_hash
    lag_hash_fields.remove(ecmp_test_hash_field)
ValueError: list.remove(x): x not in list
```
some algorithm config is missing i have listed one of many errors whose root cause is same 


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
- To add support for CISCO specific supported hash alogrithms and fields
#### How did you do it?
- added asic_type = 'cisco-8000'check for platform specific algo and fields to be picked 

#### How did you verify/test it?
Tested it on T1/T0 cisco platforms where correct calulation was done after my fox and only supported fields were picked 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
