### PR TITLE
T2/snappi: Use natsort instead of sort for sorting the asic list in disable_pfcwd and enable_pfcwd functions.

### DIFF
--- a/tests/common/snappi_tests/qos_fixtures.py
+++ b/tests/common/snappi_tests/qos_fixtures.py
@@ -1,6 +1,7 @@
 import pytest
 import time
 import json
+from natsort import natsorted
 from tests.common.snappi_tests.common_helpers import \
         stop_pfcwd, disable_packet_aging, enable_packet_aging
 from tests.common.utilities import get_running_config
@@ -125,7 +126,7 @@ def get_pfcwd_config(duthost):
         all_configs = []
         output = duthost.shell("ip netns | awk '{print $1}'")['stdout']
         all_asic_list = output.split("\n")
-        all_asic_list.sort()
+        all_asic_list = natsorted(all_asic_list)
         all_asic_list.insert(0, None)
         for space in all_asic_list:
             config = get_running_config(duthost, space)
@@ -145,7 +146,7 @@ def reapply_pfcwd(duthost, pfcwd_config):
     elif type(pfcwd_config) is list:
         output = duthost.shell("ip netns | awk '{print $1}'")['stdout']
         all_asic_list = output.split("\n")
-        all_asic_list.sort()
+        all_asic_list = natsorted(all_asic_list)
         all_asic_list.insert(0, None)
 
         all_files = []


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Even after https://github.com/sonic-net/sonic-mgmt/pull/15863, the problem is still seen in RP. The issue is that the sort() function only sorts alphabetically, not numerically. So we need to use natsort module instead of normal sort() in these functions.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Seeing a lot of loganalyzer messages, but in RP only.

#### How did you do it?
Change sort to natsort().

#### How did you verify/test it?
Running in my TB, I don't see the LA error anymore.

#### Any platform specific information?
T2 mAsic only.