### PR TITLE
Temporarily remove cisco-8000 from pfcwd/PFC_STORM_TIMEOUT.

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -734,7 +734,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         test_ports_info = {self.pfc_wd['rx_port'][0]: self.pfc_wd}
         queues = [self.storm_hndle.pfc_queue_idx]
 
-        extra_pfc_storm_timeout_needed = dut.facts['asic_type'] in ["mellanox", "cisco-8000"]
+        extra_pfc_storm_timeout_needed = dut.facts['asic_type'] in ["mellanox"]
         if extra_pfc_storm_timeout_needed:
             PFC_STORM_TIMEOUT = 30
             pfcwd_stats_before_test = check_pfc_storm_state(dut, port, self.storm_hndle.pfc_queue_idx)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
We need to verify the new code before enabling it for cisco-8000. For now, we are temporarily disabling it.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Temporarily remove cisco-8000 from using the new code for mellanox.

#### How did you do it?
Removed the cisco-8000 string from the supported list.

#### How did you verify/test it?
Running in my TB:
```
=========================================================================================================== PASSES ===========================================================================================================
_______________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_actions[croc-t1-dut] ________________________________________________________________________________________
______________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_multi_port[croc-t1-dut] ______________________________________________________________________________________
______________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_mmu_change[croc-t1-dut] ______________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_port_toggle[croc-t1-dut] ______________________________________________________________________________________
______________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_no_traffic[croc-t1-dut] ______________________________________________________________________________________
------------------------------------------------------------------ generated xml file: /run_logs/rraghav/pfcwd/test_pfcwd_function_2025-01-24-00-30-43.xml -------------------------------------------------------------------
--------------------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------------------
01:04:13 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================================== short test summary info ===================================================================================================
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[croc-t1-dut]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[croc-t1-dut]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[croc-t1-dut]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[croc-t1-dut]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[croc-t1-dut]
========================================================================================= 5 passed, 1 warning in 2007.76s (0:33:27) ==========================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_pfcwd_no_traffic[croc-t1-dut]>
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
