### PR TITLE
Adds a check for neighbor type in test_bgp_session_flap

### DIFF
--- a/tests/bgp/test_bgp_session_flap.py
+++ b/tests/bgp/test_bgp_session_flap.py
@@ -12,6 +12,7 @@ import time
 from tests.common.utilities import InterruptableThread
 import textfsm
 import traceback
+from tests.common.devices.sonic import SonicHost
 
 from natsort import natsorted
 
@@ -93,8 +94,15 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand_one_
 
     logger.info("DUT BGP Config: {}".format(duthost.shell("vtysh -n {} -c \"show run bgp\"".format(namespace),
                                                           module_ignore_errors=True)))
-    logger.info("Neighbor BGP Config: {}".format(
-        nbrhosts[tor1]["host"].eos_command(commands=["show run | section bgp"])))
+    # If host it sonic use 'show runningconfig bgp'
+    if isinstance(nbrhosts[tor1]["host"], SonicHost):
+        logger.info("Neighbor BGP Config: {}".format(
+           nbrhosts[tor1]["host"].command("show runningconfig bgp")))
+    else:
+        # Else use industry standard 'show run | sec bgp'
+        logger.info("Neighbor BGP Config: {}".format(
+           nbrhosts[tor1]["host"].commands(commands=["show run | section bgp"])))
+
     logger.info('Setup_info: {}'.format(setup_info))
 
     #  get baseline BGP CPU and Memory Utilization

--- a/tests/bgp/test_bgp_session_flap.py
+++ b/tests/bgp/test_bgp_session_flap.py
@@ -101,7 +101,7 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand_one_
     else:
         # Else use industry standard 'show run | sec bgp'
         logger.info("Neighbor BGP Config: {}".format(
-           nbrhosts[tor1]["host"].command(commands=["show run | section bgp"])))
+           nbrhosts[tor1]["host"].eos_command(commands=["show run | section bgp"])))
 
     logger.info('Setup_info: {}'.format(setup_info))
 

--- a/tests/bgp/test_bgp_session_flap.py
+++ b/tests/bgp/test_bgp_session_flap.py
@@ -101,7 +101,7 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand_one_
     else:
         # Else use industry standard 'show run | sec bgp'
         logger.info("Neighbor BGP Config: {}".format(
-           nbrhosts[tor1]["host"].commands(commands=["show run | section bgp"])))
+           nbrhosts[tor1]["host"].command(commands=["show run | section bgp"])))
 
     logger.info('Setup_info: {}'.format(setup_info))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #16883

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
This test case fails when a sonic-mgmt topo has Sonic VM neighbors

#### How did you do it?
Adds a check for instance type before determining which show command to run

#### How did you verify/test it?
Passes on T0/T1 topo

bgp/test_bgp_session_flap.py::test_bgp_single_session_flaps[usschq-nswdut-t002-None] PASSED [ 50%]
bgp/test_bgp_session_flap.py::test_bgp_multiple_session_flaps[usschq-nswdut-t002-None] PASSED [100%]


