### PR TITLE
Add some qos/pfcwd tests to PR checker and skip some tests in PR test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -177,7 +177,6 @@ t0:
   - test_interfaces.py
   - test_procdockerstatsd.py
   - testbed_setup/test_populate_fdb.py
-  - upgrade_path/test_upgrade_path.py
   - vlan/test_autostate_disabled.py
   - vlan/test_host_vlan.py
   - vlan/test_vlan.py
@@ -229,9 +228,13 @@ t0:
   - l2/test_l2_configure.py
   - srv6/test_srv6_basic_sanity.py
   - pfcwd/test_pfcwd_all_port_storm.py
+  - pfcwd/test_pfcwd_cli.py
   - pfcwd/test_pfcwd_function.py
   - pfcwd/test_pfcwd_timer_accuracy.py
   - pfcwd/test_pfcwd_warm_reboot.py
+  - qos/test_pfc_counters.py
+  - qos/test_pfc_pause.py
+  - qos/test_qos_dscp_mapping.py
 
 t0-2vlans:
   - dhcp_relay/test_dhcp_relay.py
@@ -444,8 +447,11 @@ t1-lag:
   - restapi/test_restapi_vxlan_ecmp.py
   - srv6/test_srv6_basic_sanity.py
   - pfcwd/test_pfcwd_all_port_storm.py
+  - pfcwd/test_pfcwd_cli.py
   - pfcwd/test_pfcwd_function.py
   - pfcwd/test_pfcwd_timer_accuracy.py
+  - qos/test_pfc_counters.py
+  - qos/test_qos_dscp_mapping.py
 
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py
@@ -487,10 +493,6 @@ onboarding_t0:
   - generic_config_updater/test_mgmt_interface.py
   - gnmi/test_gnmi_smartswitch.py
   - gnmi/test_gnoi_killprocess.py
-  - qos/test_pfc_counters.py
-  - qos/test_pfc_pause.py
-  - qos/test_qos_dscp_mapping.py
-
 
 onboarding_t1:
   - pc/test_lag_member_forwarding.py
@@ -499,8 +501,6 @@ onboarding_t1:
   - generic_config_updater/test_mgmt_interface.py
   - gnmi/test_gnmi_smartswitch.py
   - gnmi/test_gnoi_killprocess.py
-  - qos/test_pfc_counters.py
-  - qos/test_qos_dscp_mapping.py
 
 onboarding_t1_multi_asic:
   - acl/test_stress_acl.py

--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -78,6 +78,9 @@ t0:
   - mvrf/test_mgmtvrf.py
   - vrf/test_vrf.py
   - vrf/test_vrf_attr.py
+  # Upgrade path test needs base and target image lists, currently do not support on KVM
+  - upgrade_path/test_upgrade_path.py
+  - upgrade_path/test_multi_hop_upgrade_path.py
 
 t1-lag:
   # KVM do not support bfd test
@@ -135,6 +138,8 @@ t1-lag:
   - mvrf/test_mgmtvrf.py
   # This test needs swap syncd support, which is not available on KVM
   - qos/test_qos_masic.py
+  # This test can only run on cisco and mnlx platforms
+  - vxlan/test_vnet_bgp_route_precedence.py
 
 t2:
   # KVM do not support bfd test
@@ -240,6 +245,7 @@ tgen:
   - snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_member_flap.py
   - snappi_tests/multidut/bgp/test_bgp_outbound_uplink_process_crash.py
   - snappi_tests/multidut/ecn/test_multidut_dequeue_ecn_with_snappi.py
+  - snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_pfc_quanta_variance_with_snappi.py
   - snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py
   - snappi_tests/multidut/ecn/test_multidut_red_accuracy_with_snappi.py
   - snappi_tests/multidut/pfc/test_lossless_response_to_external_pause_storms.py

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2292,6 +2292,15 @@ test_vs_chassis_setup.py:
       - "asic_type not in ['vs']"
 
 #######################################
+#####         upgrade_path        #####
+#######################################
+upgrade_path:
+  skip:
+    reason: "Upgrade path test needs base and target image lists, currently do not support on KVM."
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
 #####            vlan             #####
 #######################################
 vlan/test_vlan.py::test_vlan_tc7_tagged_qinq_switch_on_outer_tag:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test can't be tested on KVM platform, we need to skip traffic test if needed.
For tests adding to PR checker list, use Elastictest to verify:
TestbedName | FilePath | TestCase | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-t1-lag | qos/test_qos_dscp_mapping.py | test_dscp_to_queue_mapping_pipe_mode | 30 | 0 | 30 | 1
vms-kvm-t1-lag | qos/test_qos_dscp_mapping.py | test_dscp_to_queue_mapping_uniform_mode | 30 | 0 | 30 | 1
vms-kvm-t1-lag | qos/test_pfc_counters.py | test_pfc_pause | 30 | 0 | 30 | 1
vms-kvm-t1-lag | qos/test_pfc_counters.py | test_pfc_unpause | 30 | 0 | 30 | 1
vms-kvm-t1-lag | qos/test_pfc_counters.py | test_fc_pause | 30 | 0 | 30 | 1
vms-kvm-t1-lag | qos/test_pfc_counters.py | test_fc_unpause | 30 | 0 | 30 | 1
vms-kvm-t1-lag | qos/test_pfc_counters.py | test_continous_pfc | 30 | 0 | 30 | 1
vms-kvm-t1-lag | pfcwd/test_pfcwd_cli.py | test_pfcwd_show_stat[vlab-03] | 30 | 0 | 30 | 1
vms-kvm-t0 | qos/test_qos_dscp_mapping.py | test_dscp_to_queue_mapping_pipe_mode | 40 | 0 | 40 | 1
vms-kvm-t0 | qos/test_qos_dscp_mapping.py | test_dscp_to_queue_mapping_uniform_mode | 40 | 0 | 40 | 1
vms-kvm-t0 | pfcwd/test_pfcwd_cli.py | test_pfcwd_show_stat[vlab-01] | 40 | 0 | 40 | 1
vms-kvm-t0 | qos/test_pfc_counters.py | test_pfc_pause | 40 | 0 | 40 | 1
vms-kvm-t0 | qos/test_pfc_counters.py | test_pfc_unpause | 40 | 0 | 40 | 1
vms-kvm-t0 | qos/test_pfc_counters.py | test_fc_pause | 40 | 0 | 40 | 1
vms-kvm-t0 | qos/test_pfc_counters.py | test_fc_unpause | 40 | 0 | 40 | 1
vms-kvm-t0 | qos/test_pfc_counters.py | test_continous_pfc | 40 | 0 | 40 | 1
vms-kvm-t0 | qos/test_pfc_pause.py | test_pfc_pause_lossless[vlab-01\|3] | 40 | 0 | 40 | 1
vms-kvm-t0 | qos/test_pfc_pause.py | test_pfc_pause_lossless[vlab-01\|4] | 40 | 0 | 40 | 1
vms-kvm-t0 | qos/test_pfc_pause.py | test_no_pfc[vlab-01\|3] | 40 | 0 | 40 | 1
vms-kvm-t0 | qos/test_pfc_pause.py | test_no_pfc[vlab-01\|4] | 40 | 0 | 40 | 1
#### How did you do it?
Add some stable tests to PR checker, add/move some tests to PR test skip list
#### How did you verify/test it?
Check with PR test and elastictest
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
