### PR TITLE
move try block from test_upgrade_path to install_sonic_image

### DIFF
--- a/tests/upgrade_path/utilities.py
+++ b/tests/upgrade_path/utilities.py
@@ -1,6 +1,4 @@
 import logging
-import re
-from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.upgrade_helpers import install_sonic, reboot, check_sonic_version
 
 logger = logging.getLogger(__name__)
@@ -8,18 +6,7 @@ logger = logging.getLogger(__name__)
 
 def boot_into_base_image(duthost, localhost, base_image, tbinfo):
     logger.info("Installing {}".format(base_image))
-    try:
-        target_version = install_sonic(duthost, base_image, tbinfo)
-    except RunAnsibleModuleFail as err:
-        migration_err_regexp = r"Traceback.*migrate_sonic_packages.*SonicRuntimeException"
-        msg = err.results['msg'].replace('\n', '')
-        if re.search(migration_err_regexp, msg):
-            logger.info(
-                "Ignore the package migration error when downgrading to base_image")
-            target_version = duthost.shell(
-                "cat /tmp/downloaded-sonic-image-version")['stdout']
-        else:
-            raise err
+    target_version = install_sonic(duthost, base_image, tbinfo)
     # Remove old config_db before rebooting the DUT in case it is not successfully
     # removed in install_sonic due to migration error
     logger.info("Remove old config_db file if exists, to load minigraph from scratch")


### PR DESCRIPTION
ignore the migration error in both downgrade and upgrade scenario

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Ignore the migration error in both downgrade and upgrade scenario

#### How did you do it?
Moved try/except block from the test itself to a new method install_sonic_image

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
