### PR TITLE
[202405] Support skip traffic test with testutils in KVM

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -599,3 +599,16 @@ def ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url, d
 
     ptfhost.copy(content=json.dumps(ports_map), dest=PTF_TEST_PORT_MAP)
     return PTF_TEST_PORT_MAP
+
+
+@pytest.fixture(scope="function")
+def skip_traffic_test(request):
+    """
+    Skip traffic test if the testcase is marked with 'skip_traffic_test' marker.
+    We are using it to skip traffic test for the testcases that are not supported in specific platforms.
+    Currently the marker is only be use in tests_mark_conditions_skip_traffic_test.yaml for VS platform.
+    """
+    for m in request.node.iter_markers():
+        if m.name == "skip_traffic_test":
+            return True
+    return False

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -1,0 +1,9 @@
+#######################################
+#####            route            #####
+#######################################
+route/test_route_perf.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+      - "is_multi_asic==True"

--- a/tests/common/plugins/ptfadapter/dummy_testutils.py
+++ b/tests/common/plugins/ptfadapter/dummy_testutils.py
@@ -1,0 +1,28 @@
+import ptf.testutils as testutils
+import inspect
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def wrapped(*args, **kwargs):
+    return True
+
+
+class DummyTestUtils:
+    def __init__(self, *args, **kwargs):
+        func_dict = {}
+        for name, func in inspect.getmembers(testutils, inspect.isfunction):
+            if name.startswith("verify"):
+                func_dict[name] = func
+        self.func_dict = func_dict
+
+    def __enter__(self, *args, **kwargs):
+        """ enter in 'with' block """
+        for name, func in self.func_dict.items():
+            setattr(testutils, name, wrapped)
+
+    def __exit__(self, *args, **kwargs):
+        """ exit from 'with' block """
+        for name, func in self.func_dict.items():
+            setattr(testutils, name, self.func_dict[name])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,7 @@ from tests.common.config_reload import config_reload
 from tests.common.connections.console_host import ConsoleHost
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.helpers.inventory_utils import trim_inventory
+from tests.common.plugins.ptfadapter.dummy_testutils import DummyTestUtils
 
 try:
     from tests.macsec import MacsecPluginT2, MacsecPluginT0
@@ -981,6 +982,21 @@ def pytest_runtest_makereport(item, call):
     # be "setup", "call", "teardown"
 
     setattr(item, "rep_" + rep.when, rep)
+
+
+# This function is a pytest hook implementation that is called in runtest call stage.
+# We are using this hook to set ptf.testutils to DummyTestUtils if the test is marked with "skip_traffic_test",
+# DummyTestUtils would always return True for all verify function in ptf.testutils.
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_call(item):
+    if "skip_traffic_test" in item.keywords:
+        logger.info("Got skip_traffic_test marker, will skip traffic test")
+        with DummyTestUtils():
+            logger.info("Set ptf.testutils to DummyTestUtils to skip traffic test")
+            yield
+            logger.info("Reset ptf.testutils")
+    else:
+        yield
 
 
 def collect_techsupport_on_dut(request, a_dut):

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -23,6 +23,7 @@ markers:
     dynamic_config: dynamic_config marker
     static_config: static_config marker
     dependency: dependency marker
+    skip_traffic_test: skip_traffic_test marker
 
 log_cli_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-7s| %(message)s
 log_file_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-7s| %(message)s


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test using ptfadapter can't be tested on KVM platform, we need to skip traffic test if needed.
#### How did you do it?
1. Add `skip_traffic_test` marker
2. Create a dummy ptf testutils library to return True for all testutils.verify function
3. Add pytest hook to capture `skip_traffic_test` marker, if with this marker, replace testutils.verify with dummy library and always get return True
4. Add `skip_traffic_test` marker for route perf test in multi-asic T1 PR test

For tests needs return value(maybe tuple, str, int) of testutils.verify function, need to add some capability change
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
