### PR TITLE
Add public sad multi hop test case

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -632,36 +632,34 @@ class AdvancedReboot:
         self.imageInstall(prebootList, inbootList, prebootFiles)
         return self.runRebootTest()
 
-    def runMultiHopRebootTestcase(self, upgrade_path_urls, prebootFiles='peer_dev_info,neigh_port_info',
-                                  base_image_setup=None, pre_hop_setup=None,
-                                  post_hop_teardown=None, multihop_advanceboot_loganalyzer_factory=None):
-        """
-        This method validates and prepares test bed for multi-hop reboot test case. It runs the reboot test case using
-        provided test arguments.
-        @param prebootList: list of operation to run before reboot process
-        @param prebootFiles: preboot files
-        """
-        # Install image A (base image)
-        self.imageInstall(None, None, prebootFiles)
+    def runMultiHopRebootTest(self, upgrade_path_urls, rebootOper=None, base_image_setup=None, pre_hop_setup=None,
+                              post_hop_teardown=None, multihop_advanceboot_loganalyzer_factory=None):
+
         if base_image_setup:
             base_image_setup()
 
-        test_results = dict()
-        test_case_name = str(self.request.node.name)
-        test_results[test_case_name] = list()
+        test_results = []
+
         for hop_index, _ in enumerate(upgrade_path_urls[1:], start=1):
+            upgrade_path_str = "{from_image} -> {to_image} (hop {hop_index})".format(
+                hop_index=hop_index, from_image=upgrade_path_urls[hop_index-1], to_image=upgrade_path_urls[hop_index])
             try:
                 if pre_hop_setup:
                     pre_hop_setup(hop_index)
                 if multihop_advanceboot_loganalyzer_factory:
                     pre_reboot_analysis, post_reboot_analysis = multihop_advanceboot_loganalyzer_factory(hop_index)
                     marker = pre_reboot_analysis()
-                event_counters = self.__setupRebootOper(None)
+
+                event_counters = self.__setupRebootOper(rebootOper)
 
                 # Run the upgrade
                 thread = InterruptableThread(
                     target=self.__runPtfRunner,
-                    kwargs={"ptf_collect_dir": "./logs/ptf_collect/hop{}/".format(hop_index)})
+                    kwargs={
+                        "ptf_collect_dir": "./logs/ptf_collect/hop{}/".format(hop_index),
+                        "rebootOper": rebootOper
+                    }
+                )
                 thread.daemon = True
                 thread.start()
                 # give the test REBOOT_CASE_TIMEOUT (1800s) to complete the reboot with IO,
@@ -672,46 +670,84 @@ class AdvancedReboot:
                 # the thread might still be running, and to catch any exceptions after pkill allow 10s to join
                 thread.join(timeout=10)
 
-                self.__verifyRebootOper(None)
+                self.__verifyRebootOper(rebootOper)
                 if self.duthost.num_asics() == 1 and not check_bgp_router_id(self.duthost, self.mgFacts):
-                    test_results[test_case_name].append("Failed to verify BGP router identifier is Loopback0 on %s" %
-                                                        self.duthost.hostname)
+                    test_results.append(
+                        "Failed to verify BGP router identifier is Loopback0 on {} during upgrade {}".format(
+                            self.duthost.hostname, upgrade_path_str))
                 if post_hop_teardown:
                     post_hop_teardown(hop_index)
             except Exception:
                 traceback_msg = traceback.format_exc()
-                err_msg = "Exception caught while running advanced-reboot test on ptf: \n{}".format(traceback_msg)
+                err_msg = "Exception caught while running advanced-reboot test on ptf during upgrade {}: \n{}".format(
+                    upgrade_path_str, traceback_msg)
                 logger.error(err_msg)
-                test_results[test_case_name].append(err_msg)
+                test_results.append(err_msg)
+                break  # Don't perfrom any further upgrade hops
             finally:
                 # capture the test logs, and print all of them in case of failure, or a summary in case of success
-                log_dir = self.__fetchTestLogs(log_dst_suffix="hop{}".format(hop_index))
+                log_dst_suffix = "{0}-hop{1}".format(rebootOper, hop_index) if rebootOper else "hop{}".format(hop_index)
+                log_dir = self.__fetchTestLogs(rebootOper, log_dst_suffix=log_dst_suffix)
                 self.print_test_logs_summary(log_dir)
                 if multihop_advanceboot_loganalyzer_factory and post_reboot_analysis:
-                    verification_errors = post_reboot_analysis(marker, event_counters=event_counters, log_dir=log_dir)
+                    verification_errors = post_reboot_analysis(marker, event_counters=event_counters,
+                                                               reboot_oper=rebootOper, log_dir=log_dir)
                     if verification_errors:
-                        logger.error("Post reboot verification failed. List of failures: {}"
-                                     .format('\n'.join(verification_errors)))
-                        test_results[test_case_name].extend(verification_errors)
+                        logger.error("Post reboot verification failed during upgrade {}. List of failures: {}"
+                                     .format(upgrade_path_str, '\n'.join(verification_errors)))
+                        test_results.extend(verification_errors)
                     # Set the post_reboot_analysis to None to avoid using it again after post_hop_teardown
                     # on the subsequent iteration in the event that we land in the finally block before
                     # the new one is initialised
                     post_reboot_analysis = None
-                self.acl_manager_checker(test_results[test_case_name])
+                self.acl_manager_checker(test_results)
                 self.__clearArpAndFdbTables()
-                self.__revertRebootOper(None)
+                self.__revertRebootOper(rebootOper)
 
-            failed_list = [(testcase, failures) for testcase, failures in list(test_results.items())
-                           if len(failures) != 0]
-            pytest_assert(len(failed_list) == 0, "Advanced-reboot failure. Failed multi-hop test {testname} "
-                                                 "on update {hop_index} from {from_image} to {to_image}, "
-                                                 "failure summary:\n{fail_summary}".format(
-                                                    testname=self.request.node.name,
-                                                    hop_index=hop_index,
-                                                    from_image=upgrade_path_urls[hop_index-1],
-                                                    to_image=upgrade_path_urls[hop_index],
-                                                    fail_summary=failed_list
-                                                ))
+        return test_results
+
+    def runMultiHopRebootTestcase(self, upgrade_path_urls, prebootList=None, inbootList=None,
+                                  prebootFiles='peer_dev_info,neigh_port_info',
+                                  base_image_setup=None, pre_hop_setup=None,
+                                  post_hop_teardown=None, multihop_advanceboot_loganalyzer_factory=None):
+        """
+        This method validates and prepares test bed for multi-hop reboot test case. It runs the reboot test case using
+        provided test arguments.
+        @param prebootList: list of operation to run before reboot process
+        @param prebootFiles: preboot files
+        """
+
+        # Validating contents of preboot and inboot list and building sadList
+        self.prebootList = prebootList
+        self.inbootList = inbootList
+        self.prebootFiles = prebootFiles
+        self.__validateAndBuildSadList()
+
+        # Update next hop IP based on Inboot list
+        self.__updateNextHopIps()
+
+        # Collect test data and set up testbed with required files/services
+        self.__setupTestbed()
+
+        # Handle mellanox platform
+        self.__handleMellanoxDut()
+
+        test_results = dict()
+
+        for reboot_oper in self.rebootData['sadList']:
+            test_case_name = str(self.request.node.name) + str(reboot_oper)
+            test_results[test_case_name] = self.runMultiHopRebootTest(upgrade_path_urls, reboot_oper, base_image_setup,
+                                                                      pre_hop_setup, post_hop_teardown,
+                                                                      multihop_advanceboot_loganalyzer_factory)
+
+        failed_list = [(testcase, failures) for testcase, failures in list(test_results.items())
+                       if len(failures) != 0]
+        pytest_assert(len(failed_list) == 0, "Advanced-reboot failure. Failed multi-hop test {testname}, "
+                                             "failure summary:\n{fail_summary}".format(
+                                                testname=self.request.node.name,
+                                                fail_summary=failed_list
+                                            ))
+
         return True  # Success
 
     def __setupRebootOper(self, rebootOper):

--- a/tests/common/helpers/upgrade_helpers.py
+++ b/tests/common/helpers/upgrade_helpers.py
@@ -224,7 +224,7 @@ def upgrade_test_helper(duthost, localhost, ptfhost, from_image, to_image,
 def multi_hop_warm_upgrade_test_helper(duthost, localhost, ptfhost, tbinfo, get_advanced_reboot, upgrade_type,
                                        upgrade_path_urls, base_image_setup=None, pre_hop_setup=None,
                                        post_hop_teardown=None, multihop_advanceboot_loganalyzer_factory=None,
-                                       enable_cpa=False):
+                                       sad_preboot_list=None, sad_inboot_list=None, enable_cpa=False):
 
     reboot_type = get_reboot_command(duthost, upgrade_type)
     if enable_cpa and "warm-reboot" in reboot_type:
@@ -237,7 +237,8 @@ def multi_hop_warm_upgrade_test_helper(duthost, localhost, ptfhost, tbinfo, get_
     advancedReboot.runMultiHopRebootTestcase(
         upgrade_path_urls, base_image_setup=base_image_setup, pre_hop_setup=pre_hop_setup,
         post_hop_teardown=post_hop_teardown,
-        multihop_advanceboot_loganalyzer_factory=multihop_advanceboot_loganalyzer_factory)
+        multihop_advanceboot_loganalyzer_factory=multihop_advanceboot_loganalyzer_factory,
+        prebootList=sad_preboot_list, inbootList=sad_inboot_list)
 
     if enable_cpa and "warm-reboot" in reboot_type:
         ptfhost.shell('supervisorctl stop ferret')

--- a/tests/upgrade_path/test_multi_hop_upgrade_path.py
+++ b/tests/upgrade_path/test_multi_hop_upgrade_path.py
@@ -3,12 +3,14 @@ import logging
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot                                   # noqa F401
 from tests.common.fixtures.consistency_checker.consistency_checker import consistency_checker_provider  # noqa F401
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.warmboot_sad_cases import SAD_CASE_LIST, get_sad_case_list
 from tests.common.reboot import get_reboot_cause
 from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import check_neighbors, \
-    multihop_advanceboot_loganalyzer_factory, verify_dut_health                                         # noqa F401
+    multihop_advanceboot_loganalyzer_factory, verify_dut_health, advanceboot_neighbor_restore           # noqa F401
 from tests.common.helpers.upgrade_helpers import SYSTEM_STABILIZE_MAX_TIME, check_copp_config, check_reboot_cause, \
     check_services, install_sonic, multi_hop_warm_upgrade_test_helper, check_asic_and_db_consistency
+from tests.common.fixtures.duthost_utils import backup_and_restore_config_db                            # noqa F401
 from tests.upgrade_path.utilities import cleanup_prev_images, boot_into_base_image
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                 # noqa F401
 
@@ -19,6 +21,21 @@ pytestmark = [
     pytest.mark.skip_check_dut_health
 ]
 logger = logging.getLogger(__name__)
+
+
+def pytest_generate_tests(metafunc):
+    # Generate one sad case per item in sad list
+    if "sad_case_type" in metafunc.fixturenames:
+        input_sad_cases = metafunc.config.getoption("sad_case_list")
+        input_sad_list = list()
+        for input_case in input_sad_cases.split(","):
+            input_case = input_case.strip()
+            if input_case.lower() not in SAD_CASE_LIST:
+                logging.warning("Unknown SAD case ({}) - skipping it.".format(input_case))
+                continue
+            input_sad_list.append(input_case)
+
+        metafunc.parametrize("sad_case_type", input_sad_list, scope="module")
 
 
 def test_multi_hop_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request,
@@ -74,3 +91,61 @@ def test_multi_hop_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfh
         base_image_setup=base_image_setup,
         pre_hop_setup=pre_hop_setup, post_hop_teardown=post_hop_teardown,
         enable_cpa=enable_cpa)
+
+
+def test_multi_hop_warm_upgrade_sad_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request,
+                                         get_advanced_reboot, multihop_advanceboot_loganalyzer_factory, # noqa F811
+                                         verify_dut_health, nbrhosts, fanouthosts, vmhost,              # noqa F811
+                                         backup_and_restore_config_db, advanceboot_neighbor_restore,    # noqa F811
+                                         sad_case_type):
+
+    duthost = duthosts[rand_one_dut_hostname]
+    multi_hop_upgrade_path = request.config.getoption('multi_hop_upgrade_path')
+    upgrade_type = request.config.getoption('upgrade_type')
+    assert upgrade_type == "warm", "test_multi_hop_upgrade_path only supports warm upgrade"
+    enable_cpa = request.config.getoption('enable_cpa')
+    upgrade_path_urls = multi_hop_upgrade_path.split(",")
+    if len(upgrade_path_urls) < 2:
+        pytest.skip("Need atleast 2 URLs to test multi-hop upgrade path")
+    sad_preboot_list, sad_inboot_list = get_sad_case_list(duthost, nbrhosts, fanouthosts, vmhost, tbinfo,
+                                                          sad_case_type)
+
+    def base_image_setup():
+        """Run only once, to boot the device into the base image"""
+        base_image = upgrade_path_urls[0]
+        logger.info("Setting up base image {}".format(base_image))
+        cleanup_prev_images(duthost)
+
+        # Install base image
+        boot_into_base_image(duthost, localhost, base_image, tbinfo)
+        logger.info("Base image setup complete")
+
+    def pre_hop_setup(hop_index):
+        """Run before each hop in the multi-hop upgrade path"""
+        # Install target image
+        to_image = upgrade_path_urls[hop_index]
+        logger.info("Installing hop {} image {}".format(hop_index, to_image))
+        install_sonic(duthost, to_image, tbinfo)
+        logger.info("Finished setup for hop {} image {}".format(hop_index, to_image))
+
+    def post_hop_teardown(hop_index):
+        """Run after each hop in the multi-hop upgrade path"""
+        to_image = upgrade_path_urls[hop_index]
+        logger.info("Starting post hop teardown for hop {} image {}".format(hop_index, to_image))
+
+        logger.info("Check reboot cause of hop {}. Expected cause {}".format(hop_index, upgrade_type))
+        networking_uptime = duthost.get_networking_uptime().seconds
+        timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 1)
+        pytest_assert(wait_until(timeout, 5, 0, check_reboot_cause, duthost, upgrade_type),
+                      "Reboot cause {} did not match the trigger - {}".format(get_reboot_cause(duthost), upgrade_type))
+        check_services(duthost)
+        check_neighbors(duthost, tbinfo)
+        check_copp_config(duthost)
+        check_asic_and_db_consistency(request.config, duthost, consistency_checker_provider)
+        logger.info("Finished post hop teardown for hop {} image {}".format(hop_index, to_image))
+
+    multi_hop_warm_upgrade_test_helper(
+        duthost, localhost, ptfhost, tbinfo, get_advanced_reboot, upgrade_type, upgrade_path_urls,
+        multihop_advanceboot_loganalyzer_factory=multihop_advanceboot_loganalyzer_factory,
+        base_image_setup=base_image_setup, pre_hop_setup=pre_hop_setup, post_hop_teardown=post_hop_teardown,
+        sad_preboot_list=sad_preboot_list, sad_inboot_list=sad_inboot_list, enable_cpa=enable_cpa)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adds sad case test coverage to upgrades. These are the same cases as in `tests/upgrade_path/test_upgrade_path.py::test_warm_upgrade_sad_path` but ported to multi-hop.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Add more test coverage

#### How did you do it?
Ported the sad case for A->B upgrade (`tests/upgrade_path/test_upgrade_path.py::test_warm_upgrade_sad_path`) to multi-hop

#### How did you verify/test it?
Tested on internal pipelines

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
t0*

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
