### PR TITLE
Increase time waiting for bgp neighbors 

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -217,6 +217,6 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
     if wait_for_bgp:
         bgp_neighbors = sonic_host.get_bgp_neighbors_per_asic(state="all")
         pytest_assert(
-            wait_until(wait + 300, 10, 0, sonic_host.check_bgp_session_state_all_asics, bgp_neighbors),
+            wait_until(wait + 120, 10, 0, sonic_host.check_bgp_session_state_all_asics, bgp_neighbors),
             "Not all bgp sessions are established after config reload",
         )

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -765,7 +765,7 @@ def convert_and_restore_config_db_to_ipv6_only(duthosts):
         if config_db_modified[duthost.hostname]:
             logger.info(f"config changed. Doing config reload for {duthost.hostname}")
             try:
-                config_reload(duthost, wait=120, wait_for_bgp=True)
+                config_reload(duthost, wait=300, wait_for_bgp=True)
             except AnsibleConnectionFailure as e:
                 # IPV4 mgmt interface been deleted by config reload
                 # In latest SONiC, config reload command will exit after mgmt interface restart


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
 Increase the wait time when calling this function instead of changing the default wait time refer to PR #16094 

#### How did you do it?
Restore default wait time, increase the wait time in duthost_utils fixture

#### How did you verify/test it?
Verify it when running ip/test_mgmt_ipv6_only test case

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
vms70-t0-sn5600-1

