### PR TITLE
Change the test case name to not include 'teamd_' in it

### DIFF
--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -260,7 +260,7 @@ class TestNeighborRetryCount:
         """
         check_lacpdu_packet_version(duthost)
 
-    def test_kill_teamd_lag_up(self, duthost, nbrhosts, higher_retry_count_on_peers, config_reload_on_cleanup):
+    def test_kill_team_lag_up(self, duthost, nbrhosts, higher_retry_count_on_peers, config_reload_on_cleanup):
         """
         Test that the lag remains up for 150 seconds after killing teamd on the peer
         """
@@ -339,7 +339,7 @@ class TestDutRetryCount:
         """
         check_lacpdu_packet_version(duthost)
 
-    def test_kill_teamd_peer_lag_up(self, duthost, nbrhosts, higher_retry_count_on_peers, config_reload_on_cleanup):
+    def test_kill_team_peer_lag_up(self, duthost, nbrhosts, higher_retry_count_on_peers, config_reload_on_cleanup):
         """
         Test that the lag remains up for 150 seconds after killing teamd on the DUT
         """


### PR DESCRIPTION
If the test case name has the 'teamd_' in it, in the loganalyzer, when add the marker, the log will be writen to the /var/log/teamd.log, but not the /var/log/syslog, it will fail the loganalyzer

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
    - [ ] Add ownership [here](https://msazure.visualstudio.com/AzureWiki/_wiki/wikis/AzureWiki.wiki/744287/TSG-for-ownership-modification)(Microsft required only)
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Change the test cases name to not fail the loganalyzer

When run the test case: tests/pc/test_retry_count.py:: TestNeighborRetryCount:: test_kill_teamd_lag_up, it failed when add_end_marker in the loganalyzer, and could reproduce it by manual. 

_sudo python /tmp/loganalyzer.py --action add_end_marker --run_id test_kill_teamd_lag_up.2025-01-05-03:24:03
Traceback (most recent call last):
  File "/tmp/loganalyzer.py", line 878, in <module>
    main(sys.argv[1:])
  File "/tmp/loganalyzer.py", line 859, in main
    analyzer.place_marker(
  File "/tmp/loganalyzer.py", line 262, in place_marker
    raise RuntimeError(
RuntimeError: cannot find marker end-LogAnalyzer-test_kill_teamd_lag_up.2025-01-05-03:24:03 in /var/log/syslog_

**The root cause of the failure is due to the “teamd_” in the log msg.  then the log will be direct to the “ /var/log/teamd.log”, so we could not find it in the /var/log/syslog.**

In the file, /etc/rsyslog.d/00-sonic.conf, we could found the redirect logic of the log
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
