### PR TITLE
Add fixture to disable IPv6 in PTF container

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -669,3 +669,19 @@ def skip_traffic_test(request):
         if m.name == "skip_traffic_test":
             return True
     return False
+
+
+@pytest.fixture(scope='function')
+def disable_ipv6(ptfhost):
+    default_ipv6_status = ptfhost.shell("sysctl -n net.ipv6.conf.all.disable_ipv6")["stdout"]
+    changed = False
+    # Disable IPv6 on all interfaces in PTF container
+    if default_ipv6_status != "1":
+        ptfhost.shell("echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6")
+        changed = True
+
+    yield
+
+    # Restore the original IPv6 setting on all interfaces in the PTF container
+    if changed:
+        ptfhost.shell("echo {} > /proc/sys/net/ipv6/conf/all/disable_ipv6".format(default_ipv6_status))

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -780,7 +780,7 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiHeadroomPoolSize(
         self, get_src_dst_asic_and_duts, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile
+        ingressLosslessProfile, disable_ipv6
     ):
         # NOTE: cisco-8800 will skip this test since there are no headroom pool
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To address the unexpected packet drops on the DUT when running the testQosSaiHeadroomPoolSize, we identified that the unexpected packets are sent from the PTF container, and the leaf fanout ARP update is forwarding them to the DUT. Therefore, a fixture has been added to disable IPv6 on the PTF container to prevent the unexpected packets, and the values are restored after the tests.

#### How did you do it?
Add fixture to disable IPv6 for all interfaces in ptf container before the test and restore the original IPv6 settings after the test.

#### How did you verify/test it?
Verify it by running tests/logs/qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[single_asic]
```
-------------------------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize[single_asic].xml -------------------
------------------------------------------------------------------------------------------- live log sessionfinish ------------------------------------------------------------------------
10:18:37 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================= 1 passed, 1 warning in 2604.32s (0:43:24) ===============================================================
```
#### Any platform specific information?
str3-7060x6-64pe-1
#### Supported testbed topology if it's a new test case?
t0-standalone-32
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
