### PR TITLE
Porting 16695 to 202411, set fake_storm to false for cisco-8000.

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -9,6 +9,7 @@ from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # no
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
 from tests.common.fixtures.ptfhost_utils import pause_garp_service          # noqa F401
 from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
+from tests.common.cisco_data import is_cisco_device
 from tests.common.helpers.pfcwd_helper import TrafficPorts, set_pfc_timers, select_test_ports
 from tests.common.utilities import str2bool
 
@@ -75,7 +76,8 @@ def fake_storm(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         fake_storm: False/True
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    return request.config.getoption('--fake-storm') if not isMellanoxDevice(duthost) else False
+    return False if (isMellanoxDevice(duthost) or is_cisco_device(duthost)) \
+        else request.config.getoption('--fake-storm')
 
 
 def update_t1_test_ports(duthost, mg_facts, test_ports, tbinfo):

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -724,7 +724,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         test_ports_info = {self.pfc_wd['rx_port'][0]: self.pfc_wd}
         queues = [self.storm_hndle.pfc_queue_idx]
 
-        if dut.facts['asic_type'] == "mellanox":
+        extra_pfc_storm_timeout_needed = dut.facts['asic_type'] in ["mellanox", "cisco-8000"]
+        if extra_pfc_storm_timeout_needed:
             PFC_STORM_TIMEOUT = 30
             pfcwd_stats_before_test = check_pfc_storm_state(dut, port, self.storm_hndle.pfc_queue_idx)
 
@@ -744,7 +745,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             if self.pfc_wd['fake_storm']:
                 PfcCmd.set_storm_status(dut, self.queue_oid, "enabled")
 
-            if dut.facts['asic_type'] in ["mellanox", "cisco-8000"]:
+            if extra_pfc_storm_timeout_needed:
                 # On Mellanox platform, more time is required for PFC storm being triggered
                 # as PFC pause sent from Non-Mellanox leaf fanout is not continuous sometimes.
                 pytest_assert(wait_until(PFC_STORM_TIMEOUT, 2, 0,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
pfcwd_multi_port test failed when using the longer PFC_STORM_TIMEOUT seconds. We found this is due to fake-storm flag. After disabling the fake-storm, the test is passing.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Enabling the longer pfc storm timeout and disabling fake-storm for cisco-8000.

#### How did you do it?
Enabled the if conditions for mellanox to include cisco-8000.

#### How did you verify/test it?
Ran it on my TB, verified on 8102, 8111 and T2:

8102 run log:

```
collected 5 items                                                                                                                                                                                                            

pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[mth-t0-64] PASSED                                                                                                                                      [ 20%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[mth-t0-64] PASSED                                                                                                                                   [ 40%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[mth-t0-64] PASSED                                                                                                                                   [ 60%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[mth-t0-64] PASSED                                                                                                                                  [ 80%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[mth-t0-64] PASSED                                                                                                                                   [100%]
----------------------------------------------------------------------------------------------------- live log teardown ------------------------------------------------------------------------------------------------------
00:51:55 conftest.core_dump_and_config_check      L2681 WARNING| Core dump or config check failed for test_pfcwd_function.py, results: {"core_dump_check": {"pass": true, "new_core_dumps": {"mth-t0-64": []}}, "config_db_check": {"pass": false, "pre_only_config": {"mth-t0-64": {"null": {}}}, "cur_only_config": {"mth-t0-64": {"null": {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "400"}}}}}, "inconsistent_config": {"mth-t0-64": {"null": {}}}}}


====================================================================================================== warnings summary ======================================================================================================
../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------------------------------------------------------ generated xml file: /run_logs/rraghav/tr_2025-01-28-00-20-04.xml ------------------------------------------------------------------------------
========================================================================================= 5 passed, 1 warning in 2040.97s (0:34:00) ==========================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_pfcwd_no_traffic[mth-t0-64]>
```

T2 run log:
```

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================================== PASSES ===========================================================================================================
_______________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_actions[xx37-lc0-1-2] _______________________________________________________________________________________
_______________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_actions[xx37-lc0-2-2] _______________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_multi_port[xx37-lc0-1-2] ______________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_multi_port[xx37-lc0-2-2] ______________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_mmu_change[xx37-lc0-1-2] ______________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_mmu_change[xx37-lc0-2-2] ______________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_port_toggle[xx37-lc0-1-2] _____________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_port_toggle[xx37-lc0-2-2] _____________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_no_traffic[xx37-lc0-1-2] ______________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_no_traffic[xx37-lc0-2-2] ______________________________________________________________________________________
_______________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_actions[xx37-lc1-1-2] _______________________________________________________________________________________
_______________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_actions[xx37-lc1-2-2] _______________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_multi_port[xx37-lc1-1-2] ______________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_multi_port[xx37-lc1-2-2] ______________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_mmu_change[xx37-lc1-1-2] ______________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_mmu_change[xx37-lc1-2-2] ______________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_port_toggle[xx37-lc1-1-2] _____________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_port_toggle[xx37-lc1-2-2] _____________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_no_traffic[xx37-lc1-1-2] ______________________________________________________________________________________
_____________________________________________________________________________________ TestPfcwdFunc.test_pfcwd_no_traffic[xx37-lc1-2-2] ______________________________________________________________________________________
------------------------------------------------- generated xml file: /run_logs/pfcwd-fake-storm/2025-01-28-17-25-12/pfcwd/pfcwd/test_pfcwd_function_2025-01-28-17-25-12.xml -------------------------------------------------
--------------------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------------------
19:13:45 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================================== short test summary info ===================================================================================================
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[xx37-lc0-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[xx37-lc0-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[xx37-lc0-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[xx37-lc0-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[xx37-lc0-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[xx37-lc0-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[xx37-lc0-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[xx37-lc0-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[xx37-lc0-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[xx37-lc0-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[xx37-lc1-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[xx37-lc1-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[xx37-lc1-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[xx37-lc1-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[xx37-lc1-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[xx37-lc1-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[xx37-lc1-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[xx37-lc1-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[xx37-lc1-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[xx37-lc1-2-2]
========================================================================================= 20 passed, 1 warning in 6511.05s (1:48:31) =========================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_pfcwd_no_traffic[xx37-lc1-2-2]>
DEBUG:tests.conftest:append custom_msg: {'dut_check_result': {'config_db_check_pass': False, 'core_dump_check_pass': True}}
INFO:root:Can not get Allure report URL. Please check logs
sonic@202405-qos-sonic-mgmt-prod:/data/tests$ 
sonic@202405-qos-sonic-mgmt-prod:/data/tests$ 
```

#### Any platform specific information?
Enabling only for cisco-8000, in addition to mellanox.