### PR TITLE
[spytest] feature: add functionality to retrieve console information

### DIFF
--- a/spytest/spytest/framework.py
+++ b/spytest/spytest/framework.py
@@ -3932,6 +3932,9 @@ class WorkArea(object):
         profile = profile or self.cfg.config_profile
         profile = profile or "na"
         return profile.lower()
+    
+    def get_console(self, dut):
+        return self._context._tb.get_console(dut)
 
     def get_device_type(self, dut):
         return self._context._tb.get_device_type(dut)

--- a/spytest/spytest/infra.py
+++ b/spytest/spytest/infra.py
@@ -405,6 +405,10 @@ def get_mgmt_ip(dut):
     return getwa().get_mgmt_ip(dut)
 
 
+def get_console_info(dut):
+    return getwa().get_console(dut)
+
+
 def get_datastore(dut, name, scope="default"):
     return getwa().get_datastore(dut, name, scope)
 

--- a/spytest/spytest/testbed.py
+++ b/spytest/spytest/testbed.py
@@ -1396,6 +1396,17 @@ class Testbed(object):
             return rv["ts"]
         return None
 
+    def get_console(self, dut, default=""):
+        dinfo = self.get_device_info(dut)
+        rv = SpyTestDict()
+        if not dinfo:
+            return default
+        if dinfo["console"]:
+            rv.ip = dinfo["console"].ip
+            rv.port = dinfo["console"].port
+            rv.protocol = dinfo["console"].protocol
+        return rv
+
     def get_rps(self, dut):
         """
         Returns RPS details read from testbed file for given DUT


### PR DESCRIPTION
### Description of PR

Summary:
Added functionality to retrieve console information from testbed devices in spytest framework. This enables access to console details (IP, port, protocol) for test cases and debugging purposes.

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Approach
#### What is the motivation for this PR?
To provide easy access to device console information within spytest framework, which helps in debugging and monitoring test cases that require console access.

#### How did you do it?
- Added new method `get_console()` in framework.py to access testbed console info
- Implemented `get_console_info()` in infra.py as a utility function
- Added `get_console()` in testbed.py to retrieve console IP, port, and protocol from device info

#### How did you verify/test it?
By running spytest with a testbed configuration that includes console information and verifying the returned console details match the configuration.

Sample testbed yaml file includes:
```
devices:
    SD1:
        device_type: DevSonic
        console: {protocol: telnet, ip: x.x.x.x, port: y}
        access: {protocol: ssh, ip: xx.xx.xx.xx, port: yy}
```

Console info retrieval from framework
```
vars = st.ensure_min_topology("D1")
console_info = st.get_console_info(vars.D1)
console_protocol = console_info.protocol
console_ip = console_info.ip
console_port = console_info.port
```

#### Any platform specific information?
No, this is platform-independent and works with any device that has console information configured in the testbed.

#### Supported testbed topology if it's a new test case?
Not applicable as this is a framework improvement.

### Documentation
This is a framework enhancement that adds new utility functions. No specific documentation updates required as the functions are self-documented through their interface.
