### PR TITLE
Move stable pfcwd tests from onboarding test set to PR test set

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -228,6 +228,10 @@ t0:
   - bgp/test_bgp_route_neigh_learning.py
   - l2/test_l2_configure.py
   - srv6/test_srv6_basic_sanity.py
+  - pfcwd/test_pfcwd_all_port_storm.py
+  - pfcwd/test_pfcwd_function.py
+  - pfcwd/test_pfcwd_timer_accuracy.py
+  - pfcwd/test_pfcwd_warm_reboot.py
 
 t0-2vlans:
   - dhcp_relay/test_dhcp_relay.py
@@ -439,6 +443,9 @@ t1-lag:
   - ipfwd/test_nhop_group.py
   - restapi/test_restapi_vxlan_ecmp.py
   - srv6/test_srv6_basic_sanity.py
+  - pfcwd/test_pfcwd_all_port_storm.py
+  - pfcwd/test_pfcwd_function.py
+  - pfcwd/test_pfcwd_timer_accuracy.py
 
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py
@@ -471,11 +478,6 @@ dpu:
   - dash/test_dash_vnet.py
 
 onboarding_t0:
-  # We will add a batch of T0 control plane cases and fix the failed cases later
-  - pfcwd/test_pfcwd_all_port_storm.py
-  - pfcwd/test_pfcwd_function.py
-  - pfcwd/test_pfcwd_timer_accuracy.py
-  - pfcwd/test_pfcwd_warm_reboot.py
   # - platform_tests/test_advanced_reboot.py
   - lldp/test_lldp_syncd.py
   # Flaky, we will triage and fix it later, move to onboarding to unblock pr check
@@ -489,9 +491,6 @@ onboarding_t0:
 
 onboarding_t1:
   - pc/test_lag_member_forwarding.py
-  - pfcwd/test_pfcwd_all_port_storm.py
-  - pfcwd/test_pfcwd_function.py
-  - pfcwd/test_pfcwd_timer_accuracy.py
   - bgp/test_bgp_bbr_default_state.py
   - bgp/test_bgp_command.py
   - generic_config_updater/test_mgmt_interface.py

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1543,6 +1543,16 @@ pfcwd/test_pfcwd_warm_reboot.py:
         - "'dualtor' in topo_name"
         - https://github.com/sonic-net/sonic-mgmt/issues/8400
 
+pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm:
+   skip:
+     reason: "Warm Reboot is not supported in T2 or in standalone topos. / Pfcwd tests skipped on m0/mx testbed. / Currently async_storm test is not supported on VS platform"
+     conditions_logical_operator: or
+     conditions:
+        - "'t2' in topo_name"
+        - "'standalone' in topo_name"
+        - "topo_type in ['m0', 'mx']"
+        - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16233"
+
 #######################################
 #####     process_monitoring      #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Some dataplane test scripts have been added to PR test and put into optional onboarding job to test case performance, I calculated the success rate of test scripts in recent 3 days, I think I can move high success rate test scripts to t0/t1 job now
TestbedName | FilePath | TestCase | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-t1-lag | pfcwd/test_pfcwd_all_port_storm.py | test_all_port_storm_restore[vlab-03] | 81 | 0 | 81 | 1
vms-kvm-t1-lag | pfcwd/test_pfcwd_function.py | test_pfcwd_actions[vlab-03] | 81 | 0 | 81 | 1
vms-kvm-t1-lag | pfcwd/test_pfcwd_function.py | test_pfcwd_multi_port[vlab-03] | 81 | 0 | 81 | 1
vms-kvm-t1-lag | pfcwd/test_pfcwd_function.py | test_pfcwd_mmu_change[vlab-03] | 81 | 0 | 81 | 1
vms-kvm-t1-lag | pfcwd/test_pfcwd_function.py | test_pfcwd_port_toggle[vlab-03] | 81 | 0 | 81 | 1
vms-kvm-t1-lag | pfcwd/test_pfcwd_function.py | test_pfcwd_no_traffic[vlab-03] | 81 | 0 | 81 | 1
vms-kvm-t1-lag | pfcwd/test_pfcwd_timer_accuracy.py | test_pfcwd_timer_accuracy[vlab-03] | 80 | 0 | 80 | 1
vms-kvm-t0 | pfcwd/test_pfcwd_all_port_storm.py | test_all_port_storm_restore[vlab-01] | 80 | 0 | 80 | 1
vms-kvm-t0 | pfcwd/test_pfcwd_timer_accuracy.py | test_pfcwd_timer_accuracy[vlab-01] | 80 | 0 | 80 | 1
vms-kvm-t0 | pfcwd/test_pfcwd_function.py | test_pfcwd_actions[vlab-01] | 80 | 0 | 80 | 1
vms-kvm-t0 | pfcwd/test_pfcwd_function.py | test_pfcwd_multi_port[vlab-01] | 80 | 0 | 80 | 1
vms-kvm-t0 | pfcwd/test_pfcwd_function.py | test_pfcwd_mmu_change[vlab-01] | 80 | 0 | 80 | 1
vms-kvm-t0 | pfcwd/test_pfcwd_function.py | test_pfcwd_port_toggle[vlab-01] | 80 | 0 | 80 | 1
vms-kvm-t0 | pfcwd/test_pfcwd_function.py | test_pfcwd_no_traffic[vlab-01] | 80 | 0 | 80 | 1
vms-kvm-t0 | pfcwd/test_pfcwd_warm_reboot.py | test_pfcwd_wb[no_storm-vlab-01] | 80 | 0 | 80 | 1
vms-kvm-t0 | pfcwd/test_pfcwd_warm_reboot.py | test_pfcwd_wb[storm-vlab-01] | 80 | 0 | 80 | 1
vms-kvm-t0 | pfcwd/test_pfcwd_warm_reboot.py | test_pfcwd_wb[async_storm-vlab-01] | 0 | 80 | 80 | 0
#### How did you do it?
1. Move stable pfcwd tests to PR test set
2. test_pfcwd_wb[async_storm-vlab-01] is always failing in config reload, error message is `2024 Dec 23 03:03:10.477773 vlab-01 ERR monit[12306]: Unix socket /var/run/monit.sock connection error -- No such file or directory`, skip with issue https://github.com/sonic-net/sonic-mgmt/issues/16233
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
