### PR TITLE
Support 2 vlan config in topology for test_acl

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -302,7 +302,7 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
         DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_M0_L3
         DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_M0_L3
         DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_M0_L3
-    if topo in ["t0", "mx", "m0_vlan"]:
+    if topo in ["mx", "m0_vlan"]:
         vlan_ports = [mg_facts["minigraph_ptf_indices"][ifname]
                       for ifname in mg_facts["minigraph_vlans"][vlan_name]["members"]]
 
@@ -310,7 +310,14 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
         vlan_table = config_facts["VLAN"]
         if "mac" in vlan_table[vlan_name]:
             vlan_mac = vlan_table[vlan_name]["mac"]
-
+    elif topo in ["t0"]:
+        vlan_ports = [mg_facts["minigraph_ptf_indices"][ifname]
+                      for ifname in list(mg_facts["minigraph_vlans"].values())[0]["members"]]
+        config_facts = rand_selected_dut.get_running_config_facts()
+        vlan_table = config_facts["VLAN"]
+        vlan_name = list(vlan_table.keys())[0]
+        if "mac" in vlan_table[vlan_name]:
+            vlan_mac = vlan_table[vlan_name]["mac"]
     # Get the list of upstream/downstream ports
     downstream_ports = defaultdict(list)
     upstream_ports = defaultdict(list)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test_acl failed due to failed on `setup with "KeyError: 'Vlan1000'"` after changing to use 2vlan in topo file.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
If enable 2vlan config in topology file(such as `ansible/vars/topo_t0-116.yml`):
change from 
```
    vlan_configs:
      default_vlan_config: one_vlan_a
```
to 
```
    vlan_configs:
      default_vlan_config: two_vlan_a
```
Then vlan name is not Vlan1000 anymore, it could be Vlan100 or Vlan200.
So, in https://github.com/sonic-net/sonic-mgmt/pull/9334/files, it sets default vlan name to Vlan1000 in `pytest_generate_tests` for T0 is not very reasonable.


#### How did you do it?
So, in test_acl, for T0 topology, still get vlan name from config, not from `vlan_name` parameter, then test_acl can pass.

#### How did you verify/test it?
Run test_acl on  testbed with 2vlan config.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
