### PR TITLE
Skip NVGRE hash tests for Broadcom SKUs

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -898,9 +898,9 @@ fib/test_fib.py::test_ipinip_hash:
 
 fib/test_fib.py::test_nvgre_hash:
   skip:
-    reason: 'Nvgre hash test is not fully supported on VS platform'
+    reason: 'Nvgre hash test is not fully supported on VS and Broadcom platform'
     conditions:
-      - "asic_type in ['vs']"
+      - "asic_type in ['vs', 'broadcom']"
 
 fib/test_fib.py::test_vxlan_hash:
   skip:

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -676,6 +676,9 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
     # For NVGRE, default hash key is inner 5-tuple.
     # Due to current limitation, NVGRE hash keys are updated for different vendors.
     # Hash-key will be updated once we get the full support.
+    if 'broadcom' in duthost.facts['asic_type'].lower():
+        pytest.skip("Skipping NVGRE hash tests in Broadcom SKUs")
+
     hash_keys = ['src-ip', 'dst-ip', 'src-port', 'dst-port', 'src-mac', 'dst-mac']
     if duthost.facts['asic_type'] in ["cisco-8000"]:
         logging.info("Cisco: hash-key is src-mac, dst-mac")

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -676,9 +676,6 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
     # For NVGRE, default hash key is inner 5-tuple.
     # Due to current limitation, NVGRE hash keys are updated for different vendors.
     # Hash-key will be updated once we get the full support.
-    if 'broadcom' in duthost.facts['asic_type'].lower():
-        pytest.skip("Skipping NVGRE hash tests in Broadcom SKUs")
-
     hash_keys = ['src-ip', 'dst-ip', 'src-port', 'dst-port', 'src-mac', 'dst-mac']
     if duthost.facts['asic_type'] in ["cisco-8000"]:
         logging.info("Cisco: hash-key is src-mac, dst-mac")


### PR DESCRIPTION
### Description of PR
To skip NVGRE hash tests for Broadcom SKUs

### Approach
#### What is the motivation for this PR?
With the default hash algorithm, NVGRE hash test fails for Broadcom SKUs, so skip.

#### How did you do it?
Check for the asic_type and skip for Broadcom SKUs.
