### PR TITLE
Ignore log messages that should be warnings instead of error messages(Cisco)

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -291,6 +291,8 @@ r, ".* ERR kernel:.*cisco-fpga-p2pm-m-slot p2pm-m-slot\.\d+: cisco_fpga_select_n
 r, ".* ERR kernel:.*cisco-fpga-pci \d+:\d+:\d+\.\d+: cisco_fpga_select_new_acpi_companion: searching for child status\d+ 0x[0-9a-f]+; fpga_id 0x[0-9a-f]+.*"
 r, ".* WARNING kernel:.*pcieport.*device.*error.*status/mask=.*"
 r, ".* ERR syncd\d*#syncd:.* -E-HLD-0- Trap.* is not supported.*"
+r, ".* ERR syncd\d*#syncd:.* -E-API-0- src/hld/system/la_device_impl.cpp::10344 clear_snoop_configuration API returned: status = Leaba_Err: Entry requested not found: virtual la_status silicon_one::gibraltar::la_device_impl::do_clear_snoop_configuration(silicon_one::la_event_e):src/hld/system/la_device_impl.cpp:10361.*"
+r, ".* ERR syncd\d*#syncd:.* SAI_LOG|SAI_API_SWITCH: punt packet parsing failed.*"
 
 # Ignore ACL EGRESS feature unavailable error on fabric cards
 r, ".* ERR syncd\d*#syncd:.* SAI_API_SWITCH:brcm_sai_get_switch_attribute.* Get switch attrib 37 failed with error Feature unavailable.*"


### PR DESCRIPTION
### Description of PR
In Cisco platforms these error messages should be warning instead of error messages. We will be making the change but in the meanwhile, I am adding an ignore in log analyzer ignore files to avoid causing testcase failures

2025 Jan  9 12:56:34.229072 sfd-lt2-lc1 ERR syncd0#syncd: 09-01-2025 12:56:34.228 -E-API-0- src/hld/system/la_device_impl.cpp::10344 clear_snoop_configuration API returned: status = Leaba_Err: Entry requested not found: virtual la_status silicon_one::gibraltar::la_device_impl::do_clear_snoop_configuration(silicon_one::la_event_e):src/hld/system/la_device_impl.cpp:10361, 

2025 Jan  9 12:57:23.457616 sfd-lt2-lc1 ERR syncd1#syncd: SAI_LOG|SAI_API_SWITCH: punt packet parsing failed

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
    - [ ] Add ownership [here](https://msazure.visualstudio.com/AzureWiki/_wiki/wikis/AzureWiki.wiki/744287/TSG-for-ownership-modification)(Microsft required only)
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
In Cisco platforms these error messages should be warning instead of error messages. We will be making the change but in the meanwhile, I am adding an ignore in log analyzer ignore files to avoid causing testcase failures

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
