### PR TITLE
[test_pfcwd_timer_accuracy]: fix pfc timer accuracy timestamp regex

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -350,21 +350,18 @@ class TestPfcwdAllTimer(object):
             syslog_msg = self.dut.shell(cmd)['stdout']
 
             # Regular expressions for the two timestamp formats
-            regex1 = re.compile(r'^[A-Za-z]{3} \d{2} \d{2}:\d{2}:\d{2}\.\d{6}')
-            regex2 = re.compile(r'^\d{4} [A-Za-z]{3}\s{1,2}\d{1,2} \d{2}:\d{2}:\d{2}\.\d{6}')
-
-            if regex1.match(syslog_msg):
-                timestamp = syslog_msg.replace('  ', ' ').split(' ')[2]
-            elif regex2.match(syslog_msg):
-                timestamp = syslog_msg.replace('  ', ' ').split(' ')[3]
+            regex = re.compile(r'\b[A-Za-z]{3}\s{1,2}\d{1,2} \d{2}:\d{2}:\d{2}\.\d{6}\b')
+            search_string = regex.search(syslog_msg)
+            if search_string:
+                timestamp = search_string.group()
             else:
-                logger.warning("Get {} timestamp: Unexpected syslog message format".format(syslog_msg))
+                logger.warning("Get timestamp: Unexpected syslog message format, syslog_msg {}".format(syslog_msg))
                 return int(0)
 
             timestamp_ms = self.dut.shell("date -d {} +%s%3N".format(timestamp))['stdout']
             return int(timestamp_ms)
         except Exception as e:
-            logger.warning("Get {} timestamp: An unexpected error occurred: {}".format(pattern, str(e)))
+            logger.warning("Get timestamp: An unexpected error occurred: pattern {} err {}".format(pattern, str(e)))
             return int(0)
 
     def test_pfcwd_timer_accuracy(self, duthosts, ptfhost, enum_rand_one_per_hwsku_frontend_hostname,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
same with https://github.com/sonic-net/sonic-mgmt/pull/16757
31202914

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Need handle regex1 too

#### How did you do it?
Follow previous PR, modify the regex1 

#### How did you verify/test it?
```

>>> regex = re.compile(r'\b[A-Za-z]{3}\s{1,2}\d{1,2} \d{2}:\d{2}:\d{2}\.\d{6}\b')
>>> syslog_msg_1 = "May 29 02:47:40.345257 str3-dut INFO"
>>> syslog_msg_2 = "May 9 02:47:40.345257 str3-dut INFO"
>>> syslog_msg_3 = "May  9 02:47:40.345257 str3-dut INFO"
>>> syslog_msg_4 = "2024 May 29 02:47:40.345257 str3-dut INFO"
>>> syslog_msg_5 = "2024 May 9 02:47:40.345257 str3-dut INFO"
>>> syslog_msg_6 = "2024 May  9 02:47:40.345257 str3-dut INFO"
>>> search_string = regex.search(syslog_msg_1)
>>> search_string
<re.Match object; span=(0, 22), match='May 29 02:47:40.345257'>
>>> search_string.group()
'May 29 02:47:40.345257'
>>> search_string = regex.search(syslog_msg_2)
>>> search_string
<re.Match object; span=(0, 21), match='May 9 02:47:40.345257'>
>>> search_string.group()
'May 9 02:47:40.345257'
>>> search_string = regex.search(syslog_msg_3)
>>> search_string
<re.Match object; span=(0, 22), match='May  9 02:47:40.345257'>
>>> search_string.group()
'May  9 02:47:40.345257'
>>> search_string = regex.search(syslog_msg_4)
>>> search_string
<re.Match object; span=(5, 27), match='May 29 02:47:40.345257'>
>>> search_string.group()
'May 29 02:47:40.345257'
>>> search_string = regex.search(syslog_msg_5)
>>> search_string
<re.Match object; span=(5, 26), match='May 9 02:47:40.345257'>
>>> search_string.group()
'May 9 02:47:40.345257'
>>> search_string = regex.search(syslog_msg_6)
>>> search_string
<re.Match object; span=(5, 27), match='May  9 02:47:40.345257'>
>>> search_string.group()
'May  9 02:47:40.345257'
>>> 
admin@bjw-can-7060-1:~$ 
admin@bjw-can-7060-1:~$ date -d 'May 29 02:47:40.345257' +%s%3N
1748486860345
admin@bjw-can-7060-1:~$ date -d 'May 9 02:47:40.345257' +%s%3N
1746758860345
admin@bjw-can-7060-1:~$ date -d 'May  9 02:47:40.345257' +%s%3N
1746758860345
admin@bjw-can-7060-1:~$ date -d 'May 29 02:47:40.345257' +%s%3N
1748486860345
admin@bjw-can-7060-1:~$ date -d 'May 9 02:47:40.345257' +%s%3N
1746758860345
admin@bjw-can-7060-1:~$ date -d 'May  9 02:47:40.345257' +%s%3N
1746758860345
admin@bjw-can-7060-1:~$ 
```



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
