### PR TITLE
Refine the logic of matching conditional mark.

### DIFF
--- a/tests/common/plugins/conditional_mark/README.md
+++ b/tests/common/plugins/conditional_mark/README.md
@@ -15,7 +15,8 @@ In `pytest_collection` hook function, it reads the specified conditions file and
 In `pytest_collection_modifyitems`, each collected test item (test case) is examined.
 For each item, all potential matching conditions found based on the test case name are identified.
 If a match is found and its mark is unique across all matches, the corresponding mark will be added to the test case.
-If there are multiple matches, the mark from the longest match is used.
+If there are multiple matches, the mark from the longest match which conditions are True is used.
+This means that if the conditions in the longest matching entry are False, we will backtrack to find the longest matching entry with conditions that are True.
 Different marks across multiple files are allowed.
 
 
@@ -82,8 +83,8 @@ folder3:
 
 This plugin process each expanded (for parametrized test cases) test cases one by one.
 For each test case, it will get all potential matches that match the pattern of test case name.
-And then, for each match, if the mark in it is unique across all matches, we will add this mark to test case based on conditions.
-Otherwise, we will use the mark which belongs to the longest match.
+And then, for each match, if the mark in it is unique across all matches, and the conditions in this mark are True, we will add this mark to test case based on conditions.
+Otherwise, we will use the mark which belongs to the longest match which conditions are True.
 
 Then we can easily apply a set of marks for specific test case in a script file and another set of marks for rest of the test cases in the same script file.
 

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -403,7 +403,7 @@ def load_basic_facts(dut_name, session):
     return results
 
 
-def find_all_matches(nodeid, conditions):
+def find_all_matches(nodeid, conditions, session, dynamic_update_skip_reason, basic_facts):
     """Find all matches of the given test case name in the conditions list.
 
     Args:
@@ -439,21 +439,27 @@ def find_all_matches(nodeid, conditions):
         length = len(case_starting_substring)
         marks = match[case_starting_substring].keys()
         for mark in marks:
-            if mark in conditional_marks:
-                if length >= max_length:
+            condition_value = evaluate_conditions(dynamic_update_skip_reason, match[mark],
+                                                  match[mark].get('conditions'), basic_facts,
+                                                  match[mark].get('conditions_logical_operator', 'AND').upper(),
+                                                  session)
+
+            if condition_value:
+                if mark in conditional_marks:
+                    if length >= max_length:
+                        conditional_marks.update({
+                            mark: {
+                                case_starting_substring: {
+                                    mark: match[case_starting_substring][mark]}
+                            }})
+                        max_length = length
+                else:
                     conditional_marks.update({
                         mark: {
                             case_starting_substring: {
                                 mark: match[case_starting_substring][mark]}
                         }})
                     max_length = length
-            else:
-                conditional_marks.update({
-                    mark: {
-                        case_starting_substring: {
-                            mark: match[case_starting_substring][mark]}
-                    }})
-                max_length = length
 
     # We may have the same matches of different marks
     # Need to remove duplicate here
@@ -619,7 +625,7 @@ def pytest_collection_modifyitems(session, config, items):
         json.dumps(basic_facts, indent=2)))
     dynamic_update_skip_reason = session.config.option.dynamic_update_skip_reason
     for item in items:
-        all_matches = find_all_matches(item.nodeid, conditions)
+        all_matches = find_all_matches(item.nodeid, conditions, session, dynamic_update_skip_reason, basic_facts)
 
         if all_matches:
             logger.debug('Found match "{}" for test case "{}"'.format(all_matches, item.nodeid))

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -439,10 +439,10 @@ def find_all_matches(nodeid, conditions, session, dynamic_update_skip_reason, ba
         length = len(case_starting_substring)
         marks = match[case_starting_substring].keys()
         for mark in marks:
-            condition_value = evaluate_conditions(dynamic_update_skip_reason, match[mark],
-                                                  match[mark].get('conditions'), basic_facts,
-                                                  match[mark].get('conditions_logical_operator', 'AND').upper(),
-                                                  session)
+            condition_value = evaluate_conditions(dynamic_update_skip_reason, match[case_starting_substring][mark],
+                                                  match[case_starting_substring][mark].get('conditions'), basic_facts,
+                                                  match[case_starting_substring][mark].get(
+                                                      'conditions_logical_operator', 'AND').upper(), session)
 
             if condition_value:
                 if mark in conditional_marks:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #14395, we optimized the matching rule for conditional marks by considering all potential matches. If a mark is unique among these matches, it is applied to the test case. Otherwise, the longest matching entry is used.

In this PR, we further refine this logic by ensuring that the longest match where the condition is true is used. This means that if the conditions of the longest matching entry are false,  we will consider the next longest matching entry.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
In PR #14395, we optimized the matching rule for conditional marks by considering all potential matches. If a mark is unique among these matches, it is applied to the test case. Otherwise, the longest matching entry is used.

In this PR, we further refine this logic by ensuring that the longest match where the condition is true is used. This means that if the conditions of the longest matching entry are false,  we will consider the next longest matching entry.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
