### PR TITLE
SNMP link-local test: wait until snmp agent fully start

### DIFF
--- a/tests/snmp/test_snmp_link_local.py
+++ b/tests/snmp/test_snmp_link_local.py
@@ -17,9 +17,9 @@ def config_reload_after_test(duthosts,
     config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
 
 
-def confirm_snmpagent_listen_on_ip(duthost, ipaddr):
+def is_snmpagent_listen_on_ip(duthost, ipaddr):
     """
-    Confirm snmpagent is listening on the specific IP address.
+    Check if snmpagent is listening on the specific IP address.
     """
     output = duthost.shell('sudo ss -tunlp | grep snmpd', module_ignore_errors=True)['stdout_lines']
     return any([ipaddr in x for x in output])
@@ -57,7 +57,7 @@ def test_snmp_link_local_ip(duthosts,
     # Restart snmp service to regenerate snmpd.conf with
     # link local IP configured in MGMT_INTERFACE
     duthost.shell("config snmpagentaddress add {}%eth0".format(link_local_ip))
-    if not wait_until(60, 5, 0, confirm_snmpagent_listen_on_ip, duthost, link_local_ip):
+    if not wait_until(60, 5, 0, is_snmpagent_listen_on_ip, duthost, link_local_ip):
         pytest.fail("SNMP agent not listen on link local IP {}".format(link_local_ip))
     stdout_lines = duthost.shell("docker exec snmp snmpget \
                                  -v2c -c {} {}%eth0 {}"

--- a/tests/snmp/test_snmp_link_local.py
+++ b/tests/snmp/test_snmp_link_local.py
@@ -1,6 +1,7 @@
 import pytest
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 from tests.common import config_reload
+from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 't1-multi-asic'),
@@ -14,6 +15,14 @@ def config_reload_after_test(duthosts,
     yield
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
+
+
+def confirm_snmpagent_listen_on_ip(duthost, ipaddr):
+    """
+    Confirm snmpagent is listening on the specific IP address.
+    """
+    output = duthost.shell('sudo ss -tunlp | grep snmpd', module_ignore_errors=True)['stdout_lines']
+    return any([ipaddr in x for x in output])
 
 
 @pytest.mark.bsl
@@ -48,6 +57,8 @@ def test_snmp_link_local_ip(duthosts,
     # Restart snmp service to regenerate snmpd.conf with
     # link local IP configured in MGMT_INTERFACE
     duthost.shell("config snmpagentaddress add {}%eth0".format(link_local_ip))
+    if not wait_until(60, 5, 0, confirm_snmpagent_listen_on_ip, duthost, link_local_ip):
+        pytest.fail("SNMP agent not listen on link local IP {}".format(link_local_ip))
     stdout_lines = duthost.shell("docker exec snmp snmpget \
                                  -v2c -c {} {}%eth0 {}"
                                  .format(creds_all_duts[duthost.hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
On Nokia-7215 platform, we observed below flaky failure:
```
invocation = {'module_args': {'_raw_params': 'docker exec snmp snmpget -v2c -c public fe80::...
_ansible_no_log = None
stdout =
stderr =
Timeout: No Response from fe80::xxxx%eth0.
```
The root cause is that Nokia-7215 has low performance and the `snmpget` command is issued before snmpagent fully start.
To resolve this issue, I added a wait_until to ensure snmpagent already listening on the link-local IP address.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
    - [ ] Add ownership [here](https://msazure.visualstudio.com/AzureWiki/_wiki/wikis/AzureWiki.wiki/744287/TSG-for-ownership-modification)(Microsft required only)
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
On Nokia-7215 platform, we observed below flaky failure:
```
Timeout: No Response from fe80::xxxx%eth0.
```
The root cause is that Nokia-7215 has low performance and the `snmpget` command is issued before snmpagent fully start.

#### How did you do it?
To resolve this issue, I added a wait_until to ensure snmpagent already listening on the link-local IP address.

#### How did you verify/test it?
Verified on Nokia-7215 Mx testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
