### PR TITLE
Fix gnmi/test_gnoi_killprocess.py checking disabled services

### DIFF
--- a/tests/gnmi/test_gnoi_killprocess.py
+++ b/tests/gnmi/test_gnoi_killprocess.py
@@ -18,16 +18,19 @@ pytestmark = [
     ("snmp", True, ""),
     ("dhcp_relay", True, ""),
     ("radv", True, ""),
-    ("restapi", True, ""),
     ("lldp", True, ""),
     ("sshd", True, ""),
     ("swss", True, ""),
     ("pmon", True, ""),
     ("rsyslog", True, ""),
-    ("telemetry", True, "")
 ])
-def test_gnoi_killprocess_then_restart(duthosts, rand_one_dut_hostname, localhost, process, is_valid, expected_msg):
+def test_gnoi_killprocess_then_restart(duthosts, rand_one_dut_hostname, localhost, process, is_valid, expected_msg,
+                                       tbinfo):
     duthost = duthosts[rand_one_dut_hostname]
+    topo_type = tbinfo["topo"]["type"]
+
+    if process in ["dhcp_relay"] and topo_type == "t1":
+        pytest.skip("Skip test as t1 does not use dhcp_relay service")
 
     if process and process != "nonexistent":
         pytest_assert(duthost.is_host_service_running(process),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
gnmi/test_gnoi_killprocess.py is a newly added test in 202411 and it aims to test functionality of a new API - KillProcess. It tests the API by killing then re-enabling services, but 2 of the tested services in the test file is disabled in upstream 202411 build config (restapi and telemtry), resulting in a `service could not be found` failure.

https://github.com/sonic-net/sonic-buildimage/blob/202411/rules/config#L134
https://github.com/sonic-net/sonic-buildimage/blob/202411/rules/config#L150
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
- [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Removing the `telemetry` and `restapi` case from the test file so it does not fail from testing disabled services. Also skipping the dhcp_relay case for t1 topos as t1 topos does not use the `dhcp_relay` service.

#### How did you verify/test it?
This test file no longer fails on `Unit XXXXX.service could not be found` on t0 and t1 topos on Arista HwSKUs.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
