### PR TITLE
[action] Continue cherry pick workflow when PR already exists.

### DIFF
--- a/.github/workflows/pr_cherrypick_prestep.yml
+++ b/.github/workflows/pr_cherrypick_prestep.yml
@@ -107,24 +107,22 @@ jobs:
           else
             # Create PR to release branch
             git push mssonicbld HEAD:cherry/$branch/${pr_id} -f
-            result=$(gh pr create -R ${repository} -H mssonicbld:cherry/$branch/${pr_id} -B $branch -t "[action] [PR:$pr_id] $title" -b "$body" 2>&1)
-            echo $result | grep "already exists" && { echo $result; return 0; }
-            echo $result | grep github.com || { echo $result; return 1; }
-            new_pr_rul=$(echo $result | grep github.com)
-            echo new_pr_rul:    $new_pr_rul
+            result=$(gh pr create -R ${repository} -H mssonicbld:cherry/$branch/${pr_id} -B $branch -t "[action] [PR:$pr_id] $title" -b "$body" 2>&1 || true)
+            new_pr_url=$(echo $result | grep -Eo https://github.com/sonic-net/sonic-mgmt/pull/[0-9]*)
+            echo new_pr_url:    $new_pr_url
 
             # Add label to old PR
             gh pr edit $pr_url --add-label "Created PR to $branch branch"
             echo Add label Created PR to $branch branch
             # Add comment to old PR
-            gh pr comment $pr_url --body "Cherry-pick PR to $branch: ${new_pr_rul}"
+            gh pr comment $pr_url --body "Cherry-pick PR to $branch: ${new_pr_url}"
             echo Add comment to old PR
 
             # Add label to new PR
-            gh pr edit $new_pr_rul --add-label "automerge"
+            gh pr edit $new_pr_url --add-label "automerge"
             echo Add label automerge to new PR
             # Add comment to new PR
-            gh pr comment $new_pr_rul --body "Original PR: ${pr_url}"
+            gh pr comment $new_pr_url --body "Original PR: ${pr_url}"
             echo Add comment to new PR
           fi
         }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix cherry pick workflow.
When there is already a PR for the cherry-pick, the action should continue the cherry-pick workflow instead of failing.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
