### PR TITLE
Revert "Temporarily skipping a test in test_arp_dualtor.py that is failing consistently"

### DIFF
--- a/tests/arp/test_arp_dualtor.py
+++ b/tests/arp/test_arp_dualtor.py
@@ -148,8 +148,6 @@ def test_arp_update_for_failed_standby_neighbor(
     4. Run `arp_update` on the active ToR
     5. Verify the incomplete entry is now reachable
     """
-    if ip_address(neighbor_ip).version == 6 and lower_tor_host.facts["asic_type"] == "vs":
-        pytest.skip("Temporarily skipped to let the sonic-swss submodule be updated.")
     # We only use ping to trigger an ARP request from the kernel, so exit early to save time
     ping_cmd = "timeout 0.2 ping -c1 -W1 -i0.2 -n -q {}".format(neighbor_ip)
 


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#16371 since the reason is not clear, and sonic-swss submodule advance PR still blocking for other KVM dualtor IPv6 issues