### PR TITLE
Change assertion to a `wait_until` in `test_route_withdraw_advertise`

### DIFF
--- a/tests/route/test_route_consistency.py
+++ b/tests/route/test_route_consistency.py
@@ -119,6 +119,15 @@ class TestRouteConsistency():
         self.__class__.sleep_interval = math.ceil(max_prefix_cnt/3000) + 120
         logger.info("max_no_of_prefix: {} sleep_interval: {}".format(max_prefix_cnt, self.sleep_interval))
 
+    def route_snapshots_match(self, duthosts, previous_route_snapshot):
+        new_route_snapshot, _ = self.get_route_prefix_snapshot_from_asicdb(duthosts)
+        """ compare the snapshot of route table from all the DUTs. In working condition, the snapshot of
+            route table should be same across all the DUTs"""
+        for dut_instance_name in previous_route_snapshot.keys():
+            if previous_route_snapshot[dut_instance_name] != new_route_snapshot[dut_instance_name]:
+                return False
+        return True
+
     def test_route_withdraw_advertise(self, duthosts, tbinfo, localhost):
 
         # withdraw the routes
@@ -158,12 +167,7 @@ class TestRouteConsistency():
             localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
             time.sleep(self.sleep_interval)
 
-            # take the snapshot of route table from all the DUTs
-            post_test_route_snapshot, _ = self.get_route_prefix_snapshot_from_asicdb(duthosts)
-            """ compare the snapshot of route table from all the DUTs. In working condition, the snapshot of
-                route table should be same across all the DUTs"""
-            for dut_instance_name in self.pre_test_route_snapshot.keys():
-                assert self.pre_test_route_snapshot[dut_instance_name] == post_test_route_snapshot[dut_instance_name]
+            assert(wait_until(300, 10, 0, self.route_snapshots_match, duthosts, self.pre_test_route_snapshot))
             logger.info("Route table is consistent across all the DUTs")
         except Exception as e:
             logger.error("Exception occurred: {}".format(e))

--- a/tests/route/test_route_consistency.py
+++ b/tests/route/test_route_consistency.py
@@ -167,7 +167,7 @@ class TestRouteConsistency():
             localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
             time.sleep(self.sleep_interval)
 
-            assert(wait_until(300, 10, 0, self.route_snapshots_match, duthosts, self.pre_test_route_snapshot))
+            assert wait_until(300, 10, 0, self.route_snapshots_match, duthosts, self.pre_test_route_snapshot)
             logger.info("Route table is consistent across all the DUTs")
         except Exception as e:
             logger.error("Exception occurred: {}".format(e))


### PR DESCRIPTION
We were seeing that we'd get occasional AssertionErrors in `test_route_withdraw_advertise` when the routes were advertised because we didn't wait long enough before the assertion.

Instead of increasing the `sleep` time further I converted the assertion to a `wait_until` so we will only wait as long as we need to.

Note: When casting to `202405` we'll need to add the include for `wait_until`, it's not in this PR because it's already included in `master`
`from tests.common.utilities import wait_until`

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
