### PR TITLE
chore: disable parallel run for ro disk test

### DIFF
--- a/tests/test_parallel_modes/cisco_t2_8800.json
+++ b/tests/test_parallel_modes/cisco_t2_8800.json
@@ -38,7 +38,6 @@
     "snmp/test_snmp_link_local.py": "FULL_PARALLEL",
     "snmp/test_snmp_memory.py": "FULL_PARALLEL",
     "snmp/test_snmp_queue.py": "RP_FIRST",
-    "tacacs/test_ro_disk.py": "RP_FIRST",
     "test_features.py": "FULL_PARALLEL",
     "test_interfaces.py": "FULL_PARALLEL"
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Disable parallel run for `tacacs/test_ro_disk.py` test.

Summary:
Fixes # (issue) Microsoft ADO 30848681

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
The `tacacs/test_ro_disk.py` test is using a special reboot process on the DUT and if we run this test with parallel run enabled, the LCs might not be ready after Supervisor's reboot. Therefore, we need to disable parallel run for this test.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
