### PR TITLE
[fdb/test_fdb_mac_learning.py] Correct regex to match log message repetition

### DIFF
--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
 
     ignore_errors = [
-        r".*ERR swss#orchagent: :- update: Failed to get port by bridge port ID.*",
+        r".*ERR swss#orchagent: .*update: Failed to get port by bridge port ID.*",
         r".* ERR swss#tunnel_packet_handler.py: All portchannels failed to come up within \d+ minutes, exiting.*"
         ]
     if loganalyzer:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [fdb/test_fdb_mac_learning.py] Correct regex to match log message repetetion
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/422

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Currently test is ignoring log `.*ERR swss#orchagent: :- update: Failed to get port by bridge port ID.*` (done through https://github.com/sonic-net/sonic-mgmt/pull/15797), but in case if the log message gets repeated multiple times then the log message looks like `ERR swss#orchagent: message repeated 3 times: [ :- update: Failed to get port by bridge port ID 0x3a000000000646.]`. Current ignore log regex is not considering log message repetition and thus failing some times during teardown.


#### How did you do it?
Updated the regex to match on log message repetition as well.

#### How did you verify/test it?
Verified the test is passing consistently with the fix.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
