### PR TITLE
T2-Snappi-Route-Conv: Fix Process Crash test for single asic linecards

### DIFF
--- a/tests/snappi_tests/multidut/bgp/files/bgp_outbound_helper.py
+++ b/tests/snappi_tests/multidut/bgp/files/bgp_outbound_helper.py
@@ -1328,8 +1328,12 @@ def get_container_names_from_asic_count(duthost, container_name):
     for line in platform_summary:
         if 'ASIC Count' in line:
             count = int(line.split(':')[-1].lstrip())
-    for i in range(0, count):
-        container_names.append(container_name+str(i))
+    if count == 1:
+        container_names.append(container_name)
+    else:
+        for i in range(0, count):
+            container_names.append(container_name+str(i))
+
     return container_names
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
T2-Snappi-Route-Convergence: Fix Process Crash test for single asic linecards

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Snappi based T2 convergence test(process crash) fails on single-asic linecard. 
 
#### How did you do it?
The container name is appended with asic# even for single-asic linecard, which is incorrect. Fixed it by explicitly checking for single-asic linecard and not appending asic# to container name..
#### How did you verify/test it?
Ran the test on Single-asic linecard and verified that the test passes
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
