### PR TITLE
Retry gnmi_get calls for potential server startup timing issue

### DIFF
--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -196,3 +196,8 @@ def rotate_telemetry_certs(duthost, localhost):
     duthost.copy(src="streamingtelemetryserver.key", dest=path)
     duthost.copy(src="dsmsroot.cer", dest=path)
     duthost.copy(src="dsmsroot.key", dest=path)
+
+
+def execute_ptf_gnmi_cli(ptfhost, cmd):
+    rc = ptfhost.shell(cmd)['rc']
+    return rc == 0

--- a/tests/telemetry/test_telemetry_cert_rotation.py
+++ b/tests/telemetry/test_telemetry_cert_rotation.py
@@ -6,6 +6,8 @@ from tests.common.utilities import wait_until, wait_tcp_connection
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from telemetry_utils import generate_client_cli
 from telemetry_utils import archive_telemetry_certs, unarchive_telemetry_certs, rotate_telemetry_certs
+from telemetry_utils import execute_ptf_gnmi_cli
+
 
 pytestmark = [
     pytest.mark.topology('any', 't1-multi-asic')
@@ -74,15 +76,12 @@ def test_telemetry_post_cert_del(duthosts, enum_rand_one_per_hwsku_hostname, ptf
     # Initial request should pass with certs
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_GET,
                               target="OTHERS", xpath="proc/uptime")
-    ret = ptfhost.shell(cmd)['rc']
-    assert ret == 0, "Telemetry server request should complete with certs"
+    pytest_assert(wait_until(30, 5, 0, execute_ptf_gnmi_cli, ptfhost, cmd), "Telemetry server request should complete with certs")
 
     # Remove certs
     archive_telemetry_certs(duthost)
 
     # Requests should fail without certs
-    cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_GET,
-                              target="OTHERS", xpath="proc/uptime")
     ret = ptfhost.shell(cmd, module_ignore_errors=True)['rc']
     assert ret != 0, "Telemetry server request should fail without certs"
 
@@ -122,10 +121,7 @@ def test_telemetry_post_cert_add(duthosts, enum_rand_one_per_hwsku_hostname, ptf
     wait_tcp_connection(localhost, dut_ip, env.gnmi_port, timeout_s=60)
 
     # Requests should successfully complete with certs
-    cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_GET,
-                              target="OTHERS", xpath="proc/uptime")
-    ret = ptfhost.shell(cmd)['rc']
-    assert ret == 0, "Telemetry server request should complete with certs"
+    pytest_assert(wait_until(30, 5, 0, execute_ptf_gnmi_cli, ptfhost, cmd), "Telemetry server request should complete with certs")
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
@@ -142,8 +138,7 @@ def test_telemetry_cert_rotate(duthosts, enum_rand_one_per_hwsku_hostname, ptfho
     # Initial request should complete with certs
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_GET,
                               target="OTHERS", xpath="proc/uptime")
-    ret = ptfhost.shell(cmd)['rc']
-    assert ret == 0, "Telemetry server request should fail without certs"
+    pytest_assert(wait_until(30, 5, 0, execute_ptf_gnmi_cli, ptfhost, cmd), "Telemetry server request should complete with certs")
 
     # Rotate certs
     rotate_telemetry_certs(duthost, localhost)
@@ -153,7 +148,4 @@ def test_telemetry_cert_rotate(duthosts, enum_rand_one_per_hwsku_hostname, ptfho
     wait_tcp_connection(localhost, dut_ip, env.gnmi_port, timeout_s=60)
 
     # Requests should successfully complete with certs
-    cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_GET,
-                              target="OTHERS", xpath="proc/uptime")
-    ret = ptfhost.shell(cmd)['rc']
-    assert ret == 0, "Telemetry server request should complete with certs"
+    pytest_assert(wait_until(30, 5, 0, execute_ptf_gnmi_cli, ptfhost, cmd), "Telemetry server request should complete with certs")

--- a/tests/telemetry/test_telemetry_cert_rotation.py
+++ b/tests/telemetry/test_telemetry_cert_rotation.py
@@ -76,7 +76,8 @@ def test_telemetry_post_cert_del(duthosts, enum_rand_one_per_hwsku_hostname, ptf
     # Initial request should pass with certs
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_GET,
                               target="OTHERS", xpath="proc/uptime")
-    pytest_assert(wait_until(30, 5, 0, execute_ptf_gnmi_cli, ptfhost, cmd), "Telemetry server request should complete with certs")
+    pytest_assert(wait_until(30, 5, 0, execute_ptf_gnmi_cli, ptfhost, cmd),
+                  "Telemetry server request should complete with certs")
 
     # Remove certs
     archive_telemetry_certs(duthost)
@@ -121,7 +122,8 @@ def test_telemetry_post_cert_add(duthosts, enum_rand_one_per_hwsku_hostname, ptf
     wait_tcp_connection(localhost, dut_ip, env.gnmi_port, timeout_s=60)
 
     # Requests should successfully complete with certs
-    pytest_assert(wait_until(30, 5, 0, execute_ptf_gnmi_cli, ptfhost, cmd), "Telemetry server request should complete with certs")
+    pytest_assert(wait_until(30, 5, 0, execute_ptf_gnmi_cli, ptfhost, cmd),
+                  "Telemetry server request should complete with certs")
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
@@ -138,7 +140,8 @@ def test_telemetry_cert_rotate(duthosts, enum_rand_one_per_hwsku_hostname, ptfho
     # Initial request should complete with certs
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_GET,
                               target="OTHERS", xpath="proc/uptime")
-    pytest_assert(wait_until(30, 5, 0, execute_ptf_gnmi_cli, ptfhost, cmd), "Telemetry server request should complete with certs")
+    pytest_assert(wait_until(30, 5, 0, execute_ptf_gnmi_cli, ptfhost, cmd),
+                  "Telemetry server request should complete with certs")
 
     # Rotate certs
     rotate_telemetry_certs(duthost, localhost)
@@ -148,4 +151,5 @@ def test_telemetry_cert_rotate(duthosts, enum_rand_one_per_hwsku_hostname, ptfho
     wait_tcp_connection(localhost, dut_ip, env.gnmi_port, timeout_s=60)
 
     # Requests should successfully complete with certs
-    pytest_assert(wait_until(30, 5, 0, execute_ptf_gnmi_cli, ptfhost, cmd), "Telemetry server request should complete with certs")
+    pytest_assert(wait_until(30, 5, 0, execute_ptf_gnmi_cli, ptfhost, cmd),
+                  "Telemetry server request should complete with certs")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 30600475

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

There are cases where gnmi_get is called when server is not fully ready after rotation which is a timing issue for a few seconds. If we retry the gnmi_get call, it will succeed. Add wait_until to retry the client calls for a period of 30 seconds.

#### How did you do it?

Add wait_until to retry for 30 seconds

#### How did you verify/test it?

Manual test/pipeline

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
