### PR TITLE
[Chassis][T2]: Reduce traffic-shift TSA/TSB tests runtime

### DIFF
--- a/tests/bgp/route_checker.py
+++ b/tests/bgp/route_checker.py
@@ -141,12 +141,12 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver, exp_community=[]):
             results[hostname] = routes
     try:
         all_routes = parallel_run(parse_routes_process, (), {}, list(
-            neigh_hosts.values()), timeout=240, concurrent_tasks=8)
+            neigh_hosts.values()), timeout=240, concurrent_tasks=12)
     except BaseException as err:
         logger.error(
             'Failed to get routes info from VMs. Got error: {}\n\nTrying one more time.'.format(err))
         all_routes = parallel_run(parse_routes_process, (), {}, list(
-            neigh_hosts.values()), timeout=240, concurrent_tasks=8)
+            neigh_hosts.values()), timeout=240, concurrent_tasks=12)
     return all_routes
 
 
@@ -193,7 +193,7 @@ def parse_routes_on_vsonic(dut_host, neigh_hosts, ip_ver):
         results[hostname] = routes
 
     all_routes = parallel_run(parse_routes_process_vsonic, (), {}, list(neigh_hosts.values()),
-                              timeout=120, concurrent_tasks=8)
+                              timeout=120, concurrent_tasks=12)
     return all_routes
 
 

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -175,14 +175,14 @@ def check_ssh_state(localhost, dut_ip, expected_state, timeout=60):
 
 
 @pytest.mark.disable_loganalyzer
-def test_tsa_tsb_service_with_dut_cold_reboot(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
+def test_tsa_tsb_service_with_dut_cold_reboot(duthosts, localhost, rand_one_dut_front_end_hostname, ptfhost,
                                               nbrhosts, traffic_shift_community, tbinfo):
     """
     Test startup TSA_TSB service after DUT cold reboot
     Verify startup_tsa_tsb.service started automatically when dut comes up
     Verify this service configures TSA and starts a timer and configures TSB once the timer is expired
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     tsa_tsb_timer = get_startup_tsb_timer(duthost)
     int_status_result, crit_process_check = True, True
     if not tsa_tsb_timer:
@@ -278,14 +278,14 @@ def test_tsa_tsb_service_with_dut_cold_reboot(duthosts, localhost, enum_rand_one
 
 
 @pytest.mark.disable_loganalyzer
-def test_tsa_tsb_service_with_dut_abnormal_reboot(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname,
+def test_tsa_tsb_service_with_dut_abnormal_reboot(duthosts, localhost, rand_one_dut_front_end_hostname,
                                                   ptfhost, nbrhosts, traffic_shift_community, tbinfo):
     """
     Test startup TSA_TSB service after DUT abnormal reboot/crash
     Verify startup_tsa_tsb.service started automatically when dut comes up after crash
     Verify this service configures TSA and starts a timer and configures TSB once the timer is expired
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     tsa_tsb_timer = get_startup_tsb_timer(duthost)
     int_status_result, crit_process_check = True, True
     if not tsa_tsb_timer:
@@ -701,7 +701,7 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
 
 
 @pytest.mark.disable_loganalyzer
-def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
+def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, rand_one_dut_front_end_hostname, ptfhost,
                                             nbrhosts, traffic_shift_community, tbinfo):
     """
     Initially, User initiates TSA on the DUT and saves the config on DUT.
@@ -709,7 +709,7 @@ def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, enum_rand_one_p
     Verify startup_tsa_tsb.service starts automatically when dut comes up
     Verify this service doesn't configure another TSA and retains the existing TSA config on DUT
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     tsa_tsb_timer = get_startup_tsb_timer(duthost)
     if not tsa_tsb_timer:
         pytest.skip("startup_tsa_tsb.service is not supported on the {}".format(duthost.hostname))
@@ -806,7 +806,7 @@ def test_tsa_tsb_service_with_user_init_tsa(duthosts, localhost, enum_rand_one_p
 
 
 @pytest.mark.disable_loganalyzer
-def test_user_init_tsa_while_service_run_on_dut(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
+def test_user_init_tsa_while_service_run_on_dut(duthosts, localhost, rand_one_dut_front_end_hostname, ptfhost,
                                                 nbrhosts, traffic_shift_community, tbinfo):
 
     """
@@ -816,7 +816,7 @@ def test_user_init_tsa_while_service_run_on_dut(duthosts, localhost, enum_rand_o
     Issue TSA while the service is running on dut, and make sure the TSA is configured
     Make sure TSA_TSB service is stopped and dut continues to be in maintenance mode
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     tsa_tsb_timer = get_startup_tsb_timer(duthost)
     int_status_result, crit_process_check = True, True
     if not tsa_tsb_timer:
@@ -923,7 +923,7 @@ def test_user_init_tsa_while_service_run_on_dut(duthosts, localhost, enum_rand_o
 
 
 @pytest.mark.disable_loganalyzer
-def test_user_init_tsb_while_service_run_on_dut(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
+def test_user_init_tsb_while_service_run_on_dut(duthosts, localhost, rand_one_dut_front_end_hostname, ptfhost,
                                                 nbrhosts, traffic_shift_community, tbinfo):
 
     """
@@ -933,7 +933,7 @@ def test_user_init_tsb_while_service_run_on_dut(duthosts, localhost, enum_rand_o
     Issue TSB while the service is running on dut, and make sure the TSB is configured
     Make sure TSA_TSB service is stopped and dut continues to be in normal mode
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     tsa_tsb_timer = get_startup_tsb_timer(duthost)
     int_status_result, crit_process_check = True, True
     if not tsa_tsb_timer:
@@ -1170,14 +1170,14 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost,
 
 
 @pytest.mark.disable_loganalyzer
-def test_tsa_tsb_timer_efficiency(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
+def test_tsa_tsb_timer_efficiency(duthosts, localhost, rand_one_dut_front_end_hostname, ptfhost,
                                   nbrhosts, traffic_shift_community, tbinfo):
     """
     Test startup TSA_TSB service after DUT cold reboot
     Verify the configured tsa_tsb_timer is sufficient for system to be stable
     Verify this service configures TSA and starts a timer and configures TSB once the timer is expired
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     tsa_tsb_timer = get_startup_tsb_timer(duthost)
     int_status_result, crit_process_check = True, True
     if not tsa_tsb_timer:

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def nbrhosts_to_dut(duthosts, rand_one_dut_front_end_hostname, nbrhosts):
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+def nbrhosts_to_dut(duthosts, enum_rand_one_per_hwsku_frontend_hostname, nbrhosts):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
     nbrhosts_to_dut = {}
     for host in list(nbrhosts.keys()):
@@ -63,13 +63,13 @@ def verify_all_routes_announce_to_neighs(dut_host, neigh_hosts, routes_dut, ip_v
     return True
 
 
-def test_TSA(duthosts, rand_one_dut_front_end_hostname, ptfhost,
+def test_TSA(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
              nbrhosts_to_dut, bgpmon_setup_teardown, traffic_shift_community, tbinfo):
     """
     Test TSA
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
     """
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     # Initially make sure both supervisor and line cards are in BGP operational normal state
     if tbinfo['topo']['type'] == 't2':
         initial_tsa_check_before_and_after_test(duthosts)
@@ -99,13 +99,13 @@ def test_TSA(duthosts, rand_one_dut_front_end_hostname, ptfhost,
             initial_tsa_check_before_and_after_test(duthosts)
 
 
-def test_TSB(duthosts, rand_one_dut_front_end_hostname, ptfhost, nbrhosts, bgpmon_setup_teardown, tbinfo):
+def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts, bgpmon_setup_teardown, tbinfo):
     """
     Test TSB.
     Establish BGP session between PTF and DUT, and verify all routes are announced to bgp monitor,
     and all routes are announced to neighbors
     """
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     # Initially make sure both supervisor and line cards are in BGP operational normal state
     if tbinfo['topo']['type'] == 't2':
         initial_tsa_check_before_and_after_test(duthosts)
@@ -147,12 +147,12 @@ def test_TSB(duthosts, rand_one_dut_front_end_hostname, ptfhost, nbrhosts, bgpmo
         initial_tsa_check_before_and_after_test(duthosts)
 
 
-def test_TSA_B_C_with_no_neighbors(duthosts, rand_one_dut_front_end_hostname,
+def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                                    bgpmon_setup_teardown, nbrhosts, core_dump_and_config_check, tbinfo):
     """
     Test TSA, TSB, TSC with no neighbors on ASIC0 in case of multi-asic and single-asic.
     """
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     bgp_neighbors = {}
     duts_data = core_dump_and_config_check
     asic_index = 0 if duthost.is_multi_asic else DEFAULT_ASIC_ID
@@ -217,13 +217,13 @@ def test_TSA_B_C_with_no_neighbors(duthosts, rand_one_dut_front_end_hostname,
 
 
 @pytest.mark.disable_loganalyzer
-def test_TSA_TSB_with_config_reload(duthosts, rand_one_dut_front_end_hostname, ptfhost, nbrhosts,
+def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts,
                                     nbrhosts_to_dut, bgpmon_setup_teardown, traffic_shift_community, tbinfo):
     """
     Test TSA after config save and config reload
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
     """
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     # Initially make sure both supervisor and line cards are in BGP operational normal state
     if tbinfo['topo']['type'] == 't2':
         initial_tsa_check_before_and_after_test(duthosts)
@@ -286,14 +286,14 @@ def test_TSA_TSB_with_config_reload(duthosts, rand_one_dut_front_end_hostname, p
 
 
 @pytest.mark.disable_loganalyzer
-def test_load_minigraph_with_traffic_shift_away(duthosts, rand_one_dut_front_end_hostname,
+def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                                                 ptfhost, nbrhosts, nbrhosts_to_dut, bgpmon_setup_teardown,
                                                 traffic_shift_community, tbinfo):
     """
     Test load_minigraph --traffic-shift-away
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
     """
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     # Initially make sure both supervisor and line cards are in BGP operational normal state
     if tbinfo['topo']['type'] == 't2':
         initial_tsa_check_before_and_after_test(duthosts)

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def nbrhosts_to_dut(duthosts, enum_rand_one_per_hwsku_frontend_hostname, nbrhosts):
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+def nbrhosts_to_dut(duthosts, rand_one_dut_front_end_hostname, nbrhosts):
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
     nbrhosts_to_dut = {}
     for host in list(nbrhosts.keys()):
@@ -63,13 +63,13 @@ def verify_all_routes_announce_to_neighs(dut_host, neigh_hosts, routes_dut, ip_v
     return True
 
 
-def test_TSA(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
+def test_TSA(duthosts, rand_one_dut_front_end_hostname, ptfhost,
              nbrhosts_to_dut, bgpmon_setup_teardown, traffic_shift_community, tbinfo):
     """
     Test TSA
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     # Initially make sure both supervisor and line cards are in BGP operational normal state
     if tbinfo['topo']['type'] == 't2':
         initial_tsa_check_before_and_after_test(duthosts)
@@ -99,13 +99,13 @@ def test_TSA(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
             initial_tsa_check_before_and_after_test(duthosts)
 
 
-def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts, bgpmon_setup_teardown, tbinfo):
+def test_TSB(duthosts, rand_one_dut_front_end_hostname, ptfhost, nbrhosts, bgpmon_setup_teardown, tbinfo):
     """
     Test TSB.
     Establish BGP session between PTF and DUT, and verify all routes are announced to bgp monitor,
     and all routes are announced to neighbors
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     # Initially make sure both supervisor and line cards are in BGP operational normal state
     if tbinfo['topo']['type'] == 't2':
         initial_tsa_check_before_and_after_test(duthosts)
@@ -147,12 +147,12 @@ def test_TSB(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrho
         initial_tsa_check_before_and_after_test(duthosts)
 
 
-def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+def test_TSA_B_C_with_no_neighbors(duthosts, rand_one_dut_front_end_hostname,
                                    bgpmon_setup_teardown, nbrhosts, core_dump_and_config_check, tbinfo):
     """
     Test TSA, TSB, TSC with no neighbors on ASIC0 in case of multi-asic and single-asic.
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     bgp_neighbors = {}
     duts_data = core_dump_and_config_check
     asic_index = 0 if duthost.is_multi_asic else DEFAULT_ASIC_ID
@@ -217,13 +217,13 @@ def test_TSA_B_C_with_no_neighbors(duthosts, enum_rand_one_per_hwsku_frontend_ho
 
 
 @pytest.mark.disable_loganalyzer
-def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, nbrhosts,
+def test_TSA_TSB_with_config_reload(duthosts, rand_one_dut_front_end_hostname, ptfhost, nbrhosts,
                                     nbrhosts_to_dut, bgpmon_setup_teardown, traffic_shift_community, tbinfo):
     """
     Test TSA after config save and config reload
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     # Initially make sure both supervisor and line cards are in BGP operational normal state
     if tbinfo['topo']['type'] == 't2':
         initial_tsa_check_before_and_after_test(duthosts)
@@ -286,14 +286,14 @@ def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
 
 
 @pytest.mark.disable_loganalyzer
-def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+def test_load_minigraph_with_traffic_shift_away(duthosts, rand_one_dut_front_end_hostname,
                                                 ptfhost, nbrhosts, nbrhosts_to_dut, bgpmon_setup_teardown,
                                                 traffic_shift_community, tbinfo):
     """
     Test load_minigraph --traffic-shift-away
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     # Initially make sure both supervisor and line cards are in BGP operational normal state
     if tbinfo['topo']['type'] == 't2':
         initial_tsa_check_before_and_after_test(duthosts)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR helps to reduce the runtime of TSA/TSB tests on T2 chassis and attempts to fix issue #15830 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

- Traffic shift test cases of BGP test suite takes longer time for execution as it involves reboot of line cards or supervisor which in turn makes the tests verification mandatory for processes, neighbors, routes, tsa-tsb-service etc. before and after test case execution.
- These lead to generate lots of log for BGP traffic shift test cases, which are difficult for analysis.

#### How did you do it?

- Instead of executing tests on each of the line card under supervisor of different HwSKU, **choose a random line card** of any HwSKU for each test.
- Increase the concurrent parallel tasks from 8 to 12 for parsing the routes.

#### How did you verify/test it?

- From what I have observed, this reduces the test run time by half without compromising the functionality check.
- Increasing the route processing tasks from 8 to 12, reduced test case execution time by 4 minutes for each test case.

For example,
```
Before these changes: Startup TSA test suite - 488.72 minutes - 8.15 hrs
After these changes:  Startup TSA test suite - 234.51 minutes - 3.9 hrs
```

Reliable-TSA tests deal with supervisor card, hence these changes are not effective on them.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
![image](https://github.com/user-attachments/assets/ac9f8eeb-1eb8-458b-b4d8-43f337232cdf)
