### PR TITLE
Skip `test_vrf_attr.py` in PR testing using conditional mark. 

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2371,18 +2371,15 @@ vrf/test_vrf.py::TestVrfAclRedirect:
 
 vrf/test_vrf_attr.py:
   skip:
-    reason: "Vrf tests are skipped both in nightly and PR testing."
+    reason: "Vrf tests are skipped in PR testing."
     conditions:
       - "asic_type in ['vs']"
 
-#######################################
-#####           vrf_attr          #####
-#######################################
 vrf/test_vrf_attr.py::TestVrfAttrSrcMac::test_vrf1_neigh_with_default_router_mac:
   skip:
-    reason: "RIF MAC taking precedence over VRF MAC"
+    reason: "RIF MAC taking precedence over VRF MAC / Vrf test are skipped in PR testing."
     conditions:
-      - "asic_type in ['barefoot']"
+      - "asic_type in ['barefoot', 'vs']"
 
 #######################################
 #####           vxlan            #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #16083, we transitioned T0 skipped test scripts from `pr_test_skip_scripts.yaml` to conditional marks. However, for the test script `test_vrf_attr.py`, we mistakenly omitted adding the condition to extended entries. This PR addresses and corrects this oversight.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In PR #16083, we transitioned T0 skipped test scripts from `pr_test_skip_scripts.yaml` to conditional marks. However, for the test script `test_vrf_attr.py`, we mistakenly omitted adding the condition to extended entries. This PR addresses and corrects this oversight.

#### How did you do it?
Add the condition to extended entries for test script `test_vrf_attr.py`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
