### PR TITLE
[202405][mgfx/pfcwd] Skip test_pfcwd_all_port_storm on m0/mx

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1264,9 +1264,12 @@ pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg:
 pfcwd/test_pfcwd_all_port_storm.py:
    skip:
      reason: "Slow pfc generation rate on 7060x6 200Gb,
-              pfc generation function on the Arista fanout device need to be improved by Arista"
+              pfc generation function on the Arista fanout device need to be improved by Arista
+              / Pfcwd tests skipped on m0/mx testbed."
+     conditions_logical_operator: or
      conditions:
       - "hwsku in ['Arista-7060X6-64PE-256x200G']"
+      - "topo_type in ['m0', 'mx']"
 
 pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic:
    skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
pfcwd related tests shouldn't run in m0/mx, it's already skipped in master with this PR https://github.com/sonic-net/sonic-mgmt/pull/14912. But when 14912 was backported to 202405, the PR to skip pfcwd_all_port_storm  in 7260 https://github.com/sonic-net/sonic-mgmt/pull/14756 hasn't been backported to 202405, which caused that backport of 14912 doesn't include skip for `pfcwd_all_port_storm`, then pfcwd_all_port_storm would run in m0/mx in 202405

#### How did you do it?
Skip pfcwd_all_port_storm  in m0/mx

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
