### PR TITLE
[test_pfcwd_timer_accuracy] handle exception during grep log

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -1,8 +1,8 @@
 import logging
 import pytest
 import time
+import re
 
-from tests.common.errors import RunAnsibleModuleFail
 from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts      # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.pfc_storm import PFCStorm
@@ -202,18 +202,39 @@ class TestPfcwdAllTimer(object):
             logger.info("Skip time detect for VS")
             return
 
+        skip_this_loop = False
         if self.dut.topo_type == 't2' and self.storm_handle.peer_device.os == 'sonic':
             storm_detect_ms = self.retrieve_timestamp("[d]etected PFC storm")
         else:
             storm_start_ms = self.retrieve_timestamp("[P]FC_STORM_START")
             storm_detect_ms = self.retrieve_timestamp("[d]etected PFC storm")
+
         logger.info("Wait for PFC storm end marker to appear in logs")
         time.sleep(16)
+
         if self.dut.topo_type == 't2' and self.storm_handle.peer_device.os == 'sonic':
             storm_restore_ms = self.retrieve_timestamp("[s]torm restored")
         else:
             storm_end_ms = self.retrieve_timestamp("[P]FC_STORM_END")
             storm_restore_ms = self.retrieve_timestamp("[s]torm restored")
+
+        if self.dut.topo_type == 't2' and self.storm_handle.peer_device.os == 'sonic':
+            if storm_detect_ms == 0 or storm_restore_ms == 0:
+                logging.warning("storm_detect_ms {} or storm_restore_ms {} is 0".format(
+                    storm_detect_ms, storm_restore_ms))
+                skip_this_loop = True
+        else:
+            if storm_start_ms == 0 or storm_detect_ms == 0 or storm_end_ms == 0 or storm_restore_ms == 0:
+                logging.warning("storm_start_ms {} or storm_detect_ms {} or "
+                                "storm_end_ms {} or storm_restore_ms {} is 0".format(
+                                    storm_start_ms, storm_detect_ms, storm_end_ms, storm_restore_ms))
+                skip_this_loop = True
+
+        if skip_this_loop:
+            logger.warning("Skip this loop due to missing timestamps")
+            return
+
+        if not (self.dut.topo_type == 't2' and self.storm_handle.peer_device.os == 'sonic'):
             real_detect_time = storm_detect_ms - storm_start_ms
             real_restore_time = storm_restore_ms - storm_end_ms
             self.all_detect_time.append(real_detect_time)
@@ -239,8 +260,8 @@ class TestPfcwdAllTimer(object):
         self.all_detect_time.sort()
         self.all_restore_time.sort()
         logger.info("Verify that real detection time is not greater than configured")
-        logger.info("all detect time {}".format(self.all_detect_time))
-        logger.info("all restore time {}".format(self.all_restore_time))
+        logger.info("sorted all detect time {}".format(self.all_detect_time))
+        logger.info("sorted all restore time {}".format(self.all_restore_time))
 
         check_point = ITERATION_NUM // 2 - 1
         config_detect_time = self.timers['pfc_wd_detect_time'] + self.timers['pfc_wd_poll_time']
@@ -324,17 +345,27 @@ class TestPfcwdAllTimer(object):
         Returns:
             timestamp_ms (int): syslog timestamp in ms for the line matching the pattern
         """
-        cmd = "grep \"{}\" /var/log/syslog".format(pattern)
-        syslog_msg_list = self.dut.shell(cmd)['stdout'].split()
         try:
-            timestamp_ms = float(self.dut.shell("date -d \"{}\" +%s%3N".format(syslog_msg_list[3]))['stdout'])
-        except RunAnsibleModuleFail:
-            timestamp_ms = float(self.dut.shell("date -d \"{}\" +%s%3N".format(syslog_msg_list[2]))['stdout'])
-        except Exception as e:
-            logging.error("Error when parsing syslog message timestamp: {}".format(repr(e)))
-            pytest.fail("Failed to parse syslog message timestamp")
+            cmd = "grep \"{}\" /var/log/syslog".format(pattern)
+            syslog_msg = self.dut.shell(cmd)['stdout']
 
-        return int(timestamp_ms)
+            # Regular expressions for the two timestamp formats
+            regex1 = re.compile(r'^[A-Za-z]{3} \d{2} \d{2}:\d{2}:\d{2}\.\d{6}')
+            regex2 = re.compile(r'^\d{4} [A-Za-z]{3} \d{2} \d{2}:\d{2}:\d{2}\.\d{6}')
+
+            if regex1.match(syslog_msg):
+                timestamp = syslog_msg.replace('  ', ' ').split(' ')[2]
+            elif regex2.match(syslog_msg):
+                timestamp = syslog_msg.replace('  ', ' ').split(' ')[3]
+            else:
+                logger.warning("Get {} timestamp: Unexpected syslog message format".format(syslog_msg))
+                return int(0)
+
+            timestamp_ms = self.dut.shell("date -d {} +%s%3N".format(timestamp))['stdout']
+            return int(timestamp_ms)
+        except Exception as e:
+            logger.warning("Get {} timestamp: An unexpected error occurred: {}".format(pattern, str(e)))
+            return int(0)
 
     def test_pfcwd_timer_accuracy(self, duthosts, ptfhost, enum_rand_one_per_hwsku_frontend_hostname,
                                   pfcwd_timer_setup_restore, fanouthosts):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
29970341

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
    - [ ] Add ownership [here](https://msazure.visualstudio.com/AzureWiki/_wiki/wikis/AzureWiki.wiki/744287/TSG-for-ownership-modification)(Microsft required only)
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Since the test environment limitation, sometimes, pfcwd could not be triggered expectedly.
It would cause exception failure due to grep pfc watchdog syslog return failure.

#### How did you do it?
Handle the exception, return failure instead of raise an exception.

#### How did you verify/test it?
inject an failure and run the case locally.

```
pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy[bjw-can-7050qx-1] 
---------------------------------------------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------------------------------------------
05:57:06 test_pfcwd_timer_accuracy.retrieve_times L0371 WARNING| ##### Randomly skip timestamp 05:56:16.168697 parsing for pattern: [d]etected PFC storm
05:57:26 test_pfcwd_timer_accuracy.run_test       L0228 WARNING| storm_start_ms 1736488575601 or storm_detect_ms 0 or storm_end_ms 1736488588756 or storm_restore_ms 1736488589364 is 0
05:57:26 test_pfcwd_timer_accuracy.run_test       L0232 WARNING| Skip this loop due to missing timestamps
06:16:58 test_pfcwd_timer_accuracy.retrieve_times L0371 WARNING| ##### Randomly skip timestamp 06:16:07.324006 parsing for pattern: [d]etected PFC storm
06:17:17 test_pfcwd_timer_accuracy.run_test       L0228 WARNING| storm_start_ms 1736489766762 or storm_detect_ms 0 or storm_end_ms 1736489779979 or storm_restore_ms 1736489780540 is 0
06:17:17 test_pfcwd_timer_accuracy.run_test       L0232 WARNING| Skip this loop due to missing timestamps
06:20:04 test_pfcwd_timer_accuracy.retrieve_times L0371 WARNING| ##### Randomly skip timestamp 06:19:08.259521 parsing for pattern: [P]FC_STORM_END
06:20:06 test_pfcwd_timer_accuracy.run_test       L0228 WARNING| storm_start_ms 1736489935710 or storm_detect_ms 1736489936402 or storm_end_ms 0 or storm_restore_ms 1736489948823 is 0
06:20:06 test_pfcwd_timer_accuracy.run_test       L0232 WARNING| Skip this loop due to missing timestamps
06:21:30 test_pfcwd_timer_accuracy.retrieve_times L0371 WARNING| ##### Randomly skip timestamp 06:20:36.569082 parsing for pattern: [s]torm restored
06:21:30 test_pfcwd_timer_accuracy.run_test       L0228 WARNING| storm_start_ms 1736490020022 or storm_detect_ms 1736490020552 or storm_end_ms 1736490035837 or storm_restore_ms 0 is 0
06:21:30 test_pfcwd_timer_accuracy.run_test       L0232 WARNING| Skip this loop due to missing timestamps
PASSED   

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
