### PR TITLE
[infra] Enforce `core_dump_and_config_check` run order

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1787,6 +1787,30 @@ def pytest_generate_tests(metafunc):        # noqa E302
                 metafunc.parametrize('vlan_name', ['no_vlan'], scope='module')
 
 
+def pytest_runtest_setup(item):
+    # HACK: ensure fixture core_dump_and_config_check runs before any
+    # other module level fixtures in setup to collect configurations
+    # without modification from test fixtures.
+    fixtureinfo = item._fixtureinfo
+    for fixturedef in fixtureinfo.name2fixturedefs.values():
+        fixturedef = fixturedef[0]
+        if fixturedef.argname == "core_dump_and_config_check":
+            fixtureinfo.names_closure.remove("core_dump_and_config_check")
+            fixtureinfo.names_closure.insert(0, "core_dump_and_config_check")
+
+
+def pytest_runtest_teardown(item, nextitem):    # noqa F811
+    # HACK: ensure fixture core_dump_and_config_check runs after any
+    # other module level fixtures in teardown, so other fixtures could
+    # restore the configruation before running core_dump_and_config_check.
+    fixtureinfo = item._fixtureinfo
+    for fixturedef in fixtureinfo.name2fixturedefs.values():
+        fixturedef = fixturedef[0]
+        if fixturedef.argname == "core_dump_and_config_check":
+            fixtureinfo.names_closure.remove("core_dump_and_config_check")
+            fixtureinfo.names_closure.append("core_dump_and_config_check")
+
+
 def get_autoneg_tests_data():
     folder = 'metadata'
     filepath = os.path.join(folder, 'autoneg-test-params.json')


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
    - [ ] Add ownership [here](https://msazure.visualstudio.com/AzureWiki/_wiki/wikis/AzureWiki.wiki/744287/TSG-for-ownership-modification)(Microsft required only)
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Test run suffers from unneccesary config reloads from `core_dump_and_config_check`;
the root cause is `core_dump_and_config_check` runs before those fixtures from testcase that restore the configuration in teardown, so the configuration check is always failing.

#### How did you do it?
Let's enforce `core_dump_and_config_check` run order:
1. runs before any other module level fixtures in setup.
2. runs after any other module level fixtures in teardown.

#### How did you verify/test it?
Runs `dualtor_io/test_tor_bgp_failure.py`, `core_dump_and_config_check` runs before [temp_enable_bgp_autorestart](https://github.com/sonic-net/sonic-mgmt/blob/54c884726ee0726dd08a2cf73b36096ed5aec6be/tests/dualtor_io/test_tor_bgp_failure.py#L36) in setup and runs after [temp_enable_bgp_autorestart](https://github.com/sonic-net/sonic-mgmt/blob/54c884726ee0726dd08a2cf73b36096ed5aec6be/tests/dualtor_io/test_tor_bgp_failure.py#L36) in teardown;
[temp_enable_bgp_autorestart](https://github.com/sonic-net/sonic-mgmt/blob/54c884726ee0726dd08a2cf73b36096ed5aec6be/tests/dualtor_io/test_tor_bgp_failure.py#L36) could recover the feature autorestart config before `core_dump_and_config_check`, and the config check will pass (no more config reload).

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
