### PR TITLE
Excluded the DPU interafces Ethernet-BP0 to Ethernet-BP7 from the minigraph_facts

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -924,6 +924,16 @@ class QosSaiBase(QosBase):
         dst_dut = get_src_dst_asic_and_duts['dst_dut']
         src_mgFacts = src_dut.get_extended_minigraph_facts(tbinfo)
         topo = tbinfo["topo"]["name"]
+        src_mgFacts['minigraph_ptf_indices'] = {
+            key: value
+            for key, value in src_mgFacts['minigraph_ptf_indices'].items()
+            if not key.startswith("Ethernet-BP")
+            }
+        src_mgFacts['minigraph_ports'] = {
+            key: value
+            for key, value in src_mgFacts['minigraph_ports'].items()
+            if not key.startswith("Ethernet-BP")
+            }
 
         # LAG ports in T1 TOPO need to be removed in Mellanox devices
         if topo in self.SUPPORTED_T0_TOPOS or (topo in self.SUPPORTED_PTF_TOPOS and isMellanoxDevice(src_dut)):


### PR DESCRIPTION
Description of PR:

This fix is to address the issue introduced by smartswicth interafces Ethernet-BP0 to Ethernet-BP7 .
These new interfaces are breaking test_qos_sai.py test cases. 

Summary:Excluded the DPU interafces Ethernet-BP0 to Ethernet-BP7 from the minigraph_facts
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
exclude new DPU interfaces Ethernet-BP0 to Ethernet-BP7 

#### What is the motivation for this PR?
The new DPU interfaces Ethernet-BP0 to Ethernet-BP7 is breaking test_qos_sai.py regression.

#### How did you do it?
Excluded the DPU interafces Ethernet-BP0 to Ethernet-BP7 from the minigraph_facts from src_mgFacts dictionary

#### How did you verify/test it?
Ran complete test_qos_sai.py regression under sonic-mgmt.

#### Any platform specific information?
Verified and Tested on Cisco-8102-28FH-DPU-O-T1.
it should not impact other vendor platforms.

#### Supported testbed topology if it's a new test case?
topo_t1_28_lag.yml

### Documentation
SKIPPED [6] qos/test_qos_sai.py:1793: multi-dut is not supported on T1 topologies
SKIPPED [6] qos/test_qos_sai.py:2001: multi-dut is not supported on T1 topologies
================================================================================== 11 passed, 224 skipped, 1 warning in 2140.90s (0:35:40) ===================================================================================
AzDevOps@sonic-ucs-m6-15:/data/tests$
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
