### PR TITLE
snappi: T2: Convert all udp port numbers to serial sequence.

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -3,7 +3,6 @@ This module allows various snappi based tests to generate various traffic config
 """
 import time
 import logging
-import random
 import re
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi_tests.common_helpers import get_egress_queue_count, pfc_class_enable_vector, \
@@ -20,6 +19,7 @@ logger = logging.getLogger(__name__)
 SNAPPI_POLL_DELAY_SEC = 2
 CONTINUOUS_MODE = -5
 ANSIBLE_POLL_DELAY_SEC = 4
+UDP_PORT_START = 5000
 
 
 def setup_base_traffic_config(testbed_config,
@@ -129,7 +129,9 @@ def generate_test_flows(testbed_config,
         test_flow.tx_rx.port.rx_name = base_flow_config["rx_port_name"]
 
         eth, ipv4, udp = test_flow.packet.ethernet().ipv4().udp()
-        src_port = random.randint(5000, 6000)
+        global UDP_PORT_START
+        src_port = UDP_PORT_START
+        UDP_PORT_START += number_of_streams
         udp.src_port.increment.start = src_port
         udp.src_port.increment.step = 1
         udp.src_port.increment.count = number_of_streams

--- a/tests/snappi_tests/multidut/ecn/files/multidut_helper.py
+++ b/tests/snappi_tests/multidut/ecn/files/multidut_helper.py
@@ -281,7 +281,8 @@ def run_ecn_test(api,
     generate_test_flows(testbed_config=testbed_config,
                         test_flow_prio_list=[lossless_prio],
                         prio_dscp_map=prio_dscp_map,
-                        snappi_extra_params=snappi_extra_params)
+                        snappi_extra_params=snappi_extra_params,
+                        number_of_streams=10)
 
     logger.info("Generating pause flows")
     generate_pause_flows(testbed_config=testbed_config,
@@ -426,7 +427,8 @@ def run_ecn_marking_port_toggle_test(
     generate_test_flows(testbed_config=testbed_config,
                         test_flow_prio_list=test_prio_list,
                         prio_dscp_map=prio_dscp_map,
-                        snappi_extra_params=snappi_extra_params)
+                        snappi_extra_params=snappi_extra_params,
+                        number_of_streams=10)
 
     snappi_extra_params.base_flow_config = base_flow_config2
 
@@ -444,7 +446,8 @@ def run_ecn_marking_port_toggle_test(
     generate_test_flows(testbed_config=testbed_config,
                         test_flow_prio_list=test_prio_list,
                         prio_dscp_map=prio_dscp_map,
-                        snappi_extra_params=snappi_extra_params)
+                        snappi_extra_params=snappi_extra_params,
+                        number_of_streams=10)
 
     flows = testbed_config.flows
 
@@ -588,7 +591,8 @@ def run_ecn_marking_test(api,
     generate_test_flows(testbed_config=testbed_config,
                         test_flow_prio_list=test_prio_list,
                         prio_dscp_map=prio_dscp_map,
-                        snappi_extra_params=snappi_extra_params)
+                        snappi_extra_params=snappi_extra_params,
+                        number_of_streams=10)
 
     snappi_extra_params.base_flow_config = base_flow_config2
 
@@ -606,7 +610,8 @@ def run_ecn_marking_test(api,
     generate_test_flows(testbed_config=testbed_config,
                         test_flow_prio_list=test_prio_list,
                         prio_dscp_map=prio_dscp_map,
-                        snappi_extra_params=snappi_extra_params)
+                        snappi_extra_params=snappi_extra_params,
+                        number_of_streams=10)
 
     flows = testbed_config.flows
 

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_external_pause_storms_helper.py
@@ -344,7 +344,8 @@ def __gen_data_flow(testbed_config,
         flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
         eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
         global UDP_PORT_START
-        src_port = UDP_PORT_START + no_of_streams
+        src_port = UDP_PORT_START
+        UDP_PORT_START += no_of_streams
         udp.src_port.increment.start = src_port
         udp.src_port.increment.step = 1
         udp.src_port.increment.count = no_of_streams

--- a/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
@@ -353,7 +353,8 @@ def __gen_data_flow(testbed_config,
         flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
         eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
         global UDP_PORT_START
-        src_port = UDP_PORT_START + no_of_streams
+        src_port = UDP_PORT_START
+        UDP_PORT_START += no_of_streams
         udp.src_port.increment.start = src_port
         udp.src_port.increment.step = 1
         udp.src_port.increment.count = no_of_streams

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -314,7 +314,8 @@ def __gen_data_flow(testbed_config,
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
     eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
     global UDP_PORT_START
-    src_port = UDP_PORT_START + no_of_streams
+    src_port = UDP_PORT_START
+    UDP_PORT_START += no_of_streams
     udp.src_port.increment.start = src_port
     udp.src_port.increment.step = 1
     udp.src_port.increment.count = no_of_streams

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_runtime_traffic_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_runtime_traffic_helper.py
@@ -154,7 +154,9 @@ def __gen_traffic(testbed_config,
         else:
             eth.pfc_queue.value = pfcQueueValueDict[prio]
 
-        src_port = UDP_PORT_START + eth.pfc_queue.value
+        global UDP_PORT_START
+        src_port = UDP_PORT_START
+        UDP_PORT_START += 1
         udp.src_port.increment.start = src_port
         udp.src_port.increment.step = 1
         udp.src_port.increment.count = 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In snappi tests, we have a number of tests with UDP streams. We need them to be counted sequentially instead of random, or any other order. This PR addresses some of the mistakes in the udp port count logic.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
The tests fail in cisco-8000 due to backplane bandwidth limitations. The backplane bandwidth limit will be avoided if the number of streams we use in the traffic is large enough to cause load balancing across the backplane, so that many backplane ports are used instead of just one. This PR addresses some of the script locations where the udp port numbers are not correctly calculated.

#### How did you do it?

#### How did you verify/test it?
Ran it on my TB, with a -e --count=2 option, for repeating the tests 2 times:
```
=========================================================================================================== PASSES ===========================================================================================================
___________________________________________________________________________________ test_ecn_marking_port_toggle[multidut_port_info0-1-2] ____________________________________________________________________________________
___________________________________________________________________________________ test_ecn_marking_port_toggle[multidut_port_info0-2-2] ____________________________________________________________________________________
___________________________________________________________________________________ test_ecn_marking_port_toggle[multidut_port_info1-1-2] ____________________________________________________________________________________
___________________________________________________________________________________ test_ecn_marking_port_toggle[multidut_port_info1-2-2] ____________________________________________________________________________________
___________________________________________________________________________________ test_ecn_marking_port_toggle[multidut_port_info2-1-2] ____________________________________________________________________________________
___________________________________________________________________________________ test_ecn_marking_port_toggle[multidut_port_info2-2-2] ____________________________________________________________________________________
___________________________________________________________________________________ test_ecn_marking_port_toggle[multidut_port_info3-1-2] ____________________________________________________________________________________
___________________________________________________________________________________ test_ecn_marking_port_toggle[multidut_port_info3-2-2] ____________________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent0-1-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent0-2-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent1-1-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent1-2-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent2-1-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent2-2-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent3-1-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent3-2-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent4-1-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent4-2-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent5-1-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent5-2-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent6-1-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent6-2-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent7-1-2] _________________________________________________________________________
_________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent7-2-2] _________________________________________________________________________
---------------------------------------------------------------- generated xml file: /run_logs/ixia/ecn_repeat/2025-01-08-22-40-28/tr_2025-01-08-22-40-28.xml ----------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
================================================================================================== short test summary info ===================================================================================================
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_info0-1-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_info0-2-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_info1-1-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_info1-2-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_info2-1-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_info2-2-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_info3-1-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_info3-2-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent0-1-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent0-2-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent1-1-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent1-2-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent2-1-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent2-2-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent3-1-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent3-2-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent4-1-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent4-2-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent5-1-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent5-2-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent6-1-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent6-2-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent7-1-2]
PASSED snappi_tests/multidut/ecn/test_multidut_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent7-2-2]
SKIPPED [16] common/helpers/assertions.py:16: ECN tests are not supported on Cisco switches yet.
SKIPPED [48] common/helpers/assertions.py:16: Invalid combination of duthosts or ASICs in snappi_ports
================================================================================= 24 passed, 64 skipped, 28 warnings in 12774.71s (3:32:54) ==================================================================================
sonic@snappi-sonic-mgmt-vanilla-202405-t2:/data/tests$ 
```