### PR TITLE
Fix ASIC check in test_pfcwd_function

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -754,7 +754,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             if self.pfc_wd['fake_storm']:
                 PfcCmd.set_storm_status(dut, self.queue_oid, "enabled")
 
-            if dut.facts['asic_type'] == ["mellanox", "cisco-8000"]:
+            if dut.facts['asic_type'] in ["mellanox", "cisco-8000"]:
                 # On Mellanox platform, more time is required for PFC storm being triggered
                 # as PFC pause sent from Non-Mellanox leaf fanout is not continuous sometimes.
                 pytest_assert(wait_until(PFC_STORM_TIMEOUT, 2, 0,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The issue was introduced by PR https://github.com/sonic-net/sonic-mgmt/pull/15772
The ASIC check is not working as expected because of the syntax error in the code. It should be `in` instead of `==`
https://github.com/sonic-net/sonic-mgmt/blob/21dbd804383d5d1e44b32e0f22c8d22b0f427a58/tests/pfcwd/test_pfcwd_function.py#L757

The issue will cause PFCWD function not stable on some platform.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
This PR is to fix a syntax issue in `test_pfcwd_function.py`.

#### How did you do it?
Fix the syntax.

#### How did you verify/test it?
The change is verified on a physical testbed.
```
collected 1 item                                                                                                                                                                                      

pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[bjw2-can-4600c-2]  ^H ^HPASSED                                                                                                        [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
