### PR TITLE
Fix agent pool for pre-test

### DIFF
--- a/.azure-pipelines/pytest-collect-only.yml
+++ b/.azure-pipelines/pytest-collect-only.yml
@@ -23,7 +23,7 @@ steps:
 - script: |
     set -x
     sudo docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
-    sudo docker run -dt --name sonic-mgmt-collect \
+    sudo docker run --rm -dt --name sonic-mgmt-collect \
       -v $(System.DefaultWorkingDirectory):/var/src/sonic-mgmt \
       sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest \
       /bin/bash

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ stages:
     displayName: "Validate Test Cases"
     timeoutInMinutes: 20
     continueOnError: false
-    pool: sonic-common
+    pool: sonic-ubuntu-1c
     steps:
     - template: .azure-pipelines/pytest-collect-only.yml
 


### PR DESCRIPTION
### Description of PR

This PR sets the agent pool for Pre_Test step to `sonic-ubuntu-1c` and backports a change from https://github.com/sonic-net/sonic-mgmt/pull/16385/files as the `sonic-common` pool is not used anymore.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [x] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

Fix broken CI

#### How did you do it?

Change agent pool

#### How did you verify/test it?

TBD

#### Any platform specific information?

No

#### Supported testbed topology if it's a new test case?

NA

### Documentation
NA