### PR TITLE
Add filtering to skip two new check items for voq chassis in sanity check

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -127,8 +127,6 @@ def filter_check_items(tbinfo, duthosts, check_items):
     if 't2' not in tbinfo['topo']['name'] or _is_voq_chassis(duthosts):
         if 'check_bfd_up_count' in filtered_check_items:
             filtered_check_items.remove('check_bfd_up_count')
-
-    if 't2' not in tbinfo['topo']['name']:
         if 'check_mac_entry_count' in filtered_check_items:
             filtered_check_items.remove('check_mac_entry_count')
 

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -108,7 +108,7 @@ def print_logs(duthosts, ptfhost, print_dual_tor_logs=False):
         logger.info("dut={}, cmd_outputs={}".format(dut.hostname, json.dumps(outputs, indent=4)))
 
 
-def filter_check_items(tbinfo, check_items):
+def filter_check_items(tbinfo, duthosts, check_items):
     filtered_check_items = copy.deepcopy(check_items)
 
     # ignore BGP check for particular topology type
@@ -118,9 +118,17 @@ def filter_check_items(tbinfo, check_items):
     if 'dualtor' not in tbinfo['topo']['name'] and 'check_mux_simulator' in filtered_check_items:
         filtered_check_items.remove('check_mux_simulator')
 
-    if 't2' not in tbinfo['topo']['name']:
+    def _is_voq_chassis(duthosts):
+        for duthost in duthosts:
+            if duthost.facts['switch_type'] == "voq":
+                return True
+        return False
+
+    if 't2' not in tbinfo['topo']['name'] or _is_voq_chassis(duthosts):
         if 'check_bfd_up_count' in filtered_check_items:
             filtered_check_items.remove('check_bfd_up_count')
+
+    if 't2' not in tbinfo['topo']['name']:
         if 'check_mac_entry_count' in filtered_check_items:
             filtered_check_items.remove('check_mac_entry_count')
 
@@ -255,7 +263,7 @@ def sanity_check_full(ptfhost, prepare_parallel_run, localhost, duthosts, reques
         cli_items_list = str(cli_check_items).split(',')
         pre_check_items = _update_check_items(pre_check_items, cli_items_list, SUPPORTED_CHECKS)
 
-    pre_check_items = filter_check_items(tbinfo, pre_check_items)  # Filter out un-supported checks.
+    pre_check_items = filter_check_items(tbinfo, duthosts, pre_check_items)  # Filter out un-supported checks.
 
     if post_check:
         # Prepare post test check items based on the collected pre test check items.
@@ -271,7 +279,7 @@ def sanity_check_full(ptfhost, prepare_parallel_run, localhost, duthosts, reques
             cli_post_items_list = str(cli_post_check_items).split(',')
             post_check_items = _update_check_items(post_check_items, cli_post_items_list, SUPPORTED_CHECKS)
 
-        post_check_items = filter_check_items(tbinfo, post_check_items)  # Filter out un-supported checks.
+        post_check_items = filter_check_items(tbinfo, duthosts, post_check_items)  # Filter out un-supported checks.
     else:
         post_check_items = set()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: "check_bfd_up_count" and "check_mac_entry_count" does not work on voq chassis, so we should skip it.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
