### PR TITLE
upload fake dutConfig and dutQosConfig parameters to support kvm PR test

### DIFF
--- a/tests/qos/files/vs/dutConfig.json
+++ b/tests/qos/files/vs/dutConfig.json
@@ -1,180 +1,47 @@
 {
-    "dutInterfaces": {
-      "0": "Ethernet0",
-      "1": "Ethernet4",
-      "4": "Ethernet16",
-      "5": "Ethernet20",
-      "16": "Ethernet64",
-      "17": "Ethernet68",
-      "20": "Ethernet80",
-      "21": "Ethernet84",
-      "34": "Ethernet136",
-      "36": "Ethernet144",
-      "37": "Ethernet148",
-      "38": "Ethernet152",
-      "39": "Ethernet156",
-      "42": "Ethernet168",
-      "44": "Ethernet176",
-      "45": "Ethernet180",
-      "46": "Ethernet184",
-      "47": "Ethernet188",
-      "50": "Ethernet200",
-      "52": "Ethernet208",
-      "53": "Ethernet212",
-      "54": "Ethernet216",
-      "55": "Ethernet220",
-      "58": "Ethernet232",
-      "60": "Ethernet240",
-      "61": "Ethernet244",
-      "62": "Ethernet248",
-      "63": "Ethernet252"
-    },
-    "uplinkPortIds": [
-      0,
-      4,
-      16,
-      20
-    ],
-    "testPortIds": {
-      "0": {
-        "0": [
-          0,
-          4,
-          16,
-          20,
-          34,
-          36,
-          37,
-          38,
-          39,
-          42,
-          44,
-          45,
-          46,
-          47,
-          50,
-          52,
-          53,
-          54,
-          55,
-          58,
-          60,
-          61,
-          62,
-          63
-        ]
-      }
-    },
-    "testPortIps": {
-      "0": {
-        "0": {
-          "34": {
-            "peer_addr": "10.0.0.33"
-          },
-          "0": {
-            "peer_addr": "10.0.0.1"
-          },
-          "36": {
-            "peer_addr": "10.0.0.35"
-          },
-          "37": {
-            "peer_addr": "10.0.0.37"
-          },
-          "4": {
-            "peer_addr": "10.0.0.5"
-          },
-          "38": {
-            "peer_addr": "10.0.0.39"
-          },
-          "39": {
-            "peer_addr": "10.0.0.41"
-          },
-          "16": {
-            "peer_addr": "10.0.0.9"
-          },
-          "42": {
-            "peer_addr": "10.0.0.43"
-          },
-          "44": {
-            "peer_addr": "10.0.0.45"
-          },
-          "20": {
-            "peer_addr": "10.0.0.13"
-          },
-          "45": {
-            "peer_addr": "10.0.0.47"
-          },
-          "46": {
-            "peer_addr": "10.0.0.49"
-          },
-          "47": {
-            "peer_addr": "10.0.0.51"
-          },
-          "50": {
-            "peer_addr": "10.0.0.53"
-          },
-          "52": {
-            "peer_addr": "10.0.0.55"
-          },
-          "53": {
-            "peer_addr": "10.0.0.57"
-          },
-          "54": {
-            "peer_addr": "10.0.0.59"
-          },
-          "55": {
-            "peer_addr": "10.0.0.61"
-          },
-          "58": {
-            "peer_addr": "10.0.0.63"
-          },
-          "60": {
-            "peer_addr": "10.0.0.65"
-          },
-          "61": {
-            "peer_addr": "10.0.0.67"
-          },
-          "62": {
-            "peer_addr": "10.0.0.69"
-          },
-          "63": {
-            "peer_addr": "10.0.0.71"
-          }
-        }
-      }
-    },
-    "testPorts": {
-      "dst_port_id": 0,
-      "dst_port_ip": "10.0.0.1",
-      "dst_port_vlan": "None",
-      "dst_port_2_id": 16,
-      "dst_port_2_ip": "10.0.0.9",
-      "dst_port_2_vlan": "None",
-      "dst_port_3_id": 20,
-      "dst_port_3_ip": "10.0.0.13",
-      "dst_port_3_vlan": "None",
-      "src_port_id": 4,
-      "src_port_ip": "10.0.0.5",
-      "src_port_vlan": "None",
-      "uplink_port_ids": [
+  "dutInterfaces": {
+    "0": "Ethernet0",
+    "1": "Ethernet4",
+    "4": "Ethernet16",
+    "5": "Ethernet20",
+    "16": "Ethernet64",
+    "17": "Ethernet68",
+    "20": "Ethernet80",
+    "21": "Ethernet84",
+    "34": "Ethernet136",
+    "36": "Ethernet144",
+    "37": "Ethernet148",
+    "38": "Ethernet152",
+    "39": "Ethernet156",
+    "42": "Ethernet168",
+    "44": "Ethernet176",
+    "45": "Ethernet180",
+    "46": "Ethernet184",
+    "47": "Ethernet188",
+    "50": "Ethernet200",
+    "52": "Ethernet208",
+    "53": "Ethernet212",
+    "54": "Ethernet216",
+    "55": "Ethernet220",
+    "58": "Ethernet232",
+    "60": "Ethernet240",
+    "61": "Ethernet244",
+    "62": "Ethernet248",
+    "63": "Ethernet252"
+  },
+  "uplinkPortIds": [
+    0,
+    4,
+    16,
+    20
+  ],
+  "testPortIds": {
+    "0": {
+      "0": [
         0,
         4,
         16,
-        20
-      ],
-      "uplink_port_ips": [
-        "10.0.0.1",
-        "10.0.0.5",
-        "10.0.0.9",
-        "10.0.0.13"
-      ],
-      "uplink_port_names": [
-        "Ethernet0",
-        "Ethernet16",
-        "Ethernet64",
-        "Ethernet80"
-      ],
-      "downlink_port_ids": [
+        20,
         34,
         36,
         37,
@@ -195,819 +62,701 @@
         61,
         62,
         63
-      ],
-      "downlink_port_ips": [
-        "10.0.0.33",
-        "10.0.0.35",
-        "10.0.0.37",
-        "10.0.0.39",
-        "10.0.0.41",
-        "10.0.0.43",
-        "10.0.0.45",
-        "10.0.0.47",
-        "10.0.0.49",
-        "10.0.0.51",
-        "10.0.0.53",
-        "10.0.0.55",
-        "10.0.0.57",
-        "10.0.0.59",
-        "10.0.0.61",
-        "10.0.0.63",
-        "10.0.0.65",
-        "10.0.0.67",
-        "10.0.0.69",
-        "10.0.0.71"
-      ],
-      "downlink_port_names": [
-        "Ethernet136",
-        "Ethernet144",
-        "Ethernet148",
-        "Ethernet152",
-        "Ethernet156",
-        "Ethernet168",
-        "Ethernet176",
-        "Ethernet180",
-        "Ethernet184",
-        "Ethernet188",
-        "Ethernet200",
-        "Ethernet208",
-        "Ethernet212",
-        "Ethernet216",
-        "Ethernet220",
-        "Ethernet232",
-        "Ethernet240",
-        "Ethernet244",
-        "Ethernet248",
-        "Ethernet252"
       ]
-    },
-    "qosConfigs": {
-      "qos_params": {
-        "kvm": {
-          "topo-any": {
-            "100000_120000m": {
-              "lossy_queue_1": {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 16000
-              },
-              "pg_drop": {
-                "dscp": 3,
-                "ecn": 1,
-                "iterations": 30,
-                "pg": 3,
-                "pkts_num_margin": 30000,
-                "pkts_num_trig_ingr_drp": 524288,
-                "pkts_num_trig_pfc": 262144,
-                "queue": 3
-              },
-              "pkts_num_leak_out": 0,
-              "wm_buf_pool_lossless": {
-                "cell_size": 8192,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8140,
-                "pg": 3,
-                "pkts_num_fill_ingr_min": 140,
-                "pkts_num_margin": 6,
-                "pkts_num_trig_pfc": 6412,
-                "queue": 3
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 8192,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 6403
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 8192,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 0,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 728
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 6144,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 19456,
-                "pkts_num_trig_ingr_drp": 12807,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 3072,
-                "pkts_num_trig_egr_drp": 16000,
-                "queue": 0
-              },
-              "wm_q_wm_all_ports": {
-                "cell_size": 6144,
-                "ecn": 1,
-                "packet_size": 6144,
-                "pkt_count": 3000,
-                "pkts_num_margin": 19456
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 6404,
-                "pkts_num_trig_pfc": 3202
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 4,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 6404,
-                "pkts_num_trig_pfc": 3202
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 2,
-                "pkts_num_trig_pfc": 3201
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 2,
-                "pkts_num_trig_pfc": 3201
-              }
-            },
-            "100000_300m": {
-              "pcbb_xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-              },
-              "pcbb_xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-              },
-              "pcbb_xoff_3": {
-                "dscp": 3,
-                "ecn": 1,
-                "outer_dscp": 2,
-                "packet_size": 1350,
-                "pg": 2,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-              },
-              "pcbb_xoff_4": {
-                "dscp": 4,
-                "ecn": 1,
-                "outer_dscp": 6,
-                "packet_size": 1350,
-                "pg": 6,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-              },
-              "pkts_num_leak_out": 0,
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_pfc": 3415,
-                "pkts_num_trig_ingr_drp": 3703,
-                "packet_size": 1350
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_pfc": 3415,
-                "pkts_num_trig_ingr_drp": 3703,
-                "packet_size": 1350
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_pfc": 3414,
-                "pkts_num_hysteresis": 1877,
-                "pkts_num_dismiss_pfc": 2,
-                "packet_size": 1350
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_pfc": 3414,
-                "pkts_num_hysteresis": 1877,
-                "pkts_num_dismiss_pfc": 2,
-                "packet_size": 1350
-              },
-              "wm_pg_shared_lossless": {
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "cell_size": 384,
-                "dscp": 3,
-                "pg": 3,
-                "pkts_num_trig_pfc": 14807
-              },
-              "wm_pg_shared_lossy": {
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "cell_size": 384,
-                "dscp": 8,
-                "pg": 0,
-                "pkts_num_trig_egr_drp": 16000
-              },
-              "wm_buf_pool_lossless": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "queue": 3,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_pfc": 3703,
-                "cell_size": 384,
-                "packet_size": 1350
-              },
-              "wm_buf_pool_lossy": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "queue": 0,
-                "pkts_num_trig_egr_drp": 4000,
-                "pkts_num_fill_egr_min": 0,
-                "cell_size": 384,
-                "packet_size": 1350
-              },
-              "wm_q_shared_lossless": {
-                "dscp": 3,
-                "ecn": 1,
-                "queue": 3,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 14815,
-                "pkts_num_margin": 3072,
-                "cell_size": 384
-              },
-              "wm_q_shared_lossy": {
-                "dscp": 8,
-                "ecn": 1,
-                "queue": 0,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 16000,
-                "pkts_num_margin": 3072,
-                "cell_size": 384
-              },
-              "lossy_queue_voq_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "flow_config": "separate",
-                "pkts_num_trig_egr_drp": 16000,
-                "pkts_num_margin": 4,
-                "packet_size": 64,
-                "cell_size": 384
-              },
-              "lossy_queue_voq_2": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "flow_config": "shared",
-                "pkts_num_trig_egr_drp": 16000,
-                "pkts_num_margin": 4,
-                "packet_size": 64,
-                "cell_size": 384
-              },
-              "lossy_queue_voq_3": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_trig_egr_drp": 16000,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "cell_size": 384
-              },
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_trig_egr_drp": 16000,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "cell_size": 384
-              },
-              "lossless_voq_1": {
-                "ecn": 1,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "pkts_num_trig_pfc": 3415,
-                "dscp": 3,
-                "pg": 3,
-                "num_of_flows": "multiple"
-              },
-              "lossless_voq_2": {
-                "ecn": 1,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "pkts_num_trig_pfc": 3415,
-                "dscp": 4,
-                "pg": 4,
-                "num_of_flows": "multiple"
-              },
-              "lossless_voq_3": {
-                "ecn": 1,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "pkts_num_trig_pfc": 3415,
-                "dscp": 3,
-                "pg": 3,
-                "num_of_flows": "single"
-              },
-              "lossless_voq_4": {
-                "ecn": 1,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "pkts_num_trig_pfc": 3415,
-                "dscp": 4,
-                "pg": 4,
-                "num_of_flows": "single"
-              },
-              "wm_q_wm_all_ports": {
-                "ecn": 1,
-                "pkt_count": 4000,
-                "pkts_num_margin": 3072,
-                "cell_size": 384,
-                "packet_size": 1350
-              },
-              "pg_drop": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "queue": 3,
-                "pkts_num_trig_pfc": 13661,
-                "pkts_num_trig_ingr_drp": 14815,
-                "pkts_num_margin": 365,
-                "iterations": 100
-              }
-            },
-            "100000_40m": {
-              "pcbb_xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-              },
-              "pcbb_xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-              },
-              "pcbb_xoff_3": {
-                "dscp": 3,
-                "ecn": 1,
-                "outer_dscp": 2,
-                "packet_size": 1350,
-                "pg": 2,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-              },
-              "pcbb_xoff_4": {
-                "dscp": 4,
-                "ecn": 1,
-                "outer_dscp": 6,
-                "packet_size": 1350,
-                "pg": 6,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-              },
-              "pkts_num_leak_out": 0
-            },
-            "100000_5m": {
-              "pcbb_xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-              },
-              "pcbb_xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-              },
-              "pcbb_xoff_3": {
-                "dscp": 3,
-                "ecn": 1,
-                "outer_dscp": 2,
-                "packet_size": 1350,
-                "pg": 2,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-              },
-              "pcbb_xoff_4": {
-                "dscp": 4,
-                "ecn": 1,
-                "outer_dscp": 6,
-                "packet_size": 1350,
-                "pg": 6,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-              },
-              "pkts_num_leak_out": 0
-            },
-            "400000_120000m": {
-              "lossy_queue_1": {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 16000
-              },
-              "pkts_num_leak_out": 0,
-              "wm_buf_pool_lossless": {
-                "cell_size": 8192,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8140,
-                "pg": 3,
-                "pkts_num_fill_ingr_min": 140,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_pfc": 23085,
-                "queue": 3
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 8192,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 23043
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 8192,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 0,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 728
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 6144,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 26624,
-                "pkts_num_trig_ingr_drp": 46087,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 3072,
-                "pkts_num_trig_egr_drp": 16000,
-                "queue": 0
-              },
-              "wm_q_wm_all_ports": {
-                "cell_size": 6144,
-                "ecn": 1,
-                "packet_size": 6144,
-                "pkt_count": 3000,
-                "pkts_num_margin": 19456
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 23044,
-                "pkts_num_trig_pfc": 11522
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 4,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 23044,
-                "pkts_num_trig_pfc": 11522
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 2,
-                "pkts_num_trig_pfc": 11521
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 2,
-                "pkts_num_trig_pfc": 11521
-              }
-            },
-            "400000_300m": {
-              "pkts_num_leak_out": 0,
-              "wrr": {
-                "ecn": 1,
-                "limit": 80,
-                "q0_num_of_pkts": 70,
-                "q1_num_of_pkts": 70,
-                "q2_num_of_pkts": 70,
-                "q3_num_of_pkts": 75,
-                "q4_num_of_pkts": 75,
-                "q5_num_of_pkts": 70,
-                "q6_num_of_pkts": 70
-              },
-              "wrr_chg": {
-                "ecn": 1,
-                "limit": 80,
-                "lossless_weight": 30,
-                "lossy_weight": 8,
-                "q0_num_of_pkts": 40,
-                "q1_num_of_pkts": 40,
-                "q2_num_of_pkts": 40,
-                "q3_num_of_pkts": 150,
-                "q4_num_of_pkts": 150,
-                "q5_num_of_pkts": 40,
-                "q6_num_of_pkts": 40
-              }
-            },
-            "400000_40m": {
-              "pkts_num_leak_out": 0
-            },
-            "400000_5m": {
-              "pkts_num_leak_out": 0
-            },
-            "cell_size": 384,
-            "hdrm_pool_wm_multiplier": 1,
-            "shared_res_size_1": {
+    }
+  },
+  "testPortIps": {
+    "0": {
+      "0": {
+        "34": {
+          "peer_addr": "10.0.0.33"
+        },
+        "0": {
+          "peer_addr": "10.0.0.1"
+        },
+        "36": {
+          "peer_addr": "10.0.0.35"
+        },
+        "37": {
+          "peer_addr": "10.0.0.37"
+        },
+        "4": {
+          "peer_addr": "10.0.0.5"
+        },
+        "38": {
+          "peer_addr": "10.0.0.39"
+        },
+        "39": {
+          "peer_addr": "10.0.0.41"
+        },
+        "16": {
+          "peer_addr": "10.0.0.9"
+        },
+        "42": {
+          "peer_addr": "10.0.0.43"
+        },
+        "44": {
+          "peer_addr": "10.0.0.45"
+        },
+        "20": {
+          "peer_addr": "10.0.0.13"
+        },
+        "45": {
+          "peer_addr": "10.0.0.47"
+        },
+        "46": {
+          "peer_addr": "10.0.0.49"
+        },
+        "47": {
+          "peer_addr": "10.0.0.51"
+        },
+        "50": {
+          "peer_addr": "10.0.0.53"
+        },
+        "52": {
+          "peer_addr": "10.0.0.55"
+        },
+        "53": {
+          "peer_addr": "10.0.0.57"
+        },
+        "54": {
+          "peer_addr": "10.0.0.59"
+        },
+        "55": {
+          "peer_addr": "10.0.0.61"
+        },
+        "58": {
+          "peer_addr": "10.0.0.63"
+        },
+        "60": {
+          "peer_addr": "10.0.0.65"
+        },
+        "61": {
+          "peer_addr": "10.0.0.67"
+        },
+        "62": {
+          "peer_addr": "10.0.0.69"
+        },
+        "63": {
+          "peer_addr": "10.0.0.71"
+        }
+      }
+    }
+  },
+  "testPorts": {
+    "dst_port_id": 0,
+    "dst_port_ip": "10.0.0.1",
+    "dst_port_vlan": "None",
+    "dst_port_2_id": 16,
+    "dst_port_2_ip": "10.0.0.9",
+    "dst_port_2_vlan": "None",
+    "dst_port_3_id": 20,
+    "dst_port_3_ip": "10.0.0.13",
+    "dst_port_3_vlan": "None",
+    "src_port_id": 4,
+    "src_port_ip": "10.0.0.5",
+    "src_port_vlan": "None",
+    "uplink_port_ids": [
+      0,
+      4,
+      16,
+      20
+    ],
+    "uplink_port_ips": [
+      "10.0.0.1",
+      "10.0.0.5",
+      "10.0.0.9",
+      "10.0.0.13"
+    ],
+    "uplink_port_names": [
+      "Ethernet0",
+      "Ethernet16",
+      "Ethernet64",
+      "Ethernet80"
+    ],
+    "downlink_port_ids": [
+      34,
+      36,
+      37,
+      38,
+      39,
+      42,
+      44,
+      45,
+      46,
+      47,
+      50,
+      52,
+      53,
+      54,
+      55,
+      58,
+      60,
+      61,
+      62,
+      63
+    ],
+    "downlink_port_ips": [
+      "10.0.0.33",
+      "10.0.0.35",
+      "10.0.0.37",
+      "10.0.0.39",
+      "10.0.0.41",
+      "10.0.0.43",
+      "10.0.0.45",
+      "10.0.0.47",
+      "10.0.0.49",
+      "10.0.0.51",
+      "10.0.0.53",
+      "10.0.0.55",
+      "10.0.0.57",
+      "10.0.0.59",
+      "10.0.0.61",
+      "10.0.0.63",
+      "10.0.0.65",
+      "10.0.0.67",
+      "10.0.0.69",
+      "10.0.0.71"
+    ],
+    "downlink_port_names": [
+      "Ethernet136",
+      "Ethernet144",
+      "Ethernet148",
+      "Ethernet152",
+      "Ethernet156",
+      "Ethernet168",
+      "Ethernet176",
+      "Ethernet180",
+      "Ethernet184",
+      "Ethernet188",
+      "Ethernet200",
+      "Ethernet208",
+      "Ethernet212",
+      "Ethernet216",
+      "Ethernet220",
+      "Ethernet232",
+      "Ethernet240",
+      "Ethernet244",
+      "Ethernet248",
+      "Ethernet252"
+    ]
+  },
+  "qosConfigs": {
+    "qos_params": {
+      "kvm": {
+        "topo-any": {
+          "100000_120000m": {
+            "lossy_queue_1": {
               "cell_size": 384,
+              "dscp": 8,
               "ecn": 1,
               "packet_size": 1350,
-              "pkts_num_margin": 1,
-              "dscps": [
-                8,
-                8,
-                8,
-                8,
-                8,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4
-              ],
-              "pgs": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4
-              ],
-              "queues": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4
-              ],
-              "src_port_i": [
-                0,
-                1,
-                2,
-                3,
-                4,
-                0,
-                0,
-                1,
-                1,
-                2,
-                2,
-                3,
-                3,
-                4,
-                4,
-                5,
-                5
-              ],
-              "dst_port_i": [
-                6,
-                7,
-                8,
-                9,
-                10,
-                6,
-                6,
-                7,
-                7,
-                8,
-                8,
-                9,
-                9,
-                10,
-                10,
-                11,
-                11
-              ],
-              "pkt_counts": [
-                3413,
-                3413,
-                3413,
-                3413,
-                3413,
-                2389,
-                2389,
-                2389,
-                1526,
-                1526,
-                1392,
-                415,
-                415,
-                415,
-                415,
-                42,
-                1
-              ],
-              "shared_limit_bytes": 46661760
+              "pg": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_egr_drp": 16000
             },
-            "shared_res_size_2": {
+            "pg_drop": {
+              "dscp": 3,
+              "ecn": 1,
+              "iterations": 30,
+              "pg": 3,
+              "pkts_num_margin": 30000,
+              "pkts_num_trig_ingr_drp": 524288,
+              "pkts_num_trig_pfc": 262144,
+              "queue": 3
+            },
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless": {
+              "cell_size": 8192,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8140,
+              "pg": 3,
+              "pkts_num_fill_ingr_min": 140,
+              "pkts_num_margin": 6,
+              "pkts_num_trig_pfc": 6412,
+              "queue": 3
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 8192,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 3,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 6403
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 8192,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_egr_drp": 728
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 6144,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 19456,
+              "pkts_num_trig_ingr_drp": 12807,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
               "cell_size": 384,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 3072,
+              "pkts_num_trig_egr_drp": 16000,
+              "queue": 0
+            },
+            "wm_q_wm_all_ports": {
+              "cell_size": 6144,
+              "ecn": 1,
+              "packet_size": 6144,
+              "pkt_count": 3000,
+              "pkts_num_margin": 19456
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 3,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_ingr_drp": 6404,
+              "pkts_num_trig_pfc": 3202
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 4,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_ingr_drp": 6404,
+              "pkts_num_trig_pfc": 3202
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 2,
+              "pkts_num_trig_pfc": 3201
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 2,
+              "pkts_num_trig_pfc": 3201
+            }
+          },
+          "100000_300m": {
+            "pcbb_xoff_1": {
+              "dscp": 3,
               "ecn": 1,
               "packet_size": 1350,
-              "pkts_num_margin": 1,
-              "dscps": [
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3
-              ],
-              "pgs": [
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3
-              ],
-              "queues": [
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3
-              ],
-              "src_port_i": [
-                0,
-                0,
-                1,
-                1,
-                2,
-                2,
-                3,
-                3,
-                4,
-                4,
-                5,
-                5,
-                6
-              ],
-              "dst_port_i": [
-                7,
-                7,
-                8,
-                8,
-                9,
-                9,
-                10,
-                10,
-                11,
-                11,
-                12,
-                12,
-                13
-              ],
-              "pkt_counts": [
-                3527,
-                3527,
-                3527,
-                3527,
-                3527,
-                3527,
-                1798,
-                1798,
-                846,
-                687,
-                687,
-                328,
-                1
-              ],
-              "shared_limit_bytes": 41943552
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3414
             },
+            "pcbb_xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_3": {
+              "dscp": 3,
+              "ecn": 1,
+              "outer_dscp": 2,
+              "packet_size": 1350,
+              "pg": 2,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_4": {
+              "dscp": 4,
+              "ecn": 1,
+              "outer_dscp": 6,
+              "packet_size": 1350,
+              "pg": 6,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3414
+            },
+            "pkts_num_leak_out": 0,
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_pfc": 3415,
+              "pkts_num_trig_ingr_drp": 3703,
+              "packet_size": 1350
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_pfc": 3415,
+              "pkts_num_trig_ingr_drp": 3703,
+              "packet_size": 1350
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_pfc": 3414,
+              "pkts_num_hysteresis": 1877,
+              "pkts_num_dismiss_pfc": 2,
+              "packet_size": 1350
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_pfc": 3414,
+              "pkts_num_hysteresis": 1877,
+              "pkts_num_dismiss_pfc": 2,
+              "packet_size": 1350
+            },
+            "wm_pg_shared_lossless": {
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 4,
+              "packet_size": 1350,
+              "cell_size": 384,
+              "dscp": 3,
+              "pg": 3,
+              "pkts_num_trig_pfc": 14807
+            },
+            "wm_pg_shared_lossy": {
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 4,
+              "packet_size": 1350,
+              "cell_size": 384,
+              "dscp": 8,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 16000
+            },
+            "wm_buf_pool_lossless": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "queue": 3,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_pfc": 3703,
+              "cell_size": 384,
+              "packet_size": 1350
+            },
+            "wm_buf_pool_lossy": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "queue": 0,
+              "pkts_num_trig_egr_drp": 4000,
+              "pkts_num_fill_egr_min": 0,
+              "cell_size": 384,
+              "packet_size": 1350
+            },
+            "wm_q_shared_lossless": {
+              "dscp": 3,
+              "ecn": 1,
+              "queue": 3,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 14815,
+              "pkts_num_margin": 3072,
+              "cell_size": 384
+            },
+            "wm_q_shared_lossy": {
+              "dscp": 8,
+              "ecn": 1,
+              "queue": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 16000,
+              "pkts_num_margin": 3072,
+              "cell_size": 384
+            },
+            "lossy_queue_voq_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "flow_config": "separate",
+              "pkts_num_trig_egr_drp": 16000,
+              "pkts_num_margin": 4,
+              "packet_size": 64,
+              "cell_size": 384
+            },
+            "lossy_queue_voq_2": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "flow_config": "shared",
+              "pkts_num_trig_egr_drp": 16000,
+              "pkts_num_margin": 4,
+              "packet_size": 64,
+              "cell_size": 384
+            },
+            "lossy_queue_voq_3": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 16000,
+              "pkts_num_margin": 4,
+              "packet_size": 1350,
+              "cell_size": 384
+            },
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 16000,
+              "pkts_num_margin": 4,
+              "packet_size": 1350,
+              "cell_size": 384
+            },
+            "lossless_voq_1": {
+              "ecn": 1,
+              "pkts_num_margin": 4,
+              "packet_size": 1350,
+              "pkts_num_trig_pfc": 3415,
+              "dscp": 3,
+              "pg": 3,
+              "num_of_flows": "multiple"
+            },
+            "lossless_voq_2": {
+              "ecn": 1,
+              "pkts_num_margin": 4,
+              "packet_size": 1350,
+              "pkts_num_trig_pfc": 3415,
+              "dscp": 4,
+              "pg": 4,
+              "num_of_flows": "multiple"
+            },
+            "lossless_voq_3": {
+              "ecn": 1,
+              "pkts_num_margin": 4,
+              "packet_size": 1350,
+              "pkts_num_trig_pfc": 3415,
+              "dscp": 3,
+              "pg": 3,
+              "num_of_flows": "single"
+            },
+            "lossless_voq_4": {
+              "ecn": 1,
+              "pkts_num_margin": 4,
+              "packet_size": 1350,
+              "pkts_num_trig_pfc": 3415,
+              "dscp": 4,
+              "pg": 4,
+              "num_of_flows": "single"
+            },
+            "wm_q_wm_all_ports": {
+              "ecn": 1,
+              "pkt_count": 4000,
+              "pkts_num_margin": 3072,
+              "cell_size": 384,
+              "packet_size": 1350
+            },
+            "pg_drop": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "queue": 3,
+              "pkts_num_trig_pfc": 13661,
+              "pkts_num_trig_ingr_drp": 14815,
+              "pkts_num_margin": 365,
+              "iterations": 100
+            }
+          },
+          "100000_40m": {
+            "pcbb_xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_3": {
+              "dscp": 3,
+              "ecn": 1,
+              "outer_dscp": 2,
+              "packet_size": 1350,
+              "pg": 2,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_4": {
+              "dscp": 4,
+              "ecn": 1,
+              "outer_dscp": 6,
+              "packet_size": 1350,
+              "pg": 6,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3414
+            },
+            "pkts_num_leak_out": 0
+          },
+          "100000_5m": {
+            "pcbb_xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_3": {
+              "dscp": 3,
+              "ecn": 1,
+              "outer_dscp": 2,
+              "packet_size": 1350,
+              "pg": 2,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_4": {
+              "dscp": 4,
+              "ecn": 1,
+              "outer_dscp": 6,
+              "packet_size": 1350,
+              "pg": 6,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3414
+            },
+            "pkts_num_leak_out": 0
+          },
+          "400000_120000m": {
+            "lossy_queue_1": {
+              "cell_size": 384,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_egr_drp": 16000
+            },
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless": {
+              "cell_size": 8192,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8140,
+              "pg": 3,
+              "pkts_num_fill_ingr_min": 140,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_pfc": 23085,
+              "queue": 3
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 8192,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 3,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 23043
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 8192,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_egr_drp": 728
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 6144,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 26624,
+              "pkts_num_trig_ingr_drp": 46087,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 384,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 3072,
+              "pkts_num_trig_egr_drp": 16000,
+              "queue": 0
+            },
+            "wm_q_wm_all_ports": {
+              "cell_size": 6144,
+              "ecn": 1,
+              "packet_size": 6144,
+              "pkt_count": 3000,
+              "pkts_num_margin": 19456
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 3,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_ingr_drp": 23044,
+              "pkts_num_trig_pfc": 11522
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 4,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_ingr_drp": 23044,
+              "pkts_num_trig_pfc": 11522
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 2,
+              "pkts_num_trig_pfc": 11521
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 2,
+              "pkts_num_trig_pfc": 11521
+            }
+          },
+          "400000_300m": {
+            "pkts_num_leak_out": 0,
             "wrr": {
               "ecn": 1,
               "limit": 80,
@@ -1033,2095 +782,2271 @@
               "q6_num_of_pkts": 40
             }
           },
-          "topo-t2": {
-            "100000_120000m": {
-              "lossy_queue_1": {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 16000
-              },
-              "lossy_queue_voq_2": {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "flow_config": "shared",
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 16000
-              },
-              "pg_drop": {
-                "cell_size": 8192,
-                "dscp": 3,
-                "ecn": 1,
-                "iterations": 30,
-                "pg": 3,
-                "pkts_num_margin": 30000,
-                "pkts_num_trig_ingr_drp": 524288,
-                "pkts_num_trig_pfc": 262144,
-                "queue": 3
-              },
-              "pkts_num_egr_mem": 1256,
-              "pkts_num_leak_out": 0,
-              "wm_buf_pool_lossless": {
-                "cell_size": 8192,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 6144,
-                "pg": 3,
-                "pkts_num_fill_ingr_min": 181,
-                "pkts_num_trig_pfc": 642,
-                "queue": 3
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 8192,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 6403
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 6144,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 6144,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 1024,
-                "pkts_num_trig_ingr_drp": 855,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 3072,
-                "pkts_num_trig_egr_drp": 16000,
-                "queue": 0
-              },
-              "wm_q_wm_all_ports": {
-                "cell_size": 6144,
-                "ecn": 1,
-                "packet_size": 6144,
-                "pkt_count": 855,
-                "pkts_num_margin": 1024
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 6404,
-                "pkts_num_trig_pfc": 3202
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 4,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 6404,
-                "pkts_num_trig_pfc": 3202
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 4,
-                "pkts_num_trig_pfc": 3202
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 4,
-                "pkts_num_trig_pfc": 3202
-              }
-            },
-            "100000_300m": {
-              "lossless_voq_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "num_of_flows": "multiple",
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3415
-              },
-              "lossless_voq_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "num_of_flows": "multiple",
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3415
-              },
-              "lossless_voq_3": {
-                "dscp": 3,
-                "ecn": 1,
-                "num_of_flows": "single",
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3415
-              },
-              "lossless_voq_4": {
-                "dscp": 4,
-                "ecn": 1,
-                "num_of_flows": "single",
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3415
-              },
-              "lossy_queue_1": {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 0,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_egr_drp": 16000
-              },
-              "pg_drop": {
-                "cell_size": 384,
-                "dscp": 3,
-                "ecn": 1,
-                "iterations": 50,
-                "pg": 3,
-                "pkts_num_margin": 375,
-                "pkts_num_trig_ingr_drp": 14819,
-                "pkts_num_trig_pfc": 13660,
-                "queue": 3
-              },
-              "pkts_num_egr_mem": 6884,
-              "pkts_num_leak_out": 0,
-              "wm_buf_pool_lossless": {
-                "cell_size": 384,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_pfc": 3415,
-                "queue": 3
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 384,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 14804
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 384,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 3072,
-                "pkts_num_trig_ingr_drp": 13660,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 3072,
-                "pkts_num_trig_egr_drp": 16000,
-                "queue": 0
-              },
-              "wm_q_wm_all_ports": {
-                "cell_size": 384,
-                "ecn": 1,
-                "pkt_count": 3000,
-                "pkts_num_margin": 1024
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 3704,
-                "pkts_num_trig_pfc": 3415
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 3704,
-                "pkts_num_trig_pfc": 3415
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 23,
-                "pkts_num_hysteresis": 1365,
-                "pkts_num_trig_pfc": 3415
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 23,
-                "pkts_num_hysteresis": 1365,
-                "pkts_num_trig_pfc": 3415
-              }
-            },
-            "400000_120000m": {
-              "lossy_queue_1": {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 16000
-              },
-              "lossy_queue_voq_2": {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "flow_config": "shared",
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 16000
-              },
-              "pg_drop": {
-                "cell_size": 8192,
-                "dscp": 3,
-                "ecn": 1,
-                "iterations": 30,
-                "pg": 3,
-                "pkts_num_margin": 108000,
-                "pkts_num_trig_ingr_drp": 1887437,
-                "pkts_num_trig_pfc": 943719,
-                "queue": 3
-              },
-              "pkts_num_egr_mem": 957,
-              "pkts_num_leak_out": 0,
-              "wm_buf_pool_lossless": {
-                "cell_size": 8192,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8140,
-                "pg": 3,
-                "pkts_num_fill_ingr_min": 140,
-                "pkts_num_trig_pfc": 642,
-                "queue": 3
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 8192,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 23043
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 6144,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 6144,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 1024,
-                "pkts_num_trig_ingr_drp": 855,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 3072,
-                "pkts_num_trig_egr_drp": 16000,
-                "queue": 0
-              },
-              "wm_q_wm_all_ports": {
-                "cell_size": 6144,
-                "ecn": 1,
-                "packet_size": 6144,
-                "pkt_count": 855,
-                "pkts_num_margin": 1024
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 23044,
-                "pkts_num_trig_pfc": 11522
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 4,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 23044,
-                "pkts_num_trig_pfc": 11522
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 4,
-                "pkts_num_trig_pfc": 11522
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 4,
-                "pkts_num_trig_pfc": 11522
-              }
-            },
-            "400000_300m": {
-              "lossless_voq_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "num_of_flows": "multiple",
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3038
-              },
-              "lossless_voq_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "num_of_flows": "multiple",
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3038
-              },
-              "lossless_voq_3": {
-                "dscp": 3,
-                "ecn": 1,
-                "num_of_flows": "single",
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3038
-              },
-              "lossless_voq_4": {
-                "dscp": 4,
-                "ecn": 1,
-                "num_of_flows": "single",
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3038
-              },
-              "lossy_queue_1": {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 16000
-              },
-              "pg_drop": {
-                "cell_size": 384,
-                "dscp": 3,
-                "ecn": 1,
-                "iterations": 50,
-                "pg": 3,
-                "pkts_num_margin": 375,
-                "pkts_num_trig_ingr_drp": 14816,
-                "pkts_num_trig_pfc": 12152,
-                "queue": 3
-              },
-              "pkts_num_egr_mem": 6884,
-              "pkts_num_leak_out": 0,
-              "wm_buf_pool_lossless": {
-                "cell_size": 384,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_pfc": 3038,
-                "queue": 3
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 384,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 14804
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 384,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 3072,
-                "pkts_num_trig_ingr_drp": 13660,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 3072,
-                "pkts_num_trig_egr_drp": 16000,
-                "queue": 0
-              },
-              "wm_q_wm_all_ports": {
-                "cell_size": 384,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pkt_count": 3000,
-                "pkts_num_margin": 1024
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 10589,
-                "pkts_num_trig_pfc": 9923
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 10589,
-                "pkts_num_trig_pfc": 9923
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 23,
-                "pkts_num_hysteresis": 1140,
-                "pkts_num_trig_pfc": 3038
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 23,
-                "pkts_num_hysteresis": 1140,
-                "pkts_num_trig_pfc": 3038
-              }
-            },
-            "wm_buf_pool_lossy": {
-              "cell_size": 384,
-              "dscp": 8,
-              "ecn": 1,
-              "packet_size": 1350,
-              "pg": 0,
-              "pkts_num_fill_egr_min": 0,
-              "pkts_num_trig_egr_drp": 4000,
-              "queue": 0
-            },
-            "wrr": {
-              "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 70,
-              "q1_num_of_pkts": 70,
-              "q2_num_of_pkts": 70,
-              "q3_num_of_pkts": 75,
-              "q4_num_of_pkts": 75,
-              "q5_num_of_pkts": 70,
-              "q6_num_of_pkts": 70
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 40,
-              "q1_num_of_pkts": 40,
-              "q2_num_of_pkts": 40,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 40,
-              "q6_num_of_pkts": 40
-            }
-          }
-        },
-        "gr": {
-          "topo-any": {
+          "400000_40m": {
+            "pkts_num_leak_out": 0
+          },
+          "400000_5m": {
+            "pkts_num_leak_out": 0
+          },
+          "cell_size": 384,
+          "hdrm_pool_wm_multiplier": 1,
+          "shared_res_size_1": {
             "cell_size": 384,
-            "hdrm_pool_wm_multiplier": 1,
-            "shared_res_size_1": {
-              "cell_size": 384,
-              "ecn": 1,
-              "packet_size": 1350,
-              "pkts_num_margin": 1
-            },
-            "shared_res_size_2": {
-              "cell_size": 384,
-              "ecn": 1,
-              "packet_size": 1350,
-              "pkts_num_margin": 1
-            }
+            "ecn": 1,
+            "packet_size": 1350,
+            "pkts_num_margin": 1,
+            "dscps": [
+              8,
+              8,
+              8,
+              8,
+              8,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4
+            ],
+            "pgs": [
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4
+            ],
+            "queues": [
+              0,
+              0,
+              0,
+              0,
+              0,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4
+            ],
+            "src_port_i": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              0,
+              0,
+              1,
+              1,
+              2,
+              2,
+              3,
+              3,
+              4,
+              4,
+              5,
+              5
+            ],
+            "dst_port_i": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              6,
+              6,
+              7,
+              7,
+              8,
+              8,
+              9,
+              9,
+              10,
+              10,
+              11,
+              11
+            ],
+            "pkt_counts": [
+              3413,
+              3413,
+              3413,
+              3413,
+              3413,
+              2389,
+              2389,
+              2389,
+              1526,
+              1526,
+              1392,
+              415,
+              415,
+              415,
+              415,
+              42,
+              1
+            ],
+            "shared_limit_bytes": 46661760
+          },
+          "shared_res_size_2": {
+            "cell_size": 384,
+            "ecn": 1,
+            "packet_size": 1350,
+            "pkts_num_margin": 1,
+            "dscps": [
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3
+            ],
+            "pgs": [
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3
+            ],
+            "queues": [
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4,
+              3
+            ],
+            "src_port_i": [
+              0,
+              0,
+              1,
+              1,
+              2,
+              2,
+              3,
+              3,
+              4,
+              4,
+              5,
+              5,
+              6
+            ],
+            "dst_port_i": [
+              7,
+              7,
+              8,
+              8,
+              9,
+              9,
+              10,
+              10,
+              11,
+              11,
+              12,
+              12,
+              13
+            ],
+            "pkt_counts": [
+              3527,
+              3527,
+              3527,
+              3527,
+              3527,
+              3527,
+              1798,
+              1798,
+              846,
+              687,
+              687,
+              328,
+              1
+            ],
+            "shared_limit_bytes": 41943552
+          },
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 70,
+            "q1_num_of_pkts": 70,
+            "q2_num_of_pkts": 70,
+            "q3_num_of_pkts": 75,
+            "q4_num_of_pkts": 75,
+            "q5_num_of_pkts": 70,
+            "q6_num_of_pkts": 70
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 40,
+            "q1_num_of_pkts": 40,
+            "q2_num_of_pkts": 40,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 40,
+            "q6_num_of_pkts": 40
           }
         },
-        "j2c+": {
-          "topo-any": {
-            "100000_120000m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 18,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 18,
-                "pkts_num_hdrm_full": 362,
-                "pkts_num_hdrm_partial": 182,
-                "pkts_num_trig_pfc": 37549,
-                "src_port_ids": [
-                  0,
-                  2,
-                  4,
-                  6,
-                  8,
-                  10,
-                  12,
-                  14,
-                  16
-                ]
-              },
-              "internal_hdr_size": 48,
-              "lossy_queue_1": {
-                "dscp": 7,
-                "ecn": 1,
-                "pg": 1,
-                "pkts_num_margin": 200,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "pkts_num_leak_out": 5,
-              "wm_buf_pool_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_ingr_drp": 216064,
-                "pkts_num_trig_pfc": 37549,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 0,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 30,
-                "pkts_num_trig_ingr_drp": 216064,
-                "pkts_num_trig_pfc": 37449
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 51,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_pfc": 37449
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 51,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 216064,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 216064,
-                "pkts_num_trig_pfc": 37449
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 216064,
-                "pkts_num_trig_pfc": 37449
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 37449
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 37449
-              }
-            },
-            "100000_2000m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 18,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 18,
-                "pkts_num_hdrm_full": 362,
-                "pkts_num_hdrm_partial": 182,
-                "pkts_num_trig_pfc": 35208,
-                "src_port_ids": [
-                  0,
-                  2,
-                  4,
-                  6,
-                  8,
-                  10,
-                  12,
-                  14,
-                  16
-                ]
-              },
-              "internal_hdr_size": 48,
-              "lossy_queue_1": {
-                "dscp": 7,
-                "ecn": 1,
-                "pg": 1,
-                "pkts_num_margin": 200,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "pkts_num_leak_out": 5,
-              "wm_buf_pool_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_ingr_drp": 38619,
-                "pkts_num_trig_pfc": 35108,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 0,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 30,
-                "pkts_num_trig_ingr_drp": 38619,
-                "pkts_num_trig_pfc": 35108
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 51,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_pfc": 9874
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 51,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 38619,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 38619,
-                "pkts_num_trig_pfc": 35108
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 38619,
-                "pkts_num_trig_pfc": 35108
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 35108
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 35108
-              }
-            },
-            "100000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 18,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 18,
-                "pkts_num_hdrm_full": 362,
-                "pkts_num_hdrm_partial": 182,
-                "pkts_num_trig_pfc": 9974,
-                "src_port_ids": [
-                  0,
-                  2,
-                  4,
-                  6,
-                  8,
-                  10,
-                  12,
-                  14,
-                  16
-                ]
-              },
-              "internal_hdr_size": 48,
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_margin": 200,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "pkts_num_leak_out": 5,
-              "wm_buf_pool_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_ingr_drp": 10861,
-                "pkts_num_trig_pfc": 9974,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 0,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 30,
-                "pkts_num_trig_ingr_drp": 10861,
-                "pkts_num_trig_pfc": 9874
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 51,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_pfc": 9874
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 51,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 10861,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 10861,
-                "pkts_num_trig_pfc": 9874
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 10861,
-                "pkts_num_trig_pfc": 9874
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 9874
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 9874
-              }
-            },
-            "400000_120000m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 18,
-                "ecn": 1,
-                "margin": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 18,
-                "pkts_num_hdrm_full": 362,
-                "pkts_num_hdrm_partial": 182,
-                "pkts_num_trig_pfc": 37549,
-                "src_port_ids": [
-                  0,
-                  2,
-                  4,
-                  6,
-                  8,
-                  10,
-                  12,
-                  14,
-                  16
-                ]
-              },
-              "internal_hdr_size": 48,
-              "lossy_queue_1": {
-                "dscp": 7,
-                "ecn": 1,
-                "pg": 1,
-                "pkts_num_margin": 3500,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "pkts_num_leak_out": 140,
-              "wm_buf_pool_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_ingr_drp": 750848,
-                "pkts_num_trig_pfc": 28160,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 0,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 30,
-                "pkts_num_trig_ingr_drp": 750848,
-                "pkts_num_trig_pfc": 37449
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 71,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_pfc": 37449
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 71,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 750848,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 750848,
-                "pkts_num_trig_pfc": 37449
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 750848,
-                "pkts_num_trig_pfc": 37449
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 37449
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 37449
-              }
-            },
-            "400000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 18,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 18,
-                "pkts_num_hdrm_full": 362,
-                "pkts_num_hdrm_partial": 182,
-                "pkts_num_trig_pfc": 28260,
-                "src_port_ids": [
-                  0,
-                  2,
-                  4,
-                  6,
-                  8,
-                  10,
-                  12,
-                  14,
-                  16
-                ]
-              },
-              "internal_hdr_size": 48,
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_margin": 3500,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "pkts_num_leak_out": 71,
-              "wm_buf_pool_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_ingr_drp": 28187,
-                "pkts_num_trig_pfc": 28160,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 0,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 30,
-                "pkts_num_trig_ingr_drp": 28187,
-                "pkts_num_trig_pfc": 28160
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 71,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_pfc": 28160
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 71,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 28187,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 28187,
-                "pkts_num_trig_pfc": 28160
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 28187,
-                "pkts_num_trig_pfc": 28160
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 28160
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 28160
-              }
-            },
-            "cell_size": 4096,
-            "ecn_1": {
-              "cell_size": 4096,
-              "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_2": {
-              "cell_size": 4096,
-              "dscp": 8,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "ecn_3": {
-              "cell_size": 4096,
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_4": {
-              "cell_size": 4096,
-              "dscp": 0,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "hdrm_pool_wm_multiplier": 1,
-            "wrr": {
-              "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 150,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80
-            }
-          }
-        },
-        "jr2": {
-          "topo-any": {
-            "100000_120000m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 18,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 18,
-                "pkts_num_hdrm_full": 362,
-                "pkts_num_hdrm_partial": 182,
-                "pkts_num_trig_pfc": 37549,
-                "src_port_ids": [
-                  0,
-                  2,
-                  4,
-                  6,
-                  8,
-                  10,
-                  12,
-                  14,
-                  16
-                ]
-              },
-              "internal_hdr_size": 48,
-              "lossy_queue_1": {
-                "dscp": 7,
-                "ecn": 1,
-                "pg": 1,
-                "pkts_num_margin": 200,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "pkts_num_leak_out": 5,
-              "wm_buf_pool_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_ingr_drp": 55808,
-                "pkts_num_trig_pfc": 37549,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 0,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 30,
-                "pkts_num_trig_ingr_drp": 55808,
-                "pkts_num_trig_pfc": 37449
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 51,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_pfc": 37449
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 51,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 55808,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 55808,
-                "pkts_num_trig_pfc": 37449
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 55808,
-                "pkts_num_trig_pfc": 37449
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 37449
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 37449
-              }
-            },
-            "100000_2000m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 18,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 18,
-                "pkts_num_hdrm_full": 362,
-                "pkts_num_hdrm_partial": 182,
-                "pkts_num_trig_pfc": 35208,
-                "src_port_ids": [
-                  0,
-                  2,
-                  4,
-                  6,
-                  8,
-                  10,
-                  12,
-                  14,
-                  16
-                ]
-              },
-              "internal_hdr_size": 48,
-              "lossy_queue_1": {
-                "dscp": 7,
-                "ecn": 1,
-                "pg": 1,
-                "pkts_num_margin": 200,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "pkts_num_leak_out": 5,
-              "wm_buf_pool_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_ingr_drp": 38619,
-                "pkts_num_trig_pfc": 35108,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 0,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 30,
-                "pkts_num_trig_ingr_drp": 38619,
-                "pkts_num_trig_pfc": 35108
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 51,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_pfc": 9874
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 51,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 38619,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 38619,
-                "pkts_num_trig_pfc": 35108
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 38619,
-                "pkts_num_trig_pfc": 35108
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 35108
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 35108
-              }
-            },
-            "100000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 18,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 18,
-                "pkts_num_hdrm_full": 362,
-                "pkts_num_hdrm_partial": 182,
-                "pkts_num_trig_pfc": 9974,
-                "src_port_ids": [
-                  0,
-                  2,
-                  4,
-                  6,
-                  8,
-                  10,
-                  12,
-                  14,
-                  16
-                ]
-              },
-              "internal_hdr_size": 48,
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "pkts_num_leak_out": 51,
-              "wm_buf_pool_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_ingr_drp": 10861,
-                "pkts_num_trig_pfc": 9974,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 0,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 30,
-                "pkts_num_trig_ingr_drp": 10861,
-                "pkts_num_trig_pfc": 9874
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 51,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_pfc": 9874
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 51,
-                "pkts_num_margin": 40,
-                "pkts_num_trig_egr_drp": 2396745
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 4096,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 10861,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 4096,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 2396745,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 10861,
-                "pkts_num_trig_pfc": 9874
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 100,
-                "pkts_num_trig_ingr_drp": 10861,
-                "pkts_num_trig_pfc": 9874
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 9874
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 200,
-                "pkts_num_margin": 150,
-                "pkts_num_trig_pfc": 9874
-              }
-            },
-            "cell_size": 4096,
-            "ecn_1": {
-              "cell_size": 4096,
-              "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_2": {
-              "cell_size": 4096,
-              "dscp": 8,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "ecn_3": {
-              "cell_size": 4096,
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_4": {
-              "cell_size": 4096,
-              "dscp": 0,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "hdrm_pool_wm_multiplier": 1,
-            "wrr": {
-              "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 150,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80
-            }
-          }
-        },
-        "mellanox": {
-          "topo-any": {
-            "ecn_1": {
-              "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_2": {
-              "dscp": 8,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "ecn_3": {
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_4": {
-              "dscp": 0,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
+        "topo-t2": {
+          "100000_120000m": {
             "lossy_queue_1": {
+              "cell_size": 384,
               "dscp": 8,
               "ecn": 1,
-              "packet_size": 300,
+              "packet_size": 1350,
               "pg": 0,
-              "pkts_num_leak_out": 0,
-              "pkts_num_margin": 4
+              "pkts_num_margin": 4,
+              "pkts_num_trig_egr_drp": 16000
             },
-            "profile": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4,
-                  2,
-                  6
-                ],
-                "ecn": 1,
-                "packet_size": 300,
-                "pgs": [
-                  3,
-                  4,
-                  2,
-                  6
-                ],
-                "pkts_num_fill_min": 0,
-                "pkts_num_leak_out": 0,
-                "pkts_num_trig_pfc": 0
-              },
-              "pkts_num_leak_out": 0,
-              "wm_pg_headroom": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 300,
-                "pg": 3,
-                "pkts_num_leak_out": 0
-              },
-              "wm_q_shared_lossless": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 300,
-                "pkts_num_fill_min": 0,
-                "pkts_num_leak_out": 0,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 300,
-                "pg": 3
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 300,
-                "pg": 4
-              },
-              "xoff_3": {
-                "dscp": 2,
-                "ecn": 1,
-                "packet_size": 300,
-                "pg": 2
-              },
-              "xoff_4": {
-                "dscp": 6,
-                "ecn": 1,
-                "packet_size": 300,
-                "pg": 6
-              }
+            "lossy_queue_voq_2": {
+              "cell_size": 384,
+              "dscp": 8,
+              "ecn": 1,
+              "flow_config": "shared",
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_egr_drp": 16000
             },
-            "wm_buf_pool_lossless": {
+            "pg_drop": {
+              "cell_size": 8192,
               "dscp": 3,
               "ecn": 1,
+              "iterations": 30,
               "pg": 3,
-              "pkts_num_fill_egr_min": 0,
-              "pkts_num_fill_ingr_min": 0,
-              "pkts_num_leak_out": 0,
+              "pkts_num_margin": 30000,
+              "pkts_num_trig_ingr_drp": 524288,
+              "pkts_num_trig_pfc": 262144,
               "queue": 3
             },
-            "wm_buf_pool_lossy": {
-              "dscp": 8,
-              "ecn": 1,
-              "pg": 0,
-              "pkts_num_fill_egr_min": 0,
-              "pkts_num_fill_ingr_min": 0,
-              "pkts_num_leak_out": 0,
-              "queue": 0
-            },
-            "wm_pg_shared_lossless": {
+            "pkts_num_egr_mem": 1256,
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless": {
+              "cell_size": 8192,
               "dscp": 3,
               "ecn": 1,
-              "packet_size": 300,
+              "packet_size": 6144,
+              "pg": 3,
+              "pkts_num_fill_ingr_min": 181,
+              "pkts_num_trig_pfc": 642,
+              "queue": 3
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 8192,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8156,
               "pg": 3,
               "pkts_num_fill_min": 0,
-              "pkts_num_leak_out": 0
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 6403
             },
-            "wm_pg_shared_lossy": {
-              "dscp": 8,
+            "wm_q_shared_lossless": {
+              "cell_size": 6144,
+              "dscp": 3,
               "ecn": 1,
-              "packet_size": 300,
-              "pg": 0,
+              "packet_size": 6144,
               "pkts_num_fill_min": 0,
-              "pkts_num_leak_out": 0
+              "pkts_num_margin": 1024,
+              "pkts_num_trig_ingr_drp": 855,
+              "queue": 3
             },
             "wm_q_shared_lossy": {
+              "cell_size": 384,
               "dscp": 8,
               "ecn": 1,
-              "packet_size": 300,
               "pkts_num_fill_min": 0,
-              "pkts_num_leak_out": 0,
+              "pkts_num_margin": 3072,
+              "pkts_num_trig_egr_drp": 16000,
               "queue": 0
             },
-            "wrr": {
+            "wm_q_wm_all_ports": {
+              "cell_size": 6144,
               "ecn": 1,
-              "limit": 80,
-              "pkts_num_leak_out": 0,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140
+              "packet_size": 6144,
+              "pkt_count": 855,
+              "pkts_num_margin": 1024
             },
-            "wrr_chg": {
+            "xoff_1": {
+              "dscp": 3,
               "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 8,
-              "lossy_weight": 8,
-              "pkts_num_leak_out": 48,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80
+              "packet_size": 8156,
+              "pg": 3,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_ingr_drp": 6404,
+              "pkts_num_trig_pfc": 3202
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 4,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_ingr_drp": 6404,
+              "pkts_num_trig_pfc": 3202
             },
             "xon_1": {
               "dscp": 3,
               "ecn": 1,
-              "packet_size": 300,
+              "packet_size": 8156,
               "pg": 3,
-              "pkts_num_leak_out": 0
+              "pkts_num_dismiss_pfc": 4,
+              "pkts_num_trig_pfc": 3202
             },
             "xon_2": {
               "dscp": 4,
               "ecn": 1,
-              "packet_size": 300,
+              "packet_size": 8156,
               "pg": 4,
+              "pkts_num_dismiss_pfc": 4,
+              "pkts_num_trig_pfc": 3202
+            }
+          },
+          "100000_300m": {
+            "lossless_voq_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "num_of_flows": "multiple",
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3415
+            },
+            "lossless_voq_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "num_of_flows": "multiple",
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3415
+            },
+            "lossless_voq_3": {
+              "dscp": 3,
+              "ecn": 1,
+              "num_of_flows": "single",
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3415
+            },
+            "lossless_voq_4": {
+              "dscp": 4,
+              "ecn": 1,
+              "num_of_flows": "single",
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3415
+            },
+            "lossy_queue_1": {
+              "cell_size": 384,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 0,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_egr_drp": 16000
+            },
+            "pg_drop": {
+              "cell_size": 384,
+              "dscp": 3,
+              "ecn": 1,
+              "iterations": 50,
+              "pg": 3,
+              "pkts_num_margin": 375,
+              "pkts_num_trig_ingr_drp": 14819,
+              "pkts_num_trig_pfc": 13660,
+              "queue": 3
+            },
+            "pkts_num_egr_mem": 6884,
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless": {
+              "cell_size": 384,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_pfc": 3415,
+              "queue": 3
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 384,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 14804
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 384,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 3072,
+              "pkts_num_trig_ingr_drp": 13660,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 384,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 3072,
+              "pkts_num_trig_egr_drp": 16000,
+              "queue": 0
+            },
+            "wm_q_wm_all_ports": {
+              "cell_size": 384,
+              "ecn": 1,
+              "pkt_count": 3000,
+              "pkts_num_margin": 1024
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_ingr_drp": 3704,
+              "pkts_num_trig_pfc": 3415
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_ingr_drp": 3704,
+              "pkts_num_trig_pfc": 3415
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 23,
+              "pkts_num_hysteresis": 1365,
+              "pkts_num_trig_pfc": 3415
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 23,
+              "pkts_num_hysteresis": 1365,
+              "pkts_num_trig_pfc": 3415
+            }
+          },
+          "400000_120000m": {
+            "lossy_queue_1": {
+              "cell_size": 384,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_egr_drp": 16000
+            },
+            "lossy_queue_voq_2": {
+              "cell_size": 384,
+              "dscp": 8,
+              "ecn": 1,
+              "flow_config": "shared",
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_egr_drp": 16000
+            },
+            "pg_drop": {
+              "cell_size": 8192,
+              "dscp": 3,
+              "ecn": 1,
+              "iterations": 30,
+              "pg": 3,
+              "pkts_num_margin": 108000,
+              "pkts_num_trig_ingr_drp": 1887437,
+              "pkts_num_trig_pfc": 943719,
+              "queue": 3
+            },
+            "pkts_num_egr_mem": 957,
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless": {
+              "cell_size": 8192,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8140,
+              "pg": 3,
+              "pkts_num_fill_ingr_min": 140,
+              "pkts_num_trig_pfc": 642,
+              "queue": 3
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 8192,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 3,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 23043
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 6144,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 6144,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 1024,
+              "pkts_num_trig_ingr_drp": 855,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 384,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 3072,
+              "pkts_num_trig_egr_drp": 16000,
+              "queue": 0
+            },
+            "wm_q_wm_all_ports": {
+              "cell_size": 6144,
+              "ecn": 1,
+              "packet_size": 6144,
+              "pkt_count": 855,
+              "pkts_num_margin": 1024
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 3,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_ingr_drp": 23044,
+              "pkts_num_trig_pfc": 11522
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 4,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_ingr_drp": 23044,
+              "pkts_num_trig_pfc": 11522
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 4,
+              "pkts_num_trig_pfc": 11522
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 8156,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 4,
+              "pkts_num_trig_pfc": 11522
+            }
+          },
+          "400000_300m": {
+            "lossless_voq_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "num_of_flows": "multiple",
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3038
+            },
+            "lossless_voq_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "num_of_flows": "multiple",
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3038
+            },
+            "lossless_voq_3": {
+              "dscp": 3,
+              "ecn": 1,
+              "num_of_flows": "single",
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3038
+            },
+            "lossless_voq_4": {
+              "dscp": 4,
+              "ecn": 1,
+              "num_of_flows": "single",
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 3038
+            },
+            "lossy_queue_1": {
+              "cell_size": 384,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_egr_drp": 16000
+            },
+            "pg_drop": {
+              "cell_size": 384,
+              "dscp": 3,
+              "ecn": 1,
+              "iterations": 50,
+              "pg": 3,
+              "pkts_num_margin": 375,
+              "pkts_num_trig_ingr_drp": 14816,
+              "pkts_num_trig_pfc": 12152,
+              "queue": 3
+            },
+            "pkts_num_egr_mem": 6884,
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless": {
+              "cell_size": 384,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_pfc": 3038,
+              "queue": 3
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 384,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 14804
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 384,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 3072,
+              "pkts_num_trig_ingr_drp": 13660,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 384,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 3072,
+              "pkts_num_trig_egr_drp": 16000,
+              "queue": 0
+            },
+            "wm_q_wm_all_ports": {
+              "cell_size": 384,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pkt_count": 3000,
+              "pkts_num_margin": 1024
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_ingr_drp": 10589,
+              "pkts_num_trig_pfc": 9923
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_ingr_drp": 10589,
+              "pkts_num_trig_pfc": 9923
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 23,
+              "pkts_num_hysteresis": 1140,
+              "pkts_num_trig_pfc": 3038
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 23,
+              "pkts_num_hysteresis": 1140,
+              "pkts_num_trig_pfc": 3038
+            }
+          },
+          "wm_buf_pool_lossy": {
+            "cell_size": 384,
+            "dscp": 8,
+            "ecn": 1,
+            "packet_size": 1350,
+            "pg": 0,
+            "pkts_num_fill_egr_min": 0,
+            "pkts_num_trig_egr_drp": 4000,
+            "queue": 0
+          },
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 70,
+            "q1_num_of_pkts": 70,
+            "q2_num_of_pkts": 70,
+            "q3_num_of_pkts": 75,
+            "q4_num_of_pkts": 75,
+            "q5_num_of_pkts": 70,
+            "q6_num_of_pkts": 70
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 40,
+            "q1_num_of_pkts": 40,
+            "q2_num_of_pkts": 40,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 40,
+            "q6_num_of_pkts": 40
+          }
+        }
+      },
+      "gr": {
+        "topo-any": {
+          "cell_size": 384,
+          "hdrm_pool_wm_multiplier": 1,
+          "shared_res_size_1": {
+            "cell_size": 384,
+            "ecn": 1,
+            "packet_size": 1350,
+            "pkts_num_margin": 1
+          },
+          "shared_res_size_2": {
+            "cell_size": 384,
+            "ecn": 1,
+            "packet_size": 1350,
+            "pkts_num_margin": 1
+          }
+        }
+      },
+      "j2c+": {
+        "topo-any": {
+          "100000_120000m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 18,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 37549,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+              ]
+            },
+            "internal_hdr_size": 48,
+            "lossy_queue_1": {
+              "dscp": 7,
+              "ecn": 1,
+              "pg": 1,
+              "pkts_num_margin": 200,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "pkts_num_leak_out": 5,
+            "wm_buf_pool_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_ingr_drp": 216064,
+              "pkts_num_trig_pfc": 37549,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 216064,
+              "pkts_num_trig_pfc": 37449
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_pfc": 37449
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 216064,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 216064,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 216064,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 37449
+            }
+          },
+          "100000_2000m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 18,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 35208,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+              ]
+            },
+            "internal_hdr_size": 48,
+            "lossy_queue_1": {
+              "dscp": 7,
+              "ecn": 1,
+              "pg": 1,
+              "pkts_num_margin": 200,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "pkts_num_leak_out": 5,
+            "wm_buf_pool_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_ingr_drp": 38619,
+              "pkts_num_trig_pfc": 35108,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 38619,
+              "pkts_num_trig_pfc": 35108
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_pfc": 9874
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 38619,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 38619,
+              "pkts_num_trig_pfc": 35108
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 38619,
+              "pkts_num_trig_pfc": 35108
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 35108
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 35108
+            }
+          },
+          "100000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 18,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 9974,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+              ]
+            },
+            "internal_hdr_size": 48,
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_margin": 200,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "pkts_num_leak_out": 5,
+            "wm_buf_pool_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9974,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_pfc": 9874
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 10861,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 9874
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 9874
+            }
+          },
+          "400000_120000m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 18,
+              "ecn": 1,
+              "margin": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 37549,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+              ]
+            },
+            "internal_hdr_size": 48,
+            "lossy_queue_1": {
+              "dscp": 7,
+              "ecn": 1,
+              "pg": 1,
+              "pkts_num_margin": 3500,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "pkts_num_leak_out": 140,
+            "wm_buf_pool_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_ingr_drp": 750848,
+              "pkts_num_trig_pfc": 28160,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 750848,
+              "pkts_num_trig_pfc": 37449
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 71,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_pfc": 37449
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 71,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 750848,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 750848,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 750848,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 37449
+            }
+          },
+          "400000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 18,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 28260,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+              ]
+            },
+            "internal_hdr_size": 48,
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_margin": 3500,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "pkts_num_leak_out": 71,
+            "wm_buf_pool_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_ingr_drp": 28187,
+              "pkts_num_trig_pfc": 28160,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 28187,
+              "pkts_num_trig_pfc": 28160
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 71,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_pfc": 28160
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 71,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 28187,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 28187,
+              "pkts_num_trig_pfc": 28160
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 28187,
+              "pkts_num_trig_pfc": 28160
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 28160
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 28160
+            }
+          },
+          "cell_size": 4096,
+          "ecn_1": {
+            "cell_size": 4096,
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 4096,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 4096,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 4096,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "hdrm_pool_wm_multiplier": 1,
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 150,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80
+          }
+        }
+      },
+      "jr2": {
+        "topo-any": {
+          "100000_120000m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 18,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 37549,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+              ]
+            },
+            "internal_hdr_size": 48,
+            "lossy_queue_1": {
+              "dscp": 7,
+              "ecn": 1,
+              "pg": 1,
+              "pkts_num_margin": 200,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "pkts_num_leak_out": 5,
+            "wm_buf_pool_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_ingr_drp": 55808,
+              "pkts_num_trig_pfc": 37549,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 55808,
+              "pkts_num_trig_pfc": 37449
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_pfc": 37449
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 55808,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 55808,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 55808,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 37449
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 37449
+            }
+          },
+          "100000_2000m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 18,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 35208,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+              ]
+            },
+            "internal_hdr_size": 48,
+            "lossy_queue_1": {
+              "dscp": 7,
+              "ecn": 1,
+              "pg": 1,
+              "pkts_num_margin": 200,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "pkts_num_leak_out": 5,
+            "wm_buf_pool_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_ingr_drp": 38619,
+              "pkts_num_trig_pfc": 35108,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 38619,
+              "pkts_num_trig_pfc": 35108
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_pfc": 9874
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 38619,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 38619,
+              "pkts_num_trig_pfc": 35108
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 38619,
+              "pkts_num_trig_pfc": 35108
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 35108
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 35108
+            }
+          },
+          "100000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 18,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 9974,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+              ]
+            },
+            "internal_hdr_size": 48,
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_margin": 20,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "pkts_num_leak_out": 51,
+            "wm_buf_pool_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9974,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_pfc": 9874
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 51,
+              "pkts_num_margin": 40,
+              "pkts_num_trig_egr_drp": 2396745
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 10861,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 2396745,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 100,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 9874
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 200,
+              "pkts_num_margin": 150,
+              "pkts_num_trig_pfc": 9874
+            }
+          },
+          "cell_size": 4096,
+          "ecn_1": {
+            "cell_size": 4096,
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 4096,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 4096,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 4096,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "hdrm_pool_wm_multiplier": 1,
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 150,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80
+          }
+        }
+      },
+      "mellanox": {
+        "topo-any": {
+          "ecn_1": {
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "lossy_queue_1": {
+            "dscp": 8,
+            "ecn": 1,
+            "packet_size": 300,
+            "pg": 0,
+            "pkts_num_leak_out": 0,
+            "pkts_num_margin": 4
+          },
+          "profile": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4,
+                2,
+                6
+              ],
+              "ecn": 1,
+              "packet_size": 300,
+              "pgs": [
+                3,
+                4,
+                2,
+                6
+              ],
+              "pkts_num_fill_min": 0,
+              "pkts_num_leak_out": 0,
+              "pkts_num_trig_pfc": 0
+            },
+            "pkts_num_leak_out": 0,
+            "wm_pg_headroom": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 300,
+              "pg": 3,
               "pkts_num_leak_out": 0
             },
-            "xon_3": {
+            "wm_q_shared_lossless": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 300,
+              "pkts_num_fill_min": 0,
+              "pkts_num_leak_out": 0,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 300,
+              "pg": 3
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 300,
+              "pg": 4
+            },
+            "xoff_3": {
               "dscp": 2,
               "ecn": 1,
               "packet_size": 300,
-              "pg": 2,
-              "pkts_num_leak_out": 0
+              "pg": 2
             },
-            "xon_4": {
+            "xoff_4": {
               "dscp": 6,
               "ecn": 1,
               "packet_size": 300,
-              "pg": 6,
-              "pkts_num_leak_out": 0
+              "pg": 6
             }
+          },
+          "wm_buf_pool_lossless": {
+            "dscp": 3,
+            "ecn": 1,
+            "pg": 3,
+            "pkts_num_fill_egr_min": 0,
+            "pkts_num_fill_ingr_min": 0,
+            "pkts_num_leak_out": 0,
+            "queue": 3
+          },
+          "wm_buf_pool_lossy": {
+            "dscp": 8,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_fill_egr_min": 0,
+            "pkts_num_fill_ingr_min": 0,
+            "pkts_num_leak_out": 0,
+            "queue": 0
+          },
+          "wm_pg_shared_lossless": {
+            "dscp": 3,
+            "ecn": 1,
+            "packet_size": 300,
+            "pg": 3,
+            "pkts_num_fill_min": 0,
+            "pkts_num_leak_out": 0
+          },
+          "wm_pg_shared_lossy": {
+            "dscp": 8,
+            "ecn": 1,
+            "packet_size": 300,
+            "pg": 0,
+            "pkts_num_fill_min": 0,
+            "pkts_num_leak_out": 0
+          },
+          "wm_q_shared_lossy": {
+            "dscp": 8,
+            "ecn": 1,
+            "packet_size": 300,
+            "pkts_num_fill_min": 0,
+            "pkts_num_leak_out": 0,
+            "queue": 0
+          },
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "pkts_num_leak_out": 0,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 8,
+            "lossy_weight": 8,
+            "pkts_num_leak_out": 48,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80
+          },
+          "xon_1": {
+            "dscp": 3,
+            "ecn": 1,
+            "packet_size": 300,
+            "pg": 3,
+            "pkts_num_leak_out": 0
+          },
+          "xon_2": {
+            "dscp": 4,
+            "ecn": 1,
+            "packet_size": 300,
+            "pg": 4,
+            "pkts_num_leak_out": 0
+          },
+          "xon_3": {
+            "dscp": 2,
+            "ecn": 1,
+            "packet_size": 300,
+            "pg": 2,
+            "pkts_num_leak_out": 0
+          },
+          "xon_4": {
+            "dscp": 6,
+            "ecn": 1,
+            "packet_size": 300,
+            "pg": 6,
+            "pkts_num_leak_out": 0
           }
-        },
-        "pac": {
-          "topo-any": {
-            "100000_300m": {
-              "lossless_voq_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "num_of_flows": "multiple",
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 2390
-              },
-              "lossless_voq_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "num_of_flows": "multiple",
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 2390
-              },
-              "lossless_voq_3": {
-                "dscp": 3,
-                "ecn": 1,
-                "num_of_flows": "single",
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 2390
-              },
-              "lossless_voq_4": {
-                "dscp": 4,
-                "ecn": 1,
-                "num_of_flows": "single",
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 2390
-              },
-              "lossy_queue_1": {
-                "cell_size": 8192,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 8140,
-                "pg": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 10241
-              },
-              "lossy_queue_voq_2": {
-                "cell_size": 8192,
-                "dscp": 8,
-                "ecn": 1,
-                "flow_config": "shared",
-                "packet_size": 8140,
-                "pg": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 10241
-              },
-              "pg_drop": {
-                "dscp": 3,
-                "ecn": 1,
-                "iterations": 30,
-                "pg": 3,
-                "pkts_num_margin": 300,
-                "pkts_num_trig_ingr_drp": 11396,
-                "pkts_num_trig_pfc": 10248,
-                "queue": 3
-              },
-              "pkts_num_leak_out": 0,
-              "wm_buf_pool_lossless": {
-                "cell_size": 384,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_pfc": 2849,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 2849,
-                "pkts_num_trig_pfc": 2562
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 2849,
-                "pkts_num_trig_pfc": 2562
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 2,
-                "pkts_num_hysteresis": 1024,
-                "pkts_num_trig_pfc": 2561
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 2,
-                "pkts_num_hysteresis": 1024,
-                "pkts_num_trig_pfc": 2561
-              }
+        }
+      },
+      "pac": {
+        "topo-any": {
+          "100000_300m": {
+            "lossless_voq_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "num_of_flows": "multiple",
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 2390
             },
-            "lossy_queue_voq_3": {
+            "lossless_voq_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "num_of_flows": "multiple",
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 2390
+            },
+            "lossless_voq_3": {
+              "dscp": 3,
+              "ecn": 1,
+              "num_of_flows": "single",
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 2390
+            },
+            "lossless_voq_4": {
+              "dscp": 4,
+              "ecn": 1,
+              "num_of_flows": "single",
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 2390
+            },
+            "lossy_queue_1": {
               "cell_size": 8192,
               "dscp": 8,
               "ecn": 1,
@@ -3130,76 +3055,258 @@
               "pkts_num_margin": 4,
               "pkts_num_trig_egr_drp": 10241
             },
-            "shared_res_size_1": {
+            "lossy_queue_voq_2": {
+              "cell_size": 8192,
+              "dscp": 8,
+              "ecn": 1,
+              "flow_config": "shared",
+              "packet_size": 8140,
+              "pg": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_egr_drp": 10241
+            },
+            "pg_drop": {
+              "dscp": 3,
+              "ecn": 1,
+              "iterations": 30,
+              "pg": 3,
+              "pkts_num_margin": 300,
+              "pkts_num_trig_ingr_drp": 11396,
+              "pkts_num_trig_pfc": 10248,
+              "queue": 3
+            },
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless": {
               "cell_size": 384,
-              "dscps": [
-                8,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4
-              ],
-              "dst_port_i": [
-                3,
-                3,
-                3,
-                4,
-                4,
-                5,
-                5
-              ],
+              "dscp": 3,
               "ecn": 1,
               "packet_size": 1350,
-              "pgs": [
-                0,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4
-              ],
-              "pkt_counts": [
-                12,
-                2560,
-                2218,
-                1536,
-                1536,
-                1359,
-                1
-              ],
-              "pkts_num_margin": 1,
-              "queues": [
-                0,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4
-              ],
-              "shared_limit_bytes": 14164224,
-              "src_port_i": [
-                0,
-                0,
-                0,
-                1,
-                1,
-                2,
-                2
-              ]
+              "pg": 3,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_pfc": 2849,
+              "queue": 3
             },
-            "wm_buf_pool_lossy": {
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 2849,
+              "pkts_num_trig_pfc": 2562
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 2849,
+              "pkts_num_trig_pfc": 2562
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 2,
+              "pkts_num_hysteresis": 1024,
+              "pkts_num_trig_pfc": 2561
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 2,
+              "pkts_num_hysteresis": 1024,
+              "pkts_num_trig_pfc": 2561
+            }
+          },
+          "lossy_queue_voq_3": {
+            "cell_size": 8192,
+            "dscp": 8,
+            "ecn": 1,
+            "packet_size": 8140,
+            "pg": 0,
+            "pkts_num_margin": 4,
+            "pkts_num_trig_egr_drp": 10241
+          },
+          "shared_res_size_1": {
+            "cell_size": 384,
+            "dscps": [
+              8,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4
+            ],
+            "dst_port_i": [
+              3,
+              3,
+              3,
+              4,
+              4,
+              5,
+              5
+            ],
+            "ecn": 1,
+            "packet_size": 1350,
+            "pgs": [
+              0,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4
+            ],
+            "pkt_counts": [
+              12,
+              2560,
+              2218,
+              1536,
+              1536,
+              1359,
+              1
+            ],
+            "pkts_num_margin": 1,
+            "queues": [
+              0,
+              3,
+              4,
+              3,
+              4,
+              3,
+              4
+            ],
+            "shared_limit_bytes": 14164224,
+            "src_port_i": [
+              0,
+              0,
+              0,
+              1,
+              1,
+              2,
+              2
+            ]
+          },
+          "wm_buf_pool_lossy": {
+            "cell_size": 8192,
+            "dscp": 8,
+            "ecn": 1,
+            "packet_size": 8140,
+            "pg": 0,
+            "pkts_num_fill_egr_min": 3,
+            "pkts_num_trig_egr_drp": 10241,
+            "queue": 0
+          },
+          "wm_pg_shared_lossless": {
+            "cell_size": 384,
+            "dscp": 3,
+            "ecn": 1,
+            "packet_size": 1350,
+            "pg": 3,
+            "pkts_num_fill_min": 0,
+            "pkts_num_margin": 4,
+            "pkts_num_trig_pfc": 11392
+          },
+          "wrr": {
+            "ecn": 1,
+            "limit": 72,
+            "packet_size": 4000,
+            "q0_num_of_pkts": 64,
+            "q1_num_of_pkts": 64,
+            "q2_num_of_pkts": 64,
+            "q3_num_of_pkts": 65,
+            "q4_num_of_pkts": 65,
+            "q5_num_of_pkts": 64,
+            "q6_num_of_pkts": 64
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 72,
+            "lossless_weight": 20,
+            "lossy_weight": 10,
+            "packet_size": 4000,
+            "q0_num_of_pkts": 50,
+            "q1_num_of_pkts": 50,
+            "q2_num_of_pkts": 50,
+            "q3_num_of_pkts": 100,
+            "q4_num_of_pkts": 100,
+            "q5_num_of_pkts": 50,
+            "q6_num_of_pkts": 50
+          }
+        },
+        "topo-t2": {
+          "100000_300m": {
+            "lossless_voq_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "num_of_flows": "multiple",
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 2390
+            },
+            "lossless_voq_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "num_of_flows": "multiple",
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 2390
+            },
+            "lossless_voq_3": {
+              "dscp": 3,
+              "ecn": 1,
+              "num_of_flows": "single",
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 2390
+            },
+            "lossless_voq_4": {
+              "dscp": 4,
+              "ecn": 1,
+              "num_of_flows": "single",
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 2390
+            },
+            "lossy_queue_1": {
               "cell_size": 8192,
               "dscp": 8,
               "ecn": 1,
               "packet_size": 8140,
               "pg": 0,
-              "pkts_num_fill_egr_min": 3,
-              "pkts_num_trig_egr_drp": 10241,
-              "queue": 0
+              "pkts_num_margin": 4,
+              "pkts_num_trig_egr_drp": 10241
+            },
+            "pg_drop": {
+              "cell_size": 384,
+              "dscp": 3,
+              "ecn": 1,
+              "iterations": 30,
+              "pg": 3,
+              "pkts_num_margin": 300,
+              "pkts_num_trig_ingr_drp": 11396,
+              "pkts_num_trig_pfc": 10248,
+              "queue": 3
+            },
+            "pkts_num_egr_mem": 5915,
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless": {
+              "cell_size": 384,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_pfc": 2562,
+              "queue": 3
             },
             "wm_pg_shared_lossless": {
               "cell_size": 384,
@@ -3211,2215 +3318,495 @@
               "pkts_num_margin": 4,
               "pkts_num_trig_pfc": 11392
             },
-            "wrr": {
-              "ecn": 1,
-              "limit": 72,
-              "packet_size": 4000,
-              "q0_num_of_pkts": 64,
-              "q1_num_of_pkts": 64,
-              "q2_num_of_pkts": 64,
-              "q3_num_of_pkts": 65,
-              "q4_num_of_pkts": 65,
-              "q5_num_of_pkts": 64,
-              "q6_num_of_pkts": 64
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 72,
-              "lossless_weight": 20,
-              "lossy_weight": 10,
-              "packet_size": 4000,
-              "q0_num_of_pkts": 50,
-              "q1_num_of_pkts": 50,
-              "q2_num_of_pkts": 50,
-              "q3_num_of_pkts": 100,
-              "q4_num_of_pkts": 100,
-              "q5_num_of_pkts": 50,
-              "q6_num_of_pkts": 50
-            }
-          },
-          "topo-t2": {
-            "100000_300m": {
-              "lossless_voq_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "num_of_flows": "multiple",
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 2390
-              },
-              "lossless_voq_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "num_of_flows": "multiple",
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 2390
-              },
-              "lossless_voq_3": {
-                "dscp": 3,
-                "ecn": 1,
-                "num_of_flows": "single",
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 2390
-              },
-              "lossless_voq_4": {
-                "dscp": 4,
-                "ecn": 1,
-                "num_of_flows": "single",
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 2390
-              },
-              "lossy_queue_1": {
-                "cell_size": 8192,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 8140,
-                "pg": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 10241
-              },
-              "pg_drop": {
-                "cell_size": 384,
-                "dscp": 3,
-                "ecn": 1,
-                "iterations": 30,
-                "pg": 3,
-                "pkts_num_margin": 300,
-                "pkts_num_trig_ingr_drp": 11396,
-                "pkts_num_trig_pfc": 10248,
-                "queue": 3
-              },
-              "pkts_num_egr_mem": 5915,
-              "pkts_num_leak_out": 0,
-              "wm_buf_pool_lossless": {
-                "cell_size": 384,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_pfc": 2562,
-                "queue": 3
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 384,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 11392
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 2849,
-                "pkts_num_trig_pfc": 2562
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 2849,
-                "pkts_num_trig_pfc": 2562
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 21,
-                "pkts_num_hysteresis": 1024,
-                "pkts_num_trig_pfc": 2562
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 21,
-                "pkts_num_hysteresis": 1024,
-                "pkts_num_trig_pfc": 2562
-              }
-            },
-            "wm_buf_pool_lossy": {
-              "cell_size": 8192,
-              "dscp": 8,
-              "ecn": 1,
-              "packet_size": 8140,
-              "pg": 0,
-              "pkts_num_fill_egr_min": 3,
-              "pkts_num_trig_egr_drp": 10241,
-              "queue": 0
-            },
-            "wrr": {
-              "ecn": 1,
-              "limit": 72,
-              "packet_size": 4000,
-              "q0_num_of_pkts": 64,
-              "q1_num_of_pkts": 64,
-              "q2_num_of_pkts": 64,
-              "q3_num_of_pkts": 65,
-              "q4_num_of_pkts": 65,
-              "q5_num_of_pkts": 64,
-              "q6_num_of_pkts": 64
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 72,
-              "lossless_weight": 20,
-              "lossy_weight": 10,
-              "packet_size": 4000,
-              "q0_num_of_pkts": 50,
-              "q1_num_of_pkts": 50,
-              "q2_num_of_pkts": 50,
-              "q3_num_of_pkts": 100,
-              "q4_num_of_pkts": 100,
-              "q5_num_of_pkts": 50,
-              "q6_num_of_pkts": 50
-            }
-          }
-        },
-        "spc3": {
-          "topo-dualtor": {
-            "100000_40m": {
-              "pcbb_xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 177916,
-                "pkts_num_trig_pfc": 176064
-              },
-              "pcbb_xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 177916,
-                "pkts_num_trig_pfc": 176064
-              },
-              "pcbb_xoff_3": {
-                "dscp": 3,
-                "ecn": 1,
-                "outer_dscp": 2,
-                "pg": 2,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 177916,
-                "pkts_num_trig_pfc": 176064
-              },
-              "pcbb_xoff_4": {
-                "dscp": 4,
-                "ecn": 1,
-                "outer_dscp": 6,
-                "pg": 6,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 177916,
-                "pkts_num_trig_pfc": 176064
-              },
-              "pkts_num_leak_out": 0
-            }
-          },
-          "topo-dualtor-64": {
-            "100000_40m": {
-              "pcbb_xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 177916,
-                "pkts_num_trig_pfc": 176064
-              },
-              "pcbb_xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 177916,
-                "pkts_num_trig_pfc": 176064
-              },
-              "pcbb_xoff_3": {
-                "dscp": 3,
-                "ecn": 1,
-                "outer_dscp": 2,
-                "pg": 2,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 177916,
-                "pkts_num_trig_pfc": 176064
-              },
-              "pcbb_xoff_4": {
-                "dscp": 4,
-                "ecn": 1,
-                "outer_dscp": 6,
-                "pg": 6,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 177916,
-                "pkts_num_trig_pfc": 176064
-              },
-              "pkts_num_leak_out": 0
-            }
-          }
-        },
-        "td2": {
-          "topo-any": {
-            "40000_300m": {
-              "breakout": {
-                "pkts_num_leak_out": 48,
-                "wm_buf_pool_lossless": {
-                  "cell_size": 208,
-                  "dscp": 3,
-                  "ecn": 1,
-                  "pg": 3,
-                  "pkts_num_fill_egr_min": 0,
-                  "pkts_num_fill_ingr_min": 6,
-                  "pkts_num_trig_ingr_drp": 5046,
-                  "pkts_num_trig_pfc": 4780,
-                  "queue": 3
-                },
-                "wm_pg_headroom": {
-                  "cell_size": 208,
-                  "dscp": 3,
-                  "ecn": 1,
-                  "pg": 3,
-                  "pkts_num_trig_ingr_drp": 5046,
-                  "pkts_num_trig_pfc": 4780
-                },
-                "wm_pg_shared_lossless": {
-                  "cell_size": 208,
-                  "dscp": 3,
-                  "ecn": 1,
-                  "packet_size": 64,
-                  "pg": 3,
-                  "pkts_num_fill_min": 6,
-                  "pkts_num_trig_pfc": 4780
-                },
-                "wm_q_shared_lossless": {
-                  "cell_size": 208,
-                  "dscp": 3,
-                  "ecn": 1,
-                  "pkts_num_fill_min": 0,
-                  "pkts_num_trig_ingr_drp": 5046,
-                  "queue": 3
-                },
-                "xoff_1": {
-                  "dscp": 3,
-                  "ecn": 1,
-                  "pg": 3,
-                  "pkts_num_trig_ingr_drp": 5046,
-                  "pkts_num_trig_pfc": 4780
-                },
-                "xoff_2": {
-                  "dscp": 4,
-                  "ecn": 1,
-                  "pg": 4,
-                  "pkts_num_trig_ingr_drp": 5046,
-                  "pkts_num_trig_pfc": 4780
-                },
-                "xon_1": {
-                  "dscp": 3,
-                  "ecn": 1,
-                  "pg": 3,
-                  "pkts_num_dismiss_pfc": 18,
-                  "pkts_num_trig_pfc": 4780
-                },
-                "xon_2": {
-                  "dscp": 4,
-                  "ecn": 1,
-                  "pg": 4,
-                  "pkts_num_dismiss_pfc": 18,
-                  "pkts_num_trig_pfc": 4780
-                }
-              },
-              "pkts_num_leak_out": 48,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 0,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 5164,
-                "pkts_num_trig_pfc": 4898,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 5164,
-                "pkts_num_trig_pfc": 4898
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 5164,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 5164,
-                "pkts_num_trig_pfc": 4898
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 5164,
-                "pkts_num_trig_pfc": 4898
-              }
-            },
-            "40000_40m": {
-              "pkts_num_leak_out": 48,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 0,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 5164,
-                "pkts_num_trig_pfc": 4898,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 5164,
-                "pkts_num_trig_pfc": 4898
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 5164,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 5164,
-                "pkts_num_trig_pfc": 4898
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 5164,
-                "pkts_num_trig_pfc": 4898
-              }
-            },
-            "40000_5m": {
-              "pkts_num_leak_out": 48,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 0,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 5164,
-                "pkts_num_trig_pfc": 4898,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 5164,
-                "pkts_num_trig_pfc": 4898
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 5164,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 5164,
-                "pkts_num_trig_pfc": 4898
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 5164,
-                "pkts_num_trig_pfc": 4898
-              }
-            },
-            "ecn_1": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_2": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "ecn_3": {
-              "cell_size": 208,
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_4": {
-              "cell_size": 208,
-              "dscp": 0,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "lossy_queue_1": {
-              "dscp": 8,
-              "ecn": 1,
-              "pg": 0,
-              "pkts_num_trig_egr_drp": 31322
-            },
-            "wm_buf_pool_lossy": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 1,
-              "pg": 0,
-              "pkts_num_fill_egr_min": 8,
-              "pkts_num_fill_ingr_min": 0,
-              "pkts_num_trig_egr_drp": 31322,
-              "queue": 0
-            },
-            "wm_pg_shared_lossless": {
-              "cell_size": 208,
+            "xoff_1": {
               "dscp": 3,
               "ecn": 1,
-              "packet_size": 64,
+              "packet_size": 1350,
               "pg": 3,
-              "pkts_num_fill_min": 6,
-              "pkts_num_trig_pfc": 4898
+              "pkts_num_trig_ingr_drp": 2849,
+              "pkts_num_trig_pfc": 2562
             },
-            "wm_pg_shared_lossy": {
-              "cell_size": 208,
-              "dscp": 1,
+            "xoff_2": {
+              "dscp": 4,
               "ecn": 1,
-              "packet_size": 64,
-              "pg": 0,
-              "pkts_num_fill_min": 0,
-              "pkts_num_trig_egr_drp": 31322
-            },
-            "wm_q_shared_lossy": {
-              "cell_size": 208,
-              "dscp": 1,
-              "ecn": 1,
-              "pkts_num_fill_min": 8,
-              "pkts_num_trig_egr_drp": 31322,
-              "queue": 1
-            },
-            "wrr": {
-              "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80
+              "packet_size": 1350,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 2849,
+              "pkts_num_trig_pfc": 2562
             },
             "xon_1": {
               "dscp": 3,
               "ecn": 1,
+              "packet_size": 1350,
               "pg": 3,
-              "pkts_num_dismiss_pfc": 12,
-              "pkts_num_trig_pfc": 4898
+              "pkts_num_dismiss_pfc": 21,
+              "pkts_num_hysteresis": 1024,
+              "pkts_num_trig_pfc": 2562
             },
             "xon_2": {
               "dscp": 4,
               "ecn": 1,
+              "packet_size": 1350,
               "pg": 4,
-              "pkts_num_dismiss_pfc": 12,
+              "pkts_num_dismiss_pfc": 21,
+              "pkts_num_hysteresis": 1024,
+              "pkts_num_trig_pfc": 2562
+            }
+          },
+          "wm_buf_pool_lossy": {
+            "cell_size": 8192,
+            "dscp": 8,
+            "ecn": 1,
+            "packet_size": 8140,
+            "pg": 0,
+            "pkts_num_fill_egr_min": 3,
+            "pkts_num_trig_egr_drp": 10241,
+            "queue": 0
+          },
+          "wrr": {
+            "ecn": 1,
+            "limit": 72,
+            "packet_size": 4000,
+            "q0_num_of_pkts": 64,
+            "q1_num_of_pkts": 64,
+            "q2_num_of_pkts": 64,
+            "q3_num_of_pkts": 65,
+            "q4_num_of_pkts": 65,
+            "q5_num_of_pkts": 64,
+            "q6_num_of_pkts": 64
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 72,
+            "lossless_weight": 20,
+            "lossy_weight": 10,
+            "packet_size": 4000,
+            "q0_num_of_pkts": 50,
+            "q1_num_of_pkts": 50,
+            "q2_num_of_pkts": 50,
+            "q3_num_of_pkts": 100,
+            "q4_num_of_pkts": 100,
+            "q5_num_of_pkts": 50,
+            "q6_num_of_pkts": 50
+          }
+        }
+      },
+      "spc3": {
+        "topo-dualtor": {
+          "100000_40m": {
+            "pcbb_xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 177916,
+              "pkts_num_trig_pfc": 176064
+            },
+            "pcbb_xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 177916,
+              "pkts_num_trig_pfc": 176064
+            },
+            "pcbb_xoff_3": {
+              "dscp": 3,
+              "ecn": 1,
+              "outer_dscp": 2,
+              "pg": 2,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 177916,
+              "pkts_num_trig_pfc": 176064
+            },
+            "pcbb_xoff_4": {
+              "dscp": 4,
+              "ecn": 1,
+              "outer_dscp": 6,
+              "pg": 6,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 177916,
+              "pkts_num_trig_pfc": 176064
+            },
+            "pkts_num_leak_out": 0
+          }
+        },
+        "topo-dualtor-64": {
+          "100000_40m": {
+            "pcbb_xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 177916,
+              "pkts_num_trig_pfc": 176064
+            },
+            "pcbb_xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 177916,
+              "pkts_num_trig_pfc": 176064
+            },
+            "pcbb_xoff_3": {
+              "dscp": 3,
+              "ecn": 1,
+              "outer_dscp": 2,
+              "pg": 2,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 177916,
+              "pkts_num_trig_pfc": 176064
+            },
+            "pcbb_xoff_4": {
+              "dscp": 4,
+              "ecn": 1,
+              "outer_dscp": 6,
+              "pg": 6,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 177916,
+              "pkts_num_trig_pfc": 176064
+            },
+            "pkts_num_leak_out": 0
+          }
+        }
+      },
+      "td2": {
+        "topo-any": {
+          "40000_300m": {
+            "breakout": {
+              "pkts_num_leak_out": 48,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 0,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 5046,
+                "pkts_num_trig_pfc": 4780,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 5046,
+                "pkts_num_trig_pfc": 4780
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 6,
+                "pkts_num_trig_pfc": 4780
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 5046,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 5046,
+                "pkts_num_trig_pfc": 4780
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 5046,
+                "pkts_num_trig_pfc": 4780
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 18,
+                "pkts_num_trig_pfc": 4780
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 18,
+                "pkts_num_trig_pfc": 4780
+              }
+            },
+            "pkts_num_leak_out": 48,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 5164,
+              "pkts_num_trig_pfc": 4898,
+              "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 5164,
+              "pkts_num_trig_pfc": 4898
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 5164,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 5164,
+              "pkts_num_trig_pfc": 4898
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 5164,
               "pkts_num_trig_pfc": 4898
             }
           },
-          "topo-t0-backend": {
-            "40000_300m": {
-              "pkts_num_leak_out": 48,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 0,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 5006,
-                "pkts_num_trig_pfc": 4703,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 5006,
-                "pkts_num_trig_pfc": 4703
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 6,
-                "pkts_num_trig_pfc": 4703
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 5006,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 5006,
-                "pkts_num_trig_pfc": 4703
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 5006,
-                "pkts_num_trig_pfc": 4703
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 16,
-                "pkts_num_trig_pfc": 4703
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 16,
-                "pkts_num_trig_pfc": 4703
-              }
-            },
-            "lossy_queue_1": {
-              "dscp": 1,
-              "ecn": 1,
-              "pg": 0,
-              "pkts_num_trig_egr_drp": 31322
-            },
-            "wm_buf_pool_lossy": {
+          "40000_40m": {
+            "pkts_num_leak_out": 48,
+            "wm_buf_pool_lossless": {
               "cell_size": 208,
-              "dscp": 1,
+              "dscp": 3,
               "ecn": 1,
-              "pg": 0,
-              "pkts_num_fill_egr_min": 8,
-              "pkts_num_fill_ingr_min": 0,
-              "pkts_num_trig_egr_drp": 31322,
-              "queue": 0
+              "pg": 3,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 5164,
+              "pkts_num_trig_pfc": 4898,
+              "queue": 3
             },
-            "wm_pg_shared_lossy": {
+            "wm_pg_headroom": {
               "cell_size": 208,
-              "dscp": 1,
+              "dscp": 3,
               "ecn": 1,
-              "packet_size": 64,
-              "pg": 0,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 5164,
+              "pkts_num_trig_pfc": 4898
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
               "pkts_num_fill_min": 0,
-              "pkts_num_trig_egr_drp": 31322
+              "pkts_num_trig_ingr_drp": 5164,
+              "queue": 3
             },
-            "wm_q_shared_lossy": {
-              "cell_size": 208,
-              "dscp": 1,
+            "xoff_1": {
+              "dscp": 3,
               "ecn": 1,
-              "pkts_num_fill_min": 8,
-              "pkts_num_trig_egr_drp": 31322,
-              "queue": 0
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 5164,
+              "pkts_num_trig_pfc": 4898
             },
-            "wrr": {
+            "xoff_2": {
+              "dscp": 4,
               "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 5164,
+              "pkts_num_trig_pfc": 4898
             }
           },
-          "topo-t1-backend": {
-            "40000_300m": {
-              "pkts_num_leak_out": 48,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 0,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 6307,
-                "pkts_num_trig_pfc": 6004,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 6307,
-                "pkts_num_trig_pfc": 6004
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 6,
-                "pkts_num_trig_pfc": 6004
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 6307,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 6307,
-                "pkts_num_trig_pfc": 6004
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 6307,
-                "pkts_num_trig_pfc": 6004
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 17,
-                "pkts_num_trig_pfc": 6004
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 17,
-                "pkts_num_trig_pfc": 6004
-              }
-            },
-            "lossy_queue_1": {
-              "dscp": 1,
-              "ecn": 1,
-              "pg": 0,
-              "pkts_num_trig_egr_drp": 31322
-            },
-            "wm_buf_pool_lossy": {
+          "40000_5m": {
+            "pkts_num_leak_out": 48,
+            "wm_buf_pool_lossless": {
               "cell_size": 208,
-              "dscp": 1,
+              "dscp": 3,
               "ecn": 1,
-              "pg": 0,
-              "pkts_num_fill_egr_min": 8,
-              "pkts_num_fill_ingr_min": 0,
-              "pkts_num_trig_egr_drp": 31322,
-              "queue": 0
+              "pg": 3,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 5164,
+              "pkts_num_trig_pfc": 4898,
+              "queue": 3
             },
-            "wm_pg_shared_lossy": {
+            "wm_pg_headroom": {
               "cell_size": 208,
-              "dscp": 1,
+              "dscp": 3,
               "ecn": 1,
-              "packet_size": 64,
-              "pg": 0,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 5164,
+              "pkts_num_trig_pfc": 4898
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
               "pkts_num_fill_min": 0,
-              "pkts_num_trig_egr_drp": 31322
+              "pkts_num_trig_ingr_drp": 5164,
+              "queue": 3
             },
-            "wm_q_shared_lossy": {
-              "cell_size": 208,
-              "dscp": 1,
+            "xoff_1": {
+              "dscp": 3,
               "ecn": 1,
-              "pkts_num_fill_min": 8,
-              "pkts_num_trig_egr_drp": 31322,
-              "queue": 0
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 5164,
+              "pkts_num_trig_pfc": 4898
             },
-            "wrr": {
+            "xoff_2": {
+              "dscp": 4,
               "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80
-            }
-          }
-        },
-        "td3": {
-          "topo-any": {
-            "100000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 10,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 18,
-                "pkts_num_hdrm_full": 362,
-                "pkts_num_hdrm_partial": 182,
-                "pkts_num_trig_pfc": 6301,
-                "src_port_ids": [
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7,
-                  8,
-                  9
-                ]
-              },
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_trig_egr_drp": 84935
-              },
-              "pcbb_xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60829,
-                "pkts_num_trig_pfc": 60204
-              },
-              "pcbb_xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60829,
-                "pkts_num_trig_pfc": 60204
-              },
-              "pcbb_xoff_3": {
-                "dscp": 3,
-                "ecn": 1,
-                "outer_dscp": 2,
-                "pg": 2,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60829,
-                "pkts_num_trig_pfc": 60204
-              },
-              "pcbb_xoff_4": {
-                "dscp": 4,
-                "ecn": 1,
-                "outer_dscp": 6,
-                "pg": 6,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60829,
-                "pkts_num_trig_pfc": 60204
-              },
-              "pkts_num_leak_out": 32,
-              "wm_buf_pool_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 60076,
-                "pkts_num_trig_pfc": 59714,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 14,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 84930,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 60076,
-                "pkts_num_trig_pfc": 59714
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 18,
-                "pkts_num_trig_pfc": 59714
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 84935
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 60076,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 7,
-                "pkts_num_trig_egr_drp": 84935,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60410,
-                "pkts_num_trig_pfc": 59784
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60410,
-                "pkts_num_trig_pfc": 59784
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 18,
-                "pkts_num_trig_pfc": 59714
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 18,
-                "pkts_num_trig_pfc": 59714
-              }
-            },
-            "50000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 10,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 18,
-                "pkts_num_hdrm_full": 240,
-                "pkts_num_hdrm_partial": 182,
-                "pkts_num_trig_pfc": 4478,
-                "src_port_ids": [
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7,
-                  8,
-                  9
-                ]
-              },
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_trig_egr_drp": 112302
-              },
-              "pkts_num_leak_out": 32,
-              "wm_buf_pool_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 58516,
-                "pkts_num_trig_pfc": 58276,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 14,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 58516,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 58516,
-                "pkts_num_trig_pfc": 58276
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 18,
-                "pkts_num_trig_pfc": 58276
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 112302
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 58516,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 7,
-                "pkts_num_trig_egr_drp": 58516,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 50,
-                "pkts_num_trig_ingr_drp": 58816,
-                "pkts_num_trig_pfc": 58576
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 50,
-                "pkts_num_trig_ingr_drp": 58816,
-                "pkts_num_trig_pfc": 58576
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 18,
-                "pkts_num_trig_pfc": 58276
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 18,
-                "pkts_num_trig_pfc": 58276
-              }
-            },
-            "cell_size": 256,
-            "ecn_1": {
-              "cell_size": 256,
-              "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_2": {
-              "cell_size": 256,
-              "dscp": 8,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "ecn_3": {
-              "cell_size": 256,
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_4": {
-              "cell_size": 256,
-              "dscp": 0,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "hdrm_pool_wm_multiplier": 1,
-            "wrr": {
-              "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 5164,
+              "pkts_num_trig_pfc": 4898
             }
           },
-          "topo-dualtor": {
-            "100000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 10,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 18,
-                "pkts_num_hdrm_full": 362,
-                "pkts_num_hdrm_partial": 182,
-                "pkts_num_trig_pfc": 6301,
-                "src_port_ids": [
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7,
-                  8,
-                  9
-                ]
-              },
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_trig_egr_drp": 84935
-              },
-              "pcbb_xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60829,
-                "pkts_num_trig_pfc": 60204
-              },
-              "pcbb_xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60829,
-                "pkts_num_trig_pfc": 60204
-              },
-              "pcbb_xoff_3": {
-                "dscp": 3,
-                "ecn": 1,
-                "outer_dscp": 2,
-                "pg": 2,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60829,
-                "pkts_num_trig_pfc": 60204
-              },
-              "pcbb_xoff_4": {
-                "dscp": 4,
-                "ecn": 1,
-                "outer_dscp": 6,
-                "pg": 6,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60829,
-                "pkts_num_trig_pfc": 60204
-              },
-              "pkts_num_leak_out": 32,
-              "wm_buf_pool_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 60076,
-                "pkts_num_trig_pfc": 59714,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 14,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 84930,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 60076,
-                "pkts_num_trig_pfc": 59714
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 18,
-                "pkts_num_trig_pfc": 59714
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 84935
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 60076,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 7,
-                "pkts_num_trig_egr_drp": 84935,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60829,
-                "pkts_num_trig_pfc": 60204
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60829,
-                "pkts_num_trig_pfc": 60204
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 18,
-                "pkts_num_trig_pfc": 59714
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 18,
-                "pkts_num_trig_pfc": 59714
-              }
-            },
-            "cell_size": 256,
-            "ecn_1": {
-              "cell_size": 256,
-              "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_2": {
-              "cell_size": 256,
-              "dscp": 8,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "ecn_3": {
-              "cell_size": 256,
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_4": {
-              "cell_size": 256,
-              "dscp": 0,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "hdrm_pool_wm_multiplier": 1,
-            "wrr": {
-              "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80
-            }
-          },
-          "topo-dualtor-56": {
-            "100000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 10,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 18,
-                "pkts_num_hdrm_full": 362,
-                "pkts_num_hdrm_partial": 182,
-                "pkts_num_trig_pfc": 6301,
-                "src_port_ids": [
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7,
-                  8,
-                  9
-                ]
-              },
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_trig_egr_drp": 84935
-              },
-              "pcbb_xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 59749,
-                "pkts_num_trig_pfc": 59124
-              },
-              "pcbb_xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 59749,
-                "pkts_num_trig_pfc": 59124
-              },
-              "pcbb_xoff_3": {
-                "dscp": 3,
-                "ecn": 1,
-                "outer_dscp": 2,
-                "pg": 2,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 59749,
-                "pkts_num_trig_pfc": 59124
-              },
-              "pcbb_xoff_4": {
-                "dscp": 4,
-                "ecn": 1,
-                "outer_dscp": 6,
-                "pg": 6,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 59749,
-                "pkts_num_trig_pfc": 59124
-              },
-              "pkts_num_leak_out": 32,
-              "wm_buf_pool_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 60076,
-                "pkts_num_trig_pfc": 59714,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 14,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 84930,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 60076,
-                "pkts_num_trig_pfc": 59714
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 18,
-                "pkts_num_trig_pfc": 59714
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 84935
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 60076,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 7,
-                "pkts_num_trig_egr_drp": 84935,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60410,
-                "pkts_num_trig_pfc": 59784
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60410,
-                "pkts_num_trig_pfc": 59784
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 18,
-                "pkts_num_trig_pfc": 59714
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 18,
-                "pkts_num_trig_pfc": 59714
-              }
-            },
-            "50000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 10,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 18,
-                "pkts_num_hdrm_full": 240,
-                "pkts_num_hdrm_partial": 182,
-                "pkts_num_trig_pfc": 4478,
-                "src_port_ids": [
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7,
-                  8,
-                  9
-                ]
-              },
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_trig_egr_drp": 112302
-              },
-              "pkts_num_leak_out": 32,
-              "wm_buf_pool_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 58516,
-                "pkts_num_trig_pfc": 58276,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 14,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 58516,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 58516,
-                "pkts_num_trig_pfc": 58276
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 18,
-                "pkts_num_trig_pfc": 58276
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 112302
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 58516,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 7,
-                "pkts_num_trig_egr_drp": 58516,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 50,
-                "pkts_num_trig_ingr_drp": 58816,
-                "pkts_num_trig_pfc": 58576
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 50,
-                "pkts_num_trig_ingr_drp": 58816,
-                "pkts_num_trig_pfc": 58576
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 18,
-                "pkts_num_trig_pfc": 58276
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 18,
-                "pkts_num_trig_pfc": 58276
-              }
-            },
-            "cell_size": 256,
-            "ecn_1": {
-              "cell_size": 256,
-              "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_2": {
-              "cell_size": 256,
-              "dscp": 8,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "ecn_3": {
-              "cell_size": 256,
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_4": {
-              "cell_size": 256,
-              "dscp": 0,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "hdrm_pool_wm_multiplier": 1,
-            "wrr": {
-              "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80
-            }
-          },
-          "topo-t1-lag": {
-            "100000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 18,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 18,
-                "pkts_num_hdrm_full": 362,
-                "pkts_num_hdrm_partial": 182,
-                "pkts_num_trig_pfc": 4478,
-                "src_port_ids": [
-                  0,
-                  2,
-                  4,
-                  6,
-                  8,
-                  10,
-                  12,
-                  14,
-                  16
-                ]
-              },
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_trig_egr_drp": 113198
-              },
-              "pkts_num_leak_out": 32,
-              "wm_buf_pool_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 59967,
-                "pkts_num_trig_pfc": 59605,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 14,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 113198,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 59967,
-                "pkts_num_trig_pfc": 59605
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 18,
-                "pkts_num_trig_pfc": 59605
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 113198
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 256,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 59967,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 256,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 7,
-                "pkts_num_trig_egr_drp": 59967,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60228,
-                "pkts_num_trig_pfc": 59605
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 60228,
-                "pkts_num_trig_pfc": 59605
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 18,
-                "pkts_num_trig_pfc": 59605
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 18,
-                "pkts_num_trig_pfc": 59605
-              }
-            },
-            "cell_size": 256,
-            "ecn_1": {
-              "cell_size": 256,
-              "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_2": {
-              "cell_size": 256,
-              "dscp": 8,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "ecn_3": {
-              "cell_size": 256,
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_4": {
-              "cell_size": 256,
-              "dscp": 0,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "hdrm_pool_wm_multiplier": 1,
-            "wrr": {
-              "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80
-            }
-          }
-        },
-        "th": {
-          "topo-any": {
-            "100000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 16,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 4,
-                "pkts_num_hdrm_full": 1292,
-                "pkts_num_hdrm_partial": 1165,
-                "pkts_num_trig_pfc": 2620,
-                "src_port_ids": [
-                  17,
-                  18
-                ]
-              },
-              "pkts_num_leak_out": 36,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 7835,
-                "pkts_num_trig_pfc": 6542,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7835,
-                "pkts_num_trig_pfc": 6542
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_min": 6,
-                "pkts_num_trig_pfc": 6542
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 8,
-                "pkts_num_trig_ingr_drp": 7835,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7835,
-                "pkts_num_trig_pfc": 6542
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 7835,
-                "pkts_num_trig_pfc": 6542
-              }
-            },
-            "40000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 24,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 10,
-                "pkts_num_hdrm_full": 520,
-                "pkts_num_hdrm_partial": 361,
-                "pkts_num_trig_pfc": 1194,
-                "src_port_ids": [
-                  25,
-                  26,
-                  27,
-                  40,
-                  41
-                ]
-              },
-              "pkts_num_leak_out": 19,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 7063,
-                "pkts_num_trig_pfc": 6542,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7063,
-                "pkts_num_trig_pfc": 6542
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 8,
-                "pkts_num_trig_ingr_drp": 7063,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7063,
-                "pkts_num_trig_pfc": 6542
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 7063,
-                "pkts_num_trig_pfc": 6542
-              }
-            },
-            "50000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 5,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 8,
-                "pkts_num_hdrm_full": 682,
-                "pkts_num_hdrm_partial": 267,
-                "pkts_num_trig_pfc": 1458,
-                "src_port_ids": [
-                  1,
-                  2,
-                  3,
-                  4
-                ]
-              },
-              "pkts_num_leak_out": 23,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 7225,
-                "pkts_num_trig_pfc": 6542,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7225,
-                "pkts_num_trig_pfc": 6542
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 8,
-                "pkts_num_trig_ingr_drp": 7225,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7225,
-                "pkts_num_trig_pfc": 6542
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 7225,
-                "pkts_num_trig_pfc": 6542
-              }
-            },
+          "ecn_1": {
             "cell_size": 208,
-            "ecn_1": {
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 208,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 208,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "lossy_queue_1": {
+            "dscp": 8,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_trig_egr_drp": 31322
+          },
+          "wm_buf_pool_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_fill_egr_min": 8,
+            "pkts_num_fill_ingr_min": 0,
+            "pkts_num_trig_egr_drp": 31322,
+            "queue": 0
+          },
+          "wm_pg_shared_lossless": {
+            "cell_size": 208,
+            "dscp": 3,
+            "ecn": 1,
+            "packet_size": 64,
+            "pg": 3,
+            "pkts_num_fill_min": 6,
+            "pkts_num_trig_pfc": 4898
+          },
+          "wm_pg_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 1,
+            "ecn": 1,
+            "packet_size": 64,
+            "pg": 0,
+            "pkts_num_fill_min": 0,
+            "pkts_num_trig_egr_drp": 31322
+          },
+          "wm_q_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 1,
+            "ecn": 1,
+            "pkts_num_fill_min": 8,
+            "pkts_num_trig_egr_drp": 31322,
+            "queue": 1
+          },
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80
+          },
+          "xon_1": {
+            "dscp": 3,
+            "ecn": 1,
+            "pg": 3,
+            "pkts_num_dismiss_pfc": 12,
+            "pkts_num_trig_pfc": 4898
+          },
+          "xon_2": {
+            "dscp": 4,
+            "ecn": 1,
+            "pg": 4,
+            "pkts_num_dismiss_pfc": 12,
+            "pkts_num_trig_pfc": 4898
+          }
+        },
+        "topo-t0-backend": {
+          "40000_300m": {
+            "pkts_num_leak_out": 48,
+            "wm_buf_pool_lossless": {
               "cell_size": 208,
-              "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_2": {
-              "cell_size": 208,
-              "dscp": 8,
+              "dscp": 3,
               "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
+              "pg": 3,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 5006,
+              "pkts_num_trig_pfc": 4703,
+              "queue": 3
             },
-            "ecn_3": {
+            "wm_pg_headroom": {
               "cell_size": 208,
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_4": {
-              "cell_size": 208,
-              "dscp": 0,
+              "dscp": 3,
               "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "hdrm_pool_wm_multiplier": 4,
-            "lossy_queue_1": {
-              "dscp": 8,
-              "ecn": 1,
-              "pg": 0,
-              "pkts_num_trig_egr_drp": 9887
-            },
-            "wm_buf_pool_lossy": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 1,
-              "pg": 0,
-              "pkts_num_fill_egr_min": 8,
-              "pkts_num_fill_ingr_min": 0,
-              "pkts_num_trig_egr_drp": 9887,
-              "queue": 0
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 5006,
+              "pkts_num_trig_pfc": 4703
             },
             "wm_pg_shared_lossless": {
               "cell_size": 208,
@@ -5428,2414 +3815,4027 @@
               "packet_size": 64,
               "pg": 3,
               "pkts_num_fill_min": 6,
-              "pkts_num_trig_pfc": 6542
+              "pkts_num_trig_pfc": 4703
             },
-            "wm_pg_shared_lossy": {
+            "wm_q_shared_lossless": {
               "cell_size": 208,
-              "dscp": 8,
+              "dscp": 3,
               "ecn": 1,
-              "packet_size": 64,
-              "pg": 0,
               "pkts_num_fill_min": 0,
-              "pkts_num_trig_egr_drp": 9887
+              "pkts_num_trig_ingr_drp": 5006,
+              "queue": 3
             },
-            "wm_q_shared_lossy": {
-              "cell_size": 208,
-              "dscp": 8,
+            "xoff_1": {
+              "dscp": 3,
               "ecn": 1,
-              "pkts_num_fill_min": 8,
-              "pkts_num_trig_egr_drp": 9887,
-              "queue": 0
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 5006,
+              "pkts_num_trig_pfc": 4703
             },
-            "wrr": {
+            "xoff_2": {
+              "dscp": 4,
               "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 5006,
+              "pkts_num_trig_pfc": 4703
             },
             "xon_1": {
               "dscp": 3,
               "ecn": 1,
               "pg": 3,
-              "pkts_num_dismiss_pfc": 12,
-              "pkts_num_trig_pfc": 6542
+              "pkts_num_dismiss_pfc": 16,
+              "pkts_num_trig_pfc": 4703
             },
             "xon_2": {
               "dscp": 4,
               "ecn": 1,
               "pg": 4,
-              "pkts_num_dismiss_pfc": 12,
-              "pkts_num_trig_pfc": 6542
+              "pkts_num_dismiss_pfc": 16,
+              "pkts_num_trig_pfc": 4703
             }
           },
-          "topo-t0-64": {
-            "100000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 16,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 4,
-                "pkts_num_hdrm_full": 1292,
-                "pkts_num_hdrm_partial": 1165,
-                "pkts_num_trig_pfc": 2620,
-                "src_port_ids": [
-                  17,
-                  18
-                ]
-              },
-              "pkts_num_leak_out": 36,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 7835,
-                "pkts_num_trig_pfc": 6542,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7835,
-                "pkts_num_trig_pfc": 6542
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_min": 6,
-                "pkts_num_trig_pfc": 6542
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 8,
-                "pkts_num_trig_ingr_drp": 7835,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7835,
-                "pkts_num_trig_pfc": 6542
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 7835,
-                "pkts_num_trig_pfc": 6542
-              }
-            },
-            "40000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 24,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 10,
-                "pkts_num_hdrm_full": 520,
-                "pkts_num_hdrm_partial": 361,
-                "pkts_num_trig_pfc": 1194,
-                "src_port_ids": [
-                  25,
-                  26,
-                  27,
-                  40,
-                  41
-                ]
-              },
-              "pkts_num_leak_out": 19,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 7063,
-                "pkts_num_trig_pfc": 6542,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7063,
-                "pkts_num_trig_pfc": 6542
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 8,
-                "pkts_num_trig_ingr_drp": 7063,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7063,
-                "pkts_num_trig_pfc": 6542
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 7063,
-                "pkts_num_trig_pfc": 6542
-              }
-            },
-            "50000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 5,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 8,
-                "pkts_num_hdrm_full": 682,
-                "pkts_num_hdrm_partial": 267,
-                "pkts_num_trig_pfc": 1458,
-                "src_port_ids": [
-                  1,
-                  2,
-                  3,
-                  4
-                ]
-              },
-              "pkts_num_leak_out": 23,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 7225,
-                "pkts_num_trig_pfc": 6542,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7225,
-                "pkts_num_trig_pfc": 6542
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 8,
-                "pkts_num_trig_ingr_drp": 7225,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7225,
-                "pkts_num_trig_pfc": 6542
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 7225,
-                "pkts_num_trig_pfc": 6542
-              }
-            },
-            "cell_size": 208,
-            "dst_port_ids": [
-              52,
-              53,
-              54
-            ],
-            "ecn_1": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_2": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "ecn_3": {
-              "cell_size": 208,
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_4": {
-              "cell_size": 208,
-              "dscp": 0,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "hdrm_pool_wm_multiplier": 4,
-            "lossy_queue_1": {
-              "dscp": 8,
-              "ecn": 1,
-              "pg": 0,
-              "pkts_num_trig_egr_drp": 9887
-            },
-            "src_port_ids": [
-              22
-            ],
-            "wm_buf_pool_lossy": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 1,
-              "pg": 0,
-              "pkts_num_fill_egr_min": 8,
-              "pkts_num_fill_ingr_min": 0,
-              "pkts_num_trig_egr_drp": 9887,
-              "queue": 0
-            },
-            "wm_pg_shared_lossless": {
-              "cell_size": 208,
-              "dscp": 3,
-              "ecn": 1,
-              "packet_size": 64,
-              "pg": 3,
-              "pkts_num_fill_min": 6,
-              "pkts_num_trig_pfc": 6542
-            },
-            "wm_pg_shared_lossy": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 1,
-              "packet_size": 64,
-              "pg": 0,
-              "pkts_num_fill_min": 0,
-              "pkts_num_trig_egr_drp": 9887
-            },
-            "wm_q_shared_lossy": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 1,
-              "pkts_num_fill_min": 8,
-              "pkts_num_trig_egr_drp": 9887,
-              "queue": 0
-            },
-            "wrr": {
-              "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80
-            },
-            "xon_1": {
-              "dscp": 3,
-              "ecn": 1,
-              "pg": 3,
-              "pkts_num_dismiss_pfc": 12,
-              "pkts_num_trig_pfc": 6542
-            },
-            "xon_2": {
-              "dscp": 4,
-              "ecn": 1,
-              "pg": 4,
-              "pkts_num_dismiss_pfc": 12,
-              "pkts_num_trig_pfc": 6542
-            }
+          "lossy_queue_1": {
+            "dscp": 1,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_trig_egr_drp": 31322
           },
-          "topo-t1-64-lag": {
-            "100000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 16,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 4,
-                "pkts_num_hdrm_full": 1292,
-                "pkts_num_hdrm_partial": 1165,
-                "pkts_num_trig_pfc": 2620,
-                "src_port_ids": [
-                  17,
-                  18
-                ]
-              },
-              "pkts_num_leak_out": 36,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 7835,
-                "pkts_num_trig_pfc": 6542,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7835,
-                "pkts_num_trig_pfc": 6542
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_min": 6,
-                "pkts_num_trig_pfc": 6542
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 8,
-                "pkts_num_trig_ingr_drp": 7835,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7835,
-                "pkts_num_trig_pfc": 6542
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 7835,
-                "pkts_num_trig_pfc": 6542
-              }
-            },
-            "40000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 24,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 10,
-                "pkts_num_hdrm_full": 520,
-                "pkts_num_hdrm_partial": 361,
-                "pkts_num_trig_pfc": 1194,
-                "src_port_ids": [
-                  25,
-                  26,
-                  27,
-                  40,
-                  41
-                ]
-              },
-              "pkts_num_leak_out": 19,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 7063,
-                "pkts_num_trig_pfc": 6542,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7063,
-                "pkts_num_trig_pfc": 6542
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 8,
-                "pkts_num_trig_ingr_drp": 7063,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7063,
-                "pkts_num_trig_pfc": 6542
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 7063,
-                "pkts_num_trig_pfc": 6542
-              }
-            },
-            "50000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 5,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 8,
-                "pkts_num_hdrm_full": 682,
-                "pkts_num_hdrm_partial": 267,
-                "pkts_num_trig_pfc": 1458,
-                "src_port_ids": [
-                  1,
-                  2,
-                  3,
-                  4
-                ]
-              },
-              "pkts_num_leak_out": 23,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 7225,
-                "pkts_num_trig_pfc": 6542,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7225,
-                "pkts_num_trig_pfc": 6542
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 8,
-                "pkts_num_trig_ingr_drp": 7225,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 7225,
-                "pkts_num_trig_pfc": 6542
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 7225,
-                "pkts_num_trig_pfc": 6542
-              }
-            },
+          "wm_buf_pool_lossy": {
             "cell_size": 208,
-            "dst_port_ids": [
-              52,
-              53,
-              54
-            ],
-            "ecn_1": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_2": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "ecn_3": {
-              "cell_size": 208,
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_4": {
-              "cell_size": 208,
-              "dscp": 0,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "hdrm_pool_wm_multiplier": 4,
-            "lossy_queue_1": {
-              "dscp": 8,
-              "ecn": 1,
-              "pg": 0,
-              "pkts_num_trig_egr_drp": 9887
-            },
-            "src_port_ids": [
-              20,
-              50
-            ],
-            "wm_buf_pool_lossy": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 1,
-              "pg": 0,
-              "pkts_num_fill_egr_min": 8,
-              "pkts_num_fill_ingr_min": 0,
-              "pkts_num_trig_egr_drp": 9887,
-              "queue": 0
-            },
-            "wm_pg_shared_lossless": {
-              "cell_size": 208,
-              "dscp": 3,
-              "ecn": 1,
-              "packet_size": 64,
-              "pg": 3,
-              "pkts_num_fill_min": 6,
-              "pkts_num_trig_pfc": 6542
-            },
-            "wm_pg_shared_lossy": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 1,
-              "packet_size": 64,
-              "pg": 0,
-              "pkts_num_fill_min": 0,
-              "pkts_num_trig_egr_drp": 9887
-            },
-            "wm_q_shared_lossy": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 1,
-              "pkts_num_fill_min": 8,
-              "pkts_num_trig_egr_drp": 9887,
-              "queue": 0
-            },
-            "wrr": {
-              "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80
-            },
-            "xon_1": {
-              "dscp": 3,
-              "ecn": 1,
-              "pg": 3,
-              "pkts_num_dismiss_pfc": 12,
-              "pkts_num_trig_pfc": 6542
-            },
-            "xon_2": {
-              "dscp": 4,
-              "ecn": 1,
-              "pg": 4,
-              "pkts_num_dismiss_pfc": 12,
-              "pkts_num_trig_pfc": 6542
-            }
+            "dscp": 1,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_fill_egr_min": 8,
+            "pkts_num_fill_ingr_min": 0,
+            "pkts_num_trig_egr_drp": 31322,
+            "queue": 0
+          },
+          "wm_pg_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 1,
+            "ecn": 1,
+            "packet_size": 64,
+            "pg": 0,
+            "pkts_num_fill_min": 0,
+            "pkts_num_trig_egr_drp": 31322
+          },
+          "wm_q_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 1,
+            "ecn": 1,
+            "pkts_num_fill_min": 8,
+            "pkts_num_trig_egr_drp": 31322,
+            "queue": 0
+          },
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80
           }
         },
-        "th2": {
-          "topo-any": {
-            "100000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 0,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 14,
-                "pkts_num_hdrm_full": 682,
-                "pkts_num_hdrm_partial": 542,
-                "pkts_num_trig_pfc": 1826,
-                "src_port_ids": [
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ]
-              },
-              "pcbb_xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 20425,
-                "pkts_num_trig_pfc": 19939
-              },
-              "pcbb_xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 20425,
-                "pkts_num_trig_pfc": 19939
-              },
-              "pcbb_xoff_3": {
-                "dscp": 3,
-                "ecn": 1,
-                "outer_dscp": 2,
-                "pg": 2,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 20425,
-                "pkts_num_trig_pfc": 19939
-              },
-              "pcbb_xoff_4": {
-                "dscp": 4,
-                "ecn": 1,
-                "outer_dscp": 6,
-                "pg": 6,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 20425,
-                "pkts_num_trig_pfc": 19939
-              },
-              "pkts_num_leak_out": 0,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 16,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 5140,
-                "pkts_num_trig_pfc": 4457,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 5140,
-                "pkts_num_trig_pfc": 4457
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 5140,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 20425,
-                "pkts_num_trig_pfc": 19939
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 20425,
-                "pkts_num_trig_pfc": 19939
-              }
+        "topo-t1-backend": {
+          "40000_300m": {
+            "pkts_num_leak_out": 48,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 6307,
+              "pkts_num_trig_pfc": 6004,
+              "queue": 3
             },
-            "40000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 32,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 19,
-                "pkts_num_hdrm_full": 520,
-                "pkts_num_hdrm_partial": 47,
-                "pkts_num_trig_pfc": 1490,
-                "src_port_ids": [
-                  6,
-                  7,
-                  8,
-                  9,
-                  10,
-                  38,
-                  39,
-                  40,
-                  41,
-                  42
-                ]
-              },
-              "pkts_num_leak_out": 0,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 16,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 4978,
-                "pkts_num_trig_pfc": 4457,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 4978,
-                "pkts_num_trig_pfc": 4457
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 4978,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 4978,
-                "pkts_num_trig_pfc": 4457
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 4978,
-                "pkts_num_trig_pfc": 4457
-              }
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 6307,
+              "pkts_num_trig_pfc": 6004
             },
-            "50000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 0,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 14,
-                "pkts_num_hdrm_full": 682,
-                "pkts_num_hdrm_partial": 542,
-                "pkts_num_trig_pfc": 1826,
-                "src_port_ids": [
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ]
-              },
-              "pkts_num_leak_out": 0,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 16,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 5140,
-                "pkts_num_trig_pfc": 4457,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 5140,
-                "pkts_num_trig_pfc": 4457
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 5140,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 20521,
-                "pkts_num_trig_pfc": 20034
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 20521,
-                "pkts_num_trig_pfc": 20034
-              }
+            "wm_pg_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 6,
+              "pkts_num_trig_pfc": 6004
             },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 6307,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 6307,
+              "pkts_num_trig_pfc": 6004
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 6307,
+              "pkts_num_trig_pfc": 6004
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 17,
+              "pkts_num_trig_pfc": 6004
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 17,
+              "pkts_num_trig_pfc": 6004
+            }
+          },
+          "lossy_queue_1": {
+            "dscp": 1,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_trig_egr_drp": 31322
+          },
+          "wm_buf_pool_lossy": {
             "cell_size": 208,
-            "ecn_1": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_2": {
-              "cell_size": 208,
-              "dscp": 8,
+            "dscp": 1,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_fill_egr_min": 8,
+            "pkts_num_fill_ingr_min": 0,
+            "pkts_num_trig_egr_drp": 31322,
+            "queue": 0
+          },
+          "wm_pg_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 1,
+            "ecn": 1,
+            "packet_size": 64,
+            "pg": 0,
+            "pkts_num_fill_min": 0,
+            "pkts_num_trig_egr_drp": 31322
+          },
+          "wm_q_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 1,
+            "ecn": 1,
+            "pkts_num_fill_min": 8,
+            "pkts_num_trig_egr_drp": 31322,
+            "queue": 0
+          },
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80
+          }
+        }
+      },
+      "td3": {
+        "topo-any": {
+          "100000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 10,
               "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 6301,
+              "src_port_ids": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+              ]
             },
-            "ecn_3": {
-              "cell_size": 208,
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_4": {
-              "cell_size": 208,
-              "dscp": 0,
-              "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
-            },
-            "hdrm_pool_wm_multiplier": 4,
             "lossy_queue_1": {
               "dscp": 8,
               "ecn": 1,
               "pg": 0,
-              "pkts_num_trig_egr_drp": 10692
+              "pkts_num_trig_egr_drp": 84935
+            },
+            "pcbb_xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60829,
+              "pkts_num_trig_pfc": 60204
+            },
+            "pcbb_xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60829,
+              "pkts_num_trig_pfc": 60204
+            },
+            "pcbb_xoff_3": {
+              "dscp": 3,
+              "ecn": 1,
+              "outer_dscp": 2,
+              "pg": 2,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60829,
+              "pkts_num_trig_pfc": 60204
+            },
+            "pcbb_xoff_4": {
+              "dscp": 4,
+              "ecn": 1,
+              "outer_dscp": 6,
+              "pg": 6,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60829,
+              "pkts_num_trig_pfc": 60204
+            },
+            "pkts_num_leak_out": 32,
+            "wm_buf_pool_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 60076,
+              "pkts_num_trig_pfc": 59714,
+              "queue": 3
             },
             "wm_buf_pool_lossy": {
-              "cell_size": 208,
+              "cell_size": 256,
               "dscp": 8,
               "ecn": 1,
               "pg": 0,
+              "pkts_num_fill_egr_min": 14,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 84930,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 60076,
+              "pkts_num_trig_pfc": 59714
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 18,
+              "pkts_num_trig_pfc": 59714
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 84935
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 60076,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 7,
+              "pkts_num_trig_egr_drp": 84935,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60410,
+              "pkts_num_trig_pfc": 59784
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60410,
+              "pkts_num_trig_pfc": 59784
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 18,
+              "pkts_num_trig_pfc": 59714
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 18,
+              "pkts_num_trig_pfc": 59714
+            }
+          },
+          "50000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 10,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 240,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 4478,
+              "src_port_ids": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+              ]
+            },
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 112302
+            },
+            "pkts_num_leak_out": 32,
+            "wm_buf_pool_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 58516,
+              "pkts_num_trig_pfc": 58276,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 14,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 58516,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 58516,
+              "pkts_num_trig_pfc": 58276
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 18,
+              "pkts_num_trig_pfc": 58276
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 112302
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 58516,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 7,
+              "pkts_num_trig_egr_drp": 58516,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 50,
+              "pkts_num_trig_ingr_drp": 58816,
+              "pkts_num_trig_pfc": 58576
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 50,
+              "pkts_num_trig_ingr_drp": 58816,
+              "pkts_num_trig_pfc": 58576
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 18,
+              "pkts_num_trig_pfc": 58276
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 18,
+              "pkts_num_trig_pfc": 58276
+            }
+          },
+          "cell_size": 256,
+          "ecn_1": {
+            "cell_size": 256,
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 256,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 256,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 256,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "hdrm_pool_wm_multiplier": 1,
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80
+          }
+        },
+        "topo-dualtor": {
+          "100000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 10,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 6301,
+              "src_port_ids": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+              ]
+            },
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 84935
+            },
+            "pcbb_xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60829,
+              "pkts_num_trig_pfc": 60204
+            },
+            "pcbb_xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60829,
+              "pkts_num_trig_pfc": 60204
+            },
+            "pcbb_xoff_3": {
+              "dscp": 3,
+              "ecn": 1,
+              "outer_dscp": 2,
+              "pg": 2,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60829,
+              "pkts_num_trig_pfc": 60204
+            },
+            "pcbb_xoff_4": {
+              "dscp": 4,
+              "ecn": 1,
+              "outer_dscp": 6,
+              "pg": 6,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60829,
+              "pkts_num_trig_pfc": 60204
+            },
+            "pkts_num_leak_out": 32,
+            "wm_buf_pool_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 60076,
+              "pkts_num_trig_pfc": 59714,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 14,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 84930,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 60076,
+              "pkts_num_trig_pfc": 59714
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 18,
+              "pkts_num_trig_pfc": 59714
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 84935
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 60076,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 7,
+              "pkts_num_trig_egr_drp": 84935,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60829,
+              "pkts_num_trig_pfc": 60204
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60829,
+              "pkts_num_trig_pfc": 60204
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 18,
+              "pkts_num_trig_pfc": 59714
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 18,
+              "pkts_num_trig_pfc": 59714
+            }
+          },
+          "cell_size": 256,
+          "ecn_1": {
+            "cell_size": 256,
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 256,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 256,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 256,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "hdrm_pool_wm_multiplier": 1,
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80
+          }
+        },
+        "topo-dualtor-56": {
+          "100000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 10,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 6301,
+              "src_port_ids": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+              ]
+            },
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 84935
+            },
+            "pcbb_xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 59749,
+              "pkts_num_trig_pfc": 59124
+            },
+            "pcbb_xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 59749,
+              "pkts_num_trig_pfc": 59124
+            },
+            "pcbb_xoff_3": {
+              "dscp": 3,
+              "ecn": 1,
+              "outer_dscp": 2,
+              "pg": 2,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 59749,
+              "pkts_num_trig_pfc": 59124
+            },
+            "pcbb_xoff_4": {
+              "dscp": 4,
+              "ecn": 1,
+              "outer_dscp": 6,
+              "pg": 6,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 59749,
+              "pkts_num_trig_pfc": 59124
+            },
+            "pkts_num_leak_out": 32,
+            "wm_buf_pool_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 60076,
+              "pkts_num_trig_pfc": 59714,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 14,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 84930,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 60076,
+              "pkts_num_trig_pfc": 59714
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 18,
+              "pkts_num_trig_pfc": 59714
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 84935
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 60076,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 7,
+              "pkts_num_trig_egr_drp": 84935,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60410,
+              "pkts_num_trig_pfc": 59784
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60410,
+              "pkts_num_trig_pfc": 59784
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 18,
+              "pkts_num_trig_pfc": 59714
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 18,
+              "pkts_num_trig_pfc": 59714
+            }
+          },
+          "50000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 10,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 240,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 4478,
+              "src_port_ids": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+              ]
+            },
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 112302
+            },
+            "pkts_num_leak_out": 32,
+            "wm_buf_pool_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 58516,
+              "pkts_num_trig_pfc": 58276,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 14,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 58516,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 58516,
+              "pkts_num_trig_pfc": 58276
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 18,
+              "pkts_num_trig_pfc": 58276
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 112302
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 58516,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 7,
+              "pkts_num_trig_egr_drp": 58516,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 50,
+              "pkts_num_trig_ingr_drp": 58816,
+              "pkts_num_trig_pfc": 58576
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 50,
+              "pkts_num_trig_ingr_drp": 58816,
+              "pkts_num_trig_pfc": 58576
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 18,
+              "pkts_num_trig_pfc": 58276
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 18,
+              "pkts_num_trig_pfc": 58276
+            }
+          },
+          "cell_size": 256,
+          "ecn_1": {
+            "cell_size": 256,
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 256,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 256,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 256,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "hdrm_pool_wm_multiplier": 1,
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80
+          }
+        },
+        "topo-t1-lag": {
+          "100000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 18,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 18,
+              "pkts_num_hdrm_full": 362,
+              "pkts_num_hdrm_partial": 182,
+              "pkts_num_trig_pfc": 4478,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+              ]
+            },
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 113198
+            },
+            "pkts_num_leak_out": 32,
+            "wm_buf_pool_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 59967,
+              "pkts_num_trig_pfc": 59605,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 14,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 113198,
+              "queue": 0
+            },
+            "wm_pg_headroom": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 59967,
+              "pkts_num_trig_pfc": 59605
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 18,
+              "pkts_num_trig_pfc": 59605
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 113198
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 256,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 59967,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 7,
+              "pkts_num_trig_egr_drp": 59967,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60228,
+              "pkts_num_trig_pfc": 59605
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 60228,
+              "pkts_num_trig_pfc": 59605
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 18,
+              "pkts_num_trig_pfc": 59605
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 18,
+              "pkts_num_trig_pfc": 59605
+            }
+          },
+          "cell_size": 256,
+          "ecn_1": {
+            "cell_size": 256,
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 256,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 256,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 256,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "hdrm_pool_wm_multiplier": 1,
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80
+          }
+        }
+      },
+      "th": {
+        "topo-any": {
+          "100000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 16,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 4,
+              "pkts_num_hdrm_full": 1292,
+              "pkts_num_hdrm_partial": 1165,
+              "pkts_num_trig_pfc": 2620,
+              "src_port_ids": [
+                17,
+                18
+              ]
+            },
+            "pkts_num_leak_out": 36,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 7835,
+              "pkts_num_trig_pfc": 6542,
+              "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7835,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_min": 6,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_ingr_drp": 7835,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7835,
+              "pkts_num_trig_pfc": 6542
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 7835,
+              "pkts_num_trig_pfc": 6542
+            }
+          },
+          "40000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 24,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 10,
+              "pkts_num_hdrm_full": 520,
+              "pkts_num_hdrm_partial": 361,
+              "pkts_num_trig_pfc": 1194,
+              "src_port_ids": [
+                25,
+                26,
+                27,
+                40,
+                41
+              ]
+            },
+            "pkts_num_leak_out": 19,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 7063,
+              "pkts_num_trig_pfc": 6542,
+              "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7063,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_ingr_drp": 7063,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7063,
+              "pkts_num_trig_pfc": 6542
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 7063,
+              "pkts_num_trig_pfc": 6542
+            }
+          },
+          "50000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 5,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 8,
+              "pkts_num_hdrm_full": 682,
+              "pkts_num_hdrm_partial": 267,
+              "pkts_num_trig_pfc": 1458,
+              "src_port_ids": [
+                1,
+                2,
+                3,
+                4
+              ]
+            },
+            "pkts_num_leak_out": 23,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 7225,
+              "pkts_num_trig_pfc": 6542,
+              "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7225,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_ingr_drp": 7225,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7225,
+              "pkts_num_trig_pfc": 6542
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 7225,
+              "pkts_num_trig_pfc": 6542
+            }
+          },
+          "cell_size": 208,
+          "ecn_1": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 208,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 208,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "hdrm_pool_wm_multiplier": 4,
+          "lossy_queue_1": {
+            "dscp": 8,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_trig_egr_drp": 9887
+          },
+          "wm_buf_pool_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_fill_egr_min": 8,
+            "pkts_num_fill_ingr_min": 0,
+            "pkts_num_trig_egr_drp": 9887,
+            "queue": 0
+          },
+          "wm_pg_shared_lossless": {
+            "cell_size": 208,
+            "dscp": 3,
+            "ecn": 1,
+            "packet_size": 64,
+            "pg": 3,
+            "pkts_num_fill_min": 6,
+            "pkts_num_trig_pfc": 6542
+          },
+          "wm_pg_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "packet_size": 64,
+            "pg": 0,
+            "pkts_num_fill_min": 0,
+            "pkts_num_trig_egr_drp": 9887
+          },
+          "wm_q_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "pkts_num_fill_min": 8,
+            "pkts_num_trig_egr_drp": 9887,
+            "queue": 0
+          },
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80
+          },
+          "xon_1": {
+            "dscp": 3,
+            "ecn": 1,
+            "pg": 3,
+            "pkts_num_dismiss_pfc": 12,
+            "pkts_num_trig_pfc": 6542
+          },
+          "xon_2": {
+            "dscp": 4,
+            "ecn": 1,
+            "pg": 4,
+            "pkts_num_dismiss_pfc": 12,
+            "pkts_num_trig_pfc": 6542
+          }
+        },
+        "topo-t0-64": {
+          "100000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 16,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 4,
+              "pkts_num_hdrm_full": 1292,
+              "pkts_num_hdrm_partial": 1165,
+              "pkts_num_trig_pfc": 2620,
+              "src_port_ids": [
+                17,
+                18
+              ]
+            },
+            "pkts_num_leak_out": 36,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 7835,
+              "pkts_num_trig_pfc": 6542,
+              "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7835,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_min": 6,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_ingr_drp": 7835,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7835,
+              "pkts_num_trig_pfc": 6542
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 7835,
+              "pkts_num_trig_pfc": 6542
+            }
+          },
+          "40000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 24,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 10,
+              "pkts_num_hdrm_full": 520,
+              "pkts_num_hdrm_partial": 361,
+              "pkts_num_trig_pfc": 1194,
+              "src_port_ids": [
+                25,
+                26,
+                27,
+                40,
+                41
+              ]
+            },
+            "pkts_num_leak_out": 19,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 7063,
+              "pkts_num_trig_pfc": 6542,
+              "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7063,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_ingr_drp": 7063,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7063,
+              "pkts_num_trig_pfc": 6542
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 7063,
+              "pkts_num_trig_pfc": 6542
+            }
+          },
+          "50000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 5,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 8,
+              "pkts_num_hdrm_full": 682,
+              "pkts_num_hdrm_partial": 267,
+              "pkts_num_trig_pfc": 1458,
+              "src_port_ids": [
+                1,
+                2,
+                3,
+                4
+              ]
+            },
+            "pkts_num_leak_out": 23,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 7225,
+              "pkts_num_trig_pfc": 6542,
+              "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7225,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_ingr_drp": 7225,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7225,
+              "pkts_num_trig_pfc": 6542
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 7225,
+              "pkts_num_trig_pfc": 6542
+            }
+          },
+          "cell_size": 208,
+          "dst_port_ids": [
+            52,
+            53,
+            54
+          ],
+          "ecn_1": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 208,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 208,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "hdrm_pool_wm_multiplier": 4,
+          "lossy_queue_1": {
+            "dscp": 8,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_trig_egr_drp": 9887
+          },
+          "src_port_ids": [
+            22
+          ],
+          "wm_buf_pool_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_fill_egr_min": 8,
+            "pkts_num_fill_ingr_min": 0,
+            "pkts_num_trig_egr_drp": 9887,
+            "queue": 0
+          },
+          "wm_pg_shared_lossless": {
+            "cell_size": 208,
+            "dscp": 3,
+            "ecn": 1,
+            "packet_size": 64,
+            "pg": 3,
+            "pkts_num_fill_min": 6,
+            "pkts_num_trig_pfc": 6542
+          },
+          "wm_pg_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "packet_size": 64,
+            "pg": 0,
+            "pkts_num_fill_min": 0,
+            "pkts_num_trig_egr_drp": 9887
+          },
+          "wm_q_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "pkts_num_fill_min": 8,
+            "pkts_num_trig_egr_drp": 9887,
+            "queue": 0
+          },
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80
+          },
+          "xon_1": {
+            "dscp": 3,
+            "ecn": 1,
+            "pg": 3,
+            "pkts_num_dismiss_pfc": 12,
+            "pkts_num_trig_pfc": 6542
+          },
+          "xon_2": {
+            "dscp": 4,
+            "ecn": 1,
+            "pg": 4,
+            "pkts_num_dismiss_pfc": 12,
+            "pkts_num_trig_pfc": 6542
+          }
+        },
+        "topo-t1-64-lag": {
+          "100000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 16,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 4,
+              "pkts_num_hdrm_full": 1292,
+              "pkts_num_hdrm_partial": 1165,
+              "pkts_num_trig_pfc": 2620,
+              "src_port_ids": [
+                17,
+                18
+              ]
+            },
+            "pkts_num_leak_out": 36,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 7835,
+              "pkts_num_trig_pfc": 6542,
+              "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7835,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_min": 6,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_ingr_drp": 7835,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7835,
+              "pkts_num_trig_pfc": 6542
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 7835,
+              "pkts_num_trig_pfc": 6542
+            }
+          },
+          "40000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 24,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 10,
+              "pkts_num_hdrm_full": 520,
+              "pkts_num_hdrm_partial": 361,
+              "pkts_num_trig_pfc": 1194,
+              "src_port_ids": [
+                25,
+                26,
+                27,
+                40,
+                41
+              ]
+            },
+            "pkts_num_leak_out": 19,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 7063,
+              "pkts_num_trig_pfc": 6542,
+              "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7063,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_ingr_drp": 7063,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7063,
+              "pkts_num_trig_pfc": 6542
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 7063,
+              "pkts_num_trig_pfc": 6542
+            }
+          },
+          "50000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 5,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 8,
+              "pkts_num_hdrm_full": 682,
+              "pkts_num_hdrm_partial": 267,
+              "pkts_num_trig_pfc": 1458,
+              "src_port_ids": [
+                1,
+                2,
+                3,
+                4
+              ]
+            },
+            "pkts_num_leak_out": 23,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 7225,
+              "pkts_num_trig_pfc": 6542,
+              "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7225,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_ingr_drp": 7225,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 7225,
+              "pkts_num_trig_pfc": 6542
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 7225,
+              "pkts_num_trig_pfc": 6542
+            }
+          },
+          "cell_size": 208,
+          "dst_port_ids": [
+            52,
+            53,
+            54
+          ],
+          "ecn_1": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 208,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 208,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "hdrm_pool_wm_multiplier": 4,
+          "lossy_queue_1": {
+            "dscp": 8,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_trig_egr_drp": 9887
+          },
+          "src_port_ids": [
+            20,
+            50
+          ],
+          "wm_buf_pool_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_fill_egr_min": 8,
+            "pkts_num_fill_ingr_min": 0,
+            "pkts_num_trig_egr_drp": 9887,
+            "queue": 0
+          },
+          "wm_pg_shared_lossless": {
+            "cell_size": 208,
+            "dscp": 3,
+            "ecn": 1,
+            "packet_size": 64,
+            "pg": 3,
+            "pkts_num_fill_min": 6,
+            "pkts_num_trig_pfc": 6542
+          },
+          "wm_pg_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "packet_size": 64,
+            "pg": 0,
+            "pkts_num_fill_min": 0,
+            "pkts_num_trig_egr_drp": 9887
+          },
+          "wm_q_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "pkts_num_fill_min": 8,
+            "pkts_num_trig_egr_drp": 9887,
+            "queue": 0
+          },
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80
+          },
+          "xon_1": {
+            "dscp": 3,
+            "ecn": 1,
+            "pg": 3,
+            "pkts_num_dismiss_pfc": 12,
+            "pkts_num_trig_pfc": 6542
+          },
+          "xon_2": {
+            "dscp": 4,
+            "ecn": 1,
+            "pg": 4,
+            "pkts_num_dismiss_pfc": 12,
+            "pkts_num_trig_pfc": 6542
+          }
+        }
+      },
+      "th2": {
+        "topo-any": {
+          "100000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 0,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 14,
+              "pkts_num_hdrm_full": 682,
+              "pkts_num_hdrm_partial": 542,
+              "pkts_num_trig_pfc": 1826,
+              "src_port_ids": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7
+              ]
+            },
+            "pcbb_xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 20425,
+              "pkts_num_trig_pfc": 19939
+            },
+            "pcbb_xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 20425,
+              "pkts_num_trig_pfc": 19939
+            },
+            "pcbb_xoff_3": {
+              "dscp": 3,
+              "ecn": 1,
+              "outer_dscp": 2,
+              "pg": 2,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 20425,
+              "pkts_num_trig_pfc": 19939
+            },
+            "pcbb_xoff_4": {
+              "dscp": 4,
+              "ecn": 1,
+              "outer_dscp": 6,
+              "pg": 6,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 20425,
+              "pkts_num_trig_pfc": 19939
+            },
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
               "pkts_num_fill_egr_min": 16,
-              "pkts_num_fill_ingr_min": 0,
-              "pkts_num_trig_egr_drp": 10692,
-              "queue": 0
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 5140,
+              "pkts_num_trig_pfc": 4457,
+              "queue": 3
             },
-            "wm_pg_shared_lossless": {
+            "wm_pg_headroom": {
               "cell_size": 208,
               "dscp": 3,
               "ecn": 1,
-              "packet_size": 64,
               "pg": 3,
-              "pkts_num_fill_min": 6,
+              "pkts_num_trig_ingr_drp": 5140,
               "pkts_num_trig_pfc": 4457
             },
-            "wm_pg_shared_lossy": {
+            "wm_q_shared_lossless": {
               "cell_size": 208,
-              "dscp": 8,
+              "dscp": 3,
               "ecn": 1,
-              "packet_size": 64,
-              "pg": 0,
               "pkts_num_fill_min": 0,
-              "pkts_num_trig_egr_drp": 10692
+              "pkts_num_trig_ingr_drp": 5140,
+              "queue": 3
             },
-            "wm_q_shared_lossy": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 1,
-              "pkts_num_fill_min": 8,
-              "pkts_num_trig_egr_drp": 10692,
-              "queue": 0
-            },
-            "wrr": {
-              "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140,
-              "q7_num_of_pkts": 140
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80,
-              "q7_num_of_pkts": 80
-            },
-            "xon_1": {
+            "xoff_1": {
               "dscp": 3,
               "ecn": 1,
               "pg": 3,
-              "pkts_num_dismiss_pfc": 12,
-              "pkts_num_trig_pfc": 4457
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 20425,
+              "pkts_num_trig_pfc": 19939
             },
-            "xon_2": {
+            "xoff_2": {
               "dscp": 4,
               "ecn": 1,
               "pg": 4,
-              "pkts_num_dismiss_pfc": 12,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 20425,
+              "pkts_num_trig_pfc": 19939
+            }
+          },
+          "40000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 32,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 19,
+              "pkts_num_hdrm_full": 520,
+              "pkts_num_hdrm_partial": 47,
+              "pkts_num_trig_pfc": 1490,
+              "src_port_ids": [
+                6,
+                7,
+                8,
+                9,
+                10,
+                38,
+                39,
+                40,
+                41,
+                42
+              ]
+            },
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 16,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 4978,
+              "pkts_num_trig_pfc": 4457,
+              "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 4978,
+              "pkts_num_trig_pfc": 4457
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 4978,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 4978,
+              "pkts_num_trig_pfc": 4457
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 4978,
               "pkts_num_trig_pfc": 4457
             }
           },
-          "topo-dualtor-aa-56": {
-            "50000_40m": {
-              "pcbb_xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 19939
-              },
-              "pcbb_xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 19939
-              },
-              "pcbb_xoff_3": {
-                "dscp": 3,
-                "ecn": 1,
-                "outer_dscp": 2,
-                "pg": 2,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 19939
-              },
-              "pcbb_xoff_4": {
-                "dscp": 4,
-                "ecn": 1,
-                "outer_dscp": 6,
-                "pg": 6,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 19939
-              }
+          "50000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 0,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 14,
+              "pkts_num_hdrm_full": 682,
+              "pkts_num_hdrm_partial": 542,
+              "pkts_num_trig_pfc": 1826,
+              "src_port_ids": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7
+              ]
+            },
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 16,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 5140,
+              "pkts_num_trig_pfc": 4457,
+              "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 5140,
+              "pkts_num_trig_pfc": 4457
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 5140,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 20521,
+              "pkts_num_trig_pfc": 20034
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 20521,
+              "pkts_num_trig_pfc": 20034
             }
           },
-          "topo-t1-64-lag": {
-            "100000_300m": {
-              "pkts_num_leak_out": 0,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 16,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 4978,
-                "pkts_num_trig_pfc": 4490,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 1,
-                "pkts_num_trig_ingr_drp": 4978,
-                "pkts_num_trig_pfc": 4490
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 4978,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 20481,
-                "pkts_num_trig_pfc": 19994
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 20481,
-                "pkts_num_trig_pfc": 19994
-              }
-            },
-            "100000_40m": {
-              "pkts_num_leak_out": 0,
-              "wm_buf_pool_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 16,
-                "pkts_num_fill_ingr_min": 6,
-                "pkts_num_trig_ingr_drp": 4779,
-                "pkts_num_trig_pfc": 4490,
-                "queue": 3
-              },
-              "wm_pg_headroom": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 1,
-                "pkts_num_trig_ingr_drp": 4779,
-                "pkts_num_trig_pfc": 4490
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 208,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 4779,
-                "queue": 3
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_ingr_drp": 4779,
-                "pkts_num_trig_pfc": 4490
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_ingr_drp": 4779,
-                "pkts_num_trig_pfc": 4490
-              }
-            },
+          "cell_size": 208,
+          "ecn_1": {
             "cell_size": 208,
-            "dst_port_ids": [
-              52,
-              53,
-              54
-            ],
-            "ecn_1": {
-              "cell_size": 208,
-              "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_2": {
-              "cell_size": 208,
-              "dscp": 8,
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 208,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 208,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "hdrm_pool_wm_multiplier": 4,
+          "lossy_queue_1": {
+            "dscp": 8,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_trig_egr_drp": 10692
+          },
+          "wm_buf_pool_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_fill_egr_min": 16,
+            "pkts_num_fill_ingr_min": 0,
+            "pkts_num_trig_egr_drp": 10692,
+            "queue": 0
+          },
+          "wm_pg_shared_lossless": {
+            "cell_size": 208,
+            "dscp": 3,
+            "ecn": 1,
+            "packet_size": 64,
+            "pg": 3,
+            "pkts_num_fill_min": 6,
+            "pkts_num_trig_pfc": 4457
+          },
+          "wm_pg_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "packet_size": 64,
+            "pg": 0,
+            "pkts_num_fill_min": 0,
+            "pkts_num_trig_egr_drp": 10692
+          },
+          "wm_q_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "pkts_num_fill_min": 8,
+            "pkts_num_trig_egr_drp": 10692,
+            "queue": 0
+          },
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140,
+            "q7_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80,
+            "q7_num_of_pkts": 80
+          },
+          "xon_1": {
+            "dscp": 3,
+            "ecn": 1,
+            "pg": 3,
+            "pkts_num_dismiss_pfc": 12,
+            "pkts_num_trig_pfc": 4457
+          },
+          "xon_2": {
+            "dscp": 4,
+            "ecn": 1,
+            "pg": 4,
+            "pkts_num_dismiss_pfc": 12,
+            "pkts_num_trig_pfc": 4457
+          }
+        },
+        "topo-dualtor-aa-56": {
+          "50000_40m": {
+            "pcbb_xoff_1": {
+              "dscp": 3,
               "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 19939
             },
-            "ecn_3": {
-              "cell_size": 208,
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_4": {
-              "cell_size": 208,
-              "dscp": 0,
+            "pcbb_xoff_2": {
+              "dscp": 4,
               "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 19939
             },
-            "hdrm_pool_wm_multiplier": 4,
+            "pcbb_xoff_3": {
+              "dscp": 3,
+              "ecn": 1,
+              "outer_dscp": 2,
+              "pg": 2,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 19939
+            },
+            "pcbb_xoff_4": {
+              "dscp": 4,
+              "ecn": 1,
+              "outer_dscp": 6,
+              "pg": 6,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 19939
+            }
+          }
+        },
+        "topo-t1-64-lag": {
+          "100000_300m": {
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 16,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 4978,
+              "pkts_num_trig_pfc": 4490,
+              "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 1,
+              "pkts_num_trig_ingr_drp": 4978,
+              "pkts_num_trig_pfc": 4490
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 4978,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 20481,
+              "pkts_num_trig_pfc": 19994
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 20481,
+              "pkts_num_trig_pfc": 19994
+            }
+          },
+          "100000_40m": {
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 16,
+              "pkts_num_fill_ingr_min": 6,
+              "pkts_num_trig_ingr_drp": 4779,
+              "pkts_num_trig_pfc": 4490,
+              "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 1,
+              "pkts_num_trig_ingr_drp": 4779,
+              "pkts_num_trig_pfc": 4490
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 4779,
+              "queue": 3
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_trig_ingr_drp": 4779,
+              "pkts_num_trig_pfc": 4490
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_trig_ingr_drp": 4779,
+              "pkts_num_trig_pfc": 4490
+            }
+          },
+          "cell_size": 208,
+          "dst_port_ids": [
+            52,
+            53,
+            54
+          ],
+          "ecn_1": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 208,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 208,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "hdrm_pool_wm_multiplier": 4,
+          "lossy_queue_1": {
+            "dscp": 8,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_trig_egr_drp": 10773
+          },
+          "src_port_ids": [
+            20,
+            50
+          ],
+          "wm_buf_pool_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "pg": 0,
+            "pkts_num_fill_egr_min": 16,
+            "pkts_num_fill_ingr_min": 0,
+            "pkts_num_trig_egr_drp": 10773,
+            "queue": 0
+          },
+          "wm_pg_shared_lossless": {
+            "cell_size": 208,
+            "dscp": 3,
+            "ecn": 1,
+            "packet_size": 64,
+            "pg": 3,
+            "pkts_num_fill_min": 6,
+            "pkts_num_trig_pfc": 4490
+          },
+          "wm_pg_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "packet_size": 64,
+            "pg": 0,
+            "pkts_num_fill_min": 0,
+            "pkts_num_trig_egr_drp": 10773
+          },
+          "wm_q_shared_lossy": {
+            "cell_size": 208,
+            "dscp": 8,
+            "ecn": 1,
+            "pkts_num_fill_min": 8,
+            "pkts_num_trig_egr_drp": 10773,
+            "queue": 0
+          },
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140,
+            "q7_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80,
+            "q7_num_of_pkts": 80
+          },
+          "xon_1": {
+            "dscp": 3,
+            "ecn": 1,
+            "pg": 3,
+            "pkts_num_dismiss_pfc": 12,
+            "pkts_num_trig_pfc": 4490
+          },
+          "xon_2": {
+            "dscp": 4,
+            "ecn": 1,
+            "pg": 4,
+            "pkts_num_dismiss_pfc": 12,
+            "pkts_num_trig_pfc": 4490
+          }
+        }
+      },
+      "th3": {
+        "topo-t0-80": {
+          "100000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 20,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 37,
+              "pkts_num_hdrm_full": 462,
+              "pkts_num_hdrm_partial": 384,
+              "pkts_num_trig_pfc": 2634,
+              "src_port_ids": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+                17,
+                18,
+                19
+              ]
+            },
             "lossy_queue_1": {
               "dscp": 8,
               "ecn": 1,
               "pg": 0,
-              "pkts_num_trig_egr_drp": 10773
+              "pkts_num_margin": 11,
+              "pkts_num_trig_egr_drp": 73394
             },
-            "src_port_ids": [
-              20,
-              50
-            ],
+            "pkts_num_egr_mem": 50,
+            "pkts_num_leak_out": 42,
+            "wm_buf_pool_lossless": {
+              "cell_size": 254,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 7,
+              "pkts_num_trig_ingr_drp": 22488,
+              "pkts_num_trig_pfc": 22026,
+              "queue": 3
+            },
             "wm_buf_pool_lossy": {
-              "cell_size": 208,
+              "cell_size": 254,
               "dscp": 8,
               "ecn": 1,
               "pg": 0,
-              "pkts_num_fill_egr_min": 16,
+              "pkts_num_fill_egr_min": 7,
               "pkts_num_fill_ingr_min": 0,
-              "pkts_num_trig_egr_drp": 10773,
+              "pkts_num_trig_egr_drp": 73394,
               "queue": 0
             },
+            "wm_pg_headroom": {
+              "cell_size": 254,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 8,
+              "pkts_num_trig_ingr_drp": 22488,
+              "pkts_num_trig_pfc": 22026
+            },
             "wm_pg_shared_lossless": {
-              "cell_size": 208,
+              "cell_size": 254,
               "dscp": 3,
               "ecn": 1,
               "packet_size": 64,
               "pg": 3,
-              "pkts_num_fill_min": 6,
-              "pkts_num_trig_pfc": 4490
+              "pkts_num_fill_min": 10,
+              "pkts_num_margin": 1,
+              "pkts_num_trig_pfc": 22026
             },
             "wm_pg_shared_lossy": {
-              "cell_size": 208,
+              "cell_size": 254,
               "dscp": 8,
               "ecn": 1,
               "packet_size": 64,
               "pg": 0,
+              "pkts_num_fill_min": 7,
+              "pkts_num_margin": 10,
+              "pkts_num_trig_egr_drp": 73394
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 254,
+              "dscp": 3,
+              "ecn": 1,
               "pkts_num_fill_min": 0,
-              "pkts_num_trig_egr_drp": 10773
+              "pkts_num_trig_ingr_drp": 22488,
+              "queue": 3
             },
             "wm_q_shared_lossy": {
-              "cell_size": 208,
+              "cell_size": 254,
               "dscp": 8,
               "ecn": 1,
-              "pkts_num_fill_min": 8,
-              "pkts_num_trig_egr_drp": 10773,
+              "pkts_num_fill_min": 7,
+              "pkts_num_trig_egr_drp": 73394,
               "queue": 0
             },
-            "wrr": {
+            "xoff_1": {
+              "dscp": 3,
               "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140,
-              "q7_num_of_pkts": 140
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 22488,
+              "pkts_num_trig_pfc": 22026
             },
-            "wrr_chg": {
+            "xoff_2": {
+              "dscp": 4,
               "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80,
-              "q7_num_of_pkts": 80
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 22488,
+              "pkts_num_trig_pfc": 22026
             },
             "xon_1": {
               "dscp": 3,
               "ecn": 1,
               "pg": 3,
-              "pkts_num_dismiss_pfc": 12,
-              "pkts_num_trig_pfc": 4490
+              "pkts_num_dismiss_pfc": 13,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 22026
             },
             "xon_2": {
               "dscp": 4,
               "ecn": 1,
               "pg": 4,
-              "pkts_num_dismiss_pfc": 12,
-              "pkts_num_trig_pfc": 4490
+              "pkts_num_dismiss_pfc": 13,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 22026
             }
+          },
+          "cell_size": 254,
+          "ecn_1": {
+            "cell_size": 254,
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 254,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 254,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 254,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "hdrm_pool_wm_multiplier": 1,
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140,
+            "q7_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80,
+            "q7_num_of_pkts": 80
           }
         },
-        "th3": {
-          "topo-t0-80": {
-            "100000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 20,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 37,
-                "pkts_num_hdrm_full": 462,
-                "pkts_num_hdrm_partial": 384,
-                "pkts_num_trig_pfc": 2634,
-                "src_port_ids": [
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7,
-                  8,
-                  9,
-                  10,
-                  11,
-                  12,
-                  13,
-                  14,
-                  15,
-                  16,
-                  17,
-                  18,
-                  19
-                ]
-              },
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_margin": 11,
-                "pkts_num_trig_egr_drp": 73394
-              },
-              "pkts_num_egr_mem": 50,
-              "pkts_num_leak_out": 42,
-              "wm_buf_pool_lossless": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 7,
-                "pkts_num_trig_ingr_drp": 22488,
-                "pkts_num_trig_pfc": 22026,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 254,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 7,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 73394,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 8,
-                "pkts_num_trig_ingr_drp": 22488,
-                "pkts_num_trig_pfc": 22026
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 10,
-                "pkts_num_margin": 1,
-                "pkts_num_trig_pfc": 22026
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 254,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 7,
-                "pkts_num_margin": 10,
-                "pkts_num_trig_egr_drp": 73394
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 22488,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 254,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 7,
-                "pkts_num_trig_egr_drp": 73394,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 22488,
-                "pkts_num_trig_pfc": 22026
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 22488,
-                "pkts_num_trig_pfc": 22026
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 13,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 22026
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 13,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 22026
-              }
+        "topo-t1-lag": {
+          "400000_300m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 29,
+              "ecn": 1,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 37,
+              "pkts_num_hdrm_full": 1472,
+              "pkts_num_hdrm_partial": 552,
+              "pkts_num_trig_pfc": 1856,
+              "src_port_ids": [
+                0,
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16,
+                17,
+                18,
+                19,
+                20,
+                21,
+                22,
+                23,
+                24,
+                25,
+                26
+              ]
             },
-            "cell_size": 254,
-            "ecn_1": {
-              "cell_size": 254,
+            "lossy_queue_1": {
               "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_margin": 5,
+              "pkts_num_trig_egr_drp": 50482
             },
-            "ecn_2": {
+            "pkts_num_egr_mem": 101,
+            "pkts_num_leak_out": 109,
+            "wm_buf_pool_lossless": {
+              "cell_size": 254,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 7,
+              "pkts_num_trig_ingr_drp": 16624,
+              "pkts_num_trig_pfc": 15152,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
               "cell_size": 254,
               "dscp": 8,
               "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
+              "pg": 0,
+              "pkts_num_fill_egr_min": 7,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 50482,
+              "queue": 0
             },
-            "ecn_3": {
+            "wm_pg_headroom": {
               "cell_size": 254,
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 16624,
+              "pkts_num_trig_pfc": 15152
             },
-            "ecn_4": {
+            "wm_pg_shared_lossless": {
               "cell_size": 254,
-              "dscp": 0,
+              "dscp": 3,
               "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 10,
+              "pkts_num_margin": 1,
+              "pkts_num_trig_pfc": 15152
             },
-            "hdrm_pool_wm_multiplier": 1,
-            "wrr": {
+            "wm_pg_shared_lossy": {
+              "cell_size": 254,
+              "dscp": 8,
               "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140,
-              "q7_num_of_pkts": 140
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 7,
+              "pkts_num_margin": 1,
+              "pkts_num_trig_egr_drp": 50482
             },
-            "wrr_chg": {
+            "wm_q_shared_lossless": {
+              "cell_size": 254,
+              "dscp": 3,
               "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80,
-              "q7_num_of_pkts": 80
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_ingr_drp": 16624,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 254,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 7,
+              "pkts_num_trig_egr_drp": 50482,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 16624,
+              "pkts_num_trig_pfc": 15152
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_ingr_drp": 16624,
+              "pkts_num_trig_pfc": 15152
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 13,
+              "pkts_num_trig_pfc": 15152
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 13,
+              "pkts_num_trig_pfc": 15152
             }
           },
-          "topo-t1-lag": {
-            "400000_300m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 29,
-                "ecn": 1,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 37,
-                "pkts_num_hdrm_full": 1472,
-                "pkts_num_hdrm_partial": 552,
-                "pkts_num_trig_pfc": 1856,
-                "src_port_ids": [
-                  0,
-                  2,
-                  4,
-                  6,
-                  8,
-                  10,
-                  12,
-                  14,
-                  16,
-                  17,
-                  18,
-                  19,
-                  20,
-                  21,
-                  22,
-                  23,
-                  24,
-                  25,
-                  26
-                ]
-              },
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_margin": 5,
-                "pkts_num_trig_egr_drp": 50482
-              },
-              "pkts_num_egr_mem": 101,
-              "pkts_num_leak_out": 109,
-              "wm_buf_pool_lossless": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_fill_egr_min": 8,
-                "pkts_num_fill_ingr_min": 7,
-                "pkts_num_trig_ingr_drp": 16624,
-                "pkts_num_trig_pfc": 15152,
-                "queue": 3
-              },
-              "wm_buf_pool_lossy": {
-                "cell_size": 254,
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_fill_egr_min": 7,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_egr_drp": 50482,
-                "queue": 0
-              },
-              "wm_pg_headroom": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 16624,
-                "pkts_num_trig_pfc": 15152
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 10,
-                "pkts_num_margin": 1,
-                "pkts_num_trig_pfc": 15152
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 254,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 7,
-                "pkts_num_margin": 1,
-                "pkts_num_trig_egr_drp": 50482
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 16624,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 254,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 7,
-                "pkts_num_trig_egr_drp": 50482,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 16624,
-                "pkts_num_trig_pfc": 15152
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_ingr_drp": 16624,
-                "pkts_num_trig_pfc": 15152
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 13,
-                "pkts_num_trig_pfc": 15152
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 13,
-                "pkts_num_trig_pfc": 15152
-              }
-            },
+          "cell_size": 254,
+          "ecn_1": {
             "cell_size": 254,
-            "ecn_1": {
+            "dscp": 8,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_2": {
+            "cell_size": 254,
+            "dscp": 8,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "ecn_3": {
+            "cell_size": 254,
+            "dscp": 0,
+            "ecn": 0,
+            "limit": 182000,
+            "min_limit": 180000,
+            "num_of_pkts": 5000
+          },
+          "ecn_4": {
+            "cell_size": 254,
+            "dscp": 0,
+            "ecn": 1,
+            "limit": 182320,
+            "min_limit": 0,
+            "num_of_pkts": 2047
+          },
+          "hdrm_pool_wm_multiplier": 1,
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140,
+            "q7_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80,
+            "q7_num_of_pkts": 80
+          }
+        }
+      },
+      "th5": {
+        "topo-t0-standalone": {
+          "200000_5m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 0,
+              "ecn": 1,
+              "margin": 2,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 50,
+              "pkts_num_hdrm_full": 1185,
+              "pkts_num_hdrm_partial": 47,
+              "pkts_num_trig_pfc": 120117,
+              "pkts_num_trig_pfc_multi": [
+                120117,
+                60096,
+                30085,
+                15079,
+                7577,
+                3825,
+                1950,
+                1012,
+                543,
+                308,
+                191,
+                133,
+                103,
+                89,
+                81,
+                78,
+                76,
+                75,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74
+              ],
+              "src_port_ids": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+                17,
+                18,
+                19,
+                20,
+                21,
+                22,
+                23,
+                24,
+                25
+              ]
+            },
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_egr_drp": 120051
+            },
+            "pkts_num_egr_mem": 238,
+            "pkts_num_leak_out": 0,
+            "wm_pg_headroom": {
+              "cell_size": 254,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 121302,
+              "pkts_num_trig_pfc": 120117
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 254,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 74,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_pfc": 120117
+            },
+            "wm_pg_shared_lossy": {
               "cell_size": 254,
               "dscp": 8,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 7,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_egr_drp": 120051
             },
-            "ecn_2": {
+            "wm_q_shared_lossless": {
+              "cell_size": 254,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 121302,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
               "cell_size": 254,
               "dscp": 8,
               "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
+              "pkts_num_fill_min": 7,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_egr_drp": 120051,
+              "queue": 0
             },
-            "ecn_3": {
-              "cell_size": 254,
-              "dscp": 0,
-              "ecn": 0,
-              "limit": 182000,
-              "min_limit": 180000,
-              "num_of_pkts": 5000
-            },
-            "ecn_4": {
-              "cell_size": 254,
-              "dscp": 0,
+            "xoff_1": {
+              "dscp": 3,
               "ecn": 1,
-              "limit": 182320,
-              "min_limit": 0,
-              "num_of_pkts": 2047
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 121302,
+              "pkts_num_trig_pfc": 120117
             },
-            "hdrm_pool_wm_multiplier": 1,
-            "wrr": {
+            "xoff_2": {
+              "dscp": 4,
               "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140,
-              "q7_num_of_pkts": 140
+              "pg": 4,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 121302,
+              "pkts_num_trig_pfc": 120117
             },
-            "wrr_chg": {
+            "xon_1": {
+              "dscp": 3,
               "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80,
-              "q7_num_of_pkts": 80
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 14,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_pfc": 120117
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 14,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_pfc": 120117
             }
+          },
+          "cell_size": 254,
+          "hdrm_pool_wm_multiplier": 1,
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140,
+            "q7_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80,
+            "q7_num_of_pkts": 80
           }
         },
-        "th5": {
-          "topo-t0-standalone": {
-            "200000_5m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 0,
-                "ecn": 1,
-                "margin": 2,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 50,
-                "pkts_num_hdrm_full": 1185,
-                "pkts_num_hdrm_partial": 47,
-                "pkts_num_trig_pfc": 120117,
-                "pkts_num_trig_pfc_multi": [
-                  120117,
-                  60096,
-                  30085,
-                  15079,
-                  7577,
-                  3825,
-                  1950,
-                  1012,
-                  543,
-                  308,
-                  191,
-                  133,
-                  103,
-                  89,
-                  81,
-                  78,
-                  76,
-                  75,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74
-                ],
-                "src_port_ids": [
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7,
-                  8,
-                  9,
-                  10,
-                  11,
-                  12,
-                  13,
-                  14,
-                  15,
-                  16,
-                  17,
-                  18,
-                  19,
-                  20,
-                  21,
-                  22,
-                  23,
-                  24,
-                  25
-                ]
-              },
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_egr_drp": 120051
-              },
-              "pkts_num_egr_mem": 238,
-              "pkts_num_leak_out": 0,
-              "wm_pg_headroom": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 121302,
-                "pkts_num_trig_pfc": 120117
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 74,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_pfc": 120117
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 254,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 7,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_egr_drp": 120051
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 121302,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 254,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 7,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_egr_drp": 120051,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 121302,
-                "pkts_num_trig_pfc": 120117
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 121302,
-                "pkts_num_trig_pfc": 120117
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 14,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_pfc": 120117
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 14,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_pfc": 120117
-              }
-            },
-            "cell_size": 254,
-            "hdrm_pool_wm_multiplier": 1,
-            "wrr": {
+        "topo-t0-standalone-256": {
+          "200000_5m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 0,
               "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140,
-              "q7_num_of_pkts": 140
+              "margin": 2,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 50,
+              "pkts_num_hdrm_full": 1185,
+              "pkts_num_hdrm_partial": 47,
+              "pkts_num_trig_pfc": 120117,
+              "pkts_num_trig_pfc_multi": [
+                120117,
+                60096,
+                30085,
+                15079,
+                7577,
+                3825,
+                1950,
+                1012,
+                543,
+                308,
+                191,
+                133,
+                103,
+                89,
+                81,
+                78,
+                76,
+                75,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74
+              ],
+              "src_port_ids": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+                17,
+                18,
+                19,
+                20,
+                21,
+                22,
+                23,
+                24,
+                25
+              ]
             },
-            "wrr_chg": {
+            "lossy_queue_1": {
+              "dscp": 8,
               "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80,
-              "q7_num_of_pkts": 80
+              "pg": 0,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_egr_drp": 120051
+            },
+            "pkts_num_egr_mem": 238,
+            "pkts_num_leak_out": 0,
+            "wm_pg_headroom": {
+              "cell_size": 254,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 121302,
+              "pkts_num_trig_pfc": 120117
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 254,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 74,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_pfc": 120117
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 254,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 7,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_egr_drp": 120051
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 254,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 121302,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 254,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 7,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_egr_drp": 120051,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 121302,
+              "pkts_num_trig_pfc": 120117
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 121302,
+              "pkts_num_trig_pfc": 120117
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 14,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_pfc": 120117
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 14,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_pfc": 120117
             }
           },
-          "topo-t0-standalone-256": {
-            "200000_5m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 0,
-                "ecn": 1,
-                "margin": 2,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 50,
-                "pkts_num_hdrm_full": 1185,
-                "pkts_num_hdrm_partial": 47,
-                "pkts_num_trig_pfc": 120117,
-                "pkts_num_trig_pfc_multi": [
-                  120117,
-                  60096,
-                  30085,
-                  15079,
-                  7577,
-                  3825,
-                  1950,
-                  1012,
-                  543,
-                  308,
-                  191,
-                  133,
-                  103,
-                  89,
-                  81,
-                  78,
-                  76,
-                  75,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74
-                ],
-                "src_port_ids": [
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7,
-                  8,
-                  9,
-                  10,
-                  11,
-                  12,
-                  13,
-                  14,
-                  15,
-                  16,
-                  17,
-                  18,
-                  19,
-                  20,
-                  21,
-                  22,
-                  23,
-                  24,
-                  25
-                ]
-              },
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_egr_drp": 120051
-              },
-              "pkts_num_egr_mem": 238,
-              "pkts_num_leak_out": 0,
-              "wm_pg_headroom": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 121302,
-                "pkts_num_trig_pfc": 120117
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 74,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_pfc": 120117
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 254,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 7,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_egr_drp": 120051
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 121302,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 254,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 7,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_egr_drp": 120051,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 121302,
-                "pkts_num_trig_pfc": 120117
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 121302,
-                "pkts_num_trig_pfc": 120117
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 14,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_pfc": 120117
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 14,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_pfc": 120117
-              }
-            },
-            "cell_size": 254,
-            "hdrm_pool_wm_multiplier": 1,
-            "wrr": {
+          "cell_size": 254,
+          "hdrm_pool_wm_multiplier": 1,
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140,
+            "q7_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80,
+            "q7_num_of_pkts": 80
+          }
+        },
+        "topo-t0-standalone-32": {
+          "200000_5m": {
+            "hdrm_pool_size": {
+              "dscps": [
+                3,
+                4
+              ],
+              "dst_port_id": 0,
               "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140,
-              "q7_num_of_pkts": 140
+              "margin": 2,
+              "pgs": [
+                3,
+                4
+              ],
+              "pgs_num": 50,
+              "pkts_num_hdrm_full": 1185,
+              "pkts_num_hdrm_partial": 47,
+              "pkts_num_trig_pfc": 120117,
+              "pkts_num_trig_pfc_multi": [
+                120117,
+                60096,
+                30085,
+                15079,
+                7577,
+                3825,
+                1950,
+                1012,
+                543,
+                308,
+                191,
+                133,
+                103,
+                89,
+                81,
+                78,
+                76,
+                75,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74,
+                74
+              ],
+              "src_port_ids": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+                17,
+                18,
+                19,
+                20,
+                21,
+                22,
+                23,
+                24,
+                25
+              ]
             },
-            "wrr_chg": {
+            "lossy_queue_1": {
+              "dscp": 8,
               "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80,
-              "q7_num_of_pkts": 80
+              "pg": 0,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_egr_drp": 120051
+            },
+            "pkts_num_egr_mem": 238,
+            "pkts_num_leak_out": 0,
+            "wm_pg_headroom": {
+              "cell_size": 254,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 121302,
+              "pkts_num_trig_pfc": 120117
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 254,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 74,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_pfc": 120117
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 254,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 7,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_egr_drp": 120051
+            },
+            "wm_q_shared_lossless": {
+              "cell_size": 254,
+              "dscp": 3,
+              "ecn": 1,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 121302,
+              "queue": 3
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 254,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 7,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_egr_drp": 120051,
+              "queue": 0
+            },
+            "xoff_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 121302,
+              "pkts_num_trig_pfc": 120117
+            },
+            "xoff_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_ingr_drp": 121302,
+              "pkts_num_trig_pfc": 120117
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 14,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_pfc": 120117
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 14,
+              "pkts_num_margin": 2,
+              "pkts_num_trig_pfc": 120117
             }
           },
-          "topo-t0-standalone-32": {
-            "200000_5m": {
-              "hdrm_pool_size": {
-                "dscps": [
-                  3,
-                  4
-                ],
-                "dst_port_id": 0,
-                "ecn": 1,
-                "margin": 2,
-                "pgs": [
-                  3,
-                  4
-                ],
-                "pgs_num": 50,
-                "pkts_num_hdrm_full": 1185,
-                "pkts_num_hdrm_partial": 47,
-                "pkts_num_trig_pfc": 120117,
-                "pkts_num_trig_pfc_multi": [
-                  120117,
-                  60096,
-                  30085,
-                  15079,
-                  7577,
-                  3825,
-                  1950,
-                  1012,
-                  543,
-                  308,
-                  191,
-                  133,
-                  103,
-                  89,
-                  81,
-                  78,
-                  76,
-                  75,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74,
-                  74
-                ],
-                "src_port_ids": [
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7,
-                  8,
-                  9,
-                  10,
-                  11,
-                  12,
-                  13,
-                  14,
-                  15,
-                  16,
-                  17,
-                  18,
-                  19,
-                  20,
-                  21,
-                  22,
-                  23,
-                  24,
-                  25
-                ]
-              },
-              "lossy_queue_1": {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_egr_drp": 120051
-              },
-              "pkts_num_egr_mem": 238,
-              "pkts_num_leak_out": 0,
-              "wm_pg_headroom": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 121302,
-                "pkts_num_trig_pfc": 120117
-              },
-              "wm_pg_shared_lossless": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 3,
-                "pkts_num_fill_min": 74,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_pfc": 120117
-              },
-              "wm_pg_shared_lossy": {
-                "cell_size": 254,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 64,
-                "pg": 0,
-                "pkts_num_fill_min": 7,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_egr_drp": 120051
-              },
-              "wm_q_shared_lossless": {
-                "cell_size": 254,
-                "dscp": 3,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 121302,
-                "queue": 3
-              },
-              "wm_q_shared_lossy": {
-                "cell_size": 254,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 7,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_egr_drp": 120051,
-                "queue": 0
-              },
-              "xoff_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 121302,
-                "pkts_num_trig_pfc": 120117
-              },
-              "xoff_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_ingr_drp": 121302,
-                "pkts_num_trig_pfc": 120117
-              },
-              "xon_1": {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 14,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_pfc": 120117
-              },
-              "xon_2": {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 14,
-                "pkts_num_margin": 2,
-                "pkts_num_trig_pfc": 120117
-              }
-            },
-            "cell_size": 254,
-            "hdrm_pool_wm_multiplier": 1,
-            "wrr": {
-              "ecn": 1,
-              "limit": 80,
-              "q0_num_of_pkts": 140,
-              "q1_num_of_pkts": 140,
-              "q2_num_of_pkts": 140,
-              "q3_num_of_pkts": 150,
-              "q4_num_of_pkts": 150,
-              "q5_num_of_pkts": 140,
-              "q6_num_of_pkts": 140,
-              "q7_num_of_pkts": 140
-            },
-            "wrr_chg": {
-              "ecn": 1,
-              "limit": 80,
-              "lossless_weight": 30,
-              "lossy_weight": 8,
-              "q0_num_of_pkts": 80,
-              "q1_num_of_pkts": 80,
-              "q2_num_of_pkts": 80,
-              "q3_num_of_pkts": 300,
-              "q4_num_of_pkts": 300,
-              "q5_num_of_pkts": 80,
-              "q6_num_of_pkts": 80,
-              "q7_num_of_pkts": 80
-            }
+          "cell_size": 254,
+          "hdrm_pool_wm_multiplier": 1,
+          "wrr": {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 140,
+            "q1_num_of_pkts": 140,
+            "q2_num_of_pkts": 140,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 140,
+            "q6_num_of_pkts": 140,
+            "q7_num_of_pkts": 140
+          },
+          "wrr_chg": {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 80,
+            "q1_num_of_pkts": 80,
+            "q2_num_of_pkts": 80,
+            "q3_num_of_pkts": 300,
+            "q4_num_of_pkts": 300,
+            "q5_num_of_pkts": 80,
+            "q6_num_of_pkts": 80,
+            "q7_num_of_pkts": 80
           }
         }
       }
-    },
-    "dutAsic": "kvm",
-    "dstDutAsic": "kvm",
-    "dutTopo": "topo-any",
-    "srcDutInstance": "<vs-kvm>",
-    "dstDutInstance": "<vs-kvm>",
-    "dualTor": "False",
-    "dualTorScenario": "True"
-  }
+    }
+  },
+  "dutAsic": "kvm",
+  "dstDutAsic": "kvm",
+  "dutTopo": "topo-any",
+  "srcDutInstance": "<vs-kvm>",
+  "dstDutInstance": "<vs-kvm>",
+  "dualTor": "False",
+  "dualTorScenario": "True"
+}

--- a/tests/qos/files/vs/dutConfig.json
+++ b/tests/qos/files/vs/dutConfig.json
@@ -1,0 +1,7841 @@
+{
+    "dutInterfaces": {
+      "0": "Ethernet0",
+      "1": "Ethernet4",
+      "4": "Ethernet16",
+      "5": "Ethernet20",
+      "16": "Ethernet64",
+      "17": "Ethernet68",
+      "20": "Ethernet80",
+      "21": "Ethernet84",
+      "34": "Ethernet136",
+      "36": "Ethernet144",
+      "37": "Ethernet148",
+      "38": "Ethernet152",
+      "39": "Ethernet156",
+      "42": "Ethernet168",
+      "44": "Ethernet176",
+      "45": "Ethernet180",
+      "46": "Ethernet184",
+      "47": "Ethernet188",
+      "50": "Ethernet200",
+      "52": "Ethernet208",
+      "53": "Ethernet212",
+      "54": "Ethernet216",
+      "55": "Ethernet220",
+      "58": "Ethernet232",
+      "60": "Ethernet240",
+      "61": "Ethernet244",
+      "62": "Ethernet248",
+      "63": "Ethernet252"
+    },
+    "uplinkPortIds": [
+      0,
+      4,
+      16,
+      20
+    ],
+    "testPortIds": {
+      "0": {
+        "0": [
+          0,
+          4,
+          16,
+          20,
+          34,
+          36,
+          37,
+          38,
+          39,
+          42,
+          44,
+          45,
+          46,
+          47,
+          50,
+          52,
+          53,
+          54,
+          55,
+          58,
+          60,
+          61,
+          62,
+          63
+        ]
+      }
+    },
+    "testPortIps": {
+      "0": {
+        "0": {
+          "34": {
+            "peer_addr": "10.0.0.33"
+          },
+          "0": {
+            "peer_addr": "10.0.0.1"
+          },
+          "36": {
+            "peer_addr": "10.0.0.35"
+          },
+          "37": {
+            "peer_addr": "10.0.0.37"
+          },
+          "4": {
+            "peer_addr": "10.0.0.5"
+          },
+          "38": {
+            "peer_addr": "10.0.0.39"
+          },
+          "39": {
+            "peer_addr": "10.0.0.41"
+          },
+          "16": {
+            "peer_addr": "10.0.0.9"
+          },
+          "42": {
+            "peer_addr": "10.0.0.43"
+          },
+          "44": {
+            "peer_addr": "10.0.0.45"
+          },
+          "20": {
+            "peer_addr": "10.0.0.13"
+          },
+          "45": {
+            "peer_addr": "10.0.0.47"
+          },
+          "46": {
+            "peer_addr": "10.0.0.49"
+          },
+          "47": {
+            "peer_addr": "10.0.0.51"
+          },
+          "50": {
+            "peer_addr": "10.0.0.53"
+          },
+          "52": {
+            "peer_addr": "10.0.0.55"
+          },
+          "53": {
+            "peer_addr": "10.0.0.57"
+          },
+          "54": {
+            "peer_addr": "10.0.0.59"
+          },
+          "55": {
+            "peer_addr": "10.0.0.61"
+          },
+          "58": {
+            "peer_addr": "10.0.0.63"
+          },
+          "60": {
+            "peer_addr": "10.0.0.65"
+          },
+          "61": {
+            "peer_addr": "10.0.0.67"
+          },
+          "62": {
+            "peer_addr": "10.0.0.69"
+          },
+          "63": {
+            "peer_addr": "10.0.0.71"
+          }
+        }
+      }
+    },
+    "testPorts": {
+      "dst_port_id": 0,
+      "dst_port_ip": "10.0.0.1",
+      "dst_port_vlan": "None",
+      "dst_port_2_id": 16,
+      "dst_port_2_ip": "10.0.0.9",
+      "dst_port_2_vlan": "None",
+      "dst_port_3_id": 20,
+      "dst_port_3_ip": "10.0.0.13",
+      "dst_port_3_vlan": "None",
+      "src_port_id": 4,
+      "src_port_ip": "10.0.0.5",
+      "src_port_vlan": "None",
+      "uplink_port_ids": [
+        0,
+        4,
+        16,
+        20
+      ],
+      "uplink_port_ips": [
+        "10.0.0.1",
+        "10.0.0.5",
+        "10.0.0.9",
+        "10.0.0.13"
+      ],
+      "uplink_port_names": [
+        "Ethernet0",
+        "Ethernet16",
+        "Ethernet64",
+        "Ethernet80"
+      ],
+      "downlink_port_ids": [
+        34,
+        36,
+        37,
+        38,
+        39,
+        42,
+        44,
+        45,
+        46,
+        47,
+        50,
+        52,
+        53,
+        54,
+        55,
+        58,
+        60,
+        61,
+        62,
+        63
+      ],
+      "downlink_port_ips": [
+        "10.0.0.33",
+        "10.0.0.35",
+        "10.0.0.37",
+        "10.0.0.39",
+        "10.0.0.41",
+        "10.0.0.43",
+        "10.0.0.45",
+        "10.0.0.47",
+        "10.0.0.49",
+        "10.0.0.51",
+        "10.0.0.53",
+        "10.0.0.55",
+        "10.0.0.57",
+        "10.0.0.59",
+        "10.0.0.61",
+        "10.0.0.63",
+        "10.0.0.65",
+        "10.0.0.67",
+        "10.0.0.69",
+        "10.0.0.71"
+      ],
+      "downlink_port_names": [
+        "Ethernet136",
+        "Ethernet144",
+        "Ethernet148",
+        "Ethernet152",
+        "Ethernet156",
+        "Ethernet168",
+        "Ethernet176",
+        "Ethernet180",
+        "Ethernet184",
+        "Ethernet188",
+        "Ethernet200",
+        "Ethernet208",
+        "Ethernet212",
+        "Ethernet216",
+        "Ethernet220",
+        "Ethernet232",
+        "Ethernet240",
+        "Ethernet244",
+        "Ethernet248",
+        "Ethernet252"
+      ]
+    },
+    "qosConfigs": {
+      "qos_params": {
+        "kvm": {
+          "topo-any": {
+            "100000_120000m": {
+              "lossy_queue_1": {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 16000
+              },
+              "pg_drop": {
+                "dscp": 3,
+                "ecn": 1,
+                "iterations": 30,
+                "pg": 3,
+                "pkts_num_margin": 30000,
+                "pkts_num_trig_ingr_drp": 524288,
+                "pkts_num_trig_pfc": 262144,
+                "queue": 3
+              },
+              "pkts_num_leak_out": 0,
+              "wm_buf_pool_lossless": {
+                "cell_size": 8192,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8140,
+                "pg": 3,
+                "pkts_num_fill_ingr_min": 140,
+                "pkts_num_margin": 6,
+                "pkts_num_trig_pfc": 6412,
+                "queue": 3
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 8192,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 6403
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 8192,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 0,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 728
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 6144,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 19456,
+                "pkts_num_trig_ingr_drp": 12807,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 3072,
+                "pkts_num_trig_egr_drp": 16000,
+                "queue": 0
+              },
+              "wm_q_wm_all_ports": {
+                "cell_size": 6144,
+                "ecn": 1,
+                "packet_size": 6144,
+                "pkt_count": 3000,
+                "pkts_num_margin": 19456
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 6404,
+                "pkts_num_trig_pfc": 3202
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 4,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 6404,
+                "pkts_num_trig_pfc": 3202
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 2,
+                "pkts_num_trig_pfc": 3201
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 2,
+                "pkts_num_trig_pfc": 3201
+              }
+            },
+            "100000_300m": {
+              "pcbb_xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+              },
+              "pcbb_xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+              },
+              "pcbb_xoff_3": {
+                "dscp": 3,
+                "ecn": 1,
+                "outer_dscp": 2,
+                "packet_size": 1350,
+                "pg": 2,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+              },
+              "pcbb_xoff_4": {
+                "dscp": 4,
+                "ecn": 1,
+                "outer_dscp": 6,
+                "packet_size": 1350,
+                "pg": 6,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+              },
+              "pkts_num_leak_out": 0,
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_pfc": 3415,
+                "pkts_num_trig_ingr_drp": 3703,
+                "packet_size": 1350
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_pfc": 3415,
+                "pkts_num_trig_ingr_drp": 3703,
+                "packet_size": 1350
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_pfc": 3414,
+                "pkts_num_hysteresis": 1877,
+                "pkts_num_dismiss_pfc": 2,
+                "packet_size": 1350
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_pfc": 3414,
+                "pkts_num_hysteresis": 1877,
+                "pkts_num_dismiss_pfc": 2,
+                "packet_size": 1350
+              },
+              "wm_pg_shared_lossless": {
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "cell_size": 384,
+                "dscp": 3,
+                "pg": 3,
+                "pkts_num_trig_pfc": 14807
+              },
+              "wm_pg_shared_lossy": {
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "cell_size": 384,
+                "dscp": 8,
+                "pg": 0,
+                "pkts_num_trig_egr_drp": 16000
+              },
+              "wm_buf_pool_lossless": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "queue": 3,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_pfc": 3703,
+                "cell_size": 384,
+                "packet_size": 1350
+              },
+              "wm_buf_pool_lossy": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "queue": 0,
+                "pkts_num_trig_egr_drp": 4000,
+                "pkts_num_fill_egr_min": 0,
+                "cell_size": 384,
+                "packet_size": 1350
+              },
+              "wm_q_shared_lossless": {
+                "dscp": 3,
+                "ecn": 1,
+                "queue": 3,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 14815,
+                "pkts_num_margin": 3072,
+                "cell_size": 384
+              },
+              "wm_q_shared_lossy": {
+                "dscp": 8,
+                "ecn": 1,
+                "queue": 0,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 16000,
+                "pkts_num_margin": 3072,
+                "cell_size": 384
+              },
+              "lossy_queue_voq_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "flow_config": "separate",
+                "pkts_num_trig_egr_drp": 16000,
+                "pkts_num_margin": 4,
+                "packet_size": 64,
+                "cell_size": 384
+              },
+              "lossy_queue_voq_2": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "flow_config": "shared",
+                "pkts_num_trig_egr_drp": 16000,
+                "pkts_num_margin": 4,
+                "packet_size": 64,
+                "cell_size": 384
+              },
+              "lossy_queue_voq_3": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_trig_egr_drp": 16000,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "cell_size": 384
+              },
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_trig_egr_drp": 16000,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "cell_size": 384
+              },
+              "lossless_voq_1": {
+                "ecn": 1,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "pkts_num_trig_pfc": 3415,
+                "dscp": 3,
+                "pg": 3,
+                "num_of_flows": "multiple"
+              },
+              "lossless_voq_2": {
+                "ecn": 1,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "pkts_num_trig_pfc": 3415,
+                "dscp": 4,
+                "pg": 4,
+                "num_of_flows": "multiple"
+              },
+              "lossless_voq_3": {
+                "ecn": 1,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "pkts_num_trig_pfc": 3415,
+                "dscp": 3,
+                "pg": 3,
+                "num_of_flows": "single"
+              },
+              "lossless_voq_4": {
+                "ecn": 1,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "pkts_num_trig_pfc": 3415,
+                "dscp": 4,
+                "pg": 4,
+                "num_of_flows": "single"
+              },
+              "wm_q_wm_all_ports": {
+                "ecn": 1,
+                "pkt_count": 4000,
+                "pkts_num_margin": 3072,
+                "cell_size": 384,
+                "packet_size": 1350
+              },
+              "pg_drop": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "queue": 3,
+                "pkts_num_trig_pfc": 13661,
+                "pkts_num_trig_ingr_drp": 14815,
+                "pkts_num_margin": 365,
+                "iterations": 100
+              }
+            },
+            "100000_40m": {
+              "pcbb_xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+              },
+              "pcbb_xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+              },
+              "pcbb_xoff_3": {
+                "dscp": 3,
+                "ecn": 1,
+                "outer_dscp": 2,
+                "packet_size": 1350,
+                "pg": 2,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+              },
+              "pcbb_xoff_4": {
+                "dscp": 4,
+                "ecn": 1,
+                "outer_dscp": 6,
+                "packet_size": 1350,
+                "pg": 6,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+              },
+              "pkts_num_leak_out": 0
+            },
+            "100000_5m": {
+              "pcbb_xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+              },
+              "pcbb_xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+              },
+              "pcbb_xoff_3": {
+                "dscp": 3,
+                "ecn": 1,
+                "outer_dscp": 2,
+                "packet_size": 1350,
+                "pg": 2,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+              },
+              "pcbb_xoff_4": {
+                "dscp": 4,
+                "ecn": 1,
+                "outer_dscp": 6,
+                "packet_size": 1350,
+                "pg": 6,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+              },
+              "pkts_num_leak_out": 0
+            },
+            "400000_120000m": {
+              "lossy_queue_1": {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 16000
+              },
+              "pkts_num_leak_out": 0,
+              "wm_buf_pool_lossless": {
+                "cell_size": 8192,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8140,
+                "pg": 3,
+                "pkts_num_fill_ingr_min": 140,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_pfc": 23085,
+                "queue": 3
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 8192,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 23043
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 8192,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 0,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 728
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 6144,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 26624,
+                "pkts_num_trig_ingr_drp": 46087,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 3072,
+                "pkts_num_trig_egr_drp": 16000,
+                "queue": 0
+              },
+              "wm_q_wm_all_ports": {
+                "cell_size": 6144,
+                "ecn": 1,
+                "packet_size": 6144,
+                "pkt_count": 3000,
+                "pkts_num_margin": 19456
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 23044,
+                "pkts_num_trig_pfc": 11522
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 4,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 23044,
+                "pkts_num_trig_pfc": 11522
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 2,
+                "pkts_num_trig_pfc": 11521
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 2,
+                "pkts_num_trig_pfc": 11521
+              }
+            },
+            "400000_300m": {
+              "pkts_num_leak_out": 0,
+              "wrr": {
+                "ecn": 1,
+                "limit": 80,
+                "q0_num_of_pkts": 70,
+                "q1_num_of_pkts": 70,
+                "q2_num_of_pkts": 70,
+                "q3_num_of_pkts": 75,
+                "q4_num_of_pkts": 75,
+                "q5_num_of_pkts": 70,
+                "q6_num_of_pkts": 70
+              },
+              "wrr_chg": {
+                "ecn": 1,
+                "limit": 80,
+                "lossless_weight": 30,
+                "lossy_weight": 8,
+                "q0_num_of_pkts": 40,
+                "q1_num_of_pkts": 40,
+                "q2_num_of_pkts": 40,
+                "q3_num_of_pkts": 150,
+                "q4_num_of_pkts": 150,
+                "q5_num_of_pkts": 40,
+                "q6_num_of_pkts": 40
+              }
+            },
+            "400000_40m": {
+              "pkts_num_leak_out": 0
+            },
+            "400000_5m": {
+              "pkts_num_leak_out": 0
+            },
+            "cell_size": 384,
+            "hdrm_pool_wm_multiplier": 1,
+            "shared_res_size_1": {
+              "cell_size": 384,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pkts_num_margin": 1,
+              "dscps": [
+                8,
+                8,
+                8,
+                8,
+                8,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4
+              ],
+              "pgs": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4
+              ],
+              "queues": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4
+              ],
+              "src_port_i": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                0,
+                0,
+                1,
+                1,
+                2,
+                2,
+                3,
+                3,
+                4,
+                4,
+                5,
+                5
+              ],
+              "dst_port_i": [
+                6,
+                7,
+                8,
+                9,
+                10,
+                6,
+                6,
+                7,
+                7,
+                8,
+                8,
+                9,
+                9,
+                10,
+                10,
+                11,
+                11
+              ],
+              "pkt_counts": [
+                3413,
+                3413,
+                3413,
+                3413,
+                3413,
+                2389,
+                2389,
+                2389,
+                1526,
+                1526,
+                1392,
+                415,
+                415,
+                415,
+                415,
+                42,
+                1
+              ],
+              "shared_limit_bytes": 46661760
+            },
+            "shared_res_size_2": {
+              "cell_size": 384,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pkts_num_margin": 1,
+              "dscps": [
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3
+              ],
+              "pgs": [
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3
+              ],
+              "queues": [
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3
+              ],
+              "src_port_i": [
+                0,
+                0,
+                1,
+                1,
+                2,
+                2,
+                3,
+                3,
+                4,
+                4,
+                5,
+                5,
+                6
+              ],
+              "dst_port_i": [
+                7,
+                7,
+                8,
+                8,
+                9,
+                9,
+                10,
+                10,
+                11,
+                11,
+                12,
+                12,
+                13
+              ],
+              "pkt_counts": [
+                3527,
+                3527,
+                3527,
+                3527,
+                3527,
+                3527,
+                1798,
+                1798,
+                846,
+                687,
+                687,
+                328,
+                1
+              ],
+              "shared_limit_bytes": 41943552
+            },
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 70,
+              "q1_num_of_pkts": 70,
+              "q2_num_of_pkts": 70,
+              "q3_num_of_pkts": 75,
+              "q4_num_of_pkts": 75,
+              "q5_num_of_pkts": 70,
+              "q6_num_of_pkts": 70
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 40,
+              "q1_num_of_pkts": 40,
+              "q2_num_of_pkts": 40,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 40,
+              "q6_num_of_pkts": 40
+            }
+          },
+          "topo-t2": {
+            "100000_120000m": {
+              "lossy_queue_1": {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 16000
+              },
+              "lossy_queue_voq_2": {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "flow_config": "shared",
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 16000
+              },
+              "pg_drop": {
+                "cell_size": 8192,
+                "dscp": 3,
+                "ecn": 1,
+                "iterations": 30,
+                "pg": 3,
+                "pkts_num_margin": 30000,
+                "pkts_num_trig_ingr_drp": 524288,
+                "pkts_num_trig_pfc": 262144,
+                "queue": 3
+              },
+              "pkts_num_egr_mem": 1256,
+              "pkts_num_leak_out": 0,
+              "wm_buf_pool_lossless": {
+                "cell_size": 8192,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 6144,
+                "pg": 3,
+                "pkts_num_fill_ingr_min": 181,
+                "pkts_num_trig_pfc": 642,
+                "queue": 3
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 8192,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 6403
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 6144,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 6144,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 1024,
+                "pkts_num_trig_ingr_drp": 855,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 3072,
+                "pkts_num_trig_egr_drp": 16000,
+                "queue": 0
+              },
+              "wm_q_wm_all_ports": {
+                "cell_size": 6144,
+                "ecn": 1,
+                "packet_size": 6144,
+                "pkt_count": 855,
+                "pkts_num_margin": 1024
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 6404,
+                "pkts_num_trig_pfc": 3202
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 4,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 6404,
+                "pkts_num_trig_pfc": 3202
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 4,
+                "pkts_num_trig_pfc": 3202
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 4,
+                "pkts_num_trig_pfc": 3202
+              }
+            },
+            "100000_300m": {
+              "lossless_voq_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "num_of_flows": "multiple",
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3415
+              },
+              "lossless_voq_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "num_of_flows": "multiple",
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3415
+              },
+              "lossless_voq_3": {
+                "dscp": 3,
+                "ecn": 1,
+                "num_of_flows": "single",
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3415
+              },
+              "lossless_voq_4": {
+                "dscp": 4,
+                "ecn": 1,
+                "num_of_flows": "single",
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3415
+              },
+              "lossy_queue_1": {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 0,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_egr_drp": 16000
+              },
+              "pg_drop": {
+                "cell_size": 384,
+                "dscp": 3,
+                "ecn": 1,
+                "iterations": 50,
+                "pg": 3,
+                "pkts_num_margin": 375,
+                "pkts_num_trig_ingr_drp": 14819,
+                "pkts_num_trig_pfc": 13660,
+                "queue": 3
+              },
+              "pkts_num_egr_mem": 6884,
+              "pkts_num_leak_out": 0,
+              "wm_buf_pool_lossless": {
+                "cell_size": 384,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_pfc": 3415,
+                "queue": 3
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 384,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 14804
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 384,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 3072,
+                "pkts_num_trig_ingr_drp": 13660,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 3072,
+                "pkts_num_trig_egr_drp": 16000,
+                "queue": 0
+              },
+              "wm_q_wm_all_ports": {
+                "cell_size": 384,
+                "ecn": 1,
+                "pkt_count": 3000,
+                "pkts_num_margin": 1024
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 3704,
+                "pkts_num_trig_pfc": 3415
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 3704,
+                "pkts_num_trig_pfc": 3415
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 23,
+                "pkts_num_hysteresis": 1365,
+                "pkts_num_trig_pfc": 3415
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 23,
+                "pkts_num_hysteresis": 1365,
+                "pkts_num_trig_pfc": 3415
+              }
+            },
+            "400000_120000m": {
+              "lossy_queue_1": {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 16000
+              },
+              "lossy_queue_voq_2": {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "flow_config": "shared",
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 16000
+              },
+              "pg_drop": {
+                "cell_size": 8192,
+                "dscp": 3,
+                "ecn": 1,
+                "iterations": 30,
+                "pg": 3,
+                "pkts_num_margin": 108000,
+                "pkts_num_trig_ingr_drp": 1887437,
+                "pkts_num_trig_pfc": 943719,
+                "queue": 3
+              },
+              "pkts_num_egr_mem": 957,
+              "pkts_num_leak_out": 0,
+              "wm_buf_pool_lossless": {
+                "cell_size": 8192,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8140,
+                "pg": 3,
+                "pkts_num_fill_ingr_min": 140,
+                "pkts_num_trig_pfc": 642,
+                "queue": 3
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 8192,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 23043
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 6144,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 6144,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 1024,
+                "pkts_num_trig_ingr_drp": 855,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 3072,
+                "pkts_num_trig_egr_drp": 16000,
+                "queue": 0
+              },
+              "wm_q_wm_all_ports": {
+                "cell_size": 6144,
+                "ecn": 1,
+                "packet_size": 6144,
+                "pkt_count": 855,
+                "pkts_num_margin": 1024
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 23044,
+                "pkts_num_trig_pfc": 11522
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 4,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 23044,
+                "pkts_num_trig_pfc": 11522
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 4,
+                "pkts_num_trig_pfc": 11522
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 4,
+                "pkts_num_trig_pfc": 11522
+              }
+            },
+            "400000_300m": {
+              "lossless_voq_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "num_of_flows": "multiple",
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3038
+              },
+              "lossless_voq_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "num_of_flows": "multiple",
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3038
+              },
+              "lossless_voq_3": {
+                "dscp": 3,
+                "ecn": 1,
+                "num_of_flows": "single",
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3038
+              },
+              "lossless_voq_4": {
+                "dscp": 4,
+                "ecn": 1,
+                "num_of_flows": "single",
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3038
+              },
+              "lossy_queue_1": {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 16000
+              },
+              "pg_drop": {
+                "cell_size": 384,
+                "dscp": 3,
+                "ecn": 1,
+                "iterations": 50,
+                "pg": 3,
+                "pkts_num_margin": 375,
+                "pkts_num_trig_ingr_drp": 14816,
+                "pkts_num_trig_pfc": 12152,
+                "queue": 3
+              },
+              "pkts_num_egr_mem": 6884,
+              "pkts_num_leak_out": 0,
+              "wm_buf_pool_lossless": {
+                "cell_size": 384,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_pfc": 3038,
+                "queue": 3
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 384,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 14804
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 384,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 3072,
+                "pkts_num_trig_ingr_drp": 13660,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 3072,
+                "pkts_num_trig_egr_drp": 16000,
+                "queue": 0
+              },
+              "wm_q_wm_all_ports": {
+                "cell_size": 384,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pkt_count": 3000,
+                "pkts_num_margin": 1024
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 10589,
+                "pkts_num_trig_pfc": 9923
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 10589,
+                "pkts_num_trig_pfc": 9923
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 23,
+                "pkts_num_hysteresis": 1140,
+                "pkts_num_trig_pfc": 3038
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 23,
+                "pkts_num_hysteresis": 1140,
+                "pkts_num_trig_pfc": 3038
+              }
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 384,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_trig_egr_drp": 4000,
+              "queue": 0
+            },
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 70,
+              "q1_num_of_pkts": 70,
+              "q2_num_of_pkts": 70,
+              "q3_num_of_pkts": 75,
+              "q4_num_of_pkts": 75,
+              "q5_num_of_pkts": 70,
+              "q6_num_of_pkts": 70
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 40,
+              "q1_num_of_pkts": 40,
+              "q2_num_of_pkts": 40,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 40,
+              "q6_num_of_pkts": 40
+            }
+          }
+        },
+        "gr": {
+          "topo-any": {
+            "cell_size": 384,
+            "hdrm_pool_wm_multiplier": 1,
+            "shared_res_size_1": {
+              "cell_size": 384,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pkts_num_margin": 1
+            },
+            "shared_res_size_2": {
+              "cell_size": 384,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pkts_num_margin": 1
+            }
+          }
+        },
+        "j2c+": {
+          "topo-any": {
+            "100000_120000m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 18,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 18,
+                "pkts_num_hdrm_full": 362,
+                "pkts_num_hdrm_partial": 182,
+                "pkts_num_trig_pfc": 37549,
+                "src_port_ids": [
+                  0,
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16
+                ]
+              },
+              "internal_hdr_size": 48,
+              "lossy_queue_1": {
+                "dscp": 7,
+                "ecn": 1,
+                "pg": 1,
+                "pkts_num_margin": 200,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "pkts_num_leak_out": 5,
+              "wm_buf_pool_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_ingr_drp": 216064,
+                "pkts_num_trig_pfc": 37549,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 0,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 30,
+                "pkts_num_trig_ingr_drp": 216064,
+                "pkts_num_trig_pfc": 37449
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 51,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_pfc": 37449
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 51,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 216064,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 216064,
+                "pkts_num_trig_pfc": 37449
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 216064,
+                "pkts_num_trig_pfc": 37449
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 37449
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 37449
+              }
+            },
+            "100000_2000m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 18,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 18,
+                "pkts_num_hdrm_full": 362,
+                "pkts_num_hdrm_partial": 182,
+                "pkts_num_trig_pfc": 35208,
+                "src_port_ids": [
+                  0,
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16
+                ]
+              },
+              "internal_hdr_size": 48,
+              "lossy_queue_1": {
+                "dscp": 7,
+                "ecn": 1,
+                "pg": 1,
+                "pkts_num_margin": 200,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "pkts_num_leak_out": 5,
+              "wm_buf_pool_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_ingr_drp": 38619,
+                "pkts_num_trig_pfc": 35108,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 0,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 30,
+                "pkts_num_trig_ingr_drp": 38619,
+                "pkts_num_trig_pfc": 35108
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 51,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_pfc": 9874
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 51,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 38619,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 38619,
+                "pkts_num_trig_pfc": 35108
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 38619,
+                "pkts_num_trig_pfc": 35108
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 35108
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 35108
+              }
+            },
+            "100000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 18,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 18,
+                "pkts_num_hdrm_full": 362,
+                "pkts_num_hdrm_partial": 182,
+                "pkts_num_trig_pfc": 9974,
+                "src_port_ids": [
+                  0,
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16
+                ]
+              },
+              "internal_hdr_size": 48,
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_margin": 200,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "pkts_num_leak_out": 5,
+              "wm_buf_pool_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_ingr_drp": 10861,
+                "pkts_num_trig_pfc": 9974,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 0,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 30,
+                "pkts_num_trig_ingr_drp": 10861,
+                "pkts_num_trig_pfc": 9874
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 51,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_pfc": 9874
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 51,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 10861,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 10861,
+                "pkts_num_trig_pfc": 9874
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 10861,
+                "pkts_num_trig_pfc": 9874
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 9874
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 9874
+              }
+            },
+            "400000_120000m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 18,
+                "ecn": 1,
+                "margin": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 18,
+                "pkts_num_hdrm_full": 362,
+                "pkts_num_hdrm_partial": 182,
+                "pkts_num_trig_pfc": 37549,
+                "src_port_ids": [
+                  0,
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16
+                ]
+              },
+              "internal_hdr_size": 48,
+              "lossy_queue_1": {
+                "dscp": 7,
+                "ecn": 1,
+                "pg": 1,
+                "pkts_num_margin": 3500,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "pkts_num_leak_out": 140,
+              "wm_buf_pool_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_ingr_drp": 750848,
+                "pkts_num_trig_pfc": 28160,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 0,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 30,
+                "pkts_num_trig_ingr_drp": 750848,
+                "pkts_num_trig_pfc": 37449
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 71,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_pfc": 37449
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 71,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 750848,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 750848,
+                "pkts_num_trig_pfc": 37449
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 750848,
+                "pkts_num_trig_pfc": 37449
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 37449
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 37449
+              }
+            },
+            "400000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 18,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 18,
+                "pkts_num_hdrm_full": 362,
+                "pkts_num_hdrm_partial": 182,
+                "pkts_num_trig_pfc": 28260,
+                "src_port_ids": [
+                  0,
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16
+                ]
+              },
+              "internal_hdr_size": 48,
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_margin": 3500,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "pkts_num_leak_out": 71,
+              "wm_buf_pool_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_ingr_drp": 28187,
+                "pkts_num_trig_pfc": 28160,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 0,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 30,
+                "pkts_num_trig_ingr_drp": 28187,
+                "pkts_num_trig_pfc": 28160
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 71,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_pfc": 28160
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 71,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 28187,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 28187,
+                "pkts_num_trig_pfc": 28160
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 28187,
+                "pkts_num_trig_pfc": 28160
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 28160
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 28160
+              }
+            },
+            "cell_size": 4096,
+            "ecn_1": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "cell_size": 4096,
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "cell_size": 4096,
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "hdrm_pool_wm_multiplier": 1,
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 150,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80
+            }
+          }
+        },
+        "jr2": {
+          "topo-any": {
+            "100000_120000m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 18,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 18,
+                "pkts_num_hdrm_full": 362,
+                "pkts_num_hdrm_partial": 182,
+                "pkts_num_trig_pfc": 37549,
+                "src_port_ids": [
+                  0,
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16
+                ]
+              },
+              "internal_hdr_size": 48,
+              "lossy_queue_1": {
+                "dscp": 7,
+                "ecn": 1,
+                "pg": 1,
+                "pkts_num_margin": 200,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "pkts_num_leak_out": 5,
+              "wm_buf_pool_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_ingr_drp": 55808,
+                "pkts_num_trig_pfc": 37549,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 0,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 30,
+                "pkts_num_trig_ingr_drp": 55808,
+                "pkts_num_trig_pfc": 37449
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 51,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_pfc": 37449
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 51,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 55808,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 55808,
+                "pkts_num_trig_pfc": 37449
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 55808,
+                "pkts_num_trig_pfc": 37449
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 37449
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 37449
+              }
+            },
+            "100000_2000m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 18,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 18,
+                "pkts_num_hdrm_full": 362,
+                "pkts_num_hdrm_partial": 182,
+                "pkts_num_trig_pfc": 35208,
+                "src_port_ids": [
+                  0,
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16
+                ]
+              },
+              "internal_hdr_size": 48,
+              "lossy_queue_1": {
+                "dscp": 7,
+                "ecn": 1,
+                "pg": 1,
+                "pkts_num_margin": 200,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "pkts_num_leak_out": 5,
+              "wm_buf_pool_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_ingr_drp": 38619,
+                "pkts_num_trig_pfc": 35108,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 0,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 30,
+                "pkts_num_trig_ingr_drp": 38619,
+                "pkts_num_trig_pfc": 35108
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 51,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_pfc": 9874
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 51,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 38619,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 38619,
+                "pkts_num_trig_pfc": 35108
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 38619,
+                "pkts_num_trig_pfc": 35108
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 35108
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 35108
+              }
+            },
+            "100000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 18,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 18,
+                "pkts_num_hdrm_full": 362,
+                "pkts_num_hdrm_partial": 182,
+                "pkts_num_trig_pfc": 9974,
+                "src_port_ids": [
+                  0,
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16
+                ]
+              },
+              "internal_hdr_size": 48,
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "pkts_num_leak_out": 51,
+              "wm_buf_pool_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_ingr_drp": 10861,
+                "pkts_num_trig_pfc": 9974,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 0,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 30,
+                "pkts_num_trig_ingr_drp": 10861,
+                "pkts_num_trig_pfc": 9874
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 51,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_pfc": 9874
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 51,
+                "pkts_num_margin": 40,
+                "pkts_num_trig_egr_drp": 2396745
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 4096,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 10861,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 4096,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 2396745,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 10861,
+                "pkts_num_trig_pfc": 9874
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 100,
+                "pkts_num_trig_ingr_drp": 10861,
+                "pkts_num_trig_pfc": 9874
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 9874
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 200,
+                "pkts_num_margin": 150,
+                "pkts_num_trig_pfc": 9874
+              }
+            },
+            "cell_size": 4096,
+            "ecn_1": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "cell_size": 4096,
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "cell_size": 4096,
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "cell_size": 4096,
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "hdrm_pool_wm_multiplier": 1,
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 150,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80
+            }
+          }
+        },
+        "mellanox": {
+          "topo-any": {
+            "ecn_1": {
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 300,
+              "pg": 0,
+              "pkts_num_leak_out": 0,
+              "pkts_num_margin": 4
+            },
+            "profile": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4,
+                  2,
+                  6
+                ],
+                "ecn": 1,
+                "packet_size": 300,
+                "pgs": [
+                  3,
+                  4,
+                  2,
+                  6
+                ],
+                "pkts_num_fill_min": 0,
+                "pkts_num_leak_out": 0,
+                "pkts_num_trig_pfc": 0
+              },
+              "pkts_num_leak_out": 0,
+              "wm_pg_headroom": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 300,
+                "pg": 3,
+                "pkts_num_leak_out": 0
+              },
+              "wm_q_shared_lossless": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 300,
+                "pkts_num_fill_min": 0,
+                "pkts_num_leak_out": 0,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 300,
+                "pg": 3
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 300,
+                "pg": 4
+              },
+              "xoff_3": {
+                "dscp": 2,
+                "ecn": 1,
+                "packet_size": 300,
+                "pg": 2
+              },
+              "xoff_4": {
+                "dscp": 6,
+                "ecn": 1,
+                "packet_size": 300,
+                "pg": 6
+              }
+            },
+            "wm_buf_pool_lossless": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_leak_out": 0,
+              "queue": 3
+            },
+            "wm_buf_pool_lossy": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 0,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_leak_out": 0,
+              "queue": 0
+            },
+            "wm_pg_shared_lossless": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 300,
+              "pg": 3,
+              "pkts_num_fill_min": 0,
+              "pkts_num_leak_out": 0
+            },
+            "wm_pg_shared_lossy": {
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 300,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_leak_out": 0
+            },
+            "wm_q_shared_lossy": {
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 300,
+              "pkts_num_fill_min": 0,
+              "pkts_num_leak_out": 0,
+              "queue": 0
+            },
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "pkts_num_leak_out": 0,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 8,
+              "lossy_weight": 8,
+              "pkts_num_leak_out": 48,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 300,
+              "pg": 3,
+              "pkts_num_leak_out": 0
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "packet_size": 300,
+              "pg": 4,
+              "pkts_num_leak_out": 0
+            },
+            "xon_3": {
+              "dscp": 2,
+              "ecn": 1,
+              "packet_size": 300,
+              "pg": 2,
+              "pkts_num_leak_out": 0
+            },
+            "xon_4": {
+              "dscp": 6,
+              "ecn": 1,
+              "packet_size": 300,
+              "pg": 6,
+              "pkts_num_leak_out": 0
+            }
+          }
+        },
+        "pac": {
+          "topo-any": {
+            "100000_300m": {
+              "lossless_voq_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "num_of_flows": "multiple",
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 2390
+              },
+              "lossless_voq_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "num_of_flows": "multiple",
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 2390
+              },
+              "lossless_voq_3": {
+                "dscp": 3,
+                "ecn": 1,
+                "num_of_flows": "single",
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 2390
+              },
+              "lossless_voq_4": {
+                "dscp": 4,
+                "ecn": 1,
+                "num_of_flows": "single",
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 2390
+              },
+              "lossy_queue_1": {
+                "cell_size": 8192,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 8140,
+                "pg": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 10241
+              },
+              "lossy_queue_voq_2": {
+                "cell_size": 8192,
+                "dscp": 8,
+                "ecn": 1,
+                "flow_config": "shared",
+                "packet_size": 8140,
+                "pg": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 10241
+              },
+              "pg_drop": {
+                "dscp": 3,
+                "ecn": 1,
+                "iterations": 30,
+                "pg": 3,
+                "pkts_num_margin": 300,
+                "pkts_num_trig_ingr_drp": 11396,
+                "pkts_num_trig_pfc": 10248,
+                "queue": 3
+              },
+              "pkts_num_leak_out": 0,
+              "wm_buf_pool_lossless": {
+                "cell_size": 384,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_pfc": 2849,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 2849,
+                "pkts_num_trig_pfc": 2562
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 2849,
+                "pkts_num_trig_pfc": 2562
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 2,
+                "pkts_num_hysteresis": 1024,
+                "pkts_num_trig_pfc": 2561
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 2,
+                "pkts_num_hysteresis": 1024,
+                "pkts_num_trig_pfc": 2561
+              }
+            },
+            "lossy_queue_voq_3": {
+              "cell_size": 8192,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 8140,
+              "pg": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_egr_drp": 10241
+            },
+            "shared_res_size_1": {
+              "cell_size": 384,
+              "dscps": [
+                8,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4
+              ],
+              "dst_port_i": [
+                3,
+                3,
+                3,
+                4,
+                4,
+                5,
+                5
+              ],
+              "ecn": 1,
+              "packet_size": 1350,
+              "pgs": [
+                0,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4
+              ],
+              "pkt_counts": [
+                12,
+                2560,
+                2218,
+                1536,
+                1536,
+                1359,
+                1
+              ],
+              "pkts_num_margin": 1,
+              "queues": [
+                0,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4
+              ],
+              "shared_limit_bytes": 14164224,
+              "src_port_i": [
+                0,
+                0,
+                0,
+                1,
+                1,
+                2,
+                2
+              ]
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 8192,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 8140,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 3,
+              "pkts_num_trig_egr_drp": 10241,
+              "queue": 0
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 384,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 1350,
+              "pg": 3,
+              "pkts_num_fill_min": 0,
+              "pkts_num_margin": 4,
+              "pkts_num_trig_pfc": 11392
+            },
+            "wrr": {
+              "ecn": 1,
+              "limit": 72,
+              "packet_size": 4000,
+              "q0_num_of_pkts": 64,
+              "q1_num_of_pkts": 64,
+              "q2_num_of_pkts": 64,
+              "q3_num_of_pkts": 65,
+              "q4_num_of_pkts": 65,
+              "q5_num_of_pkts": 64,
+              "q6_num_of_pkts": 64
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 72,
+              "lossless_weight": 20,
+              "lossy_weight": 10,
+              "packet_size": 4000,
+              "q0_num_of_pkts": 50,
+              "q1_num_of_pkts": 50,
+              "q2_num_of_pkts": 50,
+              "q3_num_of_pkts": 100,
+              "q4_num_of_pkts": 100,
+              "q5_num_of_pkts": 50,
+              "q6_num_of_pkts": 50
+            }
+          },
+          "topo-t2": {
+            "100000_300m": {
+              "lossless_voq_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "num_of_flows": "multiple",
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 2390
+              },
+              "lossless_voq_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "num_of_flows": "multiple",
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 2390
+              },
+              "lossless_voq_3": {
+                "dscp": 3,
+                "ecn": 1,
+                "num_of_flows": "single",
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 2390
+              },
+              "lossless_voq_4": {
+                "dscp": 4,
+                "ecn": 1,
+                "num_of_flows": "single",
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 2390
+              },
+              "lossy_queue_1": {
+                "cell_size": 8192,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 8140,
+                "pg": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 10241
+              },
+              "pg_drop": {
+                "cell_size": 384,
+                "dscp": 3,
+                "ecn": 1,
+                "iterations": 30,
+                "pg": 3,
+                "pkts_num_margin": 300,
+                "pkts_num_trig_ingr_drp": 11396,
+                "pkts_num_trig_pfc": 10248,
+                "queue": 3
+              },
+              "pkts_num_egr_mem": 5915,
+              "pkts_num_leak_out": 0,
+              "wm_buf_pool_lossless": {
+                "cell_size": 384,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_pfc": 2562,
+                "queue": 3
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 384,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 11392
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 2849,
+                "pkts_num_trig_pfc": 2562
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 2849,
+                "pkts_num_trig_pfc": 2562
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 21,
+                "pkts_num_hysteresis": 1024,
+                "pkts_num_trig_pfc": 2562
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 21,
+                "pkts_num_hysteresis": 1024,
+                "pkts_num_trig_pfc": 2562
+              }
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 8192,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 8140,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 3,
+              "pkts_num_trig_egr_drp": 10241,
+              "queue": 0
+            },
+            "wrr": {
+              "ecn": 1,
+              "limit": 72,
+              "packet_size": 4000,
+              "q0_num_of_pkts": 64,
+              "q1_num_of_pkts": 64,
+              "q2_num_of_pkts": 64,
+              "q3_num_of_pkts": 65,
+              "q4_num_of_pkts": 65,
+              "q5_num_of_pkts": 64,
+              "q6_num_of_pkts": 64
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 72,
+              "lossless_weight": 20,
+              "lossy_weight": 10,
+              "packet_size": 4000,
+              "q0_num_of_pkts": 50,
+              "q1_num_of_pkts": 50,
+              "q2_num_of_pkts": 50,
+              "q3_num_of_pkts": 100,
+              "q4_num_of_pkts": 100,
+              "q5_num_of_pkts": 50,
+              "q6_num_of_pkts": 50
+            }
+          }
+        },
+        "spc3": {
+          "topo-dualtor": {
+            "100000_40m": {
+              "pcbb_xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 177916,
+                "pkts_num_trig_pfc": 176064
+              },
+              "pcbb_xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 177916,
+                "pkts_num_trig_pfc": 176064
+              },
+              "pcbb_xoff_3": {
+                "dscp": 3,
+                "ecn": 1,
+                "outer_dscp": 2,
+                "pg": 2,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 177916,
+                "pkts_num_trig_pfc": 176064
+              },
+              "pcbb_xoff_4": {
+                "dscp": 4,
+                "ecn": 1,
+                "outer_dscp": 6,
+                "pg": 6,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 177916,
+                "pkts_num_trig_pfc": 176064
+              },
+              "pkts_num_leak_out": 0
+            }
+          },
+          "topo-dualtor-64": {
+            "100000_40m": {
+              "pcbb_xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 177916,
+                "pkts_num_trig_pfc": 176064
+              },
+              "pcbb_xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 177916,
+                "pkts_num_trig_pfc": 176064
+              },
+              "pcbb_xoff_3": {
+                "dscp": 3,
+                "ecn": 1,
+                "outer_dscp": 2,
+                "pg": 2,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 177916,
+                "pkts_num_trig_pfc": 176064
+              },
+              "pcbb_xoff_4": {
+                "dscp": 4,
+                "ecn": 1,
+                "outer_dscp": 6,
+                "pg": 6,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 177916,
+                "pkts_num_trig_pfc": 176064
+              },
+              "pkts_num_leak_out": 0
+            }
+          }
+        },
+        "td2": {
+          "topo-any": {
+            "40000_300m": {
+              "breakout": {
+                "pkts_num_leak_out": 48,
+                "wm_buf_pool_lossless": {
+                  "cell_size": 208,
+                  "dscp": 3,
+                  "ecn": 1,
+                  "pg": 3,
+                  "pkts_num_fill_egr_min": 0,
+                  "pkts_num_fill_ingr_min": 6,
+                  "pkts_num_trig_ingr_drp": 5046,
+                  "pkts_num_trig_pfc": 4780,
+                  "queue": 3
+                },
+                "wm_pg_headroom": {
+                  "cell_size": 208,
+                  "dscp": 3,
+                  "ecn": 1,
+                  "pg": 3,
+                  "pkts_num_trig_ingr_drp": 5046,
+                  "pkts_num_trig_pfc": 4780
+                },
+                "wm_pg_shared_lossless": {
+                  "cell_size": 208,
+                  "dscp": 3,
+                  "ecn": 1,
+                  "packet_size": 64,
+                  "pg": 3,
+                  "pkts_num_fill_min": 6,
+                  "pkts_num_trig_pfc": 4780
+                },
+                "wm_q_shared_lossless": {
+                  "cell_size": 208,
+                  "dscp": 3,
+                  "ecn": 1,
+                  "pkts_num_fill_min": 0,
+                  "pkts_num_trig_ingr_drp": 5046,
+                  "queue": 3
+                },
+                "xoff_1": {
+                  "dscp": 3,
+                  "ecn": 1,
+                  "pg": 3,
+                  "pkts_num_trig_ingr_drp": 5046,
+                  "pkts_num_trig_pfc": 4780
+                },
+                "xoff_2": {
+                  "dscp": 4,
+                  "ecn": 1,
+                  "pg": 4,
+                  "pkts_num_trig_ingr_drp": 5046,
+                  "pkts_num_trig_pfc": 4780
+                },
+                "xon_1": {
+                  "dscp": 3,
+                  "ecn": 1,
+                  "pg": 3,
+                  "pkts_num_dismiss_pfc": 18,
+                  "pkts_num_trig_pfc": 4780
+                },
+                "xon_2": {
+                  "dscp": 4,
+                  "ecn": 1,
+                  "pg": 4,
+                  "pkts_num_dismiss_pfc": 18,
+                  "pkts_num_trig_pfc": 4780
+                }
+              },
+              "pkts_num_leak_out": 48,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 0,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 5164,
+                "pkts_num_trig_pfc": 4898,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 5164,
+                "pkts_num_trig_pfc": 4898
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 5164,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 5164,
+                "pkts_num_trig_pfc": 4898
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 5164,
+                "pkts_num_trig_pfc": 4898
+              }
+            },
+            "40000_40m": {
+              "pkts_num_leak_out": 48,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 0,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 5164,
+                "pkts_num_trig_pfc": 4898,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 5164,
+                "pkts_num_trig_pfc": 4898
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 5164,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 5164,
+                "pkts_num_trig_pfc": 4898
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 5164,
+                "pkts_num_trig_pfc": 4898
+              }
+            },
+            "40000_5m": {
+              "pkts_num_leak_out": 48,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 0,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 5164,
+                "pkts_num_trig_pfc": 4898,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 5164,
+                "pkts_num_trig_pfc": 4898
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 5164,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 5164,
+                "pkts_num_trig_pfc": 4898
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 5164,
+                "pkts_num_trig_pfc": 4898
+              }
+            },
+            "ecn_1": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "cell_size": 208,
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "cell_size": 208,
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 31322
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 31322,
+              "queue": 0
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 6,
+              "pkts_num_trig_pfc": 4898
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 1,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 31322
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 1,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_egr_drp": 31322,
+              "queue": 1
+            },
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 12,
+              "pkts_num_trig_pfc": 4898
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 12,
+              "pkts_num_trig_pfc": 4898
+            }
+          },
+          "topo-t0-backend": {
+            "40000_300m": {
+              "pkts_num_leak_out": 48,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 0,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 5006,
+                "pkts_num_trig_pfc": 4703,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 5006,
+                "pkts_num_trig_pfc": 4703
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 6,
+                "pkts_num_trig_pfc": 4703
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 5006,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 5006,
+                "pkts_num_trig_pfc": 4703
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 5006,
+                "pkts_num_trig_pfc": 4703
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 16,
+                "pkts_num_trig_pfc": 4703
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 16,
+                "pkts_num_trig_pfc": 4703
+              }
+            },
+            "lossy_queue_1": {
+              "dscp": 1,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 31322
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 208,
+              "dscp": 1,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 31322,
+              "queue": 0
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 1,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 31322
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 1,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_egr_drp": 31322,
+              "queue": 0
+            },
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80
+            }
+          },
+          "topo-t1-backend": {
+            "40000_300m": {
+              "pkts_num_leak_out": 48,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 0,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 6307,
+                "pkts_num_trig_pfc": 6004,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 6307,
+                "pkts_num_trig_pfc": 6004
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 6,
+                "pkts_num_trig_pfc": 6004
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 6307,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 6307,
+                "pkts_num_trig_pfc": 6004
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 6307,
+                "pkts_num_trig_pfc": 6004
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 17,
+                "pkts_num_trig_pfc": 6004
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 17,
+                "pkts_num_trig_pfc": 6004
+              }
+            },
+            "lossy_queue_1": {
+              "dscp": 1,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 31322
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 208,
+              "dscp": 1,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 31322,
+              "queue": 0
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 1,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 31322
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 1,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_egr_drp": 31322,
+              "queue": 0
+            },
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80
+            }
+          }
+        },
+        "td3": {
+          "topo-any": {
+            "100000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 10,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 18,
+                "pkts_num_hdrm_full": 362,
+                "pkts_num_hdrm_partial": 182,
+                "pkts_num_trig_pfc": 6301,
+                "src_port_ids": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9
+                ]
+              },
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_trig_egr_drp": 84935
+              },
+              "pcbb_xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60829,
+                "pkts_num_trig_pfc": 60204
+              },
+              "pcbb_xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60829,
+                "pkts_num_trig_pfc": 60204
+              },
+              "pcbb_xoff_3": {
+                "dscp": 3,
+                "ecn": 1,
+                "outer_dscp": 2,
+                "pg": 2,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60829,
+                "pkts_num_trig_pfc": 60204
+              },
+              "pcbb_xoff_4": {
+                "dscp": 4,
+                "ecn": 1,
+                "outer_dscp": 6,
+                "pg": 6,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60829,
+                "pkts_num_trig_pfc": 60204
+              },
+              "pkts_num_leak_out": 32,
+              "wm_buf_pool_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 60076,
+                "pkts_num_trig_pfc": 59714,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 14,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 84930,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 60076,
+                "pkts_num_trig_pfc": 59714
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 18,
+                "pkts_num_trig_pfc": 59714
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 84935
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 60076,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 7,
+                "pkts_num_trig_egr_drp": 84935,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60410,
+                "pkts_num_trig_pfc": 59784
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60410,
+                "pkts_num_trig_pfc": 59784
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 18,
+                "pkts_num_trig_pfc": 59714
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 18,
+                "pkts_num_trig_pfc": 59714
+              }
+            },
+            "50000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 10,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 18,
+                "pkts_num_hdrm_full": 240,
+                "pkts_num_hdrm_partial": 182,
+                "pkts_num_trig_pfc": 4478,
+                "src_port_ids": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9
+                ]
+              },
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_trig_egr_drp": 112302
+              },
+              "pkts_num_leak_out": 32,
+              "wm_buf_pool_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 58516,
+                "pkts_num_trig_pfc": 58276,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 14,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 58516,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 58516,
+                "pkts_num_trig_pfc": 58276
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 18,
+                "pkts_num_trig_pfc": 58276
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 112302
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 58516,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 7,
+                "pkts_num_trig_egr_drp": 58516,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 50,
+                "pkts_num_trig_ingr_drp": 58816,
+                "pkts_num_trig_pfc": 58576
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 50,
+                "pkts_num_trig_ingr_drp": 58816,
+                "pkts_num_trig_pfc": 58576
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 18,
+                "pkts_num_trig_pfc": 58276
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 18,
+                "pkts_num_trig_pfc": 58276
+              }
+            },
+            "cell_size": 256,
+            "ecn_1": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "cell_size": 256,
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "cell_size": 256,
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "hdrm_pool_wm_multiplier": 1,
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80
+            }
+          },
+          "topo-dualtor": {
+            "100000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 10,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 18,
+                "pkts_num_hdrm_full": 362,
+                "pkts_num_hdrm_partial": 182,
+                "pkts_num_trig_pfc": 6301,
+                "src_port_ids": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9
+                ]
+              },
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_trig_egr_drp": 84935
+              },
+              "pcbb_xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60829,
+                "pkts_num_trig_pfc": 60204
+              },
+              "pcbb_xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60829,
+                "pkts_num_trig_pfc": 60204
+              },
+              "pcbb_xoff_3": {
+                "dscp": 3,
+                "ecn": 1,
+                "outer_dscp": 2,
+                "pg": 2,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60829,
+                "pkts_num_trig_pfc": 60204
+              },
+              "pcbb_xoff_4": {
+                "dscp": 4,
+                "ecn": 1,
+                "outer_dscp": 6,
+                "pg": 6,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60829,
+                "pkts_num_trig_pfc": 60204
+              },
+              "pkts_num_leak_out": 32,
+              "wm_buf_pool_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 60076,
+                "pkts_num_trig_pfc": 59714,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 14,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 84930,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 60076,
+                "pkts_num_trig_pfc": 59714
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 18,
+                "pkts_num_trig_pfc": 59714
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 84935
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 60076,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 7,
+                "pkts_num_trig_egr_drp": 84935,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60829,
+                "pkts_num_trig_pfc": 60204
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60829,
+                "pkts_num_trig_pfc": 60204
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 18,
+                "pkts_num_trig_pfc": 59714
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 18,
+                "pkts_num_trig_pfc": 59714
+              }
+            },
+            "cell_size": 256,
+            "ecn_1": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "cell_size": 256,
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "cell_size": 256,
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "hdrm_pool_wm_multiplier": 1,
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80
+            }
+          },
+          "topo-dualtor-56": {
+            "100000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 10,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 18,
+                "pkts_num_hdrm_full": 362,
+                "pkts_num_hdrm_partial": 182,
+                "pkts_num_trig_pfc": 6301,
+                "src_port_ids": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9
+                ]
+              },
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_trig_egr_drp": 84935
+              },
+              "pcbb_xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 59749,
+                "pkts_num_trig_pfc": 59124
+              },
+              "pcbb_xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 59749,
+                "pkts_num_trig_pfc": 59124
+              },
+              "pcbb_xoff_3": {
+                "dscp": 3,
+                "ecn": 1,
+                "outer_dscp": 2,
+                "pg": 2,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 59749,
+                "pkts_num_trig_pfc": 59124
+              },
+              "pcbb_xoff_4": {
+                "dscp": 4,
+                "ecn": 1,
+                "outer_dscp": 6,
+                "pg": 6,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 59749,
+                "pkts_num_trig_pfc": 59124
+              },
+              "pkts_num_leak_out": 32,
+              "wm_buf_pool_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 60076,
+                "pkts_num_trig_pfc": 59714,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 14,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 84930,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 60076,
+                "pkts_num_trig_pfc": 59714
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 18,
+                "pkts_num_trig_pfc": 59714
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 84935
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 60076,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 7,
+                "pkts_num_trig_egr_drp": 84935,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60410,
+                "pkts_num_trig_pfc": 59784
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60410,
+                "pkts_num_trig_pfc": 59784
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 18,
+                "pkts_num_trig_pfc": 59714
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 18,
+                "pkts_num_trig_pfc": 59714
+              }
+            },
+            "50000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 10,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 18,
+                "pkts_num_hdrm_full": 240,
+                "pkts_num_hdrm_partial": 182,
+                "pkts_num_trig_pfc": 4478,
+                "src_port_ids": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9
+                ]
+              },
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_trig_egr_drp": 112302
+              },
+              "pkts_num_leak_out": 32,
+              "wm_buf_pool_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 58516,
+                "pkts_num_trig_pfc": 58276,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 14,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 58516,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 58516,
+                "pkts_num_trig_pfc": 58276
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 18,
+                "pkts_num_trig_pfc": 58276
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 112302
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 58516,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 7,
+                "pkts_num_trig_egr_drp": 58516,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 50,
+                "pkts_num_trig_ingr_drp": 58816,
+                "pkts_num_trig_pfc": 58576
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 50,
+                "pkts_num_trig_ingr_drp": 58816,
+                "pkts_num_trig_pfc": 58576
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 18,
+                "pkts_num_trig_pfc": 58276
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 18,
+                "pkts_num_trig_pfc": 58276
+              }
+            },
+            "cell_size": 256,
+            "ecn_1": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "cell_size": 256,
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "cell_size": 256,
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "hdrm_pool_wm_multiplier": 1,
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80
+            }
+          },
+          "topo-t1-lag": {
+            "100000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 18,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 18,
+                "pkts_num_hdrm_full": 362,
+                "pkts_num_hdrm_partial": 182,
+                "pkts_num_trig_pfc": 4478,
+                "src_port_ids": [
+                  0,
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16
+                ]
+              },
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_trig_egr_drp": 113198
+              },
+              "pkts_num_leak_out": 32,
+              "wm_buf_pool_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 59967,
+                "pkts_num_trig_pfc": 59605,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 14,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 113198,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 59967,
+                "pkts_num_trig_pfc": 59605
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 18,
+                "pkts_num_trig_pfc": 59605
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 113198
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 256,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 59967,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 256,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 7,
+                "pkts_num_trig_egr_drp": 59967,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60228,
+                "pkts_num_trig_pfc": 59605
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 60228,
+                "pkts_num_trig_pfc": 59605
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 18,
+                "pkts_num_trig_pfc": 59605
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 18,
+                "pkts_num_trig_pfc": 59605
+              }
+            },
+            "cell_size": 256,
+            "ecn_1": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "cell_size": 256,
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "cell_size": 256,
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "cell_size": 256,
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "hdrm_pool_wm_multiplier": 1,
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80
+            }
+          }
+        },
+        "th": {
+          "topo-any": {
+            "100000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 16,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 4,
+                "pkts_num_hdrm_full": 1292,
+                "pkts_num_hdrm_partial": 1165,
+                "pkts_num_trig_pfc": 2620,
+                "src_port_ids": [
+                  17,
+                  18
+                ]
+              },
+              "pkts_num_leak_out": 36,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 7835,
+                "pkts_num_trig_pfc": 6542,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7835,
+                "pkts_num_trig_pfc": 6542
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_min": 6,
+                "pkts_num_trig_pfc": 6542
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 8,
+                "pkts_num_trig_ingr_drp": 7835,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7835,
+                "pkts_num_trig_pfc": 6542
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 7835,
+                "pkts_num_trig_pfc": 6542
+              }
+            },
+            "40000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 24,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 10,
+                "pkts_num_hdrm_full": 520,
+                "pkts_num_hdrm_partial": 361,
+                "pkts_num_trig_pfc": 1194,
+                "src_port_ids": [
+                  25,
+                  26,
+                  27,
+                  40,
+                  41
+                ]
+              },
+              "pkts_num_leak_out": 19,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 7063,
+                "pkts_num_trig_pfc": 6542,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7063,
+                "pkts_num_trig_pfc": 6542
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 8,
+                "pkts_num_trig_ingr_drp": 7063,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7063,
+                "pkts_num_trig_pfc": 6542
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 7063,
+                "pkts_num_trig_pfc": 6542
+              }
+            },
+            "50000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 5,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 8,
+                "pkts_num_hdrm_full": 682,
+                "pkts_num_hdrm_partial": 267,
+                "pkts_num_trig_pfc": 1458,
+                "src_port_ids": [
+                  1,
+                  2,
+                  3,
+                  4
+                ]
+              },
+              "pkts_num_leak_out": 23,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 7225,
+                "pkts_num_trig_pfc": 6542,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7225,
+                "pkts_num_trig_pfc": 6542
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 8,
+                "pkts_num_trig_ingr_drp": 7225,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7225,
+                "pkts_num_trig_pfc": 6542
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 7225,
+                "pkts_num_trig_pfc": 6542
+              }
+            },
+            "cell_size": 208,
+            "ecn_1": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "cell_size": 208,
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "cell_size": 208,
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "hdrm_pool_wm_multiplier": 4,
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 9887
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 9887,
+              "queue": 0
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 6,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 9887
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_egr_drp": 9887,
+              "queue": 0
+            },
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 12,
+              "pkts_num_trig_pfc": 6542
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 12,
+              "pkts_num_trig_pfc": 6542
+            }
+          },
+          "topo-t0-64": {
+            "100000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 16,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 4,
+                "pkts_num_hdrm_full": 1292,
+                "pkts_num_hdrm_partial": 1165,
+                "pkts_num_trig_pfc": 2620,
+                "src_port_ids": [
+                  17,
+                  18
+                ]
+              },
+              "pkts_num_leak_out": 36,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 7835,
+                "pkts_num_trig_pfc": 6542,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7835,
+                "pkts_num_trig_pfc": 6542
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_min": 6,
+                "pkts_num_trig_pfc": 6542
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 8,
+                "pkts_num_trig_ingr_drp": 7835,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7835,
+                "pkts_num_trig_pfc": 6542
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 7835,
+                "pkts_num_trig_pfc": 6542
+              }
+            },
+            "40000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 24,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 10,
+                "pkts_num_hdrm_full": 520,
+                "pkts_num_hdrm_partial": 361,
+                "pkts_num_trig_pfc": 1194,
+                "src_port_ids": [
+                  25,
+                  26,
+                  27,
+                  40,
+                  41
+                ]
+              },
+              "pkts_num_leak_out": 19,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 7063,
+                "pkts_num_trig_pfc": 6542,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7063,
+                "pkts_num_trig_pfc": 6542
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 8,
+                "pkts_num_trig_ingr_drp": 7063,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7063,
+                "pkts_num_trig_pfc": 6542
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 7063,
+                "pkts_num_trig_pfc": 6542
+              }
+            },
+            "50000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 5,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 8,
+                "pkts_num_hdrm_full": 682,
+                "pkts_num_hdrm_partial": 267,
+                "pkts_num_trig_pfc": 1458,
+                "src_port_ids": [
+                  1,
+                  2,
+                  3,
+                  4
+                ]
+              },
+              "pkts_num_leak_out": 23,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 7225,
+                "pkts_num_trig_pfc": 6542,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7225,
+                "pkts_num_trig_pfc": 6542
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 8,
+                "pkts_num_trig_ingr_drp": 7225,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7225,
+                "pkts_num_trig_pfc": 6542
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 7225,
+                "pkts_num_trig_pfc": 6542
+              }
+            },
+            "cell_size": 208,
+            "dst_port_ids": [
+              52,
+              53,
+              54
+            ],
+            "ecn_1": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "cell_size": 208,
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "cell_size": 208,
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "hdrm_pool_wm_multiplier": 4,
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 9887
+            },
+            "src_port_ids": [
+              22
+            ],
+            "wm_buf_pool_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 9887,
+              "queue": 0
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 6,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 9887
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_egr_drp": 9887,
+              "queue": 0
+            },
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 12,
+              "pkts_num_trig_pfc": 6542
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 12,
+              "pkts_num_trig_pfc": 6542
+            }
+          },
+          "topo-t1-64-lag": {
+            "100000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 16,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 4,
+                "pkts_num_hdrm_full": 1292,
+                "pkts_num_hdrm_partial": 1165,
+                "pkts_num_trig_pfc": 2620,
+                "src_port_ids": [
+                  17,
+                  18
+                ]
+              },
+              "pkts_num_leak_out": 36,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 7835,
+                "pkts_num_trig_pfc": 6542,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7835,
+                "pkts_num_trig_pfc": 6542
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_min": 6,
+                "pkts_num_trig_pfc": 6542
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 8,
+                "pkts_num_trig_ingr_drp": 7835,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7835,
+                "pkts_num_trig_pfc": 6542
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 7835,
+                "pkts_num_trig_pfc": 6542
+              }
+            },
+            "40000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 24,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 10,
+                "pkts_num_hdrm_full": 520,
+                "pkts_num_hdrm_partial": 361,
+                "pkts_num_trig_pfc": 1194,
+                "src_port_ids": [
+                  25,
+                  26,
+                  27,
+                  40,
+                  41
+                ]
+              },
+              "pkts_num_leak_out": 19,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 7063,
+                "pkts_num_trig_pfc": 6542,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7063,
+                "pkts_num_trig_pfc": 6542
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 8,
+                "pkts_num_trig_ingr_drp": 7063,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7063,
+                "pkts_num_trig_pfc": 6542
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 7063,
+                "pkts_num_trig_pfc": 6542
+              }
+            },
+            "50000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 5,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 8,
+                "pkts_num_hdrm_full": 682,
+                "pkts_num_hdrm_partial": 267,
+                "pkts_num_trig_pfc": 1458,
+                "src_port_ids": [
+                  1,
+                  2,
+                  3,
+                  4
+                ]
+              },
+              "pkts_num_leak_out": 23,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 7225,
+                "pkts_num_trig_pfc": 6542,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7225,
+                "pkts_num_trig_pfc": 6542
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 8,
+                "pkts_num_trig_ingr_drp": 7225,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 7225,
+                "pkts_num_trig_pfc": 6542
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 7225,
+                "pkts_num_trig_pfc": 6542
+              }
+            },
+            "cell_size": 208,
+            "dst_port_ids": [
+              52,
+              53,
+              54
+            ],
+            "ecn_1": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "cell_size": 208,
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "cell_size": 208,
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "hdrm_pool_wm_multiplier": 4,
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 9887
+            },
+            "src_port_ids": [
+              20,
+              50
+            ],
+            "wm_buf_pool_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 8,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 9887,
+              "queue": 0
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 6,
+              "pkts_num_trig_pfc": 6542
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 9887
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_egr_drp": 9887,
+              "queue": 0
+            },
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 12,
+              "pkts_num_trig_pfc": 6542
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 12,
+              "pkts_num_trig_pfc": 6542
+            }
+          }
+        },
+        "th2": {
+          "topo-any": {
+            "100000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 0,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 14,
+                "pkts_num_hdrm_full": 682,
+                "pkts_num_hdrm_partial": 542,
+                "pkts_num_trig_pfc": 1826,
+                "src_port_ids": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ]
+              },
+              "pcbb_xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 20425,
+                "pkts_num_trig_pfc": 19939
+              },
+              "pcbb_xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 20425,
+                "pkts_num_trig_pfc": 19939
+              },
+              "pcbb_xoff_3": {
+                "dscp": 3,
+                "ecn": 1,
+                "outer_dscp": 2,
+                "pg": 2,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 20425,
+                "pkts_num_trig_pfc": 19939
+              },
+              "pcbb_xoff_4": {
+                "dscp": 4,
+                "ecn": 1,
+                "outer_dscp": 6,
+                "pg": 6,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 20425,
+                "pkts_num_trig_pfc": 19939
+              },
+              "pkts_num_leak_out": 0,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 16,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 5140,
+                "pkts_num_trig_pfc": 4457,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 5140,
+                "pkts_num_trig_pfc": 4457
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 5140,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 20425,
+                "pkts_num_trig_pfc": 19939
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 20425,
+                "pkts_num_trig_pfc": 19939
+              }
+            },
+            "40000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 32,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 19,
+                "pkts_num_hdrm_full": 520,
+                "pkts_num_hdrm_partial": 47,
+                "pkts_num_trig_pfc": 1490,
+                "src_port_ids": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10,
+                  38,
+                  39,
+                  40,
+                  41,
+                  42
+                ]
+              },
+              "pkts_num_leak_out": 0,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 16,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 4978,
+                "pkts_num_trig_pfc": 4457,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 4978,
+                "pkts_num_trig_pfc": 4457
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 4978,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 4978,
+                "pkts_num_trig_pfc": 4457
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 4978,
+                "pkts_num_trig_pfc": 4457
+              }
+            },
+            "50000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 0,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 14,
+                "pkts_num_hdrm_full": 682,
+                "pkts_num_hdrm_partial": 542,
+                "pkts_num_trig_pfc": 1826,
+                "src_port_ids": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ]
+              },
+              "pkts_num_leak_out": 0,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 16,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 5140,
+                "pkts_num_trig_pfc": 4457,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 5140,
+                "pkts_num_trig_pfc": 4457
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 5140,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 20521,
+                "pkts_num_trig_pfc": 20034
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 20521,
+                "pkts_num_trig_pfc": 20034
+              }
+            },
+            "cell_size": 208,
+            "ecn_1": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "cell_size": 208,
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "cell_size": 208,
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "hdrm_pool_wm_multiplier": 4,
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 10692
+            },
+            "wm_buf_pool_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 16,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 10692,
+              "queue": 0
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 6,
+              "pkts_num_trig_pfc": 4457
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 10692
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_egr_drp": 10692,
+              "queue": 0
+            },
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140,
+              "q7_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80,
+              "q7_num_of_pkts": 80
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 12,
+              "pkts_num_trig_pfc": 4457
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 12,
+              "pkts_num_trig_pfc": 4457
+            }
+          },
+          "topo-dualtor-aa-56": {
+            "50000_40m": {
+              "pcbb_xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 19939
+              },
+              "pcbb_xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 19939
+              },
+              "pcbb_xoff_3": {
+                "dscp": 3,
+                "ecn": 1,
+                "outer_dscp": 2,
+                "pg": 2,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 19939
+              },
+              "pcbb_xoff_4": {
+                "dscp": 4,
+                "ecn": 1,
+                "outer_dscp": 6,
+                "pg": 6,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 19939
+              }
+            }
+          },
+          "topo-t1-64-lag": {
+            "100000_300m": {
+              "pkts_num_leak_out": 0,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 16,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 4978,
+                "pkts_num_trig_pfc": 4490,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 1,
+                "pkts_num_trig_ingr_drp": 4978,
+                "pkts_num_trig_pfc": 4490
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 4978,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 20481,
+                "pkts_num_trig_pfc": 19994
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 20481,
+                "pkts_num_trig_pfc": 19994
+              }
+            },
+            "100000_40m": {
+              "pkts_num_leak_out": 0,
+              "wm_buf_pool_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 16,
+                "pkts_num_fill_ingr_min": 6,
+                "pkts_num_trig_ingr_drp": 4779,
+                "pkts_num_trig_pfc": 4490,
+                "queue": 3
+              },
+              "wm_pg_headroom": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 1,
+                "pkts_num_trig_ingr_drp": 4779,
+                "pkts_num_trig_pfc": 4490
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 208,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 4779,
+                "queue": 3
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_ingr_drp": 4779,
+                "pkts_num_trig_pfc": 4490
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_ingr_drp": 4779,
+                "pkts_num_trig_pfc": 4490
+              }
+            },
+            "cell_size": 208,
+            "dst_port_ids": [
+              52,
+              53,
+              54
+            ],
+            "ecn_1": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "cell_size": 208,
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "cell_size": 208,
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "hdrm_pool_wm_multiplier": 4,
+            "lossy_queue_1": {
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_trig_egr_drp": 10773
+            },
+            "src_port_ids": [
+              20,
+              50
+            ],
+            "wm_buf_pool_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "pg": 0,
+              "pkts_num_fill_egr_min": 16,
+              "pkts_num_fill_ingr_min": 0,
+              "pkts_num_trig_egr_drp": 10773,
+              "queue": 0
+            },
+            "wm_pg_shared_lossless": {
+              "cell_size": 208,
+              "dscp": 3,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 3,
+              "pkts_num_fill_min": 6,
+              "pkts_num_trig_pfc": 4490
+            },
+            "wm_pg_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "packet_size": 64,
+              "pg": 0,
+              "pkts_num_fill_min": 0,
+              "pkts_num_trig_egr_drp": 10773
+            },
+            "wm_q_shared_lossy": {
+              "cell_size": 208,
+              "dscp": 8,
+              "ecn": 1,
+              "pkts_num_fill_min": 8,
+              "pkts_num_trig_egr_drp": 10773,
+              "queue": 0
+            },
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140,
+              "q7_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80,
+              "q7_num_of_pkts": 80
+            },
+            "xon_1": {
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_dismiss_pfc": 12,
+              "pkts_num_trig_pfc": 4490
+            },
+            "xon_2": {
+              "dscp": 4,
+              "ecn": 1,
+              "pg": 4,
+              "pkts_num_dismiss_pfc": 12,
+              "pkts_num_trig_pfc": 4490
+            }
+          }
+        },
+        "th3": {
+          "topo-t0-80": {
+            "100000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 20,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 37,
+                "pkts_num_hdrm_full": 462,
+                "pkts_num_hdrm_partial": 384,
+                "pkts_num_trig_pfc": 2634,
+                "src_port_ids": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9,
+                  10,
+                  11,
+                  12,
+                  13,
+                  14,
+                  15,
+                  16,
+                  17,
+                  18,
+                  19
+                ]
+              },
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_margin": 11,
+                "pkts_num_trig_egr_drp": 73394
+              },
+              "pkts_num_egr_mem": 50,
+              "pkts_num_leak_out": 42,
+              "wm_buf_pool_lossless": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 7,
+                "pkts_num_trig_ingr_drp": 22488,
+                "pkts_num_trig_pfc": 22026,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 254,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 7,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 73394,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 8,
+                "pkts_num_trig_ingr_drp": 22488,
+                "pkts_num_trig_pfc": 22026
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 10,
+                "pkts_num_margin": 1,
+                "pkts_num_trig_pfc": 22026
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 254,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 7,
+                "pkts_num_margin": 10,
+                "pkts_num_trig_egr_drp": 73394
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 22488,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 254,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 7,
+                "pkts_num_trig_egr_drp": 73394,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 22488,
+                "pkts_num_trig_pfc": 22026
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 22488,
+                "pkts_num_trig_pfc": 22026
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 13,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 22026
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 13,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 22026
+              }
+            },
+            "cell_size": 254,
+            "ecn_1": {
+              "cell_size": 254,
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "cell_size": 254,
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "cell_size": 254,
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "cell_size": 254,
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "hdrm_pool_wm_multiplier": 1,
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140,
+              "q7_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80,
+              "q7_num_of_pkts": 80
+            }
+          },
+          "topo-t1-lag": {
+            "400000_300m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 29,
+                "ecn": 1,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 37,
+                "pkts_num_hdrm_full": 1472,
+                "pkts_num_hdrm_partial": 552,
+                "pkts_num_trig_pfc": 1856,
+                "src_port_ids": [
+                  0,
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16,
+                  17,
+                  18,
+                  19,
+                  20,
+                  21,
+                  22,
+                  23,
+                  24,
+                  25,
+                  26
+                ]
+              },
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_margin": 5,
+                "pkts_num_trig_egr_drp": 50482
+              },
+              "pkts_num_egr_mem": 101,
+              "pkts_num_leak_out": 109,
+              "wm_buf_pool_lossless": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_fill_egr_min": 8,
+                "pkts_num_fill_ingr_min": 7,
+                "pkts_num_trig_ingr_drp": 16624,
+                "pkts_num_trig_pfc": 15152,
+                "queue": 3
+              },
+              "wm_buf_pool_lossy": {
+                "cell_size": 254,
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_fill_egr_min": 7,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_egr_drp": 50482,
+                "queue": 0
+              },
+              "wm_pg_headroom": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 16624,
+                "pkts_num_trig_pfc": 15152
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 10,
+                "pkts_num_margin": 1,
+                "pkts_num_trig_pfc": 15152
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 254,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 7,
+                "pkts_num_margin": 1,
+                "pkts_num_trig_egr_drp": 50482
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 16624,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 254,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 7,
+                "pkts_num_trig_egr_drp": 50482,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 16624,
+                "pkts_num_trig_pfc": 15152
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_ingr_drp": 16624,
+                "pkts_num_trig_pfc": 15152
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 13,
+                "pkts_num_trig_pfc": 15152
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 13,
+                "pkts_num_trig_pfc": 15152
+              }
+            },
+            "cell_size": 254,
+            "ecn_1": {
+              "cell_size": 254,
+              "dscp": 8,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_2": {
+              "cell_size": 254,
+              "dscp": 8,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "ecn_3": {
+              "cell_size": 254,
+              "dscp": 0,
+              "ecn": 0,
+              "limit": 182000,
+              "min_limit": 180000,
+              "num_of_pkts": 5000
+            },
+            "ecn_4": {
+              "cell_size": 254,
+              "dscp": 0,
+              "ecn": 1,
+              "limit": 182320,
+              "min_limit": 0,
+              "num_of_pkts": 2047
+            },
+            "hdrm_pool_wm_multiplier": 1,
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140,
+              "q7_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80,
+              "q7_num_of_pkts": 80
+            }
+          }
+        },
+        "th5": {
+          "topo-t0-standalone": {
+            "200000_5m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 0,
+                "ecn": 1,
+                "margin": 2,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 50,
+                "pkts_num_hdrm_full": 1185,
+                "pkts_num_hdrm_partial": 47,
+                "pkts_num_trig_pfc": 120117,
+                "pkts_num_trig_pfc_multi": [
+                  120117,
+                  60096,
+                  30085,
+                  15079,
+                  7577,
+                  3825,
+                  1950,
+                  1012,
+                  543,
+                  308,
+                  191,
+                  133,
+                  103,
+                  89,
+                  81,
+                  78,
+                  76,
+                  75,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74
+                ],
+                "src_port_ids": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9,
+                  10,
+                  11,
+                  12,
+                  13,
+                  14,
+                  15,
+                  16,
+                  17,
+                  18,
+                  19,
+                  20,
+                  21,
+                  22,
+                  23,
+                  24,
+                  25
+                ]
+              },
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_egr_drp": 120051
+              },
+              "pkts_num_egr_mem": 238,
+              "pkts_num_leak_out": 0,
+              "wm_pg_headroom": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 121302,
+                "pkts_num_trig_pfc": 120117
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 74,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_pfc": 120117
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 254,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 7,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_egr_drp": 120051
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 121302,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 254,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 7,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_egr_drp": 120051,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 121302,
+                "pkts_num_trig_pfc": 120117
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 121302,
+                "pkts_num_trig_pfc": 120117
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 14,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_pfc": 120117
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 14,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_pfc": 120117
+              }
+            },
+            "cell_size": 254,
+            "hdrm_pool_wm_multiplier": 1,
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140,
+              "q7_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80,
+              "q7_num_of_pkts": 80
+            }
+          },
+          "topo-t0-standalone-256": {
+            "200000_5m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 0,
+                "ecn": 1,
+                "margin": 2,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 50,
+                "pkts_num_hdrm_full": 1185,
+                "pkts_num_hdrm_partial": 47,
+                "pkts_num_trig_pfc": 120117,
+                "pkts_num_trig_pfc_multi": [
+                  120117,
+                  60096,
+                  30085,
+                  15079,
+                  7577,
+                  3825,
+                  1950,
+                  1012,
+                  543,
+                  308,
+                  191,
+                  133,
+                  103,
+                  89,
+                  81,
+                  78,
+                  76,
+                  75,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74
+                ],
+                "src_port_ids": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9,
+                  10,
+                  11,
+                  12,
+                  13,
+                  14,
+                  15,
+                  16,
+                  17,
+                  18,
+                  19,
+                  20,
+                  21,
+                  22,
+                  23,
+                  24,
+                  25
+                ]
+              },
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_egr_drp": 120051
+              },
+              "pkts_num_egr_mem": 238,
+              "pkts_num_leak_out": 0,
+              "wm_pg_headroom": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 121302,
+                "pkts_num_trig_pfc": 120117
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 74,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_pfc": 120117
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 254,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 7,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_egr_drp": 120051
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 121302,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 254,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 7,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_egr_drp": 120051,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 121302,
+                "pkts_num_trig_pfc": 120117
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 121302,
+                "pkts_num_trig_pfc": 120117
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 14,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_pfc": 120117
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 14,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_pfc": 120117
+              }
+            },
+            "cell_size": 254,
+            "hdrm_pool_wm_multiplier": 1,
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140,
+              "q7_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80,
+              "q7_num_of_pkts": 80
+            }
+          },
+          "topo-t0-standalone-32": {
+            "200000_5m": {
+              "hdrm_pool_size": {
+                "dscps": [
+                  3,
+                  4
+                ],
+                "dst_port_id": 0,
+                "ecn": 1,
+                "margin": 2,
+                "pgs": [
+                  3,
+                  4
+                ],
+                "pgs_num": 50,
+                "pkts_num_hdrm_full": 1185,
+                "pkts_num_hdrm_partial": 47,
+                "pkts_num_trig_pfc": 120117,
+                "pkts_num_trig_pfc_multi": [
+                  120117,
+                  60096,
+                  30085,
+                  15079,
+                  7577,
+                  3825,
+                  1950,
+                  1012,
+                  543,
+                  308,
+                  191,
+                  133,
+                  103,
+                  89,
+                  81,
+                  78,
+                  76,
+                  75,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74,
+                  74
+                ],
+                "src_port_ids": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9,
+                  10,
+                  11,
+                  12,
+                  13,
+                  14,
+                  15,
+                  16,
+                  17,
+                  18,
+                  19,
+                  20,
+                  21,
+                  22,
+                  23,
+                  24,
+                  25
+                ]
+              },
+              "lossy_queue_1": {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_egr_drp": 120051
+              },
+              "pkts_num_egr_mem": 238,
+              "pkts_num_leak_out": 0,
+              "wm_pg_headroom": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 121302,
+                "pkts_num_trig_pfc": 120117
+              },
+              "wm_pg_shared_lossless": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 3,
+                "pkts_num_fill_min": 74,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_pfc": 120117
+              },
+              "wm_pg_shared_lossy": {
+                "cell_size": 254,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 64,
+                "pg": 0,
+                "pkts_num_fill_min": 7,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_egr_drp": 120051
+              },
+              "wm_q_shared_lossless": {
+                "cell_size": 254,
+                "dscp": 3,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 121302,
+                "queue": 3
+              },
+              "wm_q_shared_lossy": {
+                "cell_size": 254,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 7,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_egr_drp": 120051,
+                "queue": 0
+              },
+              "xoff_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 121302,
+                "pkts_num_trig_pfc": 120117
+              },
+              "xoff_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_ingr_drp": 121302,
+                "pkts_num_trig_pfc": 120117
+              },
+              "xon_1": {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 14,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_pfc": 120117
+              },
+              "xon_2": {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 14,
+                "pkts_num_margin": 2,
+                "pkts_num_trig_pfc": 120117
+              }
+            },
+            "cell_size": 254,
+            "hdrm_pool_wm_multiplier": 1,
+            "wrr": {
+              "ecn": 1,
+              "limit": 80,
+              "q0_num_of_pkts": 140,
+              "q1_num_of_pkts": 140,
+              "q2_num_of_pkts": 140,
+              "q3_num_of_pkts": 150,
+              "q4_num_of_pkts": 150,
+              "q5_num_of_pkts": 140,
+              "q6_num_of_pkts": 140,
+              "q7_num_of_pkts": 140
+            },
+            "wrr_chg": {
+              "ecn": 1,
+              "limit": 80,
+              "lossless_weight": 30,
+              "lossy_weight": 8,
+              "q0_num_of_pkts": 80,
+              "q1_num_of_pkts": 80,
+              "q2_num_of_pkts": 80,
+              "q3_num_of_pkts": 300,
+              "q4_num_of_pkts": 300,
+              "q5_num_of_pkts": 80,
+              "q6_num_of_pkts": 80,
+              "q7_num_of_pkts": 80
+            }
+          }
+        }
+      }
+    },
+    "dutAsic": "kvm",
+    "dstDutAsic": "kvm",
+    "dutTopo": "topo-any",
+    "srcDutInstance": "<vs-kvm>",
+    "dstDutInstance": "<vs-kvm>",
+    "dualTor": "False",
+    "dualTorScenario": "True"
+  }

--- a/tests/qos/files/vs/dutQosConfig.json
+++ b/tests/qos/files/vs/dutQosConfig.json
@@ -1,874 +1,792 @@
 {
-    "param":
-    {
-        "100000_120000m":
-        {
-            "lossy_queue_1":
-            {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 16000
-            },
-            "pg_drop":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "iterations": 30,
-                "pg": 3,
-                "pkts_num_margin": 30000,
-                "pkts_num_trig_ingr_drp": 524288,
-                "pkts_num_trig_pfc": 262144,
-                "queue": 3
-            },
-            "pkts_num_leak_out": 0,
-            "wm_buf_pool_lossless":
-            {
-                "cell_size": 8192,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8140,
-                "pg": 3,
-                "pkts_num_fill_ingr_min": 140,
-                "pkts_num_margin": 6,
-                "pkts_num_trig_pfc": 6412,
-                "queue": 3
-            },
-            "wm_pg_shared_lossless":
-            {
-                "cell_size": 8192,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 6403
-            },
-            "wm_pg_shared_lossy":
-            {
-                "cell_size": 8192,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 0,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 728
-            },
-            "wm_q_shared_lossless":
-            {
-                "cell_size": 6144,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 19456,
-                "pkts_num_trig_ingr_drp": 12807,
-                "queue": 3
-            },
-            "wm_q_shared_lossy":
-            {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 3072,
-                "pkts_num_trig_egr_drp": 16000,
-                "queue": 0
-            },
-            "wm_q_wm_all_ports":
-            {
-                "cell_size": 6144,
-                "ecn": 1,
-                "packet_size": 6144,
-                "pkt_count": 3000,
-                "pkts_num_margin": 19456
-            },
-            "xoff_1":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 6404,
-                "pkts_num_trig_pfc": 3202
-            },
-            "xoff_2":
-            {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 4,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 6404,
-                "pkts_num_trig_pfc": 3202
-            },
-            "xon_1":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 2,
-                "pkts_num_trig_pfc": 3201
-            },
-            "xon_2":
-            {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 2,
-                "pkts_num_trig_pfc": 3201
-            }
-        },
-        "100000_300m":
-        {
-            "pcbb_xoff_1":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-            },
-            "pcbb_xoff_2":
-            {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-            },
-            "pcbb_xoff_3":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "outer_dscp": 2,
-                "packet_size": 1350,
-                "pg": 2,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-            },
-            "pcbb_xoff_4":
-            {
-                "dscp": 4,
-                "ecn": 1,
-                "outer_dscp": 6,
-                "packet_size": 1350,
-                "pg": 6,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-            },
-            "pkts_num_leak_out": 0,
-            "xoff_1":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_pfc": 3415,
-                "pkts_num_trig_ingr_drp": 3703,
-                "packet_size": 1350
-            },
-            "xoff_2":
-            {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_pfc": 3415,
-                "pkts_num_trig_ingr_drp": 3703,
-                "packet_size": 1350
-            },
-            "xon_1":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "pkts_num_trig_pfc": 3414,
-                "pkts_num_hysteresis": 1877,
-                "pkts_num_dismiss_pfc": 2,
-                "packet_size": 1350
-            },
-            "xon_2":
-            {
-                "dscp": 4,
-                "ecn": 1,
-                "pg": 4,
-                "pkts_num_trig_pfc": 3414,
-                "pkts_num_hysteresis": 1877,
-                "pkts_num_dismiss_pfc": 2,
-                "packet_size": 1350
-            },
-            "wm_pg_shared_lossless":
-            {
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "cell_size": 384,
-                "dscp": 3,
-                "pg": 3,
-                "pkts_num_trig_pfc": 14807
-            },
-            "wm_pg_shared_lossy":
-            {
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "cell_size": 384,
-                "dscp": 8,
-                "pg": 0,
-                "pkts_num_trig_egr_drp": 16000
-            },
-            "wm_buf_pool_lossless":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "queue": 3,
-                "pkts_num_fill_ingr_min": 0,
-                "pkts_num_trig_pfc": 3703,
-                "cell_size": 384,
-                "packet_size": 1350
-            },
-            "wm_buf_pool_lossy":
-            {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "queue": 0,
-                "pkts_num_trig_egr_drp": 4000,
-                "pkts_num_fill_egr_min": 0,
-                "cell_size": 384,
-                "packet_size": 1350
-            },
-            "wm_q_shared_lossless":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "queue": 3,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_ingr_drp": 14815,
-                "pkts_num_margin": 3072,
-                "cell_size": 384
-            },
-            "wm_q_shared_lossy":
-            {
-                "dscp": 8,
-                "ecn": 1,
-                "queue": 0,
-                "pkts_num_fill_min": 0,
-                "pkts_num_trig_egr_drp": 16000,
-                "pkts_num_margin": 3072,
-                "cell_size": 384
-            },
-            "lossy_queue_voq_1":
-            {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "flow_config": "separate",
-                "pkts_num_trig_egr_drp": 16000,
-                "pkts_num_margin": 4,
-                "packet_size": 64,
-                "cell_size": 384
-            },
-            "lossy_queue_voq_2":
-            {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "flow_config": "shared",
-                "pkts_num_trig_egr_drp": 16000,
-                "pkts_num_margin": 4,
-                "packet_size": 64,
-                "cell_size": 384
-            },
-            "lossy_queue_voq_3":
-            {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_trig_egr_drp": 16000,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "cell_size": 384
-            },
-            "lossy_queue_1":
-            {
-                "dscp": 8,
-                "ecn": 1,
-                "pg": 0,
-                "pkts_num_trig_egr_drp": 16000,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "cell_size": 384
-            },
-            "lossless_voq_1":
-            {
-                "ecn": 1,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "pkts_num_trig_pfc": 3415,
-                "dscp": 3,
-                "pg": 3,
-                "num_of_flows": "multiple"
-            },
-            "lossless_voq_2":
-            {
-                "ecn": 1,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "pkts_num_trig_pfc": 3415,
-                "dscp": 4,
-                "pg": 4,
-                "num_of_flows": "multiple"
-            },
-            "lossless_voq_3":
-            {
-                "ecn": 1,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "pkts_num_trig_pfc": 3415,
-                "dscp": 3,
-                "pg": 3,
-                "num_of_flows": "single"
-            },
-            "lossless_voq_4":
-            {
-                "ecn": 1,
-                "pkts_num_margin": 4,
-                "packet_size": 1350,
-                "pkts_num_trig_pfc": 3415,
-                "dscp": 4,
-                "pg": 4,
-                "num_of_flows": "single"
-            },
-            "wm_q_wm_all_ports":
-            {
-                "ecn": 1,
-                "pkt_count": 4000,
-                "pkts_num_margin": 3072,
-                "cell_size": 384,
-                "packet_size": 1350
-            },
-            "pg_drop":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "pg": 3,
-                "queue": 3,
-                "pkts_num_trig_pfc": 13661,
-                "pkts_num_trig_ingr_drp": 14815,
-                "pkts_num_margin": 365,
-                "iterations": 100
-            }
-        },
-        "100000_40m":
-        {
-            "pcbb_xoff_1":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-            },
-            "pcbb_xoff_2":
-            {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-            },
-            "pcbb_xoff_3":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "outer_dscp": 2,
-                "packet_size": 1350,
-                "pg": 2,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-            },
-            "pcbb_xoff_4":
-            {
-                "dscp": 4,
-                "ecn": 1,
-                "outer_dscp": 6,
-                "packet_size": 1350,
-                "pg": 6,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-            },
-            "pkts_num_leak_out": 0
-        },
-        "100000_5m":
-        {
-            "pcbb_xoff_1":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 3,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-            },
-            "pcbb_xoff_2":
-            {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 4,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-            },
-            "pcbb_xoff_3":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "outer_dscp": 2,
-                "packet_size": 1350,
-                "pg": 2,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-            },
-            "pcbb_xoff_4":
-            {
-                "dscp": 4,
-                "ecn": 1,
-                "outer_dscp": 6,
-                "packet_size": 1350,
-                "pg": 6,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 3414
-            },
-            "pkts_num_leak_out": 0
-        },
-        "400000_120000m":
-        {
-            "lossy_queue_1":
-            {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 1350,
-                "pg": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 16000
-            },
-            "pkts_num_leak_out": 0,
-            "wm_buf_pool_lossless":
-            {
-                "cell_size": 8192,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8140,
-                "pg": 3,
-                "pkts_num_fill_ingr_min": 140,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_pfc": 23085,
-                "queue": 3
-            },
-            "wm_pg_shared_lossless":
-            {
-                "cell_size": 8192,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_pfc": 23043
-            },
-            "wm_pg_shared_lossy":
-            {
-                "cell_size": 8192,
-                "dscp": 8,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 0,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 4,
-                "pkts_num_trig_egr_drp": 728
-            },
-            "wm_q_shared_lossless":
-            {
-                "cell_size": 6144,
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 26624,
-                "pkts_num_trig_ingr_drp": 46087,
-                "queue": 3
-            },
-            "wm_q_shared_lossy":
-            {
-                "cell_size": 384,
-                "dscp": 8,
-                "ecn": 1,
-                "pkts_num_fill_min": 0,
-                "pkts_num_margin": 3072,
-                "pkts_num_trig_egr_drp": 16000,
-                "queue": 0
-            },
-            "wm_q_wm_all_ports":
-            {
-                "cell_size": 6144,
-                "ecn": 1,
-                "packet_size": 6144,
-                "pkt_count": 3000,
-                "pkts_num_margin": 19456
-            },
-            "xoff_1":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 23044,
-                "pkts_num_trig_pfc": 11522
-            },
-            "xoff_2":
-            {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 4,
-                "pkts_num_margin": 20,
-                "pkts_num_trig_ingr_drp": 23044,
-                "pkts_num_trig_pfc": 11522
-            },
-            "xon_1":
-            {
-                "dscp": 3,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 3,
-                "pkts_num_dismiss_pfc": 2,
-                "pkts_num_trig_pfc": 11521
-            },
-            "xon_2":
-            {
-                "dscp": 4,
-                "ecn": 1,
-                "packet_size": 8156,
-                "pg": 4,
-                "pkts_num_dismiss_pfc": 2,
-                "pkts_num_trig_pfc": 11521
-            }
-        },
-        "400000_300m":
-        {
-            "pkts_num_leak_out": 0,
-            "wrr":
-            {
-                "ecn": 1,
-                "limit": 80,
-                "q0_num_of_pkts": 70,
-                "q1_num_of_pkts": 70,
-                "q2_num_of_pkts": 70,
-                "q3_num_of_pkts": 75,
-                "q4_num_of_pkts": 75,
-                "q5_num_of_pkts": 70,
-                "q6_num_of_pkts": 70
-            },
-            "wrr_chg":
-            {
-                "ecn": 1,
-                "limit": 80,
-                "lossless_weight": 30,
-                "lossy_weight": 8,
-                "q0_num_of_pkts": 40,
-                "q1_num_of_pkts": 40,
-                "q2_num_of_pkts": 40,
-                "q3_num_of_pkts": 150,
-                "q4_num_of_pkts": 150,
-                "q5_num_of_pkts": 40,
-                "q6_num_of_pkts": 40
-            }
-        },
-        "400000_40m":
-        {
-            "pkts_num_leak_out": 0
-        },
-        "400000_5m":
-        {
-            "pkts_num_leak_out": 0
-        },
+  "param": {
+    "100000_120000m": {
+      "lossy_queue_1": {
         "cell_size": 384,
-        "hdrm_pool_wm_multiplier": 1,
-        "shared_res_size_1":
-        {
-            "cell_size": 384,
-            "ecn": 1,
-            "packet_size": 1350,
-            "pkts_num_margin": 1,
-            "dscps":
-            [
-                8,
-                8,
-                8,
-                8,
-                8,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4
-            ],
-            "pgs":
-            [
-                0,
-                0,
-                0,
-                0,
-                0,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4
-            ],
-            "queues":
-            [
-                0,
-                0,
-                0,
-                0,
-                0,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4
-            ],
-            "src_port_i":
-            [
-                0,
-                1,
-                2,
-                3,
-                4,
-                0,
-                0,
-                1,
-                1,
-                2,
-                2,
-                3,
-                3,
-                4,
-                4,
-                5,
-                5
-            ],
-            "dst_port_i":
-            [
-                6,
-                7,
-                8,
-                9,
-                10,
-                6,
-                6,
-                7,
-                7,
-                8,
-                8,
-                9,
-                9,
-                10,
-                10,
-                11,
-                11
-            ],
-            "pkt_counts":
-            [
-                3413,
-                3413,
-                3413,
-                3413,
-                3413,
-                2389,
-                2389,
-                2389,
-                1526,
-                1526,
-                1392,
-                415,
-                415,
-                415,
-                415,
-                42,
-                1
-            ],
-            "shared_limit_bytes": 46661760
-        },
-        "shared_res_size_2":
-        {
-            "cell_size": 384,
-            "ecn": 1,
-            "packet_size": 1350,
-            "pkts_num_margin": 1,
-            "dscps":
-            [
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3
-            ],
-            "pgs":
-            [
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3
-            ],
-            "queues":
-            [
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3,
-                4,
-                3
-            ],
-            "src_port_i":
-            [
-                0,
-                0,
-                1,
-                1,
-                2,
-                2,
-                3,
-                3,
-                4,
-                4,
-                5,
-                5,
-                6
-            ],
-            "dst_port_i":
-            [
-                7,
-                7,
-                8,
-                8,
-                9,
-                9,
-                10,
-                10,
-                11,
-                11,
-                12,
-                12,
-                13
-            ],
-            "pkt_counts":
-            [
-                3527,
-                3527,
-                3527,
-                3527,
-                3527,
-                3527,
-                1798,
-                1798,
-                846,
-                687,
-                687,
-                328,
-                1
-            ],
-            "shared_limit_bytes": 41943552
-        },
-        "wrr":
-        {
-            "ecn": 1,
-            "limit": 80,
-            "q0_num_of_pkts": 70,
-            "q1_num_of_pkts": 70,
-            "q2_num_of_pkts": 70,
-            "q3_num_of_pkts": 75,
-            "q4_num_of_pkts": 75,
-            "q5_num_of_pkts": 70,
-            "q6_num_of_pkts": 70
-        },
-        "wrr_chg":
-        {
-            "ecn": 1,
-            "limit": 80,
-            "lossless_weight": 30,
-            "lossy_weight": 8,
-            "q0_num_of_pkts": 40,
-            "q1_num_of_pkts": 40,
-            "q2_num_of_pkts": 40,
-            "q3_num_of_pkts": 150,
-            "q4_num_of_pkts": 150,
-            "q5_num_of_pkts": 40,
-            "q6_num_of_pkts": 40
-        }
+        "dscp": 8,
+        "ecn": 1,
+        "packet_size": 1350,
+        "pg": 0,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_egr_drp": 16000
+      },
+      "pg_drop": {
+        "dscp": 3,
+        "ecn": 1,
+        "iterations": 30,
+        "pg": 3,
+        "pkts_num_margin": 30000,
+        "pkts_num_trig_ingr_drp": 524288,
+        "pkts_num_trig_pfc": 262144,
+        "queue": 3
+      },
+      "pkts_num_leak_out": 0,
+      "wm_buf_pool_lossless": {
+        "cell_size": 8192,
+        "dscp": 3,
+        "ecn": 1,
+        "packet_size": 8140,
+        "pg": 3,
+        "pkts_num_fill_ingr_min": 140,
+        "pkts_num_margin": 6,
+        "pkts_num_trig_pfc": 6412,
+        "queue": 3
+      },
+      "wm_pg_shared_lossless": {
+        "cell_size": 8192,
+        "dscp": 3,
+        "ecn": 1,
+        "packet_size": 8156,
+        "pg": 3,
+        "pkts_num_fill_min": 0,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_pfc": 6403
+      },
+      "wm_pg_shared_lossy": {
+        "cell_size": 8192,
+        "dscp": 8,
+        "ecn": 1,
+        "packet_size": 8156,
+        "pg": 0,
+        "pkts_num_fill_min": 0,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_egr_drp": 728
+      },
+      "wm_q_shared_lossless": {
+        "cell_size": 6144,
+        "dscp": 3,
+        "ecn": 1,
+        "packet_size": 8156,
+        "pkts_num_fill_min": 0,
+        "pkts_num_margin": 19456,
+        "pkts_num_trig_ingr_drp": 12807,
+        "queue": 3
+      },
+      "wm_q_shared_lossy": {
+        "cell_size": 384,
+        "dscp": 8,
+        "ecn": 1,
+        "pkts_num_fill_min": 0,
+        "pkts_num_margin": 3072,
+        "pkts_num_trig_egr_drp": 16000,
+        "queue": 0
+      },
+      "wm_q_wm_all_ports": {
+        "cell_size": 6144,
+        "ecn": 1,
+        "packet_size": 6144,
+        "pkt_count": 3000,
+        "pkts_num_margin": 19456
+      },
+      "xoff_1": {
+        "dscp": 3,
+        "ecn": 1,
+        "packet_size": 8156,
+        "pg": 3,
+        "pkts_num_margin": 20,
+        "pkts_num_trig_ingr_drp": 6404,
+        "pkts_num_trig_pfc": 3202
+      },
+      "xoff_2": {
+        "dscp": 4,
+        "ecn": 1,
+        "packet_size": 8156,
+        "pg": 4,
+        "pkts_num_margin": 20,
+        "pkts_num_trig_ingr_drp": 6404,
+        "pkts_num_trig_pfc": 3202
+      },
+      "xon_1": {
+        "dscp": 3,
+        "ecn": 1,
+        "packet_size": 8156,
+        "pg": 3,
+        "pkts_num_dismiss_pfc": 2,
+        "pkts_num_trig_pfc": 3201
+      },
+      "xon_2": {
+        "dscp": 4,
+        "ecn": 1,
+        "packet_size": 8156,
+        "pg": 4,
+        "pkts_num_dismiss_pfc": 2,
+        "pkts_num_trig_pfc": 3201
+      }
     },
-    "portSpeedCableLength": "100000_300m"
+    "100000_300m": {
+      "pcbb_xoff_1": {
+        "dscp": 3,
+        "ecn": 1,
+        "packet_size": 1350,
+        "pg": 3,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_pfc": 3414
+      },
+      "pcbb_xoff_2": {
+        "dscp": 4,
+        "ecn": 1,
+        "packet_size": 1350,
+        "pg": 4,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_pfc": 3414
+      },
+      "pcbb_xoff_3": {
+        "dscp": 3,
+        "ecn": 1,
+        "outer_dscp": 2,
+        "packet_size": 1350,
+        "pg": 2,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_pfc": 3414
+      },
+      "pcbb_xoff_4": {
+        "dscp": 4,
+        "ecn": 1,
+        "outer_dscp": 6,
+        "packet_size": 1350,
+        "pg": 6,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_pfc": 3414
+      },
+      "pkts_num_leak_out": 0,
+      "xoff_1": {
+        "dscp": 3,
+        "ecn": 1,
+        "pg": 3,
+        "pkts_num_trig_pfc": 3415,
+        "pkts_num_trig_ingr_drp": 3703,
+        "packet_size": 1350
+      },
+      "xoff_2": {
+        "dscp": 4,
+        "ecn": 1,
+        "pg": 4,
+        "pkts_num_trig_pfc": 3415,
+        "pkts_num_trig_ingr_drp": 3703,
+        "packet_size": 1350
+      },
+      "xon_1": {
+        "dscp": 3,
+        "ecn": 1,
+        "pg": 3,
+        "pkts_num_trig_pfc": 3414,
+        "pkts_num_hysteresis": 1877,
+        "pkts_num_dismiss_pfc": 2,
+        "packet_size": 1350
+      },
+      "xon_2": {
+        "dscp": 4,
+        "ecn": 1,
+        "pg": 4,
+        "pkts_num_trig_pfc": 3414,
+        "pkts_num_hysteresis": 1877,
+        "pkts_num_dismiss_pfc": 2,
+        "packet_size": 1350
+      },
+      "wm_pg_shared_lossless": {
+        "ecn": 1,
+        "pkts_num_fill_min": 0,
+        "pkts_num_margin": 4,
+        "packet_size": 1350,
+        "cell_size": 384,
+        "dscp": 3,
+        "pg": 3,
+        "pkts_num_trig_pfc": 14807
+      },
+      "wm_pg_shared_lossy": {
+        "ecn": 1,
+        "pkts_num_fill_min": 0,
+        "pkts_num_margin": 4,
+        "packet_size": 1350,
+        "cell_size": 384,
+        "dscp": 8,
+        "pg": 0,
+        "pkts_num_trig_egr_drp": 16000
+      },
+      "wm_buf_pool_lossless": {
+        "dscp": 3,
+        "ecn": 1,
+        "pg": 3,
+        "queue": 3,
+        "pkts_num_fill_ingr_min": 0,
+        "pkts_num_trig_pfc": 3703,
+        "cell_size": 384,
+        "packet_size": 1350
+      },
+      "wm_buf_pool_lossy": {
+        "dscp": 8,
+        "ecn": 1,
+        "pg": 0,
+        "queue": 0,
+        "pkts_num_trig_egr_drp": 4000,
+        "pkts_num_fill_egr_min": 0,
+        "cell_size": 384,
+        "packet_size": 1350
+      },
+      "wm_q_shared_lossless": {
+        "dscp": 3,
+        "ecn": 1,
+        "queue": 3,
+        "pkts_num_fill_min": 0,
+        "pkts_num_trig_ingr_drp": 14815,
+        "pkts_num_margin": 3072,
+        "cell_size": 384
+      },
+      "wm_q_shared_lossy": {
+        "dscp": 8,
+        "ecn": 1,
+        "queue": 0,
+        "pkts_num_fill_min": 0,
+        "pkts_num_trig_egr_drp": 16000,
+        "pkts_num_margin": 3072,
+        "cell_size": 384
+      },
+      "lossy_queue_voq_1": {
+        "dscp": 8,
+        "ecn": 1,
+        "pg": 0,
+        "flow_config": "separate",
+        "pkts_num_trig_egr_drp": 16000,
+        "pkts_num_margin": 4,
+        "packet_size": 64,
+        "cell_size": 384
+      },
+      "lossy_queue_voq_2": {
+        "dscp": 8,
+        "ecn": 1,
+        "pg": 0,
+        "flow_config": "shared",
+        "pkts_num_trig_egr_drp": 16000,
+        "pkts_num_margin": 4,
+        "packet_size": 64,
+        "cell_size": 384
+      },
+      "lossy_queue_voq_3": {
+        "dscp": 8,
+        "ecn": 1,
+        "pg": 0,
+        "pkts_num_trig_egr_drp": 16000,
+        "pkts_num_margin": 4,
+        "packet_size": 1350,
+        "cell_size": 384
+      },
+      "lossy_queue_1": {
+        "dscp": 8,
+        "ecn": 1,
+        "pg": 0,
+        "pkts_num_trig_egr_drp": 16000,
+        "pkts_num_margin": 4,
+        "packet_size": 1350,
+        "cell_size": 384
+      },
+      "lossless_voq_1": {
+        "ecn": 1,
+        "pkts_num_margin": 4,
+        "packet_size": 1350,
+        "pkts_num_trig_pfc": 3415,
+        "dscp": 3,
+        "pg": 3,
+        "num_of_flows": "multiple"
+      },
+      "lossless_voq_2": {
+        "ecn": 1,
+        "pkts_num_margin": 4,
+        "packet_size": 1350,
+        "pkts_num_trig_pfc": 3415,
+        "dscp": 4,
+        "pg": 4,
+        "num_of_flows": "multiple"
+      },
+      "lossless_voq_3": {
+        "ecn": 1,
+        "pkts_num_margin": 4,
+        "packet_size": 1350,
+        "pkts_num_trig_pfc": 3415,
+        "dscp": 3,
+        "pg": 3,
+        "num_of_flows": "single"
+      },
+      "lossless_voq_4": {
+        "ecn": 1,
+        "pkts_num_margin": 4,
+        "packet_size": 1350,
+        "pkts_num_trig_pfc": 3415,
+        "dscp": 4,
+        "pg": 4,
+        "num_of_flows": "single"
+      },
+      "wm_q_wm_all_ports": {
+        "ecn": 1,
+        "pkt_count": 4000,
+        "pkts_num_margin": 3072,
+        "cell_size": 384,
+        "packet_size": 1350
+      },
+      "pg_drop": {
+        "dscp": 3,
+        "ecn": 1,
+        "pg": 3,
+        "queue": 3,
+        "pkts_num_trig_pfc": 13661,
+        "pkts_num_trig_ingr_drp": 14815,
+        "pkts_num_margin": 365,
+        "iterations": 100
+      }
+    },
+    "100000_40m": {
+      "pcbb_xoff_1": {
+        "dscp": 3,
+        "ecn": 1,
+        "packet_size": 1350,
+        "pg": 3,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_pfc": 3414
+      },
+      "pcbb_xoff_2": {
+        "dscp": 4,
+        "ecn": 1,
+        "packet_size": 1350,
+        "pg": 4,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_pfc": 3414
+      },
+      "pcbb_xoff_3": {
+        "dscp": 3,
+        "ecn": 1,
+        "outer_dscp": 2,
+        "packet_size": 1350,
+        "pg": 2,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_pfc": 3414
+      },
+      "pcbb_xoff_4": {
+        "dscp": 4,
+        "ecn": 1,
+        "outer_dscp": 6,
+        "packet_size": 1350,
+        "pg": 6,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_pfc": 3414
+      },
+      "pkts_num_leak_out": 0
+    },
+    "100000_5m": {
+      "pcbb_xoff_1": {
+        "dscp": 3,
+        "ecn": 1,
+        "packet_size": 1350,
+        "pg": 3,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_pfc": 3414
+      },
+      "pcbb_xoff_2": {
+        "dscp": 4,
+        "ecn": 1,
+        "packet_size": 1350,
+        "pg": 4,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_pfc": 3414
+      },
+      "pcbb_xoff_3": {
+        "dscp": 3,
+        "ecn": 1,
+        "outer_dscp": 2,
+        "packet_size": 1350,
+        "pg": 2,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_pfc": 3414
+      },
+      "pcbb_xoff_4": {
+        "dscp": 4,
+        "ecn": 1,
+        "outer_dscp": 6,
+        "packet_size": 1350,
+        "pg": 6,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_pfc": 3414
+      },
+      "pkts_num_leak_out": 0
+    },
+    "400000_120000m": {
+      "lossy_queue_1": {
+        "cell_size": 384,
+        "dscp": 8,
+        "ecn": 1,
+        "packet_size": 1350,
+        "pg": 0,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_egr_drp": 16000
+      },
+      "pkts_num_leak_out": 0,
+      "wm_buf_pool_lossless": {
+        "cell_size": 8192,
+        "dscp": 3,
+        "ecn": 1,
+        "packet_size": 8140,
+        "pg": 3,
+        "pkts_num_fill_ingr_min": 140,
+        "pkts_num_margin": 20,
+        "pkts_num_trig_pfc": 23085,
+        "queue": 3
+      },
+      "wm_pg_shared_lossless": {
+        "cell_size": 8192,
+        "dscp": 3,
+        "ecn": 1,
+        "packet_size": 8156,
+        "pg": 3,
+        "pkts_num_fill_min": 0,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_pfc": 23043
+      },
+      "wm_pg_shared_lossy": {
+        "cell_size": 8192,
+        "dscp": 8,
+        "ecn": 1,
+        "packet_size": 8156,
+        "pg": 0,
+        "pkts_num_fill_min": 0,
+        "pkts_num_margin": 4,
+        "pkts_num_trig_egr_drp": 728
+      },
+      "wm_q_shared_lossless": {
+        "cell_size": 6144,
+        "dscp": 3,
+        "ecn": 1,
+        "packet_size": 8156,
+        "pkts_num_fill_min": 0,
+        "pkts_num_margin": 26624,
+        "pkts_num_trig_ingr_drp": 46087,
+        "queue": 3
+      },
+      "wm_q_shared_lossy": {
+        "cell_size": 384,
+        "dscp": 8,
+        "ecn": 1,
+        "pkts_num_fill_min": 0,
+        "pkts_num_margin": 3072,
+        "pkts_num_trig_egr_drp": 16000,
+        "queue": 0
+      },
+      "wm_q_wm_all_ports": {
+        "cell_size": 6144,
+        "ecn": 1,
+        "packet_size": 6144,
+        "pkt_count": 3000,
+        "pkts_num_margin": 19456
+      },
+      "xoff_1": {
+        "dscp": 3,
+        "ecn": 1,
+        "packet_size": 8156,
+        "pg": 3,
+        "pkts_num_margin": 20,
+        "pkts_num_trig_ingr_drp": 23044,
+        "pkts_num_trig_pfc": 11522
+      },
+      "xoff_2": {
+        "dscp": 4,
+        "ecn": 1,
+        "packet_size": 8156,
+        "pg": 4,
+        "pkts_num_margin": 20,
+        "pkts_num_trig_ingr_drp": 23044,
+        "pkts_num_trig_pfc": 11522
+      },
+      "xon_1": {
+        "dscp": 3,
+        "ecn": 1,
+        "packet_size": 8156,
+        "pg": 3,
+        "pkts_num_dismiss_pfc": 2,
+        "pkts_num_trig_pfc": 11521
+      },
+      "xon_2": {
+        "dscp": 4,
+        "ecn": 1,
+        "packet_size": 8156,
+        "pg": 4,
+        "pkts_num_dismiss_pfc": 2,
+        "pkts_num_trig_pfc": 11521
+      }
+    },
+    "400000_300m": {
+      "pkts_num_leak_out": 0,
+      "wrr": {
+        "ecn": 1,
+        "limit": 80,
+        "q0_num_of_pkts": 70,
+        "q1_num_of_pkts": 70,
+        "q2_num_of_pkts": 70,
+        "q3_num_of_pkts": 75,
+        "q4_num_of_pkts": 75,
+        "q5_num_of_pkts": 70,
+        "q6_num_of_pkts": 70
+      },
+      "wrr_chg": {
+        "ecn": 1,
+        "limit": 80,
+        "lossless_weight": 30,
+        "lossy_weight": 8,
+        "q0_num_of_pkts": 40,
+        "q1_num_of_pkts": 40,
+        "q2_num_of_pkts": 40,
+        "q3_num_of_pkts": 150,
+        "q4_num_of_pkts": 150,
+        "q5_num_of_pkts": 40,
+        "q6_num_of_pkts": 40
+      }
+    },
+    "400000_40m": {
+      "pkts_num_leak_out": 0
+    },
+    "400000_5m": {
+      "pkts_num_leak_out": 0
+    },
+    "cell_size": 384,
+    "hdrm_pool_wm_multiplier": 1,
+    "shared_res_size_1": {
+      "cell_size": 384,
+      "ecn": 1,
+      "packet_size": 1350,
+      "pkts_num_margin": 1,
+      "dscps": [
+        8,
+        8,
+        8,
+        8,
+        8,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4
+      ],
+      "pgs": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4
+      ],
+      "queues": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4
+      ],
+      "src_port_i": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        0,
+        0,
+        1,
+        1,
+        2,
+        2,
+        3,
+        3,
+        4,
+        4,
+        5,
+        5
+      ],
+      "dst_port_i": [
+        6,
+        7,
+        8,
+        9,
+        10,
+        6,
+        6,
+        7,
+        7,
+        8,
+        8,
+        9,
+        9,
+        10,
+        10,
+        11,
+        11
+      ],
+      "pkt_counts": [
+        3413,
+        3413,
+        3413,
+        3413,
+        3413,
+        2389,
+        2389,
+        2389,
+        1526,
+        1526,
+        1392,
+        415,
+        415,
+        415,
+        415,
+        42,
+        1
+      ],
+      "shared_limit_bytes": 46661760
+    },
+    "shared_res_size_2": {
+      "cell_size": 384,
+      "ecn": 1,
+      "packet_size": 1350,
+      "pkts_num_margin": 1,
+      "dscps": [
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3
+      ],
+      "pgs": [
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3
+      ],
+      "queues": [
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        3
+      ],
+      "src_port_i": [
+        0,
+        0,
+        1,
+        1,
+        2,
+        2,
+        3,
+        3,
+        4,
+        4,
+        5,
+        5,
+        6
+      ],
+      "dst_port_i": [
+        7,
+        7,
+        8,
+        8,
+        9,
+        9,
+        10,
+        10,
+        11,
+        11,
+        12,
+        12,
+        13
+      ],
+      "pkt_counts": [
+        3527,
+        3527,
+        3527,
+        3527,
+        3527,
+        3527,
+        1798,
+        1798,
+        846,
+        687,
+        687,
+        328,
+        1
+      ],
+      "shared_limit_bytes": 41943552
+    },
+    "wrr": {
+      "ecn": 1,
+      "limit": 80,
+      "q0_num_of_pkts": 70,
+      "q1_num_of_pkts": 70,
+      "q2_num_of_pkts": 70,
+      "q3_num_of_pkts": 75,
+      "q4_num_of_pkts": 75,
+      "q5_num_of_pkts": 70,
+      "q6_num_of_pkts": 70
+    },
+    "wrr_chg": {
+      "ecn": 1,
+      "limit": 80,
+      "lossless_weight": 30,
+      "lossy_weight": 8,
+      "q0_num_of_pkts": 40,
+      "q1_num_of_pkts": 40,
+      "q2_num_of_pkts": 40,
+      "q3_num_of_pkts": 150,
+      "q4_num_of_pkts": 150,
+      "q5_num_of_pkts": 40,
+      "q6_num_of_pkts": 40
+    }
+  },
+  "portSpeedCableLength": "100000_300m"
 }

--- a/tests/qos/files/vs/dutQosConfig.json
+++ b/tests/qos/files/vs/dutQosConfig.json
@@ -1,0 +1,874 @@
+{
+    "param":
+    {
+        "100000_120000m":
+        {
+            "lossy_queue_1":
+            {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 16000
+            },
+            "pg_drop":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "iterations": 30,
+                "pg": 3,
+                "pkts_num_margin": 30000,
+                "pkts_num_trig_ingr_drp": 524288,
+                "pkts_num_trig_pfc": 262144,
+                "queue": 3
+            },
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless":
+            {
+                "cell_size": 8192,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8140,
+                "pg": 3,
+                "pkts_num_fill_ingr_min": 140,
+                "pkts_num_margin": 6,
+                "pkts_num_trig_pfc": 6412,
+                "queue": 3
+            },
+            "wm_pg_shared_lossless":
+            {
+                "cell_size": 8192,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 6403
+            },
+            "wm_pg_shared_lossy":
+            {
+                "cell_size": 8192,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 0,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 728
+            },
+            "wm_q_shared_lossless":
+            {
+                "cell_size": 6144,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 19456,
+                "pkts_num_trig_ingr_drp": 12807,
+                "queue": 3
+            },
+            "wm_q_shared_lossy":
+            {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 3072,
+                "pkts_num_trig_egr_drp": 16000,
+                "queue": 0
+            },
+            "wm_q_wm_all_ports":
+            {
+                "cell_size": 6144,
+                "ecn": 1,
+                "packet_size": 6144,
+                "pkt_count": 3000,
+                "pkts_num_margin": 19456
+            },
+            "xoff_1":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 6404,
+                "pkts_num_trig_pfc": 3202
+            },
+            "xoff_2":
+            {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 4,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 6404,
+                "pkts_num_trig_pfc": 3202
+            },
+            "xon_1":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 2,
+                "pkts_num_trig_pfc": 3201
+            },
+            "xon_2":
+            {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 2,
+                "pkts_num_trig_pfc": 3201
+            }
+        },
+        "100000_300m":
+        {
+            "pcbb_xoff_1":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_2":
+            {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_3":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "outer_dscp": 2,
+                "packet_size": 1350,
+                "pg": 2,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_4":
+            {
+                "dscp": 4,
+                "ecn": 1,
+                "outer_dscp": 6,
+                "packet_size": 1350,
+                "pg": 6,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+            },
+            "pkts_num_leak_out": 0,
+            "xoff_1":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_pfc": 3415,
+                "pkts_num_trig_ingr_drp": 3703,
+                "packet_size": 1350
+            },
+            "xoff_2":
+            {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_pfc": 3415,
+                "pkts_num_trig_ingr_drp": 3703,
+                "packet_size": 1350
+            },
+            "xon_1":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "pkts_num_trig_pfc": 3414,
+                "pkts_num_hysteresis": 1877,
+                "pkts_num_dismiss_pfc": 2,
+                "packet_size": 1350
+            },
+            "xon_2":
+            {
+                "dscp": 4,
+                "ecn": 1,
+                "pg": 4,
+                "pkts_num_trig_pfc": 3414,
+                "pkts_num_hysteresis": 1877,
+                "pkts_num_dismiss_pfc": 2,
+                "packet_size": 1350
+            },
+            "wm_pg_shared_lossless":
+            {
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "cell_size": 384,
+                "dscp": 3,
+                "pg": 3,
+                "pkts_num_trig_pfc": 14807
+            },
+            "wm_pg_shared_lossy":
+            {
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "cell_size": 384,
+                "dscp": 8,
+                "pg": 0,
+                "pkts_num_trig_egr_drp": 16000
+            },
+            "wm_buf_pool_lossless":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "queue": 3,
+                "pkts_num_fill_ingr_min": 0,
+                "pkts_num_trig_pfc": 3703,
+                "cell_size": 384,
+                "packet_size": 1350
+            },
+            "wm_buf_pool_lossy":
+            {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "queue": 0,
+                "pkts_num_trig_egr_drp": 4000,
+                "pkts_num_fill_egr_min": 0,
+                "cell_size": 384,
+                "packet_size": 1350
+            },
+            "wm_q_shared_lossless":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "queue": 3,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_ingr_drp": 14815,
+                "pkts_num_margin": 3072,
+                "cell_size": 384
+            },
+            "wm_q_shared_lossy":
+            {
+                "dscp": 8,
+                "ecn": 1,
+                "queue": 0,
+                "pkts_num_fill_min": 0,
+                "pkts_num_trig_egr_drp": 16000,
+                "pkts_num_margin": 3072,
+                "cell_size": 384
+            },
+            "lossy_queue_voq_1":
+            {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "flow_config": "separate",
+                "pkts_num_trig_egr_drp": 16000,
+                "pkts_num_margin": 4,
+                "packet_size": 64,
+                "cell_size": 384
+            },
+            "lossy_queue_voq_2":
+            {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "flow_config": "shared",
+                "pkts_num_trig_egr_drp": 16000,
+                "pkts_num_margin": 4,
+                "packet_size": 64,
+                "cell_size": 384
+            },
+            "lossy_queue_voq_3":
+            {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_trig_egr_drp": 16000,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "cell_size": 384
+            },
+            "lossy_queue_1":
+            {
+                "dscp": 8,
+                "ecn": 1,
+                "pg": 0,
+                "pkts_num_trig_egr_drp": 16000,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "cell_size": 384
+            },
+            "lossless_voq_1":
+            {
+                "ecn": 1,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "pkts_num_trig_pfc": 3415,
+                "dscp": 3,
+                "pg": 3,
+                "num_of_flows": "multiple"
+            },
+            "lossless_voq_2":
+            {
+                "ecn": 1,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "pkts_num_trig_pfc": 3415,
+                "dscp": 4,
+                "pg": 4,
+                "num_of_flows": "multiple"
+            },
+            "lossless_voq_3":
+            {
+                "ecn": 1,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "pkts_num_trig_pfc": 3415,
+                "dscp": 3,
+                "pg": 3,
+                "num_of_flows": "single"
+            },
+            "lossless_voq_4":
+            {
+                "ecn": 1,
+                "pkts_num_margin": 4,
+                "packet_size": 1350,
+                "pkts_num_trig_pfc": 3415,
+                "dscp": 4,
+                "pg": 4,
+                "num_of_flows": "single"
+            },
+            "wm_q_wm_all_ports":
+            {
+                "ecn": 1,
+                "pkt_count": 4000,
+                "pkts_num_margin": 3072,
+                "cell_size": 384,
+                "packet_size": 1350
+            },
+            "pg_drop":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "pg": 3,
+                "queue": 3,
+                "pkts_num_trig_pfc": 13661,
+                "pkts_num_trig_ingr_drp": 14815,
+                "pkts_num_margin": 365,
+                "iterations": 100
+            }
+        },
+        "100000_40m":
+        {
+            "pcbb_xoff_1":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_2":
+            {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_3":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "outer_dscp": 2,
+                "packet_size": 1350,
+                "pg": 2,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_4":
+            {
+                "dscp": 4,
+                "ecn": 1,
+                "outer_dscp": 6,
+                "packet_size": 1350,
+                "pg": 6,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+            },
+            "pkts_num_leak_out": 0
+        },
+        "100000_5m":
+        {
+            "pcbb_xoff_1":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 3,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_2":
+            {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 4,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_3":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "outer_dscp": 2,
+                "packet_size": 1350,
+                "pg": 2,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+            },
+            "pcbb_xoff_4":
+            {
+                "dscp": 4,
+                "ecn": 1,
+                "outer_dscp": 6,
+                "packet_size": 1350,
+                "pg": 6,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 3414
+            },
+            "pkts_num_leak_out": 0
+        },
+        "400000_120000m":
+        {
+            "lossy_queue_1":
+            {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 1350,
+                "pg": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 16000
+            },
+            "pkts_num_leak_out": 0,
+            "wm_buf_pool_lossless":
+            {
+                "cell_size": 8192,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8140,
+                "pg": 3,
+                "pkts_num_fill_ingr_min": 140,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_pfc": 23085,
+                "queue": 3
+            },
+            "wm_pg_shared_lossless":
+            {
+                "cell_size": 8192,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_pfc": 23043
+            },
+            "wm_pg_shared_lossy":
+            {
+                "cell_size": 8192,
+                "dscp": 8,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 0,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 4,
+                "pkts_num_trig_egr_drp": 728
+            },
+            "wm_q_shared_lossless":
+            {
+                "cell_size": 6144,
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 26624,
+                "pkts_num_trig_ingr_drp": 46087,
+                "queue": 3
+            },
+            "wm_q_shared_lossy":
+            {
+                "cell_size": 384,
+                "dscp": 8,
+                "ecn": 1,
+                "pkts_num_fill_min": 0,
+                "pkts_num_margin": 3072,
+                "pkts_num_trig_egr_drp": 16000,
+                "queue": 0
+            },
+            "wm_q_wm_all_ports":
+            {
+                "cell_size": 6144,
+                "ecn": 1,
+                "packet_size": 6144,
+                "pkt_count": 3000,
+                "pkts_num_margin": 19456
+            },
+            "xoff_1":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 23044,
+                "pkts_num_trig_pfc": 11522
+            },
+            "xoff_2":
+            {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 4,
+                "pkts_num_margin": 20,
+                "pkts_num_trig_ingr_drp": 23044,
+                "pkts_num_trig_pfc": 11522
+            },
+            "xon_1":
+            {
+                "dscp": 3,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 3,
+                "pkts_num_dismiss_pfc": 2,
+                "pkts_num_trig_pfc": 11521
+            },
+            "xon_2":
+            {
+                "dscp": 4,
+                "ecn": 1,
+                "packet_size": 8156,
+                "pg": 4,
+                "pkts_num_dismiss_pfc": 2,
+                "pkts_num_trig_pfc": 11521
+            }
+        },
+        "400000_300m":
+        {
+            "pkts_num_leak_out": 0,
+            "wrr":
+            {
+                "ecn": 1,
+                "limit": 80,
+                "q0_num_of_pkts": 70,
+                "q1_num_of_pkts": 70,
+                "q2_num_of_pkts": 70,
+                "q3_num_of_pkts": 75,
+                "q4_num_of_pkts": 75,
+                "q5_num_of_pkts": 70,
+                "q6_num_of_pkts": 70
+            },
+            "wrr_chg":
+            {
+                "ecn": 1,
+                "limit": 80,
+                "lossless_weight": 30,
+                "lossy_weight": 8,
+                "q0_num_of_pkts": 40,
+                "q1_num_of_pkts": 40,
+                "q2_num_of_pkts": 40,
+                "q3_num_of_pkts": 150,
+                "q4_num_of_pkts": 150,
+                "q5_num_of_pkts": 40,
+                "q6_num_of_pkts": 40
+            }
+        },
+        "400000_40m":
+        {
+            "pkts_num_leak_out": 0
+        },
+        "400000_5m":
+        {
+            "pkts_num_leak_out": 0
+        },
+        "cell_size": 384,
+        "hdrm_pool_wm_multiplier": 1,
+        "shared_res_size_1":
+        {
+            "cell_size": 384,
+            "ecn": 1,
+            "packet_size": 1350,
+            "pkts_num_margin": 1,
+            "dscps":
+            [
+                8,
+                8,
+                8,
+                8,
+                8,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4
+            ],
+            "pgs":
+            [
+                0,
+                0,
+                0,
+                0,
+                0,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4
+            ],
+            "queues":
+            [
+                0,
+                0,
+                0,
+                0,
+                0,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4
+            ],
+            "src_port_i":
+            [
+                0,
+                1,
+                2,
+                3,
+                4,
+                0,
+                0,
+                1,
+                1,
+                2,
+                2,
+                3,
+                3,
+                4,
+                4,
+                5,
+                5
+            ],
+            "dst_port_i":
+            [
+                6,
+                7,
+                8,
+                9,
+                10,
+                6,
+                6,
+                7,
+                7,
+                8,
+                8,
+                9,
+                9,
+                10,
+                10,
+                11,
+                11
+            ],
+            "pkt_counts":
+            [
+                3413,
+                3413,
+                3413,
+                3413,
+                3413,
+                2389,
+                2389,
+                2389,
+                1526,
+                1526,
+                1392,
+                415,
+                415,
+                415,
+                415,
+                42,
+                1
+            ],
+            "shared_limit_bytes": 46661760
+        },
+        "shared_res_size_2":
+        {
+            "cell_size": 384,
+            "ecn": 1,
+            "packet_size": 1350,
+            "pkts_num_margin": 1,
+            "dscps":
+            [
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3
+            ],
+            "pgs":
+            [
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3
+            ],
+            "queues":
+            [
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3,
+                4,
+                3
+            ],
+            "src_port_i":
+            [
+                0,
+                0,
+                1,
+                1,
+                2,
+                2,
+                3,
+                3,
+                4,
+                4,
+                5,
+                5,
+                6
+            ],
+            "dst_port_i":
+            [
+                7,
+                7,
+                8,
+                8,
+                9,
+                9,
+                10,
+                10,
+                11,
+                11,
+                12,
+                12,
+                13
+            ],
+            "pkt_counts":
+            [
+                3527,
+                3527,
+                3527,
+                3527,
+                3527,
+                3527,
+                1798,
+                1798,
+                846,
+                687,
+                687,
+                328,
+                1
+            ],
+            "shared_limit_bytes": 41943552
+        },
+        "wrr":
+        {
+            "ecn": 1,
+            "limit": 80,
+            "q0_num_of_pkts": 70,
+            "q1_num_of_pkts": 70,
+            "q2_num_of_pkts": 70,
+            "q3_num_of_pkts": 75,
+            "q4_num_of_pkts": 75,
+            "q5_num_of_pkts": 70,
+            "q6_num_of_pkts": 70
+        },
+        "wrr_chg":
+        {
+            "ecn": 1,
+            "limit": 80,
+            "lossless_weight": 30,
+            "lossy_weight": 8,
+            "q0_num_of_pkts": 40,
+            "q1_num_of_pkts": 40,
+            "q2_num_of_pkts": 40,
+            "q3_num_of_pkts": 150,
+            "q4_num_of_pkts": 150,
+            "q5_num_of_pkts": 40,
+            "q6_num_of_pkts": 40
+        }
+    },
+    "portSpeedCableLength": "100000_300m"
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

TO support PR test of QoS SAI, need to provide varous configuration to mock dutConfig and dutQosConfig

#### How did you do it?

collect dutConfig and dutQosConfig on a single box 8102, and upload as fake parameter for mock purpose

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
