### PR TITLE
Temporarily skipping a failing test in test_arp_extended.py

### DIFF
--- a/tests/arp/test_arp_extended.py
+++ b/tests/arp/test_arp_extended.py
@@ -65,6 +65,9 @@ def test_proxy_arp(rand_selected_dut, proxy_arp_enabled, ip_and_intf_info, ptfad
 
     ip_version, outgoing_packet, expected_packet = packets_for_test
 
+    if ip_version == "v6" and rand_selected_dut.facts["asic_type"] == "vs":
+        pytest.skip("Temporarily skipped to let the sonic-swss submodule be updated.")
+
     if ip_version == 'v4':
         pytest_require(ptf_intf_ipv4_addr is not None, 'No IPv4 VLAN address configured on device')
     elif ip_version == 'v6':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR temporarily skips test_proxy_arp when the test is executed on a KVM testbed and IPv6 packets are used for testing. The reason is that this test case is currently blocking sonic-swss submodule from being updated.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
    - [ ] Add ownership [here](https://msazure.visualstudio.com/AzureWiki/_wiki/wikis/AzureWiki.wiki/744287/TSG-for-ownership-modification)(Microsft required only)
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Unblocking sonic-swss submodule update.

#### How did you do it?
Skipped the failing test case when the test is executed on a KVM testbed and IPv6 packets are used for testing.

#### How did you verify/test it?
Tested on a local dualtor KVM testbed.

#### Any platform specific information?
The test is only skipped on VS switches.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A