### PR TITLE
Temporarily skipping a failing test in test_arp_dualtor.py

### DIFF
--- a/tests/arp/test_arp_dualtor.py
+++ b/tests/arp/test_arp_dualtor.py
@@ -191,6 +191,8 @@ def test_standby_unsolicited_neigh_learning(
     2. Run arp_update on the active ToR
     3. Confirm that the standby ToR learned the entry and it is REACHABLE
     """
+    if ip_address(neighbor_ip).version == 6 and lower_tor_host.facts["asic_type"] == "vs":
+        pytest.skip("Temporarily skipped to let the sonic-swss submodule be updated.")
     ping_cmd = "timeout 0.2 ping -c1 -W1 -i0.2 -n -q {}".format(neighbor_ip)
 
     upper_tor_host.shell(ping_cmd, module_ignore_errors=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR temporarily skips test_standby_unsolicited_neigh_learning when the test is executed on a KVM testbed and the neighbor IP is an IPv6 address. The reason is that this test case is currently blocking sonic-swss submodule from being updated.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Unblocking sonic-swss submodule update.

#### How did you do it?
Skipped the failing test case when the test is executed on a KVM testbed and the neighbor IP is an IPv6 address.

#### How did you verify/test it?
Tested on a local dualtor KVM testbed.

#### Any platform specific information?
The test is only skipped on VS switches.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A