### PR TITLE
Add tgen_port_info to dynamically adjust multidut_port_info fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1848,6 +1848,11 @@ def pytest_generate_tests(metafunc):        # noqa E302
     if 'enum_pfc_pause_delay_test_params' in metafunc.fixturenames:
         metafunc.parametrize("enum_pfc_pause_delay_test_params", pfc_pause_delay_test_params(metafunc))
 
+    if 'tgen_port_info' in metafunc.fixturenames:
+        with open("snappi_tests/tgen_port_config.json", "r") as file:
+            port_info = json.load(file)
+            metafunc.parametrize("tgen_port_info", port_info.get(tbinfo['conf-name'], port_info.get("default")))
+
     if 'topo_scenario' in metafunc.fixturenames:
         if tbinfo['topo']['type'] == 'm0' and 'topo_scenario' in metafunc.fixturenames:
             metafunc.parametrize('topo_scenario', ['m0_vlan_scenario', 'm0_l3_scenario'], scope='module')

--- a/tests/snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py
@@ -10,14 +10,12 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
     snappi_api, snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config      # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,\
     lossless_prio_list, lossy_prio_list     # noqa F401
-from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.pfcwd.files.pfcwd_burst_storm_helper import run_pfcwd_burst_storm_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_pfcwd_burst_storm_single_lossless_prio(snappi_api,             # noqa: F811
                                                 conn_graph_facts,       # noqa: F811
                                                 fanout_graph_facts_multidut,     # noqa: F811
@@ -25,7 +23,7 @@ def test_pfcwd_burst_storm_single_lossless_prio(snappi_api,             # noqa: 
                                                 lossless_prio_list,    # noqa: F811
                                                 get_snappi_ports,    # noqa: F811
                                                 tbinfo,      # noqa: F811
-                                                multidut_port_info,
+                                                tgen_port_info,
                                                 prio_dscp_map,               # noqa: F811
                                                 ):
 
@@ -46,7 +44,7 @@ def test_pfcwd_burst_storm_single_lossless_prio(snappi_api,             # noqa: 
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
+    for testbed_subtype, rdma_ports in tgen_port_info.items():
         tx_port_count = 1
         rx_port_count = 1
         snappi_port_list = get_snappi_ports
@@ -56,16 +54,16 @@ def test_pfcwd_burst_storm_single_lossless_prio(snappi_api,             # noqa: 
         pytest_assert(len(rdma_ports['tx_ports']) >= tx_port_count,
                       'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
                       testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
+                      format(tbinfo['conf-name'], testbed_subtype))
 
         pytest_assert(len(rdma_ports['rx_ports']) >= rx_port_count,
                       'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
                       testbed {}, subtype {} in variables.py'.
-                      format(MULTIDUT_TESTBED, testbed_subtype))
+                      format(tbinfo['conf-name'], testbed_subtype))
         logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
         if is_snappi_multidut(duthosts):
             snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+                                                     tx_port_count, rx_port_count, tbinfo['conf-name'])
         else:
             snappi_ports = get_snappi_ports
         testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,

--- a/tests/snappi_tests/tgen_port_config.json
+++ b/tests/snappi_tests/tgen_port_config.json
@@ -1,0 +1,41 @@
+{
+  "vms-snappi-sonic-multidut": [
+    {
+      "multi-dut-single-asic": {
+        "rx_ports": [
+          {"hostname": "sonic-s6100-dut1", "port_name": "Ethernet72"},
+          {"host_name": "sonic-s6100-dut2", "port_name": "Ethernet76"}
+        ],
+        "tx_ports": [
+          {"hostname": "sonic-s6100-dut2", "port_name": "Ethernet64"},
+          {"hostname": "sonic-s6100-dut2", "port_name": "Ethernet68"}
+        ]
+      }
+    },
+    {
+      "single-dut-single-asic": {
+        "rx_ports": [
+          {"hostname": "sonic-s6100-dut1", "port_name": "Ethernet72"},
+          {"hostname": "sonic-s6100-dut1", "port_name": "Ethernet76"}
+        ],
+        "tx_ports": [
+          {"hostname": "sonic-s6100-dut1", "port_name": "Ethernet64"},
+          {"hostname": "sonic-s6100-dut1", "port_name": "Ethernet68"}
+        ]
+      }
+    }
+  ],
+  "default": [
+    {
+      "default": {
+        "rx_ports": [
+          {"hostname": "dummy-dut-1", "port_name": "Ethernet1"}
+        ],
+        "tx_ports": [
+          {"hostname": "dummy-dut-2", "port_name": "Ethernet2"},
+          {"hostname": "dummy-dut-3", "port_name": "Ethernet3"}
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
