### PR TITLE
skipping dynamic_acl TC on Cisco Q200 platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -935,13 +935,15 @@ generic_config_updater/test_dhcp_relay.py:
 generic_config_updater/test_dynamic_acl.py:
   skip:
     reason: "Device SKUs do not support the custom ACL_TABLE_TYPE that we use in this test.  Known log error unrelated to test
-    on m0-2vlan testbed causes consistent failures / generic_config_updater is not a supported feature for T2"
+    on m0-2vlan testbed causes consistent failures / generic_config_updater is not a supported feature for T2
+    / Dynamic ACL is not supported in Cisco Q200 based platforms"
     conditions_logical_operator: "OR"
     conditions:
       - "release in ['202311', '202405'] and platform in ['armhf-nokia_ixs7215_52x-r0']"
       - "hwsku in ['Cisco-8111-O64']"
       - "topo_name in ['m0-2vlan']"
       - "'t2' in topo_name"
+      - "platform in ['x86_64-8101_32fh_o-r0', 'x86_64-8102_64h_o-r0', 'Cisco-8101-32FH-O-C01']"
 
 generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
   skip:


### PR DESCRIPTION
**What is the motivation for this PR?**
Skipping generic_config_updater/test_dynamic_acl.py on Q200 platforms as its not supported on Q200

**How did you do it?**
Added a skip condition for generic_config_updater/test_dynamic_acl.py for Q200 platforms in tests/common/plugins/conditional_mark/tests_mark_conditions.yaml

**Type of change** 
-Test modification

**Back port request** 
-202311
-202405

**How did you verify/test it?**
Made sure that TC is skipped on Q200 platforms