### PR TITLE
[202405] Add ERR log ignore for ECMP/LAG hash not supported

### DIFF
--- a/tests/bgp/test_bgp_bbr_default_state.py
+++ b/tests/bgp/test_bgp_bbr_default_state.py
@@ -126,8 +126,13 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts):
     return setup_info
 
 
-def test_bbr_disabled_constants_yml_default(duthosts, rand_one_dut_hostname, setup, config_bbr_disabled):
+def test_bbr_disabled_constants_yml_default(duthosts, rand_one_dut_hostname, setup, config_bbr_disabled, loganalyzer):
     duthost = duthosts[rand_one_dut_hostname]
+    if duthost.sonichost.facts['platform_asic'] == 'broadcom':
+        ignore_regex = r".* ERR swss#orchagent:\s*.*\s*queryAattributeEnumValuesCapability:\s*returned value " \
+            r"\d+ is not allowed on SAI_SWITCH_ATTR_(?:ECMP|LAG)_DEFAULT_HASH_ALGORITHM.*"
+        loganalyzer[duthost.hostname].ignore_regex.extend([ignore_regex])
+
     duthost.shell("sudo config save -y")
     config_reload(duthost)
     is_bbr_enabled = duthost.shell("show runningconfiguration bgp | grep allowas", module_ignore_errors=True)['stdout']

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -60,6 +60,10 @@ def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loga
     if loganalyzer:  # Skip if loganalyzer is enabled
         loganalyzer[duthost.hostname].ignore_regex.extend(CopperCableIgnoreRegex)
         loganalyzer[duthost.hostname].ignore_regex.extend(SAISwitchIgnoreRegex)
+        if duthost.sonichost.facts['platform_asic'] == 'broadcom':
+            ignore_regex = r".* ERR swss#orchagent:\s*.*\s*queryAattributeEnumValuesCapability:\s*returned value " \
+                r"\d+ is not allowed on SAI_SWITCH_ATTR_(?:ECMP|LAG)_DEFAULT_HASH_ALGORITHM.*"
+            loganalyzer[duthost.hostname].ignore_regex.extend([ignore_regex])
 
 
 @pytest.fixture(autouse=True, scope="module")

--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -75,7 +75,7 @@ def get_asic_interface(inter_facts):
 
 def test_snmp_queue_counters(duthosts,
                              enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-                             creds_all_duts):
+                             creds_all_duts, loganalyzer):
     """
     Test SNMP queue counters
       - Set "create_only_config_db_buffers" to true in config db, to create
@@ -90,6 +90,10 @@ def test_snmp_queue_counters(duthosts,
     """
 
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    if duthost.sonichost.facts['platform_asic'] == 'broadcom':
+        ignore_regex = r".* ERR swss#orchagent:\s*.*\s*queryAattributeEnumValuesCapability:\s*returned value " \
+            r"\d+ is not allowed on SAI_SWITCH_ATTR_(?:ECMP|LAG)_DEFAULT_HASH_ALGORITHM.*"
+        loganalyzer[duthost.hostname].ignore_regex.extend([ignore_regex])
     global ORIG_CFG_DB, CFG_DB_PATH
     hostip = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_host']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
On Broadcom platforms, ECMP/LAG hash is not supported. Adding ERR log ignore as it is expected for this error log to print.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
On Broadcom platforms, ECMP/LAG hash is not supported. Adding ERR log ignore as it is expected for this error log to print.

#### How did you do it?
Add by extending log regex in individual test cases. Not adding to loganalyzer_common_ignore.txt because that would cause expected fail tests to pass during CI.

#### How did you verify/test it?
The following tests no longer fail on 7060X6 t1
`snmp/test_snmp_queue_counters.py`
`drop_packets/drop_packets.py`
`bgp/test_bgp_bbr_default_state.py`

#### Any platform specific information?
Only applies to Broadcom platform.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
