### PR TITLE
Add a timeout for acquiring dpkg lock. 

### DIFF
--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -11,7 +11,7 @@ steps:
 - script: |
     set -x
 
-    sudo apt-get update && sudo apt-get install -y jq
+    sudo apt-get -o DPkg::Lock::Timeout=600 update && sudo apt-get -o DPkg::Lock::Timeout=600 -y install jq
 
     TEST_SCRIPTS=$(echo '$(TEST_SCRIPTS)' | jq -r -c '."${{ parameters.TOPOLOGY }}"')
 

--- a/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
+++ b/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
@@ -21,7 +21,7 @@ steps:
     pip install PyYAML
     pip install natsort
 
-    sudo apt-get install -y jq
+    sudo apt-get -o DPkg::Lock::Timeout=600 -y install jq
 
     FINAL_FEATURES=""
     IFS=' ' read -ra FEATURES_LIST <<< "$(DIFF_FOLDERS)"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In our Impacted Area Based PR testing, we noticed some failure beacuse of the error `Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 5166 (dpkg)`. In this PR, we add a timeout for acquiring dpkg lock to avoid this issue. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In our Impacted Area Based PR testing, we noticed some failure beacuse of the error `Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 5166 (dpkg)`. In this PR, we add a timeout for acquiring dpkg lock to avoid this issue. 

#### How did you do it?
In this PR, we add a timeout for acquiring dpkg lock to avoid this issue. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
