### PR TITLE
Add topology marks `t1-multi-asic` for some subtype topologies. 

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -10,7 +10,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.sonic_db import redis_get_keys
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any', "t1-multi-asic")
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -18,7 +18,10 @@ from tests.route.utils import generate_intf_neigh, generate_route_file, prepare_
 CRM_POLL_INTERVAL = 1
 CRM_DEFAULT_POLL_INTERVAL = 300
 
-pytestmark = [pytest.mark.topology("any"), pytest.mark.device_type("vs")]
+pytestmark = [
+    pytest.mark.topology("any", "t1-multi-asic"),
+    pytest.mark.device_type("vs")
+]
 
 logger = logging.getLogger(__name__)
 

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -14,7 +14,7 @@ from telemetry_utils import generate_client_cli, parse_gnmi_output, check_gnmi_c
 from tests.common import config_reload
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any', 't1-multi-asic')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/telemetry/test_telemetry_cert_rotation.py
+++ b/tests/telemetry/test_telemetry_cert_rotation.py
@@ -8,7 +8,7 @@ from telemetry_utils import generate_client_cli
 from telemetry_utils import archive_telemetry_certs, unarchive_telemetry_certs, rotate_telemetry_certs
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any', 't1-multi-asic')
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #15162, we introduced new topology markers for specific subtypes, such as `t1-multi-asic`, and applied these markers to the relevant test scripts. However, some newly added test scripts are missing these markers. To prepare for enabling the multi_asic checker in Impacted Area-Based PR testing, this PR adds the appropriate markers to those scripts.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
    - [ ] Add ownership [here](https://msazure.visualstudio.com/AzureWiki/_wiki/wikis/AzureWiki.wiki/744287/TSG-for-ownership-modification)(Microsft required only)
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
In PR #15162, we introduced new topology markers for specific subtypes, such as `t1-multi-asic`, and applied these markers to the relevant test scripts. However, some newly added test scripts are missing these markers. To prepare for enabling the multi_asic checker in Impacted Area-Based PR testing, this PR adds the appropriate markers to those scripts.

#### How did you do it?
Add the appropriate markers to newly added scripts. 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
