### PR TITLE
Add module as an input parameter for gnoi_request.

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -406,7 +406,7 @@ def gnoi_reboot(duthost, method, delay, message):
         return 0, output['stdout']
 
 
-def gnoi_request(duthost, localhost, rpc, request_json_data):
+def gnoi_request(duthost, localhost, module, rpc, request_json_data):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     ip = duthost.mgmt_ip
     port = env.gnmi_port
@@ -414,7 +414,7 @@ def gnoi_request(duthost, localhost, rpc, request_json_data):
     cmd += "-cert /etc/sonic/telemetry/gnmiclient.crt "
     cmd += "-key /etc/sonic/telemetry/gnmiclient.key "
     cmd += "-ca /etc/sonic/telemetry/gnmiCA.pem "
-    cmd += "-logtostderr -rpc {} ".format(rpc)
+    cmd += "-logtostderr -module {} -rpc {} ".format(module, rpc)
     cmd += f'-jsonin \'{request_json_data}\''
     output = duthost.shell(cmd, module_ignore_errors=True)
     if output['stderr']:

--- a/tests/gnmi/test_gnoi_killprocess.py
+++ b/tests/gnmi/test_gnoi_killprocess.py
@@ -33,14 +33,14 @@ def test_gnoi_killprocess_then_restart(duthosts, rand_one_dut_hostname, localhos
         pytest.skip("{} is not running".format(process))
 
     request_kill_json_data = '{{"name": "{}", "signal": 1}}'.format(process)
-    ret, msg = gnoi_request(duthost, localhost, "KillProcess", request_kill_json_data)
+    ret, msg = gnoi_request(duthost, localhost, "System", "KillProcess", request_kill_json_data)
     if is_valid:
         pytest_assert(ret == 0, "KillProcess API unexpectedly reported failure")
         pytest_assert(not is_container_running(duthost, process),
                       "{} found running after KillProcess reported success".format(process))
 
         request_restart_json_data = '{{"name": "{}", "restart": true, "signal": 1}}'.format(process)
-        ret, msg = gnoi_request(duthost, localhost, "KillProcess", request_restart_json_data)
+        ret, msg = gnoi_request(duthost, localhost, "System",  "KillProcess", request_restart_json_data)
         pytest_assert(ret == 0,
                       "KillProcess API unexpectedly reported failure when attempting to restart {}".format(process))
         pytest_assert(duthost.is_host_service_running(process),
@@ -61,7 +61,7 @@ def test_gnoi_killprocess_then_restart(duthosts, rand_one_dut_hostname, localhos
 def test_gnoi_killprocess_restart(duthosts, rand_one_dut_hostname, localhost, request_restart_value, is_valid):
     duthost = duthosts[rand_one_dut_hostname]
     request_json_data = f'{{"name": "snmp", "restart": {request_restart_value}, "signal": 1}}'
-    ret, msg = gnoi_request(duthost, localhost, "KillProcess", request_json_data)
+    ret, msg = gnoi_request(duthost, localhost, "System", "KillProcess", request_json_data)
     if is_valid:
         pytest_assert(ret == 0, "KillProcess API unexpectedly reported failure")
         pytest_assert(is_container_running(duthost, "snmp"),
@@ -76,7 +76,7 @@ def test_gnoi_killprocess_restart(duthosts, rand_one_dut_hostname, localhost, re
 def test_invalid_signal(duthosts, rand_one_dut_hostname, localhost):
     duthost = duthosts[rand_one_dut_hostname]
     request_json_data = '{"name": "snmp", "restart": true, "signal": 2}'
-    ret, msg = gnoi_request(duthost, localhost, "KillProcess", request_json_data)
+    ret, msg = gnoi_request(duthost, localhost, "System", "KillProcess", request_json_data)
     pytest_assert(ret != 0, "KillProcess API unexpectedly succeeded with invalid request parameters")
     pytest_assert("KillProcess only supports SIGNAL_TERM (option 1)" in msg,
                   "Unexpected error message in response to invalid gNOI request")

--- a/tests/gnmi/test_gnoi_system.py
+++ b/tests/gnmi/test_gnoi_system.py
@@ -23,7 +23,7 @@ def test_gnoi_system_time(duthosts, rand_one_dut_hostname, localhost):
     duthost = duthosts[rand_one_dut_hostname]
 
     # Get current time
-    ret, msg = gnoi_request(duthost, localhost, "Time", "")
+    ret, msg = gnoi_request(duthost, localhost, "System", "Time", "")
     pytest_assert(ret == 0, "System.Time API reported failure (rc = {}) with message: {}".format(ret, msg))
     logging.info("System.Time API returned msg: {}".format(msg))
     # Message should contain a json substring like this {"time":1735921221909617549}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add module as an input parameter for gnoi_request. Previously it implicitly rely on "gnoi_client" having a “-module" flag with
default value "System". This change make it possible to use other module like "OS."


Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
Add module as a parameter to gnoi_request.
#### What is the motivation for this PR?
Support other module parameter value.

#### How did you do it?
Add module as a parameter to gnoi_request.


#### How did you verify/test it?
On KVM: gnmi:test_gnoi_system.py.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
