### PR TITLE
[202405][gcu][dhcp_relay] Fix dhcp_relay container is not running in gcu test (#16460)

### DIFF
--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -1,0 +1,16 @@
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+
+
+def restart_dhcp_service(duthost):
+    duthost.shell('systemctl reset-failed dhcp_relay')
+    duthost.shell('systemctl restart dhcp_relay')
+    duthost.shell('systemctl reset-failed dhcp_relay')
+
+    def _is_dhcp_relay_ready():
+        output = duthost.shell('docker exec dhcp_relay supervisorctl status | grep dhcp | awk \'{print $2}\'',
+                               module_ignore_errors=True)
+        return (not output['rc'] and output['stderr'] == '' and len(output['stdout_lines']) != 0 and
+                all(element == 'RUNNING' for element in output['stdout_lines']))
+
+    pytest_assert(wait_until(120, 1, 10, _is_dhcp_relay_ready), "dhcp_relay is not ready after restarting")


### PR DESCRIPTION


What is the motivation for this PR?
In gcu dhcp_relay test, it would add 2 vlans with 4 dhcp servers. Previously all 8 dhcp servers are added by cli separately, it would restart dhcp_relay container 8 times, which would cause dhcp_relay container is not running in gcu test in some low performance devices.

How did you do it?
Use sonic-db-cli to add dhcp servers, then manually resetart dhcp_relay container once.

How did you verify/test it?
Run tests

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
    - [ ] Add ownership [here](https://msazure.visualstudio.com/AzureWiki/_wiki/wikis/AzureWiki.wiki/744287/TSG-for-ownership-modification)(Microsft required only)
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Manually cherry-pick and resolve conflict of this PR: https://github.com/sonic-net/sonic-mgmt/pull/16460

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
