### PR TITLE
Test for ecn counter increment for ECT marked packets

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -104,6 +104,7 @@ def generate_test_flows(testbed_config,
                         test_flow_prio_list,
                         prio_dscp_map,
                         snappi_extra_params,
+                        congested=False,
                         number_of_streams=1,
                         flow_index=None):
     """
@@ -166,8 +167,8 @@ def generate_test_flows(testbed_config,
         ipv4.dst.value = base_flow_config["rx_port_config"].ip
         ipv4.priority.choice = ipv4.priority.DSCP
         ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
-        ipv4.priority.dscp.ecn.value = (
-            ipv4.priority.dscp.ecn.CAPABLE_TRANSPORT_1)
+        ipv4.priority.dscp.ecn.value = (ipv4.priority.dscp.ecn.CONGESTION_ENCOUNTERED if congested else
+                                        ipv4.priority.dscp.ecn.CAPABLE_TRANSPORT_1)
 
         test_flow.size.fixed = data_flow_config["flow_pkt_size"]
         test_flow.rate.percentage = data_flow_config["flow_rate_percent"][prio]
@@ -369,6 +370,15 @@ def clear_dut_que_counters(duthost):
     duthost.command("sonic-clear queuecounters \n")
 
 
+def clear_dut_pfc_counters(duthost):
+    """
+    Clears the dut pfc counter.
+    Args:
+        duthost (obj): DUT host object
+    """
+    duthost.command("sonic-clear pfccounters \n")
+
+
 def run_traffic(duthost,
                 api,
                 config,
@@ -416,6 +426,7 @@ def run_traffic(duthost,
                      *snappi_extra_params.multi_dut_params.egress_duthosts, duthost]):
         clear_dut_interface_counters(host)
         clear_dut_que_counters(host)
+        clear_dut_pfc_counters(host)
 
     logger.info("Starting transmit on all flows ...")
     ts = api.transmit_state()

--- a/tests/snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py
+++ b/tests/snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py
@@ -10,7 +10,8 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
     lossless_prio_list, disable_pfcwd   # noqa F401
 from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut, enable_debug_shell  # noqa: F401
-from tests.snappi_tests.multidut.ecn.files.multidut_helper import run_ecn_marking_test, run_ecn_marking_port_toggle_test
+from tests.snappi_tests.multidut.ecn.files.multidut_helper import run_ecn_marking_test, \
+    run_ecn_marking_port_toggle_test, run_ecn_marking_ect_marked_pkts
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.cisco_data import is_cisco_device
 logger = logging.getLogger(__name__)
@@ -98,17 +99,14 @@ def test_ecn_marking_port_toggle(
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
-    try:
-        run_ecn_marking_port_toggle_test(
-                                api=snappi_api,
-                                testbed_config=testbed_config,
-                                port_config_list=port_config_list,
-                                dut_port=snappi_ports[0]['peer_port'],
-                                test_prio_list=lossless_prio_list,
-                                prio_dscp_map=prio_dscp_map,
-                                snappi_extra_params=snappi_extra_params)
-    finally:
-        cleanup_config(duthosts, snappi_ports)
+    run_ecn_marking_port_toggle_test(
+                            api=snappi_api,
+                            testbed_config=testbed_config,
+                            port_config_list=port_config_list,
+                            dut_port=snappi_ports[0]['peer_port'],
+                            test_prio_list=lossless_prio_list,
+                            prio_dscp_map=prio_dscp_map,
+                            snappi_extra_params=snappi_extra_params)
 
 
 test_flow_percent_list = [[90, 15], [53, 49], [15, 90], [49, 49], [50, 50], [60, 60], [60, 90], [90, 60]]
@@ -153,15 +151,56 @@ def test_ecn_marking_lossless_prio(
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
-    try:
-        run_ecn_marking_test(
-                                api=snappi_api,
-                                testbed_config=testbed_config,
-                                port_config_list=port_config_list,
-                                dut_port=snappi_ports[0]['peer_port'],
-                                test_prio_list=lossless_prio_list,
-                                prio_dscp_map=prio_dscp_map,
-                                test_flow_percent=test_flow_percent,
-                                snappi_extra_params=snappi_extra_params)
-    finally:
-        cleanup_config(duthosts, snappi_ports)
+    run_ecn_marking_test(
+                            api=snappi_api,
+                            testbed_config=testbed_config,
+                            port_config_list=port_config_list,
+                            dut_port=snappi_ports[0]['peer_port'],
+                            test_prio_list=lossless_prio_list,
+                            prio_dscp_map=prio_dscp_map,
+                            test_flow_percent=test_flow_percent,
+                            snappi_extra_params=snappi_extra_params)
+
+
+def test_ecn_marking_ect_marked_pkts(
+                                snappi_api,                       # noqa: F811
+                                conn_graph_facts,                 # noqa: F811
+                                fanout_graph_facts_multidut,               # noqa: F811
+                                duthosts,
+                                lossless_prio_list,     # noqa: F811
+                                get_snappi_ports,     # noqa: F811
+                                tbinfo,      # noqa: F811
+                                disable_pfcwd,  # noqa: F811
+                                setup_ports_and_dut,     # noqa: F811
+                                prio_dscp_map):                    # noqa: F811
+    """
+    Verify ECN marking for ECT marked pkts
+    Args:
+        request (pytest fixture): pytest request object
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        lossless_prio_list (pytest fixture): list of all the lossless priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        tbinfo (pytest fixture): fixture provides information about testbed
+        get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
+    Returns:
+        N/A
+    """
+
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+
+    logger.info("Snappi Ports : {}".format(snappi_ports))
+    snappi_extra_params = SnappiTestParams()
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    run_ecn_marking_ect_marked_pkts(
+                            api=snappi_api,
+                            testbed_config=testbed_config,
+                            port_config_list=port_config_list,
+                            dut_port=snappi_ports[0]['peer_port'],
+                            test_prio_list=lossless_prio_list,
+                            prio_dscp_map=prio_dscp_map,
+                            snappi_extra_params=snappi_extra_params)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

Verify if ingress congestion experienced markets pkts (ECT bit b11) are causing the ecn counter increment on the DUT as expected on congestion

#### How did you do it?

Wrote snappi test to cause congestion on the port

#### How did you verify/test it?

Injected frames with ECT bit set and caused congestion on the egress port.

Verified that the DUT is counting the ECN marking and the counter is incrementing.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
