### PR TITLE
[dhcp_relay] Remove skip dhcp_relay test when dhcp_server is enabled

### DIFF
--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -39,8 +39,6 @@ def pytest_addoption(parser):
 def check_dhcp_feature_status(duthost):
     feature_status_output = duthost.show_and_parse("show feature status")
     for feature in feature_status_output:
-        if feature["feature"] == "dhcp_server" and feature["state"] == "enabled":
-            pytest.skip("DHCPv4 relay is not supported when dhcp_server is enabled")
         if feature["feature"] == "dhcp_relay" and feature["state"] != "enabled":
             pytest.skip("dhcp_relay is not enabled")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
This skip condition would take effect on all test cases under `dhcp_relay` folder, which would skip dhcpv6_relay tests too. But we don't want to skip it when dhcp_server is enabled.
And dhcpv4_relay test is only running in m0 and t0, which wouldn't enable dhcp_server

#### How did you do it?
Remove skip check

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
