### PR TITLE
snappi_tests:T2: Serialize the udp ports for all_to_all test

### DIFF
--- a/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
@@ -7,7 +7,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     snappi_api, get_snappi_ports, is_snappi_multidut, \
     get_snappi_ports_single_dut, snappi_testbed_config, \
     get_snappi_ports_multi_dut, snappi_dut_base_config, cleanup_config, get_snappi_ports_for_rdma  # noqa: F401
-from tests.common.snappi_tests.qos_fixtures import lossless_prio_list, prio_dscp_map                # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import lossless_prio_list, prio_dscp_map, disable_pfcwd  # noqa: F401
 from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_pfc_test                      # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
@@ -26,7 +26,8 @@ def test_global_pause(snappi_api,                                   # noqa: F811
                       prio_dscp_map,                                # noqa: F811
                       lossless_prio_list,                           # noqa: F811
                       tbinfo,                                      # noqa: F811
-                      multidut_port_info):
+                      multidut_port_info,
+                      disable_pfcwd):                              # noqa: F811
     """
     Test if IEEE 802.3X pause (a.k.a., global pause) will impact any priority
 

--- a/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfc/test_multidut_global_pause_with_snappi.py
@@ -7,7 +7,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     snappi_api, get_snappi_ports, is_snappi_multidut, \
     get_snappi_ports_single_dut, snappi_testbed_config, \
     get_snappi_ports_multi_dut, snappi_dut_base_config, cleanup_config, get_snappi_ports_for_rdma  # noqa: F401
-from tests.common.snappi_tests.qos_fixtures import lossless_prio_list, prio_dscp_map, disable_pfcwd  # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import lossless_prio_list, prio_dscp_map                # noqa: F401
 from tests.snappi_tests.multidut.pfc.files.multidut_helper import run_pfc_test                      # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
@@ -26,8 +26,7 @@ def test_global_pause(snappi_api,                                   # noqa: F811
                       prio_dscp_map,                                # noqa: F811
                       lossless_prio_list,                           # noqa: F811
                       tbinfo,                                      # noqa: F811
-                      multidut_port_info,
-                      disable_pfcwd):                              # noqa: F811
+                      multidut_port_info):
     """
     Test if IEEE 802.3X pause (a.k.a., global pause) will impact any priority
 

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_multi_node_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_multi_node_helper.py
@@ -1,7 +1,6 @@
 import time
 from math import ceil
 import logging
-import random
 
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
@@ -24,6 +23,7 @@ WARM_UP_TRAFFIC_DUR = 1
 DATA_PKT_SIZE = 1024
 SNAPPI_POLL_DELAY_SEC = 2
 TOLERANCE_THRESHOLD = 0.05
+UDP_SRC_START = 5000
 
 
 def run_pfcwd_multi_node_test(api,
@@ -416,7 +416,9 @@ def __gen_data_flow(testbed_config,
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
 
     eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-    src_port = random.randint(5000, 6000)
+    global UDP_SRC_START
+    src_port = UDP_SRC_START
+    UDP_SRC_START += 1
     udp.src_port.increment.start = src_port
     udp.src_port.increment.step = 1
     udp.src_port.increment.count = 1

--- a/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_multi_node_helper.py
+++ b/tests/snappi_tests/multidut/pfcwd/files/pfcwd_multidut_multi_node_helper.py
@@ -1,6 +1,7 @@
 import time
 from math import ceil
 import logging
+import random
 
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
@@ -23,7 +24,6 @@ WARM_UP_TRAFFIC_DUR = 1
 DATA_PKT_SIZE = 1024
 SNAPPI_POLL_DELAY_SEC = 2
 TOLERANCE_THRESHOLD = 0.05
-UDP_SRC_START = 5000
 
 
 def run_pfcwd_multi_node_test(api,
@@ -416,9 +416,7 @@ def __gen_data_flow(testbed_config,
     flow.tx_rx.port.rx_name = testbed_config.ports[dst_port_id].name
 
     eth, ipv4, udp = flow.packet.ethernet().ipv4().udp()
-    global UDP_SRC_START
-    src_port = UDP_SRC_START
-    UDP_SRC_START += 1
+    src_port = random.randint(5000, 6000)
     udp.src_port.increment.start = src_port
     udp.src_port.increment.step = 1
     udp.src_port.increment.count = 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The all_to_all test is still using the random udp ports, and runs into random failures. This PR serializes the udp ports for traffic streams.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Random failure in all_to_all multidut snappi tests.

#### How did you do it?
Serialized the udp port numbers used by this script.

#### How did you verify/test it?
Ran it on my TB. I verified that I could recreate the issue first, and then after the modifications, it passed:
```=============================================================================================== PASSES ===============================================================================================
_____________________________________________________________________ test_multidut_pfcwd_all_to_all[multidut_port_info3-False] ______________________________________________________________________
--------------------------------------------------- generated xml file: /run_logs/ixia/20188-reruns/2025-01-21-09-42-25/tr_2025-01-21-09-42-25.xml ---------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
====================================================================================== short test summary info =======================================================================================
PASSED snappi_tests/multidut/pfcwd/test_multidut_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all[multidut_port_info3-False]
============================================================================= 1 passed, 4 warnings in 411.17s (0:06:51) ==============================================================================
sonic@snappi-sonic-mgmt-vanilla-202405-t2:/data/tests$ 
```