### PR TITLE
Fix test_sysuptime conversion error

### DIFF
--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -247,7 +247,7 @@ def test_sysuptime(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, gnxi_pat
     for line_info in system_uptime_info:
         if "total" in line_info:
             try:
-                system_uptime_2nd = float(line_info.split(":")[1].strip())
+                system_uptime_2nd = float(line_info.split(":")[1].strip().rstrip(','))
                 found_system_uptime_field = True
             except ValueError as err:
                 pytest.fail(


### PR DESCRIPTION
This PR fixes the second occurrence of the conversion error when running test_sysuptime.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

Fix broken telemetry test_sysuptime.

#### How did you do it?

Fix string parsing.

#### How did you verify/test it?

on 7050cx3

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA