### PR TITLE
Revert wrong change done by PR15531 shut to noshut

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -885,7 +885,7 @@ def test_nhop_group_interface_flap(duthosts, enum_rand_one_per_hwsku_frontend_ho
                                                             gather_facts['src_port'][i])
             logger.debug("Shut fanout sw: %s, port: %s", fanout, fanout_port)
             if is_vs_device(duthost) is False:
-                fanout.no_shutdown(fanout_port)
+                fanout.shutdown(fanout_port)
         nhop.add_ip_route(ip_prefix, ips)
 
         nhop.program_routes()


### PR DESCRIPTION

### Description of PR
Test ipfwd/test_nhop_group.py::test_nhop_group_interface_flap failing as the fanout port was configured no-shut instead of shutdown. This was done by PR15531 and same reverted to pass this test in this PR.

Below PR changed the fanout port shut to no_shut as part of adding other condition check.
https://github.com/sonic-net/sonic-mgmt/pull/15531

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
