### PR TITLE
[Snappi]: Adding FEC Error Insertion Test Script (#14)

### DIFF
--- a/tests/snappi_tests/dataplane/test_fec_error_injection.py
+++ b/tests/snappi_tests/dataplane/test_fec_error_injection.py
@@ -1,0 +1,146 @@
+from tests.snappi_tests.dataplane.imports import *        # noqa: F401
+from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config     # noqa: F401
+from tests.common.snappi_tests.common_helpers import traffic_flow_mode      # noqa: F401
+from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics      # noqa: F401
+logger = logging.getLogger(__name__)
+pytestmark = [pytest.mark.topology('tgen')]
+
+ErrorTypes = ['codeWords',
+              'laneMarkers',
+              'minConsecutiveUncorrectableWithLossOfLink',
+              'maxConsecutiveUncorrectableWithoutLossOfLink'
+              ]
+
+
+def get_ti_stats(ixnet):
+    tiStatistics = StatViewAssistant(ixnet, 'Traffic Item Statistics')
+    tdf = pd.DataFrame(tiStatistics.Rows.RawData, columns=tiStatistics.ColumnHeaders)
+    selected_columns = ['Tx Frames', 'Rx Frames', 'Frames Delta', 'Loss %', 'Tx Frame Rate', 'Rx Frame Rate']
+    tmp = tdf[selected_columns]
+    return tmp
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup_config(snappi_api,
+                 snappi_testbed_config,
+                 conn_graph_facts,
+                 fanout_graph_facts,
+                 duthosts,
+                 rand_one_dut_portname_oper_up,
+                 rand_one_dut_hostname):
+    """
+    Fixture to initialize resources for the test.
+    """
+    dut_hostname, dut_port = rand_one_dut_portname_oper_up.split('|')
+    testbed_config, port_config_list = snappi_testbed_config
+    duthost = duthosts[rand_one_dut_hostname]
+    api = snappi_api
+    conn_data = conn_graph_facts
+    fanout_data = fanout_graph_facts
+    snappi_extra_params = None    
+
+    if snappi_extra_params is None:
+        snappi_extra_params = SnappiTestParams()
+    port_id = get_dut_port_id(duthost.hostname,
+                              dut_port,
+                              conn_data,
+                              fanout_data)
+
+    pytest_assert(port_id is not None,
+                'Fail to get ID for port {}'.format(dut_port))
+    snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,
+                                                                     port_config_list=port_config_list,
+                                                                     port_id=port_id)
+    base_flow = snappi_extra_params.base_flow_config
+    test_flow = testbed_config.flows.flow(name='IPv4 Traffic')[-1]
+    test_flow.tx_rx.device.tx_names = [testbed_config.devices[0].name]
+    test_flow.tx_rx.device.rx_names = [testbed_config.devices[1].name]
+    test_flow.metrics.enable = True
+    test_flow.metrics.loss = True
+    test_flow.size.fixed = 64
+    test_flow.rate.percentage = 10
+    api.set_config(testbed_config)
+    test_platform = TestPlatform(snappi_api._address)
+    test_platform.Authenticate(snappi_api._username, snappi_api._password)
+    id = test_platform.Sessions.find()[-1].Id
+    session_assistant = SessionAssistant(IpAddress=snappi_api._address,
+                                         RestPort=snappi_api._port,
+                                         SessionId=id,
+                                         UserName=snappi_api._username,
+                                         Password=snappi_api._password)
+    yield api, port_config_list, session_assistant
+
+
+@pytest.mark.parametrize('error_type', ErrorTypes)
+def test_fec_error_injection(duthosts,
+                             error_type,
+                             setup_config):
+    """
+    Test to check if packets get dropped on injecting fec errors
+    """
+    api, port_config_list, session_assistant = setup_config
+    ixnet = api._ixnetwork
+    logger.info("Wait for Arp to Resolve ...")
+    wait_for_arp(api, max_attempts=30, poll_interval_sec=2)
+
+    port1 = ixnet.Vport.find()[port_config_list[0].id]
+    logger.info('|----------------------------------------|')
+    logger.info('| Setting FEC Error Type to : {} |'.format(error_type))
+    logger.info('|----------------------------------------|')
+    port1.L1Config.FecErrorInsertion.ErrorType = error_type
+    if error_type == 'codeWords':
+        port1.L1Config.FecErrorInsertion.PerCodeword = 16
+    port1.L1Config.FecErrorInsertion.Continuous = True
+
+    logger.info('Starting Traffic ...')
+    ts = api.control_state()
+    ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.START
+    api.set_control_state(ts)
+    wait(10, "For traffic to start")
+    try:
+        logger.info('Starting FEC Error Insertion')
+        port1.StartFecErrorInsertion()
+        wait(15, "For error insertion to start")
+        logger.info('Dumping Traffic Item statistics :\n {}'.format(tabulate(get_ti_stats(ixnet), headers='keys', tablefmt='psql')))
+        if error_type == 'minConsecutiveUncorrectableWithLossOfLink' or error_type == 'codeWords' or error_type == 'laneMarkers':
+            pytest_assert(duthosts[0].links_status_down(port_config_list[0].peer_port) is True,
+                          "FAIL: Link is still up after injecting FEC Error")
+            logger.info('|----------------------------------------|')
+            logger.info("PASS: Link Went down after injecting FEC Error: {}".format(error_type))
+            logger.info('|----------------------------------------|')
+        elif error_type == 'maxConsecutiveUncorrectableWithoutLossOfLink':
+            pytest_assert(duthosts[0].links_status_down(port_config_list[0].peer_port) is False,
+                          "FAIL: Link went down after injecting FEC Error")
+            logger.info('|----------------------------------------|')
+            logger.info("PASS: Link didn't go down after injecting FEC Error: {}".format(error_type))
+            logger.info('|----------------------------------------|')
+
+        flow_metrics = fetch_snappi_flow_metrics(api, ['IPv4 Traffic'])[0]
+        pytest_assert(flow_metrics.frames_tx > 0 and int(flow_metrics.loss) > 0,
+                    "FAIL: Rx Port did not stop receiving packets after starting FEC Error Insertion")
+        logger.info('PASS : Rx Port stopped receiving packets after starting FEC Error Insertion')
+        logger.info('Stopping FEC Error Insertion')
+        port1.StopFecErrorInsertion()
+        wait(15, "For error insertion to stop")
+        if error_type == 'minConsecutiveUncorrectableWithLossOfLink' or error_type == 'laneMarkers' or error_type == 'codeWords':
+            pytest_assert(duthosts[0].links_status_down(port_config_list[0].peer_port) is False,
+                          "FAIL: Link is still down after stopping FEC Error")
+            logger.info('|----------------------------------------|')
+            logger.info("PASS: Link is up after stopping FEC Error injection: {}".format(error_type))
+            logger.info('|----------------------------------------|')
+        ixnet.ClearStats()
+        wait(10, "For clear stats operation to complete")
+        logger.info('Dumping Traffic Item statistics :\n {}'.
+                    format(tabulate(get_ti_stats(ixnet), headers='keys', tablefmt='psql')))
+        flow_metrics = fetch_snappi_flow_metrics(api, ['IPv4 Traffic'])[0]
+        pytest_assert(int(flow_metrics.frames_rx_rate) > 0 and int(flow_metrics.loss) == 0,
+                      "FAIL: Rx Port did not resume receiving packets after stopping FEC Error Insertion")
+        logger.info('PASS : Rx Port resumed receiving packets after stopping FEC Error Insertion')
+        logger.info('Stopping Traffic ...')
+        ts = api.control_state()
+        ts.traffic.flow_transmit.state = ts.traffic.flow_transmit.STOP
+        api.set_control_state(ts)
+        wait(10, "For traffic to stop")
+    finally:
+        logger.info('....Finally Block')
+        port1.StopFecErrorInsertion()


### PR DESCRIPTION
* [Snappi]: Adding FEC Error Insertion Test Script

* inclusing loss check

* Adding link status check

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Adding FEC Error Insertion Test Script
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
### Output
------------------------------------------------------------------- live log call --------------------------------------------------------------------
21:35:30 connection._warn                         L0332 WARNING| Verification of certificates is disabled
21:35:30 connection._info                         L0329 INFO   | Determining the platform and rest_port using the 10.36.84.33 address...
21:35:30 connection._warn                         L0332 WARNING| Unable to connect to http://10.36.84.33:443.
21:35:30 connection._info                         L0329 INFO   | Connection established to `https://10.36.84.33:443 on linux`
21:35:44 connection._info                         L0329 INFO   | Using IxNetwork api server version 10.25.2406.5
21:35:44 connection._info                         L0329 INFO   | User info IxNetwork/ixnetworkweb/admin-47-5125
21:35:44 snappi_api.info                          L1252 INFO   | snappi-1.17.1
21:35:44 snappi_api.info                          L1252 INFO   | snappi_ixnetwork-1.17.0
21:35:44 snappi_api.info                          L1252 INFO   | ixnetwork_restpy-1.5.0
21:35:44 snappi_api.info                          L1252 INFO   | Config validation 0.005s
21:35:50 snappi_api.info                          L1252 INFO   | Ports configuration 5.404s
21:35:50 snappi_api.info                          L1252 INFO   | Captures configuration 0.140s
21:35:53 snappi_api.info                          L1252 INFO   | Add location hosts [10.36.84.33] 2.272s
21:35:57 snappi_api.info                          L1252 INFO   | Location hosts ready [10.36.84.33] 4.282s
21:35:58 snappi_api.info                          L1252 INFO   | Speed conversion is not require for (port.name, speed) : [('Port 0', 'aresOne-M-OneByEightHundredGigPAM4-106G'), ('Port 1', 'aresOne-M-OneByEightHundredGigPAM4-106G')]
21:35:58 snappi_api.info                          L1252 INFO   | Aggregation mode speed change 0.579s
21:36:02 snappi_api.info                          L1252 INFO   | Location preemption [10.36.84.33/1, 10.36.84.33/2] 0.140s
21:36:24 snappi_api.info                          L1252 INFO   | Location connect [Port 0, Port 1] 21.644s
21:36:24 snappi_api.info                          L1252 INFO   | Location state check [Port 0, Port 1] 0.209s
21:36:24 snappi_api.info                          L1252 INFO   | Location configuration 33.880s
21:37:23 snappi_api.info                          L1252 INFO   | Layer1 configuration 58.873s
21:37:23 snappi_api.info                          L1252 INFO   | Lag Configuration 0.072s
21:37:24 snappi_api.info                          L1252 INFO   | Convert device config : 0.204s
21:37:24 snappi_api.info                          L1252 INFO   | Create IxNetwork device config : 0.000s
21:37:24 snappi_api.info                          L1252 INFO   | Push IxNetwork device config : 0.524s
21:37:24 snappi_api.info                          L1252 INFO   | Devices configuration 0.795s
21:37:26 snappi_api.info                          L1252 INFO   | Flows configuration 1.763s
21:37:33 snappi_api.info                          L1252 INFO   | Start interfaces 6.678s
21:37:33 snappi_api.info                          L1252 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
21:37:33 snappi_api.info                          L1252 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
21:37:33 test_fec_error_injection.test_fec_error_ L0065 INFO   | Wait for Arp to Resolve ...
21:37:34 test_fec_error_injection.test_fec_error_ L0069 INFO   | |----------------------------------------|
21:37:34 test_fec_error_injection.test_fec_error_ L0070 INFO   | | Setting FEC Error Type to : minConsecutiveUncorrectableWithLossOfLink |
21:37:34 test_fec_error_injection.test_fec_error_ L0071 INFO   | |----------------------------------------|
21:37:46 test_fec_error_injection.test_fec_error_ L0077 INFO   | Starting Traffic ...
21:37:52 snappi_api.info                          L1252 INFO   | Flows generate/apply 5.427s
21:38:05 snappi_api.info                          L1252 INFO   | Flows clear statistics 12.599s
21:38:05 snappi_api.info                          L1252 INFO   | Captures start 0.000s
21:38:07 snappi_api.info                          L1252 INFO   | Flows start 2.643s
21:38:08 snappi_api.info                          L1252 INFO   | IxNet - The frame size was increased to 66 bytes to accommodate encapsulation requirements.  - The frame size was adjusted to conform to the encapsulation requirements
21:38:08 utilities.wait                           L0117 INFO   | Pause 10 seconds, reason: For traffic to start
21:38:18 test_fec_error_injection.test_fec_error_ L0083 INFO   | Starting FEC Error Insertion
21:38:18 utilities.wait                           L0117 INFO   | Pause 15 seconds, reason: For error insertion to start
21:38:34 test_fec_error_injection.test_fec_error_ L0087 INFO   | Dumping Traffic Item statistics :
 +----+-------------+-------------+----------------+----------+-----------------+-----------------+
|    |   Tx Frames |   Rx Frames |   Frames Delta |   Loss % |   Tx Frame Rate |   Rx Frame Rate |
|----+-------------+-------------+----------------+----------+-----------------+-----------------|
|  0 |  2777671489 |  1452278386 |     1325393103 |   47.716 |     1.16279e+08 |               0 |
+----+-------------+-------------+----------------+----------+-----------------+-----------------+
21:38:36 sonic.links_status_down                  L2540 INFO   | Interface Ethernet0 is down on sonic-s6100-dut1
21:38:36 test_fec_error_injection.test_fec_error_ L0089 INFO   | |----------------------------------------|
21:38:36 test_fec_error_injection.test_fec_error_ L0090 INFO   | PASS: Link Went down after injecting FEC Error
21:38:36 test_fec_error_injection.test_fec_error_ L0091 INFO   | |----------------------------------------|
21:38:37 test_fec_error_injection.test_fec_error_ L0095 INFO   | PASS : Rx Port stopped receiving packets after starting FEC Error Insertion
21:38:37 test_fec_error_injection.test_fec_error_ L0096 INFO   | Stopping FEC Error Insertion
21:38:37 utilities.wait                           L0117 INFO   | Pause 15 seconds, reason: For error insertion to stop
21:38:54 sonic.links_status_down                  L2543 INFO   | Interface Ethernet0 is up on sonic-s6100-dut1
21:38:54 test_fec_error_injection.test_fec_error_ L0100 INFO   | |----------------------------------------|
21:38:54 test_fec_error_injection.test_fec_error_ L0101 INFO   | PASS: Link is up after stopping FEC Error injection
21:38:54 test_fec_error_injection.test_fec_error_ L0102 INFO   | |----------------------------------------|
21:38:56 utilities.wait                           L0117 INFO   | Pause 10 seconds, reason: For clear stats operation to complete
21:39:07 test_fec_error_injection.test_fec_error_ L0105 INFO   | Dumping Traffic Item statistics :
 +----+-------------+-------------+----------------+----------+-----------------+-----------------+
|    |   Tx Frames |   Rx Frames |   Frames Delta |   Loss % |   Tx Frame Rate |   Rx Frame Rate |
|----+-------------+-------------+----------------+----------+-----------------+-----------------|
|  0 |   854013471 |   854013138 |            333 |        0 |     1.16279e+08 |     1.16279e+08 |
+----+-------------+-------------+----------------+----------+-----------------+-----------------+
21:39:09 test_fec_error_injection.test_fec_error_ L0109 INFO   | PASS : Rx Port resumed receiving packets after stopping FEC Error Insertion
21:39:09 test_fec_error_injection.test_fec_error_ L0110 INFO   | Stopping Traffic ...
21:39:14 snappi_api.info                          L1252 INFO   | Flows stop 5.337s
21:39:15 utilities.wait                           L0117 INFO   | Pause 10 seconds, reason: For traffic to stop
PASSED                                           