### PR TITLE
fix t1-isolated-d28u1 link mapping

### DIFF
--- a/ansible/generate_topo.py
+++ b/ansible/generate_topo.py
@@ -205,7 +205,7 @@ def generate_topo(role: str,
                     per_role_vm_count[vm_role_cfg["role"]] = 0
                 per_role_vm_count[vm_role_cfg["role"]] += 1
 
-                if link_id % link_step == 0 and panel_port_id not in skip_ports:
+                if (link_id - link_id_start) % link_step == 0 and panel_port_id not in skip_ports:
                     vm = VM(link_id, len(vm_list), per_role_vm_count[vm_role_cfg["role"]],
                             dut_role_cfg["asn"], vm_role_cfg, link_id)
                     vm_list.append(vm)
@@ -214,7 +214,7 @@ def generate_topo(role: str,
                     elif link_type == 'down':
                         downlinkif_list.append(link_id)
             else:
-                if link_id % link_step == 0 and panel_port_id not in skip_ports:
+                if (link_id - link_id_start) % link_step == 0 and panel_port_id not in skip_ports:
                     hostif = HostInterface(link_id)
                     downlinkif_list.append(hostif)
         print(panel_port_id, link_id_start, link_id_end, link_step, vm_role_cfg)

--- a/ansible/vars/topo_t1-isolated-d28u1.yml
+++ b/ansible/vars/topo_t1-isolated-d28u1.yml
@@ -28,65 +28,65 @@ topology:
       vlans:
         - 48
       vm_offset: 6
-    ARISTA55T0:
+    ARISTA49T0:
       vlans:
-        - 56
+        - 50
       vm_offset: 7
-    ARISTA61T0:
+    ARISTA57T0:
       vlans:
-        - 64
+        - 60
       vm_offset: 8
-    ARISTA69T0:
+    ARISTA65T0:
       vlans:
-        - 72
+        - 68
       vm_offset: 9
-    ARISTA77T0:
+    ARISTA73T0:
       vlans:
-        - 80
+        - 76
       vm_offset: 10
-    ARISTA85T0:
+    ARISTA81T0:
       vlans:
-        - 88
+        - 84
       vm_offset: 11
-    ARISTA93T0:
+    ARISTA89T0:
       vlans:
-        - 96
+        - 92
       vm_offset: 12
-    ARISTA101T0:
+    ARISTA97T0:
       vlans:
-        - 104
+        - 100
       vm_offset: 13
-    ARISTA109T0:
+    ARISTA105T0:
       vlans:
-        - 112
+        - 108
       vm_offset: 14
-    ARISTA117T0:
+    ARISTA113T0:
       vlans:
-        - 120
+        - 116
       vm_offset: 15
-    ARISTA125T0:
+    ARISTA121T0:
       vlans:
-        - 128
+        - 124
       vm_offset: 16
-    ARISTA133T0:
+    ARISTA129T0:
       vlans:
-        - 136
+        - 132
       vm_offset: 17
-    ARISTA141T0:
+    ARISTA137T0:
       vlans:
-        - 144
+        - 140
       vm_offset: 18
-    ARISTA149T0:
+    ARISTA145T0:
       vlans:
-        - 152
+        - 148
       vm_offset: 19
-    ARISTA157T0:
+    ARISTA153T0:
       vlans:
-        - 160
+        - 156
       vm_offset: 20
-    ARISTA163T0:
+    ARISTA161T0:
       vlans:
-        - 168
+        - 166
       vm_offset: 21
     ARISTA169T0:
       vlans:
@@ -274,7 +274,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.50/24
       ipv6: fc0a::32/64
-  ARISTA55T0:
+  ARISTA49T0:
     properties:
     - common
     - tor
@@ -282,19 +282,19 @@ configuration:
       asn: 64007
       peers:
         65100:
-          - 10.0.0.112
-          - fc00::e1
+          - 10.0.0.100
+          - fc00::c9
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.57/32
-        ipv6: 2064:100:0:39::/128
+        ipv4: 100.1.0.51/32
+        ipv6: 2064:100:0:33::/128
       Ethernet1:
-        ipv4: 10.0.0.113/31
-        ipv6: fc00::e2/126
+        ipv4: 10.0.0.101/31
+        ipv6: fc00::ca/126
     bp_interface:
-      ipv4: 10.10.246.58/24
-      ipv6: fc0a::3a/64
-  ARISTA61T0:
+      ipv4: 10.10.246.52/24
+      ipv6: fc0a::34/64
+  ARISTA57T0:
     properties:
     - common
     - tor
@@ -302,19 +302,19 @@ configuration:
       asn: 64008
       peers:
         65100:
-          - 10.0.0.128
-          - fc00::101
+          - 10.0.0.120
+          - fc00::f1
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.65/32
-        ipv6: 2064:100:0:41::/128
+        ipv4: 100.1.0.61/32
+        ipv6: 2064:100:0:3d::/128
       Ethernet1:
-        ipv4: 10.0.0.129/31
-        ipv6: fc00::102/126
+        ipv4: 10.0.0.121/31
+        ipv6: fc00::f2/126
     bp_interface:
-      ipv4: 10.10.246.66/24
-      ipv6: fc0a::42/64
-  ARISTA69T0:
+      ipv4: 10.10.246.62/24
+      ipv6: fc0a::3e/64
+  ARISTA65T0:
     properties:
     - common
     - tor
@@ -322,19 +322,19 @@ configuration:
       asn: 64009
       peers:
         65100:
-          - 10.0.0.144
-          - fc00::121
+          - 10.0.0.136
+          - fc00::111
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.73/32
-        ipv6: 2064:100:0:49::/128
+        ipv4: 100.1.0.69/32
+        ipv6: 2064:100:0:45::/128
       Ethernet1:
-        ipv4: 10.0.0.145/31
-        ipv6: fc00::122/126
+        ipv4: 10.0.0.137/31
+        ipv6: fc00::112/126
     bp_interface:
-      ipv4: 10.10.246.74/24
-      ipv6: fc0a::4a/64
-  ARISTA77T0:
+      ipv4: 10.10.246.70/24
+      ipv6: fc0a::46/64
+  ARISTA73T0:
     properties:
     - common
     - tor
@@ -342,19 +342,19 @@ configuration:
       asn: 64010
       peers:
         65100:
-          - 10.0.0.160
-          - fc00::141
+          - 10.0.0.152
+          - fc00::131
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.81/32
-        ipv6: 2064:100:0:51::/128
+        ipv4: 100.1.0.77/32
+        ipv6: 2064:100:0:4d::/128
       Ethernet1:
-        ipv4: 10.0.0.161/31
-        ipv6: fc00::142/126
+        ipv4: 10.0.0.153/31
+        ipv6: fc00::132/126
     bp_interface:
-      ipv4: 10.10.246.82/24
-      ipv6: fc0a::52/64
-  ARISTA85T0:
+      ipv4: 10.10.246.78/24
+      ipv6: fc0a::4e/64
+  ARISTA81T0:
     properties:
     - common
     - tor
@@ -362,19 +362,19 @@ configuration:
       asn: 64011
       peers:
         65100:
-          - 10.0.0.176
-          - fc00::161
+          - 10.0.0.168
+          - fc00::151
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.89/32
-        ipv6: 2064:100:0:59::/128
+        ipv4: 100.1.0.85/32
+        ipv6: 2064:100:0:55::/128
       Ethernet1:
-        ipv4: 10.0.0.177/31
-        ipv6: fc00::162/126
+        ipv4: 10.0.0.169/31
+        ipv6: fc00::152/126
     bp_interface:
-      ipv4: 10.10.246.90/24
-      ipv6: fc0a::5a/64
-  ARISTA93T0:
+      ipv4: 10.10.246.86/24
+      ipv6: fc0a::56/64
+  ARISTA89T0:
     properties:
     - common
     - tor
@@ -382,19 +382,19 @@ configuration:
       asn: 64012
       peers:
         65100:
-          - 10.0.0.192
-          - fc00::181
+          - 10.0.0.184
+          - fc00::171
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.97/32
-        ipv6: 2064:100:0:61::/128
+        ipv4: 100.1.0.93/32
+        ipv6: 2064:100:0:5d::/128
       Ethernet1:
-        ipv4: 10.0.0.193/31
-        ipv6: fc00::182/126
+        ipv4: 10.0.0.185/31
+        ipv6: fc00::172/126
     bp_interface:
-      ipv4: 10.10.246.98/24
-      ipv6: fc0a::62/64
-  ARISTA101T0:
+      ipv4: 10.10.246.94/24
+      ipv6: fc0a::5e/64
+  ARISTA97T0:
     properties:
     - common
     - tor
@@ -402,19 +402,19 @@ configuration:
       asn: 64013
       peers:
         65100:
-          - 10.0.0.208
-          - fc00::1a1
+          - 10.0.0.200
+          - fc00::191
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.105/32
-        ipv6: 2064:100:0:69::/128
+        ipv4: 100.1.0.101/32
+        ipv6: 2064:100:0:65::/128
       Ethernet1:
-        ipv4: 10.0.0.209/31
-        ipv6: fc00::1a2/126
+        ipv4: 10.0.0.201/31
+        ipv6: fc00::192/126
     bp_interface:
-      ipv4: 10.10.246.106/24
-      ipv6: fc0a::6a/64
-  ARISTA109T0:
+      ipv4: 10.10.246.102/24
+      ipv6: fc0a::66/64
+  ARISTA105T0:
     properties:
     - common
     - tor
@@ -422,19 +422,19 @@ configuration:
       asn: 64014
       peers:
         65100:
-          - 10.0.0.224
-          - fc00::1c1
+          - 10.0.0.216
+          - fc00::1b1
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.113/32
-        ipv6: 2064:100:0:71::/128
+        ipv4: 100.1.0.109/32
+        ipv6: 2064:100:0:6d::/128
       Ethernet1:
-        ipv4: 10.0.0.225/31
-        ipv6: fc00::1c2/126
+        ipv4: 10.0.0.217/31
+        ipv6: fc00::1b2/126
     bp_interface:
-      ipv4: 10.10.246.114/24
-      ipv6: fc0a::72/64
-  ARISTA117T0:
+      ipv4: 10.10.246.110/24
+      ipv6: fc0a::6e/64
+  ARISTA113T0:
     properties:
     - common
     - tor
@@ -442,19 +442,19 @@ configuration:
       asn: 64015
       peers:
         65100:
-          - 10.0.0.240
-          - fc00::1e1
+          - 10.0.0.232
+          - fc00::1d1
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.121/32
-        ipv6: 2064:100:0:79::/128
+        ipv4: 100.1.0.117/32
+        ipv6: 2064:100:0:75::/128
       Ethernet1:
-        ipv4: 10.0.0.241/31
-        ipv6: fc00::1e2/126
+        ipv4: 10.0.0.233/31
+        ipv6: fc00::1d2/126
     bp_interface:
-      ipv4: 10.10.246.122/24
-      ipv6: fc0a::7a/64
-  ARISTA125T0:
+      ipv4: 10.10.246.118/24
+      ipv6: fc0a::76/64
+  ARISTA121T0:
     properties:
     - common
     - tor
@@ -462,19 +462,19 @@ configuration:
       asn: 64016
       peers:
         65100:
-          - 10.0.1.0
-          - fc00::201
+          - 10.0.0.248
+          - fc00::1f1
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.129/32
-        ipv6: 2064:100:0:81::/128
+        ipv4: 100.1.0.125/32
+        ipv6: 2064:100:0:7d::/128
       Ethernet1:
-        ipv4: 10.0.1.1/31
-        ipv6: fc00::202/126
+        ipv4: 10.0.0.249/31
+        ipv6: fc00::1f2/126
     bp_interface:
-      ipv4: 10.10.246.130/24
-      ipv6: fc0a::82/64
-  ARISTA133T0:
+      ipv4: 10.10.246.126/24
+      ipv6: fc0a::7e/64
+  ARISTA129T0:
     properties:
     - common
     - tor
@@ -482,19 +482,19 @@ configuration:
       asn: 64017
       peers:
         65100:
-          - 10.0.1.16
-          - fc00::221
+          - 10.0.1.8
+          - fc00::211
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.137/32
-        ipv6: 2064:100:0:89::/128
+        ipv4: 100.1.0.133/32
+        ipv6: 2064:100:0:85::/128
       Ethernet1:
-        ipv4: 10.0.1.17/31
-        ipv6: fc00::222/126
+        ipv4: 10.0.1.9/31
+        ipv6: fc00::212/126
     bp_interface:
-      ipv4: 10.10.246.138/24
-      ipv6: fc0a::8a/64
-  ARISTA141T0:
+      ipv4: 10.10.246.134/24
+      ipv6: fc0a::86/64
+  ARISTA137T0:
     properties:
     - common
     - tor
@@ -502,19 +502,19 @@ configuration:
       asn: 64018
       peers:
         65100:
-          - 10.0.1.32
-          - fc00::241
+          - 10.0.1.24
+          - fc00::231
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.145/32
-        ipv6: 2064:100:0:91::/128
+        ipv4: 100.1.0.141/32
+        ipv6: 2064:100:0:8d::/128
       Ethernet1:
-        ipv4: 10.0.1.33/31
-        ipv6: fc00::242/126
+        ipv4: 10.0.1.25/31
+        ipv6: fc00::232/126
     bp_interface:
-      ipv4: 10.10.246.146/24
-      ipv6: fc0a::92/64
-  ARISTA149T0:
+      ipv4: 10.10.246.142/24
+      ipv6: fc0a::8e/64
+  ARISTA145T0:
     properties:
     - common
     - tor
@@ -522,19 +522,19 @@ configuration:
       asn: 64019
       peers:
         65100:
-          - 10.0.1.48
-          - fc00::261
+          - 10.0.1.40
+          - fc00::251
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.153/32
-        ipv6: 2064:100:0:99::/128
+        ipv4: 100.1.0.149/32
+        ipv6: 2064:100:0:95::/128
       Ethernet1:
-        ipv4: 10.0.1.49/31
-        ipv6: fc00::262/126
+        ipv4: 10.0.1.41/31
+        ipv6: fc00::252/126
     bp_interface:
-      ipv4: 10.10.246.154/24
-      ipv6: fc0a::9a/64
-  ARISTA157T0:
+      ipv4: 10.10.246.150/24
+      ipv6: fc0a::96/64
+  ARISTA153T0:
     properties:
     - common
     - tor
@@ -542,19 +542,19 @@ configuration:
       asn: 64020
       peers:
         65100:
-          - 10.0.1.64
-          - fc00::281
+          - 10.0.1.56
+          - fc00::271
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.161/32
-        ipv6: 2064:100:0:a1::/128
+        ipv4: 100.1.0.157/32
+        ipv6: 2064:100:0:9d::/128
       Ethernet1:
-        ipv4: 10.0.1.65/31
-        ipv6: fc00::282/126
+        ipv4: 10.0.1.57/31
+        ipv6: fc00::272/126
     bp_interface:
-      ipv4: 10.10.246.162/24
-      ipv6: fc0a::a2/64
-  ARISTA163T0:
+      ipv4: 10.10.246.158/24
+      ipv6: fc0a::9e/64
+  ARISTA161T0:
     properties:
     - common
     - tor
@@ -562,18 +562,18 @@ configuration:
       asn: 64021
       peers:
         65100:
-          - 10.0.1.80
-          - fc00::2a1
+          - 10.0.1.76
+          - fc00::299
     interfaces:
       Loopback0:
-        ipv4: 100.1.0.169/32
-        ipv6: 2064:100:0:a9::/128
+        ipv4: 100.1.0.167/32
+        ipv6: 2064:100:0:a7::/128
       Ethernet1:
-        ipv4: 10.0.1.81/31
-        ipv6: fc00::2a2/126
+        ipv4: 10.0.1.77/31
+        ipv6: fc00::29a/126
     bp_interface:
-      ipv4: 10.10.246.170/24
-      ipv6: fc0a::aa/64
+      ipv4: 10.10.246.168/24
+      ipv6: fc0a::a8/64
   ARISTA169T0:
     properties:
     - common


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In d28u1 topology, current link was not selected correctly for t1 hwsku.

```
Ethernet96  121,122,123,124     400G   9100    N/A  Ethernet13/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet100  125,126,127,128     400G   9100    N/A  Ethernet13/5  routed    down     down  OSFP 8X Pluggable Transceiver         off
Ethernet112               97     100G   9100     rs  Ethernet15/1  routed    down     down  OSFP 8X Pluggable Transceiver         off
Ethernet113               98     100G   9100     rs  Ethernet15/2  routed    down     down  OSFP 8X Pluggable Transceiver         off
Ethernet114               99     100G   9100     rs  Ethernet15/3  routed    down     down  OSFP 8X Pluggable Transceiver         off
Ethernet115              100     100G   9100     rs  Ethernet15/4  routed    down     down  OSFP 8X Pluggable Transceiver         off
Ethernet116              101     100G   9100     rs  Ethernet15/5  routed    down     down  OSFP 8X Pluggable Transceiver         off
Ethernet117              102     100G   9100     rs  Ethernet15/6  routed    down     down  OSFP 8X Pluggable Transceiver         off
Ethernet118              103     100G   9100     rs  Ethernet15/7  routed      up       up  OSFP 8X Pluggable Transceiver         off
```

After the fix:
```
admin@xxxx:~$ show interface status | grep up
  Ethernet0               17     100G   9100     rs   Ethernet1/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
 Ethernet16                9     100G   9100     rs   Ethernet3/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
 Ethernet32               57     100G   9100     rs   Ethernet5/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
 Ethernet48               33     100G   9100     rs   Ethernet7/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
 Ethernet64               89     100G   9100     rs   Ethernet9/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
 Ethernet80               65     100G   9100     rs  Ethernet11/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
 Ethernet96  121,122,123,124     400G   9100    N/A  Ethernet13/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet112               97     100G   9100     rs  Ethernet15/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet144              129     100G   9100     rs  Ethernet19/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet160              185     100G   9100     rs  Ethernet21/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet176              161     100G   9100     rs  Ethernet23/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet192              217     100G   9100     rs  Ethernet25/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet208              193     100G   9100     rs  Ethernet27/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet224              249     100G   9100     rs  Ethernet29/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet240              225     100G   9100     rs  Ethernet31/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet256              273     100G   9100     rs  Ethernet33/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet272              265     100G   9100     rs  Ethernet35/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet288              313     100G   9100     rs  Ethernet37/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet304              289     100G   9100     rs  Ethernet39/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet320              345     100G   9100     rs  Ethernet41/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet336              321     100G   9100     rs  Ethernet43/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet368              353     100G   9100     rs  Ethernet47/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet400              385     100G   9100     rs  Ethernet51/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet416              441     100G   9100     rs  Ethernet53/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet432              417     100G   9100     rs  Ethernet55/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet448              473     100G   9100     rs  Ethernet57/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet464              449     100G   9100     rs  Ethernet59/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet480              505     100G   9100     rs  Ethernet61/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
Ethernet496              481     100G   9100     rs  Ethernet63/1  routed      up       up  OSFP 8X Pluggable Transceiver         off
admin@xxx:~$
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202412

### Approach
#### What is the motivation for this PR?
update topology with correct link

#### How did you do it?
update the check for current port

#### How did you verify/test it?
on physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
