### PR TITLE
Ignore gnmi client stderr

### DIFF
--- a/tests/dash/gnmi_utils.py
+++ b/tests/dash/gnmi_utils.py
@@ -272,10 +272,7 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list):
     if error in output['stdout']:
         result = output['stdout'].split(error, 1)
         raise Exception("GRPC error:" + result[1])
-    if output['stderr']:
-        raise Exception("error:" + output['stderr'])
-    else:
-        return
+    return
 
 
 def gnmi_get(duthost, ptfhost, path_list):
@@ -307,21 +304,18 @@ def gnmi_get(duthost, ptfhost, path_list):
         path = path.replace('sonic-db:', '')
         cmd += " " + path
     output = ptfhost.shell(cmd, module_ignore_errors=True)
-    if output['stderr']:
-        raise Exception("error:" + output['stderr'])
+    msg = output['stdout'].replace('\\', '')
+    error = "GRPC error\n"
+    if error in msg:
+        result = msg.split(error, 1)
+        raise Exception("GRPC error:" + result[1])
+    mark = 'The GetResponse is below\n' + '-'*25 + '\n'
+    if mark in msg:
+        result = msg.split(mark, 1)
+        msg_list = result[1].split('-'*25)[0:-1]
+        return [msg.strip("\n") for msg in msg_list]
     else:
-        msg = output['stdout'].replace('\\', '')
-        error = "GRPC error\n"
-        if error in msg:
-            result = msg.split(error, 1)
-            raise Exception("GRPC error:" + result[1])
-        mark = 'The GetResponse is below\n' + '-'*25 + '\n'
-        if mark in msg:
-            result = msg.split(mark, 1)
-            msg_list = result[1].split('-'*25)[0:-1]
-            return [msg.strip("\n") for msg in msg_list]
-        else:
-            raise Exception("error:" + msg)
+        raise Exception("error:" + msg)
 
 
 def apply_gnmi_file(localhost, duthost, ptfhost, dest_path=None, config_json=None,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Microsoft ADO: 30577576

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
We have detected a syntax warning when using the gNMI client with Python 3:

E           Exception: error:/root/gnxi/gnmi_cli_py/py_gnmicli.py:508: SyntaxWarning: "is not" with a literal. Did you mean "!="?
E             if filter_event_regex is not "":
E           /root/gnxi/gnmi_cli_py/py_gnmicli.py:510: SyntaxWarning: "is not" with a literal. Did you mean "!="?
E             if len(match) is not 0:

#### How did you do it?
Do not check stderr in the test

#### How did you verify/test it?
Run gnmi end to end test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
