### PR TITLE
fix: remove comma before converting

### DIFF
--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -66,7 +66,7 @@ def ensure_no_l3_drops(duthost, packets_count):
     unexpected_drops = {}
     for iface, value in list(intf_l3_counters.items()):
         try:
-            rx_err_value = int(value[RX_ERR])
+            rx_err_value = int(value[RX_ERR].replace(",", ""))
         except ValueError as err:
             logger.info("Unable to verify L3 drops on iface {}, L3 counters may not be supported on this platform\n{}"
                         .format(iface, err))
@@ -83,7 +83,7 @@ def ensure_no_l2_drops(duthost, packets_count):
     unexpected_drops = {}
     for iface, value in list(intf_l2_counters.items()):
         try:
-            rx_drp_value = int(value[RX_DRP])
+            rx_drp_value = int(value[RX_DRP].replace(",", ""))
         except ValueError as err:
             logger.warning("Unable to verify L2 drops on iface {}\n{}".format(iface, err))
             continue


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Remove the comma(s) before converting the string to an integer in drop counter test to avoid getting "invalid literal for int() with base 10" warnings.

Summary:
Fixes # (issue) Microsoft ADO 30056122

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
We are getting several "invalid literal for int() with base 10" warnings in `drop_packets/test_drop_counters.py`, and the reason is that there might be one or more commas in string representation of a number, e.g. "1,000". Therefore, we need to remove the comma(s) before converting.

![image](https://github.com/user-attachments/assets/8722438f-7764-4310-b9f5-c7f100c1073b)

![image](https://github.com/user-attachments/assets/b5375f21-b35b-43e8-9fc9-7718e8d21529)


#### How did you do it?

#### How did you verify/test it?
I ran the updated code and can confirm it's working well.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
