### PR TITLE
[SRv6] Add SRv6 control plane test case

### DIFF
--- a/tests/srv6/test_srv6_static_config.py
+++ b/tests/srv6/test_srv6_static_config.py
@@ -2,81 +2,103 @@ import time
 import logging
 import pytest
 
+pytestmark = [
+    pytest.mark.topology('t0')
+]
+
 WAIT_TIME = 5
 
-def test_uN_config(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_uN_config(duthosts, enum_frontend_dut_hostname, enum_rand_one_asic_index):
+    duthost = duthosts[enum_frontend_dut_hostname]
+    asic_index = enum_rand_one_asic_index
+
+    if duthost.is_multi_asic:
+        cli_options = " -n " + duthost.get_namespace_from_asic_id(asic_index)
+    else:
+        cli_options = ''
+
+    sonic_db_cli = "sonic-db-cli" + cli_options
+    vtysh_shell = "vtysh" + cli_options
 
     # add a locator configuration entry
-    duthost.command("sonic-db-cli CONFIG_DB HSET SRV6_MY_LOCATORS\\|loc1 prefix fcbb:bbbb:1::")
+    duthost.command(sonic_db_cli + " CONFIG_DB HSET SRV6_MY_LOCATORS\\|loc1 prefix fcbb:bbbb:1::")
     # add a uN sid configuration entry
-    duthost.command("sonic-db-cli CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1:1:: action uN")
+    duthost.command(sonic_db_cli + " CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1:1:: action uN")
     time.sleep(WAIT_TIME)
 
-    frr_config = duthost.command("vtysh -c \"show running-config\"")["stdout"]
+    frr_config = duthost.command(vtysh_shell + " -c \"show running-config\"")["stdout"]
 
     # verify that bgpcfgd generates FRR config correctly
     assert "locator loc1" in frr_config
     assert "sid fcbb:bbbb:1:1::/64 locator loc1 behavior uN" in frr_config
 
-    appl_db_my_sids = duthost.command("sonic-db-cli APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
+    appl_db_my_sids = duthost.command(sonic_db_cli + " APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
 
     # verify that APPL_DB gets programmed by FRR correctly
     assert "SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:1::" in appl_db_my_sids
 
     # delete the configurations
-    duthost.command("sonic-db-cli CONFIG_DB DEL SRV6_MY_LOCATORS\\|loc1")
-    duthost.command("sonic-db-cli CONFIG_DB DEL SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1:1::")
+    duthost.command(sonic_db_cli + " CONFIG_DB DEL SRV6_MY_LOCATORS\\|loc1")
+    duthost.command(sonic_db_cli + " CONFIG_DB DEL SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1:1::")
     time.sleep(WAIT_TIME)
 
-    frr_config = duthost.command("vtysh -c \"show running-config\"")["stdout"]
+    frr_config = duthost.command(vtysh_shell + " -c \"show running-config\"")["stdout"]
 
     # verify that bgpcfgd deletes relevant FRR config
     assert "locator loc1" not in frr_config
     assert "sid fcbb:bbbb:1:1::/64 locator loc1 behavior uN" not in frr_config
 
-    appl_db_my_sids = duthost.command("sonic-db-cli APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
+    appl_db_my_sids = duthost.command(sonic_db_cli + " APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
 
     # verify that the APPL_DB entry gets cleaned correctly
     assert "SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:1::" not in appl_db_my_sids
 
 
-def test_uDT46_config(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_uDT46_config(duthosts, enum_frontend_dut_hostname, enum_rand_one_asic_index):
+    duthost = duthosts[enum_frontend_dut_hostname]
+    asic_index = enum_rand_one_asic_index
+
+    if duthost.is_multi_asic:
+        cli_options = " -n " + duthost.get_namespace_from_asic_id(asic_index)
+    else:
+        cli_options = ''
+
+    sonic_db_cli = "sonic-db-cli" + cli_options
+    vtysh_shell = "vtysh" + cli_options
 
     # add Vrf1 config
     duthost.command("config vrf add Vrf1")
     duthost.command("sysctl -w net.vrf.strict_mode=1")
 
     # add a locator configuration entry
-    duthost.command("sonic-db-cli CONFIG_DB HSET SRV6_MY_LOCATORS\\|loc1 prefix fcbb:bbbb:1::")
+    duthost.command(sonic_db_cli + " CONFIG_DB HSET SRV6_MY_LOCATORS\\|loc1 prefix fcbb:bbbb:1::")
     # add a uDT46 sid configuration entry
-    duthost.command("sonic-db-cli CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1:2:: action uDT46 decap_vrf Vrf1")
+    duthost.command(sonic_db_cli + " CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1:2:: action uDT46 decap_vrf Vrf1")
     time.sleep(WAIT_TIME)
 
-    frr_config = duthost.command("vtysh -c \"show running-config\"")["stdout"]
+    frr_config = duthost.command(vtysh_shell + " -c \"show running-config\"")["stdout"]
 
     # verify that bgpcfgd generates FRR config correctly
     assert "locator loc1" in frr_config
     assert "sid fcbb:bbbb:1:2::/64 locator loc1 behavior uDT46 vrf Vrf1" in frr_config
 
-    appl_db_my_sids = duthost.command("sonic-db-cli APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
+    appl_db_my_sids = duthost.command(sonic_db_cli + " APPL_DB keys SRV6_MY_SID_TABLE*".format(cli_options))["stdout"]
 
     # verify that APPL_DB gets programmed by FRR correctly
     assert "SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:2::" in appl_db_my_sids
 
     # delete the configurations
-    duthost.command("sonic-db-cli CONFIG_DB DEL SRV6_MY_LOCATORS\\|loc1")
-    duthost.command("sonic-db-cli CONFIG_DB DEL SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1:2::")
+    duthost.command(sonic_db_cli + " CONFIG_DB DEL SRV6_MY_LOCATORS\\|loc1")
+    duthost.command(sonic_db_cli + " CONFIG_DB DEL SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1:2::")
     time.sleep(WAIT_TIME)
 
-    frr_config = duthost.command("vtysh -c \"show running-config\"")["stdout"]
+    frr_config = duthost.command(vtysh_shell + " -c \"show running-config\"")["stdout"]
 
     # verify that bgpcfgd deletes relevant FRR config
     assert "locator loc1" not in frr_config
     assert "sid fcbb:bbbb:1:2::/64 locator loc1 behavior uDT46 vrf Vrf1" not in frr_config
 
-    appl_db_my_sids = duthost.command("sonic-db-cli APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
+    appl_db_my_sids = duthost.command(sonic_db_cli + " APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
 
     # verify that the APPL_DB entry gets cleaned correctly
     assert "SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:2::" not in appl_db_my_sids

--- a/tests/srv6/test_srv6_static_config.py
+++ b/tests/srv6/test_srv6_static_config.py
@@ -23,7 +23,8 @@ def test_uN_config(duthosts, enum_frontend_dut_hostname, enum_rand_one_asic_inde
     # add a locator configuration entry
     duthost.command(sonic_db_cli + " CONFIG_DB HSET SRV6_MY_LOCATORS\\|loc1 prefix fcbb:bbbb:1::")
     # add a uN sid configuration entry
-    duthost.command(sonic_db_cli + " CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48 action uN decap_dscp_mode pipe")
+    duthost.command(sonic_db_cli + 
+                    " CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48 action uN decap_dscp_mode pipe")
     time.sleep(WAIT_TIME)
 
     frr_config = duthost.command(vtysh_shell + " -c \"show running-config\"")["stdout"]
@@ -36,7 +37,8 @@ def test_uN_config(duthosts, enum_frontend_dut_hostname, enum_rand_one_asic_inde
 
     # verify that APPL_DB gets programmed by FRR correctly
     assert "SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1::" in appl_db_my_sids
-    assert "un" == duthost.command(sonic_db_cli + " APPL_DB hget SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1:: action")["stdout"]
+    assert "un" == duthost.command(sonic_db_cli + 
+                                   " APPL_DB hget SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1:: action")["stdout"]
 
     # delete the configurations
     duthost.command(sonic_db_cli + " CONFIG_DB DEL SRV6_MY_LOCATORS\\|loc1")
@@ -74,7 +76,8 @@ def test_uDT46_config(duthosts, enum_frontend_dut_hostname, enum_rand_one_asic_i
     # add a locator configuration entry
     duthost.command(sonic_db_cli + " CONFIG_DB HSET SRV6_MY_LOCATORS\\|loc1 prefix fcbb:bbbb:1::")
     # add a uDT46 sid configuration entry
-    duthost.command(sonic_db_cli + " CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1:2::/64 action uDT46 decap_vrf Vrf1 decap_dscp_mode uniform")
+    duthost.command(sonic_db_cli + " CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1:2::/64 \
+                    action uDT46 decap_vrf Vrf1 decap_dscp_mode uniform")
     time.sleep(WAIT_TIME)
 
     frr_config = duthost.command(vtysh_shell + " -c \"show running-config\"")["stdout"]
@@ -87,8 +90,10 @@ def test_uDT46_config(duthosts, enum_frontend_dut_hostname, enum_rand_one_asic_i
 
     # verify that APPL_DB gets programmed by FRR correctly
     assert "SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:2::" in appl_db_my_sids
-    assert "udt46" == duthost.command(sonic_db_cli + " APPL_DB hget SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:2:: action")["stdout"]
-    assert "Vrf1" == duthost.command(sonic_db_cli + " APPL_DB hget SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:2:: vrf")["stdout"]
+    assert "udt46" == duthost.command(sonic_db_cli + 
+                                      " APPL_DB hget SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:2:: action")["stdout"]
+    assert "Vrf1" == duthost.command(sonic_db_cli + 
+                                     " APPL_DB hget SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:2:: vrf")["stdout"]
 
     # delete the configurations
     duthost.command(sonic_db_cli + " CONFIG_DB DEL SRV6_MY_LOCATORS\\|loc1")

--- a/tests/srv6/test_srv6_static_config.py
+++ b/tests/srv6/test_srv6_static_config.py
@@ -23,7 +23,7 @@ def test_uN_config(duthosts, enum_frontend_dut_hostname, enum_rand_one_asic_inde
     # add a locator configuration entry
     duthost.command(sonic_db_cli + " CONFIG_DB HSET SRV6_MY_LOCATORS\\|loc1 prefix fcbb:bbbb:1::")
     # add a uN sid configuration entry
-    duthost.command(sonic_db_cli + 
+    duthost.command(sonic_db_cli +
                     " CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48 action uN decap_dscp_mode pipe")
     time.sleep(WAIT_TIME)
 
@@ -37,7 +37,7 @@ def test_uN_config(duthosts, enum_frontend_dut_hostname, enum_rand_one_asic_inde
 
     # verify that APPL_DB gets programmed by FRR correctly
     assert "SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1::" in appl_db_my_sids
-    assert "un" == duthost.command(sonic_db_cli + 
+    assert "un" == duthost.command(sonic_db_cli +
                                    " APPL_DB hget SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1:: action")["stdout"]
 
     # delete the configurations
@@ -90,9 +90,9 @@ def test_uDT46_config(duthosts, enum_frontend_dut_hostname, enum_rand_one_asic_i
 
     # verify that APPL_DB gets programmed by FRR correctly
     assert "SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:2::" in appl_db_my_sids
-    assert "udt46" == duthost.command(sonic_db_cli + 
+    assert "udt46" == duthost.command(sonic_db_cli +
                                       " APPL_DB hget SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:2:: action")["stdout"]
-    assert "Vrf1" == duthost.command(sonic_db_cli + 
+    assert "Vrf1" == duthost.command(sonic_db_cli +
                                      " APPL_DB hget SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:2:: vrf")["stdout"]
 
     # delete the configurations

--- a/tests/srv6/test_srv6_static_config.py
+++ b/tests/srv6/test_srv6_static_config.py
@@ -2,7 +2,7 @@ import time
 import pytest
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0', 't1')
 ]
 
 WAIT_TIME = 5

--- a/tests/srv6/test_srv6_static_config.py
+++ b/tests/srv6/test_srv6_static_config.py
@@ -1,5 +1,4 @@
 import time
-import logging
 import pytest
 
 pytestmark = [
@@ -7,6 +6,7 @@ pytestmark = [
 ]
 
 WAIT_TIME = 5
+
 
 def test_uN_config(duthosts, enum_frontend_dut_hostname, enum_rand_one_asic_index):
     duthost = duthosts[enum_frontend_dut_hostname]
@@ -82,7 +82,7 @@ def test_uDT46_config(duthosts, enum_frontend_dut_hostname, enum_rand_one_asic_i
     assert "locator loc1" in frr_config
     assert "sid fcbb:bbbb:1:2::/64 locator loc1 behavior uDT46 vrf Vrf1" in frr_config
 
-    appl_db_my_sids = duthost.command(sonic_db_cli + " APPL_DB keys SRV6_MY_SID_TABLE*".format(cli_options))["stdout"]
+    appl_db_my_sids = duthost.command(sonic_db_cli + " APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
 
     # verify that APPL_DB gets programmed by FRR correctly
     assert "SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:2::" in appl_db_my_sids

--- a/tests/srv6/test_srv6_static_config.py
+++ b/tests/srv6/test_srv6_static_config.py
@@ -1,0 +1,85 @@
+import time
+import logging
+import pytest
+
+WAIT_TIME = 5
+
+def test_uN_config(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+
+    # add a locator configuration entry
+    duthost.command("sonic-db-cli CONFIG_DB HSET SRV6_MY_LOCATORS\\|loc1 prefix fcbb:bbbb:1::")
+    # add a uN sid configuration entry
+    duthost.command("sonic-db-cli CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1:1:: action uN")
+    time.sleep(WAIT_TIME)
+
+    frr_config = duthost.command("vtysh -c \"show running-config\"")["stdout"]
+
+    # verify that bgpcfgd generates FRR config correctly
+    assert "locator loc1" in frr_config
+    assert "sid fcbb:bbbb:1:1::/64 locator loc1 behavior uN" in frr_config
+
+    appl_db_my_sids = duthost.command("sonic-db-cli APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
+
+    # verify that APPL_DB gets programmed by FRR correctly
+    assert "SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:1::" in appl_db_my_sids
+
+    # delete the configurations
+    duthost.command("sonic-db-cli CONFIG_DB DEL SRV6_MY_LOCATORS\\|loc1")
+    duthost.command("sonic-db-cli CONFIG_DB DEL SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1:1::")
+    time.sleep(WAIT_TIME)
+
+    frr_config = duthost.command("vtysh -c \"show running-config\"")["stdout"]
+
+    # verify that bgpcfgd deletes relevant FRR config
+    assert "locator loc1" not in frr_config
+    assert "sid fcbb:bbbb:1:1::/64 locator loc1 behavior uN" not in frr_config
+
+    appl_db_my_sids = duthost.command("sonic-db-cli APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
+
+    # verify that the APPL_DB entry gets cleaned correctly
+    assert "SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:1::" not in appl_db_my_sids
+
+
+def test_uDT46_config(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+
+    # add Vrf1 config
+    duthost.command("config vrf add Vrf1")
+    duthost.command("sysctl -w net.vrf.strict_mode=1")
+
+    # add a locator configuration entry
+    duthost.command("sonic-db-cli CONFIG_DB HSET SRV6_MY_LOCATORS\\|loc1 prefix fcbb:bbbb:1::")
+    # add a uDT46 sid configuration entry
+    duthost.command("sonic-db-cli CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1:2:: action uDT46 decap_vrf Vrf1")
+    time.sleep(WAIT_TIME)
+
+    frr_config = duthost.command("vtysh -c \"show running-config\"")["stdout"]
+
+    # verify that bgpcfgd generates FRR config correctly
+    assert "locator loc1" in frr_config
+    assert "sid fcbb:bbbb:1:2::/64 locator loc1 behavior uDT46 vrf Vrf1" in frr_config
+
+    appl_db_my_sids = duthost.command("sonic-db-cli APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
+
+    # verify that APPL_DB gets programmed by FRR correctly
+    assert "SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:2::" in appl_db_my_sids
+
+    # delete the configurations
+    duthost.command("sonic-db-cli CONFIG_DB DEL SRV6_MY_LOCATORS\\|loc1")
+    duthost.command("sonic-db-cli CONFIG_DB DEL SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1:2::")
+    time.sleep(WAIT_TIME)
+
+    frr_config = duthost.command("vtysh -c \"show running-config\"")["stdout"]
+
+    # verify that bgpcfgd deletes relevant FRR config
+    assert "locator loc1" not in frr_config
+    assert "sid fcbb:bbbb:1:2::/64 locator loc1 behavior uDT46 vrf Vrf1" not in frr_config
+
+    appl_db_my_sids = duthost.command("sonic-db-cli APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
+
+    # verify that the APPL_DB entry gets cleaned correctly
+    assert "SRV6_MY_SID_TABLE:32:16:16:0:fcbb:bbbb:1:2::" not in appl_db_my_sids
+
+    # delete the Vrf config
+    duthost.command("config vrf del Vrf1")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add a control plane test case to verify that SRv6 static SIDs gets programmed correctly from CONFIG_DB to APPL_DB.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412

### Approach
#### What is the motivation for this PR?
Verify the functionality of SRv6 in Control Plane
#### How did you do it?
Add two test cases to test the configuration of uN and uDT46 SIDs.
#### How did you verify/test it?
Run it on VS testbed
#### Any platform specific information?
VS by now
#### Supported testbed topology if it's a new test case?
T0 only by now
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
