### PR TITLE
[TACACS] Increase tacacs server reachability check timeout

### DIFF
--- a/tests/common/helpers/tacacs/tacacs_helper.py
+++ b/tests/common/helpers/tacacs/tacacs_helper.py
@@ -39,7 +39,7 @@ def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip,
     """setup tacacs client"""
 
     # UT should failed when set reachable TACACS server with this setup_tacacs_client
-    retry = 5
+    retry = 20
     while retry > 0:
         ping_result = duthost.shell("ping {} -c 1 -W 3".format(tacacs_server_ip), module_ignore_errors=True)['stdout']
         logger.info("TACACS server ping result: {}".format(ping_result))

--- a/tests/common/helpers/tacacs/tacacs_helper.py
+++ b/tests/common/helpers/tacacs/tacacs_helper.py
@@ -39,7 +39,8 @@ def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip,
     """setup tacacs client"""
 
     # UT should failed when set reachable TACACS server with this setup_tacacs_client
-    retry = 20
+    # IPV6 network may not stable on some environment, retry timeout is 2 minutes
+    retry = 24
     while retry > 0:
         ping_result = duthost.shell("ping {} -c 1 -W 3".format(tacacs_server_ip), module_ignore_errors=True)['stdout']
         logger.info("TACACS server ping result: {}".format(ping_result))


### PR DESCRIPTION
Increase tacacs server reachability check timeout.

#### Why I did it
In some test environments, the IPV6 network is not stable, increase timeout to improve test case pass rate. 

##### Work item tracking
- Microsoft ADO: 31219981

#### How I did it
Increase timeout to 2 minutes.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Increase tacacs server reachability check timeout

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
