### PR TITLE
feat: add one_dut fixture to only use one dut

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1582,7 +1582,7 @@ def generate_dut_backend_asics(request, duts_selected):
     return dut_asic_list
 
 
-def generate_priority_lists(request, prio_scope, with_completeness_level=False):
+def generate_priority_lists(request, prio_scope, with_completeness_level=False, one_dut_only=False):
     empty = []
 
     tbname = request.config.getoption("--testbed")
@@ -1608,6 +1608,9 @@ def generate_priority_lists(request, prio_scope, with_completeness_level=False):
         for p in priorities:
             ret.append('{}|{}'.format(dut, p))
 
+        if one_dut_only:
+            break
+
     if with_completeness_level:
         completeness_level = get_completeness_level_metadata(request)
         # if completeness_level in ["debug", "basic", "confident"],
@@ -1623,6 +1626,9 @@ def generate_priority_lists(request, prio_scope, with_completeness_level=False):
                 if priorities:
                     p = random.choice(priorities)
                     ret.append('{}|{}'.format(dut, p))
+
+                if one_dut_only:
+                    break
 
     return ret if ret else empty
 
@@ -1817,14 +1823,28 @@ def pytest_generate_tests(metafunc):        # noqa E302
         metafunc.parametrize("enum_dut_all_prio", generate_priority_lists(metafunc, 'all'))
     if 'enum_dut_lossless_prio' in metafunc.fixturenames:
         metafunc.parametrize("enum_dut_lossless_prio", generate_priority_lists(metafunc, 'lossless'))
+    if 'enum_one_dut_lossless_prio' in metafunc.fixturenames:
+        metafunc.parametrize("enum_one_dut_lossless_prio",
+                             generate_priority_lists(metafunc, 'lossless', one_dut_only=True))
     if 'enum_dut_lossless_prio_with_completeness_level' in metafunc.fixturenames:
         metafunc.parametrize("enum_dut_lossless_prio_with_completeness_level",
                              generate_priority_lists(metafunc, 'lossless', with_completeness_level=True))
+    if 'enum_one_dut_lossless_prio_with_completeness_level' in metafunc.fixturenames:
+        metafunc.parametrize("enum_one_dut_lossless_prio_with_completeness_level",
+                             generate_priority_lists(metafunc, 'lossless', with_completeness_level=True,
+                                                     one_dut_only=True))
     if 'enum_dut_lossy_prio' in metafunc.fixturenames:
         metafunc.parametrize("enum_dut_lossy_prio", generate_priority_lists(metafunc, 'lossy'))
+    if 'enum_one_dut_lossy_prio' in metafunc.fixturenames:
+        metafunc.parametrize("enum_one_dut_lossy_prio", generate_priority_lists(metafunc, 'lossy',
+                                                                                one_dut_only=True))
     if 'enum_dut_lossy_prio_with_completeness_level' in metafunc.fixturenames:
         metafunc.parametrize("enum_dut_lossy_prio_with_completeness_level",
                              generate_priority_lists(metafunc, 'lossy', with_completeness_level=True))
+    if 'enum_one_dut_lossy_prio_with_completeness_level' in metafunc.fixturenames:
+        metafunc.parametrize("enum_one_dut_lossy_prio_with_completeness_level",
+                             generate_priority_lists(metafunc, 'lossy', with_completeness_level=True,
+                                                     one_dut_only=True))
     if 'enum_pfc_pause_delay_test_params' in metafunc.fixturenames:
         metafunc.parametrize("enum_pfc_pause_delay_test_params", pfc_pause_delay_test_params(metafunc))
 

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossless_with_snappi.py
@@ -28,7 +28,7 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
                                         conn_graph_facts,               # noqa: F811
                                         fanout_graph_facts_multidut,    # noqa: F811
                                         duthosts,
-                                        enum_dut_lossless_prio,
+                                        enum_one_dut_lossless_prio,
                                         prio_dscp_map,                  # noqa: F811
                                         lossless_prio_list,             # noqa: F811
                                         all_prio_list,                  # noqa: F811
@@ -58,7 +58,7 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
 
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
-    _, lossless_prio = enum_dut_lossless_prio.split('|')
+    _, lossless_prio = enum_one_dut_lossless_prio.split('|')
     lossless_prio = int(lossless_prio)
     pause_prio_list = [lossless_prio]
     test_prio_list = [lossless_prio]
@@ -142,7 +142,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                   # n
                                                fanout_graph_facts_multidut,  # noqa: F811
                                                duthosts,
                                                localhost,
-                                               enum_dut_lossless_prio_with_completeness_level,    # noqa: F811
+                                               enum_one_dut_lossless_prio_with_completeness_level,    # noqa: F811
                                                prio_dscp_map,            # noqa: F811
                                                lossless_prio_list,         # noqa: F811
                                                all_prio_list,        # noqa: F811
@@ -171,7 +171,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                   # n
     """
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
-    _, lossless_prio = enum_dut_lossless_prio_with_completeness_level.split('|')
+    _, lossless_prio = enum_one_dut_lossless_prio_with_completeness_level.split('|')
     lossless_prio = int(lossless_prio)
     pause_prio_list = [lossless_prio]
     test_prio_list = [lossless_prio]

--- a/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_pfc_pause_lossy_with_snappi.py
@@ -28,7 +28,7 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
                                      conn_graph_facts,          # noqa: F811
                                      fanout_graph_facts_multidut,        # noqa: F811
                                      duthosts,
-                                     enum_dut_lossy_prio,
+                                     enum_one_dut_lossy_prio,
                                      prio_dscp_map,             # noqa: F811
                                      lossy_prio_list,           # noqa: F811
                                      all_prio_list,             # noqa: F811
@@ -57,7 +57,7 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
     """
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
-    _, lossy_prio = enum_dut_lossy_prio.split('|')
+    _, lossy_prio = enum_one_dut_lossy_prio.split('|')
     lossy_prio = int(lossy_prio)
     pause_prio_list = [lossy_prio]
     test_prio_list = [lossy_prio]
@@ -150,7 +150,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
                                             fanout_graph_facts_multidut,     # noqa: F811
                                             duthosts,
                                             localhost,
-                                            enum_dut_lossy_prio_with_completeness_level,
+                                            enum_one_dut_lossy_prio_with_completeness_level,
                                             prio_dscp_map,          # noqa: F811
                                             lossy_prio_list,        # noqa: F811
                                             all_prio_list,          # noqa: F811
@@ -180,7 +180,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
     """
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
-    _, lossy_prio = enum_dut_lossy_prio_with_completeness_level.split('|')
+    _, lossy_prio = enum_one_dut_lossy_prio_with_completeness_level.split('|')
     lossy_prio = int(lossy_prio)
     pause_prio_list = [lossy_prio]
     test_prio_list = [lossy_prio]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Currently, test_pfc_pause_single_lossy_prio and test_pfc_pause_single_lossy_prio_reboot are using more parameters than its needed, resulting in a longer execution time

Fixes # (issue) 30562817

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

Reducing the number of DUT but still give enough priorities for coverage

#### How did you do it?

Modify the current fixture to add an option to pick 1 DUT for testing only

#### How did you verify/test it?

physical testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
