### PR TITLE
[Qos]Compensating the actual leak out packets for Wrr test

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3706,7 +3706,6 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
         queue_7_num_of_pkts = int(self.test_params.get('q7_num_of_pkts', 0))
         limit = int(self.test_params['limit'])
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
-        hwsku = self.test_params['hwsku']
         pkts_num_egr_mem = int(self.test_params.get('pkts_num_egr_mem', 0))
         lossless_weight = int(self.test_params.get('lossless_weight', 1))
         lossy_weight = int(self.test_params.get('lossy_weight', 1))

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3785,8 +3785,8 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id], disable_port_by_block_queue=False)
 
         try:
-            #send 1 pkt as leakout &
-            #apply dynamically compensation for Broadcom-dnx.
+            # send 1 pkt as leakout &
+            # apply dynamically compensation for Broadcom-dnx.
             if platform_asic and platform_asic == "broadcom-dnx":
                 pkts_num_leak_out = 1
 
@@ -3964,7 +3964,6 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
         finally:
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id],
                                            enable_port_by_unblock_queue=False)
-
 
 
 class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3784,69 +3784,109 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
 
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id], disable_port_by_block_queue=False)
 
-        # send 1 pkt as leakout &
-        # apply dynamically compensation for Broadcom-dnx.
-        if platform_asic and platform_asic == "broadcom-dnx":
-            pkts_num_leak_out = 1
+        try:
+            #send 1 pkt as leakout &
+            #apply dynamically compensation for Broadcom-dnx.
+            if platform_asic and platform_asic == "broadcom-dnx":
+                pkts_num_leak_out = 1
 
-        send_packet(self, src_port_id, pkt, pkts_num_leak_out)
-        if platform_asic and platform_asic == "broadcom-dnx":
-            dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
-                                           port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
-                                           xmit_counters_base, self, src_port_id, pkt, 10)
+            send_packet(self, src_port_id, pkt, pkts_num_leak_out)
+            if platform_asic and platform_asic == "broadcom-dnx":
+                dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
+                                               port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
+                                               xmit_counters_base, self, src_port_id, pkt, 10)
 
-        if 'hwsku' in self.test_params and self.test_params['hwsku'] in ('Arista-7060X6-64PE-256x200G'):
+            if 'hwsku' in self.test_params and self.test_params['hwsku'] in ('Arista-7060X6-64PE-256x200G'):
 
-            prio_lossless = (3, 4)
-            prio_lossy = tuple(set(prio_list) - set(prio_lossless))
-            pkts_egr_lossless = int(pkts_num_egr_mem * (lossless_weight / (lossless_weight + lossy_weight)))
-            pkts_egr_lossy = int(pkts_num_egr_mem - pkts_egr_lossless)
-            pkts_egr_lossless, mod_lossless = divmod(pkts_egr_lossless, len(prio_lossless))
-            pkts_egr_lossy, mod_lossy = divmod(pkts_egr_lossy, len(prio_lossy))
-            pkts_egr = {prio: pkts_egr_lossless if prio in prio_lossless else pkts_egr_lossy for prio in prio_list}
-            for prio in prio_lossless[:mod_lossless] + prio_lossy[:mod_lossy]:
-                pkts_egr[prio] += 1
+                prio_lossless = (3, 4)
+                prio_lossy = tuple(set(prio_list) - set(prio_lossless))
+                pkts_egr_lossless = int(pkts_num_egr_mem * (lossless_weight / (lossless_weight + lossy_weight)))
+                pkts_egr_lossy = int(pkts_num_egr_mem - pkts_egr_lossless)
+                pkts_egr_lossless, mod_lossless = divmod(pkts_egr_lossless, len(prio_lossless))
+                pkts_egr_lossy, mod_lossy = divmod(pkts_egr_lossy, len(prio_lossy))
+                pkts_egr = {prio: pkts_egr_lossless if prio in prio_lossless else pkts_egr_lossy for prio in prio_list}
+                for prio in prio_lossless[:mod_lossless] + prio_lossy[:mod_lossy]:
+                    pkts_egr[prio] += 1
 
-            for prio in prio_list:
-                pkt = construct_ip_pkt(64,
+                for prio in prio_list:
+                    pkt = construct_ip_pkt(64,
+                                           pkt_dst_mac,
+                                           src_port_mac,
+                                           src_port_ip,
+                                           dst_port_ip,
+                                           prio,
+                                           src_port_vlan,
+                                           ip_id=exp_ip_id + 1,
+                                           ecn=ecn,
+                                           ttl=64)
+                    send_packet(self, src_port_id, pkt, pkts_egr[prio])
+
+            # Get a snapshot of counter values
+            port_counters_base, queue_counters_base = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
+
+            # Send packets to each queue based on priority/dscp field
+            for prio, pkt_cnt, queue in zip(prio_list, q_pkt_cnt, q_list):
+                pkt = construct_ip_pkt(default_packet_length,
                                        pkt_dst_mac,
                                        src_port_mac,
                                        src_port_ip,
                                        dst_port_ip,
                                        prio,
                                        src_port_vlan,
-                                       ip_id=exp_ip_id + 1,
+                                       ip_id=exp_ip_id,
                                        ecn=ecn,
                                        ttl=64)
-                send_packet(self, src_port_id, pkt, pkts_egr[prio])
+                if 'cisco-8000' in asic_type and pkt_cnt > 0:
+                    fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type)
+                    pkt_cnt -= 1
+                send_packet(self, src_port_id, pkt, pkt_cnt)
 
-        # Get a snapshot of counter values
-        port_counters_base, queue_counters_base = sai_thrift_read_port_counters(
-            self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            # Set receiving socket buffers to some big value
+            for p in list(self.dataplane.ports.values()):
+                p.socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 41943040)
 
-        # Send packets to each queue based on priority/dscp field
-        for prio, pkt_cnt, queue in zip(prio_list, q_pkt_cnt, q_list):
-            pkt = construct_ip_pkt(default_packet_length,
-                                   pkt_dst_mac,
-                                   src_port_mac,
-                                   src_port_ip,
-                                   dst_port_ip,
-                                   prio,
-                                   src_port_vlan,
-                                   ip_id=exp_ip_id,
-                                   ecn=ecn,
-                                   ttl=64)
-            if 'cisco-8000' in asic_type and pkt_cnt > 0:
-                fill_leakout_plus_one(self, src_port_id, dst_port_id, pkt, queue, asic_type)
-                pkt_cnt -= 1
-            send_packet(self, src_port_id, pkt, pkt_cnt)
+            # recv packets for leakout
+            if 'cisco-8000' in asic_type:
+                recv_pkt = scapy.Ether()
 
-        # Set receiving socket buffers to some big value
-        for p in list(self.dataplane.ports.values()):
-            p.socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 41943040)
+                while recv_pkt:
+                    received = self.dataplane.poll(
+                        device_number=0, port_number=dst_port_id, timeout=2)
+                    if isinstance(received, self.dataplane.PollFailure):
+                        recv_pkt = None
+                        break
+                    recv_pkt = scapy.Ether(received.packet)
 
-        # recv packets for leakout
-        if 'cisco-8000' in asic_type:
+            if asic_type == 'cisco-8000':
+                out, err, ret = self.exec_cmd_on_dut(
+                    self.dst_server_ip,
+                    self.test_params['dut_username'],
+                    self.test_params['dut_password'],
+                    "show platform summary | egrep 'ASIC Count' | awk -F: '{print $2}'")
+                cmd_opt = "-n asic{}".format(self.test_params['dst_asic_index'])
+                if out[0].strip() == "1":
+                    cmd_opt = ""
+                cmd = "sudo show platform npu script {} -s set_scheduler.py".format(cmd_opt)
+                out, err, ret = self.exec_cmd_on_dut(
+                    self.dst_server_ip,
+                    self.test_params['dut_username'],
+                    self.test_params['dut_password'],
+                    cmd)
+                if err and out == []:
+                    raise RuntimeError("cmd({}) might have failed in the DUT. Error:{}".format(cmd, err))
+                else:
+                    print("Success in setting scheduler in DUT.", file=sys.stderr)
+            else:
+                # Release port
+                self.sai_thrift_port_tx_enable(
+                    self.dst_client,
+                    asic_type,
+                    [dst_port_id],
+                    enable_port_by_unblock_queue=False)
+
+            cnt = 0
+            pkts = []
             recv_pkt = scapy.Ether()
 
             while recv_pkt:
@@ -3857,109 +3897,74 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                     break
                 recv_pkt = scapy.Ether(received.packet)
 
-        if asic_type == 'cisco-8000':
-            out, err, ret = self.exec_cmd_on_dut(
-                self.dst_server_ip,
-                self.test_params['dut_username'],
-                self.test_params['dut_password'],
-                "show platform summary | egrep 'ASIC Count' | awk -F: '{print $2}'")
-            cmd_opt = "-n asic{}".format(self.test_params['dst_asic_index'])
-            if out[0].strip() == "1":
-                cmd_opt = ""
-            cmd = "sudo show platform npu script {} -s set_scheduler.py".format(cmd_opt)
-            out, err, ret = self.exec_cmd_on_dut(
-                self.dst_server_ip,
-                self.test_params['dut_username'],
-                self.test_params['dut_password'],
-                cmd)
-            if err and out == []:
-                raise RuntimeError("cmd({}) might have failed in the DUT. Error:{}".format(cmd, err))
-            else:
-                print("Success in setting scheduler in DUT.", file=sys.stderr)
-        else:
-            # Release port
-            self.sai_thrift_port_tx_enable(
-                self.dst_client,
-                asic_type,
-                [dst_port_id],
-                enable_port_by_unblock_queue=False)
+                try:
+                    if recv_pkt[scapy.IP].src == src_port_ip and recv_pkt[scapy.IP].dst == dst_port_ip and \
+                            recv_pkt[scapy.IP].id == exp_ip_id:
+                        cnt += 1
+                        pkts.append(recv_pkt)
+                except AttributeError:
+                    continue
+                except IndexError:
+                    # Ignore captured non-IP packet
+                    continue
 
-        cnt = 0
-        pkts = []
-        recv_pkt = scapy.Ether()
+            if asic_type == 'cisco-8000':
+                # Release port
+                self.sai_thrift_port_tx_enable(
+                    self.dst_client,
+                    asic_type,
+                    [dst_port_id],
+                    enable_port_by_unblock_queue=False)
 
-        while recv_pkt:
-            received = self.dataplane.poll(
-                device_number=0, port_number=dst_port_id, timeout=2)
-            if isinstance(received, self.dataplane.PollFailure):
-                recv_pkt = None
-                break
-            recv_pkt = scapy.Ether(received.packet)
+            queue_pkt_counters = [0] * (max(prio_list) + 1)
+            queue_num_of_pkts = [0] * (max(prio_list) + 1)
+            for prio, q_cnt in zip(prio_list, q_pkt_cnt):
+                queue_num_of_pkts[prio] = q_cnt
 
-            try:
-                if recv_pkt[scapy.IP].src == src_port_ip and recv_pkt[scapy.IP].dst == dst_port_ip and \
-                        recv_pkt[scapy.IP].id == exp_ip_id:
-                    cnt += 1
-                    pkts.append(recv_pkt)
-            except AttributeError:
-                continue
-            except IndexError:
-                # Ignore captured non-IP packet
-                continue
+            total_pkts = 0
 
-        if asic_type == 'cisco-8000':
-            # Release port
-            self.sai_thrift_port_tx_enable(
-                self.dst_client,
-                asic_type,
-                [dst_port_id],
-                enable_port_by_unblock_queue=False)
+            diff_list = []
 
-        queue_pkt_counters = [0] * (max(prio_list) + 1)
-        queue_num_of_pkts = [0] * (max(prio_list) + 1)
-        for prio, q_cnt in zip(prio_list, q_pkt_cnt):
-            queue_num_of_pkts[prio] = q_cnt
+            for pkt_to_inspect in pkts:
+                if 'backend' in topo:
+                    dscp_of_pkt = pkt_to_inspect[scapy.Dot1Q].prio
+                else:
+                    dscp_of_pkt = pkt_to_inspect.payload.tos >> 2
+                total_pkts += 1
 
-        total_pkts = 0
+                # Count packet ordering
 
-        diff_list = []
+                queue_pkt_counters[dscp_of_pkt] += 1
+                if queue_pkt_counters[dscp_of_pkt] == queue_num_of_pkts[dscp_of_pkt]:
+                    diff_list.append((dscp_of_pkt, q_cnt_sum - total_pkts))
 
-        for pkt_to_inspect in pkts:
-            if 'backend' in topo:
-                dscp_of_pkt = pkt_to_inspect[scapy.Dot1Q].prio
-            else:
-                dscp_of_pkt = pkt_to_inspect.payload.tos >> 2
-            total_pkts += 1
+                print(queue_pkt_counters, file=sys.stderr)
 
-            # Count packet ordering
+            print("Difference for each dscp: ", file=sys.stderr)
+            print(diff_list, file=sys.stderr)
 
-            queue_pkt_counters[dscp_of_pkt] += 1
-            if queue_pkt_counters[dscp_of_pkt] == queue_num_of_pkts[dscp_of_pkt]:
-                diff_list.append((dscp_of_pkt, q_cnt_sum - total_pkts))
+            for dscp, diff in diff_list:
+                if platform_asic and platform_asic == "broadcom-dnx":
+                    logging.info(
+                        "On J2C+ can't control how packets are dequeued (CS00012272267) - so ignoring diff check now")
+                elif not dry_run:
+                    assert diff < limit, "Difference for %d is %d which exceeds limit %d" % (
+                        dscp, diff, limit)
 
-            print(queue_pkt_counters, file=sys.stderr)
+            # Read counters
+            print("DST port counters: ")
+            port_counters, queue_counters = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            print(list(map(operator.sub, queue_counters,
+                           queue_counters_base)), file=sys.stderr)
 
-        print("Difference for each dscp: ", file=sys.stderr)
-        print(diff_list, file=sys.stderr)
+            print([q_cnt_sum, total_pkts], file=sys.stderr)
+            # All packets sent should be received intact
+            assert (q_cnt_sum == total_pkts)
+        finally:
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id],
+                                           enable_port_by_unblock_queue=False)
 
-        for dscp, diff in diff_list:
-            if platform_asic and platform_asic == "broadcom-dnx":
-                logging.info(
-                    "On J2C+ can't control how packets are dequeued (CS00012272267) - so ignoring diff check now")
-            elif not dry_run:
-                assert diff < limit, "Difference for %d is %d which exceeds limit %d" % (
-                    dscp, diff, limit)
-
-        # Read counters
-        print("DST port counters: ")
-        port_counters, queue_counters = sai_thrift_read_port_counters(
-            self.dst_client, asic_type, port_list['dst'][dst_port_id])
-        print(list(map(operator.sub, queue_counters,
-                       queue_counters_base)), file=sys.stderr)
-
-        print([q_cnt_sum, total_pkts], file=sys.stderr)
-        # All packets sent should be received intact
-        assert (q_cnt_sum == total_pkts)
 
 
 class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
For broadcom-dnx chassis instead of sending fixed number of leakout packets to drain voq credits, send few pkts and dynamically compensate the actual leakout packets
Summary:
Fixes # (issue)
Intermittent failures seen in DWRR test with 1 or 2 packet with -  RQP (PRP_UC_DISCARD_PACKETS) error
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
    - [ ] Add ownership [here](https://msazure.visualstudio.com/AzureWiki/_wiki/wikis/AzureWiki.wiki/744287/TSG-for-ownership-modification)(Microsft required only)
- [x] Test case improvement


### Back port request
- [ ] 202012
- [x] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Intermittent failures seen in DWRR test 
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
