### PR TITLE
[snappi]: Remove references of 'sudo ip netns exec asic' for ECN configuration in common_helpers file

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -500,9 +500,9 @@ def config_wred(host_ans, kmin, kmax, pmax, kdrop=None, profile=None, asic_value
         kdrop_cmd = ' '.join(['sudo ecnconfig -p {}', kdrop_arg, '{}'])
 
         if asic_value is not None:
-            kmax_cmd = ' '.join(['sudo ip netns exec', asic_value, 'ecnconfig -p {}', kmax_arg, '{}'])
-            kmin_cmd = ' '.join(['sudo ip netns exec', asic_value, 'ecnconfig -p {}', kmin_arg, '{}'])
-            kdrop_cmd = ' '.join(['sudo ip netns exec', asic_value, 'ecnconfig -p {}', kdrop_arg, '{}'])
+            kmax_cmd = ' '.join(['sudo ecnconfig -n', asic_value, '-p {}', kmax_arg, '{}'])
+            kmin_cmd = ' '.join(['sudo ecnconfig -n', asic_value, '-p {}', kmin_arg, '{}'])
+            kdrop_cmd = ' '.join(['sudo ecnconfig -n', asic_value, '-p {}', kdrop_arg, '{}'])
             if asic_type == 'broadcom':
                 disable_packet_aging(host_ans, asic_value)
 
@@ -537,8 +537,8 @@ def enable_ecn(host_ans, prio, asic_value=None):
         if re.search("queue {}: on".format(prio), results['stdout']):
             return True
     else:
-        host_ans.shell('sudo ip netns exec {} ecnconfig -q {} on'.format(asic_value, prio))
-        results = host_ans.shell('sudo ip netns exec {} ecnconfig -q {}'.format(asic_value, prio))
+        host_ans.shell('sudo ecnconfig -n {} -q {} on'.format(asic_value, prio))
+        results = host_ans.shell('sudo ecnconfig -n {} -q {}'.format(asic_value, prio))
         if re.search("queue {}: on".format(prio), results['stdout']):
             return True
     return False
@@ -560,7 +560,7 @@ def disable_ecn(host_ans, prio, asic_value=None):
         host_ans.shell('sudo ecnconfig -q {} off'.format(prio))
     else:
         asic_type = str(host_ans.facts["asic_type"])
-        host_ans.shell('sudo ip netns exec {} ecnconfig -q {} off'.format(asic_value, prio))
+        host_ans.shell('sudo ecnconfig -n {} -q {} off'.format(asic_value, prio))
         if asic_type == 'broadcom':
             enable_packet_aging(host_ans, asic_value)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The ECN configuration commands still used 'sudo ip netns exec asicX' command to check and configure the ECN. 

In 202405, there were changes done to fix the ECN configuration CLIs and hence the above needs to modified.

The correct way to reference ECN configuration is : sudo ecnconfig -n asicX - to check and configure ECN on SONIC DUTs.

Fixes # (issue)
#16304 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
The use of 'sudo ip netns exec asic' to check and configure ECN fails in 2405 release. With new changes, the ecnconfig -n asic - will be required to check and change ECN configuration.


#### How did you do it?
All changes are done in tests/common/snappi_tests/common_helpers.py:
1. For enable_ecn and disable_ecn functions, changed the reference from - sudo ip netns exec asic - to - sudo ecnconfig -n asic.
2. For config_wred function, changed kmax_cmd, kmin_cmd and kdrop_cmd to use - sudo ecnconfig -n instead of - sudo ip netns exec asic.

#### How did you verify/test it?
Verification logs:

1. Running the ECN test with specific Kmin, Kmax and Pmax values set.

Test is setting Kmin, Kmax and Pmax to 800k, 2000k and 25 respectively.
It is enabling ECN configuration for Priority#3.

```
---------------------------------------------------------------------------------------------------- live log call ----------------------------------------------------------------------------------------------------
18:34:45 test_multidut_dequeue_ecn_brcm_dnx.test_ L0101 INFO   | Running test for testbed subtype: multi-dut-single-asic
18:34:48 snappi_fixtures.__intf_config_multidut   L0933 INFO   | Configuring Dut: ixre-egl-board73 with port Ethernet8 with IP 20.10.1.0/31
18:34:49 snappi_fixtures.__intf_config_multidut   L0933 INFO   | Configuring Dut: ixre-egl-board74 with port Ethernet0 with IP 20.10.1.2/31
18:34:51 test_multidut_dequeue_ecn_brcm_dnx.test_ L0111 INFO   | Selected lossless priority:3
18:34:51 test_multidut_dequeue_ecn_brcm_dnx.test_ L0131 INFO   | Selecting different Kmin, Kmax and Pmax for DNX based platform
18:34:51 test_multidut_dequeue_ecn_brcm_dnx.test_ L0137 INFO   | Running ECN dequeue test with params: {'kmin': 800000, 'kmax': 2000000, 'pmax': 25} and 800 packets
18:34:51 restpy_multidut_helper.run_ecn_test      L0068 INFO   | Stopping PFC watchdog
18:34:52 restpy_multidut_helper.run_ecn_test      L0072 INFO   | Disabling packet aging if necessary
18:34:56 restpy_multidut_helper.run_ecn_test      L0077 INFO   | Configuring WRED and ECN thresholds

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB set_trace (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /data/tests/snappi_tests/multidut/ecn/files/restpy_multidut_helper.py(80)run_ecn_test()
-> if (not default_ecn):
```

3. Checking the ECN configuration before the test:
On board#74
```
admin@ixre-egl-board74:~$ date; sudo ecnconfig -n asic0 -l
Thu Jan  2 06:35:17 PM UTC 2025
Profile: AZURE_LOSSLESS
-----------------------  --------
ecn                      ecn_all
green_drop_probability   5
green_max_threshold      10000000
green_min_threshold      2000000
red_drop_probability     5
red_max_threshold        10000000
red_min_threshold        2000000
wred_green_enable        true
wred_red_enable          true
wred_yellow_enable       true
yellow_drop_probability  5
yellow_max_threshold     10000000
yellow_min_threshold     2000000
-----------------------  --------
```

On board#73:
```
admin@ixre-egl-board73:~$ date; sudo ecnconfig -n asic0 -l
Thu Jan  2 06:36:12 PM UTC 2025
Profile: AZURE_LOSSLESS
-----------------------  --------
ecn                      ecn_all
green_drop_probability   5
green_max_threshold      10000000
green_min_threshold      2000000
red_drop_probability     5
red_max_threshold        10000000
red_min_threshold        2000000
wred_green_enable        true
wred_red_enable          true
wred_yellow_enable       true
yellow_drop_probability  5
yellow_max_threshold     10000000
yellow_min_threshold     2000000
-----------------------  --------
```

4. Setting the ECN configuration and checking the values:
On board#73:
```
admin@ixre-egl-board73:~$ date; sudo ecnconfig -n asic0 -l
Thu Jan  2 06:36:58 PM UTC 2025
Profile: AZURE_LOSSLESS
-----------------------  --------
ecn                      ecn_all
green_drop_probability   5
green_max_threshold      10000000
green_min_threshold      2000000
red_drop_probability     25
red_max_threshold        2000000
red_min_threshold        800000
wred_green_enable        true
wred_red_enable          true
wred_yellow_enable       true
yellow_drop_probability  5
yellow_max_threshold     10000000
yellow_min_threshold     2000000
-----------------------  --------

```
On board#74:
```
admin@ixre-egl-board74:~$ date; sudo ecnconfig -n asic0 -l
Thu Jan  2 06:37:06 PM UTC 2025
Profile: AZURE_LOSSLESS
-----------------------  --------
ecn                      ecn_all
green_drop_probability   5
green_max_threshold      10000000
green_min_threshold      2000000
red_drop_probability     25
red_max_threshold        2000000
red_min_threshold        800000
wred_green_enable        true
wred_red_enable          true
wred_yellow_enable       true
yellow_drop_probability  5
yellow_max_threshold     10000000
yellow_min_threshold     2000000
-----------------------  --------

```
5. Setting the queue for priority 3 on both board#73 and board#74:
Before the test:
```

admin@ixre-egl-board74:~$ ### modifying the queue configuration
admin@ixre-egl-board74:~$ date; sudo ecnconfig -n asic0 -q 4
Thu Jan  2 06:37:50 PM UTC 2025
ECN status for namespace asic0:
queue 4: off
admin@ixre-egl-board74:~$ date; sudo ecnconfig -n asic0 -q 3
Thu Jan  2 06:38:11 PM UTC 2025
ECN status for namespace asic0:
queue 3: off

admin@ixre-egl-board73:~$ date; sudo ecnconfig -n asic0 -q 4
Thu Jan  2 06:38:01 PM UTC 2025
ECN status for namespace asic0:
queue 4: off
admin@ixre-egl-board73:~$ date; sudo ecnconfig -n asic0 -q 3
Thu Jan  2 06:38:07 PM UTC 2025
ECN status for namespace asic0:
queue 3: off

```

Test:
```
> /data/tests/snappi_tests/multidut/ecn/files/restpy_multidut_helper.py(80)run_ecn_test()
-> if (not default_ecn):
(Pdb) c

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB continue (IO-capturing resumed) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB set_trace (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /data/tests/snappi_tests/multidut/ecn/files/restpy_multidut_helper.py(99)run_ecn_test()
-> logger.info("Enabling ECN markings")
(Pdb) c
```


After the test:
```
admin@ixre-egl-board73:~$ date; sudo ecnconfig -n asic0 -q 4
Thu Jan  2 06:38:29 PM UTC 2025
ECN status for namespace asic0:
queue 4: off
admin@ixre-egl-board73:~$ date; sudo ecnconfig -n asic0 -q 3
Thu Jan  2 06:38:32 PM UTC 2025
ECN status for namespace asic0:
queue 3: on

admin@ixre-egl-board74:~$ date; sudo ecnconfig -n asic0 -q 4
Thu Jan  2 06:38:36 PM UTC 2025
ECN status for namespace asic0:
queue 4: off
admin@ixre-egl-board74:~$ date; sudo ecnconfig -n asic0 -q 3
Thu Jan  2 06:38:38 PM UTC 2025
ECN status for namespace asic0:
queue 3: on

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
