### PR TITLE
T2: Snappi Based Route Convergence Test Changes 

### DIFF
--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_member_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_member_flap.py
@@ -5,7 +5,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
      fanout_graph_facts_multidut                                                                     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
      snappi_api, multidut_snappi_ports_for_bgp                                                       # noqa: F401
-from tests.snappi_tests.variables import t1_t2_device_hostnames                                      # noqa: F401
+from tests.snappi_tests.variables import t1_t2_device_hostnames, t2_uplink_portchannel_members       # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
      get_hw_platform, run_bgp_outbound_link_flap_test)                                              # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
@@ -81,6 +81,18 @@ def test_bgp_outbound_uplink_po_member_flap(snappi_api,                         
             logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
                         format(device_hostname, ansible_dut_hostnames))
             pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
+
+    # Skip the test if the uplink_portchannels has less than 2 members
+    uplink_lc = t1_t2_device_hostnames[hw_platform][1]
+    portchannel_data = t2_uplink_portchannel_members[hw_platform][uplink_lc]
+
+    po0_list = []
+    if 'asic0' in portchannel_data:
+        po0_list = portchannel_data['asic0']['PortChannel0']
+    else:
+        po0_list = portchannel_data['PortChannel0']
+
+    pytest_require(len(po0_list) >= 2, "Portchannel has less than 2 members")
 
     for duthost in duthosts:
         if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:

--- a/tests/snappi_tests/variables.py
+++ b/tests/snappi_tests/variables.py
@@ -150,8 +150,10 @@ T1_DUT_AS_NUM = 65200
 AS_PATHS = [65002]
 
 snappi_community_for_t1 = ["8075:54000"]
+snappi_community_for_t1_drop = ["8075:54001"]
 snappi_community_for_t2 = ["8075:316", "8075:10400"]
 fanout_presence = True
+num_regionalhubs = 2
 # Note: Increase the MaxSessions in /etc/ssh/sshd_config if the number of fanout ports used is more than 10
 t2_uplink_fanout_info = {
     'HW_PLATFORM1': {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
T2 Snappi based automation testcases, currently didnt have Different types of upstream neighbors support.
As part of this PR, 

1. Different upstream neighbors support is added. 
2. Fixed a bug where t2_uplink_fanout_info was not parsed correctly.
3. Po members flap test to skip if num_po_members < 2.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
T2 Snappi based automation testcases, currently didnt have Different types of upstream neighbors support.

#### How did you do it?
Different upstream neighbors support is added. This also covers different route policies on different types of upstream neighbors

#### How did you verify/test it?
Ran the testcases locally and captured the results.

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
