### PR TITLE
chore: add exec_tsb to more tests in reliable tsa

### DIFF
--- a/tests/bgp/reliable_tsa/test_reliable_tsa_flaky.py
+++ b/tests/bgp/reliable_tsa/test_reliable_tsa_flaky.py
@@ -318,7 +318,7 @@ def test_dut_tsa_with_conf_reload_when_sup_on_tsa_dut_on_tsb_init(duthosts, loca
         # Verify dut config_reload scenario for one of the line card to make sure tsa config is in sync
         first_linecard = duthosts.frontend_nodes[0]
         first_linecard.shell('sudo config save -y')
-        config_reload(first_linecard, safe_reload=True, check_intf_up_ports=True)
+        config_reload(first_linecard, safe_reload=True, check_intf_up_ports=True, exec_tsb=True)
 
         # Verify DUT is in maintenance state.
         pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(first_linecard, cmd='TSC no-stats'),

--- a/tests/bgp/reliable_tsa/test_reliable_tsa_stable.py
+++ b/tests/bgp/reliable_tsa/test_reliable_tsa_stable.py
@@ -913,7 +913,7 @@ def test_sup_tsa_act_when_duts_on_tsa_with_sup_config_reload(duthosts, localhost
                 executor.submit(verify_tsa_after_sup_tsa, linecard)
 
         # Do config_reload on the supervisor and verify configs are same as before
-        config_reload(suphost, wait=300, safe_reload=True)
+        config_reload(suphost, wait=300, safe_reload=True, exec_tsb=True)
         pytest_assert('true' == get_tsa_chassisdb_config(suphost),
                       "Supervisor {} tsa_enabled config is not enabled".format(suphost.hostname))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add `exec_tsb=True` to the rest `config_reload()` calls in reliable tsa test.

Summary:
Fixes # (issue) https://github.com/sonic-net/sonic-buildimage/issues/21586

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
We introduced `exec_tsb=True` in PR #16807, but we missed a few there, so we decided to add them.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
