### PR TITLE
Add support for test_power_off_reboot for Cisco 8808 chassis

### DIFF
--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -82,10 +82,6 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
     @param power_off_delay: Pytest parameter. The delay between turning off and on the PSU
     """
     duthost = duthosts[enum_supervisor_dut_hostname]
-    UNSUPPORTED_ASIC_TYPE = ["cisco-8000"]
-    if duthost.facts["asic_type"] in UNSUPPORTED_ASIC_TYPE:
-        pytest.skip("Skipping test_power_off_reboot. Test unsupported on {} platform"
-                    .format(duthost.facts["asic_type"]))
     pdu_ctrl = get_pdu_controller(duthost)
     if pdu_ctrl is None:
         pytest.skip("No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
@@ -114,14 +110,23 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
     poweroff_reboot_kwargs = {"dut": duthost}
 
     try:
-        for power_on_seq in power_on_seq_list:
+        if is_chassis and duthost.facts["asic_type"] in ["cisco-8000"]:
             poweroff_reboot_kwargs["pdu_ctrl"] = pdu_ctrl
             poweroff_reboot_kwargs["all_outlets"] = all_outlets
-            poweroff_reboot_kwargs["power_on_seq"] = power_on_seq
+            poweroff_reboot_kwargs["power_on_seq"] = all_outlets
             poweroff_reboot_kwargs["delay_time"] = power_off_delay
             reboot_and_check(localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
-                             xcvr_skip_list, REBOOT_TYPE_POWEROFF, _power_off_reboot_helper,
-                             poweroff_reboot_kwargs, duthosts)
+                                xcvr_skip_list, REBOOT_TYPE_POWEROFF,
+                                _power_off_reboot_helper, poweroff_reboot_kwargs, duthosts=duthosts)
+        else:
+            for power_on_seq in power_on_seq_list:
+                poweroff_reboot_kwargs["pdu_ctrl"] = pdu_ctrl
+                poweroff_reboot_kwargs["all_outlets"] = all_outlets
+                poweroff_reboot_kwargs["power_on_seq"] = power_on_seq
+                poweroff_reboot_kwargs["delay_time"] = power_off_delay
+                reboot_and_check(localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
+                                xcvr_skip_list, REBOOT_TYPE_POWEROFF,
+                                _power_off_reboot_helper, poweroff_reboot_kwargs)
 
     except Exception as e:
         logging.debug("Restore power after test failure")

--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -115,18 +115,20 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
             poweroff_reboot_kwargs["all_outlets"] = all_outlets
             poweroff_reboot_kwargs["power_on_seq"] = all_outlets
             poweroff_reboot_kwargs["delay_time"] = power_off_delay
-            reboot_and_check(localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
-                                xcvr_skip_list, REBOOT_TYPE_POWEROFF,
-                                _power_off_reboot_helper, poweroff_reboot_kwargs, duthosts=duthosts)
+            reboot_and_check(
+                localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
+                xcvr_skip_list, REBOOT_TYPE_POWEROFF,
+                _power_off_reboot_helper, poweroff_reboot_kwargs, duthosts=duthosts)
         else:
             for power_on_seq in power_on_seq_list:
                 poweroff_reboot_kwargs["pdu_ctrl"] = pdu_ctrl
                 poweroff_reboot_kwargs["all_outlets"] = all_outlets
                 poweroff_reboot_kwargs["power_on_seq"] = power_on_seq
                 poweroff_reboot_kwargs["delay_time"] = power_off_delay
-                reboot_and_check(localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
-                                xcvr_skip_list, REBOOT_TYPE_POWEROFF,
-                                _power_off_reboot_helper, poweroff_reboot_kwargs)
+                reboot_and_check(
+                    localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
+                    xcvr_skip_list, REBOOT_TYPE_POWEROFF,
+                    _power_off_reboot_helper, poweroff_reboot_kwargs)
 
     except Exception as e:
         logging.debug("Restore power after test failure")


### PR DESCRIPTION
### Description of PR
Add support for test_power_off_reboot for Cisco 8808 chassis. For chassis, till we can add calculation to find minimum number of PSU up based on the load of the system, we will bringup all the PSU before we continue the test.

Summary:
Fixes # (issue)

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Add support for test_power_off_reboot for Cisco 8808 chassis. For chassis, till we can add calculation to find minimum number of PSU up based on the load of the system, we will bringup all the PSU before we continue the test.

#### How did you do it?

#### How did you verify/test it?
On T2 profiles

#### Any platform specific information?
Cisco 8808 chassis

#### Supported testbed topology if it's a new test case?

### Documentation
=========================================================================================== PASSES ===========================================================================================
______________________________________________________________________________ test_power_off_reboot[5-yy39-rp] ______________________________________________________________________________
_____________________________________________________________________________ test_power_off_reboot[15-yy39-rp] ______________________________________________________________________________
------------------------------------------ generated xml file: /run_logs/20590_nightly/platform_tests/test_power_off_reboot_2025-01-30-22-08-39.xml ------------------------------------------
================================================================================== short test summary info ===================================================================================
PASSED platform_tests/test_power_off_reboot.py::test_power_off_reboot[5-yy39-rp]
PASSED platform_tests/test_power_off_reboot.py::test_power_off_reboot[15-yy39-rp]
========================================================================= 2 passed, 1 warning in 2467.92s (0:41:07) ==========================================================================