### PR TITLE
Fix do_init function in telemetry/conftest.py

### DIFF
--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -40,11 +40,12 @@ def setup_streaming_telemetry(request, duthosts, enum_rand_one_per_hwsku_hostnam
 def do_init(duthost):
     for i in [BASE_DIR, DATA_DIR]:
         try:
-            os.mkdir(i)
+            os.makedirs(i, exist_ok=True)
         except OSError as e:
-            logger.info("Dir/file already exists: {}, skipping mkdir".format(e))
+            logger.error("Unexpected error while creating directory: {}".format(e))
 
-        duthost.copy(src="telemetry/validate_yang_events.py", dest="~/")
+    # Copy validate_yang_events.py from sonic-mgmt to DUT
+    duthost.copy(src="telemetry/validate_yang_events.py", dest="~/")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix `do_init` function in `telemetry/conftest.py`
Fixes #
Test case `telemetry/test_events.py::test_events` failed in fixture `test_eventd_healthy` with error message `FileNotFoundError: [Errno 2] No such file or directory: 'logs/telemetry/files/heartbeat.json'`

- **Issue1**: The `os.mkdir()` function can only create one-level directory and cannot automatically create multiple directories. When create `logs/telemetry`, if "logs" directory does not exist, it will raise an error. Use `os.makedirs()` function can avoid this issue.

- **Issue2**: The error message `Dir/file already exists` in the except section is inaccurate. Failure may also be due to other reasons, and this log might be confusing.

- **Issue3**: Just copy `telemetry/validate_yang_events.py` once


Add pdb output
```
> /root/mars/workspace/sonic-mgmt/tests/telemetry/conftest.py(158)do_init()
(Pdb) os.getcwd()
'/root/mars/workspace/sonic-mgmt/tests'
-> for i in [BASE_DIR, DATA_DIR]:
(Pdb) DATA_DIR
'logs/telemetry/files'
(Pdb) BASE_DIR
'logs/telemetry'
(Pdb) n
> /root/mars/workspace/sonic-mgmt/tests/telemetry/conftest.py(159)do_init()
-> try:
(Pdb) n
> /root/mars/workspace/sonic-mgmt/tests/telemetry/conftest.py(160)do_init()
-> os.mkdir(i)
(Pdb) n
FileNotFoundError: [Errno 2] No such file or directory: 'logs/telemetry'
> /root/mars/workspace/sonic-mgmt/tests/telemetry/conftest.py(160)do_init()
-> os.mkdir(i)
(Pdb) n
> /root/mars/workspace/sonic-mgmt/tests/telemetry/conftest.py(161)do_init()
-> except OSError as e:
(Pdb) n
> /root/mars/workspace/sonic-mgmt/tests/telemetry/conftest.py(162)do_init()
-> logger.info("Dir/file already exists: {}, skipping mkdir".format(e))
(Pdb) n
04:58:02 conftest.do_init                         L0162 INFO   | Dir/file already exists: [Errno 2] No such file or directory: 'logs/telemetry', skipping mkdir
```


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
