### PR TITLE
add safe_reload flag in test_bbr_disabled_constants_yml_default

### DIFF
--- a/tests/bgp/test_bgp_bbr_default_state.py
+++ b/tests/bgp/test_bgp_bbr_default_state.py
@@ -137,6 +137,6 @@ def test_bbr_disabled_constants_yml_default(duthosts, rand_one_dut_hostname, set
         loganalyzer[duthost.hostname].ignore_regex.extend([ignore_regex])
 
     duthost.shell("sudo config save -y")
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True)
     is_bbr_enabled = duthost.shell("show runningconfiguration bgp | grep allowas", module_ignore_errors=True)['stdout']
     pytest_assert(is_bbr_enabled == "", "BBR is not disabled when it should be.")


### PR DESCRIPTION
Add safe_reload flag to config_reload method to ensure device is ready to execute commands.
Otherwise the following command `show runningconfiguration bgp | grep allowas` may fail.

Change-Id: Ibb4c83671b31d4d9267bc024d6640f9315974b88

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
I've run the `test_bbr_disabled_constants_yml_default` test in a loop to verify there is no issue with executing commands on the DUT right after a config reload.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
