### PR TITLE
[Log Analyzer] Update the log analyzer init flow

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -827,6 +827,7 @@ def main(argv):
 
     result = {}
     if action == "init":
+        analyzer.flush_rsyslogd()
         analyzer.place_marker(log_file_list, analyzer.create_start_marker())
         return 0
     elif action == "analyze":

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -828,6 +828,7 @@ def main(argv):
     result = {}
     if action == "init":
         analyzer.flush_rsyslogd()
+        time.sleep(2)
         analyzer.place_marker(log_file_list, analyzer.create_start_marker())
         return 0
     elif action == "analyze":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Because we have the rsyslog rate limit, there could be wrong loganalyzer failures in the below scenario:
1. log analyzer is disabled in test A, and it produces a lot of syslogs including errors, which is expected.
2. The errors are suppressed due to the log rate limit.
3. Test B starts with loganalyzer, and the errors are printed to syslog during test B.
4. Log analyzer reports the errors which should be ignored in test A.

We should flush the rsyslog before the log analyzer adds start marker.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
See the summary.
#### How did you do it?
See the summary.
#### How did you verify/test it?
Run regression with the change, issue not reproduced, no side effects observed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
