### PR TITLE
[fanout connect playbook] Fix variable undefined in rootfanout_connect.yml

### DIFF
--- a/ansible/fanout_connect.yml
+++ b/ansible/fanout_connect.yml
@@ -11,7 +11,6 @@
         - set_fact:
             server: "{{ inventory_hostname|lower }}"
             server_port: "{{ external_port }}"
-            clean_before_add: "{{ clean_before_add | default('y') }}"
 
         - set_fact: root_fanout_connect=true
           when: root_fanout_connect is not defined

--- a/ansible/roles/fanout/tasks/rootfanout_connect.yml
+++ b/ansible/roles/fanout/tasks/rootfanout_connect.yml
@@ -7,6 +7,9 @@
 - set_fact: dut="{{ leaf_name }}"
   when: deploy_leaf
 
+- set_fact:
+    clean_before_add: "{{ clean_before_add | default('y') }}"
+
 - debug: msg="Configuring fanout switch for {{ dut }}"
 
 - name: Gathering connection facts about the DUTs or leaffanout device


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In PR: #15643, it add a new optional variable `clean_before_add` for template `arista_7260_connect.j2` to indicate whether clean vlan range before add vlan range, however, this variable are defined in `fanout_connect.yml` which will call `rootfanout_connect.yml`, this will be a bug, because when `rootfanout_connect.yml` is called by other playbook, it will raise error: clean_before_add undefined, so, to fix this bug, we move the `clean_before_add` definition from `fanout_connect.yml`  to 
 `rootfanout_connect.yml`.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
this will be a bug, because when `rootfanout_connect.yml` is called by other playbook, it will raise error: clean_before_add undefined
#### How did you do it?
 move the `clean_before_add` definition from `fanout_connect.yml`  to 
 `rootfanout_connect.yml`.
#### How did you verify/test it?
local run playbook
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
