### PR TITLE
Add loganalyzer ignore for routeCheck in test_route_consistency.py

### DIFF
--- a/tests/route/test_route_consistency.py
+++ b/tests/route/test_route_consistency.py
@@ -96,6 +96,18 @@ class TestRouteConsistency():
             max_prefix_cnt = max(max_prefix_cnt, len(prefix_snapshot[dut_instance_name]))
         return prefix_snapshot, max_prefix_cnt
 
+    @pytest.fixture(autouse=True)
+    def ignore_expected_loganalyzer_exceptions(self, duthosts, loganalyzer):
+        """Ignore expected error syslogs during test execution."""
+        if loganalyzer:
+            for duthost in duthosts:
+                loganalyzer[duthost.hostname].ignore_regex.extend(
+                    [
+                        # Withdrawing/announcing routes as well as bgp shut/noshut can make routeCheck fail
+                        r".*ERR.* 'routeCheck' status failed.*",
+                    ]
+                )
+
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, duthosts):
         # take the snapshot of route table from all the DUTs


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #16389

This test changes routes by withdrawing/announcing and this can cause temporary routeCheck fails.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Ran on t2min and confirmed test is now consistently passing without loganalyzer failing the test due to routeCheck errors.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
