### PR TITLE
Enhance minigraph link template for autonegotiation and remove requirement to add autoneg interfaces in topo file

### DIFF
--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -63,22 +63,22 @@
 {% for iface_name in device_conn[inventory_hostname].keys() %}
     {% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}
         {% if 'on' in device_conn[inventory_hostname][iface_name]['autoneg'] %}
-            <a:LinkMetadata>
-                <a:Name i:nil="true"/>
-                <a:Properties>
-                    <a:DeviceProperty>
-                        <a:Name>AutoNegotiation</a:Name>
-                        <a:Value>True</a:Value>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
                     </a:DeviceProperty>
-                    {% if msft_an_enabled is defined %}
-                        <a:DeviceProperty>
-                            <a:Name>FECDisabled</a:Name>
-                            <a:Reference i:nil="true"/>
-                            <a:Value>True</a:Value>
-                        </a:DeviceProperty>
-                    {% endif %}
-                </a:Properties>
-                <a:Key>{{ device_conn[inventory_hostname][iface_name]['peerdevice'] }}:{{ device_conn[inventory_hostname][iface_name]['peerport'] }};{{ inventory_hostname }}:{{ port_name_map[iface_name] }}</a:Key>
+            {% if msft_an_enabled is defined %}
+                 <a:DeviceProperty>
+                     <a:Name>FECDisabled</a:Name>
+                     <a:Reference i:nil="true"/>
+                     <a:Value>True</a:Value>
+                 </a:DeviceProperty>
+            {% endif %}
+            </a:Properties>
+            <a:Key>{{ device_conn[inventory_hostname][iface_name]['peerdevice'] }}:{{ device_conn[inventory_hostname][iface_name]['peerport'] }};{{ inventory_hostname }}:{{ port_name_map[iface_name] }}</a:Key>
             </a:LinkMetadata>
         {% endif %}
     {% endif %}
@@ -88,4 +88,3 @@
     </Link>
   </LinkMetadataDeclaration>
 {% endif %}
-

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -53,12 +53,16 @@
   </LinkMetadataDeclaration>
 {% endif %}
 
+{% set ns = namespace(is_autoneg_on=False) %}
 
-  <LinkMetadataDeclaration>
-  <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% for iface_name in device_conn[inventory_hostname].keys() %}
   {% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}
     {% if 'on' in device_conn[inventory_hostname][iface_name]['autoneg'] %}
+        {% if not ns.is_autoneg_on %}
+        {% set ns.is_autoneg_on = True %}
+  <LinkMetadataDeclaration>
+  <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      {% endif %}
       <a:LinkMetadata>
           <a:Name i:nil="true"/>
           <a:Properties>
@@ -80,5 +84,7 @@
   {% endif %}
 {% endfor %}
 
+{% if ns.is_autoneg_on == True %}
     </Link>
-</LinkMetadataDeclaration>
+  </LinkMetadataDeclaration>
+{% endif %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -1,9 +1,15 @@
 {% set link_defined = False %}
 
-{% if 'dualtor' in topo or (macsec_card is defined and macsec_card == True and 't2' in topo) or any('on' in device_conn[inventory_hostname][iface_name]['autoneg'] for iface_name in device_conn[inventory_hostname] if 'autoneg' in device_conn[inventory_hostname][iface_name]) %}
+{% if 'dualtor' in topo or 
+      (macsec_card is defined and macsec_card == True and 't2' in topo) or 
+      (device_conn is defined and inventory_hostname in device_conn and 
+      any('autoneg' in device_conn[inventory_hostname][iface] and 
+          'on' in device_conn[inventory_hostname][iface]['autoneg'] 
+          for iface in device_conn[inventory_hostname])) %}
+
     {% set link_defined = True %}
-    <LinkMetadataDeclaration>
-        <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+  <LinkMetadataDeclaration>
+      <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% endif %}
 
 
@@ -79,7 +85,7 @@
 {% endfor %}
 
 {% if link_defined %}
-        </Link>
-    </LinkMetadataDeclaration>
+      </Link>
+  </LinkMetadataDeclaration>
 {% endif %}
 

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -53,33 +53,32 @@
   </LinkMetadataDeclaration>
 {% endif %}
 
-{% if msft_an_enabled is defined and vm_topo_config.get('autoneg_interfaces') is not none %}
+{% if vm_topo_config.get('autoneg_interfaces') is not none %}
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-{% for if_index in vm_topo_config['autoneg_interfaces']['intfs'] %}
-
-{% if "mellanox" in device_info[inventory_hostname]['HwSku']|lower %}
-{% set autoneg_intf = "etp" ~ if_index %}
-{% else %}
-{% set autoneg_intf = "Ethernet" ~ if_index ~ "/1" %}
-{% endif %}
-{% if port_alias_map[autoneg_intf] in device_conn[inventory_hostname] and device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['autoneg']|lower == "on" %}
+{% for iface_name in device_conn[inventory_hostname].keys() %}
+      {% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}
+        {% if 'on' in device_conn[inventory_hostname][iface_name]['autoneg'] %}
         <a:LinkMetadata>
             <a:Name i:nil="true"/>
             <a:Properties>
             <a:DeviceProperty>
-                 <a:Name>AutoNegotiation</a:Name>
-                 <a:Value>True</a:Value>
+                <a:Name>AutoNegotiation</a:Name>
+                <a:Reference i:nil="true"/>
+                <a:Value>True</a:Value>
             </a:DeviceProperty>
+            {% if msft_an_enabled is defined %}
             <a:DeviceProperty>
-                 <a:Name>FECDisabled</a:Name>
-                 <a:Reference i:nil="true"/>
+                <a:Name>FECDisabled</a:Name>
+                <a:Reference i:nil="true"/>
                  <a:Value>True</a:Value>
             </a:DeviceProperty>
+            {% endif %}
             </a:Properties>
-            <a:Key>{{ device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['peerdevice'] }}:{{ device_conn[inventory_hostname][port_alias_map[autoneg_intf]]['peerport'] }};{{ inventory_hostname }}:{{ autoneg_intf }}</a:Key>
-        </a:LinkMetadata>
-{% endif %}
+        <a:Key>{{ device_conn[inventory_hostname][iface_name]['peerdevice'] }}:{{ device_conn[inventory_hostname][iface_name]['peerport'] }};{{ inventory_hostname }}:{{ port_name_map[iface_name] }}</a:Key>
+      </a:LinkMetadata>
+        {% endif %}
+      {% endif %}
 {% endfor %}
     </Link>
   </LinkMetadataDeclaration>

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -1,90 +1,84 @@
+{% set link_defined = False %}
+
+{% if 'dualtor' in topo or (macsec_card is defined and macsec_card == True and 't2' in topo) or any('on' in device_conn[inventory_hostname][iface_name]['autoneg'] for iface_name in device_conn[inventory_hostname] if 'autoneg' in device_conn[inventory_hostname][iface_name]) %}
+    {% set link_defined = True %}
+    <LinkMetadataDeclaration>
+        <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+{% endif %}
+
 {% if 'dualtor' in topo %}
-  <LinkMetadataDeclaration>
-    <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-{% for tunnel in tunnel_configs %}
-      <a:LinkMetadata>
-          <a:Name i:nil="true" />
-          <a:Properties>
-            <a:DeviceProperty>
-              <a:Name>GeminiPeeringLink</a:Name>
-              <a:Reference i:nil="true" />
-              <a:Value>True</a:Value>
-            </a:DeviceProperty>
-            <a:DeviceProperty>
-              <a:Name>UpperTOR</a:Name>
-              <a:Reference i:nil="true" />
-              <a:Value>{{ dual_tor_facts['positions']['upper'] }}</a:Value>
-            </a:DeviceProperty>
-            <a:DeviceProperty>
-              <a:Name>LowerTOR</a:Name>
-              <a:Reference i:nil="true" />
-              <a:Value>{{ dual_tor_facts['positions']['lower'] }}</a:Value>
-            </a:DeviceProperty>
-          </a:Properties>
-        <a:Key>{{ dual_tor_facts['positions']['lower'] }}:{{ tunnel }};{{ dual_tor_facts['positions']['upper'] }}:{{ tunnel }}</a:Key>
-      </a:LinkMetadata>
-{% endfor %}
-    </Link>
-  </LinkMetadataDeclaration>
+    {% for tunnel in tunnel_configs %}
+        <a:LinkMetadata>
+            <a:Name i:nil="true" />
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>GeminiPeeringLink</a:Name>
+                    <a:Reference i:nil="true" />
+                    <a:Value>True</a:Value>
+                </a:DeviceProperty>
+                <a:DeviceProperty>
+                    <a:Name>UpperTOR</a:Name>
+                    <a:Reference i:nil="true" />
+                    <a:Value>{{ dual_tor_facts['positions']['upper'] }}</a:Value>
+                </a:DeviceProperty>
+                <a:DeviceProperty>
+                    <a:Name>LowerTOR</a:Name>
+                    <a:Reference i:nil="true" />
+                    <a:Value>{{ dual_tor_facts['positions']['lower'] }}</a:Value>
+                </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>{{ dual_tor_facts['positions']['lower'] }}:{{ tunnel }};{{ dual_tor_facts['positions']['upper'] }}:{{ tunnel }}</a:Key>
+        </a:LinkMetadata>
+    {% endfor %}
 {% endif %}
 
 {% if macsec_card is defined and macsec_card == True and 't2' in topo %}
-  <LinkMetadataDeclaration>
-    <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-{% for index in range(vms_number) %}
-{% set vm_intfs=vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|sort %}
-{% set dut_intfs=vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int]|sort %}
-{% for if_index in range(vm_intfs | length) %}
-{% if 'IB' not in port_alias[dut_intfs[if_index]] %}
-        <a:LinkMetadata>
-            <a:Name i:nil="true"/>
-            <a:Properties>
-            <a:DeviceProperty>
-                <a:Name>MacSecEnabled</a:Name>
-                <a:Value>True</a:Value>
-            </a:DeviceProperty>
-            </a:Properties>
-            <a:Key>{{ vms[index] }}:{{ vm_intfs[if_index] }};{{ inventory_hostname }}:{{ port_alias[dut_intfs[if_index]] }}</a:Key>
-        </a:LinkMetadata>
+    {% for index in range(vms_number) %}
+        {% set vm_intfs = vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int] | sort %}
+        {% set dut_intfs = vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int] | sort %}
+        {% for if_index in range(vm_intfs | length) %}
+            {% if 'IB' not in port_alias[dut_intfs[if_index]] %}
+                <a:LinkMetadata>
+                    <a:Name i:nil="true"/>
+                    <a:Properties>
+                        <a:DeviceProperty>
+                            <a:Name>MacSecEnabled</a:Name>
+                            <a:Value>True</a:Value>
+                        </a:DeviceProperty>
+                    </a:Properties>
+                    <a:Key>{{ vms[index] }}:{{ vm_intfs[if_index] }};{{ inventory_hostname }}:{{ port_alias[dut_intfs[if_index]] }}</a:Key>
+                </a:LinkMetadata>
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
 {% endif %}
-{% endfor %}
-{% endfor %}
-    </Link>
-  </LinkMetadataDeclaration>
-{% endif %}
-
-{% set ns = namespace(is_autoneg_on=False) %}
 
 {% for iface_name in device_conn[inventory_hostname].keys() %}
-  {% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}
-    {% if 'on' in device_conn[inventory_hostname][iface_name]['autoneg'] %}
-        {% if not ns.is_autoneg_on %}
-        {% set ns.is_autoneg_on = True %}
-  <LinkMetadataDeclaration>
-  <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-      {% endif %}
-      <a:LinkMetadata>
-          <a:Name i:nil="true"/>
-          <a:Properties>
-          <a:DeviceProperty>
-              <a:Name>AutoNegotiation</a:Name>
-              <a:Value>True</a:Value>
-          </a:DeviceProperty>
-          {% if msft_an_enabled is defined %}
-          <a:DeviceProperty>
-              <a:Name>FECDisabled</a:Name>
-              <a:Reference i:nil="true"/>
-              <a:Value>True</a:Value>
-          </a:DeviceProperty>
-          {% endif %}
-          </a:Properties>
-      <a:Key>{{ device_conn[inventory_hostname][iface_name]['peerdevice'] }}:{{ device_conn[inventory_hostname][iface_name]['peerport'] }};{{ inventory_hostname }}:{{ port_name_map[iface_name] }}</a:Key>
-      </a:LinkMetadata>
+    {% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}
+        {% if 'on' in device_conn[inventory_hostname][iface_name]['autoneg'] %}
+            <a:LinkMetadata>
+                <a:Name i:nil="true"/>
+                <a:Properties>
+                    <a:DeviceProperty>
+                        <a:Name>AutoNegotiation</a:Name>
+                        <a:Value>True</a:Value>
+                    </a:DeviceProperty>
+                    {% if msft_an_enabled is defined %}
+                        <a:DeviceProperty>
+                            <a:Name>FECDisabled</a:Name>
+                            <a:Reference i:nil="true"/>
+                            <a:Value>True</a:Value>
+                        </a:DeviceProperty>
+                    {% endif %}
+                </a:Properties>
+                <a:Key>{{ device_conn[inventory_hostname][iface_name]['peerdevice'] }}:{{ device_conn[inventory_hostname][iface_name]['peerport'] }};{{ inventory_hostname }}:{{ port_name_map[iface_name] }}</a:Key>
+            </a:LinkMetadata>
+        {% endif %}
     {% endif %}
-  {% endif %}
 {% endfor %}
 
-{% if ns.is_autoneg_on == True %}
-    </Link>
-  </LinkMetadataDeclaration>
+{% if link_defined %}
+        </Link>
+    </LinkMetadataDeclaration>
 {% endif %}
+

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -1,20 +1,20 @@
-{% set link_defined = False %}
+{% set link_metadata_defined = False %}
 
 {% if 'dualtor' in topo or
       (macsec_card is defined and macsec_card == True and 't2' in topo) %}
-    {% set link_defined = True %}
+    {% set link_metadata_defined = True %}
 {% endif %}
 
 {% if device_conn is defined and inventory_hostname in device_conn %}
     {% for iface in device_conn[inventory_hostname] %}
         {% if 'autoneg' in device_conn[inventory_hostname][iface] and
            'on' in device_conn[inventory_hostname][iface]['autoneg'] %}
-            {% set link_defined = True %}
+            {% set link_metadata_defined = True %}
         {% endif %}
     {% endfor %}
 {% endif %}
 
-{% if link_defined %}
+{% if link_metadata_defined %}
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% endif %}
@@ -92,7 +92,7 @@
 {% endfor %}
 {% endif %}
 
-{% if link_defined %}
+{% if link_metadata_defined %}
     </Link>
   </LinkMetadataDeclaration>
 {% endif %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -66,7 +66,6 @@
 {% endfor %}
 {% endif %}
 
-
 {% if device_conn is defined and inventory_hostname in device_conn %}
 {% for iface_name in device_conn[inventory_hostname].keys() %}
     {% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -53,16 +53,12 @@
   </LinkMetadataDeclaration>
 {% endif %}
 
-{% set ns = namespace(is_autoneg_on=False) %}
 
+  <LinkMetadataDeclaration>
+  <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% for iface_name in device_conn[inventory_hostname].keys() %}
   {% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}
     {% if 'on' in device_conn[inventory_hostname][iface_name]['autoneg'] %}
-        {% if not ns.is_autoneg_on %}
-        {% set ns.is_autoneg_on = True %}
-  <LinkMetadataDeclaration>
-  <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-      {% endif %}
       <a:LinkMetadata>
           <a:Name i:nil="true"/>
           <a:Properties>
@@ -84,7 +80,5 @@
   {% endif %}
 {% endfor %}
 
-{% if ns.is_autoneg_on == True %}
     </Link>
 </LinkMetadataDeclaration>
-{% endif %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -67,6 +67,7 @@
 {% endif %}
 
 
+{% if device_conn is defined and inventory_hostname in device_conn %}
 {% for iface_name in device_conn[inventory_hostname].keys() %}
     {% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}
         {% if 'on' in device_conn[inventory_hostname][iface_name]['autoneg'] %}
@@ -90,6 +91,7 @@
         {% endif %}
     {% endif %}
 {% endfor %}
+{% endif %}
 
 {% if link_defined %}
     </Link>

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -10,7 +10,6 @@
         {% if 'autoneg' in device_conn[inventory_hostname][iface] and
            'on' in device_conn[inventory_hostname][iface]['autoneg'] %}
             {% set link_defined = True %}
-            {% break %}
         {% endif %}
     {% endfor %}
 {% endif %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -1,15 +1,15 @@
 {% set link_defined = False %}
 
-{% if 'dualtor' in topo or 
-      (macsec_card is defined and macsec_card == True and 't2' in topo) or 
-      (device_conn is defined and inventory_hostname in device_conn and 
-      any('autoneg' in device_conn[inventory_hostname][iface] and 
-          'on' in device_conn[inventory_hostname][iface]['autoneg'] 
+{% if 'dualtor' in topo or
+      (macsec_card is defined and macsec_card == True and 't2' in topo) or
+      (device_conn is defined and inventory_hostname in device_conn and
+      any('autoneg' in device_conn[inventory_hostname][iface] and
+          'on' in device_conn[inventory_hostname][iface]['autoneg']
           for iface in device_conn[inventory_hostname])) %}
 
     {% set link_defined = True %}
   <LinkMetadataDeclaration>
-      <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+    <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% endif %}
 
 
@@ -85,7 +85,7 @@
 {% endfor %}
 
 {% if link_defined %}
-      </Link>
+    </Link>
   </LinkMetadataDeclaration>
 {% endif %}
 

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -53,33 +53,38 @@
   </LinkMetadataDeclaration>
 {% endif %}
 
-{% if vm_topo_config.get('autoneg_interfaces') is not none %}
-  <LinkMetadataDeclaration>
-    <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+{% set ns = namespace(is_autoneg_on=False) %}
+
 {% for iface_name in device_conn[inventory_hostname].keys() %}
-      {% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}
-        {% if 'on' in device_conn[inventory_hostname][iface_name]['autoneg'] %}
-        <a:LinkMetadata>
-            <a:Name i:nil="true"/>
-            <a:Properties>
-            <a:DeviceProperty>
-                <a:Name>AutoNegotiation</a:Name>
-                <a:Reference i:nil="true"/>
-                <a:Value>True</a:Value>
-            </a:DeviceProperty>
-            {% if msft_an_enabled is defined %}
-            <a:DeviceProperty>
-                <a:Name>FECDisabled</a:Name>
-                <a:Reference i:nil="true"/>
-                 <a:Value>True</a:Value>
-            </a:DeviceProperty>
-            {% endif %}
-            </a:Properties>
-        <a:Key>{{ device_conn[inventory_hostname][iface_name]['peerdevice'] }}:{{ device_conn[inventory_hostname][iface_name]['peerport'] }};{{ inventory_hostname }}:{{ port_name_map[iface_name] }}</a:Key>
-      </a:LinkMetadata>
-        {% endif %}
+  {% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}
+    {% if 'on' in device_conn[inventory_hostname][iface_name]['autoneg'] %}
+        {% if not ns.is_autoneg_on %}
+        {% set ns.is_autoneg_on = True %}
+  <LinkMetadataDeclaration>
+  <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       {% endif %}
+      <a:LinkMetadata>
+          <a:Name i:nil="true"/>
+          <a:Properties>
+          <a:DeviceProperty>
+              <a:Name>AutoNegotiation</a:Name>
+              <a:Value>True</a:Value>
+          </a:DeviceProperty>
+          {% if msft_an_enabled is defined %}
+          <a:DeviceProperty>
+              <a:Name>FECDisabled</a:Name>
+              <a:Reference i:nil="true"/>
+              <a:Value>True</a:Value>
+          </a:DeviceProperty>
+          {% endif %}
+          </a:Properties>
+      <a:Key>{{ device_conn[inventory_hostname][iface_name]['peerdevice'] }}:{{ device_conn[inventory_hostname][iface_name]['peerport'] }};{{ inventory_hostname }}:{{ port_name_map[iface_name] }}</a:Key>
+      </a:LinkMetadata>
+    {% endif %}
+  {% endif %}
 {% endfor %}
+
+{% if ns.is_autoneg_on == True %}
     </Link>
-  </LinkMetadataDeclaration>
+</LinkMetadataDeclaration>
 {% endif %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -6,52 +6,53 @@
         <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% endif %}
 
+
 {% if 'dualtor' in topo %}
-    {% for tunnel in tunnel_configs %}
-        <a:LinkMetadata>
-            <a:Name i:nil="true" />
-            <a:Properties>
-                <a:DeviceProperty>
-                    <a:Name>GeminiPeeringLink</a:Name>
-                    <a:Reference i:nil="true" />
-                    <a:Value>True</a:Value>
-                </a:DeviceProperty>
-                <a:DeviceProperty>
-                    <a:Name>UpperTOR</a:Name>
-                    <a:Reference i:nil="true" />
-                    <a:Value>{{ dual_tor_facts['positions']['upper'] }}</a:Value>
-                </a:DeviceProperty>
-                <a:DeviceProperty>
-                    <a:Name>LowerTOR</a:Name>
-                    <a:Reference i:nil="true" />
-                    <a:Value>{{ dual_tor_facts['positions']['lower'] }}</a:Value>
-                </a:DeviceProperty>
-            </a:Properties>
-            <a:Key>{{ dual_tor_facts['positions']['lower'] }}:{{ tunnel }};{{ dual_tor_facts['positions']['upper'] }}:{{ tunnel }}</a:Key>
-        </a:LinkMetadata>
-    {% endfor %}
+{% for tunnel in tunnel_configs %}
+      <a:LinkMetadata>
+          <a:Name i:nil="true" />
+          <a:Properties>
+            <a:DeviceProperty>
+              <a:Name>GeminiPeeringLink</a:Name>
+              <a:Reference i:nil="true" />
+              <a:Value>True</a:Value>
+            </a:DeviceProperty>
+            <a:DeviceProperty>
+              <a:Name>UpperTOR</a:Name>
+              <a:Reference i:nil="true" />
+              <a:Value>{{ dual_tor_facts['positions']['upper'] }}</a:Value>
+            </a:DeviceProperty>
+            <a:DeviceProperty>
+              <a:Name>LowerTOR</a:Name>
+              <a:Reference i:nil="true" />
+              <a:Value>{{ dual_tor_facts['positions']['lower'] }}</a:Value>
+            </a:DeviceProperty>
+          </a:Properties>
+        <a:Key>{{ dual_tor_facts['positions']['lower'] }}:{{ tunnel }};{{ dual_tor_facts['positions']['upper'] }}:{{ tunnel }}</a:Key>
+      </a:LinkMetadata>
+{% endfor %}
 {% endif %}
 
 {% if macsec_card is defined and macsec_card == True and 't2' in topo %}
-    {% for index in range(vms_number) %}
-        {% set vm_intfs = vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int] | sort %}
-        {% set dut_intfs = vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int] | sort %}
-        {% for if_index in range(vm_intfs | length) %}
-            {% if 'IB' not in port_alias[dut_intfs[if_index]] %}
-                <a:LinkMetadata>
-                    <a:Name i:nil="true"/>
-                    <a:Properties>
-                        <a:DeviceProperty>
-                            <a:Name>MacSecEnabled</a:Name>
-                            <a:Value>True</a:Value>
-                        </a:DeviceProperty>
-                    </a:Properties>
-                    <a:Key>{{ vms[index] }}:{{ vm_intfs[if_index] }};{{ inventory_hostname }}:{{ port_alias[dut_intfs[if_index]] }}</a:Key>
-                </a:LinkMetadata>
-            {% endif %}
-        {% endfor %}
-    {% endfor %}
+{% for index in range(vms_number) %}
+{% set vm_intfs=vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|sort %}
+{% set dut_intfs=vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int]|sort %}
+{% for if_index in range(vm_intfs | length) %}
+{% if 'IB' not in port_alias[dut_intfs[if_index]] %}
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+            <a:DeviceProperty>
+                <a:Name>MacSecEnabled</a:Name>
+                <a:Value>True</a:Value>
+            </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>{{ vms[index] }}:{{ vm_intfs[if_index] }};{{ inventory_hostname }}:{{ port_alias[dut_intfs[if_index]] }}</a:Key>
+        </a:LinkMetadata>
 {% endif %}
+{% endfor %}
+{% endif %}
+
 
 {% for iface_name in device_conn[inventory_hostname].keys() %}
     {% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -1,17 +1,24 @@
 {% set link_defined = False %}
 
 {% if 'dualtor' in topo or
-      (macsec_card is defined and macsec_card == True and 't2' in topo) or
-      (device_conn is defined and inventory_hostname in device_conn and
-      any('autoneg' in device_conn[inventory_hostname][iface] and
-          'on' in device_conn[inventory_hostname][iface]['autoneg']
-          for iface in device_conn[inventory_hostname])) %}
-
+      (macsec_card is defined and macsec_card == True and 't2' in topo) %}
     {% set link_defined = True %}
+{% endif %}
+
+{% if device_conn is defined and inventory_hostname in device_conn %}
+    {% for iface in device_conn[inventory_hostname] %}
+        {% if 'autoneg' in device_conn[inventory_hostname][iface] and
+           'on' in device_conn[inventory_hostname][iface]['autoneg'] %}
+            {% set link_defined = True %}
+            {% break %}
+        {% endif %}
+    {% endfor %}
+{% endif %}
+
+{% if link_defined %}
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% endif %}
-
 
 {% if 'dualtor' in topo %}
 {% for tunnel in tunnel_configs %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -63,6 +63,7 @@
         </a:LinkMetadata>
 {% endif %}
 {% endfor %}
+{% endfor %}
 {% endif %}
 
 

--- a/ansible/vars/topo_t0-56-o8v48.yml
+++ b/ansible/vars/topo_t0-56-o8v48.yml
@@ -106,8 +106,6 @@ topology:
         - 31
       vm_offset: 7
   DUT:
-    autoneg_interfaces:
-      intfs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:

--- a/ansible/vars/topo_t0-56-o8v48.yml
+++ b/ansible/vars/topo_t0-56-o8v48.yml
@@ -106,6 +106,8 @@ topology:
         - 31
       vm_offset: 7
   DUT:
+    autoneg_interfaces:
+      intfs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     vlan_configs:
       default_vlan_config: one_vlan_a
       one_vlan_a:


### PR DESCRIPTION





<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR updates the `minigraph_link_meta.j2` template and topology configuration to enhance how AutoNegotiation (`autoneg`) interfaces are processed in SONiC's Ansible scripts. The changes streamline interface detection and remove redundant conditions.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
- Removed dependency on `msft_an_enabled` for processing `autoneg_interfaces`.
- Improved logic to check for `'autoneg'` directly in `device_conn` rather than relying on predefined interface lists.
- Ensured FEC settings are included only if `msft_an_enabled` is defined.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
