### PR TITLE
Adjust TSA-TSB related sonic-mgmt testcases

### DIFF
--- a/tests/bgp/test_reliable_tsa.py
+++ b/tests/bgp/test_reliable_tsa.py
@@ -1002,7 +1002,7 @@ def test_sup_tsa_act_with_sup_reboot(duthosts, localhost, enum_supervisor_dut_ho
             if not (int_status_result[lc] and crit_process_check[lc] and
                     TS_NORMAL == get_traffic_shift_state(lc, cmd='TSC no-stats')):
                 logging.info("DUT is not in normal state after supervisor cold reboot, doing config-reload")
-                config_reload(lc, safe_reload=True, check_intf_up_ports=True)
+                config_reload(lc, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         # Make sure linecards are in Normal state, if not do config-reload on the dut
         with SafeThreadPoolExecutor(max_workers=8) as executor:
@@ -1230,7 +1230,7 @@ def test_dut_tsa_act_with_reboot_when_sup_dut_on_tsb_init(duthosts, localhost, e
             if not (int_status_result[lc] and crit_process_check[lc] and
                     TS_NORMAL == get_traffic_shift_state(lc, cmd='TSC no-stats')):
                 logging.info("DUT is not in normal state after supervisor cold reboot, doing config-reload")
-                config_reload(lc, safe_reload=True, check_intf_up_ports=True)
+                config_reload(lc, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         # Make sure linecards are in Normal state, if not do config-reload on the dut to recover
         with SafeThreadPoolExecutor(max_workers=8) as executor:
@@ -1613,7 +1613,7 @@ def test_sup_tsa_when_startup_tsa_tsb_service_running(duthosts, localhost, enum_
             if not (int_status_result[lc] and crit_process_check[lc] and
                     TS_NORMAL == get_traffic_shift_state(lc, cmd='TSC no-stats')):
                 logging.info("DUT is not in normal state after supervisor cold reboot, doing config-reload")
-                config_reload(lc, safe_reload=True, check_intf_up_ports=True)
+                config_reload(lc, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         # Make sure linecards are in Normal state, if not do config-reload on the dut to recover
         with SafeThreadPoolExecutor(max_workers=8) as executor:
@@ -1723,7 +1723,7 @@ def test_sup_tsb_when_startup_tsa_tsb_service_running(duthosts, localhost, enum_
             if not (int_status_result and crit_process_check and
                     TS_NORMAL == get_traffic_shift_state(lc, cmd='TSC no-stats')):
                 logging.info("DUT is not in normal state after supervisor cold reboot, doing config-reload")
-                config_reload(lc, safe_reload=True, check_intf_up_ports=True)
+                config_reload(lc, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
             for linecard in duthosts.frontend_nodes:

--- a/tests/bgp/test_startup_tsa_tsb_service.py
+++ b/tests/bgp/test_startup_tsa_tsb_service.py
@@ -332,7 +332,7 @@ def test_tsa_tsb_service_with_dut_cold_reboot(request, duthosts, localhost, nbrh
                 )
 
                 logging.info("DUT is not in normal state after cold reboot, doing config-reload")
-                config_reload(lc, safe_reload=True, check_intf_up_ports=True)
+                config_reload(lc, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
             for linecard in frontend_nodes_per_hwsku:
@@ -481,7 +481,7 @@ def test_tsa_tsb_service_with_dut_abnormal_reboot(request, duthosts, localhost, 
                 )
 
                 logging.info("DUT is not in normal state after abnormal reboot, doing config-reload")
-                config_reload(lc, safe_reload=True, check_intf_up_ports=True)
+                config_reload(lc, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
             for linecard in frontend_nodes_per_hwsku:
@@ -625,7 +625,7 @@ def test_tsa_tsb_service_with_supervisor_cold_reboot(duthosts, localhost, enum_s
                 )
 
                 logging.info("DUT is not in normal state after supervisor cold reboot, doing config-reload")
-                config_reload(lc, safe_reload=True, check_intf_up_ports=True)
+                config_reload(lc, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         # Make sure DUT is in normal state after supervisor cold reboot
         with SafeThreadPoolExecutor(max_workers=8) as executor:
@@ -792,7 +792,7 @@ def test_tsa_tsb_service_with_supervisor_abnormal_reboot(duthosts, localhost, en
                 )
 
                 logging.info("DUT is not in normal state after SUP abnormal reboot, doing config-reload")
-                config_reload(lc, safe_reload=True, check_intf_up_ports=True)
+                config_reload(lc, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         # Make sure DUT is in normal state after supervisor abnormal reboot
         with SafeThreadPoolExecutor(max_workers=8) as executor:
@@ -920,7 +920,7 @@ def test_tsa_tsb_service_with_user_init_tsa(request, duthosts, localhost, nbrhos
             # Recover to Normal state
             lc.shell("TSB")
             lc.shell('sudo config save -y')
-            config_reload(lc, safe_reload=True, check_intf_up_ports=True)
+            config_reload(lc, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
             for linecard in frontend_nodes_per_hwsku:
@@ -1070,7 +1070,7 @@ def test_user_init_tsa_while_service_run_on_dut(request, duthosts, localhost, nb
                 )
 
                 logging.info("DUT is not in normal state after cold reboot, doing config-reload")
-                config_reload(lc, safe_reload=True, check_intf_up_ports=True)
+                config_reload(lc, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
             for linecard in frontend_nodes_per_hwsku:
@@ -1209,7 +1209,7 @@ def test_user_init_tsb_while_service_run_on_dut(request, duthosts, localhost, nb
                 )
 
                 logging.info("DUT is not in normal state after cold reboot, doing config-reload")
-                config_reload(lc, safe_reload=True, check_intf_up_ports=True)
+                config_reload(lc, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
             for linecard in frontend_nodes_per_hwsku:
@@ -1359,7 +1359,7 @@ def test_user_init_tsb_on_sup_while_service_run_on_dut(duthosts, localhost, enum
                 )
 
                 logging.info("DUT is not in normal state after supervisor cold reboot, doing config-reload")
-                config_reload(lc, safe_reload=True, check_intf_up_ports=True)
+                config_reload(lc, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         # Make sure linecards are in Normal state and save the config to proceed further
         with SafeThreadPoolExecutor(max_workers=8) as executor:
@@ -1501,7 +1501,7 @@ def test_tsa_tsb_timer_efficiency(request, duthosts, localhost, nbrhosts, traffi
                 )
 
                 logging.info("DUT is not in normal state after cold reboot, doing config-reload")
-                config_reload(lc, safe_reload=True, check_intf_up_ports=True)
+                config_reload(lc, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
             for linecard in frontend_nodes_per_hwsku:
@@ -1644,7 +1644,7 @@ def test_tsa_tsb_service_with_tsa_on_sup(duthosts, localhost, enum_supervisor_du
                 )
 
                 logging.info("DUT is not in normal state after supervisor cold reboot, doing config-reload")
-                config_reload(lc, safe_reload=True, check_intf_up_ports=True)
+                config_reload(lc, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         with SafeThreadPoolExecutor(max_workers=8) as executor:
             for linecard in duthosts.frontend_nodes:

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -116,7 +116,7 @@ def pfcwd_feature_enabled(duthost):
 def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True,
                   safe_reload=False, wait_before_force_reload=0, wait_for_bgp=False,
                   check_intf_up_ports=False, traffic_shift_away=False, override_config=False,
-                  golden_config_path=DEFAULT_GOLDEN_CONFIG_PATH, is_dut=True):
+                  golden_config_path=DEFAULT_GOLDEN_CONFIG_PATH, is_dut=True, exec_tsb=False):
     """
     reload SONiC configuration
     :param sonic_host: SONiC host object
@@ -220,3 +220,6 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
             wait_until(wait + 120, 10, 0, sonic_host.check_bgp_session_state_all_asics, bgp_neighbors),
             "Not all bgp sessions are established after config reload",
         )
+
+    if exec_tsb:
+        sonic_host.shell("TSB")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
TSA-TSB service Testcases: Adjust the testcases to adhere to new behavior of config_reload

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
As a fix for the issue https://github.com/sonic-net/sonic-buildimage/issues/21586, TSA-TSB service is invoked upon swss bring up(https://github.com/sonic-net/sonic-buildimage/pull/21587).
This affects config_reload behavior, where after config reload the tsa-tsb service will be restarted, and the device will be in TSA state till timer expires. Adjusting the testcase to explicitly execute TSB for the DUT to be ready for next testcase,

#### How did you do it?
Enhanced the config_reload api to optionally take exec_tsb parameter. For startup-TSA-TSB and reliable TSA-TSB testcases, pass this flag to True to explicitly execute TSB on the device after config reload.
 
#### How did you verify/test it?
Ran the tests on t2 
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
