### PR TITLE
Enable running pc/test_lag_member.py::test_lag_member_status on KVM T0

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1518,10 +1518,14 @@ pc/test_lag_2.py::test_lag_db_status_with_po_update:
 
 pc/test_lag_member.py:
   skip:
-    reason: "Not support dualtor or t0 backend topo / Have an issue on kvm t0"
-    conditions_logical_operator: or
+    reason: "Not support dualtor or t0 backend topo"
     conditions:
         - "'dualtor' in topo_name or 't0-backend' in topo_name"
+
+pc/test_lag_member.py::test_lag_member_traffic:
+  skip:
+    reason: "Have an issue on kvm t0"
+    conditions:
         - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/13898"
 
 pc/test_po_cleanup.py:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

The pc/test_lag_member.py::test_lag_member_status test case can be run on KVM T0.

#### How did you do it?

Allow this test case to run, to at least enable some coverage of the code in this file. Modify the conditional markings so that all test cases still get skipped on dualtor or backend T0, and only `lag_member_traffic` gets skipped on KVM.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
