### PR TITLE
[chassis]: Fix minigraph_dpg_asic template for Chassis LCs

### DIFF
--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -193,8 +193,10 @@
 {% for neigh_asic in  asic_config['neigh_asic'] %}
 {% set neigh_asic_index = neigh_asic.split('ASIC')[1]|int %}
 {% set po_intf = 'PortChannel' + port_channel_id(asic_index, neigh_asic_index).zfill(2) %}
-{{- internal_static_routes_ipv4_device_pair.append(po_intf + ',' + asic_config['neigh_asic'][neigh_asic]['bgp_ipv4'][0]) -}}
-{{- internal_static_routes_ipv6_device_pair.append(po_intf +  ',' + asic_config['neigh_asic'][neigh_asic]['bgp_ipv6'][0]) -}}
+{% for intf_index in range(asic_config['neigh_asic'][neigh_asic]['bgp_ipv4'][0]|length) %}
+{{- internal_static_routes_ipv4_device_pair.append(po_intf + ',' + asic_config['neigh_asic'][neigh_asic]['bgp_ipv4'][0][intf_index]) -}}
+{{- internal_static_routes_ipv6_device_pair.append(po_intf +  ',' + asic_config['neigh_asic'][neigh_asic]['bgp_ipv6'][0][intf_index]) -}}
+{% endfor %}
 {% endfor %}
       <IPNextHop>
          <ElementType>IPNextHop</ElementType>


### PR DESCRIPTION
Signed-off-by: Anand Mehra anamehra@cisco.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->


Summary:
Fixes # [(issue)]https://github.com/sonic-net/sonic-mgmt/issues/16463

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202411

### Approach
#### What is the motivation for this PR?
delopy-mg fails to create minigraph.xml for LCs on a chassis-packet Chassis. The creation fails in minigraph_dpg_asic.j2 
```
{% include 'minigraph_cpg.j2' %}
{% include 'minigraph_dpg.j2' %}
{% include 'minigraph_png.j2' %}
{% include 'minigraph_device.j2' %}
{% include 'minigraph_meta.j2' %}
{% include 'minigraph_link_meta.j2' %}
  <Hostname>{{ inventory_hostname }}</Hostname>
  <HwSku>{{ hwsku }}</HwSku>
</DeviceMiniGraph>
): coercing to Unicode: need string or buffer, list found"}  
```

https://github.com/sonic-net/sonic-mgmt/pull/14595 introduced changes for smarswitch and caused this regression.

#### How did you do it?
Fixes minigraph_dpg_asic.j2 template to comply with https://github.com/sonic-net/sonic-mgmt/pull/14595 changes. 

#### How did you verify/test it?
Ran deploy-mg on chassis-packet system and executed some tests cases.

#### Any platform specific information?
LC on Chassis (observed on Cisco chassis)

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

UT Logs:
```
      <IPNextHop>
         <ElementType>IPNextHop</ElementType>
         <Name i:nil="true"/>
         <Address>2603:10e2:400::4/128</Address>
         <AttachTo>PortChannel02,2603:10E2:400:2::2;PortChannel01,2603:10E2:400:1::2;PortChannel04,2603:10E2:400:4::2;PortChannel03,2603:10E2:400:3::2</AttachTo>
         <Type>StaticRoute</Type>
      </IPNextHop>
      <IPNextHop>
         <ElementType>IPNextHop</ElementType>
         <Name i:nil="true"/>
         <Address>3.3.3.5/32</Address>
         <AttachTo>PortChannel02,20.0.2.3;PortChannel01,20.0.1.3;PortChannel04,20.0.4.3;PortChannel03,20.0.3.3</AttachTo>
         <Type>StaticRoute</Type>
      </IPNextHop>
      <IPNextHop>
         <ElementType>IPNextHop</ElementType>
         <Name i:nil="true"/>
         <Address>2603:10e2:400::5/128</Address>
         <AttachTo>PortChannel02,2603:10E2:400:2::3;PortChannel01,2603:10E2:400:1::3;PortChannel04,2603:10E2:400:4::3;PortChannel03,2603:10E2:400:3::3</AttachTo>
         <Type>StaticRoute</Type>
      </IPNextHop>
      <IPNextHop>
         <ElementType>IPNextHop</ElementType>
         <Name i:nil="true"/>
         <Address>3.3.3.6/32</Address>
         <AttachTo>PortChannel02,20.0.2.4;PortChannel01,20.0.1.4;PortChannel04,20.0.4.4;PortChannel03,20.0.3.4</AttachTo>
         <Type>StaticRoute</Type>
      </IPNextHop>

```