### PR TITLE
Increase Orch CPU utilization timeout before link flap

### DIFF
--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -101,7 +101,12 @@ class TestContLinkFlap(object):
 
         # Make Sure Orch CPU < orch_cpu_threshold before starting test.
         logging.info("Make Sure orchagent CPU utilization is less that %d before link flap", orch_cpu_threshold)
-        pytest_assert(wait_until(600, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
+        if 't2' in tbinfo['topo']['name']:
+            # To address bug 16186
+            wait_timeout = 600
+        else:
+            wait_timeout = 100
+        pytest_assert(wait_until(wait_timeout, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
                       "Orch CPU utilization {} > orch cpu threshold {} before link flap"
                       .format(duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
                               orch_cpu_threshold))

--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -101,7 +101,7 @@ class TestContLinkFlap(object):
 
         # Make Sure Orch CPU < orch_cpu_threshold before starting test.
         logging.info("Make Sure orchagent CPU utilization is less that %d before link flap", orch_cpu_threshold)
-        pytest_assert(wait_until(100, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
+        pytest_assert(wait_until(600, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
                       "Orch CPU utilization {} > orch cpu threshold {} before link flap"
                       .format(duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
                               orch_cpu_threshold))

--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -102,7 +102,8 @@ class TestContLinkFlap(object):
         # Make Sure Orch CPU < orch_cpu_threshold before starting test.
         logging.info("Make Sure orchagent CPU utilization is less that %d before link flap", orch_cpu_threshold)
         if 't2' in tbinfo['topo']['name']:
-            # To address bug 16186
+            # In T2 topology, if the test is run on uplink LC first, it needs more time for the CPU to cool down
+            # More details in bug 16186
             wait_timeout = 600
         else:
             wait_timeout = 100


### PR DESCRIPTION
This change was made because in modular chassis with multi-asic LCs, the link flap test might run on the uplink LC followed by the downlink LC. Since the uplink has a lot of neighbors the downlink CPU is busy re-routing the different pathways. In such a scenario, the downlink LC will still be hot (above 10% utilization) before we flap its interfaces. Hence, the increase in timeout.

We tested it with a timeout of 500 and it failed so we are increasing it to 600 which has been passing on our local T2 testbeds.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #16186

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
To make sure that the timeout for the Orchagent CPU utilization check is large enough for the test to pass.

#### How did you do it?
Increased the timeout from 100 to 600.

#### How did you verify/test it?
Ran the test on T2 testbed with a timeout of 600 (Passed) and 500 (Failed)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
