### PR TITLE
fix: pfc timer accuracy timestamp regex

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -351,7 +351,7 @@ class TestPfcwdAllTimer(object):
 
             # Regular expressions for the two timestamp formats
             regex1 = re.compile(r'^[A-Za-z]{3} \d{2} \d{2}:\d{2}:\d{2}\.\d{6}')
-            regex2 = re.compile(r'^\d{4} [A-Za-z]{3} \d{2} \d{2}:\d{2}:\d{2}\.\d{6}')
+            regex2 = re.compile(r'^\d{4} [A-Za-z]{3}\s{1,2}\d{1,2} \d{2}:\d{2}:\d{2}\.\d{6}')
 
             if regex1.match(syslog_msg):
                 timestamp = syslog_msg.replace('  ', ' ').split(' ')[2]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 31202914

From #16446 we are changing to use regex to capture the timestamp for pfc timer accuracy. However, the regex does not cover the scenario where date digit is 1. For example: `2025 Jan  5 00:53:14.103188 `



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Comparing between:
- `2025 Jan 26 17:36:31.27789`
- `2025 Feb  2 15:17:24.055182`

We can see that we might need up to 2 spaces after month and the number of day digits can vary between 1 to 2.
#### How did you do it?
Adjust the regex so it matches for both format

#### How did you verify/test it?

![image](https://github.com/user-attachments/assets/31a72bdd-bed8-4b01-80d9-fc2e8366ac2c)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
