### PR TITLE
Fixed logic to delete the interface from BUFFER_QUEUE

### DIFF
--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -126,7 +126,7 @@ def test_snmp_queue_counters(duthosts,
 
     # Get appropriate buffer queue value to delete
     buffer_queues = list(data['BUFFER_QUEUE'].keys())
-    iface_buffer_queues = [bq for bq in buffer_queues if any(val in interface for val in bq.split('|'))]
+    iface_buffer_queues = [bq for bq in buffer_queues if bq.split('|')[0] == interface]
     if iface_buffer_queues:
         buffer_queue_to_del = iface_buffer_queues[0]
     else:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

The interface from  where the queuestats fetched was different from the interface that was deleted from the BUFFER_QUEUE.

Github  issue: https://github.com/aristanetworks/sonic-qual.msft/issues/371
This issue is seen after PR: https://github.com/sonic-net/sonic-mgmt/pull/15688

The issue was that 
XML dump  is below for context
```
buffer_queue_to_del = 'Ethernet112|6'
buffer_queues = ['Ethernet112|0-1', 'Ethernet112|2-4', 'Ethernet112|5', 'Ethernet112|6', 'Ethernet112|7', 'Ethernet116|0-1', ...]
buffer_queues_removed = 1
interface  = 'Ethernet68'
```

When the string 'Ethernet112|6' when split with delimiter "|" the string in 1st index "6" is a substring of "Ethernet68" and it picked as a candidate to delete it from BQ, which is wrong.


<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/371



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
to address the issue https://github.com/aristanetworks/sonic-qual.msft/issues/371

#### How did you do it?
Through code-walk and xml dump from TC run.

#### How did you verify/test it?
I re-ran the test to make sure the interface delete logic is working fine

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
