### PR TITLE
chore: enable parallel run for override in 202405

### DIFF
--- a/tests/test_parallel_modes/cisco_t2_8800.json
+++ b/tests/test_parallel_modes/cisco_t2_8800.json
@@ -8,6 +8,7 @@
     "iface_namingmode/test_iface_namingmode.py": "FULL_PARALLEL",
     "lldp/test_lldp.py": "FULL_PARALLEL",
     "memory_checker/test_memory_checker.py": "FULL_PARALLEL",
+    "override_config_table/test_override_config_table_masic.py": "FULL_PARALLEL",
     "passw_hardening/test_passw_hardening.py": "FULL_PARALLEL",
     "pc/test_po_cleanup.py": "FULL_PARALLEL",
     "platform_tests/api/test_chassis.py": "FULL_PARALLEL",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Enable parallel run for `override_config_table/test_override_config_table_masic.py` in 202405

Summary:
Fixes # (issue) Microsoft ADO 30056122

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Previously we disabled parallel run for `override_config_table/test_override_config_table_masic.py` in 202405 as it's not compatible with the existing infra. Now this test has been enhanced in #16226 so we can enable parallel run for it.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
