### PR TITLE
Ignoring updating switch mac addr log more broadly

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -303,6 +303,7 @@ r, ".* ERR rsyslogd: imrelp.*error 'error when receiving data, session broken', 
 # SAI implement missing for the https://github.com/sonic-net/sonic-buildimage/pull/18912 caused the err msg pop up, need to ignore the err msgs before it SAI implement is done.
 r, ".* ERR swss#orchagent:.*doAppSwitchTableTask.*Unsupported Attribute ecmp_hash_offset.*"
 r, ".* ERR swss#orchagent:.*doAppSwitchTableTask.*Unsupported Attribute lag_hash_offset.*"
+r, ".* ERR syncd\d*#syncd.*brcm_sai_set_switch_attribute.*updating switch mac addr failed with error.*"
 
 # ignore SAI_API_BUFFER for DNX platforms
 r, ".* ERR syncd\d*#syncd.*SAI_API_BUFFER.*Unsupported buffer pool.*"

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -62,10 +62,7 @@ DUMMY_INNER_DST_IP = '10.10.10.10'
 
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exception(get_src_dst_asic_and_duts, loganalyzer):
-    """ignore the syslog ERR syncd0#syncd: [03:00.0] brcm_sai_set_switch_
-       attribute:1920 updating switch mac addr failed with error -2"""
     ignore_regex = [
-        ".*ERR syncd[0-9]*#syncd.*brcm_sai_set_switch_attribute.*updating switch mac addr failed with error.*",
         # The following error log is related to the bug of https://github.com/sonic-net/sonic-buildimage/issues/13265
         ".*ERR lldp[0-9]*#lldpmgrd.*Command failed.*lldpcli.*configure.*ports.*unable to connect to socket.*",
         ".*ERR lldp[0-9]*#lldpmgrd.*Command failed.*lldpcli.*configure.*ports.*lldp.*unknown command from argument"


### PR DESCRIPTION
We still see this log cause LogAnalyzer to fail in qos tests, so moving this ignore logre to be more broad.

E.G. qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[multi_dut_shortlink_to_shortlink-xoff_1]
```
Failed: Processes "['analyze_logs--<MultiAsicSonicHost cmp227-4>']" failed with exit code "1"
Exception:
match: 1
expected_match: 0
expected_missing_match: 0

Match Messages:
2024 Dec 16 15:37:17.167501 cmp227-4 ERR syncd0#syncd: message repeated 3 times: [ [06:00.0] SAI_API_SWITCH:brcm_sai_set_switch_attribute:5087 updating switch mac addr failed with error -2.]

Traceback:
Traceback (most recent call last):
  File "/data/tests/common/helpers/parallel.py", line 35, in run
    Process.run(self)
  File "/usr/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/data/tests/common/helpers/parallel.py", line 248, in wrapper
    target(*args, **kwargs)
  File "/data/tests/common/plugins/loganalyzer/__init__.py", line 45, in analyze_logs
    dut_analyzer.analyze(markers[node.hostname], fail_test, store_la_logs=store_la_logs)
  File "/data/tests/common/plugins/loganalyzer/loganalyzer.py", line 409, in analyze
    self._verify_log(analyzer_summary)
  File "/data/tests/common/plugins/loganalyzer/loganalyzer.py", line 140, in _verify_log
    raise LogAnalyzerError(result_str)
tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 1
expected_match: 0
expected_missing_match: 0

Match Messages:
2024 Dec 16 15:37:17.167501 cmp227-4 ERR syncd0#syncd: message repeated 3 times: [ [06:00.0] SAI_API_SWITCH:brcm_sai_set_switch_attribute:5087 updating switch mac addr failed with error -2.]
```

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
