### PR TITLE
[ecmp] Skip warm-reboot tests on dualtor

### DIFF
--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -3,6 +3,7 @@ import re
 import logging
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_require
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import get_host_visible_vars
 from tests.common.reboot import reboot, REBOOT_TYPE_COLD, REBOOT_TYPE_WARM
@@ -201,6 +202,11 @@ def test_ecmp_hash_seed_value(localhost, duthosts, tbinfo, enum_rand_one_per_hws
     """
     Check ecmp HASH_SEED
     """
+    pytest_require(
+        not (parameter == "warm-reboot" and "dualtor" in tbinfo["topo"]["name"]),
+        "Skip warm reboot test on dualtor topology"
+    )
+
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic = duthost.facts["asic_type"]
     topo_type = tbinfo['topo']['type']
@@ -250,6 +256,10 @@ def test_ecmp_offset_value(localhost, duthosts, tbinfo, enum_rand_one_per_hwsku_
     """
     Check ecmp HASH_OFFSET
     """
+    pytest_require(
+        not (parameter == "warm-reboot" and "dualtor" in tbinfo["topo"]["name"]),
+        "Skip warm reboot test on dualtor topology"
+    )
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic = duthost.facts["asic_type"]
     topo_type = tbinfo['topo']['type']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Dualtor doesn't support warm reboot, so the warm reboot tests in `test_ecmp_hash_seed_value` will leave the DUT dataplane in an inconsistent state. Let's skip them.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As the motivation.

#### How did you verify/test it?
Run on dualtor.
```
ecmp/test_ecmp_sai_value.py::test_ecmp_hash_seed_value[str2-7050cx3-acs-09-common] PASSED                                                                                                                                                                              [ 10%]
ecmp/test_ecmp_sai_value.py::test_ecmp_hash_seed_value[str2-7050cx3-acs-09-restart_syncd] PASSED                                                                                                                                                                       [ 20%]
ecmp/test_ecmp_sai_value.py::test_ecmp_hash_seed_value[str2-7050cx3-acs-09-reload] PASSED                                                                                                                                                                              [ 30%]
ecmp/test_ecmp_sai_value.py::test_ecmp_hash_seed_value[str2-7050cx3-acs-09-reboot] PASSED                                                                                                                                                                              [ 40%]
ecmp/test_ecmp_sai_value.py::test_ecmp_hash_seed_value[str2-7050cx3-acs-09-warm-reboot] SKIPPED (Skip warm reboot test on dualtor topology)                                                                                                                            [ 50%]
ecmp/test_ecmp_sai_value.py::test_ecmp_offset_value[str2-7050cx3-acs-09-common] PASSED                                                                                                                                                                                 [ 60%]
ecmp/test_ecmp_sai_value.py::test_ecmp_offset_value[str2-7050cx3-acs-09-restart_syncd] PASSED                                                                                                                                                                          [ 70%]
ecmp/test_ecmp_sai_value.py::test_ecmp_offset_value[str2-7050cx3-acs-09-reload] PASSED                                                                                                                                                                                 [ 80%]
ecmp/test_ecmp_sai_value.py::test_ecmp_offset_value[str2-7050cx3-acs-09-reboot] PASSED                                                                                                                                                                                 [ 90%]
ecmp/test_ecmp_sai_value.py::test_ecmp_offset_value[str2-7050cx3-acs-09-warm-reboot] SKIPPED (Skip warm reboot test on dualtor topology)                                                                                                                               [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
