### PR TITLE
Reg: New Test Case of SAI VOQ Counter

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2492,6 +2492,13 @@ voq/test_fabric_reach.py:
       - "not any(i in platform for i in ['arista_7800', 'x86_64-nokia_ixr7250e'])"
       - "(asic_type in ['cisco-8000'])"
 
+voq/test_voq_counter.py::test_voq_drop_counter:
+  skip:
+    reason: "Testcase ignored due to sonic-mgmt issue: https://github.com/sonic-net/sonic-mgmt/issues/16140"
+    conditions:
+      - "(switch_type=='voq')"
+      - "('t2' in topo_name)"
+
 voq/test_voq_counter.py::TestVoqCounter::test_voq_queue_counter[multi_dut_shortlink_to_longlink]:
   skip:
     reason: "Testcase ignored due to sonic-mgmt issue: https://github.com/sonic-net/sonic-buildimage/issues/21098"

--- a/tests/voq/test_voq_counter.py
+++ b/tests/voq/test_voq_counter.py
@@ -1,0 +1,60 @@
+import logging
+import pytest
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.utilities import wait_until
+
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('t2')
+]
+
+
+def test_voq_drop_counter(duthosts, tbinfo, ptfadapter,
+                          nbrhosts, enum_rand_one_per_hwsku_hostname, enum_rand_one_asic_index):
+    """
+    Skipping the Test Case as For Verification of SAI_SWITCH_STAT_PACKET_INTEGRITY_DROP
+    the simulation of Packet integrity (CRC, RQP errors) is not possible
+    with the issue https://github.com/sonic-net/sonic-mgmt/issues/16140
+    The functionality is in https://github.com/sonic-net/sonic-utilities/pull/3322
+    """
+
+
+def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    """This test implicitly verifies that queue counters --voq (i.e. Credit-WD-Del/pkts)
+            are working as expected by disabling the fabric ports
+        """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    bcm_changes = False
+    # Ensure the device is a Broadcom device
+    pytest_require((duthost.facts.get('platform_asic') == "broadcom-dnx"),
+                   "The Test Case is only supported on Broadcom-dnx ASIC")
+
+    cmd_bcmcmd_false = "'port enable sfi false'"
+    cmd_bcmcmd_true = "'port enable sfi true'"
+    cmd = "show queue counters --voq --nonzero| grep -i '{}' |grep -i '{}' |awk '{{print $7}}'".format("Ethernet-IB",
+                                                                                                       "VOQ0")
+    try:
+        bcm_changes = True
+        for asic in duthost.asics:
+            bcmcmd = "bcmcmd {} ".format("-n " + str(asic.asic_index)) + cmd_bcmcmd_false
+            res = duthost.shell(bcmcmd, module_ignore_errors=True)
+            if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
+                pytest.fail("BCMCMD Failed")
+
+        def queue_counter_assertion():
+            out = duthost.shell(cmd)['stdout'].split('\n')
+            integers = [int(item.replace(',', '')) for item in out if item.replace(',', '').strip().isdigit()]
+            return any(num > 0 for num in integers)
+
+        pytest_assert(wait_until(300, 0, 0, queue_counter_assertion),
+                      "Credit-WD-Del/pkts is not incresing "
+                      "Ref: https://github.com/sonic-net/sonic-buildimage/issues/21098")
+    finally:
+        if bcm_changes:
+            for asic in duthost.asics:
+                cmd = "bcmcmd {} ".format("-n " + str(asic.asic_index)) + cmd_bcmcmd_true
+                res = duthost.shell(cmd, module_ignore_errors=True)
+                if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
+                    pytest.fail("BCMCMD Failed")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Refer:https://github.com/sonic-net/sonic-mgmt/pull/13926. Original PR with Comments
New Test Cases for SAI_SWITCH_STAT_PACKET_INTEGRITY_DROP counter in show dropcounter counts command and show SAI_QUEUE_STAT_CREDIT_WD_DELETED_PACKETS counters in show queue counter --voq command.
With Reference of https://github.com/sonic-net/sonic-utilities/pull/3322

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
New Test Case for New SAI VOQ Counter

#### How did you do it?
For 'test_voq_queue_counter'.
Disabling the fabric port using BCMCMD causes the queue counters Credit-WD-Del/pkts to increase on VOQ0 for Ethernet-IBs

For `test_voq_drop_counter`.
Please refer: https://github.com/sonic-net/sonic-mgmt/issues/16140
#### How did you verify/test it?

#### Any platform specific information?
Verified on a T2 VOQ Chassis with dnx platform
#### Supported testbed topology if it's a new test case?
T2 VOQ Chassis
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Refer https://github.com/sonic-net/sonic-utilities/pull/3322
Refer https://github.com/sonic-net/sonic-mgmt/pull/13926
