### PR TITLE
Exclude tests that are not intended for the virtual switch

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -95,6 +95,16 @@ def skip_release_for_platform(duthost, release_list, platform_list):
                     duthost.os_version, duthost.facts['platform'], ", ".join(release_list), ", ".join(platform_list)))
 
 
+def skip_for_asic(duthost, asic_list):
+    """
+    @summary: Skip current test if any given asic keywords are in asic_type
+    @param duthost: The DUT
+    @param asic_list: A list of incompatible asic types
+    """
+    if any(asic in duthost.facts['asic_type'] for asic in asic_list):
+        pytest.skip("DUT has asic type {} and test does not support {}".format(duthost.facts['asic_type'], ", ".join(asic_list)))
+
+
 def get_sup_node_or_random_node(duthosts):
     # accomodate for T2 chassis, which only SUP has pdu info
     # try to find sup node in multi-dut

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -13,7 +13,7 @@ from retry.api import retry_call
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.helpers.psu_helpers import turn_on_all_outlets, get_grouped_pdus_by_psu
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
-from tests.common.utilities import wait_until, get_sup_node_or_random_node
+from tests.common.utilities import skip_for_asic, wait_until, get_sup_node_or_random_node
 from tests.common.platform.device_utils import get_dut_psu_line_pattern
 from tests.common.helpers.thermal_control_test_helper import ThermalPolicyFileContext,\
     check_cli_output_with_mocker, restart_thermal_control_daemon, check_thermal_algorithm_status, \
@@ -176,12 +176,10 @@ def get_healthy_psu_num(duthost):
         @param: DUT host instance
         @return: Number of healthy PSUs
     """
+    skip_for_asic(duthost, ['vs'])
     PSUUTIL_CMD = "sudo psuutil status"
     healthy_psus = 0
     psuutil_status_output = duthost.command(PSUUTIL_CMD, module_ignore_errors=True)
-    # For kvm testbed, we will get expected Error code `ERROR_CHASSIS_LOAD = 2` here.
-    if duthost.facts["asic_type"] == "vs" and psuutil_status_output['rc'] == 2:
-        return
     assert psuutil_status_output["rc"] == 0, "Run command '{}' failed".format(PSUUTIL_CMD)
 
     psus_status = psuutil_status_output["stdout_lines"][2:]
@@ -254,8 +252,6 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
     psu_line_pattern = get_dut_psu_line_pattern(duthost)
 
     psu_num = get_healthy_psu_num(duthost)
-    # For kvm testbed, psu_num will return None
-    # Only physical testbeds need to check the psu number
     if psu_num:
         pytest_require(
             psu_num >= 2, "At least 2 PSUs required for rest of the testing in this case")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
- Add a new 'skip_for_asic' common utility
- Skip the platform cli tests which are not intended for the virtual switch

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Platform tests like test_platform_serial_no are not intended for virtual switch. Tests are failing when running on virtual switch.

#### How did you do it?
Skip the platform tests by calling skip_for_asic for asic type "vs".

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
