### PR TITLE
Retry from the first provided password if none of the passwords work

### DIFF
--- a/ansible/roles/test/files/ptftests/device_connection.py
+++ b/ansible/roles/test/files/ptftests/device_connection.py
@@ -33,7 +33,7 @@ class DeviceConnection:
         self.hostname = hostname
         self.username = username
         self.passwords = [password]
-        if self.alt_password:
+        if alt_password:
             self.passwords += alt_password
         self.password_index = 0
 

--- a/ansible/roles/test/files/ptftests/device_connection.py
+++ b/ansible/roles/test/files/ptftests/device_connection.py
@@ -32,9 +32,10 @@ class DeviceConnection:
         '''
         self.hostname = hostname
         self.username = username
-        self.password = password
-        self.alt_password = alt_password
-        self.alt_password_index = 0
+        self.passwords = [password]
+        if self.alt_password:
+            self.passwords += alt_password
+        self.password_index = 0
 
     @retry(
         stop_max_attempt_number=4,
@@ -62,7 +63,7 @@ class DeviceConnection:
         retValue = 1
         try:
             client.connect(self.hostname, username=self.username,
-                           password=self.password, allow_agent=False)
+                           password=self.passwords[self.password_index], allow_agent=False)
             si, so, se = client.exec_command(cmd, timeout=timeout)
             stdOut = so.readlines()
             stdErr = se.readlines()
@@ -70,10 +71,9 @@ class DeviceConnection:
         except AuthenticationException as authenticationException:
             logger.error('SSH Authentication failure with message: %s' %
                          authenticationException)
-            if self.alt_password is not None and self.alt_password_index < len(self.alt_password):
-                # attempt retry with alt_password
-                self.password = self.alt_password[self.alt_password_index]
-                self.alt_password_index += 1
+            if len(self.passwords) > 1:
+                # attempt retry with another password
+                self.password_index = (self.password_index + 1) % len(self.passwords)
                 raise AuthenticationException
         except SSHException as sshException:
             logger.error('SSH Command failed with message: %s' % sshException)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

In the DeviceConnection class, if none of the passwords appear to work, then try again from the first provided password. The reason for this is if a a device initially needs some password specified in the alternate passwords list, but then later needs to use some earlier-specified password (because of some config change), then connection attempts will fail until a new DeviceConnection object is instantiated.

#### How did you do it?

Instead, work around that by trying the passwords in a loop (i.e. from the beginning again). This also means that the class doesn't really need to keep track of what password might be the "primary" password and what password might be alternates.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
