### PR TITLE
Added safe reload=True option for config reload performed in syslog_rate_limit to eliminate intermittent failures

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -90,7 +90,7 @@ def test_syslog_rate_limit(rand_selected_dut):
     # Save configuration and reload, verify the configuration can be loaded
     logger.info('Persist syslog rate limit configuration to DB and do config reload')
     rand_selected_dut.command('config save -y')
-    config_reload(rand_selected_dut)
+    config_reload(rand_selected_dut, safe_reload=True)
 
     # database does not support syslog rate limit configuration persist
     verify_container_rate_limit(rand_selected_dut, ignore_containers=['database'])


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR addresses an issue where the syslog rate_limit configuration command does not take effect properly because certain containers are not fully initialized before the command execution. To resolve this, "safe reload" option has been added to the config reload. This ensures that all containers and critical processes are up and running before the configuration is applied, ensuring successful configuration
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Intermittent syslog_rate_limit testcase failure on Nokia-7215 platforms
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Fix intermittent failure caused by containers not up before rate_limit config command execution
#### How did you do it?
Added safe=True option to config reload
#### How did you verify/test it?
Run test_syslog_rate_limit testcase on Nokia-7215 platforms
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
