### PR TITLE
[dualtor] Fix `testFdbMacLearning`

### DIFF
--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -9,6 +9,8 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa
 from tests.ptf_runner import ptf_runner
 from .utils import fdb_table_has_dummy_mac_for_interface
 from tests.common.helpers.ptf_tests_helper import upstream_links    # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
+
 
 pytestmark = [
     pytest.mark.topology('t0')
@@ -234,7 +236,8 @@ class TestFdbMacLearning:
             duthost.shell("sudo config interface startup {}".format(uplink_intf))
 
     def testFdbMacLearning(self, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request, prepare_test,
-                           upstream_links, setup_standby_ports_on_rand_unselected_tor_unconditionally): # noqa F811
+                           upstream_links, setup_standby_ports_on_rand_unselected_tor_unconditionally,                  # noqa F811
+                           toggle_all_simulator_ports_to_rand_selected_tor_m):                                          # noqa F811
         """
             TestFdbMacLearning verifies stale MAC entries are not present in MAC table after doing sonic-clear fdb all
             -shut down all ports


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
`testFdbMacLearning` is flaky on dualtor.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Let's toggle the mux ports to the random selected DUT, so all packets will be forwarded to it.

#### How did you verify/test it?
```
fdb/test_fdb_mac_learning.py::TestFdbMacLearning::testFdbMacLearning PASSED                                                                                                                                                                                            [100%]

================================================================================================================= 1 passed, 3 warnings in 1558.19s (0:25:58) =================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
