### PR TITLE
Increase verify_db_timeout as github issue #15644

### DIFF
--- a/tests/common/dualtor/control_plane_utils.py
+++ b/tests/common/dualtor/control_plane_utils.py
@@ -257,7 +257,7 @@ def verify_tor_states(
     expected_standby_health='healthy', intf_names='all',
     cable_type=CableType.default_type, skip_state_db=False,
     skip_tunnel_route=True, standalone_tunnel_route=False,
-    verify_db_timeout=30
+    verify_db_timeout=60
 ):
     """
     Verifies that the expected states for active and standby ToRs are


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Increase verify_db_timeout as github issue #15644
Fixes # 
Test case `test_lower_tor_config_reload_downstream_upper_tor[active-active]` failed in sonic image 202405. The current timeout value of verify db is 30s after config reload, but in 202405 image all interfaces in `active` status takes more than 30s, which lead to case fail. 
The issue is same as github issue https://github.com/sonic-net/sonic-mgmt/issues/15644. So Increase verify_db_timeout value to 60s

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
