### PR TITLE
[golden_config_infra] Remove tables that has no YANG model

### DIFF
--- a/tests/golden_config_infra/templates/sample_golden_config_db.j2
+++ b/tests/golden_config_infra/templates/sample_golden_config_db.j2
@@ -1,18 +1,2 @@
-{% set portchannels= [] %}
-{% if PORTCHANNEL is defined %}
-    {% for pc, value in PORTCHANNEL.items() %}
-        {% set _ = portchannels.append(pc) %}
-    {% endfor %}
-{% endif %}
-
 {
-    "NEW_FEATURE": {
-        "test_entry": {
-            "platform": "{{ DEVICE_METADATA.localhost.platform }}"
-            {% if portchannels %}
-                ,
-                "ports": "{{ portchannels | join(',') }}"
-            {% endif %}
-        }
-    }
 }

--- a/tests/golden_config_infra/templates/sample_golden_config_db.j2
+++ b/tests/golden_config_infra/templates/sample_golden_config_db.j2
@@ -1,2 +1,18 @@
+{% set portchannels= [] %}
+{% if PORTCHANNEL is defined %}
+    {% for pc, value in PORTCHANNEL.items() %}
+        {% set _ = portchannels.append(pc) %}
+    {% endfor %}
+{% endif %}
+
 {
+    "NEW_FEATURE": {
+        "test_entry": {
+            "platform": "{{ DEVICE_METADATA.localhost.platform }}"
+            {% if portchannels %}
+                ,
+                "ports": "{{ portchannels | join(',') }}"
+            {% endif %}
+        }
+    }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

ADO: 30864778
Summary: Remove table that has no yang support in golden infra test
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
We plan on strict yang enforcement on config CLI. Thus it will fail for non-yang supported NEW_FEATURE table
#### How did you do it?
Remove non-YANG supported tables in test 
#### How did you verify/test it?
E2E test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
