### PR TITLE
[sanity-check] Add IPv4 MGMT reachability check

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -14,6 +14,7 @@ from tests.common.plugins.sanity_check.checks import *      # noqa: F401, F403
 from tests.common.plugins.sanity_check.recover import recover, recover_chassis
 from tests.common.plugins.sanity_check.constants import STAGE_PRE_TEST, STAGE_POST_TEST
 from tests.common.helpers.assertions import pytest_assert as pt_assert
+from tests.common.helpers.custom_msg_utils import add_custom_msg
 from tests.common.helpers.constants import (
     DUT_CHECK_NAMESPACE
 )

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -14,7 +14,6 @@ from tests.common.plugins.sanity_check.checks import *      # noqa: F401, F403
 from tests.common.plugins.sanity_check.recover import recover, recover_chassis
 from tests.common.plugins.sanity_check.constants import STAGE_PRE_TEST, STAGE_POST_TEST
 from tests.common.helpers.assertions import pytest_assert as pt_assert
-from tests.common.helpers.custom_msg_utils import add_custom_msg
 from tests.common.helpers.constants import (
     DUT_CHECK_NAMESPACE
 )

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -15,7 +15,6 @@ from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR, NIC
 from tests.common.dualtor.dual_tor_common import CableType, active_standby_ports                # noqa F401
 from tests.common.cache import FactsCache
 from tests.common.plugins.sanity_check.constants import STAGE_PRE_TEST, STAGE_POST_TEST
-from tests.common.helpers.custom_msg_utils import add_custom_msg
 from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
 from tests.common.dualtor.mux_simulator_control import _probe_mux_ports
 from tests.common.fixtures.duthost_utils import check_bgp_router_id

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -1053,7 +1053,7 @@ def check_ipv4_mgmt(duthosts, localhost):
         check_result = {"failed": False, "check_item": "ipv4_mgmt", "host": dut.hostname}
 
         if dut.mgmt_ip is None or dut.mgmt_ip == "":
-            logger.info("%s doesn't have ipv4 mgmt configured. Skipping the ipv4 mgmt reachability check..." % dut.hostname)
+            logger.info("%s doesn't have ipv4 mgmt configured. Skip the ipv4 mgmt reachability check." % dut.hostname)
             results[dut.hostname] = check_result
             return
 

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -15,6 +15,7 @@ from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR, NIC
 from tests.common.dualtor.dual_tor_common import CableType, active_standby_ports                # noqa F401
 from tests.common.cache import FactsCache
 from tests.common.plugins.sanity_check.constants import STAGE_PRE_TEST, STAGE_POST_TEST
+from tests.common.helpers.custom_msg_utils import add_custom_msg
 from tests.common.helpers.parallel import parallel_run, reset_ansible_local_tmp
 from tests.common.dualtor.mux_simulator_control import _probe_mux_ports
 from tests.common.fixtures.duthost_utils import check_bgp_router_id
@@ -35,6 +36,7 @@ CHECK_ITEMS = [
     'check_monit',
     'check_secureboot',
     'check_neighbor_macsec_empty',
+    'check_ipv4_mgmt',
     'check_ipv6_mgmt',
     'check_mux_simulator',
     'check_orchagent_usage',
@@ -1033,6 +1035,42 @@ def check_neighbor_macsec_empty(ctrl_links):
             init_check_result["hosts"] = list(unhealthy_dut)
         return init_check_result
 
+    return _check
+
+
+# check ipv4 neighbor reachability
+@pytest.fixture(scope="module")
+def check_ipv4_mgmt(duthosts, localhost):
+    def _check(*args, **kwargs):
+        init_result = {"failed": False, "check_item": "ipv4_mgmt"}
+        result = parallel_run(_check_ipv4_mgmt_to_dut, args, kwargs, duthosts, timeout=30, init_result=init_result)
+        return list(result.values())
+
+    def _check_ipv4_mgmt_to_dut(*args, **kwargs):
+        dut = kwargs['node']
+        results = kwargs['results']
+
+        logger.info("Checking ipv4 mgmt interface reachability on %s..." % dut.hostname)
+        check_result = {"failed": False, "check_item": "ipv4_mgmt", "host": dut.hostname}
+
+        if dut.mgmt_ip is None or dut.mgmt_ip == "":
+            logger.info("%s doesn't have ipv4 mgmt configured. Skipping the ipv4 mgmt reachability check..." % dut.hostname)
+            results[dut.hostname] = check_result
+            return
+
+        # most of the testbed should reply within 10 ms, Set the timeout to 2 seconds to reduce the impact of delay.
+        try:
+            shell_result = localhost.shell("ping -c 2 -W 2 " + dut.mgmt_ip)
+            logging.info("ping output: %s" % shell_result["stdout"])
+        except RunAnsibleModuleFail as e:
+            check_result["failed"] = True
+            logging.info("Failed to ping ipv4 mgmt interface on %s, exception: %s" % (dut.hostname, repr(e)))
+        except Exception as e:
+            check_result["failed"] = True
+            logger.info("Exception while checking ipv4_mgmt reachability for %s: %s" % (dut.hostname, repr(e)))
+        finally:
+            logger.info("Done checking ipv4 management reachability on %s" % dut.hostname)
+            results[dut.hostname] = check_result
     return _check
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Recently, we observed some DUT lost IPv4 MGMT reachability. However, since it's still IPv6 MGMT reachable, the issue is hard to be noticed.
To catch such issue, this PR introduces IPv4 MGMT sanity check. **If the device has IPv4 MGMT IP assigned but it's unreachable, then sanity_check will fail the testcase.**

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Recently, we observed some DUT lost IPv4 MGMT reachability. However, since it's still IPv6 MGMT reachable, the issue is hard to be noticed.


#### How did you do it?
To catch such issue, this PR introduces IPv4 MGMT sanity check. **If the device has IPv4 MGMT IP assigned but it's unreachable, then sanity_check will fail the testcase.**


#### How did you verify/test it?

Verified by run `test_bgp_fact` with sanity_check.

When DUT IPv4 MGMT is reachable, sanity_check will pass and we can see below logs:
```
    {
        "failed": false,
        "check_item": "ipv4_mgmt",
        "host": "bjw2-can-720dt-1"
    },
```

If manually remove the DUT IPv4 MGMT address from eth0, then sanity_check fails with below error logs:
```
E                   Failed: !!!!!!!!!!!!!!!!Pre-test sanity check failed: !!!!!!!!!!!!!!!!
E                   [
E                       {
E                           "failed": true,
E                           "check_item": "ipv4_mgmt",
E                           "host": "720dt-1"
E                       }
E                   ]
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
