### PR TITLE
Add new topo files for T2 Snappi route-conv automation tests

### DIFF
--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -205,12 +205,10 @@
 {% set dev_type = 'LeafRouter' %}
 {% elif 'T2' in dev %}
 {% set dev_type = 'SpineRouter' %}
+{% elif 'Snappi_T3' in dev %}
+{% set dev_type = 'RegionalHub' if loop.index <= 2 else 'AZNGHub' %}
 {% elif 'T3' in dev %}
-{% if loop.index|int % 2 %}
-{% set dev_type = 'RegionalHub' %}
-{% else %}
-{% set dev_type = 'AZNGHub' %}
-{% endif %}
+{% set dev_type = 'RegionalHub' if loop.index is odd else 'AZNGHub' %}
 {% elif ('T0' in dev) and (enable_compute_ai_deployment|default('false')|bool) %}
 {% set dev_type = 'BackEndToRRouter' %}
 {% elif 'T0' in dev %}

--- a/ansible/vars/topo_tgen_t2_2lc_masic_route_conv.yml
+++ b/ansible/vars/topo_tgen_t2_2lc_masic_route_conv.yml
@@ -1,0 +1,472 @@
+topology:
+  # 3 DUTs - 2 linecards (dut 0,1) and 1 Supervisor card (dut 2).
+  #
+  #  - 8 ports(port1-8) on dut0, asic0 connected to Ixia
+  #  - 8 ports(port9-16) on dut0, asic1 connected to Ixia
+  #  - 1 port on dut1 connected to T1
+  #
+  # No ptf ports, this is to setup the DUT for ixia testing.
+
+  dut_num: 3
+  VMs:
+    Snappi_T3_1:
+      vlans:
+        - 0.0@0
+        - 0.1@1
+      vm_offset: 0
+    Snappi_T3_2:
+      vlans:
+        - 0.2@2
+      vm_offset: 1
+    Snappi_T3_3:
+      vlans:
+        - 0.3@3
+      vm_offset: 2
+    Snappi_T3_4:
+      vlans:
+        - 0.5@4
+      vm_offset: 3
+    Snappi_T3_5:
+      vlans:
+        - 0.6@5
+      vm_offset: 4
+    Snappi_T3_6:
+      vlans:
+        - 0.7@6
+      vm_offset: 5
+    Snappi_T3_7:
+      vlans:
+        - 0.8@7
+      vm_offset: 6
+    Snappi_T3_8:
+      vlans:
+        - 0.18@8
+      vm_offset: 7
+    Snappi_T3_9:
+      vlans:
+        - 0.19@9
+      vm_offset: 8
+    Snappi_T3_10:
+      vlans:
+        - 0.20@10
+      vm_offset: 9
+    Snappi_T3_11:
+      vlans:
+        - 0.21@11
+      vm_offset: 10
+    Snappi_T3_12:
+      vlans:
+        - 0.22@12
+      vm_offset: 11
+    Snappi_T3_13:
+      vlans:
+        - 0.23@13
+      vm_offset: 12
+    Snappi_T3_14:
+      vlans:
+        - 0.24@14
+      vm_offset: 13
+    Snappi_T3_15:
+      vlans:
+        - 0.25@15
+      vm_offset: 14
+    T1_1:
+      vlans:
+        - 1.0@16
+      vm_offset: 15
+
+  DUT:
+    loopback:
+      ipv4:
+        - 10.1.0.1/32
+        - 10.1.0.2/32
+      ipv6:
+        - FC00:10::1/128
+        - FC00:11::1/128
+
+configuration_properties:
+  common:
+    podset_number: 400
+    tor_number: 16
+    tor_subnet_number: 8
+    max_tor_subnet_number: 32
+    tor_subnet_size: 128
+    dut_asn: 65100
+    dut_type: SpineRouter
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+  core:
+    swrole: core
+  leaf:
+    swrole: leaf
+
+configuration:
+  Snappi_T3_1:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.3.1.0
+          - 2000:1:1:4::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.3.1.1/31
+        ipv6: 2000:1:1:4::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_2:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.4.1.0
+          - 2000:1:1:5::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.4.1.1/31
+        ipv6: 2000:1:1:5::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.5.1.0
+          - 2000:1:1:6::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.5.1.1/31
+        ipv6: 2000:1:1:6::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_4:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.6.1.0
+          - 2000:1:1:7::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.6.1.1/31
+        ipv6: 2000:1:1:7::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_5:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.7.1.0
+          - 2000:1:1:8::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.7.1.1/31
+        ipv6: 2000:1:1:8::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_6:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.8.1.0
+          - 2000:1:1:9::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.8.1.1/31
+        ipv6: 2000:1:1:9::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_7:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.9.1.0
+          - 2000:1:1:a::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.9.1.1/31
+        ipv6: 2000:1:1:a::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_8:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.10.1.0
+          - 2000:1:1:b::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.10.1.1/31
+        ipv6: 2000:1:1:b::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_9:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.11.1.0
+          - 2000:1:1:c::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.11.1.1/31
+        ipv6: 2000:1:1:c::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_10:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.12.1.0
+          - 2000:1:1:d::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.12.1.1/31
+        ipv6: 2000:1:1:d::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_11:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.13.1.0
+          - 2000:1:1:e::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.13.1.1/31
+        ipv6: 2000:1:1:e::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_12:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.14.1.0
+          - 2000:1:1:f::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.14.1.1/31
+        ipv6: 2000:1:1:f::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_13:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.15.1.0
+          - 2000:1:1:10::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.15.1.1/31
+        ipv6: 2000:1:1:10::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_14:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.16.1.0
+          - 2000:1:1:11::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.16.1.1/31
+        ipv6: 2000:1:1:11::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_15:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.17.1.0
+          - 2000:1:1:12::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.17.1.1/31
+        ipv6: 2000:1:1:12::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  T1_1:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 20.2.1.1
+          - 2000:1:1:3::2
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.2/32
+        ipv6: 2064:100::2/128
+      Ethernet1:
+        ipv4: 20.2.1.0/31
+        ipv6: 2000:1:1:3::1/126
+        dut_index: 1
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64

--- a/ansible/vars/topo_tgen_t2_2lc_route_conv.yml
+++ b/ansible/vars/topo_tgen_t2_2lc_route_conv.yml
@@ -1,0 +1,471 @@
+topology:
+  # 3 DUTs - 2 linecards (dut 0,1) and 1 Supervisor card (dut 2).
+  #
+  #  - 16 ports(port1-16) on dut0 connected to Ixia
+  #  - 1 port on dut1 connected to T1
+  #
+  # No ptf ports, this is to setup the DUT for ixia testing.
+
+  dut_num: 3
+  VMs:
+    Snappi_T3_1:
+      vlans:
+        - 0.0@0
+        - 0.1@1
+      vm_offset: 0
+    Snappi_T3_2:
+      vlans:
+        - 0.2@2
+      vm_offset: 1
+    Snappi_T3_3:
+      vlans:
+        - 0.3@3
+      vm_offset: 2
+    Snappi_T3_4:
+      vlans:
+        - 0.4@4
+      vm_offset: 3
+    Snappi_T3_5:
+      vlans:
+        - 0.5@5
+      vm_offset: 4
+    Snappi_T3_6:
+      vlans:
+        - 0.6@6
+      vm_offset: 5
+    Snappi_T3_7:
+      vlans:
+        - 0.7@7
+      vm_offset: 6
+    Snappi_T3_8:
+      vlans:
+        - 0.8@8
+      vm_offset: 7
+    Snappi_T3_9:
+      vlans:
+        - 0.9@9
+      vm_offset: 8
+    Snappi_T3_10:
+      vlans:
+        - 0.10@10
+      vm_offset: 9
+    Snappi_T3_11:
+      vlans:
+        - 0.11@11
+      vm_offset: 10
+    Snappi_T3_12:
+      vlans:
+        - 0.12@12
+      vm_offset: 11
+    Snappi_T3_13:
+      vlans:
+        - 0.13@13
+      vm_offset: 12
+    Snappi_T3_14:
+      vlans:
+        - 0.14@14
+      vm_offset: 13
+    Snappi_T3_15:
+      vlans:
+        - 0.15@15
+      vm_offset: 14
+    T1_1:
+      vlans:
+        - 1.0@16
+      vm_offset: 15
+
+  DUT:
+    loopback:
+      ipv4:
+        - 10.1.0.1/32
+        - 10.1.0.2/32
+      ipv6:
+        - FC00:10::1/128
+        - FC00:11::1/128
+
+configuration_properties:
+  common:
+    podset_number: 400
+    tor_number: 16
+    tor_subnet_number: 8
+    max_tor_subnet_number: 32
+    tor_subnet_size: 128
+    dut_asn: 65100
+    dut_type: SpineRouter
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+  core:
+    swrole: core
+  leaf:
+    swrole: leaf
+
+configuration:
+  Snappi_T3_1:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.3.1.0
+          - 2000:1:1:4::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Ethernet2:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.3.1.1/31
+        ipv6: 2000:1:1:4::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_2:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.4.1.0
+          - 2000:1:1:5::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.4.1.1/31
+        ipv6: 2000:1:1:5::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.5.1.0
+          - 2000:1:1:6::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.5.1.1/31
+        ipv6: 2000:1:1:6::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_4:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.6.1.0
+          - 2000:1:1:7::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.6.1.1/31
+        ipv6: 2000:1:1:7::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_5:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.7.1.0
+          - 2000:1:1:8::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.7.1.1/31
+        ipv6: 2000:1:1:8::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_6:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.8.1.0
+          - 2000:1:1:9::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.8.1.1/31
+        ipv6: 2000:1:1:9::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_7:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.9.1.0
+          - 2000:1:1:a::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.9.1.1/31
+        ipv6: 2000:1:1:a::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_8:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.10.1.0
+          - 2000:1:1:b::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.10.1.1/31
+        ipv6: 2000:1:1:b::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_9:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.11.1.0
+          - 2000:1:1:c::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.11.1.1/31
+        ipv6: 2000:1:1:c::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_10:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.12.1.0
+          - 2000:1:1:d::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.12.1.1/31
+        ipv6: 2000:1:1:d::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_11:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.13.1.0
+          - 2000:1:1:e::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.13.1.1/31
+        ipv6: 2000:1:1:e::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_12:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.14.1.0
+          - 2000:1:1:f::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.14.1.1/31
+        ipv6: 2000:1:1:f::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_13:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.15.1.0
+          - 2000:1:1:10::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.15.1.1/31
+        ipv6: 2000:1:1:10::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_14:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.16.1.0
+          - 2000:1:1:11::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.16.1.1/31
+        ipv6: 2000:1:1:11::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  Snappi_T3_15:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65400
+      peers:
+        65100:
+          - 20.17.1.0
+          - 2000:1:1:12::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+        dut_index: 0
+      Port-Channel1:
+        ipv4: 20.17.1.1/31
+        ipv6: 2000:1:1:12::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+  T1_1:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 20.2.1.1
+          - 2000:1:1:3::2
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.2/32
+        ipv6: 2064:100::2/128
+      Ethernet1:
+        ipv4: 20.2.1.0/31
+        ipv6: 2000:1:1:3::1/126
+        dut_index: 1
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Created 2 new topology files for T2 Snappi based convergence tests.
topo_tgen_t2_2lc_masic_route_conv.yml: for muti-asic testbed
topo_tgen_t2_2lc_route_conv.yml: for single asic testbed

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Currently snappi based T2 convergence tests assumes DUT to be in certain initial state. And as part of tests, it configures BGP neighbors/Portchannel/Interface IPs etc. This is error prone. Also bringing DUT to that initial state requires manual steps.. 

#### How did you do it?
Created new topology files. The testbeds for snappi based convergence tests will use these topology files to generate initial DUT config(deploy-mg).
With this, the DUT config portion is automated, and hence we could remove the DUT config part as part of snappi tests going forward..

#### How did you verify/test it?
Ran the deploy-mg on both single and multi-asic testbed and could verify that config is as expected.
Ran the snappi tests by commenting out dut_config part and it goes through fine.
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
