### PR TITLE
[override] Remove table test which has no YANG model

### DIFF
--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -169,7 +169,6 @@ def test_load_minigraph_with_golden_config(duthosts, setup_env,
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     load_minigraph_with_golden_empty_input(duthost)
     load_minigraph_with_golden_partial_config(duthost)
-    load_minigraph_with_golden_new_feature(duthost)
     full_config = setup_env
     load_minigraph_with_golden_full_config(duthost, full_config)
     load_minigraph_with_golden_empty_table_removal(duthost)

--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -121,27 +121,6 @@ def load_minigraph_with_golden_partial_config(duthost):
     )
 
 
-def load_minigraph_with_golden_new_feature(duthost):
-    """Test Golden Config with new feature
-    """
-    new_feature_config = {
-        "NEW_FEATURE_TABLE": {
-            "entry": {
-                "field": "value",
-                "state": "disabled"
-            }
-        }
-    }
-    reload_minigraph_with_golden_config(duthost, new_feature_config)
-
-    current_config = get_running_config(duthost)
-    pytest_assert(
-        'NEW_FEATURE_TABLE' in current_config and
-        current_config['NEW_FEATURE_TABLE'] == new_feature_config['NEW_FEATURE_TABLE'],
-        "new feature config update fail: {}".format(current_config['NEW_FEATURE_TABLE'])
-    )
-
-
 def load_minigraph_with_golden_full_config(duthost, full_config):
     """Test Golden Config fully override minigraph config
     """

--- a/tests/override_config_table/test_override_config_table_masic.py
+++ b/tests/override_config_table/test_override_config_table_masic.py
@@ -154,44 +154,6 @@ def load_minigraph_with_golden_partial_config(duthost):
     )
 
 
-def load_minigraph_with_golden_new_feature(duthost):
-    """Test Golden Config with new feature
-    """
-    new_feature_config = {
-        "localhost": {
-            "NEW_FEATURE_TABLE": {
-                "entry": {
-                    "field": "value",
-                    "state": "disabled"
-                }
-            }
-        },
-        "asic0": {
-            "NEW_FEATURE_TABLE": {
-                "entry": {
-                    "field": "value",
-                    "state": "disabled"
-                }
-            }
-        }
-    }
-    reload_minigraph_with_golden_config(duthost, new_feature_config)
-
-    host_current_config = get_running_config(duthost)
-    pytest_assert(
-        'NEW_FEATURE_TABLE' in host_current_config and
-        host_current_config['NEW_FEATURE_TABLE'] == new_feature_config['localhost']['NEW_FEATURE_TABLE'],
-        "new feature config update fail: {}".format(host_current_config['NEW_FEATURE_TABLE'])
-    )
-
-    asic0_current_config = get_running_config(duthost, "asic0")
-    pytest_assert(
-        'NEW_FEATURE_TABLE' in asic0_current_config and
-        asic0_current_config['NEW_FEATURE_TABLE'] == new_feature_config['asic0']['NEW_FEATURE_TABLE'],
-        "new feature config update fail: {}".format(asic0_current_config['NEW_FEATURE_TABLE'])
-    )
-
-
 def load_minigraph_with_golden_empty_table_removal(duthost):
     """Test Golden Config with empty table removal.
 

--- a/tests/override_config_table/test_override_config_table_masic.py
+++ b/tests/override_config_table/test_override_config_table_masic.py
@@ -209,5 +209,4 @@ def test_load_minigraph_with_golden_config(duthosts, setup_env, tbinfo, enum_ran
         # since the handling of empty golden config doesn't work on upstream linecards
         load_minigraph_with_golden_empty_input(duthost)
     load_minigraph_with_golden_partial_config(duthost)
-    load_minigraph_with_golden_new_feature(duthost)
     load_minigraph_with_golden_empty_table_removal(duthost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
ADO: 30864778
Summary:Remove test for no yang supported table test
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
    - [ ] Add ownership [here](https://msazure.visualstudio.com/AzureWiki/_wiki/wikis/AzureWiki.wiki/744287/TSG-for-ownership-modification)(Microsft required only)
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
We plan on strict yang enforcement on config CLI. Thus it will fail for non-yang supported NEW_FEATURE_TABLE
#### How did you do it?
Remove test for tables without yang model
#### How did you verify/test it?
E2E test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
