### PR TITLE
[ip/test_mgmt_ipv6_only]: Refactor to properly cleanup on failure

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -13,7 +13,7 @@ from pytest_ansible.errors import AnsibleConnectionFailure
 from paramiko.ssh_exception import AuthenticationException
 
 from tests.common import config_reload
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert as pt_assert
 from tests.common.utilities import wait_until
 from jinja2 import Template
 from netaddr import valid_ipv4, valid_ipv6
@@ -240,12 +240,12 @@ def shutdown_ebgp(duthosts, rand_one_dut_hostname):
         # Shutdown all eBGP neighbors
         duthost.command("sudo config bgp shutdown all")
         # Verify that the total eBGP routes are 0.
-        pytest_assert(wait_until(60, 2, 5, check_ebgp_routes, 0, 0, duthost),
-                      "eBGP routes are not 0 after shutting down all neighbors on {}".format(duthost))
-        pytest_assert(wait_until(orch_cpu_timeout, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
-                      "Orch CPU utilization {} > orch cpu threshold {} after shutdown all eBGP"
-                      .format(duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
-                              orch_cpu_threshold))
+        pt_assert(wait_until(60, 2, 5, check_ebgp_routes, 0, 0, duthost),
+                  "eBGP routes are not 0 after shutting down all neighbors on {}".format(duthost))
+        pt_assert(wait_until(orch_cpu_timeout, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
+                  "Orch CPU utilization {} > orch cpu threshold {} after shutdown all eBGP"
+                  .format(duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
+                          orch_cpu_threshold))
 
     yield
 
@@ -257,13 +257,13 @@ def shutdown_ebgp(duthosts, rand_one_dut_hostname):
         # Verify that total eBGP routes are what they were before shutdown of all eBGP neighbors
         orig_v4_ebgp = v4ebgps[duthost.hostname]
         orig_v6_ebgp = v6ebgps[duthost.hostname]
-        pytest_assert(wait_until(120, 10, 10, check_ebgp_routes, orig_v4_ebgp, orig_v6_ebgp, duthost),
-                      "eBGP v4 routes are {}, and v6 route are {}, and not what they were originally after enabling "
-                      "all neighbors on {}".format(orig_v4_ebgp, orig_v6_ebgp, duthost))
-        pytest_assert(wait_until(orch_cpu_timeout, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
-                      "Orch CPU utilization {} > orch cpu threshold {} after startup all eBGP"
-                      .format(duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
-                              orch_cpu_threshold))
+        pt_assert(wait_until(120, 10, 10, check_ebgp_routes, orig_v4_ebgp, orig_v6_ebgp, duthost),
+                  "eBGP v4 routes are {}, and v6 route are {}, and not what they were originally after enabling "
+                  "all neighbors on {}".format(orig_v4_ebgp, orig_v6_ebgp, duthost))
+        pt_assert(wait_until(orch_cpu_timeout, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
+                  "Orch CPU utilization {} > orch cpu threshold {} after startup all eBGP"
+                  .format(duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
+                          orch_cpu_threshold))
 
 
 @pytest.fixture(scope="module")
@@ -624,7 +624,7 @@ def wait_bgp_sessions(duthost, timeout=120):
     A helper function to wait bgp sessions on DUT
     """
     bgp_neighbors = duthost.get_bgp_neighbors_per_asic(state="all")
-    pytest_assert(
+    pt_assert(
         wait_until(timeout, 10, 0, duthost.check_bgp_session_state_all_asics, bgp_neighbors),
         "Not all bgp sessions are established after config reload",
     )
@@ -705,10 +705,10 @@ def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_config_db_on_duts):
                     finally:
                         ssh_client.close()
 
-        pytest_assert(len(ipv6_address[duthost.hostname]) > 0,
-                      f"{duthost.hostname} doesn't have IPv6 Management IP address")
-        pytest_assert(has_available_ipv6_addr,
-                      f"{duthost.hostname} doesn't have available IPv6 Management IP address")
+        pt_assert(len(ipv6_address[duthost.hostname]) > 0,
+                  f"{duthost.hostname} doesn't have IPv6 Management IP address")
+        pt_assert(has_available_ipv6_addr,
+                  f"{duthost.hostname} doesn't have available IPv6 Management IP address")
 
     # Remove IPv4 mgmt-ip
     for duthost in duthosts.nodes:
@@ -817,10 +817,10 @@ def assert_addr_in_output(addr_set: Dict[str, List], hostname: str,
     """
     for addr in addr_set[hostname]:
         if expect_exists:
-            pytest_assert(addr in cmd_output,
-                          f"{addr} not appeared in {hostname} {cmd_desc}")
+            pt_assert(addr in cmd_output,
+                      f"{addr} not appeared in {hostname} {cmd_desc}")
             logger.info(f"{addr} exists in the output of {cmd_desc}")
         else:
-            pytest_assert(addr not in cmd_output,
-                          f"{hostname} {cmd_desc} still with addr {addr}")
+            pt_assert(addr not in cmd_output,
+                      f"{hostname} {cmd_desc} still with addr {addr}")
             logger.info(f"{addr} not exists in the output of {cmd_desc} which is expected")

--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -6,10 +6,8 @@ from tests.common.helpers.assertions import pytest_assert
 
 
 @contextmanager
-def _context_for_setup_ntp(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6):
+def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
     """setup ntp client and server"""
-    duthost = duthosts[rand_one_dut_hostname]
-
     ptfhost.lineinfile(path="/etc/ntp.conf", line="server 127.127.1.0 prefer")
 
     # restart ntp server
@@ -44,7 +42,7 @@ def _context_for_setup_ntp(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv
 
 @pytest.fixture(scope="function")
 def setup_ntp_func(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6):
-    with _context_for_setup_ntp(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6) as result:
+    with setup_ntp_context(ptfhost, duthosts[rand_one_dut_hostname], ptf_use_ipv6) as result:
         yield result
 
 
@@ -55,10 +53,8 @@ def check_ntp_status(host):
     return True
 
 
-def run_ntp(duthosts, rand_one_dut_hostname, setup_ntp):
+def run_ntp(duthost):
     """ Verify that DUT is synchronized with configured NTP server """
-    duthost = duthosts[rand_one_dut_hostname]
-
     ntpsec_conf_stat = duthost.stat(path="/etc/ntpsec/ntp.conf")
     using_ntpsec = ntpsec_conf_stat["stat"]["exists"]
 

--- a/tests/common/helpers/tacacs/tacacs_helper.py
+++ b/tests/common/helpers/tacacs/tacacs_helper.py
@@ -308,8 +308,7 @@ def restore_tacacs_servers(duthost):
 
 
 @contextmanager
-def _context_for_check_tacacs_v6(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds): # noqa F811
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+def tacacs_v6_context(ptfhost, duthost, tacacs_creds):
     ptfhost_vars = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars
     if 'ansible_hostv6' not in ptfhost_vars:
         pytest.skip("Skip IPv6 test. ptf ansible_hostv6 not configured.")
@@ -322,12 +321,6 @@ def _context_for_check_tacacs_v6(ptfhost, duthosts, enum_rand_one_per_hwsku_host
 
     cleanup_tacacs(ptfhost, tacacs_creds, duthost)
     restore_tacacs_servers(duthost)
-
-
-@pytest.fixture(scope="function")
-def check_tacacs_v6_func(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds): # noqa F811
-    with _context_for_check_tacacs_v6(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds) as result:
-        yield result
 
 
 def tacacs_running(ptfhost):

--- a/tests/common/helpers/telemetry_helper.py
+++ b/tests/common/helpers/telemetry_helper.py
@@ -1,4 +1,3 @@
-import pytest
 import logging
 from contextlib import contextmanager
 from tests.common.errors import RunAnsibleModuleFail
@@ -82,14 +81,11 @@ def restore_telemetry_forpyclient(duthost, default_client_auth):
 
 
 @contextmanager
-def _context_for_setup_streaming_telemetry(request, duthosts, enum_rand_one_per_hwsku_hostname,
-                                           localhost, ptfhost, gnxi_path):
+def setup_streaming_telemetry_context(is_ipv6, duthost, localhost, ptfhost, gnxi_path):
     """
     @summary: Post setting up the streaming telemetry before running the test.
     """
-    is_ipv6 = request.param
     try:
-        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         has_gnmi_config = check_gnmi_config(duthost)
         if not has_gnmi_config:
             create_gnmi_config(duthost)
@@ -119,10 +115,3 @@ def _context_for_setup_streaming_telemetry(request, duthosts, enum_rand_one_per_
     restore_telemetry_forpyclient(duthost, default_client_auth)
     if not has_gnmi_config:
         delete_gnmi_config(duthost)
-
-
-@pytest.fixture(scope="function")
-def setup_streaming_telemetry_func(request, duthosts, enum_rand_one_per_hwsku_hostname, localhost, ptfhost, gnxi_path):
-    with _context_for_setup_streaming_telemetry(request, duthosts, enum_rand_one_per_hwsku_hostname,
-                                                localhost, ptfhost, gnxi_path) as result:
-        yield result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,7 +91,8 @@ pytest_plugins = ('tests.common.plugins.ptfadapter',
                   'tests.common.plugins.allure_server',
                   'tests.common.plugins.conditional_mark',
                   'tests.common.plugins.random_seed',
-                  'tests.common.plugins.memory_utilization')
+                  'tests.common.plugins.memory_utilization',
+                  'tests.common.fixtures.duthost_utils')
 
 
 def pytest_addoption(parser):

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -9,9 +9,10 @@ from tests.common.helpers.bgp import run_bgp_facts
 from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run_retry, tacacs_v6_context
 from tests.common.helpers.ntp_helper import run_ntp, setup_ntp_context
 from tests.common.helpers.telemetry_helper import setup_streaming_telemetry_context
-from tests.common.helpers.syslog_helpers import run_syslog
+from tests.common.helpers.syslog_helpers import run_syslog, check_default_route     # noqa F401
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from tests.common.fixtures.duthost_utils import duthosts_ipv6_mgmt_only # noqa F401
+from tests.common.fixtures.tacacs import tacacs_creds # noqa F401
 
 
 pytestmark = [
@@ -120,9 +121,9 @@ def test_image_download_ipv6_only(creds, duthosts_ipv6_mgmt_only,   # noqa F411
 @pytest.mark.parametrize("dummy_syslog_server_ip_a, dummy_syslog_server_ip_b",
                          [("fd82:b34f:cc99::100", None),
                           ("fd82:b34f:cc99::100", "fd82:b34f:cc99::200")])
-def test_syslog_ipv6_only(duthosts_ipv6_mgmt_only,          # noqa F411
+def test_syslog_ipv6_only(duthosts_ipv6_mgmt_only, check_default_route,          # noqa F411
                           rand_selected_dut, dummy_syslog_server_ip_a,
-                          dummy_syslog_server_ip_b, check_default_route):
+                          dummy_syslog_server_ip_b):
     # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
     log_eth0_interface_info(duthosts_ipv6_mgmt_only)
     run_syslog(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b, check_default_route)
@@ -147,9 +148,8 @@ def test_snmp_ipv6_only(duthosts_ipv6_mgmt_only,            # noqa F411
     assert "SONiC Software Version" in result[0], "Sysdescr not found in SNMP result from DUT IPv6 {}".format(hostipv6)
 
 
-def test_ro_user_ipv6_only(localhost, ptfhost, duthosts_ipv6_mgmt_only,     # noqa F411
-                           enum_rand_one_per_hwsku_hostname,
-                           tacacs_creds):
+def test_ro_user_ipv6_only(localhost, ptfhost, duthosts_ipv6_mgmt_only, tacacs_creds,     # noqa F411
+                           enum_rand_one_per_hwsku_hostname):
     duthost = duthosts_ipv6_mgmt_only[enum_rand_one_per_hwsku_hostname]
     with tacacs_v6_context(ptfhost, duthost, tacacs_creds):
         # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
@@ -162,9 +162,8 @@ def test_ro_user_ipv6_only(localhost, ptfhost, duthosts_ipv6_mgmt_only,     # no
         check_output(res, 'test', 'remote_user')
 
 
-def test_rw_user_ipv6_only(localhost, ptfhost, duthosts_ipv6_mgmt_only,     # noqa F411
-                           enum_rand_one_per_hwsku_hostname,
-                           tacacs_creds):
+def test_rw_user_ipv6_only(localhost, ptfhost, duthosts_ipv6_mgmt_only, tacacs_creds,    # noqa F411
+                           enum_rand_one_per_hwsku_hostname):
     duthost = duthosts_ipv6_mgmt_only[enum_rand_one_per_hwsku_hostname]
     with tacacs_v6_context(ptfhost, duthost, tacacs_creds):
         # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -6,13 +6,12 @@ import re
 from tests.common.utilities import get_mgmt_ipv6, check_output, run_show_features
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.helpers.bgp import run_bgp_facts
-from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run_retry, check_tacacs_v6_func    # noqa F401
-from tests.common.fixtures.tacacs import tacacs_creds   # noqa F401
-from tests.common.helpers.ntp_helper import run_ntp, setup_ntp_func     # noqa F401
-from tests.common.helpers.telemetry_helper import setup_streaming_telemetry_func    # noqa F401
-from tests.common.helpers.syslog_helpers import run_syslog, check_default_route   # noqa F401
+from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run_retry, tacacs_v6_context
+from tests.common.helpers.ntp_helper import run_ntp, setup_ntp_context
+from tests.common.helpers.telemetry_helper import setup_streaming_telemetry_context
+from tests.common.helpers.syslog_helpers import run_syslog
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
-from tests.common.fixtures.duthost_utils import convert_and_restore_config_db_to_ipv6_only  # noqa F401
+from tests.common.fixtures.duthost_utils import duthosts_ipv6_mgmt_only # noqa F401
 
 
 pytestmark = [
@@ -82,27 +81,28 @@ def log_tacacs(duthosts, ptfhost):
             logging.debug(f"forced_mgmt_routes: {forced_mgmt_rte}, interface address: {intf_values[2]}")
 
 
-def test_bgp_facts_ipv6_only(duthosts, enum_frontend_dut_hostname, enum_asic_index,
-                             convert_and_restore_config_db_to_ipv6_only): # noqa F811
+def test_bgp_facts_ipv6_only(duthosts_ipv6_mgmt_only,       # noqa F411
+                             enum_frontend_dut_hostname, enum_asic_index):
     # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
-    log_eth0_interface_info(duthosts)
-    run_bgp_facts(duthosts, enum_frontend_dut_hostname, enum_asic_index)
+    log_eth0_interface_info(duthosts_ipv6_mgmt_only)
+    run_bgp_facts(duthosts_ipv6_mgmt_only, enum_frontend_dut_hostname, enum_asic_index)
 
 
-def test_show_features_ipv6_only(duthosts, enum_dut_hostname, convert_and_restore_config_db_to_ipv6_only): # noqa F811
+def test_show_features_ipv6_only(duthosts_ipv6_mgmt_only,   # noqa F411
+                                 enum_dut_hostname):
     # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
-    log_eth0_interface_info(duthosts)
-    run_show_features(duthosts, enum_dut_hostname)
+    log_eth0_interface_info(duthosts_ipv6_mgmt_only)
+    run_show_features(duthosts_ipv6_mgmt_only, enum_dut_hostname)
 
 
-def test_image_download_ipv6_only(creds, duthosts, enum_dut_hostname,
-                                  convert_and_restore_config_db_to_ipv6_only): # noqa F811
+def test_image_download_ipv6_only(creds, duthosts_ipv6_mgmt_only,   # noqa F411
+                                  enum_dut_hostname):
     """
     Test image download in mgmt ipv6 only scenario
     """
     # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
-    log_eth0_interface_info(duthosts)
-    duthost = duthosts[enum_dut_hostname]
+    log_eth0_interface_info(duthosts_ipv6_mgmt_only)
+    duthost = duthosts_ipv6_mgmt_only[enum_dut_hostname]
     image_url = creds.get("test_image_url", {}).get("ipv6", "")
     pytest_require(len(image_url) != 0, "Cannot get image url")
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
@@ -120,18 +120,19 @@ def test_image_download_ipv6_only(creds, duthosts, enum_dut_hostname,
 @pytest.mark.parametrize("dummy_syslog_server_ip_a, dummy_syslog_server_ip_b",
                          [("fd82:b34f:cc99::100", None),
                           ("fd82:b34f:cc99::100", "fd82:b34f:cc99::200")])
-def test_syslog_ipv6_only(duthosts, rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b,
-                          check_default_route, convert_and_restore_config_db_to_ipv6_only): # noqa F811
+def test_syslog_ipv6_only(duthosts_ipv6_mgmt_only,          # noqa F411
+                          rand_selected_dut, dummy_syslog_server_ip_a,
+                          dummy_syslog_server_ip_b, check_default_route):
     # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
-    log_eth0_interface_info(duthosts)
+    log_eth0_interface_info(duthosts_ipv6_mgmt_only)
     run_syslog(rand_selected_dut, dummy_syslog_server_ip_a, dummy_syslog_server_ip_b, check_default_route)
 
 
-def test_snmp_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_all_duts,
-                        convert_and_restore_config_db_to_ipv6_only): # noqa F811
+def test_snmp_ipv6_only(duthosts_ipv6_mgmt_only,            # noqa F411
+                        enum_rand_one_per_hwsku_hostname, localhost, creds_all_duts):
     # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
-    log_eth0_interface_info(duthosts)
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    log_eth0_interface_info(duthosts_ipv6_mgmt_only)
+    duthost = duthosts_ipv6_mgmt_only[enum_rand_one_per_hwsku_hostname]
     hostipv6 = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_hostv6']
 
@@ -146,62 +147,62 @@ def test_snmp_ipv6_only(duthosts, enum_rand_one_per_hwsku_hostname, localhost, c
     assert "SONiC Software Version" in result[0], "Sysdescr not found in SNMP result from DUT IPv6 {}".format(hostipv6)
 
 
-# use function scope fixture so that convert_and_restore_config_db_to_ipv6_only will setup before check_tacacs_v6_func.
-# Otherwise, tacacs_v6 config may be lost after config reload in ipv6_only fixture.
-def test_ro_user_ipv6_only(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
-                           tacacs_creds, convert_and_restore_config_db_to_ipv6_only, check_tacacs_v6_func): # noqa F811
+def test_ro_user_ipv6_only(localhost, ptfhost, duthosts_ipv6_mgmt_only,     # noqa F411
+                           enum_rand_one_per_hwsku_hostname,
+                           tacacs_creds):
+    duthost = duthosts_ipv6_mgmt_only[enum_rand_one_per_hwsku_hostname]
+    with tacacs_v6_context(ptfhost, duthost, tacacs_creds):
+        # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
+        log_eth0_interface_info(duthosts_ipv6_mgmt_only)
+        dutipv6 = get_mgmt_ipv6(duthost)
+        log_tacacs(duthosts_ipv6_mgmt_only, ptfhost)
+
+        res = ssh_remote_run_retry(localhost, dutipv6, ptfhost, tacacs_creds['tacacs_ro_user'],
+                                   tacacs_creds['tacacs_ro_user_passwd'], 'cat /etc/passwd')
+        check_output(res, 'test', 'remote_user')
+
+
+def test_rw_user_ipv6_only(localhost, ptfhost, duthosts_ipv6_mgmt_only,     # noqa F411
+                           enum_rand_one_per_hwsku_hostname,
+                           tacacs_creds):
+    duthost = duthosts_ipv6_mgmt_only[enum_rand_one_per_hwsku_hostname]
+    with tacacs_v6_context(ptfhost, duthost, tacacs_creds):
+        # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
+        log_eth0_interface_info(duthosts_ipv6_mgmt_only)
+        dutipv6 = get_mgmt_ipv6(duthost)
+        log_tacacs(duthosts_ipv6_mgmt_only, ptfhost)
+
+        res = ssh_remote_run_retry(localhost, dutipv6, ptfhost, tacacs_creds['tacacs_rw_user'],
+                                   tacacs_creds['tacacs_rw_user_passwd'], "cat /etc/passwd")
+        check_output(res, 'testadmin', 'remote_user_su')
+
+
+def test_telemetry_output_ipv6_only(duthosts_ipv6_mgmt_only,        # noqa F411
+                                    enum_rand_one_per_hwsku_hostname,
+                                    localhost, ptfhost, gnxi_path):
     # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
-    log_eth0_interface_info(duthosts)
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dutipv6 = get_mgmt_ipv6(duthost)
-    log_tacacs(duthosts, ptfhost)
+    duthost = duthosts_ipv6_mgmt_only[enum_rand_one_per_hwsku_hostname]
+    with setup_streaming_telemetry_context(True, duthost, localhost, ptfhost, gnxi_path):
+        log_eth0_interface_info(duthosts_ipv6_mgmt_only)
+        env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
+        if duthost.is_supervisor_node():
+            pytest.skip(
+                "Skipping test as no Ethernet0 frontpanel port on supervisor")
+        dut_ip = get_mgmt_ipv6(duthost)
+        cmd = "~/gnmi_get -xpath_target COUNTERS_DB -xpath COUNTERS/Ethernet0 -target_addr \
+            [%s]:%s -logtostderr -insecure" % (dut_ip, env.gnmi_port)
+        show_gnmi_out = duthost.shell(cmd)['stdout']
+        result = str(show_gnmi_out)
+        inerrors_match = re.search("SAI_PORT_STAT_IF_IN_ERRORS", result)
+        pytest_assert(inerrors_match is not None,
+                      "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi output")
 
-    res = ssh_remote_run_retry(localhost, dutipv6, ptfhost, tacacs_creds['tacacs_ro_user'],
-                               tacacs_creds['tacacs_ro_user_passwd'], 'cat /etc/passwd')
-    check_output(res, 'test', 'remote_user')
 
-
-# use function scope fixture so that convert_and_restore_config_db_to_ipv6_only will setup before check_tacacs_v6_func.
-# Otherwise, tacacs_v6 config may be lost after config reload in ipv6_only fixture.
-def test_rw_user_ipv6_only(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
-                           tacacs_creds, convert_and_restore_config_db_to_ipv6_only, check_tacacs_v6_func): # noqa F811
+# use function scope fixture so that duthosts_ipv6_mgmt_only will run before setup_ntp_func
+def test_ntp_ipv6_only(duthosts_ipv6_mgmt_only,             # noqa F411
+                       rand_one_dut_hostname, ptfhost, ptf_use_ipv6):
     # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
-    log_eth0_interface_info(duthosts)
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dutipv6 = get_mgmt_ipv6(duthost)
-    log_tacacs(duthosts, ptfhost)
-
-    res = ssh_remote_run_retry(localhost, dutipv6, ptfhost, tacacs_creds['tacacs_rw_user'],
-                               tacacs_creds['tacacs_rw_user_passwd'], "cat /etc/passwd")
-    check_output(res, 'testadmin', 'remote_user_su')
-
-
-# use function scope fixture so that convert_and_restore_config_db_to_ipv6_only will setup before
-# setup_streaming_telemetry_func. Otherwise, telemetry config may be lost after config reload in ipv6_only fixture.
-@pytest.mark.parametrize('setup_streaming_telemetry_func', [True], indirect=True)
-def test_telemetry_output_ipv6_only(convert_and_restore_config_db_to_ipv6_only, # noqa F811
-                                    duthosts, enum_rand_one_per_hwsku_hostname,
-                                    setup_streaming_telemetry_func): # noqa F811
-    # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
-    log_eth0_interface_info(duthosts)
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
-    if duthost.is_supervisor_node():
-        pytest.skip(
-            "Skipping test as no Ethernet0 frontpanel port on supervisor")
-    dut_ip = get_mgmt_ipv6(duthost)
-    cmd = "~/gnmi_get -xpath_target COUNTERS_DB -xpath COUNTERS/Ethernet0 -target_addr \
-          [%s]:%s -logtostderr -insecure" % (dut_ip, env.gnmi_port)
-    show_gnmi_out = duthost.shell(cmd)['stdout']
-    result = str(show_gnmi_out)
-    inerrors_match = re.search("SAI_PORT_STAT_IF_IN_ERRORS", result)
-    pytest_assert(inerrors_match is not None,
-                  "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi output")
-
-
-# use function scope fixture so that convert_and_restore_config_db_to_ipv6_only will run before setup_ntp_func
-def test_ntp_ipv6_only(duthosts, rand_one_dut_hostname,
-                                  convert_and_restore_config_db_to_ipv6_only, setup_ntp_func): # noqa F811
-    # Add a temporary debug log to see if DUTs are reachable via IPv6 mgmt-ip. Will remove later
-    log_eth0_interface_info(duthosts)
-    run_ntp(duthosts, rand_one_dut_hostname, setup_ntp_func)
+    duthost = duthosts_ipv6_mgmt_only[rand_one_dut_hostname]
+    with setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
+        log_eth0_interface_info(duthosts_ipv6_mgmt_only)
+        run_ntp(duthost)

--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -1,6 +1,6 @@
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.ntp_helper import check_ntp_status, run_ntp, _context_for_setup_ntp
+from tests.common.helpers.ntp_helper import check_ntp_status, run_ntp, setup_ntp_context
 import logging
 import time
 import pytest
@@ -50,7 +50,7 @@ def config_long_jump(duthost, enable=False):
 def setup_ntp(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6):
     if ptf_use_ipv6 and not ptfhost.mgmt_ipv6:
         pytest.skip("No IPv6 address on PTF host")
-    with _context_for_setup_ntp(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6) as result:
+    with setup_ntp_context(ptfhost, duthosts[rand_one_dut_hostname], ptf_use_ipv6) as result:
         yield result
 
 
@@ -104,4 +104,4 @@ def test_ntp_long_jump_disabled(duthosts, rand_one_dut_hostname, setup_ntp, setu
 
 
 def test_ntp(duthosts, rand_one_dut_hostname, setup_ntp):
-    run_ntp(duthosts, rand_one_dut_hostname, setup_ntp)
+    run_ntp(duthosts[rand_one_dut_hostname])

--- a/tests/tacacs/conftest.py
+++ b/tests/tacacs/conftest.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 from tests.common.fixtures.tacacs import tacacs_creds     # noqa F401
 from tests.common.helpers.tacacs.tacacs_helper import setup_tacacs_client, setup_tacacs_server,\
-                    cleanup_tacacs, restore_tacacs_servers, _context_for_check_tacacs_v6
+                    cleanup_tacacs, restore_tacacs_servers, tacacs_v6_context
 
 logger = logging.getLogger(__name__)
 
@@ -41,5 +41,5 @@ def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_cre
 
 @pytest.fixture(scope="module")
 def check_tacacs_v6(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds): # noqa F811
-    with _context_for_check_tacacs_v6(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds) as result:
+    with tacacs_v6_context(ptfhost, duthosts[enum_rand_one_per_hwsku_hostname], tacacs_creds) as result:
         yield result

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -6,7 +6,7 @@ import sys
 from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.utilities import wait_until
 from tests.telemetry.telemetry_utils import get_list_stdout
-from tests.common.helpers.telemetry_helper import _context_for_setup_streaming_telemetry
+from tests.common.helpers.telemetry_helper import setup_streaming_telemetry_context
 
 EVENTS_TESTS_PATH = "./telemetry/events"
 sys.path.append(EVENTS_TESTS_PATH)
@@ -32,8 +32,9 @@ def verify_telemetry_dockerimage(duthosts, enum_rand_one_per_hwsku_hostname):
 
 @pytest.fixture(scope="module")
 def setup_streaming_telemetry(request, duthosts, enum_rand_one_per_hwsku_hostname, localhost, ptfhost, gnxi_path):
-    with _context_for_setup_streaming_telemetry(request, duthosts, enum_rand_one_per_hwsku_hostname,
-                                                localhost, ptfhost, gnxi_path) as result:
+    is_ipv6 = request.param
+    with setup_streaming_telemetry_context(is_ipv6, duthosts[enum_rand_one_per_hwsku_hostname],
+                                           localhost, ptfhost, gnxi_path) as result:
         yield result
 
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
ipv6 mgmt only tests can fail in setup, after config has been modified, leading to the teardown to not be run, and the duts to be left in an unreachable state. Refactor the test to split backing up and restoring the config into an independent fixture, such that failures in setting the mgmt IPs won't nuke the testbed. Also refactor / cleanup some other aspects of the tests to enhance clarity. 

Summary:
Fixes #16441

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
    - [ ] Add ownership [here](https://msazure.visualstudio.com/AzureWiki/_wiki/wikis/AzureWiki.wiki/744287/TSG-for-ownership-modification)(Microsft required only)
- [x ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Fix failures in test setup leaving the testbed in a wedged state, due to removed ipv4 mgmt IPs

#### How did you do it?
Refactor the test to have config backup and restore in a separate fixture

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
