### PR TITLE
[dualtor][mux simulator] Fine-tune the mux simulator control post timeout

### DIFF
--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -200,7 +200,7 @@ def _post(server_url, data):
         server_url = '{}?reqId={}'.format(server_url, uuid.uuid4())  # Add query string param reqId for debugging
         logger.debug('POST {} with {}'.format(server_url, data))
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
-        resp = session.post(server_url, json=data, headers=headers, timeout=10)
+        resp = session.post(server_url, json=data, headers=headers, timeout=(3.5, 30))
         logger.debug('Received response {}/{} with content {}'.format(resp.status_code, resp.reason, resp.text))
         return resp.status_code == 200
     except Exception as e:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
This is to fix https://github.com/sonic-net/sonic-mgmt/issues/16495.
The root cause is that, on dualtor testbed, the post request to `mux_simulator` to toggle all mux ports can take up to 15+ seconds to finish; but the post timeout is 10s, so the post request to toggle all mux ports always timeout.

Here is the workflow for a HTTP requests to `mux_simulator`:
```
#
# how does a HTTP request to mux_simulator work?
#         +------------+       +------------+      +-------------+       +--------------+
# ------->|listen queue+------>|accept queue+----->|mux simulator+------>| mux simulator|
#         +------------+       +------------+      |  dispatcher |       |handler worker|
#                                                  +-------------+       +--------------+
```
The HTTP requests are handled by TCP listen/accept queue first; after the connection is established, `mux_simulator` will consume the request and dispatch the request to workers to handle the request.
Back to the toggle all mux ports post request, the client times out and disconnects, but the request has already been dispatched by the `mux_simulator`, its handler worker is still busy handling the request. If our test code send more timeout requests to `mux_simulator`, those inundated requests could overload the `mux_simulator` handler workers and a kind of denial-of-service occurs. Even worse, with more HTTP requests coming, the listen/accept queue will overflow.

This PR is to stop creating timeout requests to `mux_simulator`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
The post timeout needs to be adjusted to allow the `mux_simulator` slowness, in addition, it should be able to detect the TCP connection slowness/failure.

Based on the [timeout specification](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts), let's use `3.5s` as the TCP connection timeout as it is slightly greater than 3 (default TCP retran timeout); and use `30s` as the mux simulator response timeout, which should covers all the mux simulator APIs.

#### How did you verify/test it?
Run the dualtor, and no more timeout happens.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
