### PR TITLE
Make test_idf_isolated_withdraw_all more robust

### DIFF
--- a/tests/bgp/test_seq_idf_isolation.py
+++ b/tests/bgp/test_seq_idf_isolation.py
@@ -167,9 +167,9 @@ def test_idf_isolated_withdraw_all(duthosts, rand_one_downlink_duthost,
         # Verify DUT is in isolated-withdraw-all state.
         pytest_assert(IDF_ISOLATED_WITHDRAW_ALL == get_idf_isolation_state(duthost),
                       "DUT is not in isolated_withdraw_all state")
-        pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(duthosts, duthost, nbrs,
-                                                                          traffic_shift_community),
-                      "Failed to verify only loopback route in isolated_withdraw_all state")
+        if not wait_until(60, 3, 0, verify_only_loopback_routes_are_announced_to_neighs,
+                          duthosts, duthost, nbrs, traffic_shift_community):
+            pytest.fail("Failed to verify only loopback route in isolated_withdraw_all state")
     finally:
         # Recover to unisolated state
         duthost.shell("sudo idf_isolation unisolated")


### PR DESCRIPTION
The test is flaky because it checks routes on neighbors immediately after isolating dut. So the test may fail if the neighbors (VM) are not able to process route withdraw in time. Make the test more robust by retrying validation for 60 seconds.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
