### PR TITLE
Add release based conditional marker for srv6/test_srv6_static_config.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2171,7 +2171,7 @@ srv6/test_srv6_static_config.py:
   skip:
     reason: "Requires particular image support, skip in PR testing"
     conditions:
-      - "release in ['202412']"
+      - "release not in ['202412']"
 
 #######################################
 #####             ssh             #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2169,9 +2169,9 @@ srv6/test_srv6_basic_sanity.py:
 
 srv6/test_srv6_static_config.py:
   skip:
-    reason: "Have an issue on kvm testbed, skip in PR testing"
+    reason: "Requires particular image support, skip in PR testing"
     conditions:
-      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16627"
+      - "release in ['202412']"
 
 #######################################
 #####             ssh             #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The srv6/test_srv6_static_config.py requires particular image support that creates a dummy interface sr0. Currently,
 only 202412 images have such support so I want to add a release based conditional marker for this test case.
Fixes #16627

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
