### PR TITLE
[test_pfcwd_timer_accuracy]: fix pfc timer accuracy date cmd input string issue

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -358,7 +358,7 @@ class TestPfcwdAllTimer(object):
                 logger.warning("Get timestamp: Unexpected syslog message format, syslog_msg {}".format(syslog_msg))
                 return int(0)
 
-            timestamp_ms = self.dut.shell("date -d {} +%s%3N".format(timestamp))['stdout']
+            timestamp_ms = self.dut.shell("date -d '{}' +%s%3N".format(timestamp))['stdout']
             return int(timestamp_ms)
         except Exception as e:
             logger.warning("Get timestamp: An unexpected error occurred: pattern {} err {}".format(pattern, str(e)))


### PR DESCRIPTION
…gument

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
It should be the day1 issue, but it was exposed by PR https://github.com/sonic-net/sonic-mgmt/pull/16897

#### How did you do it?
add quotes to ensure that the entire string is treated as a single argument


#### How did you verify/test it?
local run 
pfcwd/test_pfcwd_timer_accuracy.py::TestPfcwdAllTimer::test_pfcwd_timer_accuracy[bjw-can-7050qx-1] 
----------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------
12:56:13 test_pfcwd_timer_accuracy.retrieve_times L0349 WARNING| Get timestamp: An unexpected error occurred: pattern [P]FC_STORM_END err run module shell failed, Ansible Results =>
failed = True
changed = True
rc = 1
cmd = grep "[P]FC_STORM_END" /var/log/syslog
start = 2025-02-14 12:56:13.380668
end = 2025-02-14 12:56:13.388690
delta = 0:00:00.008022
msg = non-zero return code
invocation = {'module_args': {'_raw_params': 'grep "[P]FC_STORM_END" /var/log/syslog', '_uses_shell': True, 'warn': False, 'stdin_add_newline': True, 'strip_empty_ends': True, 'argv': None, 'chdir': None, 'executable': None, 'creates': None, 'removes': None, 'stdin': None}}
_ansible_no_log = None
stdout =
stderr =

12:56:15 test_pfcwd_timer_accuracy.run_test       L0221 WARNING| storm_start_ms 1739537704533 or storm_detect_ms 1739537705154 or storm_end_ms 0 or storm_restore_ms 1739537737593 is 0
12:56:15 test_pfcwd_timer_accuracy.run_test       L0227 WARNING| Skip this loop due to missing timestamps
PASSED                     

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
