### PR TITLE
Fix incorrect conditional mark for `test_get_transceiver_threshold_info`

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -653,8 +653,9 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_threshold_info:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['cisco-8000', 'vs'] and release in ['202012']"
+      - "asic_type in ['cisco-8000'] and release in ['202012']"
       - "is_multi_asic==True and release in ['201911']"
+      - "asic_type in ['vs']"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_get_tx_bias:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #16083, we used conditional marks to skip certain test scripts on vs testbeds. However, we mistakenly added the condition for `test_get_transceiver_threshold_info`. This PR corrects this issue.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In PR #16083, we used conditional marks to skip certain test scripts on vs testbeds. However, we mistakenly added the condition for `test_get_transceiver_threshold_info`. This PR corrects this issue.

#### How did you do it?
Add another condition to skip on vs testbed. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
