### PR TITLE
[chassis] Reduce timeout for packet chassis

### DIFF
--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.snmp_helpers import get_snmp_facts
+from tests.common.helpers.snmp_helpers import get_snmp_facts, SNMP_DEFAULT_TIMEOUT
 from tests.common.utilities import get_data_acl, recover_acl_rule
 
 try:
@@ -83,9 +83,12 @@ def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cr
 
         pytest_assert(res.is_failed, "SSH did not timeout when expected. {}".format(res.get('msg', '')))
 
+        snmp_timeout = SNMP_DEFAULT_TIMEOUT
+        if duthost.facts['switch_type'] == "chassis-packet":
+            snmp_timeout = 5
         # Ensure we CANNOT gather basic SNMP facts from the device
         res = get_snmp_facts(duthost, localhost, host=dut_mgmt_ip, version='v2c', community=creds['snmp_rocommunity'],
-                             module_ignore_errors=True)
+                             module_ignore_errors=True, snmp_timeout=snmp_timeout)
 
         pytest_assert('ansible_facts' not in res and "No SNMP response received before timeout" in res.get('msg', ''))
 

--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 DEF_WAIT_TIMEOUT = 300
 DEF_CHECK_INTERVAL = 10
+SNMP_DEFAULT_TIMEOUT = 20
 
 global_snmp_facts = {}
 
@@ -24,19 +25,22 @@ def is_snmp_subagent_running(duthost):
     return False
 
 
-def _get_snmp_facts(localhost, host, version, community, is_dell, include_swap, module_ignore_errors):
+def _get_snmp_facts(localhost, host, version, community, is_dell, include_swap, module_ignore_errors,
+                    timeout=SNMP_DEFAULT_TIMEOUT):
     snmp_facts = localhost.snmp_facts(host=host, version=version, community=community, is_dell=is_dell,
-                                      module_ignore_errors=module_ignore_errors, include_swap=include_swap)
+                                      module_ignore_errors=module_ignore_errors, include_swap=include_swap,
+                                      timeout=timeout)
     return snmp_facts
 
 
-def _update_snmp_facts(localhost, host, version, community, is_dell, include_swap, duthost):
+def _update_snmp_facts(localhost, host, version, community, is_dell, include_swap, duthost,
+                       timeout=SNMP_DEFAULT_TIMEOUT):
     global global_snmp_facts
 
     try:
         snmp_subagent_running = is_snmp_subagent_running(duthost)
         global_snmp_facts = _get_snmp_facts(localhost, host, version, community, is_dell, include_swap,
-                                            module_ignore_errors=False)
+                                            module_ignore_errors=False, timeout=timeout)
     except RunAnsibleModuleFail as e:
         logger.info("encountered error when getting snmp facts: {}".format(e))
         global_snmp_facts = {}
@@ -46,14 +50,16 @@ def _update_snmp_facts(localhost, host, version, community, is_dell, include_swa
 
 
 def get_snmp_facts(duthost, localhost, host, version, community, is_dell=False, module_ignore_errors=False,
-                   wait=False, include_swap=False, timeout=DEF_WAIT_TIMEOUT, interval=DEF_CHECK_INTERVAL):
+                   wait=False, include_swap=False, timeout=DEF_WAIT_TIMEOUT, interval=DEF_CHECK_INTERVAL,
+                   snmp_timeout=SNMP_DEFAULT_TIMEOUT):
     if not wait:
-        return _get_snmp_facts(localhost, host, version, community, is_dell, include_swap, module_ignore_errors)
+        return _get_snmp_facts(localhost, host, version, community, is_dell, include_swap, module_ignore_errors,
+                               timeout=snmp_timeout)
 
     global global_snmp_facts
 
     pytest_assert(wait_until(timeout, interval, 0, _update_snmp_facts, localhost, host, version,
-                             community, is_dell, include_swap, duthost), "Timeout waiting for SNMP facts")
+                             community, is_dell, include_swap, duthost, snmp_timeout), "Timeout waiting for SNMP facts")
     return global_snmp_facts
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #30114164

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Fix the cacl test failure on Cisco chassis packet.
#### How did you do it?
Reduce the timeout setting.
#### How did you verify/test it?
Run on physical testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
