### PR TITLE
Skip `test_advanced_reboot.py` in PR testing. 

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1034,11 +1034,12 @@ platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset:
 #######################################
 platform_tests/test_advanced_reboot.py:
   skip:
-    reason: "Unsupported platform"
+    reason: "Unsupported platform / Skip in PR testing as taking too much time."
     conditions_logical_operator: or
     conditions:
       - "platform in ['x86_64-arista_7050_qx32s']"
       - "'dualtor' in topo_name and release in ['202012']"
+      - "asic_type in ['vs']"
 
 platform_tests/test_advanced_reboot.py::test_fast_reboot_from_other_vendor:
   skip:
@@ -1048,6 +1049,12 @@ platform_tests/test_advanced_reboot.py::test_fast_reboot_from_other_vendor:
       - "https://github.com/sonic-net/sonic-mgmt/issues/11007"
       - "platform in ['x86_64-arista_7050_qx32s']"
       - "'dualtor' in topo_name and release in ['202012']"
+
+platform_tests/test_advanced_reboot.py::test_warm_reboot:
+  skip:
+    reason: "Skip in PR testing as taking too much time."
+    conditions:
+      - "asic_type in ['vs'] and 't0' not in topo_name"
 
 #######################################
 #####   test_cont_warm_reboot.py  #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The script `test_advanced_reboot.py` has an extensive runtime in PR testing. To optimize efficiency, we will skip this script during PR testing, except for the `test_warm_reboot` test case on the T0 topology in consistency with original PR testing. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
The script `test_advanced_reboot.py` has an extensive runtime in PR testing. To optimize efficiency, we will skip this script during PR testing, except for the `test_warm_reboot` test case on the T0 topology in consistency with original PR testing. 

#### How did you do it?
Skip `test_advanced_reboot.py` except for the `test_warm_reboot` test case on the T0 topology using conditional mark. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
