### PR TITLE
Add multi-asic awareness for swss to ignore [ecmp|lag]_hash_offset logs

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -301,8 +301,8 @@ r, ".* ERR rsyslogd: imrelp.*error 'error when receiving data, session broken', 
 
 # Errors for config reload/reboot on mellanox platform
 # SAI implement missing for the https://github.com/sonic-net/sonic-buildimage/pull/18912 caused the err msg pop up, need to ignore the err msgs before it SAI implement is done.
-r, ".* ERR swss#orchagent:.*doAppSwitchTableTask.*Unsupported Attribute ecmp_hash_offset.*"
-r, ".* ERR swss#orchagent:.*doAppSwitchTableTask.*Unsupported Attribute lag_hash_offset.*"
+r, ".* ERR swss\d*#orchagent:.*doAppSwitchTableTask.*Unsupported Attribute ecmp_hash_offset.*"
+r, ".* ERR swss\d*#orchagent:.*doAppSwitchTableTask.*Unsupported Attribute lag_hash_offset.*"
 
 # ignore SAI_API_BUFFER for DNX platforms
 r, ".* ERR syncd\d*#syncd.*SAI_API_BUFFER.*Unsupported buffer pool.*"


### PR DESCRIPTION
### Description of PR

This patches fixes the log ignore so that it matches correctly on multi-ASIC linecards, which run multiple swss containers (one per ASIC), which was causing test failures in our infrastructure. 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

Not having flexibility to ignore swss logs for multi ASICs was causing test failures with drop counters in our infrastructures. This change came in the form of fixing that bug.

#### How did you do it?

Using regular expression to cover broad range of ASICs.

#### How did you verify/test it?

Ran the relevant sonic-mgmt test suite on our infrastructure.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
