### PR TITLE
Temporary skip dualtor test in baseline test

### DIFF
--- a/.azure-pipelines/baseline_test/baseline.test.template.yml
+++ b/.azure-pipelines/baseline_test/baseline.test.template.yml
@@ -55,24 +55,26 @@ jobs:
       STOP_ON_FAILURE: "False"
       TEST_PLAN_NUM: $(BASELINE_MGMT_PUBLIC_MASTER_TEST_NUM)
 
-- job: dualtor_elastictest
-  displayName: "kvmtest-dualtor-t0 by Elastictest"
-  timeoutInMinutes: 240
-  continueOnError: false
-  pool: sonic-ubuntu-1c
-  steps:
-    - template: ../run-test-elastictest-template.yml
-      parameters:
-        TOPOLOGY: dualtor
-        MIN_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
-        MAX_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
-        COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
-        KVM_IMAGE_BRANCH: "master"
-        MGMT_BRANCH: "master"
-        BUILD_REASON: "BaselineTest"
-        RETRY_TIMES: "0"
-        STOP_ON_FAILURE: "False"
-        TEST_PLAN_NUM: $(BASELINE_MGMT_PUBLIC_MASTER_TEST_NUM)
+# Temporary skip dualtor test in baseline test for KVM dualtor test is not stable.
+# Platform owner will work on it recently, planning to add back in 1 or 2 months.
+# - job: dualtor_elastictest
+#   displayName: "kvmtest-dualtor-t0 by Elastictest"
+#   timeoutInMinutes: 240
+#   continueOnError: false
+#   pool: sonic-ubuntu-1c
+#   steps:
+#     - template: ../run-test-elastictest-template.yml
+#       parameters:
+#         TOPOLOGY: dualtor
+#         MIN_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
+#         MAX_WORKER: $(T0_DUALTOR_INSTANCE_NUM)
+#         COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
+#         KVM_IMAGE_BRANCH: "master"
+#         MGMT_BRANCH: "master"
+#         BUILD_REASON: "BaselineTest"
+#         RETRY_TIMES: "0"
+#         STOP_ON_FAILURE: "False"
+#         TEST_PLAN_NUM: $(BASELINE_MGMT_PUBLIC_MASTER_TEST_NUM)
 
 - job: multi_asic_elastictest
   displayName: "kvmtest-multi-asic-t1-lag by Elastictest"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Currently KVM dualtor test is not stable enough, baseline test is continuously generating work items for KVM dualtor, but some of them are duplicate. Platform owner will take actions to fix the issue recently, too much work items will cause noise during the fix.
#### How did you do it?
Temporary skip dualtor test in baseline test.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
