### PR TITLE
update pkts_num_trig_pfc of wm_pg_shared_lossless in yaml file

### DIFF
--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -492,7 +492,7 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 14804
+                    pkts_num_trig_pfc: 14812
                     pkts_num_fill_min: 0
                     pkts_num_margin: 4
                     packet_size: 1350
@@ -617,7 +617,7 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 14804
+                    pkts_num_trig_pfc: 14812
                     pkts_num_fill_min: 0
                     pkts_num_margin: 4
                     packet_size: 1350


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://migsonic.atlassian.net/browse/MIGSMSFT-855

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Fix failure of case qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[multi_dut_shortlink_to_longlink-wm_pg_shared_lossless]

#### How did you do it?
Update pkts_num_trig_pfc of wm_pg_shared_lossless in yaml file.
pkts_num_trig_pfc in this case means the maximum buffers in queue, which is 14812.

```
Source queue counters for Ethernet0 tc 3:
   SQ buffer counter 14812
   SQ congestion state Xoff
   SQ headroom counter in buffers 1156 (trigger ingress drop)
```


#### How did you verify/test it?
Verified it in T2 testbed.
```
------------ generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark_2025-01-08-21-54-09.xml ------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------- live log sessionfinish --------------------------------------------------------
22:19:57 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
======================================================= short test summary info =======================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[multi_dut_shortlink_to_longlink-wm_pg_shared_lossless]
SKIPPED [1] qos/test_qos_sai.py:1619: The lossy test is not valid for multiAsic configuration.
======================================== 1 passed, 1 skipped, 1 warning in 1546.54s (0:25:46) =========================================
sonic@sonic-ucs-m6-09:/data/tests$ 

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
