### PR TITLE
Ensure that packets start sending after tcpdump has started in advanced-reboot

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1873,9 +1873,20 @@ class ReloadTest(BaseTest):
         processes_list = []
         for iface in self.tcpdump_data_ifaces:
             iface_pcap_path = '{}_{}'.format(pcap_path, iface)
-            process = subprocess.Popen(['tcpdump', '-i', iface, tcpdump_filter, '-w', iface_pcap_path])
+            process = subprocess.Popen(
+                ['tcpdump', '-i', iface, tcpdump_filter, '-w', iface_pcap_path],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True
+            )
             self.log('Tcpdump sniffer starting on iface: {}'.format(iface))
             processes_list.append(process)
+
+        for proc in processes_list:
+            while True:
+                line = proc.stderr.readline()
+                if not line or 'listening on' in line:
+                    break
 
         # Unblock waiter for the send_in_background.
         self.sniffer_started.set()

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1839,8 +1839,6 @@ class ReloadTest(BaseTest):
         sniffer.start()
         # Let the scapy sniff initialize completely.
         time.sleep(2)
-        # Unblock waiter for the send_in_background.
-        self.sniffer_started.set()
         sniffer.join()
         self.log("Sniffer has been running for %s" %
                  str(datetime.datetime.now() - sniffer_start))
@@ -1878,6 +1876,9 @@ class ReloadTest(BaseTest):
             process = subprocess.Popen(['tcpdump', '-i', iface, tcpdump_filter, '-w', iface_pcap_path])
             self.log('Tcpdump sniffer starting on iface: {}'.format(iface))
             processes_list.append(process)
+
+        # Unblock waiter for the send_in_background.
+        self.sniffer_started.set()
 
         time_start = time.time()
         while not self.kill_sniffer:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Improve timing of starting tcpdump relative to packet sending in advanced-reboot
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
In advanced-reboot, sender can start after the sleep but there is no guarantee that the sniffer (tcpdump) would be ready by then. 

#### How did you do it?
Move start of sender to after tcpdump has fully started to ensure all packets are captured.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
