### PR TITLE
[duthost]: Convert wait(critical_services_fully_started) to duthost method

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -184,8 +184,7 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
     elif test_type == "reboot":
         reboot(duthost, localhost, reboot_type="warm", wait_warmboot_finalizer=True, warmboot_finalizer_timeout=360)
 
-    pytest_assert(wait_until(360, 10, 120, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started(timeout=360, poll_interval=10, wait=120)
 
     if failure_type == "interface":
         for port in local_interfaces:
@@ -202,7 +201,6 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
             nbrhosts[neighbor_name]['host'].no_shutdown(neighbor_port)
             time.sleep(1)
 
-    pytest_assert(wait_until(120, 10, 30, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started(timeout=120, poll_interval=10, wait=30)
     pytest_assert(wait_until(60, 10, 0, duthost.check_bgp_session_state, list(setup['neighhosts'].keys())),
                   "Not all BGP sessions are established on DUT")

--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -605,8 +605,7 @@ def do_and_wait_reboot(duthost, localhost, reboot_type):
     with allure.step("Do {}".format(reboot_type)):
         reboot(duthost, localhost, reboot_type=reboot_type, reboot_helper=None, reboot_kwargs=None,
                wait_warmboot_finalizer=True)
-        pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                      "All critical services should be fully started!")
+        duthost.wait_critical_services_fully_started()
         pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
                       "Not all ports that are admin up on are operationally up")
 

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -987,8 +987,8 @@ def test_user_init_tsb_while_service_run_on_dut(duthosts, localhost, enum_rand_o
                       "startup_tsa_tsb service is not in inactive state after user init TSB")
 
         # Make sure DUT continues to be in good state after TSB
-        assert wait_until(300, 20, 2, duthost.critical_services_fully_started), \
-            "Not all critical services are fully started on {}".format(duthost.hostname)
+        duthost.wait_critical_services_fully_started(wait=2)
+
         crit_process_check = wait_until(600, 20, 0, _all_critical_processes_healthy, duthost)
         int_status_result = wait_until(1200, 20, 0, check_interface_status_of_up_ports, duthost)
 
@@ -1216,8 +1216,7 @@ def test_tsa_tsb_timer_efficiency(duthosts, localhost, enum_rand_one_per_hwsku_f
                       "startup_tsa_tsb service started much later than the expected time after dut reboot")
 
         logging.info("Wait until all critical services are fully started")
-        pytest_assert(wait_until(300, 20, 2, duthost.critical_services_fully_started)), \
-            "Not all critical services are fully started on {}".format(duthost.hostname)
+        duthost.wait_critical_services_fully_started(wait=2)
 
         logging.info("Wait until all critical processes are fully started")
         crit_process_check = wait_until(600, 20, 0, _all_critical_processes_healthy, duthost)

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -199,8 +199,8 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
         # time it takes for containers to come back up. Therefore, add 5
         # minutes to the maximum wait time. If it's ready sooner, then the
         # function will return sooner.
-        pytest_assert(wait_until(wait + 300, 20, 0, sonic_host.critical_services_fully_started),
-                      "All critical services should be fully started!")
+        sonic_host.wait_critical_services_fully_started(timeout=(wait + 300))
+
         wait_critical_processes(sonic_host)
         # PFCWD feature does not enable on some topology, for example M0
         if config_source == 'minigraph' and pfcwd_feature_enabled(sonic_host):

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -18,7 +18,7 @@ from tests.common.devices.base import AnsibleHostBase
 from tests.common.devices.constants import ACL_COUNTERS_UPDATE_INTERVAL_IN_SEC
 from tests.common.helpers.dut_utils import is_supervisor_node, is_macsec_capable_node
 from tests.common.str_utils import str2bool
-from tests.common.utilities import get_host_visible_vars
+from tests.common.utilities import get_host_visible_vars, wait_until
 from tests.common.cache import cached
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, DEFAULT_NAMESPACE
 from tests.common.helpers.platform_api.chassis import is_inband_port
@@ -516,6 +516,10 @@ class SonicHost(AnsibleHostBase):
         result = self.critical_services_status()
         logging.debug("Status of critical services: %s" % str(result))
         return all(result.values())
+
+    def wait_critical_services_fully_started(self, timeout=300, poll_interval=20, wait=0):
+        if not wait_until(timeout, poll_interval, wait, self.critical_services_fully_started):
+            raise TimeoutError(f"{self.hostname}: Not all critical services are fully started")
 
     def get_monit_services_status(self):
         """

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -257,7 +257,11 @@ def check_services(duthost):
     Perform a health check of services
     """
     logging.info("Wait until all critical services are fully started")
-    if not wait_until(330, 30, 0, duthost.critical_services_fully_started):
+    try:
+        duthost.wait_critical_services_fully_started(timeout=330)
+    except TimeoutError as e:
+        logging.error(f"Timed out: {e}")
+        # reraise as reboot error
         raise RebootHealthError("dut.critical_services_fully_started is False")
 
     logging.info("Check critical service status")

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -306,8 +306,8 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         # time it takes for containers to come back up. Therefore, add 5
         # minutes to the maximum wait time. If it's ready sooner, then the
         # function will return sooner.
-        pytest_assert(wait_until(wait + 400, 20, 0, duthost.critical_services_fully_started),
-                      "{}: All critical services should be fully started!".format(hostname))
+        duthost.wait_critical_services_fully_started(timeout=(wait + 400))
+
         wait_critical_processes(duthost)
 
         if check_intf_up_ports:

--- a/tests/configlet/util/base_test.py
+++ b/tests/configlet/util/base_test.py
@@ -133,8 +133,7 @@ def restore_orig_minigraph(duthost, skip_load=False):
 def load_minigraph(duthost):
     log_info("Loading minigraph")
     config_reload(duthost, config_source="minigraph", wait=RELOAD_WAIT_TIME, start_bgp=True)
-    assert wait_until(300, 20, 0, duthost.critical_services_fully_started), \
-        "All critical services should fully started!"
+    duthost.wait_critical_services_fully_started()
     assert wait_until(300, 20, 0, chk_for_pfc_wd, duthost), \
         "PFC_WD is missing in CONFIG-DB"
 

--- a/tests/configlet/util/mock_for_switch.py
+++ b/tests/configlet/util/mock_for_switch.py
@@ -94,6 +94,10 @@ class DutHost:
 
         return True
 
+    def wait_critical_services_fully_started(self, timeout=300, poll_interval=20, wait=0):
+        if not wait_until(timeout, poll_interval, wait, self.critical_services_fully_started):
+            raise TimeoutError(f"{self.hostname}: Not all critical services are fully started")
+
     def get_bgp_neighbor_info(self, neighbor_ip):
         """
         @summary: return bgp neighbor info

--- a/tests/dns/static_dns/test_static_dns.py
+++ b/tests/dns/static_dns/test_static_dns.py
@@ -90,8 +90,7 @@ def test_static_dns_basic(request, duthost, localhost, mgmt_interfaces):
             config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
         else:
             reboot(duthost, localhost, reboot_type)
-            pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                          "All critical services should be fully started!")
+            duthost.wait_critical_services_fully_started()
             pytest_assert(wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
                           "Not all ports that are admin up on are operationally up")
 

--- a/tests/hash/test_generic_hash.py
+++ b/tests/hash/test_generic_hash.py
@@ -675,8 +675,7 @@ def test_reboot(duthost, tbinfo, ptfhost, localhost, fine_params, mg_facts, rest
         else:
             reboot(duthost, localhost, reboot_type=reboot_type)
         # Wait for the dut to recover
-        pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                      "Not all critical services are fully started.")
+        duthost.wait_critical_services_fully_started()
     with allure.step('Check the generic hash config after the reboot'):
         check_global_hash_config(duthost, global_hash_capabilities['ecmp'], global_hash_capabilities['lag'])
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:

--- a/tests/iface_loopback_action/test_iface_loopback_action.py
+++ b/tests/iface_loopback_action/test_iface_loopback_action.py
@@ -113,8 +113,7 @@ def test_loopback_action_reload(request, duthost, localhost, ptfadapter, ports_c
             config_reload(duthost, safe_reload=True)
         else:
             reboot(duthost, localhost, reboot_type)
-            pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                          "All critical services should be fully started!")
+            duthost.wait_critical_services_fully_started()
         pytest_assert(wait_until(60, 20, 0, check_interface_status_of_up_ports, duthost),
                       "Not all ports that are admin up on are operationally up")
         # Wait for the rif counter to initialize

--- a/tests/ixia/pfc/test_pfc_pause_lossless.py
+++ b/tests/ixia/pfc/test_pfc_pause_lossless.py
@@ -3,9 +3,8 @@ import pytest
 
 from .files.helper import run_pfc_test
 from tests.common.cisco_data import is_cisco_device
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.assertions import pytest_require
 from tests.common.reboot import reboot
-from tests.common.utilities import wait_until
 from tests.ixia.files.helper import skip_warm_reboot
 
 logger = logging.getLogger(__name__)
@@ -238,8 +237,7 @@ def test_pfc_pause_single_lossless_prio_reboot(ixia_api,
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfc_test(api=ixia_api,
                  testbed_config=testbed_config,
@@ -306,8 +304,7 @@ def test_pfc_pause_multi_lossless_prio_reboot(ixia_api,
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfc_test(api=ixia_api,
                  testbed_config=testbed_config,

--- a/tests/ixia/pfc/test_pfc_pause_lossy.py
+++ b/tests/ixia/pfc/test_pfc_pause_lossy.py
@@ -2,14 +2,13 @@ import logging
 import pytest
 
 from .files.helper import run_pfc_test
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts         # noqa F401
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config                     # noqa F401
 from tests.common.ixia.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list                                                                             # noqa F401
 from tests.common.reboot import reboot
-from tests.common.utilities import wait_until
 from tests.ixia.files.helper import skip_warm_reboot
 
 logger = logging.getLogger(__name__)
@@ -164,8 +163,7 @@ def test_pfc_pause_single_lossy_prio_reboot(ixia_api, ixia_testbed_config, conn_
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfc_test(api=ixia_api,
                  testbed_config=testbed_config,
@@ -225,8 +223,7 @@ def test_pfc_pause_multi_lossy_prio_reboot(ixia_api, ixia_testbed_config, conn_g
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfc_test(api=ixia_api,
                  testbed_config=testbed_config,

--- a/tests/ixia/pfcwd/test_pfcwd_basic.py
+++ b/tests/ixia/pfcwd/test_pfcwd_basic.py
@@ -1,13 +1,12 @@
 import pytest
 import logging
 
-from tests.common.helpers.assertions import pytest_require, pytest_assert
+from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa F401
 from tests.common.ixia.ixia_fixtures import ixia_api_serv_ip, ixia_api_serv_port,\
     ixia_api_serv_user, ixia_api_serv_passwd, ixia_api, ixia_testbed_config                 # noqa F401
 from tests.common.ixia.qos_fixtures import prio_dscp_map, lossless_prio_list                # noqa F401
 from tests.common.reboot import reboot
-from tests.common.utilities import wait_until
 from tests.ixia.files.helper import skip_warm_reboot
 from .files.pfcwd_basic_helper import run_pfcwd_basic_test
 from .files.helper import skip_pfcwd_test
@@ -152,8 +151,7 @@ def test_pfcwd_basic_single_lossless_prio_reboot(ixia_api, ixia_testbed_config, 
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfcwd_basic_test(api=ixia_api,
                          testbed_config=testbed_config,
@@ -208,8 +206,7 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(ixia_api, ixia_testbed_config, c
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfcwd_basic_test(api=ixia_api,
                          testbed_config=testbed_config,
@@ -267,8 +264,7 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(ixia_api, ixia_testbed
         duthost.command("systemctl reset-failed {}".format(service))
     duthost.command("systemctl restart {}".format(restart_service))
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfcwd_basic_test(api=ixia_api,
                          testbed_config=testbed_config,
@@ -324,8 +320,7 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(ixia_api, ixia_testbed_
         duthost.command("systemctl reset-failed {}".format(service))
     duthost.command("systemctl restart {}".format(restart_service))
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfcwd_basic_test(api=ixia_api,
                          testbed_config=testbed_config,

--- a/tests/mclag/test_mclag_l3.py
+++ b/tests/mclag/test_mclag_l3.py
@@ -247,8 +247,7 @@ class TestActiveDeviceStatusChange():
         duthost1.shell("config save -y")
         pytest_assert(wait_until(120, 5, 0, check_partner_lag_member, ptfhost, check_portchannels, "UP"),
                       "Expected partner Lag members isnt up")
-        pytest_assert(wait_until(300, 20, 0, duthost1.critical_services_fully_started),
-                      "All critical services should fully started!{}".format(duthost1.critical_services))
+        duthost1.wait_critical_services_fully_started()
 
     def test_active_down(self, duthost1, duthost2, ptfadapter, ptfhost, collect, get_routes, mclag_intf_num,
                          update_and_clean_ptf_agent, pre_active_setup):
@@ -298,8 +297,7 @@ class TestStandByDeviceStatusChange():
         duthost2.shell("config save -y")
         pytest_assert(wait_until(120, 5, 0, check_partner_lag_member, ptfhost, check_portchannels, "UP"),
                       "Expected partner Lag members isnt up")
-        pytest_assert(wait_until(300, 20, 0, duthost2.critical_services_fully_started),
-                      "All critical services should fully started!{}".format(duthost2.critical_services))
+        duthost2.wait_critical_services_fully_started()
 
     def test_standby_down(self, duthost1, duthost2, ptfadapter, ptfhost, collect, get_routes, mclag_intf_num,
                           update_and_clean_ptf_agent, pre_standby_setup):

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -282,9 +282,7 @@ class TestReboot():
         duthost = duthosts[rand_one_dut_hostname]
         duthost.command("sudo config save -y")  # This will override config_db.json with mgmt vrf config
         reboot(duthost, localhost, reboot_type="warm")
-        pytest_assert(wait_until(120, 20, 0, duthost.critical_services_fully_started),
-                      "Not all critical services are fully started")
-
+        duthost.wait_critical_services_fully_started(timeout=120)
         # Change default critical services to check services that starts with bootOn timer
         # In some images, we have gnmi container only
         # In some images, we have telemetry container only
@@ -299,8 +297,7 @@ class TestReboot():
             critical_services.append('telemetry')
         duthost.reset_critical_services_tracking_list(critical_services)
 
-        pytest_assert(wait_until(180, 20, 0, duthost.critical_services_fully_started),
-                      "Not all services which start with bootOn timer are fully started")
+        duthost.wait_critical_services_fully_started(timeout=180)
         self.basic_check_after_reboot(duthost, localhost, ptfhost, creds)
 
     @pytest.mark.disable_loganalyzer
@@ -308,8 +305,7 @@ class TestReboot():
         duthost = duthosts[rand_one_dut_hostname]
         duthost.command("sudo config save -y")  # This will override config_db.json with mgmt vrf config
         reboot(duthost, localhost)
-        pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                      "Not all critical services are fully started")
+        duthost.wait_critical_services_fully_started()
         self.basic_check_after_reboot(duthost, localhost, ptfhost, creds)
 
     @pytest.mark.disable_loganalyzer
@@ -317,6 +313,5 @@ class TestReboot():
         duthost = duthosts[rand_one_dut_hostname]
         duthost.command("sudo config save -y")  # This will override config_db.json with mgmt vrf config
         reboot(duthost, localhost, reboot_type="fast")
-        pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                      "Not all critical services are fully started")
+        duthost.wait_critical_services_fully_started()
         self.basic_check_after_reboot(duthost, localhost, ptfhost, creds)

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -539,8 +539,7 @@ def test_po_update_with_higher_lagids(
     wait_critical_processes(suphost)
 
     # Ensure all critical services have started on the supervisor node
-    pytest_assert(wait_until(330, 20, 0, suphost.critical_services_fully_started),
-                  "All critical services should fully started! {}".format(suphost.hostname))
+    duthost.wait_critical_services_fully_started(timeout=330)
 
     # For each linecard (frontend node), wait for startup and critical processes to start
     for linecard in duthosts.frontend_nodes:
@@ -552,8 +551,7 @@ def test_po_update_with_higher_lagids(
         wait_critical_processes(linecard)
 
         # Ensure all critical services have started on the linecard
-        pytest_assert(wait_until(330, 20, 0, linecard.critical_services_fully_started),
-                      "All critical services should fully started! {}".format(linecard.hostname))
+        duthost.wait_critical_services_fully_started(timeout=330)
 
     # Perform a sanity check on the LAG set
     lag_set_sanity(duthosts)

--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -7,8 +7,6 @@ from tests.platform_tests.counterpoll.cpu_memory_helper import counterpoll_type 
 from tests.platform_tests.counterpoll.counterpoll_helper import ConterpollHelper
 from tests.platform_tests.counterpoll.counterpoll_constants import CounterpollConstants
 from tests.common.mellanox_data import is_mellanox_device
-from tests.common.utilities import wait_until
-from tests.common.helpers.assertions import pytest_assert
 
 
 pytestmark = [
@@ -60,8 +58,7 @@ def test_cpu_memory_usage(duthosts, enum_rand_one_per_hwsku_hostname, setup_thre
     """Check DUT memory usage and process cpu usage are within threshold."""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     # Wait until all critical services is fully started
-    pytest_assert(wait_until(360, 20, 0, duthost.critical_services_fully_started),
-                  "All critical services must be fully started!{}".format(duthost.critical_services))
+    duthost.wait_critical_services_fully_started(timeout=360)
     MonitResult = namedtuple('MonitResult', ['processes', 'memory'])
     monit_results = duthost.monit_process(iterations=24)['monit_results']
 

--- a/tests/read_mac/test_read_mac_metadata.py
+++ b/tests/read_mac/test_read_mac_metadata.py
@@ -1,9 +1,7 @@
 import pytest
 import logging
 
-from tests.common.utilities import wait_until
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
-from tests.common.helpers.assertions import pytest_assert
 from tests.common.reboot import reboot
 from tests.common import config_reload
 
@@ -92,8 +90,7 @@ class ReadMACMetadata():
                 self.deploy_image_to_duthost(duthost, counter)
                 reboot(duthost, localhost, wait=120)
                 logger.info("Wait until system is stable")
-                pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                              "Not all critical services are fully started")
+                duthost.wait_critical_services_fully_started()
 
             if current_minigraph:
                 logger.info("Execute cli 'config load_minigraph -y' to apply new minigraph")

--- a/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
@@ -1,8 +1,7 @@
 import logging
 from tabulate import tabulate
 from statistics import mean
-from tests.common.utilities import (wait, wait_until)
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait
 logger = logging.getLogger(__name__)
 
 TGEN_AS_NUM = 65200
@@ -993,6 +992,5 @@ def cleanup_config(duthost):
         "/etc/sonic/config_db_backup.json", "/etc/sonic/config_db.json"))
     duthost.shell("sudo config reload -y \n")
     logger.info("Wait until all critical services are fully started")
-    pytest_assert(wait_until(360, 10, 1, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started(timeout=360, poll_interval=10, wait=1)
     logger.info('Convergence Test Completed')

--- a/tests/snappi_tests/bgp/files/bgp_test_gap_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_test_gap_helper.py
@@ -1,6 +1,5 @@
 from tabulate import tabulate
-from tests.common.utilities import (wait, wait_until)
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait
 import logging
 logger = logging.getLogger(__name__)
 
@@ -711,6 +710,5 @@ def cleanup_config(duthost):
     duthost.command("sudo cp {} {}".format("/etc/sonic/config_db_backup.json", "/etc/sonic/config_db.json"))
     duthost.shell("sudo config reload -y \n")
     logger.info("Wait until all critical services are fully started")
-    pytest_assert(wait_until(360, 10, 1, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started(timeout=360, poll_interval=10, wait=1)
     logger.info('Convergence Test Completed')

--- a/tests/snappi_tests/lacp/files/lacp_dut_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_dut_helper.py
@@ -1,7 +1,6 @@
 import logging
 from tabulate import tabulate
-from tests.common.utilities import (wait, wait_until)
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait
 logger = logging.getLogger(__name__)
 
 TGEN_AS_NUM = 65200
@@ -385,6 +384,5 @@ def cleanup_config(duthost):
     duthost.command("sudo cp {} {}".format(
         "/etc/sonic/config_db_backup.json", "/etc/sonic/config_db.json"))
     duthost.shell("sudo config reload -y \n")
-    pytest_assert(wait_until(360, 10, 1, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started(timeout=360, poll_interval=10, wait=1)
     logger.info('Convergence Test Completed')

--- a/tests/snappi_tests/lacp/files/lacp_physical_helper.py
+++ b/tests/snappi_tests/lacp/files/lacp_physical_helper.py
@@ -1,8 +1,7 @@
 import logging
 from tabulate import tabulate
 from statistics import mean
-from tests.common.utilities import (wait, wait_until)
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait
 logger = logging.getLogger(__name__)
 
 TGEN_AS_NUM = 65200
@@ -435,6 +434,5 @@ def cleanup_config(duthost):
     duthost.command("sudo cp {} {}".format(
         "/etc/sonic/config_db_backup.json", "/etc/sonic/config_db.json"))
     duthost.shell("sudo config reload -y \n")
-    pytest_assert(wait_until(360, 10, 1, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started(timeout=360, poll_interval=10, wait=1)
     logger.info('Convergence Test Completed')

--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
@@ -33,7 +33,8 @@ def number_of_tx_rx_ports():
 
 
 @pytest.fixture(autouse=False)
-def save_restore_config(setup_ports_and_dut):
+def save_restore_config(setup_ports_and_dut     # noqa: F811
+                        ):
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
     timestamp = time.time()
     dest = f'~/{timestamp}'
@@ -287,8 +288,7 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
             duthost.command("sudo systemctl reset-failed {}".format(proc))
             duthost.command("sudo systemctl restart {}".format(proc))
             logger.info("Wait until the system is stable")
-            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
-                          "Not all critical services are fully started")
+            duthost.wait_critical_services_fully_started(timeout=WAIT_TIME, poll_interval=INTERVAL)
             pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, check_interface_status_of_up_ports, duthost),
                           "Not all interfaces are up.")
             pytest_assert(wait_until(
@@ -300,8 +300,7 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
             duthost.command("systemctl reset-failed {}".format(restart_service))
             duthost.command("systemctl restart {}".format(restart_service))
             logger.info("Wait until the system is stable")
-            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
-                          "Not all critical services are fully started")
+            duthost.wait_critical_services_fully_started(timeout=WAIT_TIME, poll_interval=INTERVAL)
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
@@ -374,8 +373,7 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
             duthost.command("sudo systemctl reset-failed {}".format(proc))
             duthost.command("sudo systemctl restart {}".format(proc))
             logger.info("Wait until the system is stable")
-            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
-                          "Not all critical services are fully started")
+            duthost.wait_critical_services_fully_started(timeout=WAIT_TIME, poll_interval=INTERVAL)
             pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, check_interface_status_of_up_ports, duthost),
                           "Not all interfaces are up.")
             pytest_assert(wait_until(
@@ -387,8 +385,7 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
             duthost.command("systemctl reset-failed {}".format(restart_service))
             duthost.command("systemctl restart {}".format(restart_service))
             logger.info("Wait until the system is stable")
-            pytest_assert(wait_until(WAIT_TIME, INTERVAL, 0, duthost.critical_services_fully_started),
-                          "Not all critical services are fully started")
+            duthost.wait_critical_services_fully_started(timeout=WAIT_TIME, poll_interval=INTERVAL)
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports

--- a/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from tests.snappi_tests.pfc.files.helper import run_pfc_test
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts                      # noqa F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port,\
@@ -11,7 +11,6 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,
     lossy_prio_list                         # noqa F401
 from tests.common.reboot import reboot
 from tests.common.platform.processes_utils import wait_critical_processes
-from tests.common.utilities import wait_until
 from tests.snappi_tests.files.helper import skip_warm_reboot
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 
@@ -249,8 +248,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                  # no
     reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
     logger.info("Wait until the system is stable")
     wait_critical_processes(duthost)
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
@@ -320,8 +318,7 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                   # no
     reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
     logger.info("Wait until the system is stable")
     wait_critical_processes(duthost)
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,

--- a/tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from tests.snappi_tests.pfc.files.helper import run_pfc_test
-from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts                      # noqa F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port,\
@@ -10,7 +10,6 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list                         # noqa F401
 from tests.common.reboot import reboot
-from tests.common.utilities import wait_until
 from tests.snappi_tests.files.helper import skip_warm_reboot
 
 logger = logging.getLogger(__name__)
@@ -184,8 +183,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,                 # noqa F
         reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,
@@ -254,8 +252,7 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,                  # noqa F
         reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfc_test(api=snappi_api,
                  testbed_config=testbed_config,

--- a/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from tests.common.helpers.assertions import pytest_require, pytest_assert
+from tests.common.helpers.assertions import pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts                      # noqa F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port,\
@@ -9,7 +9,6 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list      # noqa F401
 from tests.common.config_reload import config_reload
 from tests.common.reboot import reboot
-from tests.common.utilities import wait_until
 from tests.snappi_tests.pfcwd.files.pfcwd_basic_helper import run_pfcwd_basic_test
 from tests.snappi_tests.files.helper import skip_warm_reboot
 
@@ -167,8 +166,7 @@ def test_pfcwd_basic_single_lossless_prio_reboot(snappi_api,                # no
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfcwd_basic_test(api=snappi_api,
                          testbed_config=testbed_config,
@@ -229,8 +227,7 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
     logger.info("Issuing a {} reboot on the dut {}".format(reboot_type, duthost.hostname))
     reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfcwd_basic_test(api=snappi_api,
                          testbed_config=testbed_config,
@@ -291,8 +288,7 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
     duthost.command("systemctl reset-failed {}".format(restart_service))
     duthost.command("systemctl restart {}".format(restart_service))
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfcwd_basic_test(api=snappi_api,
                          testbed_config=testbed_config,
@@ -353,8 +349,7 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
     duthost.command("systemctl reset-failed {}".format(restart_service))
     duthost.command("systemctl restart {}".format(restart_service))
     logger.info("Wait until the system is stable")
-    pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
-                  "Not all critical services are fully started")
+    duthost.wait_critical_services_fully_started()
 
     run_pfcwd_basic_test(api=snappi_api,
                          testbed_config=testbed_config,

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -11,7 +11,6 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.helpers.thermal_control_test_helper import disable_thermal_policy     # noqa F401
 from .device_mocker import device_mocker_factory        # noqa F401
-from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.duthost_utils import is_support_mock_asic    # noqa F401
 
 pytestmark = [
@@ -544,5 +543,4 @@ class ProcessExitContext:
         self.dut.command('docker exec -t {} bash -c "supervisorctl start {}"'.format(
             self.container_name, self.process_name))
         # check with delay in which the dockers can be restarted
-        pytest_assert(wait_until(300, 20, 8, self.dut.critical_services_fully_started),
-                      "Not all critical services are fully started")
+        self.dut.wait_critical_services_fully_started(wait=8)

--- a/tests/voq/test_voq_chassis_app_db_consistency.py
+++ b/tests/voq/test_voq_chassis_app_db_consistency.py
@@ -175,8 +175,7 @@ def test_voq_chassis_app_db_consistency(duthosts, enum_rand_one_per_hwsku_fronte
             pytest_assert(check_db_consistency(duthosts, duthost, post_change_db_dump),
                           "DB_Consistency Failed During Reboot")
             localhost.wait_for(host=duthost.mgmt_ip, port=22, state="started", delay=10, timeout=300)
-            pytest_assert(wait_until(330, 20, 0, duthost.critical_services_fully_started),
-                          "All critical services should fully started!")
+            duthost.wait_critical_services_fully_started(timeout=330)
             pytest_assert(wait_until(600, 30, 0, check_db_consistency, duthosts, duthost, init_dump),
                           "DB_Consistency Failed After Reboot")
 


### PR DESCRIPTION
### Description of PR

Use duthost method to perform waits for critical_services_fully_started, rather than `pytest_assert(wait_until..`, to increase maintainability, and allow timeout enhancements in future
The new method will raise a TimeoutError if the wait fails

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Centralise administration of wait_for_critical_services timeouts, to ease modifying it for different platforms

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
