### PR TITLE
[wol] Fix wol tests bug

### DIFF
--- a/tests/wol/test_wol.py
+++ b/tests/wol/test_wol.py
@@ -7,7 +7,7 @@ from socket import inet_aton
 from scapy.all import Ether, UDP, Raw
 from tests.common.helpers.assertions import pytest_assert
 import ptf.testutils as testutils
-import ptf.dataplane as dataplane
+from ptf.dataplane import match_exp_pkt
 
 pytestmark = [
     pytest.mark.topology('mx'),
@@ -31,7 +31,7 @@ def p2b(password: str) -> bytes:
         return binascii.unhexlify(password.replace(':', ''))
     if '.' in password:
         return inet_aton(password)
-    pytest.fail("invalid password %s" % password)
+    pytest.fail("invalid password {}".format(password))
 
 
 def m2b(mac: str) -> bytes:
@@ -49,13 +49,12 @@ def get_packets_on_specified_ports(ptfadapter, verifier=None, ports=None, device
     """
     Get the packets on the specified ports and device for the specified duration
     """
-    logging.info("Get pkts on device %d, port %r", device_number, ports)
+    logging.info("Get pkts on device {}, port {}".format(device_number, ports))
 
     received_pkts_res = {}
     start_time = time.time()
     while (time.time() - start_time) < duration:
         result = testutils.dp_poll(ptfadapter, device_number=device_number, timeout=timeout)
-        logging.info(result)
         if isinstance(result, ptfadapter.dataplane.PollSuccess) and (ports is None or result.port in ports):
             if verifier is None or verifier(result.packet):
                 if result.port in received_pkts_res:
@@ -74,7 +73,8 @@ def verify_packets(ptfadapter, verifier, ports, count=1, interval=None, device_n
     pytest_assert(set(received_pkts.keys()) == (set(ports) if count != 0 else set()),
                   "Received packets on ports other than {}: {}".format(ports, list(received_pkts.keys())))
     pytest_assert(all(map(lambda pkts: len(pkts) == count, received_pkts.values())),
-                  "Did not receive exactly {} of expected packets on all {}: {}".format(count, ports, received_pkts))
+                  "Did not receive exactly {} of expected packets on all {}: received {} total packets {}"
+                  .format(count, ports, sum(map(len, received_pkts.values())), received_pkts))
     if count >= 2 and interval is not None:
         for results in received_pkts.values():
             ts = list(map(lambda result: result.time, results))
@@ -87,8 +87,9 @@ def verify_packet_any(ptfadapter, verifier, ports, count=1, interval=None, devic
     received_pkts = get_packets_on_specified_ports(ptfadapter, verifier, None, device_number, duration, timeout)
     pytest_assert(set(received_pkts.keys()).issubset(ports),
                   "Received packets on ports other than {}: {}".format(ports, list(received_pkts.keys())))
-    pytest_assert(sum(map(lambda pkts: len(pkts), received_pkts.values())) == count,
-                  "Did not receive a total of exactly {} packets on any of {}: {}".format(count, ports, received_pkts))
+    pytest_assert(sum(map(len, received_pkts.values())) == count,
+                  "Did not receive a total of exactly {} packets on any of {}: received {} total packets {}"
+                  .format(count, ports, sum(map(len, received_pkts.values())), received_pkts))
     if count >= 2 and interval is not None:
         ts = []
         for results in received_pkts.values():
@@ -154,7 +155,7 @@ class TestWOLSendFromInterface:
         duthost.shell(build_wol_cmd(random_dut_intf, password=password,
                       broadcast=broadcast, count=count, interval=interval))
 
-        verify_packet(ptfadapter, lambda pkt: dataplane.match_exp_pkt(exp_pkt, pkt),
+        verify_packet(ptfadapter, lambda pkt: match_exp_pkt(exp_pkt, pkt),
                       random_ptf_index, count=1 if count is None else count,
                       interval=0 if interval is None else interval)
 
@@ -229,7 +230,7 @@ class TestWOLSendFromVlan:
                       count=count, interval=interval))
 
         remaining_ptf_index_under_vlan = list(map(lambda item: item[1], remaining_intf_pair_under_vlan))
-        verify_packets(ptfadapter, lambda pkt: dataplane.match_exp_pkt(exp_pkt, pkt),
+        verify_packets(ptfadapter, lambda pkt: match_exp_pkt(exp_pkt, pkt),
                        remaining_ptf_index_under_vlan, count=1 if count is None else count,
                        interval=0 if interval is None else interval)
 

--- a/tests/wol/test_wol.py
+++ b/tests/wol/test_wol.py
@@ -133,7 +133,7 @@ def build_wol_cmd(intf, target_mac=TARGET_MAC, dst_ip=None, dport=None, password
 
 
 class TestWOLSendFromInterface:
-    @pytest.mark.parametrize("count,interval", [(None, None), (2, 0), (2, 2000), (5, 0), (5, 2000)])
+    @pytest.mark.parametrize("count,interval", [(None, None), (2, 2000), (5, 0)])
     @pytest.mark.parametrize("password", [None, "11:22:33:44:55:66", "192.168.0.1"])
     @pytest.mark.parametrize("broadcast", [False, True])
     def test_wol_send_from_interface(
@@ -176,7 +176,7 @@ class TestWOLSendFromInterface:
 
         verify_packet(ptfadapter, get_udp_verifier(DEFAULT_IP, DEFAULT_PORT, payload), random_ptf_index)
 
-    @pytest.mark.parametrize("count,interval", [(None, None), (2, 0), (2, 2000), (5, 0), (5, 2000)])
+    @pytest.mark.parametrize("count,interval", [(None, None), (2, 0), (5, 2000)])
     @pytest.mark.parametrize("password", [None, "11:22:33:44:55:66", "192.168.0.1"])
     @pytest.mark.parametrize("dport", [None, 5678])
     @pytest.mark.parametrize("dst_ip_intf", ["ipv4", "ipv6"], indirect=True)
@@ -207,7 +207,7 @@ class TestWOLSendFromInterface:
 
 
 class TestWOLSendFromVlan:
-    @pytest.mark.parametrize("count,interval", [(None, None), (2, 0), (2, 2000), (5, 0), (5, 2000)])
+    @pytest.mark.parametrize("count,interval", [(None, None), (2, 2000), (5, 0)])
     @pytest.mark.parametrize("password", [None, "11:22:33:44:55:66", "192.168.0.1"])
     def test_wol_send_from_vlan(
         self,
@@ -252,7 +252,7 @@ class TestWOLSendFromVlan:
         remaining_ptf_index_under_vlan = list(map(lambda item: item[1], remaining_intf_pair_under_vlan))
         verify_packets(ptfadapter, get_udp_verifier(DEFAULT_IP, DEFAULT_PORT, payload), remaining_ptf_index_under_vlan)
 
-    @pytest.mark.parametrize("count,interval", [(None, None), (2, 0), (2, 2000), (5, 0), (5, 2000)])
+    @pytest.mark.parametrize("count,interval", [(None, None), (2, 0), (5, 2000)])
     @pytest.mark.parametrize("password", [None, "11:22:33:44:55:66", "192.168.0.1"])
     @pytest.mark.parametrize("dport", [None, 5678])
     @pytest.mark.parametrize("dst_ip_vlan", ["ipv4", "ipv6"], indirect=True)

--- a/tests/wol/test_wol.py
+++ b/tests/wol/test_wol.py
@@ -133,7 +133,7 @@ def build_wol_cmd(intf, target_mac=TARGET_MAC, dst_ip=None, dport=None, password
 
 
 class TestWOLSendFromInterface:
-    @pytest.mark.parametrize("count,interval", [(None, None), (2, 2000), (5, 0)])
+    @pytest.mark.parametrize("count,interval", [(None, None), (3, 1000)])
     @pytest.mark.parametrize("password", [None, "11:22:33:44:55:66", "192.168.0.1"])
     @pytest.mark.parametrize("broadcast", [False, True])
     def test_wol_send_from_interface(
@@ -176,7 +176,7 @@ class TestWOLSendFromInterface:
 
         verify_packet(ptfadapter, get_udp_verifier(DEFAULT_IP, DEFAULT_PORT, payload), random_ptf_index)
 
-    @pytest.mark.parametrize("count,interval", [(None, None), (2, 0), (5, 2000)])
+    @pytest.mark.parametrize("count,interval", [(None, None), (3, 1000)])
     @pytest.mark.parametrize("password", ["11:22:33:44:55:66", "192.168.0.1"])
     @pytest.mark.parametrize("dport", [5678])
     @pytest.mark.parametrize("dst_ip_intf", ["ipv4", "ipv6"], indirect=True)
@@ -207,7 +207,7 @@ class TestWOLSendFromInterface:
 
 
 class TestWOLSendFromVlan:
-    @pytest.mark.parametrize("count,interval", [(None, None), (2, 2000), (5, 0)])
+    @pytest.mark.parametrize("count,interval", [(None, None), (3, 1000)])
     @pytest.mark.parametrize("password", [None, "11:22:33:44:55:66", "192.168.0.1"])
     def test_wol_send_from_vlan(
         self,
@@ -252,7 +252,7 @@ class TestWOLSendFromVlan:
         remaining_ptf_index_under_vlan = list(map(lambda item: item[1], remaining_intf_pair_under_vlan))
         verify_packets(ptfadapter, get_udp_verifier(DEFAULT_IP, DEFAULT_PORT, payload), remaining_ptf_index_under_vlan)
 
-    @pytest.mark.parametrize("count,interval", [(None, None), (2, 0), (5, 2000)])
+    @pytest.mark.parametrize("count,interval", [(None, None), (3, 1000)])
     @pytest.mark.parametrize("password", ["11:22:33:44:55:66", "192.168.0.1"])
     @pytest.mark.parametrize("dport", [5678])
     @pytest.mark.parametrize("dst_ip_vlan", ["ipv4", "ipv6"], indirect=True)

--- a/tests/wol/test_wol.py
+++ b/tests/wol/test_wol.py
@@ -177,8 +177,8 @@ class TestWOLSendFromInterface:
         verify_packet(ptfadapter, get_udp_verifier(DEFAULT_IP, DEFAULT_PORT, payload), random_ptf_index)
 
     @pytest.mark.parametrize("count,interval", [(None, None), (2, 0), (5, 2000)])
-    @pytest.mark.parametrize("password", [None, "11:22:33:44:55:66", "192.168.0.1"])
-    @pytest.mark.parametrize("dport", [None, 5678])
+    @pytest.mark.parametrize("password", ["11:22:33:44:55:66", "192.168.0.1"])
+    @pytest.mark.parametrize("dport", [5678])
     @pytest.mark.parametrize("dst_ip_intf", ["ipv4", "ipv6"], indirect=True)
     def test_wol_send_from_interface_udp(
         self,
@@ -253,8 +253,8 @@ class TestWOLSendFromVlan:
         verify_packets(ptfadapter, get_udp_verifier(DEFAULT_IP, DEFAULT_PORT, payload), remaining_ptf_index_under_vlan)
 
     @pytest.mark.parametrize("count,interval", [(None, None), (2, 0), (5, 2000)])
-    @pytest.mark.parametrize("password", [None, "11:22:33:44:55:66", "192.168.0.1"])
-    @pytest.mark.parametrize("dport", [None, 5678])
+    @pytest.mark.parametrize("password", ["11:22:33:44:55:66", "192.168.0.1"])
+    @pytest.mark.parametrize("dport", [5678])
     @pytest.mark.parametrize("dst_ip_vlan", ["ipv4", "ipv6"], indirect=True)
     def test_wol_send_from_vlan_udp(
         self,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Fix bug with wol tests. Checking for received packets is always flaky. 1 in 10-20 of tests will fail. Packets will not arrive on time for one test and be received in later tests, breaking 2 tests at once. It is caused by importing ptf.dataplane as dataplane. dataplane is a module and a variable at the same time. Importing it and naming it dataplane breaks existing ptf.testutils behaviors (like flushing and syncing) and causing flaking packet analysis in testutils. 

Also some parametrize options are removed to prevent tests from running too long.

wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[False-None-None-None] PASSED                                                 [  1%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[False-None-2-0] PASSED                                                       [  2%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[False-None-2-2000] PASSED                                                    [  3%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[False-None-5-0] PASSED                                                       [  4%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[False-None-5-2000] PASSED                                                    [  5%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[False-11:22:33:44:55:66-None-None] PASSED                                    [  6%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[False-11:22:33:44:55:66-2-0] PASSED                                          [  7%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[False-11:22:33:44:55:66-2-2000] PASSED                                       [  8%]
...    
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface_udp[ipv6-5678-192.168.0.1-2-2000] PASSED                                     [ 97%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface_udp[ipv6-5678-192.168.0.1-5-0] PASSED                                        [ 98%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface_udp[ipv6-5678-192.168.0.1-5-2000] PASSED                                     [100%]

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Fix bug with wol tests

#### How did you do it?

#### How did you verify/test it?
Run tests on mx devices.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
