### PR TITLE
Add function to wrap verify_only_loopback_routes with assert and wait_until

### DIFF
--- a/tests/bgp/route_checker.py
+++ b/tests/bgp/route_checker.py
@@ -6,6 +6,7 @@ from tests.bgp.bgp_helpers import parse_rib
 from tests.common.devices.eos import EosHost
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.parallel import parallel_run
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -204,6 +205,18 @@ def verify_only_loopback_routes_are_announced_to_neighs(dut_hosts, duthost, neig
     return verify_loopback_route_with_community(dut_hosts, duthost, neigh_hosts, 4, community) and \
         verify_loopback_route_with_community(
             dut_hosts, duthost, neigh_hosts, 6, community)
+
+
+def assert_only_loopback_routes_announced_to_neighs(dut_hosts, duthost, neigh_hosts, community,
+                                                    error_msg=""):
+    if not error_msg:
+        error_msg = "Failed to verify only loopback routes are announced to neighbours"
+
+    pytest_assert(
+        wait_until(180, 10, 5, verify_only_loopback_routes_are_announced_to_neighs,
+                   dut_hosts, duthost, neigh_hosts, community),
+        error_msg
+    )
 
 
 def parse_routes_on_neighbors(dut_host, neigh_hosts, ip_ver, exp_community=[]):

--- a/tests/bgp/test_reliable_tsa.py
+++ b/tests/bgp/test_reliable_tsa.py
@@ -13,7 +13,7 @@ from tests.common.platform.interface_utils import check_interface_status_of_up_p
 from tests.bgp.bgp_helpers import get_tsa_chassisdb_config, get_sup_cfggen_tsa_value, verify_dut_configdb_tsa_value
 from tests.bgp.traffic_checker import get_traffic_shift_state
 from tests.bgp.route_checker import parse_routes_on_neighbors, check_and_log_routes_diff, \
-    verify_current_routes_announced_to_neighs, verify_only_loopback_routes_are_announced_to_neighs
+    verify_current_routes_announced_to_neighs, assert_only_loopback_routes_announced_to_neighs
 from tests.bgp.constants import TS_NORMAL, TS_MAINTENANCE
 from tests.bgp.test_startup_tsa_tsb_service import get_tsa_tsb_service_uptime, get_tsa_tsb_service_status, \
     get_startup_tsb_timer, enable_disable_startup_tsa_tsb_service     # noqa: F401
@@ -309,11 +309,9 @@ def test_sup_tsa_act_when_sup_duts_on_tsb_initially(duthosts, localhost, enum_su
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
         set_tsb_on_sup_duts_before_and_after_test(duthosts, enum_supervisor_dut_hostname)
@@ -383,11 +381,9 @@ def test_sup_tsa_act_when_sup_on_tsb_duts_on_tsa_initially(duthosts, localhost, 
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
         set_tsb_on_sup_duts_before_and_after_test(duthosts, enum_supervisor_dut_hostname)
@@ -443,11 +439,9 @@ def test_sup_tsb_act_when_sup_on_tsa_duts_on_tsb_initially(duthosts, localhost, 
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
 
         # Issue TSB on the supervisor
         suphost.shell('TSB')
@@ -543,11 +537,9 @@ def test_sup_tsb_act_when_sup_and_duts_on_tsa_initially(duthosts, localhost, enu
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
         set_tsb_on_sup_duts_before_and_after_test(duthosts, enum_supervisor_dut_hostname)
@@ -605,11 +597,9 @@ def test_dut_tsa_act_when_sup_duts_on_tsb_initially(duthosts, localhost, enum_su
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
 
         # Verify supervisor still has tsa_enabled 'false' config
         pytest_assert('false' == get_tsa_chassisdb_config(suphost),
@@ -690,11 +680,9 @@ def test_dut_tsa_act_when_sup_on_tsa_duts_on_tsb_initially(duthosts, localhost, 
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
 
         # Verify supervisor still has tsa_enabled 'true' config
         pytest_assert('true' == get_tsa_chassisdb_config(suphost),
@@ -759,11 +747,9 @@ def test_dut_tsb_act_when_sup_on_tsb_duts_on_tsa_initially(duthosts, localhost, 
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
 
         def run_tsb_on_linecard_and_verify(lc):
             lc.shell('TSB')
@@ -859,11 +845,9 @@ def test_dut_tsb_act_when_sup_and_duts_on_tsa_initially(duthosts, localhost, enu
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
 
         # Verify supervisor still has tsa_enabled 'true' config
         pytest_assert('true' == get_tsa_chassisdb_config(suphost),
@@ -1007,11 +991,9 @@ def test_sup_tsa_act_with_sup_reboot(duthosts, localhost, enum_supervisor_dut_ho
                 executor.submit(verify_linecard_tsa_tsb, linecard)
 
         for linecard in duthosts.frontend_nodes:
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
         set_tsb_on_sup_duts_before_and_after_test(duthosts, enum_supervisor_dut_hostname)
@@ -1116,11 +1098,9 @@ def test_sup_tsa_act_when_duts_on_tsa_with_sup_config_reload(duthosts, localhost
                 executor.submit(verify_line_card_after_sup_config_reload, linecard)
 
         for linecard in duthosts.frontend_nodes:
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
         set_tsb_on_sup_duts_before_and_after_test(duthosts, enum_supervisor_dut_hostname)
@@ -1234,11 +1214,9 @@ def test_dut_tsa_act_with_reboot_when_sup_dut_on_tsb_init(duthosts, localhost, e
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced to neighbors when the linecards are in TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
 
         # Verify supervisor still has tsa_enabled 'false' config
         pytest_assert('false' == get_tsa_chassisdb_config(suphost),
@@ -1324,12 +1302,10 @@ def test_dut_tsa_with_conf_reload_when_sup_on_tsa_dut_on_tsb_init(duthosts, loca
         # Verify DUT is in maintenance state.
         pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(first_linecard, cmd='TSC no-stats'),
                       "DUT is not in maintenance state after config reload")
-
-        pytest_assert(
-            wait_until(180, 10, 10,
-                       verify_only_loopback_routes_are_announced_to_neighs,
-                       duthosts, first_linecard, dut_nbrhosts[first_linecard], traffic_shift_community),
-            "Failed to verify routes on nbr in TSA")
+        assert_only_loopback_routes_announced_to_neighs(duthosts, first_linecard, 
+                                                        dut_nbrhosts[first_linecard], 
+                                                        traffic_shift_community,
+                                                        "Failed to verify routes on nbr in TSA")
 
         # Verify supervisor still has tsa_enabled 'true' config
         pytest_assert('true' == get_tsa_chassisdb_config(suphost),
@@ -1417,11 +1393,9 @@ def test_user_init_tsa_on_dut_followed_by_sup_tsa(duthosts, localhost, enum_supe
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced with TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
         set_tsb_on_sup_duts_before_and_after_test(duthosts, enum_supervisor_dut_hostname)
@@ -1504,11 +1478,9 @@ def test_user_init_tsa_on_dut_followed_by_sup_tsb(duthosts, localhost, enum_supe
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced with TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
         set_tsb_on_sup_duts_before_and_after_test(duthosts, enum_supervisor_dut_hostname)
@@ -1630,11 +1602,9 @@ def test_sup_tsa_when_startup_tsa_tsb_service_running(duthosts, localhost, enum_
 
         # Verify only loopback routes are announced to neighbors at this state
         for linecard in duthosts.frontend_nodes:
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
         set_tsb_on_sup_duts_before_and_after_test(duthosts, enum_supervisor_dut_hostname)
@@ -1806,11 +1776,9 @@ def test_sup_tsb_followed_by_dut_bgp_restart_when_sup_on_tsa_duts_on_tsb(
             pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(linecard, cmd='TSC no-stats'),
                           "DUT is not in maintenance state")
             # Verify only loopback routes are announced after TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
 
         # Issue TSB on the supervisor
         suphost.shell('TSB')
@@ -1929,11 +1897,9 @@ def test_sup_tsb_followed_by_dut_bgp_restart_when_sup_and_duts_on_tsa(duthosts, 
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
         set_tsb_on_sup_duts_before_and_after_test(duthosts, enum_supervisor_dut_hostname)
@@ -1996,11 +1962,9 @@ def test_dut_tsb_followed_by_dut_bgp_restart_when_sup_on_tsb_duts_on_tsa(duthost
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
 
         def run_tsb_on_linecard_and_verify(lc):
             lc.shell('TSB')
@@ -2148,11 +2112,9 @@ def test_dut_tsb_followed_by_dut_bgp_restart_when_sup_and_duts_on_tsa(duthosts, 
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(
-                wait_until(180, 10, 10,
-                           verify_only_loopback_routes_are_announced_to_neighs,
-                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            assert_only_loopback_routes_announced_to_neighs(duthosts, linecard, dut_nbrhosts[linecard],
+                                                            traffic_shift_community,
+                                                            "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
         set_tsb_on_sup_duts_before_and_after_test(duthosts, enum_supervisor_dut_hostname)

--- a/tests/bgp/test_reliable_tsa.py
+++ b/tests/bgp/test_reliable_tsa.py
@@ -309,8 +309,10 @@ def test_sup_tsa_act_when_sup_duts_on_tsb_initially(duthosts, localhost, enum_su
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
@@ -381,8 +383,10 @@ def test_sup_tsa_act_when_sup_on_tsb_duts_on_tsa_initially(duthosts, localhost, 
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
@@ -439,8 +443,10 @@ def test_sup_tsb_act_when_sup_on_tsa_duts_on_tsb_initially(duthosts, localhost, 
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
 
         # Issue TSB on the supervisor
@@ -537,8 +543,10 @@ def test_sup_tsb_act_when_sup_and_duts_on_tsa_initially(duthosts, localhost, enu
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
@@ -597,8 +605,10 @@ def test_dut_tsa_act_when_sup_duts_on_tsb_initially(duthosts, localhost, enum_su
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
 
         # Verify supervisor still has tsa_enabled 'false' config
@@ -680,8 +690,10 @@ def test_dut_tsa_act_when_sup_on_tsa_duts_on_tsb_initially(duthosts, localhost, 
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
 
         # Verify supervisor still has tsa_enabled 'true' config
@@ -747,8 +759,10 @@ def test_dut_tsb_act_when_sup_on_tsb_duts_on_tsa_initially(duthosts, localhost, 
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
 
         def run_tsb_on_linecard_and_verify(lc):
@@ -845,8 +859,10 @@ def test_dut_tsb_act_when_sup_and_duts_on_tsa_initially(duthosts, localhost, enu
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
 
         # Verify supervisor still has tsa_enabled 'true' config
@@ -991,8 +1007,10 @@ def test_sup_tsa_act_with_sup_reboot(duthosts, localhost, enum_supervisor_dut_ho
                 executor.submit(verify_linecard_tsa_tsb, linecard)
 
         for linecard in duthosts.frontend_nodes:
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
@@ -1098,8 +1116,10 @@ def test_sup_tsa_act_when_duts_on_tsa_with_sup_config_reload(duthosts, localhost
                 executor.submit(verify_line_card_after_sup_config_reload, linecard)
 
         for linecard in duthosts.frontend_nodes:
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
@@ -1214,8 +1234,10 @@ def test_dut_tsa_act_with_reboot_when_sup_dut_on_tsb_init(duthosts, localhost, e
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced to neighbors when the linecards are in TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
 
         # Verify supervisor still has tsa_enabled 'false' config
@@ -1303,8 +1325,10 @@ def test_dut_tsa_with_conf_reload_when_sup_on_tsa_dut_on_tsb_init(duthosts, loca
         pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(first_linecard, cmd='TSC no-stats'),
                       "DUT is not in maintenance state after config reload")
 
-        pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-            duthosts, first_linecard, dut_nbrhosts[first_linecard], traffic_shift_community),
+        pytest_assert(
+            wait_until(180, 10, 10,
+                       verify_only_loopback_routes_are_announced_to_neighs,
+                       duthosts, first_linecard, dut_nbrhosts[first_linecard], traffic_shift_community),
             "Failed to verify routes on nbr in TSA")
 
         # Verify supervisor still has tsa_enabled 'true' config
@@ -1393,8 +1417,10 @@ def test_user_init_tsa_on_dut_followed_by_sup_tsa(duthosts, localhost, enum_supe
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced with TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
@@ -1478,9 +1504,11 @@ def test_user_init_tsa_on_dut_followed_by_sup_tsb(duthosts, localhost, enum_supe
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced with TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+                "Failed to verify routes on nbr in TSA")      
     finally:
         # Bring back the supervisor and line cards to the normal state
         set_tsb_on_sup_duts_before_and_after_test(duthosts, enum_supervisor_dut_hostname)
@@ -1602,8 +1630,10 @@ def test_sup_tsa_when_startup_tsa_tsb_service_running(duthosts, localhost, enum_
 
         # Verify only loopback routes are announced to neighbors at this state
         for linecard in duthosts.frontend_nodes:
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
@@ -1776,8 +1806,10 @@ def test_sup_tsb_followed_by_dut_bgp_restart_when_sup_on_tsa_duts_on_tsb(
             pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(linecard, cmd='TSC no-stats'),
                           "DUT is not in maintenance state")
             # Verify only loopback routes are announced after TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
 
         # Issue TSB on the supervisor
@@ -1897,8 +1929,10 @@ def test_sup_tsb_followed_by_dut_bgp_restart_when_sup_and_duts_on_tsa(duthosts, 
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
@@ -1962,8 +1996,10 @@ def test_dut_tsb_followed_by_dut_bgp_restart_when_sup_on_tsb_duts_on_tsa(duthost
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
 
         def run_tsb_on_linecard_and_verify(lc):
@@ -2112,8 +2148,10 @@ def test_dut_tsb_followed_by_dut_bgp_restart_when_sup_and_duts_on_tsa(duthosts, 
 
         for linecard in duthosts.frontend_nodes:
             # Verify only loopback routes are announced after TSA
-            pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(
-                duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
+            pytest_assert(
+                wait_until(180, 10, 10,
+                           verify_only_loopback_routes_are_announced_to_neighs,
+                           duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
                 "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state

--- a/tests/bgp/test_reliable_tsa.py
+++ b/tests/bgp/test_reliable_tsa.py
@@ -1302,8 +1302,8 @@ def test_dut_tsa_with_conf_reload_when_sup_on_tsa_dut_on_tsb_init(duthosts, loca
         # Verify DUT is in maintenance state.
         pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(first_linecard, cmd='TSC no-stats'),
                       "DUT is not in maintenance state after config reload")
-        assert_only_loopback_routes_announced_to_neighs(duthosts, first_linecard, 
-                                                        dut_nbrhosts[first_linecard], 
+        assert_only_loopback_routes_announced_to_neighs(duthosts, first_linecard,
+                                                        dut_nbrhosts[first_linecard],
                                                         traffic_shift_community,
                                                         "Failed to verify routes on nbr in TSA")
 

--- a/tests/bgp/test_reliable_tsa.py
+++ b/tests/bgp/test_reliable_tsa.py
@@ -1508,7 +1508,7 @@ def test_user_init_tsa_on_dut_followed_by_sup_tsb(duthosts, localhost, enum_supe
                 wait_until(180, 10, 10,
                            verify_only_loopback_routes_are_announced_to_neighs,
                            duthosts, linecard, dut_nbrhosts[linecard], traffic_shift_community),
-                "Failed to verify routes on nbr in TSA")      
+                "Failed to verify routes on nbr in TSA")
     finally:
         # Bring back the supervisor and line cards to the normal state
         set_tsb_on_sup_duts_before_and_after_test(duthosts, enum_supervisor_dut_hostname)

--- a/tests/bgp/test_seq_idf_isolation.py
+++ b/tests/bgp/test_seq_idf_isolation.py
@@ -5,7 +5,7 @@ from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.constants import DEFAULT_ASIC_ID
 from tests.common.utilities import wait_until
-from route_checker import verify_only_loopback_routes_are_announced_to_neighs, parse_routes_on_neighbors
+from route_checker import assert_only_loopback_routes_announced_to_neighs, parse_routes_on_neighbors
 from route_checker import verify_current_routes_announced_to_neighs, check_and_log_routes_diff
 
 pytestmark = [
@@ -167,9 +167,9 @@ def test_idf_isolated_withdraw_all(duthosts, rand_one_downlink_duthost,
         # Verify DUT is in isolated-withdraw-all state.
         pytest_assert(IDF_ISOLATED_WITHDRAW_ALL == get_idf_isolation_state(duthost),
                       "DUT is not in isolated_withdraw_all state")
-        if not wait_until(60, 3, 0, verify_only_loopback_routes_are_announced_to_neighs,
-                          duthosts, duthost, nbrs, traffic_shift_community):
-            pytest.fail("Failed to verify only loopback route in isolated_withdraw_all state")
+        assert_only_loopback_routes_announced_to_neighs(duthosts, duthost, nbrs, traffic_shift_community,
+                                                        "Failed to verify only loopback route \
+                                                            in isolated_withdraw_all state")
     finally:
         # Recover to unisolated state
         duthost.shell("sudo idf_isolation unisolated")
@@ -281,9 +281,9 @@ def test_idf_isolation_withdraw_all_with_config_reload(duthosts, rand_one_downli
         # Verify DUT is in isolated-withdraw-all state.
         pytest_assert(IDF_ISOLATED_WITHDRAW_ALL == get_idf_isolation_state(duthost),
                       "DUT is not isolated_no_export state")
-        pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(duthosts, duthost, nbrs,
-                                                                          traffic_shift_community),
-                      "Failed to verify only loopback route in isolated_withdraw_all state")
+        assert_only_loopback_routes_announced_to_neighs(duthosts, duthost, nbrs, traffic_shift_community,
+                                                        "Failed to verify only loopback route in \
+                                                            isolated_withdraw_all state")
     finally:
         """
         Recover to unisolated state

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -9,7 +9,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.constants import DEFAULT_ASIC_ID
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
-from tests.bgp.route_checker import verify_only_loopback_routes_are_announced_to_neighs, parse_routes_on_neighbors, \
+from tests.bgp.route_checker import assert_only_loopback_routes_announced_to_neighs, parse_routes_on_neighbors, \
     verify_current_routes_announced_to_neighs, check_and_log_routes_diff
 from tests.bgp.traffic_checker import get_traffic_shift_state, check_tsa_persistence_support, \
     verify_traffic_shift_per_asic
@@ -88,9 +88,8 @@ def test_TSA(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost,
                                                              bgpmon_setup_teardown['namespace']) == [],
                           "Not all routes are announced to bgpmon")
 
-        pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(duthosts, duthost, nbrhosts_to_dut,
-                                                                          traffic_shift_community),
-                      "Failed to verify routes on nbr in TSA")
+        assert_only_loopback_routes_announced_to_neighs(duthosts, duthost, nbrhosts_to_dut, traffic_shift_community,
+                                                        "Failed to verify routes on nbr in TSA")
     finally:
         # Recover to Normal state
         duthost.shell("TSB")
@@ -249,10 +248,8 @@ def test_TSA_TSB_with_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
             pytest_assert(get_routes_not_announced_to_bgpmon(duthost, ptfhost,
                                                              bgpmon_setup_teardown['namespace']) == [],
                           "Not all routes are announced to bgpmon")
-
-        pytest_assert(wait_until(90, 10, 0, verify_only_loopback_routes_are_announced_to_neighs, duthosts, duthost,
-                                 nbrhosts_to_dut, traffic_shift_community),
-                      "Failed to verify routes on nbr in TSA")
+        assert_only_loopback_routes_announced_to_neighs(duthosts, duthost, nbrhosts_to_dut, traffic_shift_community,
+                                                        "Failed to verify routes on nbr in TSA")
     finally:
         """
         Test TSB after config save and config reload
@@ -319,9 +316,8 @@ def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsk
                                                              bgpmon_setup_teardown['namespace']) == [],
                           "Not all routes are announced to bgpmon")
 
-        pytest_assert(verify_only_loopback_routes_are_announced_to_neighs(duthosts, duthost, nbrhosts_to_dut,
-                                                                          traffic_shift_community),
-                      "Failed to verify routes on nbr in TSA")
+        assert_only_loopback_routes_announced_to_neighs(duthosts, duthost, nbrhosts_to_dut, traffic_shift_community,
+                                                        "Failed to verify routes on nbr in TSA")
     finally:
         """
         Recover with TSB and verify route advertisement


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Partially tackles #16577 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Tests are flaky, sometimes failing on `verify_only_loopback_routes_are_announced_to_neighs`: `Failed to verify routes on nbr in TSA`
#### How did you do it?
Add a function wrapping `verify_only_loopback_routes_are_announced_to_neighs` with wait_until and assert to allow time for neighbor to update routes
#### How did you verify/test it?
These logs were seen in passed tests, showing that wait_until helps avoid false negatives
```
17/01/2025 05:42:18 utilities.wait_until                     L0153 DEBUG  | verify_only_loopback_routes_are_announced_to_neighs is False, wait 10 seconds and check again

05:42:12 route_checker.verify_loopback_route_with L0014 INFO   | Verifying only loopback routes are announced to bgp neighbors
05:42:18 parallel.on_terminate                    L0085 INFO   | process parse_routes_process--<EosHost VM71002> terminated with exit code None
05:42:18 parallel.on_terminate                    L0085 INFO   | process parse_routes_process--<EosHost VM71003> terminated with exit code None
05:42:18 parallel.on_terminate                    L0085 INFO   | process parse_routes_process--<EosHost VM71001> terminated with exit code None
05:42:18 parallel.on_terminate                    L0085 INFO   | process parse_routes_process--<EosHost VM71000> terminated with exit code None
05:42:18 parallel.parallel_run                    L0221 INFO   | Completed running processes for target "parse_routes_process" in 0:00:03.470030 seconds
05:42:18 route_checker.verify_loopback_route_with L0035 INFO   | Verifying only loopback routes(ipv4) are announced to ARISTA04T3
05:42:18 route_checker.verify_loopback_route_with L0047 WARNING| missing loopback address or some other routes present on neighbor
05:42:28 route_checker.verify_loopback_route_with L0014 INFO   | Verifying only loopback routes are announced to bgp neighbors
05:42:34 parallel.on_terminate                    L0085 INFO   | process parse_routes_process--<EosHost VM71002> terminated with exit code None
05:42:34 parallel.on_terminate                    L0085 INFO   | process parse_routes_process--<EosHost VM71000> terminated with exit code None
05:42:34 parallel.on_terminate                    L0085 INFO   | process parse_routes_process--<EosHost VM71003> terminated with exit code None
05:42:34 parallel.on_terminate                    L0085 INFO   | process parse_routes_process--<EosHost VM71001> terminated with exit code None
05:42:34 parallel.parallel_run                    L0221 INFO   | Completed running processes for target "parse_routes_process" in 0:00:03.332572 seconds
05:42:34 route_checker.verify_loopback_route_with L0035 INFO   | Verifying only loopback routes(ipv4) are announced to ARISTA04T3
05:42:34 route_checker.verify_loopback_route_with L0035 INFO   | Verifying only loopback routes(ipv4) are announced to ARISTA01T3
05:42:34 route_checker.verify_loopback_route_with L0035 INFO   | Verifying only loopback routes(ipv4) are announced to ARISTA06T3
05:42:34 route_checker.verify_loopback_route_with L0035 INFO   | Verifying only loopback routes(ipv4) are announced to ARISTA03T3
05:42:34 route_checker.verify_loopback_route_with L0014 INFO   | Verifying only loopback routes are announced to bgp neighbors
05:42:39 parallel.on_terminate                    L0085 INFO   | process parse_routes_process--<EosHost VM71000> terminated with exit code None
05:42:39 parallel.on_terminate                    L0085 INFO   | process parse_routes_process--<EosHost VM71002> terminated with exit code None
05:42:39 parallel.on_terminate                    L0085 INFO   | process parse_routes_process--<EosHost VM71001> terminated with exit code None
05:42:39 parallel.on_terminate                    L0085 INFO   | process parse_routes_process--<EosHost VM71003> terminated with exit code None
05:42:39 parallel.parallel_run                    L0221 INFO   | Completed running processes for target "parse_routes_process" in 0:00:02.681303 seconds
```

All affected test suites were run
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A