### PR TITLE
Add sanity check command to debug PTF unreachable issue

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -207,8 +207,8 @@ def run_test(
     return tor_IO
 
 
-def cleanup(ptfadapter, duthosts_list):
-    print_logs(duthosts_list, print_dual_tor_logs=True)
+def cleanup(ptfadapter, duthosts_list, ptfhost):
+    print_logs(duthosts_list, ptfhost, print_dual_tor_logs=True)
     # cleanup torIO
     ptfadapter.dataplane.flush()
     for duthost in duthosts_list:
@@ -303,7 +303,7 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
     yield t1_to_server_io_test
 
-    cleanup(ptfadapter, duthosts)
+    cleanup(ptfadapter, duthosts, ptfhost)
 
 
 @pytest.fixture
@@ -373,7 +373,7 @@ def send_server_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
     yield server_to_t1_io_test
 
-    cleanup(ptfadapter, duthosts)
+    cleanup(ptfadapter, duthosts, ptfhost)
 
 
 @pytest.fixture
@@ -402,7 +402,7 @@ def send_soc_to_t1_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
     yield soc_to_t1_io_test
 
-    cleanup(ptfadapter, duthosts)
+    cleanup(ptfadapter, duthosts, ptfhost)
 
 
 @pytest.fixture
@@ -433,7 +433,7 @@ def send_t1_to_soc_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
     yield t1_to_soc_io_test
 
-    cleanup(ptfadapter, duthosts)
+    cleanup(ptfadapter, duthosts, ptfhost)
 
 
 @pytest.fixture
@@ -479,4 +479,4 @@ def send_server_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
     yield server_to_server_io_test
 
-    cleanup(ptfadapter, duthosts)
+    cleanup(ptfadapter, duthosts, ptfhost)

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -91,11 +91,11 @@ def print_logs(duthosts, ptfhost, print_dual_tor_logs=False):
             cmds.remove(constants.PRINT_LOGS['mux_config'])
 
         # check PTF device reachability
-        if not ptfhost.mgmt_ip:
+        if ptfhost.mgmt_ip:
             cmds.append("ping {} -c 1 -W 3".format(ptfhost.mgmt_ip))
             cmds.append("traceroute {}".format(ptfhost.mgmt_ip))
 
-        if not ptfhost.mgmt_ipv6:
+        if ptfhost.mgmt_ipv6:
             cmds.append("ping6 {} -c 1 -W 3".format(ptfhost.mgmt_ipv6))
             cmds.append("traceroute6 {}".format(ptfhost.mgmt_ipv6))
 

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -80,7 +80,7 @@ def _update_check_items(old_items, new_items, supported_items):
     return updated_items
 
 
-def print_logs(duthosts, print_dual_tor_logs=False):
+def print_logs(duthosts, ptfhost, print_dual_tor_logs=False):
     for dut in duthosts:
         logger.info("Run commands to print logs")
 
@@ -89,6 +89,9 @@ def print_logs(duthosts, print_dual_tor_logs=False):
         if print_dual_tor_logs is False:
             cmds.remove(constants.PRINT_LOGS['mux_status'])
             cmds.remove(constants.PRINT_LOGS['mux_config'])
+
+        # check PTF device reachability
+        cmds.add("ping {} -c 1 -W 3".format(ptfhost.mgmt_ip))
 
         results = dut.shell_cmds(cmds=cmds, module_ignore_errors=True, verbose=False)['results']
         outputs = []
@@ -285,7 +288,7 @@ def sanity_check_full(ptfhost, prepare_parallel_run, localhost, duthosts, reques
         for item in set(pre_check_items):
             request.fixturenames.append(item)
         dual_tor = 'dualtor' in tbinfo['topo']['name']
-        print_logs(duthosts, print_dual_tor_logs=dual_tor)
+        print_logs(duthosts, ptfhost, print_dual_tor_logs=dual_tor)
 
         check_results = do_checks(request, pre_check_items, stage=STAGE_PRE_TEST)
         logger.debug("Pre-test sanity check results:\n%s" %

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -92,6 +92,7 @@ def print_logs(duthosts, ptfhost, print_dual_tor_logs=False):
 
         # check PTF device reachability
         cmds.add("ping {} -c 1 -W 3".format(ptfhost.mgmt_ip))
+        cmds.add("traceroute {}".format(ptfhost.mgmt_ip))
 
         results = dut.shell_cmds(cmds=cmds, module_ignore_errors=True, verbose=False)['results']
         outputs = []

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -91,8 +91,13 @@ def print_logs(duthosts, ptfhost, print_dual_tor_logs=False):
             cmds.remove(constants.PRINT_LOGS['mux_config'])
 
         # check PTF device reachability
-        cmds.append("ping {} -c 1 -W 3".format(ptfhost.mgmt_ip))
-        cmds.append("traceroute {}".format(ptfhost.mgmt_ip))
+        if not ptfhost.mgmt_ip:
+            cmds.append("ping {} -c 1 -W 3".format(ptfhost.mgmt_ip))
+            cmds.append("traceroute {}".format(ptfhost.mgmt_ip))
+
+        if not ptfhost.mgmt_ipv6:
+            cmds.append("ping6 {} -c 1 -W 3".format(ptfhost.mgmt_ipv6))
+            cmds.append("traceroute6 {}".format(ptfhost.mgmt_ipv6))
 
         results = dut.shell_cmds(cmds=cmds, module_ignore_errors=True, verbose=False)['results']
         outputs = []

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -91,8 +91,8 @@ def print_logs(duthosts, ptfhost, print_dual_tor_logs=False):
             cmds.remove(constants.PRINT_LOGS['mux_config'])
 
         # check PTF device reachability
-        cmds.add("ping {} -c 1 -W 3".format(ptfhost.mgmt_ip))
-        cmds.add("traceroute {}".format(ptfhost.mgmt_ip))
+        cmds.append("ping {} -c 1 -W 3".format(ptfhost.mgmt_ip))
+        cmds.append("traceroute {}".format(ptfhost.mgmt_ip))
 
         results = dut.shell_cmds(cmds=cmds, module_ignore_errors=True, verbose=False)['results']
         outputs = []


### PR DESCRIPTION
Add sanity check command to debug PTF unreachable issue.

#### Why I did it
TACACS test case failed because PTF device unreachable, need more info to debug.


##### Work item tracking
- Microsoft ADO: 30626367

#### How I did it
Add sanity check command to debug PTF unreachable issue.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Add sanity check command to debug PTF unreachable issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
