### PR TITLE
Remove golden config file and revert config when load golden config failed.

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1320,9 +1320,11 @@ def reload_minigraph_with_golden_config(duthost, json_data, safe_reload=True):
     from tests.common.config_reload import config_reload
     golden_config = "/etc/sonic/golden_config_db.json"
     duthost.copy(content=json.dumps(json_data, indent=4), dest=golden_config)
-    config_reload(duthost, config_source="minigraph", safe_reload=safe_reload, override_config=True)
-    # Cleanup golden config because some other test or device recover may reload config with golden config
-    duthost.command('mv {} {}_backup'.format(golden_config, golden_config))
+    try:
+        config_reload(duthost, config_source="minigraph", safe_reload=safe_reload, override_config=True)
+    finally:
+        # Cleanup golden config because some other test or device recover may reload config with golden config
+        duthost.command('mv {} {}_backup'.format(golden_config, golden_config))
 
 
 def file_exists_on_dut(duthost, filename):

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -650,7 +650,11 @@ def test_fallback_to_local_authorization_with_config_reload(
             tacacs_server_ip: {"priority": "60", "tcp_port": "59", "timeout": "2"}
         }
     }
-    reload_minigraph_with_golden_config(duthost, override_config)
+    try:
+        reload_minigraph_with_golden_config(duthost, override_config)
+    except:
+        restore_config(duthost, CONFIG_DB, CONFIG_DB_BACKUP)
+        pytest_assert(false, "Apply TACACS golden config failed.")
 
     # Shutdown tacacs server to simulate network unreachable because BGP shutdown
     stop_tacacs_server(ptfhost)

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -652,19 +652,16 @@ def test_fallback_to_local_authorization_with_config_reload(
     }
     try:
         reload_minigraph_with_golden_config(duthost, override_config)
-    except:
+
+        # Shutdown tacacs server to simulate network unreachable because BGP shutdown
+        stop_tacacs_server(ptfhost)
+    
+        # Test "sudo config save -y" can success after reload minigraph
+        exit_code, stdout, stderr = ssh_run_command(remote_rw_user_client, "sudo config save -y")
+        pytest_assert(exit_code == 0)
+    
+        #  Cleanup UT.
+        start_tacacs_server(ptfhost)
+    finally:
+        #  Restore config after test finish
         restore_config(duthost, CONFIG_DB, CONFIG_DB_BACKUP)
-        pytest_assert(false, "Apply TACACS golden config failed.")
-
-    # Shutdown tacacs server to simulate network unreachable because BGP shutdown
-    stop_tacacs_server(ptfhost)
-
-    # Test "sudo config save -y" can success after reload minigraph
-    exit_code, stdout, stderr = ssh_run_command(remote_rw_user_client, "sudo config save -y")
-    pytest_assert(exit_code == 0)
-
-    #  Cleanup UT.
-    start_tacacs_server(ptfhost)
-
-    #  Restore config after test finish
-    restore_config(duthost, CONFIG_DB, CONFIG_DB_BACKUP)

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -655,11 +655,11 @@ def test_fallback_to_local_authorization_with_config_reload(
 
         # Shutdown tacacs server to simulate network unreachable because BGP shutdown
         stop_tacacs_server(ptfhost)
-    
+
         # Test "sudo config save -y" can success after reload minigraph
         exit_code, stdout, stderr = ssh_run_command(remote_rw_user_client, "sudo config save -y")
         pytest_assert(exit_code == 0)
-    
+
         #  Cleanup UT.
         start_tacacs_server(ptfhost)
     finally:


### PR DESCRIPTION
Remove golden config file and revert config when load golden config failed.

#### Why I did it
Fix bug https://github.com/sonic-net/sonic-mgmt/issues/16338
TACACS test case reload golden config failed, and golden config not remove because a code bug, then all test case failed after that because login failed.


##### Work item tracking
- Microsoft ADO: 30667311

#### How I did it
add try finally to make sure golden config always remove after reload config.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Remove golden config file and revert config when load golden config failed.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
