### PR TITLE
Update acl script to permit nic simulator path under dualtor scenario

### DIFF
--- a/tests/acl/templates/acltb_test_rules_part_1.j2
+++ b/tests/acl/templates/acltb_test_rules_part_1.j2
@@ -125,7 +125,7 @@
                                         "destination-port": "179"
                                     }
                                 }
-                            },
+                            }{% if is_dualtor == "yes" %},
                             "29": {
                                 "actions": {
                                     "config": {
@@ -140,7 +140,23 @@
                                         "destination-ip-address": "{{ loopback_ip }}/32"
                                     }
                                 }
+                            },
+                            "30": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 30
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "{{ loopback_ip_nic }}/32"
+                                    }
+                                }
                             }
+                            {% endif %}
                         }
                     }
                 }

--- a/tests/acl/templates/acltb_test_rules_part_2.j2
+++ b/tests/acl/templates/acltb_test_rules_part_2.j2
@@ -510,7 +510,7 @@
                                         "destination-ip-address": "192.168.0.122/32"
                                     }
                                 }
-                            },
+                            }{% if is_dualtor == "yes" %},
                             "34": {
                                 "actions": {
                                     "config": {
@@ -525,7 +525,23 @@
                                         "destination-ip-address": "{{ loopback_ip }}/32"
                                     }
                                 }
+                            },
+                            "35": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 35
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "{{ loopback_ip_nic }}/32"
+                                    }
+                                }
                             }
+                            {% endif %}
                         }
                     }
                 }

--- a/tests/acl/templates/acltb_test_rules_permit_loopback.j2
+++ b/tests/acl/templates/acltb_test_rules_permit_loopback.j2
@@ -510,7 +510,7 @@
                                         "destination-ip-address": "192.168.0.122/32"
                                     }
                                 }
-                            },
+                            }{% if is_dualtor == "yes" %},
                             "34": {
                                 "actions": {
                                     "config": {
@@ -525,7 +525,23 @@
                                         "destination-ip-address": "{{ loopback_ip }}/32"
                                     }
                                 }
+                            },
+                            "35": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 35
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "{{ loopback_ip_nic }}/32"
+                                    }
+                                }
                             }
+                            {% endif %}
                         }
                     }
                 }


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Permit gRPC path for nic simulator in dualtor active active setup for mellanox platform

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
At mellanox platform, in dualtor active-active setup, gRPC path for NIC simulator should be permited by acl rules.
#### How did you do it?
Permit the destination IP address of gRPC path, which is the loopback ip address choosen for NIC simulator.
#### How did you verify/test it?
Run it in internal regression
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
