### PR TITLE
[202411] Ignore nss_tacplus error message reported by NTPD

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -306,5 +306,8 @@ r, ".* ERR syncd\d*#syncd.*SAI_API_BUFFER.*Unsupported buffer pool.*"
 # ignore leap second file NTP daemon (ntpd) is using has passed its expiration date
 r, ".* ERR ntpd\[\d*\]:.*leapsecond file ('/usr/share/zoneinfo/leap-seconds.list'): expired.*"
 
+# ignore NTP nss_tacplus error, which will happen when reload config, because NTPD will invoke getpwnap API but nss_tacplus will re-render during reload config
+r, ".* ERR ntpd\[\d*\]: nss_tacplus: .*"
+
 # Ignore auditd error
 r, ".* ERR auditd\[\d*\]: Error receiving audit netlink packet \(No buffer space available\)"


### PR DESCRIPTION
Ignore nss_tacplus error log report by NTPD during config reload.
This is a cherry-pick PR: https://github.com/sonic-net/sonic-mgmt/pull/16239

#### Why I did it
During config reload, tacacs config will be re-render by hostcfgd, NTPD will call getpwnam API during config reload, so will report nss_tacplus error.
These error can be ignored, getpwnam API will success in this case.

##### Work item tracking
- Microsoft ADO: 

#### How I did it
Ignore nss_tacplus error log report by NTPD.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Ignore nss_tacplus error log report by NTPD during config reload.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
