### PR TITLE
Add logic to handler err msg detected by loganalyzer

### DIFF
--- a/tests/common/plugins/loganalyzer/bug_handler_helper.py
+++ b/tests/common/plugins/loganalyzer/bug_handler_helper.py
@@ -1,0 +1,16 @@
+
+def skip_loganalyzer_bug_handler(duthost, request):
+    """
+    return True if the bug handler will be skipped.
+    User could implement their own logic here.
+    """
+    return True
+
+
+def log_analyzer_bug_handler(duthost, request):
+    """
+    If the not skip bug handler after the loganalyzer, run this function to handle the err msg detected in the
+    loganalyzer.
+    User could implement their own logic here.
+    """
+    pass


### PR DESCRIPTION
In this change it has following function:
1. Add ability to handle the err msg detected by loganalyzer
2. Do not run the loganalyzer in parallel if there is only 1 loganalyzer need to run
3. Increase the timeout from 120 to 240 for the parallel run of the loganalyzer since if lot of err msgs need to be handler, it will take more time to finish it.
4. When load the ignore regex list, also load the value of "extended_ignore_list" in the cache

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
