### PR TITLE
[Infra][add/remove topo] Improve `vm_topology` performance

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -1465,6 +1465,7 @@ class VMTopology(object):
         remove dut port from the ptf docker
         """
         logging.info("=== Remove host ports ===")
+
         def _remove_host_port(i, intf):
             if self._is_multi_duts:
                 if isinstance(intf, list):
@@ -2042,7 +2043,7 @@ class VMTopologyWorker(object):
             finally:
                 if self.use_thread_worker:
                     logging.debug("Finish task %s, arguments (%s, %s), worker %s",
-                                func, args, kwargs, threading.current_thread().ident)
+                                  func, args, kwargs, threading.current_thread().ident)
                     logging.debug(LOG_SEPARATOR)
                     self.thread_buffer_handler.flush_current_thread_logs()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
`vm_topology` builds up the testbed connections (`veth` links, ovs bridges, etc) on the test server by running Linux commands, which involves a lot of waiting for I/O operations.

* the `vm_topology` script running statistics with `restart-ptf`:
```
real    18m50.615s
user    0m0.009s
sys     0m0.099s
```
With the I/O bound nature, `vm_topology` runtime could be greatly decreased by using threading pool to parallelize the I/O operations.

Signed-off-by: Longxiang <lolv@microsoft.com>

#### How did you do it?
Introduce the thread pool to `vm_topology` to parallel run functions that take time to finish.

* `restart-ptf` on `dualtor-120` `vm_topology` profile statistics:
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/d1954cbd-a51e-48f4-922f-7792890431ee" />

Top three total run time function call:

|function name|total run time|
|-|-|
|`add_host_ports`|1040s|
|`bind_fp_ports`|96.3s|
|`init`|16.7s|


* `remove-topo` on `dualtor-120` `vm_topology`  profile statistics:
<img width="1382" alt="image" src="https://github.com/user-attachments/assets/342fdafa-68a8-4a84-aafd-b39e5efb5d43" />
Top three total run time function call:

|function name|total run time|
|-|-|
|`remove_host_ports`|165s|
|`unbind_fp_ports`|40.6s|
|`remove_injected_fp_ports_from_docker`|3.3s|

Let's use thread pool to parallel run the following functions that take most of time from the above statistics:
* `add_host_ports`
* `remove_host_ports`
* `bind_fp_ports`
* `unbind_fp_ports`

Two new classes are introduced to support this feature:
*  class `VMTopologyWorker`: a worker class to support work in either single thread mode or thread pool mode.
*  class `ThreadBufferHandler`: a logging handler to buffer logs from each task submitted to the `VMTopologyWorker` and flush when the task ends. This is to ensure `vm_topology` logs are grouped by the tasks, logs from different tasks will not be mixed together.

#### How did you verify/test it?
Let's test this PR on a `dualtor-120` testbed with this PR, and the thread pool has 13 thread workers.

|operation|`vm_topology` run time without this PR|`vm_topology` run time with this PR|
|-|-|-|
|`remove-topo`|3m19.786s|1m18.430s|
|`restart-ptf`|18m50.615s|3m58.963s|

* `restart-ptf` with-this-PR `vm_topology` profile statistics:
<img width="1388" alt="image" src="https://github.com/user-attachments/assets/c340659d-e6ff-4290-b91b-c423d4b618c0" />

|function name|total run time without this PR|total run time with this PR|
|-|-|-|
|`add_host_ports`|1040s|169s|
|`bind_fp_ports`|96.3s|39.3s|


* `remove-topo` with-this-pR `vm_topology` profile statistics:
<img width="1391" alt="image" src="https://github.com/user-attachments/assets/fbd34dab-de6a-44fc-b321-bc59f027f826" />

|function name|total run time without this PR|total run time with this PR|
|-|-|-|
|`remove_host_ports`|165s|68.8s|
|`unbind_fp_ports`|40.6s|8.4|


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
