### PR TITLE
[202405]Enhance advance reboot test  (#15880)

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1003,8 +1003,14 @@ class ReloadTest(BaseTest):
         self.finalizer_state = self.get_warmboot_finalizer_state()
         self.log('warmboot finalizer service state {}'.format(self.finalizer_state))
         count = 0
-        while self.finalizer_state == 'activating':
-            self.finalizer_state = self.get_warmboot_finalizer_state()
+        while self.finalizer_state != 'inactive':
+            try:
+                self.finalizer_state = self.get_warmboot_finalizer_state()
+            except Exception:
+                traceback_msg = traceback.format_exc()
+                self.log("Exception happened during get warmboot finalizer service state: {}".format(traceback_msg))
+                raise
+
             self.log('warmboot finalizer service state {}'.format(self.finalizer_state))
             time.sleep(10)
             if count * 10 > int(self.test_params['warm_up_timeout_secs']):
@@ -1434,10 +1440,13 @@ class ReloadTest(BaseTest):
             return non_zero[-1]
 
     def get_teamd_state(self):
+        self.log("Start to Get the teamd state")
         stdout, stderr, _ = self.dut_connection.execCommand(
             'sudo systemctl is-active teamd.service')
         if stderr:
             self.fails['dut'].add("Error collecting teamd state. stderr: {}, stdout:{}".format(
+                str(stderr), str(stdout)))
+            self.log("Error collecting teamd state. stderr: {}, stdout:{}".format(
                 str(stderr), str(stdout)))
             raise Exception("Error collecting teamd state. stderr: {}, stdout:{}".format(
                 str(stderr), str(stdout)))
@@ -1446,6 +1455,7 @@ class ReloadTest(BaseTest):
             return ''
 
         teamd_state = stdout[0].strip()
+        self.log("The teamd state is: {}".format(teamd_state))
         return teamd_state
 
     def wait_until_teamd_goes_down(self):
@@ -1457,14 +1467,24 @@ class ReloadTest(BaseTest):
 
         while teamd_state == 'active':
             time.sleep(1)
-            dut_datetime_during_shutdown = self.get_now_time()
+            try:
+                dut_datetime_during_shutdown = self.get_now_time()
+            except Exception:
+                traceback_msg = traceback.format_exc()
+                self.log("Exception happened during get dut time: {}".format(traceback_msg))
+                continue
             time_passed = float(dut_datetime_during_shutdown.strftime(
                 "%s")) - float(dut_datetime.strftime("%s"))
             if time_passed > teamd_shutdown_timeout:
                 self.fails['dut'].add(
                     'Teamd service did not go down')
                 raise TimeoutError
-            teamd_state = self.get_teamd_state()
+            try:
+                teamd_state = self.get_teamd_state()
+            except Exception:
+                traceback_msg = traceback.format_exc()
+                self.log("Exception happened during get teamd state: {}".format(traceback_msg))
+                raise
 
         self.log('teamd service state: {}'.format(teamd_state))
 


### PR DESCRIPTION
* Add more debug information to the advance reboot

1. Add more debug information
2. When get the dut time has exception, need to not break the get teamd state function
3. When get the finalizer_state, if the state is set to empty should not return.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
cherry-pick for https://github.com/sonic-net/sonic-mgmt/pull/1588
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
