### PR TITLE
add fanout support for 202405 and 202411

### DIFF
--- a/ansible/roles/fanout/tasks/fanout_sonic.yml
+++ b/ansible/roles/fanout/tasks/fanout_sonic.yml
@@ -65,9 +65,9 @@
       when: dry_run is not defined and incremental is not defined
   when: "'2023' in fanout_sonic_version['build_version']"
 
-- name: deploy SONiC fanout with image version 202405
+- name: deploy SONiC fanout with image version 202405 or 202411
   block:
-    - name: deploy SONiC fanout not incremental and not dry_run
+    - name: deploy SONiC fanout not incremental and not dry_run with 2024 images
       include_tasks:
         sonic/fanout_sonic_202405.yml
       when: dry_run is not defined and incremental is not defined

--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202405.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202405.yml
@@ -1,1 +1,156 @@
-fanout_sonic_202311.yml
+- name: Copy port_config.ini to fanout switch
+  block:
+    - name: collect fanout port config
+      port_config_gen:
+        hwsku: "{{ device_info[inventory_hostname]['HwSku'] }}"
+        hwsku_type: "{{ device_info[inventory_hostname]['HwSkuType'] | default('predefined') }}"
+        device_conn: "{{ device_conn[inventory_hostname] }}"
+
+    - name: Copy port_config.ini to fanout switch
+      copy:
+        src: "{{ device_info[inventory_hostname]['PortConfigIni'] }}"
+        dest: "/usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/port_config.ini"
+  become: yes
+  when: device_info[inventory_hostname]['PortConfigIni'] is defined
+
+- name: Copy sonic_sku_create.py to fanout switch
+  copy:
+    src: "roles/fanout/library/sonic_sku_create.py"
+    dest: "/tmp/sonic_sku_create.py"
+    mode: "+x"
+  become: yes
+  when: device_info[inventory_hostname]['HwSkuType'] == "dynamic"
+
+- name: collect fanout port config
+  port_config_gen:
+    hwsku: "{{ device_info[inventory_hostname]['HwSku'] }}"
+    hwsku_type: "{{ device_info[inventory_hostname]['HwSkuType'] | default('predefined') }}"
+    device_conn: "{{ device_conn[inventory_hostname] }}"
+  become: yes
+
+- name: Ensure TPID enabled in SAI
+  lineinfile:
+    path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/sai.profile
+    line: 'SAI_USER_DEFINED_TPID=1'
+    state: present
+  become: yes
+  when: "'mellanox' in fanout_sonic_version.asic_type"
+
+- name: Disable software control module function
+  block:
+    - name: Disable software control module function in SAI
+      lineinfile:
+        path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/sai.profile
+        line: 'SAI_INDEPENDENT_MODULE_MODE=1'
+        state: absent
+
+    - name: Check whether pmon_daemon_control.json exist
+      stat:
+        path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/pmon_daemon_control.json
+      register: pmon_daemon_control_json
+
+    - name: Skip transceiver cmis manager
+      lineinfile:
+        path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/pmon_daemon_control.json
+        regexp: '"skip_xcvrd_cmis_mgr": false'
+        line: '    "skip_xcvrd_cmis_mgr": true'
+      when: pmon_daemon_control_json.stat.exists
+
+    - name: Remove media setting file
+      file:
+        path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/media_settings.json
+        state: absent
+
+    - name: Remove optical setting file
+      file:
+        path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/optics_si_settings.json
+        state: absent
+  become: yes
+  when: "'mellanox' in fanout_sonic_version.asic_type"
+
+- name: build fanout startup config
+  template:
+    src: "sonic_deploy_202405.j2"
+    dest: "/tmp/base_config.json"
+
+- name: generate config_db.json
+  shell: sonic-cfggen -H -j /tmp/base_config.json --print-data > /etc/sonic/config_db.json
+  become: yes
+
+- name: disable all copp rules
+  copy:
+    content: "{}"
+    dest: "/usr/share/sonic/templates/copp_cfg.j2"
+  become: yes
+  when: "'mellanox' not in fanout_sonic_version.asic_type"
+
+- name: Overwrite copp rules for Mellanox FanoutLeaf
+  copy:
+    src: "copp_cfg_mlnx.j2"
+    dest: "/usr/share/sonic/templates/copp_cfg.j2"
+  become: yes
+  when: "'mellanox' in fanout_sonic_version.asic_type"
+
+- name: Disable feature teamd and remove teamd container (avoid swss crash after config reload)
+  block:
+    - name: Check if teamd container exists
+      shell: "docker ps -a -q -f name=teamd"
+      register: teamd_container
+
+    - name: disable feature teamd and remove container
+      block:
+        - name: disable feature teamd
+          shell: config feature state teamd disabled
+          become: true
+        - name: ensure teamd container is stopped
+          docker_container:
+            name: teamd
+            state: stopped
+          become: true
+          ignore_errors: yes
+        - name: remove teamd container
+          docker_container:
+            name: teamd
+            state: absent
+          become: true
+      when: teamd_container.stdout != ""
+
+- name: SONiC update config db
+  shell: config reload -y -f
+  become: true
+
+- name: wait for SONiC update config db finish
+  pause:
+    seconds: 180
+
+- name: Shutdown arp_update process in swss (avoid fanout broadcasting it's MAC address)
+  shell: docker exec -i swss supervisorctl stop arp_update
+  become: yes
+
+- name: Setup broadcom based fanouts
+  block:
+    - name: reinit fp entries
+      shell: "bcmcmd 'fp detach' && bcmcmd 'fp init'"
+      become: yes
+  when: "'broadcom' in fanout_sonic_version.asic_type"
+
+- block:
+  - name: Remove ipv6 parameter
+    lineinfile:
+      path: /etc/sysctl.conf
+      line: 'net.ipv6.conf.all.disable_ipv6 = 0'
+      state: absent
+    become: yes
+
+  - name: Update IPv6 parameter
+    lineinfile:
+      path: /etc/sysctl.conf
+      line: 'net.ipv6.conf.all.disable_ipv6 = 1'
+      state: present
+    become: yes
+
+  - name: Apply parameter to disable IPv6 function
+    shell: "sysctl -p"
+    become: yes
+
+  when: "'mellanox' in fanout_sonic_version.asic_type"

--- a/ansible/roles/fanout/templates/sonic_deploy_202405.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202405.j2
@@ -1,0 +1,462 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "default_pfcwd_status": "disable",
+            "hwsku": "{{ fanout_hwsku }}",
+            "hostname": "{{ inventory_hostname }}"
+        }
+    },
+
+    "PORT": {
+    {% for port_name in fanout_port_config %}
+        "{{ port_name }}": {
+            "alias": "{{ fanout_port_config[port_name]['alias'] }}",
+            "speed" : "{{ fanout_port_config[port_name]['speed'] | default('100000') }}",
+            "index": "{{ fanout_port_config[port_name]['index'] }}",
+            "lanes": "{{ fanout_port_config[port_name]['lanes'] }}",
+            "pfc_asym": "off",
+            "mtu": "9100",
+    {% if fanout_hwsku == "Arista-720DT-G48S4" and (fanout_port_config[port_name]['lanes'] | int) <= 24 %}
+            "autoneg": "on",
+    {% endif %}
+    {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
+            "fec" : "rs",
+    {% endif %}
+    {% if 'broadcom' in fanout_sonic_version["asic_type"] or 'marvell' in fanout_sonic_version["asic_type"] or 'mellanox' in fanout_sonic_version["asic_type"] %}
+        {% if port_name in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][port_name]["mode"].lower() == "access" %}
+            "tpid": "0x9100",
+        {% endif %}
+    {% endif %}
+    {% if 'peerdevice' in fanout_port_config[port_name] %}
+            "admin_status": "up"
+    {% else %}
+            "admin_status": "down"
+    {% endif %}
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+
+    "VLAN": {
+    {% for vlanid in device_vlan_list[inventory_hostname] | unique %}
+        "Vlan{{ vlanid }}": {
+            "vlanid": "{{ vlanid }}"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+
+    {% set ns = {'firstPrinted': False} %}
+    "VLAN_MEMBER": {
+    {% if device_info[inventory_hostname]['PortConfigIni'] is defined %}
+      {% set port_config = fanout_port_config %}
+    {% else %}
+      {% set port_config = device_port_vlans[inventory_hostname] %}
+    {% endif %}
+    {% for port_name in port_config %}
+    {% if port_name in device_port_vlans[inventory_hostname] %}
+    {% if device_port_vlans[inventory_hostname][port_name]['mode'].lower() == 'access' %}
+    {% if ns.firstPrinted %},{% endif %}
+        "Vlan{{ device_port_vlans[inventory_hostname][port_name]['vlanids'] }}|{{ fanout_port_config[port_name]['name'] }}": {
+            "tagging_mode" : "untagged"
+        }
+    {% if ns.update({'firstPrinted': True}) %} {% endif %}
+    {% elif device_port_vlans[inventory_hostname][port_name]['mode'].lower() == 'trunk' %}
+    {% for vlanid in device_port_vlans[inventory_hostname][port_name]['vlanlist'] %}
+    {% if ns.firstPrinted %},{% endif %}
+        "Vlan{{ vlanid }}|{{ fanout_port_config[port_name]['name'] }}": {
+            "tagging_mode" : "tagged"
+        }
+    {% if ns.update({'firstPrinted': True}) %} {% endif %}
+    {% endfor %}
+    {% endif %}
+    {% endif %}
+    {% endfor %}
+    },
+
+    "MGMT_INTERFACE": {
+        "eth0|{{ device_info[inventory_hostname]["ManagementIp"] }}": {
+            "gwaddr": "{{ device_info[inventory_hostname]["ManagementGw"] }}"
+        }
+    },
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0"
+        }
+    },
+
+    "VERSIONS": {
+        "DATABASE": {
+            "VERSION": "version_1_0_1"
+        }
+    },
+{% if 'mellanox' in fanout_sonic_version["asic_type"] %}
+    "BUFFER_POOL": {
+        "egress_lossless_pool": {
+            "mode": "dynamic",
+            "size": "60817392",
+            "type": "egress"
+        },
+        "egress_lossy_pool": {
+            "mode": "dynamic",
+            "size": "49946624",
+            "type": "egress"
+        },
+        "ingress_lossless_pool": {
+            "mode": "dynamic",
+            "size": "49946624",
+            "type": "ingress",
+            "xoff": "4063232"
+        },
+        "ingress_zero_pool": {
+            "mode": "static",
+            "size": "0",
+            "type": "ingress"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "egress_lossless_profile": {
+            "dynamic_th": "7",
+            "pool": "egress_lossless_pool",
+            "size": "0"
+        },
+        "egress_lossless_zero_profile": {
+            "dynamic_th": "-8",
+            "pool": "egress_lossless_pool",
+            "size": "0"
+        },
+        "egress_lossy_profile": {
+            "dynamic_th": "7",
+            "pool": "egress_lossy_pool",
+            "size": "9216"
+        },
+        "egress_lossy_zero_profile": {
+            "dynamic_th": "-8",
+            "pool": "egress_lossy_pool",
+            "size": "0"
+        },
+        "ingress_lossless_profile": {
+            "dynamic_th": "7",
+            "pool": "ingress_lossless_pool",
+            "size": "0"
+        },
+        "ingress_lossless_zero_profile": {
+            "dynamic_th": "-8",
+            "pool": "ingress_lossless_pool",
+            "size": "0"
+        },
+        "ingress_lossy_pg_zero_profile": {
+            "pool": "ingress_zero_pool",
+            "size": "0",
+            "static_th": "0"
+        },
+        "ingress_lossy_profile": {
+            "dynamic_th": "3",
+            "pool": "ingress_lossless_pool",
+            "size": "0"
+        },
+        "pg_lossless_200000_5m_profile": {
+            "dynamic_th": "0",
+            "pool": "ingress_lossless_pool",
+            "size": "19456",
+            "xoff": "66560",
+            "xon": "19456"
+        },
+        "pg_lossless_400000_5m_profile": {
+            "dynamic_th": "0",
+            "pool": "ingress_lossless_pool",
+            "size": "38912",
+            "xoff": "115712",
+            "xon": "38912"
+        },
+        "q_lossy_profile": {
+            "dynamic_th": "3",
+            "pool": "egress_lossy_pool",
+            "size": "0"
+        }
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
+    {% for port_name in fanout_port_config %}
+         "{{ port_name }}": {
+            "profile_list": "egress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
+    {% for port_name in fanout_port_config %}
+         "{{ port_name }}": {
+            "profile_list": "ingress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+{% endif %}
+{% if fanout_hwsku not in ("Nokia-7215", "Nokia-7215-A1", "Arista-720DT-G48S4") and "Arista-7060X6-64PE" not in fanout_hwsku %}
+    "BUFFER_QUEUE": {
+    {% for port_name in fanout_port_config %}
+         "{{ port_name }}|0-7": {
+            "profile": "q_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+    "BUFFER_PG": {
+    {% for port_name in fanout_port_config %}
+         "{{ port_name }}|0-7": {
+            "profile": "ingress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+{% endif %}
+{% if fanout_hwsku in ("Nokia-7215", "Nokia-7215-A1", "Arista-720DT-G48S4") %}
+
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "BUFFER_POOL_WATERMARK": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "PFCWD": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "PG_DROP": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "PG_WATERMARK": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "PORT": {
+            "FLEX_COUNTER_STATUS": "enable"
+        },
+        "PORT_BUFFER_DROP": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "QUEUE": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "QUEUE_WATERMARK": {
+            "FLEX_COUNTER_STATUS": "disable"
+        },
+        "RIF": {
+            "FLEX_COUNTER_STATUS": "disable"
+        }
+    },
+
+{% else %}
+
+    "FLEX_COUNTER_TABLE": {
+        "PFCWD": {
+            "FLEX_COUNTER_STATUS": "enable"
+        },
+        "PORT": {
+            "FLEX_COUNTER_STATUS": "enable"
+        },
+        "QUEUE": {
+            "FLEX_COUNTER_STATUS": "enable"
+        }
+    },
+
+    "QUEUE": {
+    {% for port_name in fanout_port_config %}
+        "{{ port_name }}|0-7": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    },
+
+    "CABLE_LENGTH": {
+        "AZURE": {
+    {% for port_name in fanout_port_config %}
+        "{{ port_name }}": "300m"{% if not loop.last %},{% endif %}
+    {% endfor %}
+        }
+    },
+
+    "PFC_WD": {
+        "GLOBAL": {
+            "POLL_INTERVAL": "200"
+        }
+    },
+
+    "SCHEDULER": {
+        "scheduler.0": {
+            "type": "DWRR",
+            "weight": "14"
+        },
+        "scheduler.1": {
+            "type": "DWRR",
+            "weight": "15"
+        }
+    },
+
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS": {
+            "red_max_threshold": "2097152",
+            "red_drop_probability": "5",
+            "wred_green_enable": "true",
+            "ecn": "ecn_all",
+            "green_min_threshold": "250000",
+            "red_min_threshold": "1048576",
+            "wred_yellow_enable": "true",
+            "yellow_min_threshold": "1048576",
+            "green_max_threshold": "2097152",
+            "green_drop_probability": "5",
+            "yellow_max_threshold": "2097152",
+            "yellow_drop_probability": "5",
+            "wred_red_enable": "true"
+        }
+    },
+
+    "SCHEDULER": {
+        "scheduler.0": {
+            "type": "DWRR",
+            "weight": "14"
+        },
+        "scheduler.1": {
+            "type": "DWRR",
+            "weight": "15"
+        }
+    },
+
+{% endif %}
+
+    "FEATURE": {
+        "acms": {
+            "auto_restart": "disabled",
+            "has_global_scope": "True",
+            "has_per_asic_scope": "False",
+            "has_timer": "False",
+            "high_mem_alert": "disabled",
+            "set_owner": "local",
+            "state": "disabled"
+        },
+        "mux": {
+            "auto_restart": "disabled",
+            "has_global_scope": "True",
+            "has_per_asic_scope": "False",
+            "has_timer": "False",
+            "high_mem_alert": "disabled",
+            "set_owner": "local",
+            "state": "disabled"
+        },
+        "bgp": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": false,
+            "has_per_asic_scope": true,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "database": {
+            "state": "always_enabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": true,
+            "auto_restart": "always_enabled",
+            "high_mem_alert": "disabled"
+        },
+        "dhcp_relay": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "lldp": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": true,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "pmon": {
+            "state": "enabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "radv": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "snmp": {
+            "state": "enabled",
+            "has_timer": true,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "swss": {
+            "state": "enabled",
+            "has_timer": false,
+            "has_global_scope": false,
+            "has_per_asic_scope": true,
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "syncd": {
+            "state": "enabled",
+            "has_timer": false,
+            "has_global_scope": false,
+            "has_per_asic_scope": true,
+            "auto_restart": "enabled",
+            "high_mem_alert": "disabled"
+        },
+        "teamd": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": false,
+            "has_per_asic_scope": true,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "mgmt-framework": {
+            "state": "disabled",
+            "has_timer": true,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "nat": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "sflow": {
+            "state": "disabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "telemetry": {
+            "state": "disabled",
+            "has_timer": true,
+            "has_global_scope": true,
+            "has_per_asic_scope": false,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+        "restapi": {
+            "auto_restart": "disabled",
+            "has_global_scope": "True",
+            "has_per_asic_scope": "False",
+            "has_timer": "False",
+            "high_mem_alert": "disabled",
+            "set_owner": "local",
+            "state": "disabled"
+        }
+    }
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Current 2024 sonic fanout is using 202311 template. 

However, with TH5, we need to skip BUFFER_PG config for now. Hence, replaced the soft link with an actual file.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Support 202405 and 202411 image.

#### How did you do it?
replace soft link with hard copy. and modified it to suit 202405 requirement.

#### How did you verify/test it?
Tested it locally.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
