### PR TITLE
test_verify_fec_stats_counters: Enhance the condition for robustness and optimize its efficiency.

### DIFF
--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -137,14 +137,14 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
         if speed not in SUPPORTED_SPEEDS:
             continue
 
-        fec_corr = intf.get('fec_corr', '').lower()
-        fec_uncorr = intf.get('fec_uncorr', '').lower()
-        fec_symbol_err = intf.get('fec_symbol_err', '').lower()
+        fec_corr = intf.get('fec_corr', '').replace(',', '').lower()
+        fec_uncorr = intf.get('fec_uncorr', '').replace(',', '').lower()
+        fec_symbol_err = intf.get('fec_symbol_err', '').replace(',', '').lower()
         # Check if fec_corr, fec_uncorr, and fec_symbol_err are valid integers
         try:
-            fec_corr_int = int(fec_corr.replace(',', ''))
-            fec_uncorr_int = int(fec_uncorr.replace(',', ''))
-            fec_symbol_err_int = int(fec_symbol_err.replace(',', ''))
+            fec_corr_int = int(fec_corr)
+            fec_uncorr_int = int(fec_uncorr)
+            fec_symbol_err_int = int(fec_symbol_err)
         except ValueError:
             pytest.fail("FEC stat counters are not valid integers for interface {}, \
                         fec_corr: {} fec_uncorr: {} fec_symbol_err: {}"
@@ -156,7 +156,7 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
                         .format(intf_name, fec_uncorr_int))
 
         # FEC correctable codeword errors should always be less than actual FEC symbol errors, check it
-        if fec_corr_int > fec_symbol_err_int:
+        if fec_corr_int > 0 and fec_corr_int > fec_symbol_err_int:
             pytest.fail("FEC symbol errors:{} are higher than FEC correctable errors:{} for interface {}"
                         .format(fec_symbol_err_int, fec_corr_int, intf_name))
 

--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -137,6 +137,7 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
         if speed not in SUPPORTED_SPEEDS:
             continue
 
+        # Removes commas from "show interfaces counters fec-stats" (i.e. 12,354 --> 12354) to allow int conversion
         fec_corr = intf.get('fec_corr', '').replace(',', '').lower()
         fec_uncorr = intf.get('fec_uncorr', '').replace(',', '').lower()
         fec_symbol_err = intf.get('fec_symbol_err', '').replace(',', '').lower()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

While the current condition if fec_corr_int > fec_symbol_err_int: correctly returns false when fec_corr_int is 0, I want to explicitly check for fec_corr_int > 0 to enhance the robustness of the test case.

Additionally, optimize the process by replacing commas in the FEC stats counters earlier, before converting them to integers.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified on Arista 7060x6 testbed where the fec-stats counters are 0's.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
