### PR TITLE
chore: disable parallel run for po cleanup test

### DIFF
--- a/tests/test_parallel_modes/cisco_t2_8800.json
+++ b/tests/test_parallel_modes/cisco_t2_8800.json
@@ -14,7 +14,6 @@
     "memory_checker/test_memory_checker.py": "FULL_PARALLEL",
     "override_config_table/test_override_config_table_masic.py": "FULL_PARALLEL",
     "passw_hardening/test_passw_hardening.py": "FULL_PARALLEL",
-    "pc/test_po_cleanup.py": "FULL_PARALLEL",
     "platform_tests/api/test_chassis.py": "FULL_PARALLEL",
     "platform_tests/api/test_component.py": "FULL_PARALLEL",
     "platform_tests/api/test_module.py": "FULL_PARALLEL",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Disable parallel run for `pc/test_po_cleanup.py` test.

Summary:
Fixes # (issue) Microsoft ADO 31368079

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
There is config reload with `wait_for_bgp=True` in `pc/test_po_cleanup.py`, so when parallel run is enabled, LCs will do config reload at different time and we cannot make sure all the iBGP in one LC can be established after config reload within the given time limit.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
