### PR TITLE
[Impacted Area Based PR testing] Enhancing regex accuracy in impacted area detection.

### DIFF
--- a/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
+++ b/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
@@ -33,7 +33,7 @@ steps:
         break
 
       # If changes only limited to specific feature, the scope of PR testing is impacted area.
-      elif [[ "$FEATURE" =~ tests\/* ]]; then
+      elif [[ "$FEATURE" =~ ^tests/.* ]]; then
         # Cut the feature path
         if [[ $FEATURE == */*/* ]]; then
             FEATURE=$(echo "$FEATURE" | cut -d'/' -f1-2)

--- a/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
+++ b/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
@@ -33,7 +33,7 @@ steps:
         break
 
       # If changes only limited to specific feature, the scope of PR testing is impacted area.
-      elif [[ "$FEATURE" =~ ^tests/.* ]]; then
+      elif [[ "$FEATURE" =~ ^tests\/.* ]]; then
         # Cut the feature path
         if [[ $FEATURE == */*/* ]]; then
             FEATURE=$(echo "$FEATURE" | cut -d'/' -f1-2)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In the `Get Impacted Area stage`, we use regular expressions to determine whether the changes in a PR are related to a specific feature. In this PR, we refine the regular expression to reduce false matches and improve accuracy.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
In the `Get Impacted Area stage`, we use regular expressions to determine whether the changes in a PR are related to a specific feature. In this PR, we refine the regular expression to reduce false matches and improve accuracy.

#### How did you do it?
In this PR, we refine the regular expression to reduce false matches and improve accuracy.

#### How did you verify/test it?
For string like `ansible/roles/files/ptftests`, we can't match the pattern. And for string start with `tests/`, we can match this pattern. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
