### PR TITLE
Stabilize stress ARP test

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -78,6 +78,8 @@ def add_arp(ptf_intf_ipv4_addr, intf1_index, ptfadapter):
                                           hw_snd=arp_src_mac,
                                           hw_tgt='ff:ff:ff:ff:ff:ff'
                                           )
+        # Add a short delay to avoid packet loss
+        time.sleep(0.001)
         testutils.send_packet(ptfadapter, intf1_index, pkt)
     logger.info("Sending {} arp entries".format(ip_num))
 
@@ -127,7 +129,7 @@ def test_ipv4_arp(duthost, garp_enabled, ip_and_intf_info, intfs_for_test,
                 # The entries we add will not exceed 10000, so the number we tolerate is 100
                 logger.debug("Expected route number: {}, real route number {}"
                              .format(arp_available, get_fdb_dynamic_mac_count(duthost)))
-                pytest_assert(wait_until(20, 1, 0,
+                pytest_assert(wait_until(40, 1, 0,
                                          lambda: abs(arp_available - get_fdb_dynamic_mac_count(duthost)) < 250),
                               "ARP Table Add failed")
         finally:
@@ -179,7 +181,8 @@ def add_nd(ptfadapter, ip_and_intf_info, ptf_intf_index, nd_available):
         nd_entry_mac = IntToMac(MacToInt(ARP_SRC_MAC) + entry)
         fake_src_addr = generate_global_addr(nd_entry_mac)
         ns_pkt = ipv6_packets_for_test(ip_and_intf_info, nd_entry_mac, fake_src_addr)
-
+        # Add a short delay to avoid packet loss
+        time.sleep(0.01)
         testutils.send_packet(ptfadapter, ptf_intf_index, ns_pkt)
     logger.info("Sending {} ipv6 neighbor entries".format(nd_available))
 
@@ -214,7 +217,7 @@ def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
                 # The entries we add will not exceed 10000, so the number we tolerate is 100
                 logger.debug("Expected route number: {}, real route number {}"
                              .format(nd_available, get_fdb_dynamic_mac_count(duthost)))
-                pytest_assert(wait_until(20, 1, 0,
+                pytest_assert(wait_until(40, 1, 0,
                                          lambda: abs(nd_available - get_fdb_dynamic_mac_count(duthost)) < 250),
                               "Neighbor Table Add failed")
         finally:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to stabilize `test_stress_arp.py` on some platform.
The test is flaky on some platform due to the low performance of CPU. This PR addressed the issue by adding a short delay in sending packet and waiting longer time for checking MAC table.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
This PR is to stabilize `test_stress_arp.py` on some platform.

#### How did you do it?
This PR addressed the issue by adding a short delay in sending packet and waiting longer time for checking MAC table.

#### How did you verify/test it?
The change is verified by running the test on a physical testbed. It can pass consistently now.
```
collected 2 items                                                                                                                                                                                                             

arp/test_stress_arp.py::test_ipv4_arp[str-msn2700-01-None] PASSED                                                                                                                                                       [ 50%]
arp/test_stress_arp.py::test_ipv6_nd[str-msn2700-01-None]  ^HPASSED                                                                                                                                                        [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
