### PR TITLE
[dhcp_relay] Add test case to verify dhcp6relay LLA waiting logic

### DIFF
--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -294,7 +294,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
 
     try:
         duthost.shell_cmds(cmds=delete_cmds)
-        duthost.shell("docker exec dhcp_relay supervisorctl restart dhcp-relay:dhcp6relay")
+        restart_dhcp_service(duthost)
         time.sleep(10)
 
         output = duthost.shell("docker exec -t dhcp_relay ss -nlp | grep dhcp6relay")["stdout"]

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -119,6 +119,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
     dhcp_relay_data_list = []
     down_interface_link_local = ""
+    down_interface_link_local_with_prefix_len = ""
 
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
@@ -182,11 +183,12 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, tbinfo):
                         uplink_interfaces.append(iface_name)
                     uplink_port_indices.append(mg_facts['minigraph_ptf_indices'][iface_name])
         if down_interface_link_local == "":
-            command = "ip addr show {} | grep inet6 | grep 'scope link' | awk '{{print $2}}' | cut -d '/' -f1"\
+            command = "ip addr show {} | grep inet6 | grep 'scope link' | awk '{{print $2}}'"\
                       .format(downlink_vlan_iface['name'])
             res = duthost.shell(command)
             if res['stdout'] != "":
-                down_interface_link_local = res['stdout']
+                down_interface_link_local_with_prefix_len = res['stdout']
+                down_interface_link_local = down_interface_link_local_with_prefix_len.split("/")[0]
 
         dhcp_relay_data = {}
         dhcp_relay_data['downlink_vlan_iface'] = downlink_vlan_iface
@@ -194,6 +196,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, tbinfo):
         dhcp_relay_data['uplink_interfaces'] = uplink_interfaces
         dhcp_relay_data['uplink_port_indices'] = uplink_port_indices
         dhcp_relay_data['down_interface_link_local'] = down_interface_link_local
+        dhcp_relay_data['down_interface_link_local_with_prefix_len'] = down_interface_link_local_with_prefix_len
         dhcp_relay_data['loopback_iface'] = mg_facts['minigraph_lo_interfaces']
         dhcp_relay_data['loopback_ipv6'] = mg_facts['minigraph_lo_interfaces'][1]['addr']
         if 'dualtor' in tbinfo['topo']['name']:
@@ -262,12 +265,56 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
         config_reload(duthost)
         wait_critical_processes(duthost)
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
-    output = duthost.shell("docker exec -t dhcp_relay ss -nlp | grep dhcp6relay")["stdout"]
-    logger.info(output)
-    for dhcp_relay in dut_dhcp_relay_data:
-        assert ("*:{}".format(dhcp_relay['downlink_vlan_iface']['name']) or "*:*" in output,
-                "{} is not found in {}".format("*:{}".format(dhcp_relay['downlink_vlan_iface']['name']), output)) or \
-               ("*:*" in output, "dhcp6relay socket is not properly binded")
+
+    # Cmds to delete LLA for all Vlans
+    delete_cmds = ["ip -6 address del {} dev {}"
+                   .format(data["down_interface_link_local_with_prefix_len"],
+                           data["downlink_vlan_iface"]["name"]) for data in dut_dhcp_relay_data]
+
+    # Cmds to add LLA for all Vlans
+    add_cmds = ["ip -6 address add {} dev {}"
+                .format(data["down_interface_link_local_with_prefix_len"],
+                        data["downlink_vlan_iface"]["name"]) for data in dut_dhcp_relay_data]
+
+    def _check_dhcp6relay_lla_socket(expect_exist):
+        res = {}
+        output = duthost.shell("docker exec -t dhcp_relay ss -nlp | grep dhcp6relay")["stdout"]
+        for dhcp_relay in dut_dhcp_relay_data:
+            key = dhcp_relay['downlink_vlan_iface']['name']
+            res[key] = "{}:547".format(key) in output
+
+        logger.info("_check_dhcp6relay_lla_socket res: {}".format(res))
+
+        # If expect socket exist, then sockets for all vlan should appear
+        if expect_exist:
+            return all(list(res.values()))
+        # If not expect socket exist, then sockets for all vlan shouldn't appear
+        else:
+            return not any(list(res.values()))
+
+    try:
+        duthost.shell_cmds(cmds=delete_cmds)
+        duthost.shell("docker exec dhcp_relay supervisorctl restart dhcp-relay:dhcp6relay")
+        time.sleep(10)
+
+        output = duthost.shell("docker exec -t dhcp_relay ss -nlp | grep dhcp6relay")["stdout"]
+        logger.info(output)
+
+        # Raw socket listen all port would startup
+        pytest_assert("*:*" in output, "Raw socket for dhcp6relay is not found")
+
+        # LLA is not ready, hence there should not be sockets listen on LLA
+        pytest_assert(_check_dhcp6relay_lla_socket(False), "LLA sockets are found, which is unexpected")
+
+        duthost.shell_cmds(cmds=add_cmds)
+
+        # Interval for checking lla in dhcp6relay is set as 60s, hence here we expect in worst scenario LLA sould
+        # be ready in 70s
+        # LLAs are ready, hence there should be sockets listen on LLA
+        pytest_assert(wait_until(70, 5, 0, _check_dhcp6relay_lla_socket, True), "Expected LLA sockets are not found")
+    finally:
+        for cmd in add_cmds:
+            duthost.shell(cmd, module_ignore_errors=True)
 
     pytest_assert("Vlan{}".format(new_vlan_id) not in output,
                   "dhcp6relay bind to Vlan{} without dhcpv6_servers configured, which is unexpected"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/16344

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
    - [ ] Add ownership [here](https://msazure.visualstudio.com/AzureWiki/_wiki/wikis/AzureWiki.wiki/744287/TSG-for-ownership-modification)(Microsft required only)
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
We add wait LLA logic in dhcp6relay with https://github.com/sonic-net/sonic-dhcp-relay/pull/52
Current PR is to add test for it to verify dhcp6relay would work well when LLA is missing

#### How did you do it?
Modify `test_interface_binding`:
1. Remove LLA for Vlans
2. Restart dhcp_relay container
3. Verify whether sockets for LLA are not established
4. Add LLA back
5. Verify whether sockets for LLA are established


#### How did you verify/test it?
Run test_dhcpv6_relay.py
```
collected 6 items                                                                                                                                                                                                                                                                  

dhcp_relay/test_dhcpv6_relay.py::test_interface_binding PASSED                                                                                                                                                                                                               [ 16%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter PASSED                                                                                                                                                                                                            [ 33%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default PASSED                                                                                                                                                                                                              [ 50%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap PASSED                                                                                                                                                                                                      [ 66%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_start_with_uplinks_down PASSED                                                                                                                                                                                              [ 83%]
dhcp_relay/test_dhcpv6_relay.py::TestDhcpv6RelayWithMultipleVlan::test_dhcp_relay_default[3] PASSED                                                                                                                                                                          [100%]

================================================================================================================================= warnings summary =================================================================================================================================
../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--------------------------------------------------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/dhcp_relay/test_dhcpv6_relay.xml ----------------------------------------------------------------------------------------------
===================================================================================================================== 6 passed, 1 warning in 967.94s (0:16:07) =====================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
