### PR TITLE
LLDP: Add multi-asic support for test_lldp_entry_table_after_syncd_orchagent and some other fixes.

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -281,15 +281,26 @@ def test_lldp_entry_table_after_syncd_orchagent(
     keys_match = wait_until(30, 5, 0, check_lldp_table_keys, duthost, db_instance)
     if not keys_match:
         assert keys_match, "LLDP_ENTRY_TABLE keys do not match 'show lldp table' output"
-
-    logging.info("Stop and start syncd and swss on DUT")
-    duthost.shell("docker restart syncd")
-    duthost.shell("docker restart swss")
-    wait_until(150, 5, 60, duthost.critical_services_fully_started)
-    # Wait until all interfaces are up and lldp entries are populated
+    # Get the ldap keys before restart syncd and swss
     lldp_entry_keys = get_lldp_entry_keys(db_instance)
+
+    logging.info("Stop and start swss and syncd on DUT")
+    # It's found that restart swss container could cause swss service to go down. In most of OC tests
+    # pre-test will set feature autorestart to be disabled. This results critical services like swss/syncd 
+    # will not restart. Use swss service restart here.
+    if duthost.is_multi_asic:
+        for asic in duthost.asics:
+            duthost.shell("sudo systemctl reset-failed")
+            duthost.shell("sudo systemctl restart {}".format(asic.get_service_name("swss")))
+    else:
+        duthost.shell("sudo systemctl reset-failed")
+        duthost.shell("sudo systemctl restart swss")
+    assert wait_until(600, 5, 120, duthost.critical_services_fully_started), \
+        "Not all critical services are fully started"
+
+    # Wait until all interfaces are up and lldp entries are populated
     for interface in lldp_entry_keys:
-        result = wait_until(120, 2, 0, verify_lldp_entry, db_instance, interface)
+        result = wait_until(300, 2, 0, verify_lldp_entry, db_instance, interface)
         entry_content = get_lldp_entry_content(db_instance, interface)
         pytest_assert(
             result,


### PR DESCRIPTION
…chagent and some other fixes.

### Description of PR
 test_lldp_entry_table_after_syncd_orchagent is a new test case added to test_lldp_syncd recently. It does not provide multi-asic support at this moment. 

This PR add following supports to test_lldp_entry_table_after_syncd_orchagent :
1) Added multi-asic support.

2) Replace "docker restart" to "sudo systemctl restart". In OC pre-tests feature autorestart is always disabled. Container restart could cause corresponding service to go down. If autorestart is not enabled service will not try to come back up. 

3) Get the lldp key entry before restart swss. Current code is getting LLDP key after restart swss and all critical services are up. There's window of that some ports are not completely up or ports are up but or LLDP packets have not been received and processed yet. This could result get_lldp_entry_keys does not have the full set of keys and result following ports up check pass quickly. Result in following LLDP check to fail. 

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Fix test_lldp_entry_table_after_syncd_orchagent failure

#### How did you do it?

#### How did you verify/test it?
Test passed consistently after code change.
#### Any platform specific information?
master
#### Supported testbed topology if it's a new test case?
