### PR TITLE
chore: add sleep to wait for redis to be ready

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -343,6 +343,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     # Use an alternative reboot check if T2 device and REBOOT_TYPE_POWEROFF
     if duthost.get_facts().get("modular_chassis") and reboot_type == REBOOT_TYPE_POWEROFF:
         wait_until(120, 5, 0, duthost.critical_processes_running, "database")
+        time.sleep(60)
         curr_reboot_cause_history = duthost.show_and_parse("show reboot-cause history")
         pytest_assert(prev_reboot_cause_history != curr_reboot_cause_history, "No new input into history-queue")
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

After database service is ready, we observe that redis is not connectable yet and showed

```
RuntimeError: Unable to connect to redis - Connection refused(1): Cannot assign requested address
```

As a result, adding some delays here to ensure this will be available before running show command.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

Described above

#### How did you do it?
Added some sleep of 1 minute to ensure database is ready to connect

#### How did you verify/test it?
Verified on T2

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
