### PR TITLE
[sanity_check][bgp] Add default route check in sanity for single asic

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -166,10 +166,10 @@ def check_bgp(duthosts, tbinfo):
         dut = kwargs['node']
         results = kwargs['results']
 
-        def _check_default_route(version, asichost):
+        def _check_default_route(version, dut):
             # Return True if successfully get default route
-            res = asichost.shell("ip {} route show default".format("" if version == 4 else "-6"),
-                                 module_ignore_errors=True)
+            res = dut.shell("ip {} route show default".format("" if version == 4 else "-6"),
+                            module_ignore_errors=True)
             return not res["rc"] and len(res["stdout"].strip()) != 0
 
         def _check_bgp_status_helper():
@@ -207,17 +207,18 @@ def check_bgp(duthosts, tbinfo):
                 # Add default route check for default route missing issue in below scenario:
                 # 1) Loopbackv4 ip address replace, it would cause all bgp routes missing
                 # 2) Announce or withdraw routes in some test cases and doesn't recover it
-                asic_host = dut.asic_instance(asic_index)
-                if not _check_default_route(4, asic_host):
-                    if asic_key not in check_result:
-                        check_result[asic_key] = {}
-                    check_result[asic_key]["no_v4_default_route"] = True
-                    a_asic_result = True
-                if not _check_default_route(6, asic_host):
-                    if asic_key not in check_result:
-                        check_result[asic_key] = {}
-                    check_result[asic_key]["no_v6_default_route"] = True
-                    a_asic_result = True
+                # Chassis and multi_asic is not supported for now
+                if not dut.is_multi_asic and not dut.get_facts().get("modular_chassis"):
+                    if not _check_default_route(4, dut):
+                        if asic_key not in check_result:
+                            check_result[asic_key] = {}
+                        check_result[asic_key]["no_v4_default_route"] = True
+                        a_asic_result = True
+                    if not _check_default_route(6, dut):
+                        if asic_key not in check_result:
+                            check_result[asic_key] = {}
+                        check_result[asic_key]["no_v6_default_route"] = True
+                        a_asic_result = True
 
                 asic_check_results.append(a_asic_result)
 

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -166,6 +166,12 @@ def check_bgp(duthosts, tbinfo):
         dut = kwargs['node']
         results = kwargs['results']
 
+        def _check_default_route(version, asichost):
+            # Return True if successfully get default route
+            res = asichost.shell("ip {} route show default".format("" if version == 4 else "-6"),
+                                 module_ignore_errors=True)
+            return not res["rc"] and len(res["stdout"].strip()) != 0
+
         def _check_bgp_status_helper():
             asic_check_results = []
             bgp_facts = dut.bgp_facts(asic_index='all')
@@ -187,21 +193,30 @@ def check_bgp(duthosts, tbinfo):
                 if a_asic_neighbors is not None and len(a_asic_neighbors) > 0:
                     down_neighbors = [k for k, v in list(a_asic_neighbors.items())
                                       if v['state'] != 'established']
+                    asic_key = 'bgp' if dut.facts['num_asic'] == 1 else 'bgp' + str(asic_index)
                     if down_neighbors:
-                        if dut.facts['num_asic'] == 1:
-                            check_result['bgp'] = {'down_neighbors': down_neighbors}
-                        else:
-                            check_result['bgp' + str(asic_index)] = {'down_neighbors': down_neighbors}
+                        check_result[asic_key] = {'down_neighbors': down_neighbors}
                         a_asic_result = True
                     else:
                         a_asic_result = False
-                        if dut.facts['num_asic'] == 1:
-                            if 'bgp' in check_result:
-                                check_result['bgp'].pop('down_neighbors', None)
-                        else:
-                            if 'bgp' + str(asic_index) in check_result:
-                                check_result['bgp' + str(asic_index)].pop('down_neighbors', None)
+                        if asic_key in check_result:
+                            check_result[asic_key].pop('down_neighbors', None)
                 else:
+                    a_asic_result = True
+
+                # Add default route check for default route missing issue in below scenario:
+                # 1) Loopbackv4 ip address replace, it would cause all bgp routes missing
+                # 2) Announce or withdraw routes in some test cases and doesn't recover it
+                asic_host = dut.asic_instance(asic_index)
+                if not _check_default_route(4, asic_host):
+                    if asic_key not in check_result:
+                        check_result[asic_key] = {}
+                    check_result[asic_key]["no_v4_default_route"] = True
+                    a_asic_result = True
+                if not _check_default_route(6, asic_host):
+                    if asic_key not in check_result:
+                        check_result[asic_key] = {}
+                    check_result[asic_key]["no_v6_default_route"] = True
                     a_asic_result = True
 
                 asic_check_results.append(a_asic_result)
@@ -243,8 +258,12 @@ def check_bgp(duthosts, tbinfo):
                     if 'down_neighbors' in check_result[a_result]:
                         logger.info('BGP neighbors down: %s on bgp instance %s on dut %s' % (
                             check_result[a_result]['down_neighbors'], a_result, dut.hostname))
+                    if "no_v4_default_route" in check_result[a_result]:
+                        logger.info('Deafult v4 route for {} {} is missing'.format(dut.hostname, a_result))
+                    if "no_v6_default_route" in check_result[a_result]:
+                        logger.info('Deafult v6 route for {} {} is missing'.format(dut.hostname, a_result))
         else:
-            logger.info('No BGP neighbors are down on %s' % dut.hostname)
+            logger.info('No BGP neighbors are down or default route missing on %s' % dut.hostname)
 
         mgFacts = dut.get_extended_minigraph_facts(tbinfo)
         if dut.num_asics() == 1 and tbinfo['topo']['type'] != 't2' and \

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -208,7 +208,7 @@ def check_bgp(duthosts, tbinfo):
                 # 1) Loopbackv4 ip address replace, it would cause all bgp routes missing
                 # 2) Announce or withdraw routes in some test cases and doesn't recover it
                 # Chassis and multi_asic is not supported for now
-                if not dut.is_multi_asic and not dut.get_facts().get("modular_chassis"):
+                if not dut.is_multi_asic and not (dut.get_facts().get("modular_chassis").lower() == "true"):
                     if not _check_default_route(4, dut):
                         if asic_key not in check_result:
                             check_result[asic_key] = {}

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -208,7 +208,8 @@ def check_bgp(duthosts, tbinfo):
                 # 1) Loopbackv4 ip address replace, it would cause all bgp routes missing
                 # 2) Announce or withdraw routes in some test cases and doesn't recover it
                 # Chassis and multi_asic is not supported for now
-                if not dut.is_multi_asic and not (dut.get_facts().get("modular_chassis").lower() == "true"):
+                if not dut.is_multi_asic and not (dut.get_facts().get("modular_chassis") is True or
+                                                  dut.get_facts().get("modular_chassis") == "True"):
                     if not _check_default_route(4, dut):
                         if asic_key not in check_result:
                             check_result[asic_key] = {}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
BGP routes would be setup during add-topo https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/roles/vm_set/tasks/add_topo.yml#L276.
But there are some scenarios that route in DUT has been messed up, but bgp sessions are all up, sanity would treat it as healthy and wouldn't take action to recover it.
1) Loopbackv4 address has been replaced, it would cause all kernel routes from bgp miss
2) In some test cases announce or withdraw routes from ptf but fail to recover (i.e. test_stress_routes)

Healthy status:
```
admin@sonic:~$ ip route show default
default nhid 282 proto bgp src 10.1.0.32 metric 20 
        nexthop via 10.0.0.57 dev PortChannel101 weight 1 
        nexthop via 10.0.0.59 dev PortChannel103 weight 1 
        nexthop via 10.0.0.61 dev PortChannel105 weight 1 
        nexthop via 10.0.0.63 dev PortChannel106 weight 1 
admin@sonic:~$ show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 2890
RIB entries 2893, using 648032 bytes of memory
Peers 6, using 4451856 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  65200        763        764         0      0       0  11:46:17             1439  ARISTA01M1
10.0.0.59      4  65200        763        765         0      0       0  11:46:17             1439  ARISTA02M1
10.0.0.61      4  65200        763        765         0      0       0  11:46:17             1439  ARISTA03M1
10.0.0.63      4  65200        763        765         0      0       0  11:46:17             1439  ARISTA04M1
10.0.0.65      4  64001        712        761         0      0       0  11:46:15                2  ARISTA01MX
10.0.0.67      4  64002        712        761         0      0       0  11:46:15                2  ARISTA02MX

Total number of neighbors 6
```

Issue status, no default route, but `show ip bgp sum` looks good
```
admin@sonic:~$ ip route show default
admin@sonic:~$ show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 2892
RIB entries 2893, using 648032 bytes of memory
Peers 6, using 4451856 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  65200        764        767         0      0       0  11:47:14             1439  ARISTA01M1
10.0.0.59      4  65200        764        768         0      0       0  11:47:14             1439  ARISTA02M1
10.0.0.61      4  65200        764        768         0      0       0  11:47:14             1439  ARISTA03M1
10.0.0.63      4  65200        764        768         0      0       0  11:47:14             1439  ARISTA04M1
10.0.0.65      4  64001        713        764         0      0       0  11:47:12                2  ARISTA01MX
10.0.0.67      4  64002        713        764         0      0       0  11:47:12                2  ARISTA02MX

Total number of neighbors 6
```

#### How did you do it?
Add default routes check in sanity check, and re-announce routes if issue happen

#### How did you verify/test it?
Run sanity check

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
