### PR TITLE
[dualtor] Improve `mux_simulator`

### DIFF
--- a/ansible/roles/vm_set/files/mux_simulator.py
+++ b/ansible/roles/vm_set/files/mux_simulator.py
@@ -51,6 +51,19 @@ if sys.version_info[0] >= 3:
     unicode = str
 
 
+MUX_SIMULATOR_LOGO = [
+    '',
+    '##     ## ##     ## ##     ##     ######  #### ##     ## ##     ## ##          ###    ########  #######  ########  ',      # noqa E501
+    '###   ### ##     ##  ##   ##     ##    ##  ##  ###   ### ##     ## ##         ## ##      ##    ##     ## ##     ## ',      # noqa E501
+    '#### #### ##     ##   ## ##      ##        ##  #### #### ##     ## ##        ##   ##     ##    ##     ## ##     ## ',      # noqa E501
+    '## ### ## ##     ##    ###        ######   ##  ## ### ## ##     ## ##       ##     ##    ##    ##     ## ########  ',      # noqa E501
+    '##     ## ##     ##   ## ##            ##  ##  ##     ## ##     ## ##       #########    ##    ##     ## ##   ##   ',      # noqa E501
+    '##     ## ##     ##  ##   ##     ##    ##  ##  ##     ## ##     ## ##       ##     ##    ##    ##     ## ##    ##  ',      # noqa E501
+    '##     ##  #######  ##     ##     ######  #### ##     ##  #######  ######## ##     ##    ##     #######  ##     ## ',      # noqa E501
+    '',
+]
+
+
 # ============================================ Error Handlers ============================================ #
 
 @app.errorhandler(Exception)
@@ -931,6 +944,21 @@ def log_message(vm_set):
     return {"success": True}
 
 
+def setup_mux_simulator(http_port, vm_set, verbose):
+    if verbose == 1:
+        app.logger.setLevel(logging.DEBUG)
+        app.config['VERBOSE'] = True
+    else:
+        app.logger.setLevel(logging.INFO)
+        app.config['VERBOSE'] = False
+
+    config_logging(http_port)
+    app.logger.info('\n'.join(MUX_SIMULATOR_LOGO))
+    app.logger.info('Starting server on port {}'.format(http_port))
+    create_muxes(vm_set)
+    app.logger.info('####################### STARTING HTTP SERVER #######################')
+
+
 if __name__ == '__main__':
     usage = '\n'.join([
         'Start mux simulator server at specified port:',
@@ -943,29 +971,19 @@ if __name__ == '__main__':
 
     http_port = sys.argv[1]
     arg_vm_set = sys.argv[2]
+    verbose = ('-v' in sys.argv)
 
-    if '-v' in sys.argv:
-        app.logger.setLevel(logging.DEBUG)
-        app.config['VERBOSE'] = True
-    else:
-        app.logger.setLevel(logging.INFO)
-        app.config['VERBOSE'] = False
+    setup_mux_simulator(http_port, arg_vm_set, verbose)
 
-    config_logging(http_port)
-    MUX_LOGO = '\n'.join([
-        '',
-        '##     ## ##     ## ##     ##     ######  #### ##     ## ##     ## ##          ###    ########  #######  ########  ',      # noqa E501
-        '###   ### ##     ##  ##   ##     ##    ##  ##  ###   ### ##     ## ##         ## ##      ##    ##     ## ##     ## ',      # noqa E501
-        '#### #### ##     ##   ## ##      ##        ##  #### #### ##     ## ##        ##   ##     ##    ##     ## ##     ## ',      # noqa E501
-        '## ### ## ##     ##    ###        ######   ##  ## ### ## ##     ## ##       ##     ##    ##    ##     ## ########  ',      # noqa E501
-        '##     ## ##     ##   ## ##            ##  ##  ##     ## ##     ## ##       #########    ##    ##     ## ##   ##   ',      # noqa E501
-        '##     ## ##     ##  ##   ##     ##    ##  ##  ##     ## ##     ## ##       ##     ##    ##    ##     ## ##    ##  ',      # noqa E501
-        '##     ##  #######  ##     ##     ######  #### ##     ##  #######  ######## ##     ##    ##     #######  ##     ## ',      # noqa E501
-        '',
-    ])
-    app.logger.info(MUX_LOGO)
-    app.logger.info('Starting server on port {}'.format(sys.argv[1]))
-    create_muxes(arg_vm_set)
-    app.logger.info('####################### STARTING HTTP SERVER #######################')
     socket.setdefaulttimeout(60)
     app.run(host='0.0.0.0', port=http_port, threaded=True)          # nosemgrep
+else:
+    http_port = os.environ.get("MUX_SIMULATOR_HTTP_PORT")
+    arg_vm_set = os.environ.get("MUX_SIMULATOR_VM_SET")
+    if http_port is None:
+        raise RuntimeError("No http port is provided.")
+    if arg_vm_set is None:
+        raise RuntimeError("No VM set is provided.")
+    verbose = int(os.environ.get("MUX_SIMULATOR_VERBOSITY", "1"))
+
+    setup_mux_simulator(http_port, arg_vm_set, verbose)

--- a/ansible/roles/vm_set/files/mux_simulator.py
+++ b/ansible/roles/vm_set/files/mux_simulator.py
@@ -14,6 +14,11 @@ import threading
 import traceback
 import time
 
+if sys.version_info.major == 2:
+    from multiprocessing.pool import ThreadPool
+else:
+    from concurrent.futures import ThreadPoolExecutor as ThreadPool
+
 from collections import defaultdict
 from logging.handlers import RotatingFileHandler
 
@@ -572,9 +577,12 @@ class Mux(object):
 
 class Muxes(object):
 
+    MUXES_CONCURRENCY = 4
+
     def __init__(self, vm_set):
         self.vm_set = vm_set
         self.muxes = {}
+        self.thread_pool = ThreadPool(Muxes.MUXES_CONCURRENCY)
         for bridge in self._mux_bridges():
             bridge_fields = bridge.split('-')
             port_index = int(bridge_fields[-1])
@@ -609,7 +617,8 @@ class Muxes(object):
             mux.set_active_side(new_active_side)
             return mux.status
         else:
-            [mux.set_active_side(new_active_side) for mux in self.muxes.values()]
+            list(self.thread_pool.map(lambda args: Mux.set_active_side(*args),
+                                      [(mux, new_active_side) for mux in self.muxes.values()]))
             return {mux.bridge: mux.status for mux in self.muxes.values()}
 
     def update_flows(self, new_action, out_sides, port_index=None):
@@ -618,7 +627,8 @@ class Muxes(object):
             mux.update_flows(new_action, out_sides)
             return mux.status
         else:
-            [mux.update_flows(new_action, out_sides) for mux in self.muxes.values()]
+            list(self.thread_pool.map(lambda args: Mux.update_flows(*args),
+                                      [(mux, new_action, out_sides) for mux in self.muxes.values()]))
             return {mux.bridge: mux.status for mux in self.muxes.values()}
 
     def reset_flows(self, port_index=None):

--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -15,12 +15,15 @@
     set_fact:
       flask_version: "1.1.2"
       werkzeug_version: "1.0.1"
+      gunicorn_version: "19.10.0"
       python_command: "python"
+      futures_version: "3.4.0"
 
   - name: Use newer Flask version for pip3
     set_fact:
       flask_version: "2.3.3"
       python_command: "python3"
+      gunicorn_version: "23.0.0"
     when: pip_executable == "pip3"
 
   - name: Use newer Werkzeug version for pip3
@@ -38,6 +41,21 @@
     pip: name=werkzeug version={{ werkzeug_version }} state=forcereinstall executable={{ pip_executable }}
     become: yes
     environment: "{{ proxy_env | default({}) }}"
+
+  - name: Install gunicorn
+    pip: name=gunicorn version={{ gunicorn_version }} state=forcereinstall executable={{ pip_executable }}
+    become: yes
+    environment: "{{ proxy_env | default({}) }}"
+
+  - name: Install futures
+    pip: name=futures version={{ futures_version }} state=forcereinstall executable={{ pip_executable }}
+    become: yes
+    environment: "{{ proxy_env | default({}) }}"
+    when: pip_executable == "pip"
+
+  - name: Increase backlog
+    shell: sysctl -w net.core.somaxconn=1024
+    become: true
 
   - name: Copy the mux simulator to test server
     copy:

--- a/ansible/roles/vm_set/templates/mux-simulator.service.j2
+++ b/ansible/roles/vm_set/templates/mux-simulator.service.j2
@@ -3,4 +3,4 @@ Description=mux simulator
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/gunicorn --preload --bind 0.0.0.0:{{ mux_simulator_port }} --chdir {{ abs_root_path }}  mux_simulator_{{ mux_simulator_port }}:app -w 1 --threads 8 --env MUX_SIMULATOR_HTTP_PORT={{ mux_simulator_port }} --env MUX_SIMULATOR_VM_SET={{ vm_set_name }} --env MUX_SIMULATOR_VERBOSITY=1
+ExecStart=/usr/local/bin/gunicorn --timeout 60 --preload --bind 0.0.0.0:{{ mux_simulator_port }} --chdir {{ abs_root_path }}  mux_simulator_{{ mux_simulator_port }}:app -w 1 --threads 8 --env MUX_SIMULATOR_HTTP_PORT={{ mux_simulator_port }} --env MUX_SIMULATOR_VM_SET={{ vm_set_name }} --env MUX_SIMULATOR_VERBOSITY=1

--- a/ansible/roles/vm_set/templates/mux-simulator.service.j2
+++ b/ansible/roles/vm_set/templates/mux-simulator.service.j2
@@ -3,4 +3,4 @@ Description=mux simulator
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/env {{python_command}} {{ abs_root_path }}/mux_simulator_{{ mux_simulator_port }}.py {{ mux_simulator_port }} {{ vm_set_name }} -v
+ExecStart=/usr/local/bin/gunicorn --preload --bind 0.0.0.0:{{ mux_simulator_port }} --chdir {{ abs_root_path }}  mux_simulator_{{ mux_simulator_port }}:app -w 1 --threads 8 --env MUX_SIMULATOR_HTTP_PORT={{ mux_simulator_port }} --env MUX_SIMULATOR_VM_SET={{ vm_set_name }} --env MUX_SIMULATOR_VERBOSITY=1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
The dualtor nightly suffers from mux simulator timeout issue, and there are always HTTP timeout failures observed.
This PR tries to improve the mux simulator performance:
1. improve the all mux toggle performance.
2. improve the mux simulator read/write throughput.

PR [1522](https://github.com/sonic-net/sonic-mgmt/pull/15226) was a quick fix to address, but it was a temporary quick fix.

#### How did you do it?
1. run mux simulator with `gunicorn` instead of its own built-in HTTP server.
The mux simulator is running with `Flask`'s own built-in HTTP server. Previously, the mux simulator is running with single-threaded mode, which limits its performance && throughput; and the mux simulator is observed stuck in reading from dead connection; PR [1522](https://github.com/sonic-net/sonic-mgmt/pull/15226) proposes a temporary by running mux simulator in threaded mode. The throughput is improved with the threaded approach, but the built-in server limits the tcp listen backlog to 128, and it is designed for development/test purpose and not recommended to be deployed([`Flask`'s deployment doc](https://flask.palletsprojects.com/en/stable/deploying/)).
So let's run the mux simulator with `gunicorn`:
* better performance/throughput with customized worker count
* increased tcp listen backlog

2. use thread pool to parallel the toggle requests.
The mux simulator handles the toggle-all request by toggling each mux port one by one, let's use a thread pool to parallel run thoses toggles to further decrease the response time.

#### How did you verify/test it?
Run the following benchmarks on a dualtor-120 testbed, and compare the performance of:
* A: the original mux simulator, with `Flask` built-in server in single-thread mode.
* B: the mux simulator with `Flask` built-in server in threaded mode.
* C: the mux simulator with this PR.


1. toggle mux status for all mux ports(one request to toggle one mux port):
* 20 concurrent users, repeated 2000 times

| mux simulator version | A   | B   | C   |
|-----------------------|-----|-----|-----|
| elapse time           | 96s | 37s | 36s |

2. toggle mux status for all mux ports(one request to toggle all mux ports):
* 1 user, repeated 1 time.

| mux simulator version | A   | B   | C  |
|-----------------------|-----|-----|----|
| elapse time           | 16s | 16s | 7s |

To summarize, mux simulator with this PR has the best performance in toggles.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
