### PR TITLE
Prevent T2 BGP neighbors going down during ACL tests

### DIFF
--- a/tests/acl/templates/acltb_v6_test_rules.j2
+++ b/tests/acl/templates/acltb_v6_test_rules.j2
@@ -228,7 +228,7 @@
                                 },
                                 "ip": {
                                     "config": {
-                                        "destination-ip-address": "20c0:a800::9/128"
+                                        "destination-ip-address": "20c0:a800::11ac:d765:2523:e5e4/128"
                                     }
                                 }
                             },

--- a/tests/acl/templates/acltb_v6_test_rules_part_2.j2
+++ b/tests/acl/templates/acltb_v6_test_rules_part_2.j2
@@ -228,7 +228,7 @@
                                 },
                                 "ip": {
                                     "config": {
-                                        "destination-ip-address": "20c0:a800::9/128"
+                                        "destination-ip-address": "20c0:a800::11ac:d765:2523:e5e4/128"
                                     }
                                 }
                             },

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -73,7 +73,7 @@ DOWNSTREAM_IP_TO_ALLOW = {
 }
 DOWNSTREAM_IP_TO_BLOCK = {
     "ipv4": "192.168.0.251",
-    "ipv6": "20c0:a800::9"
+    "ipv6": "20c0:a800::11ac:d765:2523:e5e4"
 }
 
 # Below M0_L3 IPs are announced to DUT by annouce_route.py, it point to neighbor mx


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/sonic-net/sonic-buildimage/issues/21183

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Prevent T2 BGP neighbors going down during ACL tests
#### How did you do it?
Prevent last 64 bits of a DROP rule IP from being the same as a BGP neighbor
#### How did you verify/test it?
Run on T2 devices
T1 regression test: https://elastictest.org/scheduler/testplan/679c3507f5a74203a8e1b10b
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
