### PR TITLE
Xfail qos/test_qos_dscp_mapping.py for all Cisco-8122 platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1683,10 +1683,10 @@ qos/test_pfc_pause.py::test_pfc_pause_lossless:
 
 qos/test_qos_dscp_mapping.py:
   xfail:
-    reason: "ECN marking in combination with tunnel decap not yet supported"
+    reason: "ECN marking in combination with tunnel decap not yet supported in all Cisco 8122 platforms"
     strict: True
     conditions:
-      - "asic_type in ['cisco-8000'] and platform in ['x86_64-8122_64eh_o-r0']"
+      - "asic_type in ['cisco-8000'] and platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
 
 qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to_queue_mapping_pipe_mode:
   skip:


### PR DESCRIPTION
**Description of PR**
**Summary:**
Xfail qos/test_qos_dscp_mapping.py for Cisco-8122.(Both x86_64-8122_64eh_o-r0 and x86_64-8122_64ehf_o-r0)

**Type of change**
Bug fix

**Back port request**
202405

**Approach**

**What is the motivation for this PR?**
This test uses ECT bit marked packets in combination with tunnel decap. ECT bit preservation is not yet supported on Cisco-8122.

**How did you do it?**
Testcase is already XFAIL for x86_64-8122_64eh_o-r0. Marking it as XFAIL on x86_64-8122_64ehf_o-r0 as well

**How did you verify/test it?**
Verified on 8122 x86_64-8122_64ehf_o-r0 platform that it reports an xfail.

**Any platform specific information?**
Cisco-8122 only.