### PR TITLE
[Snappi] increase tolerance for rounding in m2o tests

### DIFF
--- a/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -142,7 +142,7 @@ def run_m2o_fluctuating_lossless_test(api,
     total_rx_pkts = rx_pkts_1 + rx_pkts_2
     # Calculate the drop percentage
     drop_percentage = 100 * pkt_drop / total_rx_pkts
-    pytest_assert(round(drop_percentage) == 8, 'FAIL: Drop packets must be around 8 percent')
+    pytest_assert(abs(drop_percentage - 8) < 1, 'FAIL: Drop packets must be around 8 percent')
 
     """ Verify Results """
     verify_m2o_fluctuating_lossless_result(flow_stats,

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -151,7 +151,7 @@ def run_pfc_m2o_oversubscribe_lossless_lossy_test(api,
     total_rx_pkts = rx_pkts_1 + rx_pkts_2
     # Calculate the drop percentage
     drop_percentage = 100 * pkt_drop / total_rx_pkts
-    pytest_assert(round(drop_percentage) == 5, 'FAIL: Drop packets must be around 5 percent')
+    pytest_assert(abs(drop_percentage - 5) < 1, 'FAIL: Drop packets must be around 5 percent')
 
     """ Verify Results """
     verify_m2o_oversubscribe_lossless_lossy_result(flow_stats,

--- a/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossy_helper.py
+++ b/tests/snappi_tests/multidut/pfc/files/m2o_oversubscribe_lossy_helper.py
@@ -151,7 +151,7 @@ def run_pfc_m2o_oversubscribe_lossy_test(api,
     total_rx_pkts = rx_pkts_1 + rx_pkts_2
     # Calculate the drop percentage
     drop_percentage = 100 * pkt_drop / total_rx_pkts
-    pytest_assert(round(drop_percentage) == 10, 'FAIL: Drop packets must be around 10 percent')
+    pytest_assert(abs(drop_percentage - 10) < 1, 'FAIL: Drop packets must be around 10 percent')
 
     """ Verify Results """
     verify_m2o_oversubscribe_lossy_result(flow_stats,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Increase some tolerance for m2o cases since the normal `round()` requires exactly .5 above to be rounded up.

Fixes # (issue) 3192364

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Increase some tolerance for our test case

#### How did you do it?

#### How did you verify/test it?
validated on T2 testbed 8800

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
