### PR TITLE
[deploy] Upgrade test server docker SDK client version to 7.1.0

### DIFF
--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -91,7 +91,7 @@
     environment: "{{ proxy_env | default({}) }}"
     ignore_errors: yes
   - name: Install python packages
-    pip: name=docker version=6.1.0 state=forcereinstall executable={{ pip_executable }}
+    pip: name=docker version=7.1.0 state=forcereinstall executable={{ pip_executable }}
     become: yes
     environment: "{{ proxy_env | default({}) }}"
   when: pip_executable=="pip3"

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -146,19 +146,10 @@
 - include_tasks: docker.yml
   when: package_installation|bool
 
-- name: Update python3 packages
-  block:
-    # Workaround for '"Error connecting: Error while fetching server API version: Not supported URL scheme http+docker'
-    # See https://github.com/docker/docker-py/issues/3256
-  - name: Remove old requests package >=2.32.0
-    pip: name=requests state=absent executable={{ pip_executable }}
-    become: yes
-    environment: "{{ proxy_env | default({}) }}"
-    ignore_errors: yes
-  - name: Install requests package <2.32.0
-    pip: name=requests version=2.31.0 state=present executable={{ pip_executable }}
-    become: yes
-    environment: "{{ proxy_env | default({}) }}"
+- name: Install requests package
+  pip: name=requests version=2.32.3 state=present executable={{ pip_executable }}
+  become: yes
+  environment: "{{ proxy_env | default({}) }}"
   when: pip_executable=="pip3"
 
 - name: Ensure {{ ansible_user }} in docker,sudo group


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Previously the upgrade of requests package caused a compatibility issue with the docker SDK client. A workaround was introduced in the playbook to force install a lower version requests package.

After the  issue was fixed in the docker SDK client side, the workaround code can be removed.

#### How did you do it?
This change removed the workaround code and upgraded the docker client to version 7.1.0.

#### How did you verify/test it?
Tested add/remove topo using the testbed-cli.sh

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
