### PR TITLE
Fix test_sysuptime failure

### DIFF
--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -230,7 +230,7 @@ def test_sysuptime(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_pat
     for line_info in system_uptime_info:
         if "total" in line_info:
             try:
-                system_uptime_1st = float(line_info.split(":")[1].strip())
+                system_uptime_1st = float(line_info.split(":")[1].strip().rstrip(','))
                 found_system_uptime_field = True
             except ValueError as err:
                 pytest.fail(


### PR DESCRIPTION
Fix `test_sysuptime` fails with error 

<img width="1045" alt="image" src="https://github.com/user-attachments/assets/bcd00971-b03a-4748-b990-37223ad90c1d" />

Summary:
Fixes # NA

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

Fix broken test

#### How did you do it?

Fix format parsing before type conversion

#### How did you verify/test it?

Tested on 7050cx3

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

NA

### Documentation