### PR TITLE
RDMA Tests Enhancements

### DIFF
--- a/tests/common/snappi_tests/qos_fixtures.py
+++ b/tests/common/snappi_tests/qos_fixtures.py
@@ -17,7 +17,7 @@ file currently holds the following fixture(s):
 
 
 @pytest.fixture(scope="module")
-def prio_dscp_map(duthosts, rand_one_dut_hostname):
+def prio_dscp_map(duthosts, rand_one_dut_front_end_hostname):
     """
     This fixture reads the QOS parameters from SONiC DUT, and creates
     priority Vs. DSCP priority port map
@@ -30,7 +30,7 @@ def prio_dscp_map(duthosts, rand_one_dut_hostname):
         Priority vs. DSCP map (dictionary, key = priority).
         Example: {0: [0], 1: [1], 2: [2], 3: [3], 4: [4] ....}
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     config_facts = duthost.config_facts(host=duthost.hostname, asic_index=0,
                                         source="running")['ansible_facts']
 
@@ -67,7 +67,7 @@ def all_prio_list(prio_dscp_map):
 
 
 @pytest.fixture(scope="module")
-def lossless_prio_list(duthosts, rand_one_dut_hostname):
+def lossless_prio_list(duthosts, rand_one_dut_front_end_hostname):
     """
     This fixture returns the list of lossless priorities
 
@@ -78,7 +78,7 @@ def lossless_prio_list(duthosts, rand_one_dut_hostname):
     Returns:
         Lossless priorities (list)
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     config_facts = duthost.config_facts(host=duthost.hostname, asic_index=0,
                                         source="running")['ansible_facts']
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
Added Change to not select supervisor while running rdma tests by changing the parameters from  rand_one_dut_hostname to rand_one_dut_front_end_hostname in qos_fixtures.py 
-->

Summary:
Fixes # (issue)
The test used to select supervisor sometimes which will not work in case of Nokia and Arista Chassis.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
