### PR TITLE
[common - config_reload] Add workaround for 202012 tests to pass

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -44,7 +44,7 @@ def config_force_option_supported(duthost):
 
 
 @ignore_loganalyzer
-def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True, safe_reload=False):
+def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True, safe_reload=False, **kwargs):
     """
     reload SONiC configuration
     :param duthost: DUT host object
@@ -52,6 +52,11 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
     :param wait: wait timeout for DUT to initialize after configuration reload
     :return:
     """
+
+    # kwargs is used in case keyword arguments are provided to this function that do not exist in this version of the function
+    for unused_argument, value in kwargs.items():
+        # Print warning log to assist in debugging these cases
+        logger.warning("Unused argument {} was passed value {}".format(unused_argument, value))
 
     if config_source not in config_sources:
         raise ValueError('invalid config source passed in "{}", must be {}'.format(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Some test cases fail due to passing keyword arguments to this function which don't exist in this branch (as it is old and relatively inactive, it does not receive the most up-to-date cherry picks). Resolving these differences would be quite time consuming and error-prone, as this branch has diverged quite significantly from the master branch.

#### How did you do it?
Added `**kwargs` to the `config_reload` function signature, along with warning logs printing any unhandled keyword arguments (to assist in debugging, in the event that these arguments are required for passing results).

#### How did you verify/test it?
Previously, running `cacl/test_cacl_application.py::test_cacl_acl_loader_commands_internal` threw the following exception:
```
08:30:07 __init__._fixture_generator_decorator    L0089 ERROR  |
TypeError("config_reload() got an unexpected keyword argument 'check_intf_up_ports'",)
Traceback (most recent call last):
  File "/var/src/sonic-mgmt_tbtk5-t0-dx010-4_65a9f3c1abd5cba890cf2075/tests/common/plugins/log_section_start/__init__.py", line 85, in _fixture_generator_decorator
    next(it)
  File "/var/src/sonic-mgmt_tbtk5-t0-dx010-4_65a9f3c1abd5cba890cf2075/tests/cacl/test_cacl_application.py", line 190, in setup_acl_tables
    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
  File "/var/src/sonic-mgmt_tbtk5-t0-dx010-4_65a9f3c1abd5cba890cf2075/tests/common/plugins/loganalyzer/utils.py", line 24, in decorated
    res = func(*args, **kwargs)
TypeError: config_reload() got an unexpected keyword argument 'check_intf_up_ports'
```
After these changes, we are able to run the testcase successfully:
<img width="861" alt="image" src="https://github.com/user-attachments/assets/808b46ab-0964-4261-ab45-e538dcf23f87" />
Additionally, warning logs are thrown containing information about any unused kwargs:
<img width="858" alt="image" src="https://github.com/user-attachments/assets/601fc814-494b-407c-8869-ed6a903c4e91" />

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
