### PR TITLE
Refactor the platform type check for longer wait time.

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -734,7 +734,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         test_ports_info = {self.pfc_wd['rx_port'][0]: self.pfc_wd}
         queues = [self.storm_hndle.pfc_queue_idx]
 
-        if dut.facts['asic_type'] == "mellanox":
+        should_wait = dut.facts['asic_type'] in ["mellanox", "cisco-8000"]
+        if should_wait:
             PFC_STORM_TIMEOUT = 30
             pfcwd_stats_before_test = check_pfc_storm_state(dut, port, self.storm_hndle.pfc_queue_idx)
 
@@ -754,8 +755,9 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             if self.pfc_wd['fake_storm']:
                 PfcCmd.set_storm_status(dut, self.queue_oid, "enabled")
 
-            if dut.facts['asic_type'] in ["mellanox", "cisco-8000"]:
-                # On Mellanox platform, more time is required for PFC storm being triggered
+            if should_wait:
+                # On Mellanox and Cisco platforms, more time is required for
+                # PFC storm being triggered
                 # as PFC pause sent from Non-Mellanox leaf fanout is not continuous sometimes.
                 pytest_assert(wait_until(PFC_STORM_TIMEOUT, 2, 0,
                                         lambda: check_pfc_storm_state(dut, port, self.storm_hndle.pfc_queue_idx) != pfcwd_stats_before_test),  # noqa: E501, E128


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Pls see the discussion in PR:[16535](https://github.com/sonic-net/sonic-mgmt/pull/16535#issuecomment-2605511259)


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
The current code is giving the problem:
```UnboundLocalError: local variable 'PFC_STORM_TIMEOUT' referenced before assignment ```
#### How did you do it?
Refactor the conditional check to include the required platform in one place.

#### How did you verify/test it?
Yet to verify. Will update the PR with logs once verification is done.

#### Any platform specific information?
Cisco-8000.