### PR TITLE
test_config_fec_oper_mode: Set the fec_mode to align with the current configuration of the interface.

### DIFF
--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release, wait_until
 
 pytestmark = [
@@ -28,6 +29,15 @@ def is_supported_platform(duthost):
         pytest.skip("DUT has platform {}, test is not supported".format(duthost.facts['platform']))
 
 
+def get_fec_oper_mode(duthost, interface):
+    """
+    @Return: FEC operational mode for a specific interface
+    """
+    logging.info("Get output of '{} {}'".format("show interfaces fec status", interface))
+    fec_status = duthost.show_and_parse("show interfaces fec status {}".format(interface))
+    return fec_status[0].get('fec oper', '').lower()
+
+
 def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                               enum_frontend_asic_index, conn_graph_facts):
     """
@@ -52,9 +62,7 @@ def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
 
             if presence == "present" and oper == "up" and speed in SUPPORTED_SPEEDS:
                 # Verify the FEC operational mode is valid
-                logging.info("Get output of '{} {}'".format("show interfaces fec status", intf['interface']))
-                fec_status = duthost.show_and_parse("show interfaces fec status {}".format(intf['interface']))
-                fec = fec_status[0].get('fec oper', '').lower()
+                fec = get_fec_oper_mode(duthost, intf['interface'])
                 if fec == "n/a":
                     pytest.fail("FEC status is N/A for interface {}".format(intf['interface']))
 
@@ -84,16 +92,18 @@ def test_config_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
             if presence == "not present" or oper != "up" or speed not in SUPPORTED_SPEEDS:
                 continue
 
-        config_status = duthost.command("sudo config interface fec {} rs"
-                                        .format(intf['interface']))
-        if config_status:
-            wait_until(30, 2, 0, duthost.is_interface_status_up, intf["interface"])
-            # Verify the FEC operational mode is restored
-            logging.info("Get output of '{} {}'".format("show interfaces fec status", intf['interface']))
-            fec_status = duthost.show_and_parse("show interfaces fec status {}".format(intf['interface']))
-            fec = fec_status[0].get('fec oper', '').lower()
+        fec_mode = get_fec_oper_mode(duthost, intf['interface'])
+        if fec_mode == "n/a":
+            pytest.fail("FEC status is N/A for interface {}".format(intf['interface']))
 
-            if not (fec == "rs"):
+        config_status = duthost.command("sudo config interface fec {} {}"
+                                        .format(intf['interface'], fec_mode))
+        if config_status:
+            pytest_assert(wait_until(30, 2, 0, duthost.is_interface_status_up, intf["interface"]), \
+                          "Interface {} did not come up after configuring FEC mode".format(intf["interface"]))
+            # Verify the FEC operational mode is restored
+            post_fec = get_fec_oper_mode(duthost, intf['interface'])
+            if not (post_fec == fec_mode):
                 pytest.fail("FEC status is not restored for interface {}".format(intf['interface']))
 
 

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -99,7 +99,7 @@ def test_config_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
         config_status = duthost.command("sudo config interface fec {} {}"
                                         .format(intf['interface'], fec_mode))
         if config_status:
-            pytest_assert(wait_until(30, 2, 0, duthost.is_interface_status_up, intf["interface"]), \
+            pytest_assert(wait_until(30, 2, 0, duthost.is_interface_status_up, intf["interface"]),
                           "Interface {} did not come up after configuring FEC mode".format(intf["interface"]))
             # Verify the FEC operational mode is restored
             post_fec = get_fec_oper_mode(duthost, intf['interface'])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
As the FEC mode can be set to "none" as well, instead of setting the FEC mode to rs when testing the configuration, set the FEC mode to existing configuration of the interface.

Summary:
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/16120

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified the fix on lab testbed where the FEC mode is set to "none" and the test case is failing before the fix.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
