### PR TITLE
[On hold, merge if required] revert: remove orchagent sanity check

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -37,7 +37,6 @@ CHECK_ITEMS = [
     'check_neighbor_macsec_empty',
     'check_ipv6_mgmt',
     'check_mux_simulator',
-    'check_orchagent_usage',
     'check_bfd_up_count',
     'check_mac_entry_count']
 
@@ -1066,28 +1065,6 @@ def check_ipv6_mgmt(duthosts, localhost):
         finally:
             logger.info("Done checking ipv6 management reachability on %s" % dut.hostname)
             results[dut.hostname] = check_result
-    return _check
-
-
-@pytest.fixture(scope="module")
-def check_orchagent_usage(duthosts):
-    def _check(*args, **kwargs):
-        init_result = {"failed": False, "check_item": "orchagent_usage"}
-        result = parallel_run(_check_orchagent_usage_on_dut, args, kwargs, duthosts,
-                              timeout=600, init_result=init_result)
-
-        return list(result.values())
-
-    def _check_orchagent_usage_on_dut(*args, **kwargs):
-        dut = kwargs['node']
-        results = kwargs['results']
-        logger.info("Checking orchagent CPU usage on %s..." % dut.hostname)
-        check_result = {"failed": False, "check_item": "orchagent_usage", "host": dut.hostname}
-        res = dut.shell("COLUMNS=512 show processes cpu | grep orchagent | awk '{print $9}'")["stdout_lines"]
-        check_result["orchagent_usage"] = res
-        logger.info("Done checking orchagent CPU usage on %s" % dut.hostname)
-        results[dut.hostname] = check_result
-
     return _check
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Remove the orchagent sanity check code added in #14263 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Previously, we added the orchagent usage sanity check in #14263 to confirm if the orchagent is behaving well in T2 Nightly runs. Now we have confirmed there is no issue with it, so we decided to revert the change.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
