### PR TITLE
feat: add wait_for_bgp option to reboot

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1321,8 +1321,7 @@ class TestAclWithReboot(TestBasicAcl):
 
         """
         dut.command("config save -y")
-        up_bgp_neighbors = dut.get_bgp_neighbors_per_asic("established")
-        reboot(dut, localhost, safe_reboot=True, check_intf_up_ports=True)
+        reboot(dut, localhost, safe_reboot=True, check_intf_up_ports=True, wait_for_bgp=True)
         # We need some additional delay on e1031
         if dut.facts["platform"] == "x86_64-cel_e1031-r0":
             time.sleep(240)
@@ -1338,9 +1337,6 @@ class TestAclWithReboot(TestBasicAcl):
             assert result, "Not all transceivers are detected or interfaces are up in {} seconds".format(
                 MAX_WAIT_TIME_FOR_INTERFACES)
 
-        pytest_assert(
-            wait_until(300, 10, 0, dut.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"),
-            "All BGP sessions are not up after reboot, no point in continuing the test")
         # Delay 10 seconds for route convergence
         time.sleep(10)
 

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -226,7 +226,7 @@ def perform_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwa
 def reboot(duthost, localhost, reboot_type='cold', delay=10,
            timeout=0, wait=0, wait_for_ssh=True, wait_warmboot_finalizer=False, warmboot_finalizer_timeout=0,
            reboot_helper=None, reboot_kwargs=None, return_after_reconnect=False,
-           safe_reboot=False, check_intf_up_ports=False):
+           safe_reboot=False, check_intf_up_ports=False, wait_for_bgp=False):
     """
     reboots DUT
     :param duthost: DUT host object
@@ -237,11 +237,13 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     :param wait: time to wait for DUT to initialize
     :param wait_for_ssh: Wait for SSH startup
     :param return_after_reconnect: Return from function as soon as SSH reconnects
-    :param wait_warmboot_finalizer=True: Wait for WARMBOOT_FINALIZER done
+    :param wait_warmboot_finalizer: Wait for WARMBOOT_FINALIZER done
+    :param warmboot_finalizer_timeout: Timeout for waiting WARMBOOT_FINALIZER
     :param reboot_helper: helper function to execute the power toggling
     :param reboot_kwargs: arguments to pass to the reboot_helper
     :param safe_reboot: arguments to wait DUT ready after reboot
     :param check_intf_up_ports: arguments to check interface after reboot
+    :param wait_for_bgp: arguments to wait for BGP after reboot
     :return:
     """
     assert not (safe_reboot and return_after_reconnect)
@@ -350,6 +352,13 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
 
         assert float(dut_uptime.strftime("%s")) > float(dut_datetime.strftime("%s")), "Device {} did not reboot". \
             format(hostname)
+
+    if wait_for_bgp:
+        bgp_neighbors = duthost.get_bgp_neighbors_per_asic(state="all")
+        pytest_assert(
+            wait_until(wait + 300, 10, 0, duthost.check_bgp_session_state_all_asics, bgp_neighbors),
+            "Not all bgp sessions are established after reboot",
+        )
 
 
 def positive_uptime(duthost, dut_datetime):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The reboot process for chassis will need longer time to wait for the BGP to be established. For example, the `acl/test_acl.py` can be flaky if we are not waiting BGP long enough. Therefore, we are introducing `wait_for_bgp` option to the `reboot()` function. 

Summary:
Fixes # (issue) Microsoft ADO 30862178

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
We found that tests like `acl/test_acl.py` can be flaky if we are not waiting for BGP long enough on chassis after reboot. Therefore, we want to mimic what we have in `config_reload()` to also introduce the `wait_for_bgp` option to the `reboot()` function.

#### How did you do it?

#### How did you verify/test it?
I ran the updated acl test code and can make sure it's working well.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
