### PR TITLE
Ignore log analyzer during reboot and config_reload

### DIFF
--- a/tests/bfd/test_bfd_static_route.py
+++ b/tests/bfd/test_bfd_static_route.py
@@ -28,7 +28,7 @@ class TestBfdStaticRoute(BfdBase):
         'diagnose': 200,
     }
 
-    def test_bfd_with_lc_reboot(self, localhost, request, select_src_dst_dut_with_asic, bfd_cleanup_db):
+    def test_bfd_with_lc_reboot(self, localhost, request, select_src_dst_dut_with_asic, bfd_cleanup_db, loganalyzer):
         """
         Author:  Harsha Golla
         Email : harsgoll@cisco.com
@@ -54,7 +54,7 @@ class TestBfdStaticRoute(BfdBase):
         src_dut.shell("sudo config save -y")
 
         # Perform a cold reboot on source dut
-        reboot(src_dut, localhost, safe_reboot=True)
+        reboot(src_dut, localhost, safe_reboot=True, ignore_loganalyzer=loganalyzer)
 
         check_bgp_status(request)
 
@@ -70,7 +70,7 @@ class TestBfdStaticRoute(BfdBase):
         src_dut.shell("sudo config save -y")
 
         # Config reload of Source dut
-        reboot(src_dut, localhost, safe_reboot=True)
+        reboot(src_dut, localhost, safe_reboot=True, ignore_loganalyzer=loganalyzer)
 
         check_bgp_status(request)
 
@@ -253,6 +253,7 @@ class TestBfdStaticRoute(BfdBase):
         enum_supervisor_dut_hostname,
         select_src_dst_dut_with_asic,
         bfd_cleanup_db,
+        loganalyzer
     ):
         """
         Author:  Harsha Golla
@@ -282,7 +283,7 @@ class TestBfdStaticRoute(BfdBase):
         dst_dut.shell("sudo config save -y")
 
         # Perform a cold reboot on RP
-        reboot(rp, localhost, safe_reboot=True)
+        reboot(rp, localhost, safe_reboot=True, ignore_loganalyzer=loganalyzer)
 
         # Waiting for all processes on Source & destination dut
         with SafeThreadPoolExecutor(max_workers=8) as executor:
@@ -304,7 +305,7 @@ class TestBfdStaticRoute(BfdBase):
         dst_dut.shell("sudo config save -y")
 
         # Perform a cold reboot on RP
-        reboot(rp, localhost, safe_reboot=True)
+        reboot(rp, localhost, safe_reboot=True, ignore_loganalyzer=loganalyzer)
 
         # Waiting for all processes on Source & destination dut
         with SafeThreadPoolExecutor(max_workers=8) as executor:
@@ -517,7 +518,7 @@ class TestBfdStaticRoute(BfdBase):
                     version,
                 )
 
-    def test_bfd_config_reload(self, request, select_src_dst_dut_with_asic, bfd_cleanup_db):
+    def test_bfd_config_reload(self, request, select_src_dst_dut_with_asic, bfd_cleanup_db, loganalyzer):
         """
         Author:  Harsha Golla
         Email : harsgoll@cisco.com
@@ -543,7 +544,7 @@ class TestBfdStaticRoute(BfdBase):
         src_dut.shell("sudo config save -y")
 
         # Config reload of Source dut
-        config_reload(src_dut, safe_reload=True)
+        config_reload(src_dut, safe_reload=True, ignore_loganalyzer=loganalyzer)
 
         check_bgp_status(request)
 
@@ -560,7 +561,7 @@ class TestBfdStaticRoute(BfdBase):
         src_dut.shell("sudo config save -y")
 
         # Config reload of Source dut
-        config_reload(src_dut, safe_reload=True)
+        config_reload(src_dut, safe_reload=True, ignore_loganalyzer=loganalyzer)
 
         check_bgp_status(request)
 
@@ -576,6 +577,7 @@ class TestBfdStaticRoute(BfdBase):
         select_src_dst_dut_with_asic,
         enum_supervisor_dut_hostname,
         bfd_cleanup_db,
+        loganalyzer
     ):
         """
         Author:  Harsha Golla
@@ -605,7 +607,7 @@ class TestBfdStaticRoute(BfdBase):
         dst_dut.shell("sudo config save -y")
 
         # Config reload of RP
-        config_reload(rp, safe_reload=True)
+        config_reload(rp, safe_reload=True, ignore_loganalyzer=loganalyzer)
 
         # Waiting for all processes on Source & destination dut
         with SafeThreadPoolExecutor(max_workers=8) as executor:
@@ -628,7 +630,7 @@ class TestBfdStaticRoute(BfdBase):
         dst_dut.shell("sudo config save -y")
 
         # Config reload of RP
-        config_reload(rp, safe_reload=True)
+        config_reload(rp, safe_reload=True, ignore_loganalyzer=loganalyzer)
 
         # Waiting for all processes on Source & destination dut
         with SafeThreadPoolExecutor(max_workers=8) as executor:
@@ -649,6 +651,7 @@ class TestBfdStaticRoute(BfdBase):
         select_src_dst_dut_with_asic,
         enum_supervisor_dut_hostname,
         bfd_cleanup_db,
+        loganalyzer
     ):
         """
         Author:  Harsha Golla
@@ -694,7 +697,7 @@ class TestBfdStaticRoute(BfdBase):
                 executor.submit(verify_bfd_only, dut, dut_nexthops, asic, "Down")
 
         # Config reload RP to bring up the swss containers
-        config_reload(rp, safe_reload=True)
+        config_reload(rp, safe_reload=True, ignore_loganalyzer=loganalyzer)
 
         # Waiting for all processes on Source & destination dut
         with SafeThreadPoolExecutor(max_workers=8) as executor:
@@ -717,7 +720,7 @@ class TestBfdStaticRoute(BfdBase):
         dst_dut.shell("sudo config save -y")
 
         # Config reload RP
-        config_reload(rp, safe_reload=True)
+        config_reload(rp, safe_reload=True, ignore_loganalyzer=loganalyzer)
 
         # Waiting for all processes on Source & destination dut
         with SafeThreadPoolExecutor(max_workers=8) as executor:

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -267,6 +267,10 @@ class LogAnalyzer:
         """
         Adds the start ignore marker to the log files
         """
+        # We copy 'loganalyzer.py' to /tmp dir during loganalyzer initialization,
+        # but the file could be auto removed by rebooting device,
+        # always copy script to make sure the marker can be added successfully.
+        self.ansible_host.copy(src=ANSIBLE_LOGANALYZER_MODULE, dest=os.path.join(self.dut_run_dir, "loganalyzer.py"))
         add_start_ignore_mark = ".".join((self.marker_prefix, time.strftime("%Y-%m-%d-%H:%M:%S", time.gmtime())))
         cmd = "python {run_dir}/loganalyzer.py --action add_start_ignore_mark --run_id {add_start_ignore_mark}"\
             .format(run_dir=self.dut_run_dir, add_start_ignore_mark=add_start_ignore_mark)
@@ -281,6 +285,10 @@ class LogAnalyzer:
         """
         Adds the end ignore marker to the log files
         """
+        # We copy 'loganalyzer.py' to /tmp dir during loganalyzer initialization,
+        # but the file could be auto removed by rebooting device,
+        # always copy script to make sure the marker can be added successfully.
+        self.ansible_host.copy(src=ANSIBLE_LOGANALYZER_MODULE, dest=os.path.join(self.dut_run_dir, "loganalyzer.py"))
         marker = self._markers.pop()
         cmd = "python {run_dir}/loganalyzer.py --action add_end_ignore_mark --run_id {marker}"\
             .format(run_dir=self.dut_run_dir, marker=marker)

--- a/tests/common/plugins/loganalyzer/utils.py
+++ b/tests/common/plugins/loganalyzer/utils.py
@@ -12,10 +12,10 @@ def ignore_loganalyzer(func):
             and set ignore_loganalyzer markers before and after the decorated function on all log analyzer instances.
         """
 
-        loganalyzer = None
-        if 'ignore_loganalyzer' in kwargs and kwargs['ignore_loganalyzer'] is not None:
-            loganalyzer = kwargs['ignore_loganalyzer']
-            kwargs.pop('ignore_loganalyzer')
+        # Need to remove parameter 'ignore_loganalyzer' from kwargs
+        # Otherwise it breaks the decorated func
+        # Since the parameter 'ignore_loganalyzer' is not defined in the signature
+        loganalyzer = kwargs.pop('ignore_loganalyzer', {})
 
         if loganalyzer:
             for _, dut_loganalyzer in list(loganalyzer.items()):

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -10,6 +10,7 @@ from collections import deque
 from .helpers.assertions import pytest_assert
 from .platform.interface_utils import check_interface_status_of_up_ports
 from .platform.processes_utils import wait_critical_processes
+from .plugins.loganalyzer.utils import ignore_loganalyzer
 from .utilities import wait_until, get_plt_reboot_ctrl
 from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs, create_duthost_console, creds_on_dut
 from tests.common.fixtures.conn_graph_facts import get_graph_facts
@@ -223,6 +224,7 @@ def perform_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwa
     return [reboot_res, dut_datetime]
 
 
+@ignore_loganalyzer
 def reboot(duthost, localhost, reboot_type='cold', delay=10,
            timeout=0, wait=0, wait_for_ssh=True, wait_warmboot_finalizer=False, warmboot_finalizer_timeout=0,
            reboot_helper=None, reboot_kwargs=None, return_after_reconnect=False,

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -95,13 +95,14 @@ def fanouthost(duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
 
 
 @pytest.fixture
-def configure_copp_drop_for_ttl_error(duthosts, rand_one_dut_hostname):
+def configure_copp_drop_for_ttl_error(duthosts, rand_one_dut_hostname, loganalyzer):
     """
     Fixture that allows to update copp configuration for dropping packets with TTL=0
 
     Args:
         duthosts: fixture to get DUT hosts defined in testbed
         rand_one_dut_hostname: fixture to return the randomly selected duthost
+        loganalyzer: loganalyzer
     """
     duthost = duthosts[rand_one_dut_hostname]
     copp_trap_group_json = "/tmp/copp_trap_group.json"
@@ -143,7 +144,7 @@ EOF
     yield
 
     duthost.command("rm {} {}".format(copp_trap_group_json, copp_trap_rule_json))
-    config_reload(duthost, safe_reload=True)
+    config_reload(duthost, safe_reload=True, ignore_loganalyzer=loganalyzer)
 
 
 def get_fanout_obj(conn_graph_facts, duthost, fanouthosts):

--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -15,9 +15,10 @@ pytestmark = [
 ]
 
 
-def load_new_cfg(duthost, data):
+def load_new_cfg(duthost, data, loganalyzer):
     duthost.copy(content=json.dumps(data, indent=4), dest=CFG_DB_PATH)
-    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True,
+                  ignore_loganalyzer=loganalyzer)
 
 
 def get_queue_ctrs(duthost, cmd):
@@ -136,7 +137,7 @@ def test_snmp_queue_counters(duthosts,
     # to removing buffer queues
     data['DEVICE_METADATA']["localhost"]["create_only_config_db_buffers"] \
         = "true"
-    load_new_cfg(duthost, data)
+    load_new_cfg(duthost, data, loganalyzer)
     stat_queue_counters_cnt_pre = get_queuestat_ctrs(duthost, get_queue_stat_cmd) * UNICAST_CTRS
     wait_until(60, 20, 0, check_snmp_cmd_output, duthost, get_bfr_queue_cntrs_cmd)
     queue_counters_cnt_pre = get_queue_ctrs(duthost, get_bfr_queue_cntrs_cmd)
@@ -148,7 +149,7 @@ def test_snmp_queue_counters(duthosts,
 
     # Remove buffer queue and reload and get number of queue counters of selected interface
     del data['BUFFER_QUEUE'][buffer_queue_to_del]
-    load_new_cfg(duthost, data)
+    load_new_cfg(duthost, data, loganalyzer)
     stat_queue_counters_cnt_post = get_queuestat_ctrs(duthost, get_queue_stat_cmd) * UNICAST_CTRS
     wait_until(60, 20, 0, check_snmp_cmd_output, duthost, get_bfr_queue_cntrs_cmd)
     queue_counters_cnt_post = get_queue_ctrs(duthost, get_bfr_queue_cntrs_cmd)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes MSFT PBI#30938349
And fix: #7313


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
1. Ignore the err logs during loganalyzer analyze on config_reload and reboot
2. Fix the bug that run with --disable_loganalyzer
#### How did you do it?
1. Add ignore_loganalyzer when calling reboot and config_reload 
2. Always remove ignore_loganalyzer from the original kwargs
#### How did you verify/test it?
Run on physical testbeds, and it works as expected.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
