### PR TITLE
Add safe_reload for config_reload in test_syslog_srouce_ip

### DIFF
--- a/tests/syslog/test_syslog_source_ip.py
+++ b/tests/syslog/test_syslog_source_ip.py
@@ -97,7 +97,7 @@ def restore_config_by_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
                            state='absent', delay=1, timeout=30)
         localhost.wait_for(host=duthost.mgmt_ip, port=SONIC_SSH_PORT, search_regex=SONIC_SSH_REGEX,
                            state='started', delay=2, timeout=180)
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Without safe_reload, it's not enough time to wait system healthy. safe_reload will check critical services after reload.
#### How did you do it?
Add safe_reload=True, for config_reload

#### How did you verify/test it?
Run test_syslog_source_ip on testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
