### PR TITLE
[test_eth_interface.py] check_interface_status() allow column headers…

### DIFF
--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -79,7 +79,7 @@ def check_interface_status(duthost, field, interface='Ethernet0'):
     output = duthost.shell(cmds)
     pytest_assert(not output['rc'])
     status_data = output["stdout_lines"]
-    field_index = status_data[0].split().index(field)
+    field_index = re.split(r" {2,}", status_data[0].strip()).index(field)
     for line in status_data:
         if interface in line:
             interface_status = line.strip()
@@ -234,7 +234,7 @@ def test_toggle_pfc_asym(duthosts, rand_one_dut_hostname, ensure_dut_readiness, 
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         expect_op_success(duthost, output)
-        current_status_pfc_asym = check_interface_status(duthost, "Asym")
+        current_status_pfc_asym = check_interface_status(duthost, "Asym PFC")
         pytest_assert(current_status_pfc_asym == pfc_asym,
                       "Failed to properly configure interface Asym PFC to requested value off")
     finally:


### PR DESCRIPTION
… a more descriptive format, with one space separating words for better readability.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
The test case test_toggle_pfc_asym() check "Asym PFC" status in check_interface_status() with "Asym" input. Normally it should use "Asym PFC" input. And this PR also can apply for any header with one space separating words.
#### How did you do it?
Use same way as check status data by **re.split(r" {2,}",status_data[0].strip())** allow status header split by two or more space characters
#### How did you verify/test it?
Run the test in my TB and see it passes
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
