### PR TITLE
Cherry-pick conflict #16773

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -269,7 +269,8 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     # Create a temporary file in tmpfs before reboot
     logger.info('DUT {} create a file /dev/shm/test_reboot before rebooting'.format(hostname))
     duthost.command('sudo touch /dev/shm/test_reboot')
-
+    # Get reboot-cause history before reboot
+    prev_reboot_cause_history = duthost.show_and_parse("show reboot-cause history")
     reboot_res, dut_datetime = perform_reboot(duthost, pool, reboot_command, reboot_helper, reboot_kwargs, reboot_type)
 
     wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res)
@@ -319,9 +320,16 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     # some device does not have onchip clock and requires obtaining system time a little later from ntp
     # or SUP to obtain the correct time so if the uptime is less than original device time, it means it
     # is most likely due to this issue which we can wait a little more until the correct time is set in place.
-    if float(dut_uptime.strftime("%s")) < float(dut_datetime.strftime("%s")):
-        logger.info('DUT {} timestamp went backwards'.format(hostname))
-        wait_until(120, 5, 0, positive_uptime, duthost, dut_datetime)
+
+    # Use an alternative reboot check if T2 device and REBOOT_TYPE_POWEROFF
+    if duthost.get_facts().get("modular_chassis") and reboot_type == REBOOT_TYPE_POWEROFF:
+        wait_until(120, 5, 0, duthost.critical_processes_running, "database")
+        curr_reboot_cause_history = duthost.show_and_parse("show reboot-cause history")
+        pytest_assert(prev_reboot_cause_history != curr_reboot_cause_history, "No new input into history-queue")
+    else:
+        if float(dut_uptime.strftime("%s")) < float(dut_datetime.strftime("%s")):
+            logger.info('DUT {} timestamp went backwards'.format(hostname))
+            wait_until(120, 5, 0, positive_uptime, duthost, dut_datetime)
 
     dut_uptime = duthost.get_up_time()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Cherry-pick #16773 conflict


Summary: 

When executing `show reboot-cause history`, swss needs to access `/var/run/redis/sonic-db/database_config.json` we're dependent on the database service to boot up.

Without waiting for this service to boot up we might run into runtime error:

```
/usr/local/lib/python3.8/dist-packages/_pytest/main.py:305: PluggyTeardownRaisedWarning: A plugin raised an exception during an old-style hookwrapper teardown.
Plugin: terminalreporter, Hook: pytest_sessionfinish
KeyboardInterrupt: 
For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning
  config.hook.pytest_sessionfinish(
Traceback (most recent call last):
  File "/var/src/sonic-mgmt-int/tests/platform_tests/test_power_off_reboot.py", line 118, in test_power_off_reboot
    reboot_and_check(
  File "/var/src/sonic-mgmt-int/tests/platform_tests/test_reboot.py", line 86, in reboot_and_check
    reboot(dut, localhost, reboot_type=reboot_type,
  File "/var/src/sonic-mgmt-int/tests/common/plugins/loganalyzer/utils.py", line 24, in decorated
    res = func(*args, **kwargs)
  File "/var/src/sonic-mgmt-int/tests/common/reboot.py", line 341, in reboot
    curr_reboot_cause_history = duthost.show_and_parse("show reboot-cause history")
  File "/var/src/sonic-mgmt-int/tests/common/devices/multi_asic.py", line 136, in _run_on_asics
    return getattr(self.sonichost, self.multi_asic_attr)(*module_args, **complex_args)
  File "/var/src/sonic-mgmt-int/tests/common/devices/sonic.py", line 1687, in show_and_parse
    output = self.shell(show_cmd, **kwargs)["stdout_lines"]
  File "/var/src/sonic-mgmt-int/tests/common/devices/base.py", line 131, in _run
    raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
tests.common.errors.RunAnsibleModuleFail: run module shell failed, Ansible Results =>
failed = True
changed = True
rc = 1
cmd = show reboot-cause history
start = 2025-02-04 03:50:33.469088
end = 2025-02-04 03:50:33.934749
delta = 0:00:00.465661
msg = non-zero return code
invocation = {'module_args': {'_raw_params': 'show reboot-cause history', '_uses_shell': True, 'warn': False, 'stdin_add_newline': True, 'strip_empty_ends': True, 'argv': None, 'chdir': None, 'executable': None, 'creates': None, 'removes': None, 'stdin': None}}
_ansible_no_log = None
stdout =
stderr =
Traceback (most recent call last):
  File "/usr/local/bin/show", line 5, in <module>
    from show.main import cli
  File "/usr/local/lib/python3.11/dist-packages/show/main.py", line 325, in <module>
    if is_gearbox_configured():
       ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/show/main.py", line 265, in is_gearbox_configured
    app_db = SonicV2Connector()
             ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 2066, in __init__
    for db_name in self.get_db_list():
                   ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 2003, in get_db_list
    return _swsscommon.SonicV2Connector_Native_get_db_list(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Sonic database config file doesn't exist at /var/run/redis/sonic-db/database_config.json
```

Fixes # (issue)31217914

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

Explained above

#### How did you do it?

Simply wait for database service is ready before executing the command

#### How did you verify/test it?

Verified on T2 testbed together with #16772 

![image](https://github.com/user-attachments/assets/60a385a7-6cd3-428d-82b6-991dbe3faa81)


