### PR TITLE
add dualtor fixture for test_dhcp_relay_stress 

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -133,7 +133,7 @@ def check_dhcp_stress_status(duthost, test_duration_seconds):
 @pytest.mark.parametrize('dhcp_type', ['discover', 'offer', 'request', 'ack'])
 def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
                            setup_standby_ports_on_rand_unselected_tor,
-                           toggle_all_simulator_ports_to_rand_selected_tor_m,
+                           toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa F811
                            dhcp_type, clean_processes_after_stress_test):
     """Test DHCP relay functionality on T0 topology
        and verify that HCP relay service can handle the maximum load without failure.

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -131,8 +131,10 @@ def check_dhcp_stress_status(duthost, test_duration_seconds):
 
 
 @pytest.mark.parametrize('dhcp_type', ['discover', 'offer', 'request', 'ack'])
-def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist,
-                           testing_config, dhcp_type, clean_processes_after_stress_test):
+def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
+                           setup_standby_ports_on_rand_unselected_tor,
+                           toggle_all_simulator_ports_to_rand_selected_tor_m,
+                           dhcp_type, clean_processes_after_stress_test):
     """Test DHCP relay functionality on T0 topology
        and verify that HCP relay service can handle the maximum load without failure.
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
To ensure proper Dual ToR setups in test_dhcp_relay_stress testcase.

#### How did you do it?
Added the Dual ToR-related fixture.

#### How did you verify/test it?
Validated that Dual ToR setups successfully pass the test_dhcp_relay_stress test case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
