### PR TITLE
Add dualtor mux port iptables entries test to PR test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -259,6 +259,7 @@ dualtor:
   - arp/test_arp_dualtor.py
   - arp/test_arp_extended.py
   - dualtor/test_ipinip.py
+  - dualtor/test_mux_port_iptables_entries.py
   - dualtor/test_standalone_tunnel_route.py
   - dualtor/test_switchover_failure.py
   - dualtor/test_switchover_faulty_ycable.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test can't be tested on KVM platform, we need to skip traffic test if needed.
Test in Elastictest, only 1 test failed in sanity check, not related to testcase:
TestbedName | FilePath | TestCase | SuccessCount | FailureCount | TotalTests | SuccessRate
-- | -- | -- | -- | -- | -- | --
vms-kvm-dual-t0 | dualtor/test_mux_port_iptables_entries.py | test_mux_port_iptables_entries | 27 | 1 | 28 | 0.9643
vms-kvm-dual-t0 | dualtor/test_mux_port_iptables_entries.py | test_multivlan_mux_port_iptables_entries | 27 | 0 | 27 | 1
#### How did you do it?
Add dualtor mux port iptables entries test to PR test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
