### PR TITLE
[Bugfix] Fix import error in `device_utils.py`.

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -18,7 +18,6 @@ from tests.common.broadcom_data import is_broadcom_device
 from tests.common.mellanox_data import is_mellanox_device
 from tests.common.platform.reboot_timing_constants import SERVICE_PATTERNS, OTHER_PATTERNS, SAIREDIS_PATTERNS, \
     OFFSET_ITEMS, TIME_SPAN_ITEMS, REQUIRED_PATTERNS
-from tests.platform_tests.api.conftest import start_platform_api_service    # noqa F401
 
 """
 Helper script for fanout switch operations
@@ -984,7 +983,7 @@ def advanceboot_neighbor_restore(duthosts, enum_rand_one_per_hwsku_frontend_host
 
 
 @pytest.fixture(scope='function')
-def platform_api_conn(duthosts, enum_rand_one_per_hwsku_hostname, start_platform_api_service):  # noqa F811
+def platform_api_conn(duthosts, enum_rand_one_per_hwsku_hostname, start_platform_api_service):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dut_ip = duthost.mgmt_ip
 

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -18,6 +18,7 @@ from tests.common.broadcom_data import is_broadcom_device
 from tests.common.mellanox_data import is_mellanox_device
 from tests.common.platform.reboot_timing_constants import SERVICE_PATTERNS, OTHER_PATTERNS, SAIREDIS_PATTERNS, \
     OFFSET_ITEMS, TIME_SPAN_ITEMS, REQUIRED_PATTERNS
+from tests.platform_tests.api.conftest import start_platform_api_service    # noqa F401
 
 """
 Helper script for fanout switch operations
@@ -983,7 +984,7 @@ def advanceboot_neighbor_restore(duthosts, enum_rand_one_per_hwsku_frontend_host
 
 
 @pytest.fixture(scope='function')
-def platform_api_conn(duthosts, enum_rand_one_per_hwsku_hostname, start_platform_api_service):
+def platform_api_conn(duthosts, enum_rand_one_per_hwsku_hostname, start_platform_api_service):  # noqa F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dut_ip = duthost.mgmt_ip
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,10 @@ cache = FactsCache()
 DUTHOSTS_FIXTURE_FAILED_RC = 15
 CUSTOM_MSG_PREFIX = "sonic_custom_msg"
 
+SERVER_FILE = 'platform_api_server.py'
+SERVER_PORT = 8000
+IPTABLES_PREPEND_RULE_CMD = 'iptables -I INPUT 1 -p tcp -m tcp --dport {} -j ACCEPT'.format(SERVER_PORT)
+
 pytest_plugins = ('tests.common.plugins.ptfadapter',
                   'tests.common.plugins.ansible_fixtures',
                   'tests.common.plugins.dut_monitor',
@@ -2742,3 +2746,50 @@ def gnxi_path(ptfhost):
     else:
         gnxipath = "/gnxi/"
     return gnxipath
+
+
+@pytest.fixture(scope='function')
+def start_platform_api_service(duthosts, enum_rand_one_per_hwsku_hostname, localhost, request):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dut_ip = duthost.mgmt_ip
+
+    res = localhost.wait_for(host=dut_ip,
+                             port=SERVER_PORT,
+                             state='started',
+                             delay=1,
+                             timeout=10,
+                             module_ignore_errors=True)
+    if res['failed'] is True:
+
+        res = duthost.command('docker exec -i pmon python3 -c "import sonic_platform"', module_ignore_errors=True)
+        py3_platform_api_available = not res['failed']
+
+        supervisor_conf = [
+            '[program:platform_api_server]',
+            'command=/usr/bin/python{} /opt/platform_api_server.py --port {}'.format('3' if py3_platform_api_available
+                                                                                     else '2', SERVER_PORT),
+            'autostart=True',
+            'autorestart=True',
+            'stdout_logfile=syslog',
+            'stderr_logfile=syslog',
+        ]
+        dest_path = os.path.join(os.sep, 'tmp', 'platform_api_server.conf')
+        pmon_path = os.path.join(os.sep, 'etc', 'supervisor', 'conf.d', 'platform_api_server.conf')
+        duthost.copy(content='\n'.join(supervisor_conf), dest=dest_path)
+        duthost.command('docker cp {} pmon:{}'.format(dest_path, pmon_path))
+
+        src_path = os.path.join('common', 'helpers', 'platform_api', 'scripts', SERVER_FILE)
+        dest_path = os.path.join(os.sep, 'tmp', SERVER_FILE)
+        pmon_path = os.path.join(os.sep, 'opt', SERVER_FILE)
+        duthost.copy(src=src_path, dest=dest_path)
+        duthost.command('docker cp {} pmon:{}'.format(dest_path, pmon_path))
+
+        # Prepend an iptables rule to allow incoming traffic to the HTTP server
+        duthost.command(IPTABLES_PREPEND_RULE_CMD)
+
+        # Reload the supervisor config and Start the HTTP server
+        duthost.command('docker exec -i pmon supervisorctl reread')
+        duthost.command('docker exec -i pmon supervisorctl update')
+
+        res = localhost.wait_for(host=dut_ip, port=SERVER_PORT, state='started', delay=1, timeout=10)
+        assert res['failed'] is False

--- a/tests/platform_tests/api/conftest.py
+++ b/tests/platform_tests/api/conftest.py
@@ -6,55 +6,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 SERVER_FILE = 'platform_api_server.py'
 SERVER_PORT = 8000
 
-IPTABLES_PREPEND_RULE_CMD = 'iptables -I INPUT 1 -p tcp -m tcp --dport {} -j ACCEPT'.format(SERVER_PORT)
 IPTABLES_DELETE_RULE_CMD = 'iptables -D INPUT -p tcp -m tcp --dport {} -j ACCEPT'.format(SERVER_PORT)
-
-
-@pytest.fixture(scope='function')
-def start_platform_api_service(duthosts, enum_rand_one_per_hwsku_hostname, localhost, request):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dut_ip = duthost.mgmt_ip
-
-    res = localhost.wait_for(host=dut_ip,
-                             port=SERVER_PORT,
-                             state='started',
-                             delay=1,
-                             timeout=10,
-                             module_ignore_errors=True)
-    if res['failed'] is True:
-
-        res = duthost.command('docker exec -i pmon python3 -c "import sonic_platform"', module_ignore_errors=True)
-        py3_platform_api_available = not res['failed']
-
-        supervisor_conf = [
-            '[program:platform_api_server]',
-            'command=/usr/bin/python{} /opt/platform_api_server.py --port {}'.format('3' if py3_platform_api_available
-                                                                                     else '2', SERVER_PORT),
-            'autostart=True',
-            'autorestart=True',
-            'stdout_logfile=syslog',
-            'stderr_logfile=syslog',
-        ]
-        dest_path = os.path.join(os.sep, 'tmp', 'platform_api_server.conf')
-        pmon_path = os.path.join(os.sep, 'etc', 'supervisor', 'conf.d', 'platform_api_server.conf')
-        duthost.copy(content='\n'.join(supervisor_conf), dest=dest_path)
-        duthost.command('docker cp {} pmon:{}'.format(dest_path, pmon_path))
-
-        src_path = os.path.join('common', 'helpers', 'platform_api', 'scripts', SERVER_FILE)
-        dest_path = os.path.join(os.sep, 'tmp', SERVER_FILE)
-        pmon_path = os.path.join(os.sep, 'opt', SERVER_FILE)
-        duthost.copy(src=src_path, dest=dest_path)
-        duthost.command('docker cp {} pmon:{}'.format(dest_path, pmon_path))
-
-        # Prepend an iptables rule to allow incoming traffic to the HTTP server
-        duthost.command(IPTABLES_PREPEND_RULE_CMD)
-
-        # Reload the supervisor config and Start the HTTP server
-        duthost.command('docker exec -i pmon supervisorctl reread')
-        duthost.command('docker exec -i pmon supervisorctl update')
-
-        res = localhost.wait_for(host=dut_ip, port=SERVER_PORT, state='started', delay=1, timeout=10)
-        assert res['failed'] is False
 
 
 @pytest.fixture(scope='module', autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #15605, the `platform_api_conn` fixture was relocated to a common location. The fixture `start_platform_api_service` used by it is not imported in this script, which will casue error `fixture 'start_platform_api_service' not found`. This PR addresses the issue by moving fixture `start_platform_api_service` to a common place `tests/conftest.py`. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
In PR #15605, the `platform_api_conn` fixture was relocated to a common location. The fixture `start_platform_api_service` used by it is not imported in this script, which will casue error `fixture 'start_platform_api_service' not found`. This PR addresses the issue by moving fixture `start_platform_api_service` to a common place `tests/conftest.py`. 

#### How did you do it?
This PR addresses the issue by moving fixture `start_platform_api_service` to a common place `tests/conftest.py`. 

#### How did you verify/test it?
Test locally to run the test script `test_reload_dpu.py`. There is no such import error.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
