### PR TITLE
Create /etc/tacacs folder on PTF when it's missing

### DIFF
--- a/tests/common/helpers/tacacs/tacacs_helper.py
+++ b/tests/common/helpers/tacacs/tacacs_helper.py
@@ -177,6 +177,7 @@ def setup_tacacs_server(ptfhost, tacacs_creds, duthost):
         logger.debug("setup_tacacs_server: duthost options does not contains config for ansible_ssh_user.")
 
     ptfhost.host.options['variable_manager'].extra_vars.update(extra_vars)
+    ptfhost.shell("mkdir -p /etc/tacacs+")
     ptfhost.template(src="tacacs/tac_plus.conf.j2", dest="/etc/tacacs+/tac_plus.conf")
 
     # Find 'python' command symbolic link target, and fix the tac_plus config file


### PR DESCRIPTION
Create /etc/tacacs folder on PTF when it's missing

#### Why I did it
TACACS test failed because /etc/tacacs+ folder does not exist, which recently missing on some version of PTF container image.

Error message:

E           msg = Destination directory /etc/tacacs+ does not exist

##### Work item tracking
- Microsoft ADO: 30626377

#### How I did it
Create /etc/tacacs folder on PTF when it's missing

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Create /etc/tacacs folder on PTF when it's missing

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
