### PR TITLE
[7215] Extend memory usage threshold to 65%

### DIFF
--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -43,7 +43,7 @@ def setup_thresholds(duthosts, enum_rand_one_per_hwsku_hostname):
     if duthost.facts['platform'] in ('x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn3800-r0',
                                      'x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0'):
         memory_threshold = 70
-    if duthost.facts['platform'] in ('x86_64-8800_rp_o-r0', 'x86_64-8800_rp-r0'):
+    if duthost.facts['platform'] in ('x86_64-8800_rp_o-r0', 'x86_64-8800_rp-r0', 'armhf-nokia_ixs7215_52x-r0'):
         memory_threshold = 65
     if duthost.facts['platform'] in ('x86_64-arista_7260cx3_64'):
         high_cpu_consume_procs['syncd'] = 80


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Testcase `platform_tests/test_cpu_memory_usage.py` flaky fails on Nokia-7215.
The failure reason is MEM usage occasionally exceed threshold 60%. So far I haven't see it exceed 61%.
```
14/01/2025 04:50:11 test_cpu_memory_usage.check_memory       L0261 DEBUG  | System memory usage: 57% (below 60%) - Result: {'total': 3097488.0, 'free': 1326536.0, 'used': 1593928.0, 'used_percent': 57.2}
14/01/2025 04:50:11 test_cpu_memory_usage.test_cpu_memory_us L0072 DEBUG  | ------ Iteration 1 ------
14/01/2025 04:50:11 test_cpu_memory_usage.check_memory       L0261 DEBUG  | System memory usage: 59% (below 60%) - Result: {'total': 3097488.0, 'free': 1270408.0, 'used': 1650052.0, 'used_percent': 59.0}
14/01/2025 04:50:11 test_cpu_memory_usage.test_cpu_memory_us L0072 DEBUG  | ------ Iteration 2 ------
14/01/2025 04:50:11 test_cpu_memory_usage.check_memory       L0261 DEBUG  | System memory usage: 60% (exceed 60%) - Result: {'total': 3097488.0, 'free': 1229432.0, 'used': 1691028.0, 'used_percent': 60.3}
14/01/2025 04:50:11 test_cpu_memory_usage.test_cpu_memory_us L0072 DEBUG  | ------ Iteration 3 ------
14/01/2025 04:50:11 test_cpu_memory_usage.check_memory       L0261 DEBUG  | System memory usage: 58% (below 60%) - Result: {'total': 3097488.0, 'free': 1288936.0, 'used': 1631524.0, 'used_percent': 58.4}
14/01/2025 04:50:11 test_cpu_memory_usage.test_cpu_memory_us L0072 DEBUG  | ------ Iteration 4 ------
14/01/2025 04:50:11 test_cpu_memory_usage.check_memory       L0261 DEBUG  | System memory usage: 58% (below 60%) - Result: {'total': 3097488.0, 'free': 1298216.0, 'used': 1622248.0, 'used_percent': 58.1}
```
To resolve this issue, increase threshold to 65%.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified by running testcase on Nokia-7215 Mx testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
