### PR TITLE
 [Impacted Area Based PR testing] Fix script timing with recent test plans

### DIFF
--- a/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
+++ b/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
@@ -94,11 +94,11 @@ def main(scripts, topology, branch):
                 "| where TestPlanType == 'PR' and Result == 'FINISHED' " \
                 f"and Topology == '{PR_CHECKER_TOPOLOGY_NAME[topology][0]}' " \
                 f"and TestBranch == '{branch}' and TestPlanName contains '{PR_CHECKER_TOPOLOGY_NAME[topology][1]}' " \
-                "and TestPlanName contains '_BaselineTest_' and UploadTime > ago(7d)" \
+                "and TestPlanName contains '_BaselineTest_'" \
+                "| take 5" \
                 "| order by UploadTime desc) on TestPlanId " \
                 f"| where FilePath == '{script}' " \
                 "| where Result !in ('failure', 'error') " \
-                "| take 5" \
                 "| summarize ActualCount = count(), TotalRuntime = sum(Runtime)"
         try:
             response = client.execute("SonicTestData", query)

--- a/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
+++ b/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
@@ -95,8 +95,8 @@ def main(scripts, topology, branch):
                 f"and Topology == '{PR_CHECKER_TOPOLOGY_NAME[topology][0]}' " \
                 f"and TestBranch == '{branch}' and TestPlanName contains '{PR_CHECKER_TOPOLOGY_NAME[topology][1]}' " \
                 "and TestPlanName contains '_BaselineTest_'" \
-                "| take 5" \
-                "| order by UploadTime desc) on TestPlanId " \
+                "| order by UploadTime desc" \
+                "| take 5) on TestPlanId " \
                 f"| where FilePath == '{script}' " \
                 "| where Result !in ('failure', 'error') " \
                 "| summarize ActualCount = count(), TotalRuntime = sum(Runtime)"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In the previous implementation, we retrieved 5 test case entries from Kusto to calculate the total running time of a script. However, the query included the condition `| where FilePath == '{script}'`, and since each script may contain multiple test cases, this approach only sampled 5 random test cases from the script. As a result, the calculated average running time was inaccurate. In this PR, we resolve the issue by selecting the most recent 5 test plans instead, ensuring that we account for all test cases executed in the script.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
    - [ ] Add ownership [here](https://msazure.visualstudio.com/AzureWiki/_wiki/wikis/AzureWiki.wiki/744287/TSG-for-ownership-modification)(Microsft required only)
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
In the previous implementation, we retrieved 5 test case entries from Kusto to calculate the total running time of a script. However, the query included the condition `| where FilePath == '{script}'`, and since each script may contain multiple test cases, this approach only sampled 5 random test cases from the script. As a result, the calculated average running time was inaccurate. In this PR, we resolve the issue by selecting the most recent 5 test plans instead, ensuring that we account for all test cases executed in the script.

#### How did you do it?
In this PR, we resolve the issue by selecting the most recent 5 test plans instead, ensuring that we account for all test cases executed in the script.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
