### PR TITLE
Adding tacacs authentication failthrough command to enable root access on sonic-dut

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -676,6 +676,7 @@
           - config tacacs passkey {{ tacacs_passkey }}
           - config tacacs authtype pap
           - config aaa authentication login tacacs+
+          - config aaa authentication failthrough enable
         loop_control:
           loop_var: tacacs_config_cmd
         ignore_errors: true


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--

-->

Summary: Adding tacacs authentication failthrough command to enable root access on sonic-dut
Fixes # 
Currently the root access is denied with recent changes in the AAA configurations.
User is not allowed to login to the dut over the root user.
Therefore, adding below command to enable root access through deploy-mg.
"config aaa authentication failthrough enable"

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [*] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
