### PR TITLE
[wol testplan] Remove unicast address test in plan

### DIFF
--- a/docs/testplan/WoL-test-plan.md
+++ b/docs/testplan/WoL-test-plan.md
@@ -91,7 +91,7 @@ The test will issue `wol` commands with various parameter combinations on DUT, t
 #### Test case #8 - Verify parameters can be set correctly by CLI
 1. Make sure interface that receving packet and command line parameter interface are same.
 1. Make sure target_mac in payload and command line parameter target_mac are same.
-1. Make sure ip address in header and command line parameter ip_address are same. (Test both ipv4 and ipv6 address with broadcase address or unicast address on VLAN interface or port interface, so there should be 8 combinations, maybe we can leverage pytest parametrize mark to realize that.)
+1. Make sure ip address in header and command line parameter ip_address are same. (Test both ipv4 and ipv6 address with broadcase address on VLAN interface or port interface, so there should be 4 combinations)
 1. Make sure when command line parameter ip_address is empty, ip address in header is default value: 255.255.255.255.
 1. Make sure udp port in header and command line parameter udp port are same.
 1. Make sure when command line parameter udp_port is empty, udp port in header is default value: 9.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Remove unicast address test in test plan, as we don't expected there is any routable unicast address to devices already shut down.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
We don't expected there is any routable unicast address to devices already shut down.

#### How did you do it?
Remove unicast address test in test plan.

#### How did you verify/test it?
NA

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
