### PR TITLE
Fix ExaBGP v4 hang during announce routes stress tests

### DIFF
--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -155,9 +155,19 @@ neighbor {{ peer_ip }} {
 }
 '''
 
-exabgp_supervisord_conf_tmpl = '''\
+# Unlike in ExaBGP V3.x, in V4+ the process API is expected to acknowledge
+# with 'done' or 'error' string back to ExaBGP. Else the pipe becomes blocked
+# and ExaBGP will hang. Alternatively the acknowledgement can be disabled.
+# https://github.com/Exa-Networks/exabgp/wiki/Migration-from-3.4-to-4.x#api
+exabgp_v4_env_tmpl = '''\
+[exabgp.api]
+ack = false
+'''
+
+exabgp_supervisord_conf_tmpl_p1 = '''\
 [program:exabgp-{{ name }}]
-command=/usr/local/bin/exabgp /etc/exabgp/{{ name }}.conf
+'''
+exabgp_supervisord_conf_tmpl_p3 = '''\
 stdout_logfile=/tmp/exabgp-{{ name }}.out.log
 stderr_logfile=/tmp/exabgp-{{ name }}.err.log
 stdout_logfile_maxbytes=10000000
@@ -169,6 +179,12 @@ autostart=true
 autorestart=true
 startsecs=1
 numprocs=1
+'''
+exabgp_supervisord_conf_tmpl_p2_v3 = '''\
+command=/usr/local/bin/exabgp /etc/exabgp/{{ name }}.conf
+'''
+exabgp_supervisord_conf_tmpl_p2_v4 = '''\
+command=/usr/local/bin/exabgp -e /etc/exabgp/exabgp.env /etc/exabgp/{{ name }}.conf
 '''
 
 
@@ -259,6 +275,15 @@ def setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn, peer_asn, p
         out_file.write(data)
 
 
+def setup_exabgp_env():
+    try:
+        os.mkdir("/etc/exabgp", 0o755)
+    except OSError:
+        pass
+    with open("/etc/exabgp/exabgp.env", 'w') as out_file:
+        out_file.write(exabgp_v4_env_tmpl)
+
+
 def remove_exabgp_conf(name):
     try:
         os.remove("/etc/exabgp/%s.conf" % name)
@@ -267,6 +292,15 @@ def remove_exabgp_conf(name):
 
 
 def setup_exabgp_supervisord_conf(name):
+    exabgp_supervisord_conf_tmpl = None
+    if six.PY2:
+        exabgp_supervisord_conf_tmpl = exabgp_supervisord_conf_tmpl_p1 + \
+            exabgp_supervisord_conf_tmpl_p2_v3 + \
+            exabgp_supervisord_conf_tmpl_p3
+    else:
+        exabgp_supervisord_conf_tmpl = exabgp_supervisord_conf_tmpl_p1 + \
+            exabgp_supervisord_conf_tmpl_p2_v4 + \
+            exabgp_supervisord_conf_tmpl_p3
     t = jinja2.Template(exabgp_supervisord_conf_tmpl)
     data = t.render(name=name)
     with open("/etc/supervisor/conf.d/exabgp-%s.conf" % name, 'w') as out_file:
@@ -318,6 +352,8 @@ def main():
     passive = module.params['passive']
 
     setup_exabgp_processor()
+    if not six.PY2:
+        setup_exabgp_env()
 
     result = {}
     try:


### PR DESCRIPTION
### Description of PR

The docker-ptf PY3 only image uses ExaBGP v4. The ExaBGP v4+ requires process API to acknowledge messages from ExaBGP else the server blocks after a while and hangs. This causes BGP timeouts in our stress tests. This PR fixes the issue.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

Not applicable to backport since it only applies to docker-ptf PY3 only image.

### Approach
#### What is the motivation for this PR?

The docker-ptf PY3 only image uses ExaBGP v4. The ExaBGP v4+ requires process API to acknowledge messages from ExaBGP else the server blocks after a while and hangs. This causes BGP timeouts in our stress tests. This PR fixes the issue.

#### How did you do it?

Set exabgp.api.ack to false.

#### How did you verify/test it?

Ran tests/stress/test_stress_routes.py on 7050cx3 to confirm.

#### Any platform specific information?

No

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA