### PR TITLE
Move some stable test scripts to standard PR checkers.

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -232,6 +232,9 @@ t0:
   - pfcwd/test_pfcwd_function.py
   - pfcwd/test_pfcwd_timer_accuracy.py
   - pfcwd/test_pfcwd_warm_reboot.py
+  - gnmi/test_gnmi_smartswitch.py
+  - gnmi/test_gnoi_killprocess.py
+  - bgp/test_bgp_command.py
 
 t0-2vlans:
   - dhcp_relay/test_dhcp_relay.py
@@ -446,6 +449,9 @@ t1-lag:
   - pfcwd/test_pfcwd_all_port_storm.py
   - pfcwd/test_pfcwd_function.py
   - pfcwd/test_pfcwd_timer_accuracy.py
+  - gnmi/test_gnmi_smartswitch.py
+  - gnmi/test_gnoi_killprocess.py
+  - bgp/test_bgp_command.py
 
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py
@@ -483,19 +489,12 @@ onboarding_t0:
   # Flaky, we will triage and fix it later, move to onboarding to unblock pr check
   - dhcp_relay/test_dhcp_relay_stress.py
   - pc/test_lag_member_forwarding.py
-  - bgp/test_bgp_command.py
   - generic_config_updater/test_mgmt_interface.py
-  - gnmi/test_gnmi_smartswitch.py
-  - gnmi/test_gnoi_killprocess.py
-
 
 onboarding_t1:
   - pc/test_lag_member_forwarding.py
   - bgp/test_bgp_bbr_default_state.py
-  - bgp/test_bgp_command.py
   - generic_config_updater/test_mgmt_interface.py
-  - gnmi/test_gnmi_smartswitch.py
-  - gnmi/test_gnoi_killprocess.py
 
 onboarding_t1_multi_asic:
   - acl/test_stress_acl.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #16229, we initially added several test scripts to the onboarding PR checkers. After monitoring their performance over a few days, some of these scripts have proven to be stable. In this PR, we promote these stable scripts from the onboarding PR checkers to the standard PR checkers.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
In PR #16229, we initially added several test scripts to the onboarding PR checkers. After monitoring their performance over a few days, some of these scripts have proven to be stable. In this PR, we promote these stable scripts from the onboarding PR checkers to the standard PR checkers.

#### How did you do it?
In this PR, we promote these stable scripts from the onboarding PR checkers to the standard PR checkers.

#### How did you verify/test it?

t0:
TestbedName | FilePath | RunDate | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-t0 | bgp/test_bgp_command.py | 2025-01-06 00:00:00.0000000 | 24 | 0 | 24 | 1
vms-kvm-t0 | gnmi/test_gnmi_smartswitch.py | 2025-01-06 00:00:00.0000000 | 12 | 0 | 12 | 1
vms-kvm-t0 | gnmi/test_gnoi_killprocess.py | 2025-01-06 00:00:00.0000000 | 192 | 0 | 192 | 1
vms-kvm-t0 | bgp/test_bgp_command.py | 2025-01-05 00:00:00.0000000 | 12 | 0 | 12 | 1
vms-kvm-t0 | gnmi/test_gnmi_smartswitch.py | 2025-01-05 00:00:00.0000000 | 6 | 0 | 6 | 1
vms-kvm-t0 | gnmi/test_gnoi_killprocess.py | 2025-01-05 00:00:00.0000000 | 96 | 0 | 96 | 1
vms-kvm-t0 | bgp/test_bgp_command.py | 2025-01-04 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t0 | gnmi/test_gnmi_smartswitch.py | 2025-01-04 00:00:00.0000000 | 9 | 0 | 9 | 1
vms-kvm-t0 | gnmi/test_gnoi_killprocess.py | 2025-01-04 00:00:00.0000000 | 144 | 0 | 144 | 1
vms-kvm-t0 | bgp/test_bgp_command.py | 2025-01-03 00:00:00.0000000 | 30 | 0 | 30 | 1
vms-kvm-t0 | gnmi/test_gnmi_smartswitch.py | 2025-01-03 00:00:00.0000000 | 15 | 0 | 15 | 1
vms-kvm-t0 | gnmi/test_gnoi_killprocess.py | 2025-01-03 00:00:00.0000000 | 240 | 0 | 240 | 1

t1-lag:
TestbedName | FilePath | RunDate | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-t1-lag | bgp/test_bgp_command.py | 2025-01-06 00:00:00.0000000 | 22 | 0 | 22 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_smartswitch.py | 2025-01-06 00:00:00.0000000 | 11 | 0 | 11 | 1
vms-kvm-t1-lag | gnmi/test_gnoi_killprocess.py | 2025-01-06 00:00:00.0000000 | 176 | 0 | 176 | 1
vms-kvm-t1-lag | bgp/test_bgp_command.py | 2025-01-05 00:00:00.0000000 | 12 | 0 | 12 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_smartswitch.py | 2025-01-05 00:00:00.0000000 | 6 | 0 | 6 | 1
vms-kvm-t1-lag | gnmi/test_gnoi_killprocess.py | 2025-01-05 00:00:00.0000000 | 96 | 0 | 96 | 1
vms-kvm-t1-lag | bgp/test_bgp_command.py | 2025-01-04 00:00:00.0000000 | 18 | 0 | 18 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_smartswitch.py | 2025-01-04 00:00:00.0000000 | 9 | 0 | 9 | 1
vms-kvm-t1-lag | gnmi/test_gnoi_killprocess.py | 2025-01-04 00:00:00.0000000 | 144 | 0 | 144 | 1
vms-kvm-t1-lag | bgp/test_bgp_command.py | 2025-01-03 00:00:00.0000000 | 34 | 0 | 34 | 1
vms-kvm-t1-lag | gnmi/test_gnmi_smartswitch.py | 2025-01-03 00:00:00.0000000 | 17 | 0 | 17 | 1
vms-kvm-t1-lag | gnmi/test_gnoi_killprocess.py | 2025-01-03 00:00:00.0000000 | 272 | 0 | 272 | 1

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
