### PR TITLE
Transition multi_asic_t1 PR checker to impacted area-based PR checker

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -284,5 +284,6 @@ stages:
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
+          NUM_ASIC: 4
           KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           MGMT_BRANCH: "master"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -261,7 +261,7 @@ stages:
           KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           MGMT_BRANCH: "master"
 
-  # This PR checker aims to run all t1 test scripts on multi asic topology.
+  # This PR checker aims to run all t1 test scripts on multi-asic topology.
   - job: impacted_area_multi_asic_t1_elastictest
     displayName: "impacted-area-kvmtest-multi_asic_t1 by Elastictest - optional"
     dependsOn: get_impacted_area

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -261,20 +261,28 @@ stages:
           KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           MGMT_BRANCH: "master"
 
-# Below is the original PR checkers
-  - job: onboarding_multi_asic_elastictest_t1
-    displayName: "onboarding t1 testcases for kvmtest-multi-asic-t1-lag by Elastictest - optional"
+  # This PR checker aims to run all t1 test scripts on multi asic topology.
+  - job: impacted_area_multi_asic_t1_elastictest
+    displayName: "impacted-area-kvmtest-multi_asic_t1 by Elastictest - optional"
+    dependsOn: get_impacted_area
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker')
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
     timeoutInMinutes: 240
     continueOnError: true
     pool: sonic-ubuntu-1c
     steps:
+      - template: .azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+        parameters:
+          TOPOLOGY: t1
+          BUILD_BRANCH: $(BUILD_BRANCH)
+
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: t1-8-lag
           STOP_ON_FAILURE: "False"
-          TEST_SET: onboarding_t1_multi_asic
-          MIN_WORKER: $(T1_MULTI_ASIC_ONBOARDING_INSTANCE_NUM)
-          MAX_WORKER: $(T1_MULTI_ASIC_ONBOARDING_INSTANCE_NUM)
-          NUM_ASIC: 4
+          SCRIPTS: $(SCRIPTS)
+          MIN_WORKER: $(INSTANCE_NUMBER)
+          MAX_WORKER: $(INSTANCE_NUMBER)
           KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           MGMT_BRANCH: "master"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In this PR, we transition the multi_asic_t1 PR checker to impacted area-based PR checker, enabling automatic selection of test scripts using pytest marks.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
In this PR, we transition the multi_asic_t1 PR checker to impacted area-based PR checker, enabling automatic selection of test scripts using pytest marks.

#### How did you do it?
Transition the multi_asic_t1 PR checker to impacted area-based PR checker,

#### How did you verify/test it?
Test by pipeline itself.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
