### PR TITLE
generate 100000_300m pcbb qos test param for th2

### DIFF
--- a/tests/qos/files/qos_params.th2.yaml
+++ b/tests/qos/files/qos_params.th2.yaml
@@ -212,6 +212,37 @@ qos_params:
                     pg: 6
                     pkts_num_trig_pfc: 19939
                     pkts_num_margin: 4
+            100000_300m:
+                pcbb_xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 20425
+                    pkts_num_trig_pfc: 19939
+                pcbb_xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 20425
+                    pkts_num_trig_pfc: 19939
+                pcbb_xoff_3:
+                    dscp: 3
+                    ecn: 1
+                    outer_dscp: 2
+                    pg: 2
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 19939
+                    pkts_num_trig_pfc: 19939
+                pcbb_xoff_4:
+                    dscp: 4
+                    ecn: 1
+                    outer_dscp: 6
+                    pg: 6
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 19939
+                    pkts_num_trig_pfc: 19939
         topo-any:
             40000_300m:
                 pkts_num_leak_out: 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

encountered KeyError: '100000_300m' when run test_xoff_for_pcbb test fro 202405 branch

```
29/11/2024 22:41:51 __init__._fixture_func_decorator         L0073 ERROR  | 
KeyError('100000_300m')
Traceback (most recent call last):
  File "/azp/_work/4/s/tests/common/plugins/log_section_start/__init__.py", line 71, in _fixture_func_decorator
    return fixture_func(*args, **kargs)
  File "/azp/_work/4/s/tests/qos/tunnel_qos_remap_base.py", line 308, in qos_config
    return qos_configs['qos_params'][dut_asic][dut_topo][profile_name]
KeyError: '100000_300m'
```

#### How did you do it?

run tests/qos/files/brcm/qos_param_generator.py to auto generate qos parameter for xoff case, and copy param to qos.yml for pcbb case.

```
25/12/2024 17:53:40 qos_param_generator.msg                  L0134 INFO   | Clone default speed cable length parameters from qos_params[50000_40m] to qos_params[100000_300m]
25/12/2024 17:53:40 qos_param_generator.msg                  L0134 INFO   | debug message:
share_buffer = ingress_lossless_pool.size (159468 cells // 4)
25/12/2024 17:53:40 qos_param_generator.msg                  L0134 INFO   | Ingress calculation: pg_min 6, avail_share_buf 19933, total_share_buf 39867, pg_hdrm 486, pg_reset_offset 12
25/12/2024 17:53:40 qos_param_generator.msg                  L0134 INFO   | Egress lossless calculation: eg_lossless_que_min 0
25/12/2024 17:53:40 qos_param_generator.msg                  L0134 INFO   | Egress lossy calculation: eg_lossy_que_min 8, eg_avail_share_buf 10631, eg_total_share_buf 31894
25/12/2024 17:53:40 qos_param_generator.msg                  L0134 INFO   | Workaround egress lossy calculation: eg_lossy_que_min 8, eg_avail_share_buf 10631, eg_total_share_buf 31894
25/12/2024 17:53:40 qos_param_generator.msg                  L0134 INFO   | Update qos_params[100000_300m][xoff_1]["pkts_num_trig_ingr_drp"] from 19939 to 20425
25/12/2024 17:53:40 qos_param_generator.msg                  L0134 INFO   | Update qos_params[100000_300m][xoff_2]["pkts_num_trig_ingr_drp"] from 19939 to 20425
25/12/2024 17:53:40 qos_param_generator.msg                  L0134 INFO   | Calculation of qos_params {'50000_40m': {'pcbb_xoff_1': {'dscp': 3, 'ecn': 1, 'pg': 3, 'pkts_num_margin': 4, 'pkts_num_trig_pfc': 19939}, 'pcbb_xoff_2': {'dscp': 4, 'ecn': 1, 'pg': 4, 'pkts_num_margin': 4, 'pkts_num_trig_pfc': 19939}, 'pcbb_xoff_3': {'dscp': 3, 'ecn': 1, 'outer_dscp': 2, 'pg': 2, 'pkts_num_margin': 4, 'pkts_num_trig_pfc': 19939}, 'pcbb_xoff_4': {'dscp': 4, 'ecn': 1, 'outer_dscp': 6, 'pg': 6, 'pkts_num_margin': 4, 'pkts_num_trig_pfc': 19939}, 'xoff_1': {'dscp': 3, 'ecn': 1, 'pg': 3, 'pkts_num_margin': 4, 'pkts_num_trig_ingr_drp': 20425, 'pkts_num_trig_pfc': 19939}, 'xoff_2': {'dscp': 4, 'ecn': 1, 'pg': 4, 'pkts_num_margin': 4, 'pkts_num_trig_ingr_drp': 20425, 'pkts_num_trig_pfc': 19939}, 'xoff_3': {'dscp': 3, 'ecn': 1, 'outer_dscp': 2, 'pg': 2, 'pkts_num_margin': 4, 'pkts_num_trig_ingr_drp': 19939, 'pkts_num_trig_pfc': 19939}, 'xoff_4': {'dscp': 4, 'ecn': 1, 'outer_dscp': 6, 'pg': 6, 'pkts_num_margin': 4, 'pkts_num_trig_ingr_drp': 19939, 'pkts_num_trig_pfc': 19939}}, '100000_300m': {'pcbb_xoff_1': {'dscp': 3, 'ecn': 1, 'pg': 3, 'pkts_num_margin': 4, 'pkts_num_trig_pfc': 19939}, 'pcbb_xoff_2': {'dscp': 4, 'ecn': 1, 'pg': 4, 'pkts_num_margin': 4, 'pkts_num_trig_pfc': 19939}, 'pcbb_xoff_3': {'dscp': 3, 'ecn': 1, 'outer_dscp': 2, 'pg': 2, 'pkts_num_margin': 4, 'pkts_num_trig_pfc': 19939}, 'pcbb_xoff_4': {'dscp': 4, 'ecn': 1, 'outer_dscp': 6, 'pg': 6, 'pkts_num_margin': 4, 'pkts_num_trig_pfc': 19939}, 'xoff_1': {'dscp': 3, 'ecn': 1, 'pg': 3, 'pkts_num_margin': 4, 'pkts_num_trig_ingr_drp': 20425, 'pkts_num_trig_pfc': 19939}, 'xoff_2': {'dscp': 4, 'ecn': 1, 'pg': 4, 'pkts_num_margin': 4, 'pkts_num_trig_ingr_drp': 20425, 'pkts_num_trig_pfc': 19939}, 'xoff_3': {'dscp': 3, 'ecn': 1, 'outer_dscp': 2, 'pg': 2, 'pkts_num_margin': 4, 'pkts_num_trig_ingr_drp': 19939, 'pkts_num_trig_pfc': 19939}, 'xoff_4': {'dscp': 4, 'ecn': 1, 'outer_dscp': 6, 'pg': 6, 'pkts_num_margin': 4, 'pkts_num_trig_ingr_drp': 19939, 'pkts_num_trig_pfc': 19939}}}
```

#### How did you verify/test it?

applied new 100000_300m param, and ran pcbb testcase. passed test.

![image](https://github.com/user-attachments/assets/7507240e-f611-4c85-8d49-e0bd9e89c7f7)

![image](https://github.com/user-attachments/assets/542920c8-9746-4eb2-ad65-3c409910e9bb)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
