### PR TITLE
[202405][sanity_check][bgp] Add default route check in sanity for single asic

### DIFF
--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -163,10 +163,12 @@ def adaptive_recover(dut, localhost, fanouthosts, nbrhosts, tbinfo, check_result
                 action = _recover_services(dut, result)
             elif result['check_item'] == 'bgp':
                 # If there is only default route missing issue, only need to re-announce routes to recover
-                if ("no_v4_default_route" in result['bgp'] and len(result['bgp']) == 1 or
-                    "no_v6_default_route" in result['bgp'] and len(result['bgp']) == 1 or
+                # Currently only support single asic
+                if (dut.facts["num_asic"] == 1 and
+                    ("no_v4_default_route" in result['bgp'] and len(result['bgp']) == 1 or
+                     "no_v6_default_route" in result['bgp'] and len(result['bgp']) == 1 or
                     ("no_v4_default_route" in result['bgp'] and "no_v6_default_route" in result['bgp'] and
-                     len(result['bgp']) == 2)):
+                     len(result['bgp']) == 2))):
                     action = re_announce_routes(localhost, tbinfo["topo"]["name"], tbinfo["ptf_ip"])
                 else:
                     action = neighbor_vm_restore(dut, nbrhosts, tbinfo, result)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Manually cherry-pick these 2 PRs due to PR check failure
https://github.com/sonic-net/sonic-mgmt/pull/16235
https://github.com/sonic-net/sonic-mgmt/pull/16264

#### How did you do it?
Add default routes check in sanity check, and re-announce routes if issue happen

#### How did you verify/test it?
Run sanity check

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
