### PR TITLE
Temporarily skip lpmode test for some transceivers with known issue

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -258,6 +258,11 @@ class TestSfpApi(PlatformApiTestBase):
         'supported_max_tx_power'
     ]
 
+    # xcvr to be skipped for lpmode test due to known issue
+    LPMODE_SKIP_LIST = [
+        {'manufacturer': 'Cloud Light', 'host_electrical_interface': '400GAUI-8 C2M (Annex 120E)'},
+    ]
+
     chassis_facts = None
     duthost_vars = None
 
@@ -310,6 +315,15 @@ class TestSfpApi(PlatformApiTestBase):
         ext_identifier = xcvr_info_dict["ext_identifier"]
         if ("QSFP" not in xcvr_type and "OSFP" not in xcvr_type) or "Power Class 1" in ext_identifier:
             return False
+
+        # Temporarily add this logic to skip lpmode test for some transceivers with known issue
+        for xcvr_to_skip in self.LPMODE_SKIP_LIST:
+            if (xcvr_info_dict["manufacturer"].strip() == xcvr_to_skip["manufacturer"] and
+                    xcvr_info_dict["host_electrical_interface"].strip() == xcvr_to_skip["host_electrical_interface"]):
+                logger.info("Temporarily skipping {} due to known issue".format(
+                    xcvr_info_dict["manufacturer"]))
+                return False
+
         return True
 
     def is_xcvr_support_power_override(self, xcvr_info_dict):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Some sfp transceivers have known issues with lpmode test, where it fails to set_lpmode successfully. After discussion, we need a firmware from optics vendor to fix this issue. 

Therefore, we will temporarily skip this set_lpmode test for known manufacturer and 400G combination until fix is available.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Temporarily skip known test failure
#### How did you do it?
check conditions to skip the test
#### How did you verify/test it?
platform_tests/api/test_sfp.py::TestSfpApi::test_lpmode[xxx-lc4] 
03:30:49 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 0 (not applicable for this transceiver type)
03:30:49 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 1 (not applicable for this transceiver type)
03:30:49 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 2 (not applicable for this transceiver type)
03:30:50 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 3 (not applicable for this transceiver type)
03:30:50 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 4 (not applicable for this transceiver type)
03:30:51 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 5 (not applicable for this transceiver type)
03:30:51 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 6 (not applicable for this transceiver type)
03:30:52 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 7 (not applicable for this transceiver type)
03:30:52 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 8 (not applicable for this transceiver type)
03:30:52 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 9 (not applicable for this transceiver type)
03:30:53 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 10 (not applicable for this transceiver type)
03:30:53 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 11 (not applicable for this transceiver type)
03:30:54 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 12 (not applicable for this transceiver type)
03:30:54 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 13 (not applicable for this transceiver type)
03:30:55 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 14 (not applicable for this transceiver type)
03:30:55 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 15 (not applicable for this transceiver type)
03:30:55 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 16 (not applicable for this transceiver type)
03:30:56 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 17 (not applicable for this transceiver type)
03:30:56 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 18 (not applicable for this transceiver type)
03:30:57 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 19 (not applicable for this transceiver type)
03:30:57 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 20 (not applicable for this transceiver type)
03:30:58 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 21 (not applicable for this transceiver type)
03:30:58 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 22 (not applicable for this transceiver type)
03:30:58 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 23 (not applicable for this transceiver type)
03:30:59 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 24 (not applicable for this transceiver type)
03:30:59 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 25 (not applicable for this transceiver type)
03:31:00 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 26 (not applicable for this transceiver type)
03:31:00 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 27 (not applicable for this transceiver type)
03:31:01 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 28 (not applicable for this transceiver type)
03:31:01 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 29 (not applicable for this transceiver type)
03:31:01 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 30 (not applicable for this transceiver type)
03:31:02 test_sfp.test_lpmode                     L0795 WARNING| test_lpmode: Skipping transceiver 31 (not applicable for this transceiver type)
PASSED                                                                                                                                                                                                                                                   [ 33%]
platform_tests/api/test_sfp.py::TestSfpApi::test_lpmode[xxx-lc2] PASSED                                                                                                                                                                          [ 66%]
platform_tests/api/test_sfp.py::TestSfpApi::test_lpmode[xxx-sup] SKIPPED (skipping for supervisor node)
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
