### PR TITLE
Update the arp update test failure

### DIFF
--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -45,7 +45,7 @@ def test_kernel_asic_mac_mismatch(
     rand_selected_dut, ip_version, setup_vlan_arp_responder,  # noqa: F811
     tbinfo
 ):
-    vlan_name, ipv4_base, ipv6_base = setup_vlan_arp_responder
+    vlan_name, ipv4_base, ipv6_base, ip_offset = setup_vlan_arp_responder
     if 'dualtor' in tbinfo['topo']['name']:
         servers = mux_cable_server_ip(rand_selected_dut)
         intf = random.choice(list(servers))
@@ -55,9 +55,9 @@ def test_kernel_asic_mac_mismatch(
             target_ip = servers[intf]['server_ipv6'].split('/')[0]
     else:
         if ip_version == 4:
-            target_ip = ipv4_base.ip + 2
+            target_ip = ipv4_base.ip + ip_offset
         else:
-            target_ip = ipv6_base.ip + 2
+            target_ip = ipv6_base.ip + ip_offset
 
     rand_selected_dut.shell(f"ping -c1 -W1 {target_ip}; true")
 

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -242,7 +242,7 @@ def setup_vlan_arp_responder(ptfhost, rand_selected_dut, tbinfo):
     logger.info("Start arp_responder")
     ptfhost.command('supervisorctl start arp_responder')
 
-    yield vlan, ipv4_base, ipv6_base
+    yield vlan, ipv4_base, ipv6_base, ip_offset
 
     ptfhost.command('supervisorctl stop arp_responder')
 


### PR DESCRIPTION
The ip used in the test case is hard coded with the base ip + 2, in some topo, the ip is not added to the arp responder, then the test could fail. update it to use dynamic offset which could make sure the target ip in in the arp responder.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
