### PR TITLE
[202405] Add additional wait for BGP up on multi-ASIC vs platform

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -215,8 +215,12 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
         time.sleep(wait)
 
     if wait_for_bgp:
+        additional_wait = 0
+        # Add an additional wait on multi-asic vs platforms to allow for BGP sessions to be established
+        if sonic_host.facts['asic_type'] == 'vs' and sonic_host.is_multi_asic:
+            additional_wait = 400
         bgp_neighbors = sonic_host.get_bgp_neighbors_per_asic(state="all")
         pytest_assert(
-            wait_until(wait + 300, 10, 0, sonic_host.check_bgp_session_state_all_asics, bgp_neighbors),
+            wait_until(wait + 300 + additional_wait, 10, 0, sonic_host.check_bgp_session_state_all_asics, bgp_neighbors), # noqa E501
             "Not all bgp sessions are established after config reload",
         )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to add some additional wait for BGP up on multi-ASIC vs platform.
We are seeing the BGP sessions are up after around 8 minutes after config reload on multi-asic vs platform. This issue leads to the flakiness in PR test.
For now, the issue is only in `202405` branch and vs testbed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
    - [ ] Add ownership [here](https://msazure.visualstudio.com/AzureWiki/_wiki/wikis/AzureWiki.wiki/744287/TSG-for-ownership-modification)(Microsft required only)
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
This PR is to add some additional wait for BGP up on multi-ASIC vs platform.

#### How did you do it?
Add an additional wait.

#### How did you verify/test it?
The change is verified by PR test.

#### Any platform specific information?
VS platform only.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
