### PR TITLE
Check AN enabled port is in connection graph

### DIFF
--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -63,7 +63,7 @@
 {% else %}
 {% set autoneg_intf = "Ethernet" ~ if_index ~ "/1" %}
 {% endif %}
-{% if device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['autoneg']|lower == "on" %}
+{% if port_alias_map[autoneg_intf] in device_conn[inventory_hostname] and device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['autoneg']|lower == "on" %}
         <a:LinkMetadata>
             <a:Name i:nil="true"/>
             <a:Properties>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to add a check in `minigraph_link_meta.j2` to ensure that AN enabled ports are present in the definition of connection graph. Otherwise the configuration will not be generated.
This change is required because it's possible that `autoneg_interfaces` is defined in the definition of topology, but the link is not defined in connection graph. In this case, `config load_minigraph` throws an exception
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'dict object' has no attribute 'Ethernet248'
fatal: [str-msn4700-01]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'Ethernet248'"}
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411 

### Approach
#### What is the motivation for this PR?
This PR is to add a check in `minigraph_link_meta.j2` to ensure that AN enabled ports are present in the definition of connection graph.
#### How did you do it?
Add a check in j2 template.

#### How did you verify/test it?
The change is verified by running `config load_minigraph` on a physical testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
