### PR TITLE
[snappi]: Fix for rx_l1_rate_gbps index error issue in traffic_generation file.

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -922,7 +922,7 @@ def tgen_curr_stats(traf_metrics, flow_metrics, data_flow_names):
         stats[metric_name+'_txrate_Gbps'] = tx_rate_gbps
         stats[metric_name+'_rxrate_fps'] = float(metric['Rx Frame Rate'])
         stats[metric_name+'_rxrate_Gbps'] = rx_rate_gbps
-        stats[metric_name+'_LI_rxrate_Gbps'] = float(metric['Rx L1 Rate (Gbps)'])
+        stats[metric_name+'_Rx_L1_Rate_bps'] = float(metric['Rx L1 Rate (bps)'])
 
     for metric in flow_metrics:
         if metric.name not in data_flow_names:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The metric 'Rx_L1_rate_Gbps' is picked from traffic item statistics. However, in 10.80, this is not working causing index error.

Switching it to Rx_L1_rate_bps in the statistics file.

Fixes # (issue)
#16731

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Resolving index error in the traffic item statistics. Instead of capturing Gbps rates, which no longer exists, switched to bps rates.

#### How did you do it?
Single line of code:
```
stats[metric_name+'_Rx_L1_Rate_bps'] = float(metric['Rx L1 Rate (bps)'])
```

#### How did you verify/test it?
Local clone.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
