### PR TITLE
[On hold, merge if required] chore: temporarily skip show mac sanity

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -130,6 +130,10 @@ def filter_check_items(tbinfo, duthosts, check_items):
         if 'check_mac_entry_count' in filtered_check_items:
             filtered_check_items.remove('check_mac_entry_count')
 
+    # Temporarily disable check_mac_entry_count sanity due to a known issue. Will be enabled after the issue is fixed.
+    if 'check_mac_entry_count' in filtered_check_items:
+        filtered_check_items.remove('check_mac_entry_count')
+
     return filtered_check_items
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Temporarily skip the `check_mac_entry_count` sanity check.

Summary:
Fixes # (issue) Microsoft ADO 31238387

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
There's a known issue for the "sudo ip netns exec asic0 show mac" command, so we wanted to skip it until we fix the issue. Microsoft ADO 31238387 was created to track this issue

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
