### PR TITLE
16079 to 202411: T2:snappi_tests: Increase the number of background flows for cisco-8000 to 10.

### DIFF
--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
@@ -5,7 +5,6 @@
 # Compiled at: 2023-02-10 09:15:26
 from math import ceil                                                                                # noqa: F401
 import logging                                                                                       # noqa: F401
-import random
 from tests.common.helpers.assertions import pytest_assert, pytest_require                            # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts              # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                                 # noqa: F401
@@ -30,6 +29,7 @@ DATA_FLOW_DELAY_SEC = 0
 SNAPPI_POLL_DELAY_SEC = 2
 PAUSE_FLOW_RATE = 15
 PAUSE_FLOW_NAME = 'PFC Traffic'
+UDP_PORT_START = 5000
 
 
 def run_lossless_response_to_external_pause_storms_test(api,
@@ -100,6 +100,9 @@ def run_lossless_response_to_external_pause_storms_test(api,
 
     test_flow_rate_percent = int(TEST_FLOW_AGGR_RATE_PERCENT)
     bg_flow_rate_percent = int(BG_FLOW_AGGR_RATE_PERCENT)
+    no_of_bg_streams = 1
+    if duthost.facts['asic_type'] == "cisco-8000":
+        no_of_bg_streams = 10
     port_id = 0
 
     # Generate base traffic config
@@ -122,7 +125,8 @@ def run_lossless_response_to_external_pause_storms_test(api,
                   bg_flow_rate_percent=bg_flow_rate_percent,
                   data_flow_dur_sec=DATA_FLOW_DURATION_SEC,
                   data_pkt_size=DATA_PKT_SIZE,
-                  prio_dscp_map=prio_dscp_map)
+                  prio_dscp_map=prio_dscp_map,
+                  no_of_bg_streams=no_of_bg_streams)
 
     flows = testbed_config.flows
     all_flow_names = [flow.name for flow in flows]
@@ -176,7 +180,8 @@ def __gen_traffic(testbed_config,
                   bg_flow_rate_percent,
                   data_flow_dur_sec,
                   data_pkt_size,
-                  prio_dscp_map):
+                  prio_dscp_map,
+                  no_of_bg_streams):
     """
     Generate configurations of flows under all to all traffic pattern, including
     test flows, background flows and pause storm. Test flows and background flows
@@ -211,7 +216,8 @@ def __gen_traffic(testbed_config,
                      flow_rate_percent=test_flow_rate_percent,
                      flow_dur_sec=data_flow_dur_sec,
                      data_pkt_size=data_pkt_size,
-                     prio_dscp_map=prio_dscp_map)
+                     prio_dscp_map=prio_dscp_map,
+                     no_of_streams=1)
 
     __gen_data_flows(testbed_config=testbed_config,
                      port_config_list=port_config_list,
@@ -222,7 +228,8 @@ def __gen_traffic(testbed_config,
                      flow_rate_percent=bg_flow_rate_percent,
                      flow_dur_sec=data_flow_dur_sec,
                      data_pkt_size=data_pkt_size,
-                     prio_dscp_map=prio_dscp_map)
+                     prio_dscp_map=prio_dscp_map,
+                     no_of_streams=no_of_bg_streams)
 
     __gen_data_flows(testbed_config=testbed_config,
                      port_config_list=port_config_list,
@@ -245,7 +252,8 @@ def __gen_data_flows(testbed_config,
                      flow_rate_percent,
                      flow_dur_sec,
                      data_pkt_size,
-                     prio_dscp_map):
+                     prio_dscp_map,
+                     no_of_streams=1):
     """
     Generate the configuration for data flows
 
@@ -278,7 +286,8 @@ def __gen_data_flows(testbed_config,
                                 flow_rate_percent=flow_rate_percent,
                                 flow_dur_sec=flow_dur_sec,
                                 data_pkt_size=data_pkt_size,
-                                prio_dscp_map=prio_dscp_map)
+                                prio_dscp_map=prio_dscp_map,
+                                no_of_streams=no_of_streams)
     else:
         __gen_data_flow(testbed_config=testbed_config,
                         port_config_list=port_config_list,
@@ -301,7 +310,8 @@ def __gen_data_flow(testbed_config,
                     flow_rate_percent,
                     flow_dur_sec,
                     data_pkt_size,
-                    prio_dscp_map):
+                    prio_dscp_map,
+                    no_of_streams=1):
     """
     Generate the configuration for a data flow
 
@@ -333,10 +343,11 @@ def __gen_data_flow(testbed_config,
         flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
         flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
         eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-        src_port = random.randint(5000, 6000)
+        global UDP_PORT_START
+        src_port = UDP_PORT_START + no_of_streams
         udp.src_port.increment.start = src_port
         udp.src_port.increment.step = 1
-        udp.src_port.increment.count = 1
+        udp.src_port.increment.count = no_of_streams
 
         eth.src.value = tx_mac
         eth.dst.value = rx_mac

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
@@ -5,7 +5,6 @@
 # Compiled at: 2023-02-10 09:15:26
 from math import ceil                                                                                      # noqa: F401
 import logging                                                                                             # noqa: F401
-import random
 from tests.common.helpers.assertions import pytest_assert, pytest_require                                  # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts                    # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                                       # noqa: F401
@@ -34,6 +33,7 @@ SNAPPI_POLL_DELAY_SEC = 2
 TOLERANCE_THRESHOLD = 0.05
 PAUSE_FLOW_DURATION_SEC = 5
 PAUSE_FLOW_DELAY_SEC = 5
+UDP_PORT_START = 5000
 
 
 def run_lossless_response_to_throttling_pause_storms_test(api,
@@ -107,6 +107,9 @@ def run_lossless_response_to_throttling_pause_storms_test(api,
 
     test_flow_rate_percent = int(TEST_FLOW_AGGR_RATE_PERCENT)
     bg_flow_rate_percent = int(BG_FLOW_AGGR_RATE_PERCENT)
+    no_of_bg_streams = 1
+    if duthost.facts['asic_type'] == "cisco-8000":
+        no_of_bg_streams = 10
     port_id = 0
 
     # Generate base traffic config
@@ -129,7 +132,8 @@ def run_lossless_response_to_throttling_pause_storms_test(api,
                   bg_flow_rate_percent=bg_flow_rate_percent,
                   data_flow_dur_sec=DATA_FLOW_DURATION_SEC,
                   data_pkt_size=DATA_PKT_SIZE,
-                  prio_dscp_map=prio_dscp_map)
+                  prio_dscp_map=prio_dscp_map,
+                  no_of_bg_streams=no_of_bg_streams)
 
     flows = testbed_config.flows
     all_flow_names = [flow.name for flow in flows]
@@ -184,7 +188,8 @@ def __gen_traffic(testbed_config,
                   bg_flow_rate_percent,
                   data_flow_dur_sec,
                   data_pkt_size,
-                  prio_dscp_map):
+                  prio_dscp_map,
+                  no_of_bg_streams):
     """
     Generate configurations of flows under all to all traffic pattern, including
     test flows, background flows and pause storm. Test flows and background flows
@@ -219,7 +224,8 @@ def __gen_traffic(testbed_config,
                      flow_rate_percent=test_flow_rate_percent,
                      flow_dur_sec=data_flow_dur_sec,
                      data_pkt_size=data_pkt_size,
-                     prio_dscp_map=prio_dscp_map)
+                     prio_dscp_map=prio_dscp_map,
+                     no_of_streams=1)
 
     __gen_data_flows(testbed_config=testbed_config,
                      port_config_list=port_config_list,
@@ -230,7 +236,8 @@ def __gen_traffic(testbed_config,
                      flow_rate_percent=bg_flow_rate_percent,
                      flow_dur_sec=data_flow_dur_sec,
                      data_pkt_size=data_pkt_size,
-                     prio_dscp_map=prio_dscp_map)
+                     prio_dscp_map=prio_dscp_map,
+                     no_of_streams=no_of_bg_streams)
 
     __gen_data_flows(testbed_config=testbed_config,
                      port_config_list=port_config_list,
@@ -241,7 +248,8 @@ def __gen_traffic(testbed_config,
                      flow_rate_percent=pause_flow_rate,
                      flow_dur_sec=data_flow_dur_sec,
                      data_pkt_size=data_pkt_size,
-                     prio_dscp_map=prio_dscp_map)
+                     prio_dscp_map=prio_dscp_map,
+                     no_of_streams=1)
 
 
 def __gen_data_flows(testbed_config,
@@ -253,7 +261,8 @@ def __gen_data_flows(testbed_config,
                      flow_rate_percent,
                      flow_dur_sec,
                      data_pkt_size,
-                     prio_dscp_map):
+                     prio_dscp_map,
+                     no_of_streams):
     """
     Generate the configuration for data flows
 
@@ -286,7 +295,8 @@ def __gen_data_flows(testbed_config,
                                 flow_rate_percent=flow_rate_percent,
                                 flow_dur_sec=flow_dur_sec,
                                 data_pkt_size=data_pkt_size,
-                                prio_dscp_map=prio_dscp_map)
+                                prio_dscp_map=prio_dscp_map,
+                                no_of_streams=no_of_streams)
     else:
         __gen_data_flow(testbed_config=testbed_config,
                         port_config_list=port_config_list,
@@ -309,7 +319,8 @@ def __gen_data_flow(testbed_config,
                     flow_rate_percent,
                     flow_dur_sec,
                     data_pkt_size,
-                    prio_dscp_map):
+                    prio_dscp_map,
+                    no_of_streams=1):
     """
     Generate the configuration for a data flow
 
@@ -341,10 +352,11 @@ def __gen_data_flow(testbed_config,
         flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
         flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
         eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-        src_port = random.randint(5000, 6000)
+        global UDP_PORT_START
+        src_port = UDP_PORT_START + no_of_streams
         udp.src_port.increment.start = src_port
         udp.src_port.increment.step = 1
-        udp.src_port.increment.count = 1
+        udp.src_port.increment.count = no_of_streams
 
         eth.src.value = tx_mac
         eth.dst.value = rx_mac

--- a/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -92,6 +92,9 @@ def run_m2o_fluctuating_lossless_test(api,
         stop_pfcwd(duthost, asic)
         disable_packet_aging(duthost)
 
+    no_of_bg_streams = 1
+    if duthost.facts['asic_type'] == "cisco-8000":
+        no_of_bg_streams = 10
     port_id = 0
     # Generate base traffic config
     snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,
@@ -111,7 +114,8 @@ def run_m2o_fluctuating_lossless_test(api,
                   bg_flow_rate_percent=BG_FLOW_AGGR_RATE_PERCENT,
                   data_flow_dur_sec=DATA_FLOW_DURATION_SEC,
                   data_pkt_size=DATA_PKT_SIZE,
-                  prio_dscp_map=prio_dscp_map)
+                  prio_dscp_map=prio_dscp_map,
+                  no_of_bg_streams=no_of_bg_streams)
 
     flows = testbed_config.flows
     all_flow_names = [flow.name for flow in flows]
@@ -161,7 +165,8 @@ def __gen_traffic(testbed_config,
                   bg_flow_rate_percent,
                   data_flow_dur_sec,
                   data_pkt_size,
-                  prio_dscp_map):
+                  prio_dscp_map,
+                  no_of_bg_streams):
     """
     Generate configurations of flows under all to all traffic pattern, including
     test flows, background flows and pause storm. Test flows and background flows
@@ -207,7 +212,8 @@ def __gen_traffic(testbed_config,
                      flow_rate_percent=BG_FLOW_AGGR_RATE_PERCENT,
                      flow_dur_sec=data_flow_dur_sec,
                      data_pkt_size=data_pkt_size,
-                     prio_dscp_map=prio_dscp_map)
+                     prio_dscp_map=prio_dscp_map,
+                     no_of_streams=no_of_bg_streams)
 
 
 def __gen_data_flows(testbed_config,
@@ -219,7 +225,8 @@ def __gen_data_flows(testbed_config,
                      flow_rate_percent,
                      flow_dur_sec,
                      data_pkt_size,
-                     prio_dscp_map):
+                     prio_dscp_map,
+                     no_of_streams=1):
     """
     Generate the configuration for data flows
 
@@ -253,7 +260,9 @@ def __gen_data_flows(testbed_config,
                                 flow_dur_sec=flow_dur_sec,
                                 data_pkt_size=data_pkt_size,
                                 prio_dscp_map=prio_dscp_map,
-                                index=None)
+                                index=None,
+                                no_of_streams=1
+                                )
     else:
         index = 1
         for rate_percent in flow_rate_percent:
@@ -271,7 +280,8 @@ def __gen_data_flows(testbed_config,
                                     flow_dur_sec=flow_dur_sec,
                                     data_pkt_size=data_pkt_size,
                                     prio_dscp_map=prio_dscp_map,
-                                    index=index)
+                                    index=index,
+                                    no_of_streams=no_of_streams)
                     index += 1
 
 
@@ -285,7 +295,8 @@ def __gen_data_flow(testbed_config,
                     flow_dur_sec,
                     data_pkt_size,
                     prio_dscp_map,
-                    index):
+                    index,
+                    no_of_streams):
     """
     Generate the configuration for a data flow
 
@@ -341,10 +352,12 @@ def __gen_data_flow(testbed_config,
         elif 'Test Flow 2 -> 0' in flow.name:
             eth.pfc_queue.value = pfcQueueValueDict[flow_prio[1]]
 
-    src_port = UDP_PORT_START + eth.pfc_queue.value
+    global UDP_PORT_START
+    src_port = UDP_PORT_START
+    UDP_PORT_START += no_of_streams
     udp.src_port.increment.start = src_port
     udp.src_port.increment.step = 1
-    udp.src_port.increment.count = 1
+    udp.src_port.increment.count = no_of_streams
 
     ipv4.src.value = tx_port_config.ip
     ipv4.dst.value = rx_port_config.ip
@@ -402,4 +415,4 @@ def verify_m2o_fluctuating_lossless_result(rows,
             pytest_assert(int(row.loss) == 0, "FAIL: {} must have 0% loss".format(row.name))
         elif 'Background Flow' in row.name:
             background_loss += float(row.loss)
-    pytest_assert(int(background_loss/4) == 10, "Each Background Flow must have an avg of 10% loss ")
+    pytest_assert(round(background_loss/4) == 10, "Each Background Flow must have an avg of 10% loss ")

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_helper.py
@@ -5,7 +5,6 @@
 # Compiled at: 2023-02-10 09:15:26
 from math import ceil                                                                   # noqa: F401
 import logging                                                                          # noqa: F401
-import random
 from tests.common.helpers.assertions import pytest_assert, pytest_require               # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                          # noqa: F401
@@ -28,6 +27,7 @@ DATA_FLOW_DURATION_SEC = 10
 DATA_FLOW_DELAY_SEC = 5
 SNAPPI_POLL_DELAY_SEC = 2
 TOLERANCE_THRESHOLD = 0.05
+UDP_PORT_START = 5000
 
 
 def run_m2o_oversubscribe_lossless_test(api,
@@ -95,6 +95,9 @@ def run_m2o_oversubscribe_lossless_test(api,
 
     test_flow_rate_percent = int(TEST_FLOW_AGGR_RATE_PERCENT)
     bg_flow_rate_percent = int(BG_FLOW_AGGR_RATE_PERCENT)
+    no_of_bg_streams = 1
+    if duthost.facts['asic_type'] == "cisco-8000":
+        no_of_bg_streams = 10
     port_id = 0
     # Generate base traffic config
     snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,
@@ -114,7 +117,8 @@ def run_m2o_oversubscribe_lossless_test(api,
                   bg_flow_rate_percent=bg_flow_rate_percent,
                   data_flow_dur_sec=DATA_FLOW_DURATION_SEC,
                   data_pkt_size=DATA_PKT_SIZE,
-                  prio_dscp_map=prio_dscp_map)
+                  prio_dscp_map=prio_dscp_map,
+                  no_of_bg_streams=no_of_bg_streams)
 
     flows = testbed_config.flows
     all_flow_names = [flow.name for flow in flows]
@@ -164,7 +168,8 @@ def __gen_traffic(testbed_config,
                   bg_flow_rate_percent,
                   data_flow_dur_sec,
                   data_pkt_size,
-                  prio_dscp_map):
+                  prio_dscp_map,
+                  no_of_bg_streams):
     """
     Generate configurations of flows under all to all traffic pattern, including
     test flows, background flows and pause storm. Test flows and background flows
@@ -199,7 +204,8 @@ def __gen_traffic(testbed_config,
                      flow_rate_percent=test_flow_rate_percent,
                      flow_dur_sec=data_flow_dur_sec,
                      data_pkt_size=data_pkt_size,
-                     prio_dscp_map=prio_dscp_map)
+                     prio_dscp_map=prio_dscp_map,
+                     no_of_streams=1)
 
     __gen_data_flows(testbed_config=testbed_config,
                      port_config_list=port_config_list,
@@ -210,7 +216,8 @@ def __gen_traffic(testbed_config,
                      flow_rate_percent=bg_flow_rate_percent,
                      flow_dur_sec=data_flow_dur_sec,
                      data_pkt_size=data_pkt_size,
-                     prio_dscp_map=prio_dscp_map)
+                     prio_dscp_map=prio_dscp_map,
+                     no_of_streams=no_of_bg_streams)
 
 
 def __gen_data_flows(testbed_config,
@@ -222,7 +229,8 @@ def __gen_data_flows(testbed_config,
                      flow_rate_percent,
                      flow_dur_sec,
                      data_pkt_size,
-                     prio_dscp_map):
+                     prio_dscp_map,
+                     no_of_streams=1):
     """
     Generate the configuration for data flows
 
@@ -254,7 +262,8 @@ def __gen_data_flows(testbed_config,
                             flow_rate_percent=flow_rate_percent,
                             flow_dur_sec=flow_dur_sec,
                             data_pkt_size=data_pkt_size,
-                            prio_dscp_map=prio_dscp_map)
+                            prio_dscp_map=prio_dscp_map,
+                            no_of_streams=no_of_streams)
 
 
 def __gen_data_flow(testbed_config,
@@ -266,7 +275,8 @@ def __gen_data_flow(testbed_config,
                     flow_rate_percent,
                     flow_dur_sec,
                     data_pkt_size,
-                    prio_dscp_map):
+                    prio_dscp_map,
+                    no_of_streams):
     """
     Generate the configuration for a data flow
 
@@ -297,10 +307,6 @@ def __gen_data_flow(testbed_config,
     flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
     eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-    src_port = random.randint(5000, 6000)
-    udp.src_port.increment.start = src_port
-    udp.src_port.increment.step = 1
-    udp.src_port.increment.count = 1
 
     eth.src.value = tx_mac
     eth.dst.value = rx_mac
@@ -319,6 +325,13 @@ def __gen_data_flow(testbed_config,
             eth.pfc_queue.value = pfcQueueValueDict[flow_prio[0]]
         elif 'Test Flow 2 -> 0' in flow.name:
             eth.pfc_queue.value = pfcQueueValueDict[flow_prio[1]]
+
+    global UDP_PORT_START
+    src_port = UDP_PORT_START
+    UDP_PORT_START += no_of_streams
+    udp.src_port.increment.start = src_port
+    udp.src_port.increment.step = 1
+    udp.src_port.increment.count = no_of_streams
 
     ipv4.src.value = tx_port_config.ip
     ipv4.dst.value = rx_port_config.ip

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -5,7 +5,6 @@
 # Compiled at: 2023-02-10 09:15:26
 from math import ceil                                                                   # noqa: F401
 import logging                                                                          # noqa: F401
-import random
 from tests.common.helpers.assertions import pytest_assert, pytest_require               # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                     # noqa: F401
@@ -30,6 +29,7 @@ DATA_FLOW_DURATION_SEC = 10
 DATA_FLOW_DELAY_SEC = 5
 SNAPPI_POLL_DELAY_SEC = 2
 TOLERANCE_THRESHOLD = 0.05
+UDP_PORT_START = 5000
 
 
 def run_pfc_m2o_oversubscribe_lossless_lossy_test(api,
@@ -100,6 +100,9 @@ def run_pfc_m2o_oversubscribe_lossless_lossy_test(api,
         stop_pfcwd(duthost, asic)
         disable_packet_aging(duthost)
 
+    no_of_lossy_streams = 1
+    if duthost.facts['asic_type'] == "cisco-8000":
+        no_of_lossy_streams = 10
     port_id = 0
     # Generate base traffic config
     snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,
@@ -119,7 +122,8 @@ def run_pfc_m2o_oversubscribe_lossless_lossy_test(api,
                   bg_flow_rate_percent=BG_FLOW_AGGR_RATE_PERCENT,
                   data_flow_dur_sec=DATA_FLOW_DURATION_SEC,
                   data_pkt_size=DATA_PKT_SIZE,
-                  prio_dscp_map=prio_dscp_map)
+                  prio_dscp_map=prio_dscp_map,
+                  no_of_lossy_streams=no_of_lossy_streams)
 
     flows = testbed_config.flows
     all_flow_names = [flow.name for flow in flows]
@@ -169,7 +173,8 @@ def __gen_traffic(testbed_config,
                   bg_flow_rate_percent,
                   data_flow_dur_sec,
                   data_pkt_size,
-                  prio_dscp_map):
+                  prio_dscp_map,
+                  no_of_lossy_streams):
     """
     Generate configurations of flows under all to all traffic pattern, including
     test flows, background flows and pause storm. Test flows and background flows
@@ -204,7 +209,8 @@ def __gen_traffic(testbed_config,
                      flow_rate_percent=TEST_FLOW_AGGR_RATE_PERCENT,
                      flow_dur_sec=data_flow_dur_sec,
                      data_pkt_size=data_pkt_size,
-                     prio_dscp_map=prio_dscp_map)
+                     prio_dscp_map=prio_dscp_map,
+                     no_of_streams=1)
 
     __gen_data_flows(testbed_config=testbed_config,
                      port_config_list=port_config_list,
@@ -215,7 +221,8 @@ def __gen_traffic(testbed_config,
                      flow_rate_percent=BG_FLOW_AGGR_RATE_PERCENT,
                      flow_dur_sec=data_flow_dur_sec,
                      data_pkt_size=data_pkt_size,
-                     prio_dscp_map=prio_dscp_map)
+                     prio_dscp_map=prio_dscp_map,
+                     no_of_streams=no_of_lossy_streams)
 
 
 def __gen_data_flows(testbed_config,
@@ -227,7 +234,8 @@ def __gen_data_flows(testbed_config,
                      flow_rate_percent,
                      flow_dur_sec,
                      data_pkt_size,
-                     prio_dscp_map):
+                     prio_dscp_map,
+                     no_of_streams):
     """
     Generate the configuration for data flows
 
@@ -259,7 +267,8 @@ def __gen_data_flows(testbed_config,
                             flow_rate_percent=flow_rate_percent[index],
                             flow_dur_sec=flow_dur_sec,
                             data_pkt_size=data_pkt_size,
-                            prio_dscp_map=prio_dscp_map)
+                            prio_dscp_map=prio_dscp_map,
+                            no_of_streams=no_of_streams)
 
 
 def __gen_data_flow(testbed_config,
@@ -271,7 +280,8 @@ def __gen_data_flow(testbed_config,
                     flow_rate_percent,
                     flow_dur_sec,
                     data_pkt_size,
-                    prio_dscp_map):
+                    prio_dscp_map,
+                    no_of_streams):
     """
     Generate the configuration for a data flow
 
@@ -303,10 +313,11 @@ def __gen_data_flow(testbed_config,
     flow.tx_rx.port.tx_name = testbed_config.ports[src_port_id].name
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
     eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-    src_port = random.randint(5000, 6000)
+    global UDP_PORT_START
+    src_port = UDP_PORT_START + no_of_streams
     udp.src_port.increment.start = src_port
     udp.src_port.increment.step = 1
-    udp.src_port.increment.count = 1
+    udp.src_port.increment.count = no_of_streams
 
     eth.src.value = tx_mac
     eth.dst.value = rx_mac


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The m2o script uses lossless and lossy flows. The cisco-8000 can send a lot of traffic to a single backplane port, ending up dropping them at the backplane in stead of the outgoing port. The m2o script checks dropped packets at the outgoing port, and due to the above condition fails - when the outgoing port itself didn't drop any of the packets.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405

### Approach
#### What is the motivation for this PR?
The intermittent failure of m2o.

#### How did you do it?
I changed the number of background flows to 10 for cisco-8000.

#### How did you verify/test it?
Ran on my TB:
```
=========================================================================================================== PASSES ===========================================================================================================
_____________________________________________________________________________________ test_m2o_fluctuating_lossless[multidut_port_info2] _____________________________________________________________________________________
--------------------------------------------------------------- generated xml file: /run_logs/ixia/19154-reruns/2024-12-15-22-51-48/tr_2024-12-15-22-51-48.xml ---------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
================================================================================================== short test summary info ===================================================================================================
PASSED snappi_tests/multidut/pfc/test_m2o_fluctuating_lossless.py::test_m2o_fluctuating_lossless[multidut_port_info2]
========================================================================================= 1 passed, 4 warnings in 574.74s (0:09:34) ==========================================================================================
sonic@snappi-sonic-mgmt-vanilla-202405-t2:/data/tests$ 
```
#### Any platform specific information?
Specific to cisco-8000.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
