### PR TITLE
Adding workaround for acl table creation failure in dhcp_relay

### DIFF
--- a/tests/dhcp_relay/test_dhcp_pkt_recv.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_recv.py
@@ -103,6 +103,21 @@ class Dhcpv6PktRecvBase:
             testutils.send_packet(ptfadapter, pkt=req_pkt, port_id=ptf_port_id)
 
 
+def remove_existing_acl_table(duthost, TABLE_NAME):
+    # Show ACL Table
+    logging.info(f"show acl table {TABLE_NAME}")
+    lines = duthost.shell(cmd=f"show acl table {TABLE_NAME}")['stdout_lines']
+    acl_existing = False
+    for line in lines:
+        if TABLE_NAME in line:
+            acl_existing = True
+            break
+    if acl_existing:
+        # Removing ACL table
+        logging.info(f"Remove ACL Table : {TABLE_NAME}")
+        duthost.shell(cmd=f"config acl remove table {TABLE_NAME}")
+
+
 class TestDhcpv6WithEmptyAclTable(Dhcpv6PktRecvBase):
     """
     Test the DUT with empty ACL table
@@ -112,6 +127,7 @@ class TestDhcpv6WithEmptyAclTable(Dhcpv6PktRecvBase):
         duthost = rand_selected_dut
         ptf_indices, dut_intf_ptf_index = setup_teardown
         ptf_intfs = [intf for intf, index in dut_intf_ptf_index.items() if index in ptf_indices]
+        remove_existing_acl_table(duthost, TABLE_NAME="EVERFLOW")
         acl_table_name = ACL_TABLE_NAME_DHCPV6_PKT_RECV_TEST
         duthost.add_acl_table(
             table_name=acl_table_name,
@@ -135,6 +151,7 @@ class TestDhcpv6WithMulticastAccpectAcl(Dhcpv6PktRecvBase):
         duthost = rand_selected_dut
         ptf_indices, dut_intf_ptf_index = setup_teardown
         ptf_intfs = [intf for intf, index in dut_intf_ptf_index.items() if index in ptf_indices]
+        remove_existing_acl_table(duthost, TABLE_NAME="EVERFLOW")
         acl_table_name = ACL_TABLE_NAME_DHCPV6_PKT_RECV_TEST
         duthost.add_acl_table(
             table_name=acl_table_name,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

The test cases TestDhcpv6WithEmptyAclTable and TestDhcpv6WithMulticastAcceptAcl may fail due to the ACL_TABLE_NAME_DHCPV6_PKT_RECV_TEST table creation failure If there is no enough TCAM space available.

- Fix Implemented:

To resolve this issue, the test case has been modified to remove an existing ACL table before creating ACL_TABLE_NAME_DHCPV6_PKT_RECV_TEST.

-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
