### PR TITLE
[wol test] Fix wol test cases failure due to parameter constrain

### DIFF
--- a/tests/wol/test_wol.py
+++ b/tests/wol/test_wol.py
@@ -402,7 +402,7 @@ def test_invalid_password(
         duthost.shell("wol %s %s -b -p %s" % (random_dut_port, target_mac, password))
     except Exception as e:
         exception_catched = True
-        pytest_assert("invalid password" in e.results['stderr'], "Unexpected exception %s" % str(e))
+        pytest_assert("invalid password" in e.results['stderr'].lower(), "Unexpected exception %s" % str(e))
     pytest_assert(exception_catched, "No exception catched")
 
 
@@ -475,7 +475,7 @@ def test_invalid_interval(
     logging.info("Test with random dut port %s and ptf port index %s" % (random_dut_port, random_ptf_port))
     exception_catched = False
     try:
-        duthost.shell("wol %s %s -b -i %s" % (random_dut_port, target_mac, invalid_interval))
+        duthost.shell("wol %s %s -b -i %s -c 1" % (random_dut_port, target_mac, invalid_interval))
     except Exception as e:
         exception_catched = True
         pytest_assert(r'Invalid value for "-i": 2001 is not in the valid range of 0 to 2000.' in e.results['stderr']
@@ -495,7 +495,7 @@ def test_invalid_count(
     logging.info("Test with random dut port %s and ptf port index %s" % (random_dut_port, random_ptf_port))
     exception_catched = False
     try:
-        duthost.shell("wol %s %s -b -c %s" % (random_dut_port, target_mac, invalid_count))
+        duthost.shell("wol %s %s -b -c %s -i 1000" % (random_dut_port, target_mac, invalid_count))
     except Exception as e:
         exception_catched = True
         pytest_assert(r'Invalid value for "-c": 10 is not in the valid range of 1 to 5.' in e.results['stderr'] or


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
When test invalid count and interval, we didn't provide both count and interval parameters, so the test could fail with two scenario, one is failed on parameter constrain that count and interval should be both provided, another is invalid value provided.

We need to narrow down the test failure scenario.

So we add parameter in test to make the parameter constrain satisfied.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Test case failed unexpecetd, because of the failure results is more than one.
#### How did you do it?
Reduce the failure result by providing enough parameter. so there will be only one failure that align with the test case
#### How did you verify/test it?
Run test on 720dt testbed
![image](https://github.com/user-attachments/assets/f4f3efa8-4449-4aa5-a9d2-985294eb998c)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
