### PR TITLE
fix flaky issue in test_set_fans_speed 

### DIFF
--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -45,7 +45,8 @@ class TestChassisFans(PlatformApiTestBase):
     # level, so we must do the same here to prevent a scope mismatch.
 
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, platform_api_conn, duthost):    # noqa F811
+    def setup(self, platform_api_conn, enum_rand_one_per_hwsku_hostname, duthosts):  # noqa F811
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         if self.num_fans is None:
             try:
                 self.num_fans = int(chassis.get_num_fans(platform_api_conn))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes wrong dut maybe selected to stop thermalctrl in chassis_fan tests.

TestChassisFans::setup fixture will select the first DUT as the duthost to stop/start thermal control daemon.
However, in the test case, it will enum_rand_one_per_hwsku_hostname to do the test.

Therefore, we will see something like the following. that lc4 is being selected to stop thermalctld, but the test is running on supervisor.
```
16/12/2024 12:42:40 base._run                                L0071 DEBUG  | /var/src/sonic-mgmt_xxx/tests/common/devices/sonic.py::stop_pmon_daemon_service#888: [xxx-lc4-1] AnsibleModule::shell, args=["docker exec pmon supervisorctl stop thermalctld"], kwargs={"module_ignore_errors": true}
......
16/12/2024 12:42:54 __init__._log_sep_line                   L0170 INFO   | ==================== platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_speed[xxx-sup-1] call ====================
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
flaky test case in test_set_fans_speed

#### How did you do it?
use enum_rand_one_per_hwsku_hostname instead of duthost to align with the test case.

#### How did you verify/test it?
ran the test 3 times, all passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
