### PR TITLE
Fix flaky get frr daemon memory usage issue in stress route test

### DIFF
--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -128,7 +128,7 @@ def get_frr_daemon_memory_usage(duthost, daemon_list):
         frr_daemon_memory_output = duthost.shell(f'vtysh -c "show memory {daemon}"')["stdout"]
         logging.info(f"{daemon} memory status: \n%s", frr_daemon_memory_output)
         output = duthost.shell(f'vtysh -c "show memory {daemon}" | grep "Free ordinary blocks"')["stdout"]
-        frr_daemon_memory = output.split()[-2]
+        frr_daemon_memory = int(output.split()[-2])
         unit = output.split()[-1]
         if unit == "KiB":
             frr_daemon_memory = frr_daemon_memory / 1000


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Stress route test have about 20% chance to fail in getting frr daemon memory usage, frr_daemon_memory parsed is expected to be integer, but sometimes it would be string
```
    def get_frr_daemon_memory_usage(duthost, daemon_list):
        frr_daemon_memory_dict = {}
        for daemon in daemon_list:
            frr_daemon_memory_output = duthost.shell(f'vtysh -c "show memory {daemon}"')["stdout"]
            logging.info(f"{daemon} memory status: \n%s", frr_daemon_memory_output)
            output = duthost.shell(f'vtysh -c "show memory {daemon}" | grep "Free ordinary blocks"')["stdout"]
            frr_daemon_memory = output.split()[-2]
            unit = output.split()[-1]
            if unit == "KiB":
>               frr_daemon_memory = frr_daemon_memory / 1000
E               TypeError: unsupported operand type(s) for /: 'str' and 'int'

frr_daemon_memory = '8977'
output     = '  Free ordinary blocks:  8977 KiB'
```
#### How did you do it?
Always convert the parsed frr_daemon_memory to integer
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
