### PR TITLE
Added sleep between restapi calls, during verifying routes on test_da…

### DIFF
--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -341,6 +341,8 @@ def test_data_path(construct_url, vlan_members, cleanup_after_testing):
     pytest_assert(r.status_code == 204)
 
     # Verify routes
+    # Add some delay before query
+    time.sleep(5)
     params = '{}'
     r = restapi.get_config_vrouter_vrf_id_routes(
         construct_url, 'vnet-guid-3', params)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Added sleep between restapi calls, during verifying routes on test_data_path.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Sometimes the test_data_path failed due to restapi query didn't include all necessary data, seems like a timing issue.

#### How did you do it?
I noticed all rest API calls has a 5 seconds sleep to enable less congestion, so I added it to the code part which it was missing.
#### How did you verify/test it?
Ran the test few times, and it passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
