### PR TITLE
Deprecate sonic-common agent pool. (#16385)

### DIFF
--- a/.azure-pipelines/pytest-collect-only.yml
+++ b/.azure-pipelines/pytest-collect-only.yml
@@ -25,7 +25,7 @@ steps:
 
     sudo docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
 
-    sudo docker run -dt --name sonic-mgmt-collect \
+    sudo docker run --rm -dt --name sonic-mgmt-collect \
       -v $(System.DefaultWorkingDirectory):/var/src/sonic-mgmt \
       sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest \
       /bin/bash

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ stages:
     displayName: "Validate Test Cases"
     timeoutInMinutes: 20
     continueOnError: false
-    pool: sonic-common
+    pool: sonic-ubuntu-1c
     steps:
     - template: .azure-pipelines/pytest-collect-only.yml
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. Use sonic-ubuntu-1c instead of sonic-common.
2. Fix docker run command to reuse agent.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
