### PR TITLE
Fixed issues with GNOI System Reboot Tests

### DIFF
--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -210,7 +210,13 @@ def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost, ptfhost):
 
     # Rollback configuration
     rollback(duthost, SETUP_ENV_CP)
-    recover_cert_config(duthost)
+    # Get the skip_gnmi_check flag from duthost options
+    skip_gnmi_check = duthost.host.options.get('skip_gnmi_check', False)
+    # Skip GNMI restart if the reboot flag is set
+    if not skip_gnmi_check:
+        recover_cert_config(duthost)
+    else:
+        logging.info("Skipping GNMI restart due to skip_gnmi_check flag")
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/gnmi/test_gnoi_system.py
+++ b/tests/gnmi/test_gnoi_system.py
@@ -59,6 +59,22 @@ def test_gnoi_system_reboot_fail_invalid_method(duthosts, rand_one_dut_hostname,
     pytest_assert(ret != 0, "System.Reboot API did not report failure with invalid method")
 
 
+def test_gnoi_system_reboot_when_reboot_active(duthosts, rand_one_dut_hostname, localhost):
+    """
+    Verify the gNOI System Reboot API fails if a reboot is already active.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    # Trigger first reboot
+    ret, msg = gnoi_request(duthost, localhost, "Reboot", '{"method": 1}')
+    pytest_assert(ret == 0, "System.Reboot API reported failure (rc = {}) with message: {}".format(ret, msg))
+    logging.info("System.Reboot API returned msg: {}".format(msg))
+
+    # Trigger second reboot while the first one is still active
+    ret, msg = gnoi_request(duthost, localhost, "Reboot", '{"method": 1}')
+    pytest_assert(ret != 0, "System.Reboot API did not report failure when reboot is already active")
+
+
 def test_gnoi_system_reboot_status_immediately(duthosts, rand_one_dut_hostname, localhost):
     """
     Verify the gNOI System RebootStatus API returns the correct status immediately after reboot.

--- a/tests/gnmi/test_gnoi_system.py
+++ b/tests/gnmi/test_gnoi_system.py
@@ -35,6 +35,18 @@ def test_gnoi_system_time(duthosts, rand_one_dut_hostname, localhost):
     pytest_assert("time" in msg_json, "System.Time API did not return time")
 
 
+def test_gnoi_system_reboot(duthosts, rand_one_dut_hostname, localhost):
+    """
+    Verify the gNOI System Reboot API triggers a reboot and the device comes back online.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    # Trigger reboot
+    ret, msg = gnoi_request(duthost, localhost, "Reboot", '{"method": 1}')
+    pytest_assert(ret == 0, "System.Reboot API reported failure (rc = {}) with message: {}".format(ret, msg))
+    logging.info("System.Reboot API returned msg: {}".format(msg))
+
+
 def extract_first_json_substring(s):
     """
     Extract the first JSON substring from a given string.

--- a/tests/gnmi/test_gnoi_system.py
+++ b/tests/gnmi/test_gnoi_system.py
@@ -54,7 +54,7 @@ def test_gnoi_system_reboot_fail_invalid_method(duthosts, rand_one_dut_hostname,
     duthost = duthosts[rand_one_dut_hostname]
 
     # Trigger reboot with invalid method
-    ret, msg = gnoi_request(duthost, localhost, "Reboot", '{"method": 2}')
+    ret, msg = gnoi_request(duthost, localhost, "Reboot", '{"method": 99}')
     pytest_assert(ret != 0, "System.Reboot API did not report failure with invalid method")
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
This PR skips GNMI recovery during teardown if a reboot is triggered, as it may not have fully restarted yet.
-->

Summary: Skip GNMI recovery during teardown if reboot was triggered"
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
