### PR TITLE
Pfcwd multi port: Fix for Multi-asic Scenario and test_multi_port Requirement of 3 routed ports

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -85,7 +85,10 @@ def update_t1_test_ports(duthost, mg_facts, test_ports, tbinfo):
     Find out active IP interfaces and use the list to
     remove inactive ports from test_ports
     """
-    ip_ifaces = duthost.get_active_ip_interfaces(tbinfo, asic_index=0)
+    ip_ifaces = {}
+    for asic in duthost.asics:
+        ip_int = duthost.get_active_ip_interfaces(tbinfo, asic_index=asic.asic_index)
+        ip_ifaces.update(ip_int)
     port_list = []
     for iface in list(ip_ifaces.keys()):
         if iface.startswith("PortChannel"):

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -986,6 +986,9 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         # wait time before we check the logs for the 'restore' signature. 'pfc_wd_restore_time_large' is in ms.
         self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)
         self.ports = setup_info['selected_test_ports']
+        rx_ports = {rp for pi in self.ports.values() for rp in
+                    (pi["rx_port"] if isinstance(pi["rx_port"], (list, tuple)) else [pi["rx_port"]])}
+        self.ports = {p: pi for p, pi in self.ports.items() if p not in rx_ports}
         selected_ports = list(self.ports.keys())[:2]
         self.test_ports_info = setup_info['test_ports']
         pytest_require(len(selected_ports) == 2, 'Pfcwd multi port test needs at least 2 ports')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. Updated the test case logic to include active interfaces from all available ASICs, preventing unnecessary skips.  
2. Ensured that the multi-port test case selects an appropriate RX port for the second port, avoiding the use of an already stormed port.

 
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/16777

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Failure of the Test Case of test_pfcwd_multi_port on min topology because of the rx port selection of stormed port and on max topo because of not including all the active interfaces on both the basics

https://github.com/sonic-net/sonic-mgmt/issues/16777

#### How did you do it?
Add the scope of using the Active interfaces from all the ASIC.
Added the requirement of not to use the RX which is going to be stormed 

#### How did you verify/test it?.
Verified on t2 voq chassis on min and max topo

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
