### PR TITLE
cisco platform-specific timeout update

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -245,6 +245,14 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     """
     pool = ThreadPool()
     hostname = duthost.hostname
+    # This is how you get platform info from the DUT
+    platform = duthost.facts['platform']  # This is how you get platform info from the DUT
+
+    # Apply the platform-specific timeout update
+    if platform == 'x86_64-8102_28fh_dpu_o-r0':
+        for reboot_type in reboot_ctrl_dict:
+            reboot_ctrl_dict[reboot_type]["timeout"] = 700
+            reboot_ctrl_dict[reboot_type]["wait"] = 300
     try:
         tc_name = os.environ.get('PYTEST_CURRENT_TEST').split(' ')[0]
         plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, tc_name, reboot_type)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
New cisco platform  x86_64-8102_28fh_dpu_o-r0' reboot timeout fix.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: New cisco platform  x86_64-8102_28fh_dpu_o-r0' reboot timeout fix.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ X] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X ] 202405
- [ ] 202411

### Approach
added new code under b/tests/common/reboot.py , the code only will execute for cisco platform x86_64-8102_28fh_dpu_o-r0.
#### What is the motivation for this PR?
Need reboot fix to execute sonic-mgmt runs on new cisco platform "x86_64-8102_28fh_dpu_o-r0"

#### How did you do it?
added new code under b/tests/common/reboot.py 

#### How did you verify/test it?
verified using below reboot test case and sure new new code got executed.
test_pretest.py::test_features_state
#### Any platform specific information?
cisco platform "x86_64-8102_28fh_dpu_o-r0"
#### Supported testbed topology if it's a new test case?
t1-28-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
