### PR TITLE
[fanout]: Increase timeout and set default autoneg off for SN5600

### DIFF
--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202311.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202311.yml
@@ -121,7 +121,7 @@
 
 - name: wait for SONiC update config db finish
   pause:
-    seconds: 180
+    seconds: 300
 
 - name: Shutdown arp_update process in swss (avoid fanout broadcasting it's MAC address)
   shell: docker exec -i swss supervisorctl stop arp_update

--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202405.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202405.yml
@@ -121,7 +121,7 @@
 
 - name: wait for SONiC update config db finish
   pause:
-    seconds: 180
+    seconds: 300
 
 - name: Shutdown arp_update process in swss (avoid fanout broadcasting it's MAC address)
   shell: docker exec -i swss supervisorctl stop arp_update

--- a/ansible/roles/fanout/templates/sonic_deploy_202405.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202405.j2
@@ -19,6 +19,9 @@
     {% if fanout_hwsku == "Arista-720DT-G48S4" and (fanout_port_config[port_name]['lanes'] | int) <= 24 %}
             "autoneg": "on",
     {% endif %}
+    {% if fanout_hwsku == "Mellanox-SN5600-C256S1" %}
+            "autoneg": "off",
+    {% endif %}
     {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
             "fec" : "rs",
     {% endif %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
1. The SN5600 testbed has more ports than the previous testbed, so increasing the waiting time
2. Because the default autoneg is off in SN5600 testbed, so explicitly set this value to off for SN5600 fanout

#### How did you do it?

1. Increasing the waiting time to 300s
2. Set the autoneg off in j2 of fanout

#### How did you verify/test it?

Check it in local testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
