### PR TITLE
[Snappi] Replacing dut.shell with dut.command for clearing counters in snappi clear_counter function

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -1117,19 +1117,19 @@ def clear_counters(duthost, port):
         None
     """
 
-    duthost.shell("sudo sonic-clear counters \n")
-    duthost.shell("sudo sonic-clear pfccounters \n")
-    duthost.shell("sudo sonic-clear priority-group drop counters \n")
-    duthost.shell("sonic-clear counters \n")
-    duthost.shell("sonic-clear pfccounters \n")
+    duthost.command("sudo sonic-clear counters \n")
+    duthost.command("sudo sonic-clear pfccounters \n")
+    duthost.command("sudo sonic-clear priority-group drop counters \n")
+    duthost.command("sudo sonic-clear queue watermark all \n")
+    duthost.command("sudo sonic-clear  priority-group drop counters \n")
+    duthost.command("sonic-clear counters \n")
+    duthost.command("sonic-clear pfccounters \n")
+    duthost.command("sonic-clear queuecounters \n")
+    duthost.command("sonic-clear queue watermark all \n")
 
     if (duthost.is_multi_asic):
         asic = duthost.get_port_asic_instance(port).get_asic_namespace()
-        duthost.shell("sudo ip netns exec {} sonic-clear queuecounters \n".format(asic))
-        duthost.shell("sudo ip netns exec {} sonic-clear dropcounters \n".format(asic))
-    else:
-        duthost.shell("sonic-clear queuecounters \n")
-        duthost.shell("sonic-clear dropcounters \n")
+        duthost.command("sudo ip netns exec {} sonic-clear dropcounters \n".format(asic))
 
 
 def get_interface_stats(duthost, port):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The clear_counter function in tests/common/snappi_tests/common_helper.py used dut.shell to clear the sonic counters.

However, the dut.shell inherently uses sudo, thus sonic clear counters in non-sudo mode were not getting cleared.

Replacing dut.shell with dut.command to ensure that sonic-clear counters works in both SUDO and non-SUDO mode.

Summary:
Fixes #16270 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
Replacing dut.shell with dut.command to clear the counters in both SUDO and non-SUDO mode.

#### How did you do it?
Replaced dut.shell with dut.command.

#### How did you verify/test it?
Local clone.

```
AzDevOps@68684a43ec9e:/data/tests$ date;python3 -m pytest --inventory ../ansible/ixia-sonic --host-pattern ixre-egl-board71,ixre-egl-board72 --testbed ixre-chassis17-t2 --testbed_file ../ansible/testbed.csv --log-cli-level info --log-file-level info --kube_master unset --showlocals -ra --show-capture stdout --junit-xml=/tmp/test.xml --skip_sanity --log-file=/tmp/test.log  --topology multidut-tgen --cache-clear --disable_loganalyzer snappi_tests/pfc/test_pfc_no_congestion_throughput.py -k test_multiple_prio_diff_dist
snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_multiple_prio_diff_dist[multidut_port_info0-port_map0] 
19:31:48 test_pfc_no_congestion_throughput.test_m L0096 INFO   | Running test for testbed subtype: multi-dut-single-asic
19:31:51 snappi_fixtures.__intf_config_multidut   L0933 INFO   | Configuring Dut: ixre-egl-board71 with port Ethernet0 with IP 20.10.1.2/31
19:31:52 snappi_fixtures.__intf_config_multidut   L0933 INFO   | Configuring Dut: ixre-egl-board72 with port Ethernet0 with IP 20.10.1.0/31
19:31:53 test_pfc_no_congestion_throughput.test_m L0129 INFO   | Selected lossless :[3, 4] and lossy priorities:[0, 2, 1] for the test
19:31:53 snappi_fixtures.clear_fabric_counters    L1504 INFO   | Clearing fabric counters for DUT:ixre-egl-board71
19:31:56 snappi_fixtures.clear_fabric_counters    L1504 INFO   | Clearing fabric counters for DUT:ixre-egl-board72
19:33:23 traffic_generation.run_traffic_and_colle L1026 INFO   | Clearing PFC, dropcounters, queuecounters and stats
PASSED                                                                                                                                                                                                          [ 33%]
snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_multiple_prio_diff_dist[multidut_port_info1-port_map0] 
19:40:41 test_pfc_no_congestion_throughput.test_m L0096 INFO   | Running test for testbed subtype: single-dut-multi-asic
19:40:44 snappi_fixtures.__intf_config_multidut   L0933 INFO   | Configuring Dut: ixre-egl-board71 with port Ethernet8 with IP 20.10.1.0/31
19:40:46 snappi_fixtures.__intf_config_multidut   L0933 INFO   | Configuring Dut: ixre-egl-board71 with port Ethernet152 with IP 20.10.1.2/31
19:40:47 test_pfc_no_congestion_throughput.test_m L0129 INFO   | Selected lossless :[3, 4] and lossy priorities:[6, 1, 5] for the test
19:40:47 snappi_fixtures.clear_fabric_counters    L1504 INFO   | Clearing fabric counters for DUT:ixre-egl-board71
19:40:49 snappi_fixtures.clear_fabric_counters    L1504 INFO   | Clearing fabric counters for DUT:ixre-egl-board72
19:42:00 traffic_generation.run_traffic_and_colle L1026 INFO   | Clearing PFC, dropcounters, queuecounters and stats
PASSED                                                                                                                                                                                                          [ 66%]
snappi_tests/pfc/test_pfc_no_congestion_throughput.py::test_multiple_prio_diff_dist[multidut_port_info2-port_map0] 
19:49:13 test_pfc_no_congestion_throughput.test_m L0096 INFO   | Running test for testbed subtype: single-dut-single-asic
19:49:16 snappi_fixtures.__intf_config_multidut   L0933 INFO   | Configuring Dut: ixre-egl-board72 with port Ethernet8 with IP 20.10.1.0/31
19:49:18 snappi_fixtures.__intf_config_multidut   L0933 INFO   | Configuring Dut: ixre-egl-board72 with port Ethernet16 with IP 20.10.1.2/31
19:49:19 test_pfc_no_congestion_throughput.test_m L0129 INFO   | Selected lossless :[3, 4] and lossy priorities:[2, 6, 0] for the test
19:49:19 snappi_fixtures.clear_fabric_counters    L1504 INFO   | Clearing fabric counters for DUT:ixre-egl-board71
19:49:21 snappi_fixtures.clear_fabric_counters    L1504 INFO   | Clearing fabric counters for DUT:ixre-egl-board72
19:50:32 traffic_generation.run_traffic_and_colle L1026 INFO   | Clearing PFC, dropcounters, queuecounters and stats
PASSED                                                                                                                                                                                                          [100%]
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
