### PR TITLE
flap interface after sfp reset

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -860,8 +860,8 @@ class MultiAsicSonicHost(object):
 
     def get_admin_up_ports(self):
         intf_status = get_dut_interfaces_status(self.sonichost)
-        up_ports = [k for k, v in intf_status.items() if v['admin'] == "up"]
-        return up_ports
+        admin_up_ports = [k for k, v in intf_status.items() if v['admin'] == "up"]
+        return admin_up_ports
 
     def shutdown_interface(self, port):
         """

--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -42,6 +42,10 @@ def parse_intf_status(lines):
 
     return result
 
+def get_dut_interfaces_status(duthost):
+    output = duthost.command("show interface description")
+    intf_status = parse_intf_status(output["stdout_lines"][2:])
+    return intf_status
 
 def check_interface_status_of_up_ports(duthost):
     if duthost.facts['asic_type'] == 'vs' and duthost.is_supervisor_node():

--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -42,10 +42,12 @@ def parse_intf_status(lines):
 
     return result
 
+
 def get_dut_interfaces_status(duthost):
     output = duthost.command("show interface description")
     intf_status = parse_intf_status(output["stdout_lines"][2:])
     return intf_status
+
 
 def check_interface_status_of_up_ports(duthost):
     if duthost.facts['asic_type'] == 'vs' and duthost.is_supervisor_node():

--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 
 I2C_WAIT_TIME_AFTER_SFP_RESET = 5  # in seconds
 
+
 def parse_transceiver_info(output_lines):
     """
     @summary: Parse the list of transceiver from DB table TRANSCEIVER_INFO content

--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -7,6 +7,7 @@ import logging
 import re
 from copy import deepcopy
 
+I2C_WAIT_TIME_AFTER_SFP_RESET = 5  # in seconds
 
 def parse_transceiver_info(output_lines):
     """

--- a/tests/common/port_toggle.py
+++ b/tests/common/port_toggle.py
@@ -9,7 +9,6 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 BASE_PORT_COUNT = 28.0  # default t0 topology has 28 ports to toggle
-I2C_WAIT_TIME_AFTER_SFP_RESET = 5  # in seconds
 WAIT_TIME_AFTER_INTF_SHUTDOWN = 5  # in seconds
 
 

--- a/tests/common/port_toggle.py
+++ b/tests/common/port_toggle.py
@@ -9,6 +9,8 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 BASE_PORT_COUNT = 28.0  # default t0 topology has 28 ports to toggle
+I2C_WAIT_TIME_AFTER_SFP_RESET = 5  # in seconds
+WAIT_TIME_AFTER_INTF_SHUTDOWN = 5  # in seconds
 
 
 def port_toggle(duthost, tbinfo, ports=None, wait_time_getter=None, wait_after_ports_up=60, watch=False):

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -8,6 +8,7 @@ from tests.common.utilities import skip_release
 from tests.common.utilities import skip_release_for_platform
 from tests.common.platform.interface_utils import get_physical_port_indices
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
+from tests.common.port_toggle import default_port_toggle_wait_time
 from tests.common.utilities import wait_until
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F401
 from tests.common.fixtures.duthost_utils import shutdown_ebgp           # noqa F401
@@ -708,7 +709,9 @@ class TestSfpApi(PlatformApiTestBase):
             for intf in intfs_changed:
                 duthost.no_shutdown_interface(intf)
 
-            if not wait_until(60, 10, 0, check_interface_status_of_up_ports, duthost):
+            _, port_up_wait_time = default_port_toggle_wait_time(duthost, len(intfs_changed))
+            if not wait_until(port_up_wait_time, 10, 0,
+                              check_interface_status_of_up_ports, duthost):
                 self.expect(False, "Not all interfaces are up after reset")
 
         self.assert_expectations()

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -9,8 +9,8 @@ from tests.common.utilities import skip_release
 from tests.common.utilities import skip_release_for_platform
 from tests.common.platform.interface_utils import get_physical_port_indices
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
-from tests.common.port_toggle import default_port_toggle_wait_time, I2C_WAIT_TIME_AFTER_SFP_RESET, \
-    WAIT_TIME_AFTER_INTF_SHUTDOWN
+from tests.common.port_toggle import default_port_toggle_wait_time, WAIT_TIME_AFTER_INTF_SHUTDOWN
+from tests.common.platform.transceiver_utils import I2C_WAIT_TIME_AFTER_SFP_RESET
 from tests.common.utilities import wait_until
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F401
 from tests.common.fixtures.duthost_utils import shutdown_ebgp           # noqa F401

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -15,7 +15,8 @@ from .util import parse_output
 from .util import get_dev_conn
 from tests.common.utilities import skip_release, wait_until
 from tests.common.fixtures.duthost_utils import shutdown_ebgp   # noqa F401
-from tests.common.port_toggle import default_port_toggle_wait_time, I2C_WAIT_TIME_AFTER_SFP_RESET
+from tests.common.port_toggle import default_port_toggle_wait_time
+from tests.common.platform.transceiver_utils import I2C_WAIT_TIME_AFTER_SFP_RESET
 from tests.common.platform.interface_utils import get_physical_port_indices
 
 cmd_sfp_presence = "sudo sfputil show presence"

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -15,7 +15,7 @@ from .util import parse_output
 from .util import get_dev_conn
 from tests.common.utilities import skip_release, wait_until
 from tests.common.fixtures.duthost_utils import shutdown_ebgp   # noqa F401
-from tests.common.port_toggle import default_port_toggle_wait_time
+from tests.common.port_toggle import default_port_toggle_wait_time, I2C_WAIT_TIME_AFTER_SFP_RESET
 from tests.common.platform.interface_utils import get_physical_port_indices
 
 cmd_sfp_presence = "sudo sfputil show presence"
@@ -34,7 +34,6 @@ DOM_DISABLED = "disabled"
 DOM_ENABLED = "enabled"
 DOM_POLLING_CONFIG_VALUES = [DOM_DISABLED, DOM_ENABLED]
 
-I2C_WAIT_TIME_AFTER_SFP_RESET = 5  # in seconds
 WAIT_TIME_AFTER_LPMODE_SET = 3  # in seconds
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes interface stays down after tests/platform_tests/api/test_sfp.py::sfp_reset()

And causing error during `shutdown_ebgp` fixture teardown.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
keep interface up after sfp_reset if it's T2 and QSFP-DD SFP.

#### How did you do it?

flap the interface after sfp_reset to restore the interface state.

#### How did you verify/test it?
passed on physical testbed with 

```
admin@svcstr2-8800-lc1-1:~$ sudo sfputil show eeprom -d -p Ethernet0
Ethernet0: SFP EEPROM detected
...
        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - Active Cable assembly with BER < 5x10^-5 - Media Assign (0x1)
                                   CAUI-4 C2M (Annex 83E) - Host Assign (0x1) - Active Cable assembly with BER < 5x10^-5 - Media Assign (0x1)
        CMIS Revision: 4.0
        Connector: No separable connector
        Encoding: N/A
        Extended Identifier: Power Class 5 (10.0W Max)
        Extended RateSelect Compliance: N/A
        Hardware Revision: 1.0
        Host Electrical Interface: 400GAUI-8 C2M (Annex 120E)
        Host Lane Assignment Options: 1
        Host Lane Count: 8
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Length Cable Assembly(m): 1.0
......
```
```
platform_tests/api/test_sfp.py::TestSfpApi::test_reset[xxx-lc1-1] PASSED [ 73%]
......
=========================== short test summary info ============================
FAILED platform_tests/api/test_sfp.py::TestSfpApi::test_lpmode[svcstr2-8800-lc1-1]                        <<<< this is separate issue, not related to this PR.
========================= 1 failed, 22 passed, 1 warning in 2104.41s (0:35:04) =========================
``
============= 1 failed, 22 passed, 1 warning in 2104.41s (0:35:04) =============
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
