### PR TITLE
Introduce margin in PFCXonTest for cisco-8000 single-asic

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2632,7 +2632,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                     send_packet(
                         self, src_port_id, pkt2,
                         (pkts_num_leak_out + pkts_num_dismiss_pfc +
-                         hysteresis) // cell_occupancy + margin - 2
+                         hysteresis) // cell_occupancy - margin - 2
                     )
                 else:
                     fill_egress_plus_one(
@@ -2675,7 +2675,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                     fill_leakout_plus_one(
                         self, src_port_id, dst_port_3_id,
                         pkt3, int(self.test_params['pg']), asic_type)
-                    send_packet(self, src_port_id, pkt3, pkts_num_leak_out)
+                    send_packet(self, src_port_id, pkt3, pkts_num_leak_out + margin * 2)
                 else:
                     fill_egress_plus_one(
                         self, src_port_id,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
PFCXonTest result is not stable for G200.
It's a no-margin case, introduce margin in it.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
To stabilize PFCXonTest for G200.

#### How did you do it?
Introduce margin into it.

#### How did you verify/test it?
Verified on testbed.
```
root@b9bf318d6392:~# /root/env-python3/bin/ptf --test-dir saitests/py3 sai_qos_tests.PFCXonTest --socket-recv-size 16384 --platform-dir ptftests --platform remote -t "router_mac='8C:44:A5:EF:24:00';src_server='4.164.1.20:9092';port_map_file='/root/ptf_test_port_map.json';sonic_asic_type='cisco-8000';sonic_version='azure_msft_202405.20233-dirty-20250116.025659';src_dut_index=0;src_asic_index=0;dst_dut_index=0;dst_asic_index=0;dut_username='cisco';dut_password='cisco123';platform_asic='cisco-8000';dst_port_id=8;dst_port_ip='10.0.0.9';dst_port_vlan=None;dst_port_2_id=12;dst_port_2_ip='10.0.0.13';dst_port_2_vlan=None;dst_port_3_id=16;dst_port_3_ip='10.0.0.17';dst_port_3_vlan=None;src_port_id=4;src_port_ip='10.0.0.5';src_port_vlan=None;dst_sys_ports={};uplink_port_ids=[];uplink_port_ips=[];uplink_port_names=[];downlink_port_ids=[];downlink_port_ips=[];downlink_port_names=[];testPortIds={0: {0: [0, 4, 8, 12, 16, 20, 24, 28, 32, 33, 36, 37, 40, 41, 44, 45, 48, 49, 52, 53, 56, 57, 60, 61]}};testPortIps={0: {0: {32: {'peer_addr': '10.0.0.33'}, 33: {'peer_addr': '10.0.0.35'}, 36: {'peer_addr': '10.0.0.37'}, 37: {'peer_addr': '10.0.0.39'}, 40: {'peer_addr': '10.0.0.41'}, 41: {'peer_addr': '10.0.0.43'}, 44: {'peer_addr': '10.0.0.45'}, 45: {'peer_addr': '10.0.0.47'}, 48: {'peer_addr': '10.0.0.49'}, 49: {'peer_addr': '10.0.0.51'}, 52: {'peer_addr': '10.0.0.53'}, 53: {'peer_addr': '10.0.0.55'}, 56: {'peer_addr': '10.0.0.57'}, 57: {'peer_addr': '10.0.0.59'}, 60: {'peer_addr': '10.0.0.61'}, 61: {'peer_addr': '10.0.0.63'}, 0: {'peer_addr': '10.0.0.1'}, 4: {'peer_addr': '10.0.0.5'}, 8: {'peer_addr': '10.0.0.9'}, 12: {'peer_addr': '10.0.0.13'}, 16: {'peer_addr': '10.0.0.17'}, 20: {'peer_addr': '10.0.0.21'}, 24: {'peer_addr': '10.0.0.25'}, 28: {'peer_addr': '10.0.0.29'}}}};testbed_type='t1-lag';test_port_ids={0: {0: [0, 4, 8, 12, 16, 20, 24, 28, 32, 33, 36, 37, 40, 41, 44, 45, 48, 49, 52, 53, 56, 57, 60, 61]}};dscp=3;ecn=1;pg=3;buffer_max_size='0';pkts_num_trig_pfc=147456;pkts_num_dismiss_pfc=2;pkts_num_leak_out=0;hwsku='Cisco-8122-O64S2';pkts_num_egr_mem=None;src_dst_asic_diff=False;pkts_num_hysteresis=8193;packet_size=64" --qlen 10000 --disable-ipv6 --disable-vxlan --disable-geneve --disable-erspan --disable-mpls --disable-nvgre --log-file /tmp/sai_qos_tests.XonHysteresisTest.log --test-case-timeout 2000
Using packet manipulation module: ptf.packet_scapy
sai_qos_tests.PFCXonTest ... dst_port_id:8, src_port_id:4
actual dst_port_id: 8
dst_port_id:12, src_port_id:4
actual dst_port_id: 13
dst_port_id:16, src_port_id:4
actual dst_port_id: 16
step 1: disable TX for dst_port_id, dst_port_2_id, dst_port_3_id

step 2: send packets to dst port 1, occupying the xon

fill_leakout_plus_one: Success, sent 935 packets, queue occupancy bytes rose from 0 to 512
step 3: send packets to dst port 2, occupying the shared buffer

fill_leakout_plus_one: Success, sent 954 packets, queue occupancy bytes rose from 0 to 512
step 4: send 1 packet to dst port 3, triggering PFC

fill_leakout_plus_one: Success, sent 953 packets, queue occupancy bytes rose from 0 to 512
step 5: enable TX for dst_port_2_id, to drain off buffer in dst_port_2

step 6: enable TX for dst_port_3_id, to drain off buffer in dst_port_3

step 7: sleep 30 seconds

ok

----------------------------------------------------------------------
Ran 1 test in 84.076s

OK
root@b9bf318d6392:~# 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
