### PR TITLE
[manual] [PR:16206] fix: bump memory limit for Cisco 8000 supervisor

### DIFF
--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -38,7 +38,8 @@ def setup_thresholds(duthosts, enum_rand_one_per_hwsku_hostname):
     if duthost.facts['platform'] in ('x86_64-arista_7050_qx32', 'x86_64-kvm_x86_64-r0', 'x86_64-arista_7050_qx32s',
                                      'x86_64-cel_e1031-r0', 'x86_64-arista_7800r3a_36dm2_lc') or is_asan:
         memory_threshold = 90
-    if duthost.facts['platform'] in ('x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn3800-r0'):
+    if duthost.facts['platform'] in ('x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn3800-r0', 'x86_64-8800_rp_o-r0',
+                                     'x86_64-8800_rp-r0'):
         memory_threshold = 65
     if duthost.facts['platform'] in ('x86_64-arista_7260cx3_64'):
         high_cpu_consume_procs['syncd'] = 80


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Increase the memory threshold for the Cisco 8000 supervisor to 65% to make the test stable.

Summary:
Fixes # (issue) Microsoft ADO 30114189

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
During recent nightly runs, we observed that the Cisco 8000 supervisor had an average memory usage of 59.7% (calculated from the values 60.3, 59.9, 58.9, 59.2, 59.8, and 60.2). Since the memory threshold is set at 60%, this resulted in two failures. To ensure the stability of the tests, we propose increasing the memory threshold for the Cisco 8000 supervisor to 65%.

#### How did you do it?

#### How did you verify/test it?
I ran the updated code on Cisco 8000 and can confirm it's working well.

#### Any platform specific information?
Cisco 8000 chassis

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
