### PR TITLE
cisco-8000: pfcwd: Open up the new pfcwd fixture for t0/t1.

### DIFF
--- a/tests/pfcwd/cisco/set_pfc_time.py
+++ b/tests/pfcwd/cisco/set_pfc_time.py
@@ -1,6 +1,7 @@
-# Verified on Q200 @ 100G port speed. e.g. 687 is bit time to pause for 50ms (clock at 900Mhz).
-
 import math
+
+# Replace INTERFACE with appropriate port when used
+arg_interface = "INTERFACE"
 
 
 def get_ifg_reg_list(slice_idx):
@@ -67,4 +68,4 @@ def set_pfc512_bit_sec(interface, time_sec):
 # Increase PFC pause time
 num_ms = 50
 print("Setting PFC frame time to {}ms".format(num_ms))
-set_pfc512_bit_sec("INTERFACE", num_ms / 1000)
+set_pfc512_bit_sec(arg_interface, num_ms / 1000)

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -267,8 +267,7 @@ def set_pfc_time_cisco_8000(
     test_ports = setup_pfc_test['test_ports']
 
     # Lets limit this to cisco and T2 only.
-    if not (duthost.facts['asic_type'] == "cisco-8000"
-            and duthost.get_facts().get("modular_chassis")):
+    if duthost.facts['asic_type'] != "cisco-8000":
         yield
         return
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
We recently introduced a new fixture to use debug-shell in cisco-8000 to remove flakyness in the pfcwd scripts that use pfc_gen.py. But the previous PR restricts the new fixture to only T2/modular-chassis. In this PR, we open up the fixture to all cisco-8000, for any topology.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Removing flakyness in pfcwdd scripts that use pfc_gen.py.

#### How did you do it?
Built on the last PR that implemented the new fixture only for T2.

#### How did you verify/test it?
Ran it on my TB:
```
---------------------------------------------------- generated xml file: /run_logs/pfcwd_t0t1/2025-02-06-21-11-50/pfcwd/pfcwd/test_pfcwd_function_2025-02-06-21-11-50.xml ----------------------------------------------------
--------------------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------------------
23:44:37 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================================== short test summary info ===================================================================================================
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[xx37-lc0-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[xx37-lc0-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[xx37-lc0-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[xx37-lc0-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[xx37-lc0-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[xx37-lc0-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[xx37-lc0-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[xx37-lc0-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[xx37-lc0-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[xx37-lc0-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[xx37-lc1-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[xx37-lc1-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[xx37-lc1-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[xx37-lc1-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[xx37-lc1-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[xx37-lc1-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[xx37-lc1-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[xx37-lc1-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[xx37-lc1-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[xx37-lc1-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[xx37-lc7-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[xx37-lc7-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[xx37-lc7-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[xx37-lc7-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[xx37-lc7-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[xx37-lc7-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[xx37-lc7-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[xx37-lc7-2-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[xx37-lc7-1-2]
PASSED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[xx37-lc7-2-2]
========================================================================================= 30 passed, 1 warning in 9165.11s (2:32:45) =========================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_pfcwd_no_traffic[xx37-lc7-2-2]>
DEBUG:tests.conftest:append custom_msg: {'dut_check_result': {'config_db_check_pass': False, 'core_dump_check_pass': True}}
INFO:root:Can not get Allure report URL. Please check logs
sonic@202405-qos-sonic-mgmt-prod:/data/tests$ 
```
#### Any platform specific information?
Specific to cisco-8000 only.