### PR TITLE
[SmartSwitch] Add tests for reboot of a smart switch

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -411,6 +411,22 @@ class SonicHost(AnsibleHostBase):
         inv_files = im._sources
         return is_supervisor_node(inv_files, self.hostname)
 
+    def is_smartswitch(self):
+        """Check if the current node is a SmartSwitch
+
+        Returns:
+            True if the current node is a SmartSwitch, else False
+        """
+        return "DPUS" in self.facts
+
+    def is_dpu(self):
+        """Check if the current node is a DPU
+
+        Returns:
+            True if the current node is a DPU, else False
+        """
+        return "DPU" in self.facts
+
     def is_frontend_node(self):
         """Check if the current node is a frontend node in case of multi-DUT.
 

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -14,7 +14,6 @@ from .utilities import wait_until, get_plt_reboot_ctrl
 from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs, create_duthost_console, creds_on_dut
 from tests.common.fixtures.conn_graph_facts import get_graph_facts
 
-
 logger = logging.getLogger(__name__)
 
 # Create the waiting power on event
@@ -141,6 +140,21 @@ reboot_ctrl_dict = {
     }
 }
 
+'''
+command : command to reboot the smartswitch DUT
+'''
+reboot_ss_ctrl_dict = {
+    REBOOT_TYPE_COLD: {
+        "command": "sudo reboot"
+    },
+    REBOOT_TYPE_KERNEL_PANIC: {
+        "command": "echo c | sudo tee /proc/sysrq-trigger"
+    },
+    REBOOT_TYPE_WATCHDOG: {
+        "command": "sudo watchdog -t 1"
+    }
+}
+
 MAX_NUM_REBOOT_CAUSE_HISTORY = 10
 REBOOT_TYPE_HISTOYR_QUEUE = deque([], MAX_NUM_REBOOT_CAUSE_HISTORY)
 REBOOT_CAUSE_HISTORY_TITLE = ["name", "cause", "time", "user", "comment"]
@@ -223,6 +237,27 @@ def perform_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwa
     return [reboot_res, dut_datetime]
 
 
+def reboot_smartswitch(duthost, reboot_type='cold'):
+    """
+    reboots SmartSwitch or a DPU
+    :param duthost: DUT host object
+    :param reboot_type: reboot type (cold)
+    """
+
+    if reboot_type not in reboot_ss_ctrl_dict:
+        logger.info("Skipping the reboot test as the reboot type {} is not supported".format(reboot_type))
+        return
+
+    hostname = duthost.hostname
+    dut_datetime = duthost.get_now_time(utc_timezone=True)
+
+    logging.info("Rebooting the DUT {} with type {}".format(hostname, reboot_type))
+
+    reboot_res = duthost.command(reboot_ss_ctrl_dict[reboot_type]["command"])
+
+    return [reboot_res, dut_datetime]
+
+
 def reboot(duthost, localhost, reboot_type='cold', delay=10,
            timeout=0, wait=0, wait_for_ssh=True, wait_warmboot_finalizer=False, warmboot_finalizer_timeout=0,
            reboot_helper=None, reboot_kwargs=None, return_after_reconnect=False,
@@ -279,7 +314,12 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     console_thread_res = pool.apply_async(
         collect_console_log, args=(duthost, localhost, timeout + wait_conlsole_connection))
     time.sleep(wait_conlsole_connection)
-    reboot_res, dut_datetime = perform_reboot(duthost, pool, reboot_command, reboot_helper, reboot_kwargs, reboot_type)
+    # Perform reboot
+    if duthost.is_smartswitch():
+        reboot_res, dut_datetime = reboot_smartswitch(duthost, reboot_type)
+    else:
+        reboot_res, dut_datetime = perform_reboot(duthost, pool, reboot_command, reboot_helper,
+                                                  reboot_kwargs, reboot_type)
 
     wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res)
 

--- a/tests/smartswitch/common/reboot.py
+++ b/tests/smartswitch/common/reboot.py
@@ -1,0 +1,88 @@
+import logging
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+from tests.common.helpers.platform_api import module
+from tests.common.reboot import reboot_ss_ctrl_dict as reboot_dict
+from tests.smartswitch.common.device_utils_dpu import check_dpu_ping_status, check_dpu_reboot_cause
+
+logger = logging.getLogger(__name__)
+
+REBOOT_TYPE_COLD = "cold"
+REBOOT_TYPE_UNKNOWN = "unknown"
+REBOOT_TYPE_KERNEL_PANIC = "Kernel Panic"
+REBOOT_TYPE_WATCHDOG = "Watchdog"
+
+
+def log_and_perform_reboot(duthost, reboot_type, dpu_name):
+    """
+    Logs and initiates the reboot process based on the host type.
+    Skips the test if the host is a DPU.
+
+    @param duthost: DUT host object
+    @param reboot_type: Type of reboot to perform
+    @param dpu_name: Name of the DPU (optional)
+    """
+    hostname = duthost.hostname
+    logger.info("Rebooting the DUT {} with type {}".format(hostname, reboot_type))
+
+    if reboot_type == REBOOT_TYPE_COLD:
+        if duthost.is_smartswitch():
+            return duthost.command("sudo reboot -d {}".format(dpu_name))
+        elif duthost.is_dpu():
+            pytest.skip("Skipping the reboot test as the DUT is a DPU")
+    else:
+        pytest.skip("Skipping the reboot test as the reboot type {} is not supported".format(reboot_type))
+
+
+def check_dpu_reboot_status(duthost, dpu_ip, dpu_name, dut_datetime):
+    """
+    Checks the DPU's status post-reboot by verifying its uptime and ping status.
+
+    @param duthost: DUT host object
+    @param dpu_ip: DPU IP address
+    @param dpu_name: Name of the DPU
+    @param dut_datetime: Datetime of DUT when reboot initiated
+    """
+    pytest_assert(wait_until(120, 30, 0, check_dpu_ping_status, duthost, dpu_ip),
+                  "DPU ping is not operational")
+
+    dut_uptime = duthost.get_up_time(utc_timezone=True)
+    assert float(dut_uptime.strftime("%s")) > float(dut_datetime.strftime("%s")), \
+        "DPU {} did not reboot".format(dpu_name)
+
+    logger.info("DUT {} uptime is {}".format(duthost.hostname, dut_uptime))
+    check_dpu_reboot_cause(duthost, dpu_name)
+
+
+def perform_and_check_reboot(duthost, platform_api_conn, reboot_type=REBOOT_TYPE_COLD,
+                             dpu_id=0, dpu_name=None):
+    """
+    Performs a reboot and validates the DPU status after reboot.
+
+    @param duthost: DUT host object
+    @param platform_api_conn: Platform API connection
+    @param reboot_type: Reboot type
+    @param dpu_id: DPU ID
+    @param dpu_name: DPU name
+    """
+    from tests.common.reboot import REBOOT_TYPE_HISTOYR_QUEUE, sync_reboot_history_queue_with_dut
+
+    if reboot_type not in reboot_dict:
+        pytest.skip("Skipping the reboot test as the reboot type {} is not supported".format(reboot_type))
+
+    logger.info("Sync reboot cause history queue with DUT reboot cause history queue")
+    sync_reboot_history_queue_with_dut(duthost)
+
+    res = log_and_perform_reboot(duthost, reboot_type, dpu_name)
+    if res.is_failed or res.rc != 0:
+        pytest.fail("Failed to reboot the DPU {}".format(dpu_name))
+
+    dut_datetime = duthost.get_now_time(utc_timezone=True)
+
+    logger.info("Appending the last reboot type to the queue")
+    REBOOT_TYPE_HISTOYR_QUEUE.append(reboot_type)
+
+    dpu_ip = module.get_ip(platform_api_conn, dpu_id)
+    check_dpu_reboot_status(duthost, dpu_ip, dpu_name, dut_datetime)

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -15,6 +15,7 @@ from tests.common.config_reload import config_force_option_supported, config_sys
 from tests.smartswitch.common.device_utils_dpu import *  # noqa: F401,F403,E501
 from tests.common.helpers.platform_api import chassis, module  # noqa: F401
 from tests.common.platform.device_utils import platform_api_conn  # noqa: F401,F403
+from tests.smartswitch.common.reboot import perform_and_check_reboot
 
 pytestmark = [
     pytest.mark.topology('smartswitch')
@@ -72,3 +73,14 @@ def test_show_ping_int_after_reload(duthosts, enum_rand_one_per_hwsku_hostname,
     pytest_assert(wait_until(30, 10, 0, check_dpu_ping_status,  # noqa: F405
                   duthost, ip_address_list),
                   "Not all DPUs operationally up")
+
+
+def test_cold_reboot_dpus(duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn, num_dpu_modules):
+    """
+    Test to reboot all DPUs in the DUT.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    for index in range(num_dpu_modules):
+        dpu_name = module.get_name(platform_api_conn, index)
+        perform_and_check_reboot(duthost, platform_api_conn, REBOOT_TYPE_COLD, index, dpu_name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->


Summary: Add sonic-mgmt tests for reboot of a smart switch and individual DPUs
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Supporting different types of reboots for smart switch

#### How did you do it?
- Extend existing reboot() method for a smart switch as well to reboot the DPUs.
- Add a test case to reboot all the DPUs individually

#### How did you verify/test it?
- Verified for any regressions on normal switch.
- Test pending on SmartSwitch (Awaiting integrated image)

#### Any platform specific information?
-Smartswitch topology

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
