### PR TITLE
[dhcp_relay] Restart bgp before dhcp_relay test

### DIFF
--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -146,7 +146,11 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
 def validate_dut_routes_exist(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data):
     """Fixture to valid a route to each DHCP server exist
     """
-    py_assert(wait_until(360, 5, 0, check_routes_to_dhcp_server, duthosts[rand_one_dut_hostname],
+    duthost = duthosts[rand_one_dut_hostname]
+    duthost.restart_service("bgp")
+    py_assert(wait_until(100, 10, 0, duthost.is_service_fully_started_per_asic_or_host, "bgp"),
+              "BGP not started.")
+    py_assert(wait_until(360, 5, 0, check_routes_to_dhcp_server, duthost,
                          dut_dhcp_relay_data),
               "Packets relayed to DHCP server should go through default route via upstream neighbor, but now it's" +
               " going through mgmt interface, which means device is in an unhealthy status")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
We found that it's flaky that before dhcp_relay test, bgp is up but there is not routes received, which would cause dhcp_relay failed. Cannot manually reproduce this issue, suspect it's because testbed is messed up by other tests. Hence add restart bgp before dhcp_relay test
```
IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 12
RIB entries 11, using 1408 bytes of memory
Peers 4, using 82368 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600         16         16        12      0       0  00:11:03                1  ARISTA01T1
10.0.0.59      4  64600         16         16        12      0       0  00:11:03                1  ARISTA02T1
10.0.0.61      4  64600         16         16        12      0       0  00:11:01                1  ARISTA03T1
10.0.0.63      4  64600         16         16        12      0       0  00:11:03                1  ARISTA04T1
```


#### How did you do it?
Restart bgp before dhcp_relay test

#### How did you verify/test it?
Run tests in t0
```
collected 7 items

dhcp_relay/test_dhcp_relay.py::test_interface_binding PASSED             [ 14%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default PASSED            [ 28%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap PASSED    [ 42%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down PASSED [ 57%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac PASSED        [ 71%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport PASSED       [ 85%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter SKIPPED (skip...) [100%]INFO:root:Can not get Allure report URL. Please check logs
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
