### PR TITLE
Remove the 'multi_sad' from the upgrade sad test since it has duplicate with other sad types

### DIFF
--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -28,6 +28,9 @@ logger = logging.getLogger(__name__)
 def pytest_generate_tests(metafunc):
     if "sad_case_type" in metafunc.fixturenames:
         sad_cases = SAD_CASE_LIST
+        # multi_sad = sad_bgp + sad_lag, no need to duplicate the sad type, it will reduce 3-4 hrs run time.
+        if "multi_sad" in sad_cases and "sad_bgp" in sad_cases and "sad_lag" in sad_cases:
+            sad_cases.remove("multi_sad")
         metafunc.parametrize("sad_case_type", sad_cases, scope="module")
 
 


### PR DESCRIPTION
Remove the 'multi_sad' from the upgrade sad test since it has duplicate with other sad types

since multi_sad == sad_bgp + sad_lag, no need to have the multi_sad type.  it will reduce the run type (3-4hrs)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
To reduce the run time of the test case
#### How did you do it?

#### How did you verify/test it?
Run the test_warm_upgrade_sad_path, it could cover all kinds of the sad type after the change. 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
