### PR TITLE
Add safe_reload and interface check for process monitoring and container check tests

### DIFF
--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -49,7 +49,7 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname):
     for hostname in selected_rand_one_per_hwsku_hostname:
         duthost = duthosts[hostname]
         logger.info("Reload config on DuT '{}' ...".format(duthost.hostname))
-        config_reload(duthost)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
         postcheck_critical_processes_status(duthost, up_bgp_neighbors[duthost])
 
 

--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -49,7 +49,7 @@ def config_reload_after_tests(duthosts, selected_rand_one_per_hwsku_hostname):
     for hostname in selected_rand_one_per_hwsku_hostname:
         duthost = duthosts[hostname]
         logger.info("Reload config on DuT '{}' ...".format(duthost.hostname))
-        config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
         postcheck_critical_processes_status(duthost, up_bgp_neighbors[duthost])
 
 

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -37,7 +37,7 @@ POST_CHECK_THRESHOLD_SECS = 360
 def config_reload_after_tests(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     yield
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
 
 @pytest.fixture(autouse=True, scope='module')

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -37,7 +37,7 @@ POST_CHECK_THRESHOLD_SECS = 360
 def config_reload_after_tests(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     yield
-    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
 
 @pytest.fixture(autouse=True, scope='module')


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Notice quite a lot flaky failures on PR test,
https://elastictest.org/scheduler/testplan/676e75562c6c7b8d3e3bd8bf?testcase=process_monitoring%2Ftest_critical_process_monitoring.py&type=console
Simply wait for 120s is not enough for multi-asic kvm testbeds, enhance the config_reload to use safe_reload to make sure the testbed is healthy.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Notice quite a lot flaky failures on PR test,
https://elastictest.org/scheduler/testplan/676e75562c6c7b8d3e3bd8bf?testcase=process_monitoring%2Ftest_critical_process_monitoring.py&type=console

#### How did you do it?
Simply wait for 120s is not enough for multi-asic kvm testbeds, enhance the config_reload to use safe_reload to make sure the testbed is healthy.

#### How did you verify/test it?
PR test will verify it.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
