### PR TITLE
Enhance Read-only disk test case, verify remote user can do TSA/TSB after monit script mitigate issue.

### DIFF
--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -258,6 +258,14 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
 
         chk_ssh_remote_run(localhost, dutip, rw_user, rw_pass, "sudo find /home -ls")
 
+        # Verify after monit fix login issue ,remote user can run TSA/TSB command.
+        res = ssh_remote_run(localhost, dutip, rw_user, rw_pass, "sudo TSA")
+        logger.debug("TSA res={}".format(res))
+        assert "System Mode: Normal -> Maintenance" in res["stdout_lines"], "Failed to TSA"
+        res = ssh_remote_run(localhost, dutip, rw_user, rw_pass, "sudo TSB")
+        logger.debug("TSB res={}".format(res))
+        assert "System Mode: Maintenance -> Normal" in res["stdout_lines"], "Failed to TSB"
+
         if not os.path.exists(DATA_DIR):
             os.makedirs(DATA_DIR)
 


### PR DESCRIPTION
Enhance Read-only disk test case, verify remote user can do TSA/TSB after monit script mitigate issue.

#### Why I did it
Verify after monit fix login issue ,remote user can run TSA/TSB command.


##### Work item tracking
- Microsoft ADO: 28263221

#### How I did it
Check remote user can do TSA/TSB after monit script mitigate issue.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Enhance Read-only disk test case, verify remote user can do TSA/TSB after monit script mitigate issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
