### PR TITLE
Fix test_console_escape in new version of netmiko

### DIFF
--- a/tests/dut_console/test_escape_character.py
+++ b/tests/dut_console/test_escape_character.py
@@ -14,5 +14,7 @@ pytestmark = [
 def test_console_escape(duthost_console):
     duthost_console.send_command("ping 127.0.0.1 -c {} -i 1".format(TOTAL_PACKETS),
                                  expect_string=r"icmp_seq={}".format(packet_number))
-    duthost_console.send_command("\x03",
-                                 expect_string=r"{} packets transmitted".format(packet_number), max_loops=300)
+    # Send interrupt character directly
+    duthost_console.write_channel("\x03")
+    # Matching the expected output content
+    duthost_console.read_until_pattern(pattern=r"{} packets transmitted".format(packet_number))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix test_console_escape in new version of netmiko
Fixes # 
The `netmiko` version was updated in the latest sonic-mgmt container. After that test case `tests/dut_console/test_escape_character.py` failed as did not match the expected pattern
**Latest version**:
- paramiko: 2.9.5
- netmiko: 3.2.0

**Root cause**
```python
    duthost_console.send_command("\x03",
                                 expect_string=r"{} packets transmitted".format(packet_number), max_loops=300)
```
In newer versions of netmiko, the `send_command` method will first try to match the command itself, so it will try to match `\x03`.
When we send `\x03` to the terminal, it displays as `^C` in the terminal, so in the output we see the string form: `^C\r\n\r\n...`.
- `\x03` is a single-byte control character (ASCII value 3)
- `^C` is a combination of two characters (^ and C)

When we read the output from the terminal, we get the display form `^C`, not the original control character `\x03`. They are not matched, so case fail

**Solution**
```python
    # Send interrupt character directly
    duthost_console.write_channel("\x03")
    # Matching the expected output content
    duthost_console.read_until_pattern(pattern=r"{} packets transmitted".format(packet_number))
```
Avoid using `send_command` to send the interrupt character. Instead, use `write_channel` to send the interrupt signal directly, and then use `read_until_pattern` to match the expected output

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
