### PR TITLE
Use number of logs instead of timestamp in `change_and_wait_aaa_config_update`

### DIFF
--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -4,7 +4,7 @@ import pytest
 from tests.common.devices.ptf import PTFHost
 from tests.common.helpers.tacacs.tacacs_helper import stop_tacacs_server, start_tacacs_server, \
     per_command_accounting_skip_versions, remove_all_tacacs_server
-from .utils import check_server_received, change_and_wait_aaa_config_update, get_auditd_config_reload_timestamp, \
+from .utils import check_server_received, change_and_wait_aaa_config_update, get_auditd_config_reload_line_count, \
     ensure_tacacs_server_running_after_ut, ssh_connect_remote_retry, ssh_run_command    # noqa: F401
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.assertions import pytest_assert
@@ -253,7 +253,7 @@ def test_accounting_tacacs_only_some_tacacs_server_down(
     # when tacacs config change multiple time in short time
     # auditd service may been request reload during reloading
     # when this happen, auditd will ignore request and only reload once
-    last_timestamp = get_auditd_config_reload_timestamp(duthost)
+    last_line_count = get_auditd_config_reload_line_count(duthost)
 
     duthost.shell("sudo config tacacs timeout 1")
     remove_all_tacacs_server(duthost)
@@ -261,7 +261,7 @@ def test_accounting_tacacs_only_some_tacacs_server_down(
     duthost.shell("sudo config tacacs add %s --port 59" % tacacs_server_ip)
     change_and_wait_aaa_config_update(duthost,
                                       "sudo config aaa accounting tacacs+",
-                                      last_timestamp)
+                                      last_line_count)
 
     cleanup_tacacs_log(ptfhost, rw_user_client)
 

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -65,27 +65,24 @@ def check_server_received(ptfhost, data, timeout=30):
     pytest_assert(exist, "Not found data: {} in tacplus server log".format(data))
 
 
-def get_auditd_config_reload_timestamp(duthost):
+def get_auditd_config_reload_line_count(duthost):
     res = duthost.shell("sudo journalctl -u auditd --boot --no-pager | grep 'audisp-tacplus re-initializing configuration'") # noqa E501
     logger.info("aaa config file timestamp {}".format(res["stdout_lines"]))
 
-    if len(res["stdout_lines"]) == 0:
-        return ""
-
-    return res["stdout_lines"][-1]
+    return len(res["stdout_lines"])
 
 
-def change_and_wait_aaa_config_update(duthost, command, last_timestamp=None, timeout=10):
-    if not last_timestamp:
-        last_timestamp = get_auditd_config_reload_timestamp(duthost)
+def change_and_wait_aaa_config_update(duthost, command, last_line_count=None, timeout=10):
+    if not last_line_count:
+        last_line_count = get_auditd_config_reload_line_count(duthost)
 
     duthost.shell(command)
 
     # After AAA config update, hostcfgd will modify config file and notify auditd reload config
     # Wait auditd reload config finish
     def log_exist(duthost):
-        latest_timestamp = get_auditd_config_reload_timestamp(duthost)
-        return latest_timestamp != last_timestamp
+        latest_line_count = get_auditd_config_reload_line_count(duthost)
+        return latest_line_count > last_line_count
 
     exist = wait_until(timeout, 1, 0, log_exist, duthost)
     pytest_assert(exist, "Not found aaa config update log: {}".format(command))


### PR DESCRIPTION
`change_and_wait_aaa_config_update` validates that the `auditd` service publishes the log `audisp-tacplus re-initializing configuration` after executing the passed in `command`.

However, it did this by checking that the timestamp in the log message was different than the previously emitted log.
As shown in https://github.com/sonic-net/sonic-mgmt/issues/16709 these message can appear within the same second and cause the test to fail.

Instead this PR changes the approach to look at how many logs have been emitted before and after the command rather than the timestamp changes.

Summary:
Fixes #16709 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
