### PR TITLE
Fix to correct the parameters passed to this API get_macsec_counters

### DIFF
--- a/tests/common/macsec/macsec_helper.py
+++ b/tests/common/macsec/macsec_helper.py
@@ -401,10 +401,9 @@ def get_macsec_attr(host, port):
     else:
         peer_ssci = None
 
-    # Get the packet number
-    ns = host.get_namespace_from_asic_id(asic.asic_index) if host.is_multi_asic else ''
-    counters = Counter(get_macsec_counters(asic, ns, macsec_ingress_sa_name))
-    pn = counters['SAI_MACSEC_SA_ATTR_CURRENT_XPN']
+    # Get the packet number from ingress SA
+    egress_dict, ingress_dict = get_macsec_counters(host, port)
+    pn = ingress_dict['SAI_MACSEC_SA_ATTR_CURRENT_XPN']
 
     return encrypt, send_sci, xpn_en, sci, an, sak, ssci, salt, int(peer_sci, 16), int(peer_an), peer_ssci, pn
 

--- a/tests/common/macsec/macsec_helper.py
+++ b/tests/common/macsec/macsec_helper.py
@@ -3,7 +3,7 @@ import re
 import json
 import logging
 import time
-from collections import defaultdict, deque, Counter
+from collections import defaultdict, deque
 from multiprocessing import Process
 
 import cryptography.exceptions


### PR DESCRIPTION
Summary:
Two of the PR's passed different set of parameters to the API get_macsec_counters.

https://github.com/sonic-net/sonic-mgmt/pull/15257
https://github.com/sonic-net/sonic-mgmt/pull/15905

Fix is to use the latest change made as per https://github.com/sonic-net/sonic-mgmt/pull/15257

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
