### PR TITLE
Add support for configurable container registry for cEOS net base image

### DIFF
--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -109,7 +109,7 @@
   become: yes
   docker_container:
     name: net_{{ vm_set_name }}_{{ vm_name }}
-    image: debian:jessie
+    image: "{{ docker_registry_host }}/debian:jessie"
     pull: no
     state: started
     restart: no


### PR DESCRIPTION
### Description of PR

PR adds ability to use configured container registry for cEOS net base containers instead of using the default (DockerHub). DockerHub throttles the number of pulls leading to error "toomanyrequests: You have reached your pull rate limit...". The PR CI and test environments use Azure container registry.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

PR adds ability to use configured container registry for cEOS net base containers instead of using the default (DockerHub). DockerHub throttles the number of pulls leading to error "toomanyrequests: You have reached your pull rate limit...". The PR CI and test environments use Azure container registry.

#### How did you do it?

Specify the container registry for the image.

#### How did you verify/test it?

Ran add-topo on test environments.

#### Any platform specific information?

No

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA