### PR TITLE
[test_snmp_queue_counters.py]: Added support for single buffer queue and fix range related issues

### DIFF
--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -161,7 +161,10 @@ def test_snmp_queue_counters(duthosts,
     # check for other duts
     else:
         range_str = str(buffer_queue_to_del.split('|')[-1])
-        buffer_queues_removed = int(range_str.split('-')[1]) - int(range_str.split('-')[0]) + 1
+        if '-' in range_str:
+            buffer_queues_removed = int(range_str.split('-')[1]) - int(range_str.split('-')[0]) + 1
+        else:
+            buffer_queues_removed = 1
         unicast_expected_diff = buffer_queues_removed * UNICAST_CTRS
         multicast_expected_diff = unicast_expected_diff + (buffer_queues_removed
                                                            * MULTICAST_CTRS)


### PR DESCRIPTION
Regression test were failing becuase it was not bale to calculate correct range
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Support for single Queue was not there such as 'Ethernet128|1' modified core to support both 
'Ethernet128|1' and 'Ethernet128|0-2'

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
