### PR TITLE
Fix GCU test_dynamic_acl failure on 2vlan config testbed

### DIFF
--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -385,12 +385,12 @@ def prepare_ptf_intf_and_ip(request, rand_selected_dut, config_facts, intfs_for_
     vlan_num = len(config_facts['VLAN_INTERFACE'])
     logging.info("It has {} vlan.".format(config_facts['VLAN_INTERFACE'].keys()))
     # by default, if it's 2 vlan config, ipv4 range for vlan1000 is 192.168.0.1/25
-    # and ipv4 range for vlan2000 192.168.0.129/25, so set increment to 65.
-    # otherwise, incrementing by 129 will cause IP overlap within the second VLAN's IP range
+    # and ipv4 range for vlan2000 192.168.0.129/25, so set increment to 65,
+    # ptf_intf_ipv4_addr will be in the first VLAN's IP range.
+    # otherwise, incrementing by 129 will cause ptf_intf_ipv4_addr overlap within the second VLAN's IP range
 
     # For 1 vlan, increment is 129
-    # for 2, increment is 65
-    # for 3, increment is 43 etc
+    # for 2 vlans, increment is 65
     increment = math.ceil(129 / vlan_num)
 
     # Increment address by 3 to offset it from the intf on which the address may be learned

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -4,6 +4,7 @@ import pytest
 import binascii
 import netaddr
 import struct
+import math
 
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 
@@ -382,14 +383,15 @@ def prepare_ptf_intf_and_ip(request, rand_selected_dut, config_facts, intfs_for_
             continue
 
     vlan_num = len(config_facts['VLAN_INTERFACE'])
-    if vlan_num == 2:
-        # by default, if it's 2 vlan config, ipv4 range for vlan1000 is 192.168.0.1/25
-        # and ipv4 range for vlan12000 192.168.0.129/25, so set increment to 65.
-        # otherwise, incrementing by 129 will cause IP overlap within the second VLAN's IP range
-        logging.info("It has vlan: {}".format(config_facts['VLAN_INTERFACE'].keys()))
-        increment = 65
-    else:
-        increment = 129
+    logging.info("It has {} vlan.".format(config_facts['VLAN_INTERFACE'].keys()))
+    # by default, if it's 2 vlan config, ipv4 range for vlan1000 is 192.168.0.1/25
+    # and ipv4 range for vlan2000 192.168.0.129/25, so set increment to 65.
+    # otherwise, incrementing by 129 will cause IP overlap within the second VLAN's IP range
+
+    # For 1 vlan, increment is 129
+    # for 2, increment is 65
+    # for 3, increment is 43 etc
+    increment = math.ceil(129 / vlan_num)
 
     # Increment address by 3 to offset it from the intf on which the address may be learned
     if intf_ipv4_addr is not None:

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -214,15 +214,15 @@ def setup(rand_selected_dut, rand_unselected_dut, tbinfo, vlan_name, topo_scenar
         scale_dest_ips[ipv4_rule_name] = ipv4_address
         scale_dest_ips[ipv6_rule_name] = ipv6_address
 
-    vlan_ips = {}
-
-    for vlan_interface_info_dict in mg_facts['minigraph_vlan_interfaces']:
-        if netaddr.IPAddress(str(vlan_interface_info_dict['addr'])).version == 6:
-            vlan_ips["V6"] = vlan_interface_info_dict['addr']
-        elif netaddr.IPAddress(str(vlan_interface_info_dict['addr'])).version == 4:
-            vlan_ips["V4"] = vlan_interface_info_dict['addr']
-
     config_facts = rand_selected_dut.config_facts(host=rand_selected_dut.hostname, source="running")['ansible_facts']
+
+    vlan_ips = {}
+    for vlan_ip_address in config_facts['VLAN_INTERFACE'][vlan_name].keys():
+        ip_address = vlan_ip_address.split("/")[0]
+        if netaddr.IPAddress(str(ip_address)).version == 6:
+            vlan_ips["V6"] = ip_address
+        elif netaddr.IPAddress(str(ip_address)).version == 4:
+            vlan_ips["V4"] = ip_address
 
     vlans = config_facts['VLAN']
     topology = tbinfo['topo']['name']

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -381,14 +381,24 @@ def prepare_ptf_intf_and_ip(request, rand_selected_dut, config_facts, intfs_for_
         except ValueError:
             continue
 
+    vlan_num = len(config_facts['VLAN_INTERFACE'])
+    if vlan_num == 2:
+        # by default, if it's 2 vlan config, ipv4 range for vlan1000 is 192.168.0.1/25
+        # and ipv4 range for vlan12000 192.168.0.129/25, so set increment to 65.
+        # otherwise, incrementing by 129 will cause IP overlap within the second VLAN's IP range
+        logging.info("It has vlan: {}".format(config_facts['VLAN_INTERFACE'].keys()))
+        increment = 65
+    else:
+        increment = 129
+
     # Increment address by 3 to offset it from the intf on which the address may be learned
     if intf_ipv4_addr is not None:
-        ptf_intf_ipv4_addr = increment_ipv4_addr(intf_ipv4_addr.network_address, incr=129)
+        ptf_intf_ipv4_addr = increment_ipv4_addr(intf_ipv4_addr.network_address, incr=increment)
     else:
         ptf_intf_ipv4_addr = None
 
     if intf_ipv6_addr is not None:
-        ptf_intf_ipv6_addr = increment_ipv6_addr(intf_ipv6_addr.network_address, incr=129)
+        ptf_intf_ipv6_addr = increment_ipv6_addr(intf_ipv6_addr.network_address, incr=increment)
     else:
         ptf_intf_ipv6_addr = None
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
1. failures of test_gcu_acl_arp_rule_creation when enabling 2 vlan config
With 2vlan config on testbed, GCU test_dynamic_acl failed due to ip conflict with the ip address of the second vlan interface,
192.168.0.129.
ping success, but there is no arp entry for this ip address.
Then case failed.

2. Failures of test_gcu_acl_dhcp_rule_creation when enabling 2 vlan config
Previous logic just picks up the latest ipv4 address or ipv6 address from `mg_facts['minigraph_vlan_interfaces']`, which doesn't work for the first vlan case

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

1. With 2vlan config on testbed, such as t0-118, by default, ipv4 range for vlan1000 is 192.168.0.1/25 and ipv4 range for vlan2000 192.168.0.129/25, so set increment to 65.

Otherwise, incrementing by 129 will cause IP overlap within the second VLAN's IP range, 192.168.0.129.

```
      two_vlan_a:
        Vlan1000:
          id: 1000
          intfs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62]
          prefix: 192.168.0.1/25
          prefix_v6: fc02:1000::1/64
          tag: 1000
        Vlan2000:
          id: 2000
          intfs: [63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117]
          prefix: 192.168.0.129/25
          prefix_v6: fc02:1000:0:1::1/64
          tag: 2000
```

2. Get the ipv4 or ipv6 address for specific vlan interface from configuration.

#### How did you do it?
1. For vlan 1000, `intf_ipv4_addr.network_address` is 192.168.0.0, after increase 129, it becomes 192.168.0.129, which is same with ip address of the second vlan interface.

`ptf_intf_ipv4_addr = increment_ipv4_addr(intf_ipv4_addr.network_address, incr=129)`

2. Parse ipv4 or ipv6 address from `config_facts['VLAN_INTERFACE'][vlan_name]`, different `vlan_name` will get differnet ip address


#### How did you verify/test it?
run tests/generic_config_updater/test_dynamic_acl.py 
```
-------------------------------------------------------------------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------------------------------------------------------------------10:29:19 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
====================================================================================================================================== 24 passed, 236 warnings in 4379.67s (1:12:59) =======================================================================================================================================DEBUG:tests.conftest:[log_custom_msg] item: <Function test_gcu_acl_nonexistent_table_removal[default-Vlan1000]>
INFO:root:Can not get Allure report URL. Please check logs

#### Any platform specific information?
```

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
