### PR TITLE
Add ansible python interpreter

### DIFF
--- a/ansible/group_vars/ptf/vars.yml
+++ b/ansible/group_vars/ptf/vars.yml
@@ -1,0 +1,1 @@
+ansible_python_interpreter: "/usr/bin/python"


### PR DESCRIPTION
### Description of PR

This PR sets the ansible_python_interpreter to ensure the correct Python version is used on mixed (Python 2 and Python 3) Docker-PTF images. Without this setting, the wrong Python version may be selected, causing test failures. This change resolves the issue with the Start/Stop PTF Portchannel step, which would otherwise fail

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

This PR sets the ansible_python_interpreter to ensure the correct Python version is used on mixed (Python 2 and Python 3) Docker-PTF images. Without this setting, the wrong Python version may be selected, causing test failures. This change resolves the issue with the Start/Stop PTF Portchannel step, which would otherwise fail

#### How did you do it?

Set python interpreter for Ansible.

#### How did you verify/test it?

Ran pipeline to setup testbed.

#### Any platform specific information?

No

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA
