### PR TITLE
Skip `test_warm_reboot_mac_jump` and `test_warm_reboot_sad` in PR testing.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1056,6 +1056,18 @@ platform_tests/test_advanced_reboot.py::test_warm_reboot:
     conditions:
       - "asic_type in ['vs'] and 't0' not in topo_name"
 
+platform_tests/test_advanced_reboot.py::test_warm_reboot_mac_jump:
+  skip:
+    reason: "Skip in PR testing as taking too much time."
+    conditions:
+      - "asic_type in ['vs']"
+
+platform_tests/test_advanced_reboot.py::test_warm_reboot_sad:
+  skip:
+    reason: "Skip in PR testing as taking too much time."
+    conditions:
+      - "asic_type in ['vs']"
+
 #######################################
 #####   test_cont_warm_reboot.py  #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #16287, we skipped `test_advanced_reboot.py` during PR testing but retained the test case `test_warm_reboot` on the T0 topology. However, the other two test cases, `test_warm_reboot_mac_jump` and `test_warm_reboot_sad`, unexpectedly matched the longest entry `platform_tests/test_advanced_reboot.py::test_warm_reboot:` and were also executed on the T0 topology. To address this issue, this PR applies the conditional mark to skip these two test cases.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
In PR #16287, we skipped `test_advanced_reboot.py` during PR testing but retained the test case `test_warm_reboot` on the T0 topology. However, the other two test cases, `test_warm_reboot_mac_jump` and `test_warm_reboot_sad`, unexpectedly matched the longest entry `platform_tests/test_advanced_reboot.py::test_warm_reboot:` and were also executed on the T0 topology. To address this issue, this PR applies the conditional mark to skip these two test cases.

#### How did you do it?
This PR applies the conditional mark to skip these test cases `test_warm_reboot_mac_jump` and `test_warm_reboot_sad`.

#### How did you verify/test it?
Test locally and it can skip test cases as expected. 

platform_tests/test_advanced_reboot.py::test_fast_reboot[vlab-02] SKIPPED [  7%]
platform_tests/test_advanced_reboot.py::test_fast_reboot_from_other_vendor[vlab-02] SKIPPED [ 14%]
platform_tests/test_advanced_reboot.py::test_warm_reboot[single-vlab-02] PASSED [ 21%]
platform_tests/test_advanced_reboot.py::test_warm_reboot[dual-vlab-02] SKIPPED [ 28%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_mac_jump[vlab-02] SKIPPED [ 35%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad[sad-vlab-02] SKIPPED [ 42%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad[multi_sad-vlab-02] SKIPPED [ 50%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad[sad_bgp-vlab-02] SKIPPED [ 57%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad[sad_lag_member-vlab-02] SKIPPED [ 64%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad[sad_lag-vlab-02] SKIPPED [ 71%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad[sad_vlan_port-vlab-02] SKIPPED [ 78%]
platform_tests/test_advanced_reboot.py::test_warm_reboot_sad[sad_inboot-vlab-02] SKIPPED [ 85%]
platform_tests/test_advanced_reboot.py::test_cancelled_fast_reboot[vlab-02] SKIPPED [ 92%]
platform_tests/test_advanced_reboot.py::test_cancelled_warm_reboot[vlab-02] SKIPPED [100%]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
