### PR TITLE
Fix bgp/test_bgp_route_neigh_learning.py BGP AS assumption

### DIFF
--- a/tests/bgp/test_bgp_route_neigh_learning.py
+++ b/tests/bgp/test_bgp_route_neigh_learning.py
@@ -24,6 +24,9 @@ def fixture_setUp(nbrhosts, duthosts, enum_frontend_dut_hostname):
     cmd = "vtysh -c 'show ip bgp summary json'"
     bgp_summary_json = json.loads(duthost.shell(cmd)['stdout'])
     bgp_info = {}
+
+    py_assert('ipv4Unicast' in bgp_summary_json)
+    py_assert('peers' in bgp_summary_json['ipv4Unicast'])
     for neighbor in bgp_summary_json['ipv4Unicast']['peers']:
         neighbor_info = bgp_summary_json['ipv4Unicast']['peers'][neighbor]
         bgp_info[neighbor_info['desc']] = neighbor_info['remoteAs']

--- a/tests/bgp/test_bgp_route_neigh_learning.py
+++ b/tests/bgp/test_bgp_route_neigh_learning.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import logging
 from tests.common.helpers.assertions import pytest_assert as py_assert
@@ -20,12 +21,12 @@ def fixture_setUp(nbrhosts, duthosts, enum_frontend_dut_hostname):
     '''
     duthost = duthosts[enum_frontend_dut_hostname]
 
-    cmd = "show ip bgp summary | tail -n+12 | head -n-2 | awk '{printf(\"%s,%s\\n\", $11, $3)}'"
-    bgp_summary_output = duthost.shell(cmd)['stdout_lines']
+    cmd = "vtysh -c 'show ip bgp summary json'"
+    bgp_summary_json = json.loads(duthost.shell(cmd)['stdout'])
     bgp_info = {}
-    for entry in bgp_summary_output:
-        entry = entry.split(",")
-        bgp_info[entry[0]] = entry[1]
+    for neighbor in bgp_summary_json['ipv4Unicast']['peers']:
+        neighbor_info = bgp_summary_json['ipv4Unicast']['peers'][neighbor]
+        bgp_info[neighbor_info['desc']] = neighbor_info['remoteAs']
 
     data = {}
     data['nbr'] = nbrhosts


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test `test_bgp_route_neigh_learning.py::test_bgp_neighbor_route_learnning` modifies the CEOS VM's BGP configuration as part of the test. However, it assumes that the BGP AS number to always be `64600`, which is not the case.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Test was failing. The reason was because the test assumes the BGP AS number to always be `64600`

#### How did you do it?
Query the DUT for each neighboring VM's BGP AS number instead of assuming its `64600`.

#### How did you verify/test it?
Test no longer fails.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
