### PR TITLE
Lower Dynamic ACL test rules to fix bug in dualtor devices

### DIFF
--- a/tests/generic_config_updater/templates/create_arp_forward_rule.json
+++ b/tests/generic_config_updater/templates/create_arp_forward_rule.json
@@ -5,7 +5,7 @@
         "value": {
             "DYNAMIC_ACL_TABLE|ARP_RULE": {
                 "ETHER_TYPE": "0x0806",
-                "PRIORITY": "9997",
+                "PRIORITY": "898",
                 "PACKET_ACTION": "FORWARD"
             }
         }

--- a/tests/generic_config_updater/templates/create_dhcp_forward_rule_both.json
+++ b/tests/generic_config_updater/templates/create_dhcp_forward_rule_both.json
@@ -7,14 +7,14 @@
                 "IP_PROTOCOL": "17",
                 "L4_DST_PORT": "67",
                 "ETHER_TYPE": "0x0800",
-                "PRIORITY": "9999",
+                "PRIORITY": "900",
                 "PACKET_ACTION": "FORWARD"
             },
             "DYNAMIC_ACL_TABLE|DHCPV6_RULE": {
                 "IP_PROTOCOL": "17",
                 "L4_DST_PORT_RANGE": "547-548",
                 "ETHER_TYPE": "0x86DD",
-                "PRIORITY": "9998",
+                "PRIORITY": "899",
                 "PACKET_ACTION": "FORWARD"
             }
         }

--- a/tests/generic_config_updater/templates/create_forward_rules.j2
+++ b/tests/generic_config_updater/templates/create_forward_rules.j2
@@ -5,12 +5,12 @@
         "value": {
             "DYNAMIC_ACL_TABLE|RULE_1": {
                 "DST_IP": "{{ ipv4_subnet }}",
-                "PRIORITY": "9999",
+                "PRIORITY": "900",
                 "PACKET_ACTION": "FORWARD"
             },
             "DYNAMIC_ACL_TABLE|RULE_2": {
                 "DST_IPV6": "{{ ipv6_subnet }}",
-                "PRIORITY": "9998",
+                "PRIORITY": "899",
                 "PACKET_ACTION": "FORWARD"
             }
         }

--- a/tests/generic_config_updater/templates/create_initial_drop_rule.j2
+++ b/tests/generic_config_updater/templates/create_initial_drop_rule.j2
@@ -4,7 +4,7 @@
         "path": "/ACL_RULE",
         "value": {
             "DYNAMIC_ACL_TABLE|RULE_3": {
-                "PRIORITY": "9997",
+                "PRIORITY": "898",
                 "PACKET_ACTION": "DROP",
                 "IN_PORTS": "{{ blocked_port }}"
             }

--- a/tests/generic_config_updater/templates/create_ndp_forward_rule.json
+++ b/tests/generic_config_updater/templates/create_ndp_forward_rule.json
@@ -5,7 +5,7 @@
         "value": {
             "DYNAMIC_ACL_TABLE|NDP_RULE": {
                 "IP_PROTOCOL": "58",
-                "PRIORITY": "9996",
+                "PRIORITY": "897",
                 "PACKET_ACTION": "FORWARD"
             }
         }

--- a/tests/generic_config_updater/templates/create_secondary_drop_rule.j2
+++ b/tests/generic_config_updater/templates/create_secondary_drop_rule.j2
@@ -3,7 +3,7 @@
         "op": "add",
         "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_3",
         "value": {
-            "PRIORITY": "9995",
+            "PRIORITY": "896",
             "PACKET_ACTION": "DROP",
             "IN_PORTS": "{{ blocked_port }}"
         }

--- a/tests/generic_config_updater/templates/create_secondary_forward_rules.j2
+++ b/tests/generic_config_updater/templates/create_secondary_forward_rules.j2
@@ -4,7 +4,7 @@
         "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_1",
         "value": {
             "DST_IP": "{{ ipv4_subnet }}",
-            "PRIORITY": "9999",
+            "PRIORITY": "900",
             "PACKET_ACTION": "FORWARD"
         }
     },
@@ -13,7 +13,7 @@
         "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_2",
         "value": {
             "DST_IPV6": "{{ ipv6_subnet }}",
-            "PRIORITY": "9998",
+            "PRIORITY": "899",
             "PACKET_ACTION": "FORWARD"
         }
     }

--- a/tests/generic_config_updater/templates/create_three_drop_rules.j2
+++ b/tests/generic_config_updater/templates/create_three_drop_rules.j2
@@ -4,17 +4,17 @@
         "path": "/ACL_RULE",
         "value": {
             "DYNAMIC_ACL_TABLE|RULE_3": {
-                "PRIORITY": "9997",
+                "PRIORITY": "898",
                 "PACKET_ACTION": "DROP",
                 "IN_PORTS": "{{ blocked_port_1 }}"
             },
             "DYNAMIC_ACL_TABLE|RULE_4": {
-                "PRIORITY": "9996",
+                "PRIORITY": "897",
                 "PACKET_ACTION": "DROP",
                 "IN_PORTS": "{{ blocked_port_2 }}"
             },
             "DYNAMIC_ACL_TABLE|RULE_5": {
-                "PRIORITY": "9995",
+                "PRIORITY": "896",
                 "PACKET_ACTION": "DROP",
                 "IN_PORTS": "{{ blocked_port_3 }}"
             }

--- a/tests/generic_config_updater/templates/replace_nonexistent_rule.json
+++ b/tests/generic_config_updater/templates/replace_nonexistent_rule.json
@@ -4,7 +4,7 @@
         "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_10",
         "value": {
             "DST_IP": "103.23.2.2/32",
-            "PRIORITY": "9999",
+            "PRIORITY": "900",
             "PACKET_ACTION": "FORWARD"
         }
     }

--- a/tests/generic_config_updater/templates/replace_rules.j2
+++ b/tests/generic_config_updater/templates/replace_rules.j2
@@ -4,7 +4,7 @@
         "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_1",
         "value": {
             "DST_IP": "{{ ipv4_subnet }}",
-            "PRIORITY": "9999",
+            "PRIORITY": "900",
             "PACKET_ACTION": "FORWARD"
         }
     },
@@ -13,7 +13,7 @@
     "path": "/ACL_RULE/DYNAMIC_ACL_TABLE|RULE_2",
         "value": {
             "DST_IPV6": "{{ ipv6_subnet }}",
-            "PRIORITY": "9998",
+            "PRIORITY": "899",
             "PACKET_ACTION": "FORWARD"
         }
     }

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -75,8 +75,8 @@ DST_IPV6_FORWARDED_SCALE_PREFIX = "103:23:4:"
 DST_IP_BLOCKED = "103.23.3.1"
 DST_IPV6_BLOCKED = "103:23:3:1::1"
 
-MAX_IP_RULE_PRIORITY = 9900
-MAX_DROP_RULE_PRIORITY = 9000
+MAX_IP_RULE_PRIORITY = 800
+MAX_DROP_RULE_PRIORITY = 200
 
 # DHCP Constants
 
@@ -704,8 +704,8 @@ def dynamic_acl_create_forward_rules(duthost, setup):
 
     outputs = format_and_apply_template(duthost, CREATE_FORWARD_RULES_TEMPLATE, extra_vars, setup)
 
-    expected_rule_1_content = ["DYNAMIC_ACL_TABLE", "RULE_1", "9999", "FORWARD", "DST_IP: " + IPV4_SUBNET, "Active"]
-    expected_rule_2_content = ["DYNAMIC_ACL_TABLE", "RULE_2", "9998", "FORWARD", "DST_IPV6: " + IPV6_SUBNET, "Active"]
+    expected_rule_1_content = ["DYNAMIC_ACL_TABLE", "RULE_1", "900", "FORWARD", "DST_IP: " + IPV4_SUBNET, "Active"]
+    expected_rule_2_content = ["DYNAMIC_ACL_TABLE", "RULE_2", "899", "FORWARD", "DST_IPV6: " + IPV6_SUBNET, "Active"]
 
     for output in outputs:
         expect_op_success(duthost, output)
@@ -727,7 +727,7 @@ def dynamic_acl_create_secondary_drop_rule(duthost, setup, blocked_port_name=Non
 
     expected_rule_content = ["DYNAMIC_ACL_TABLE",
                              "RULE_3",
-                             "9995",
+                             "896",
                              "DROP",
                              "IN_PORTS: " + blocked_name,
                              "Active"]
@@ -749,7 +749,7 @@ def dynamic_acl_create_drop_rule_initial(duthost, setup):
 
     expected_rule_content = ["DYNAMIC_ACL_TABLE",
                              "RULE_3",
-                             "9997",
+                             "898",
                              "DROP",
                              "IN_PORTS: " + setup["blocked_src_port_name"],
                              "Active"]
@@ -777,19 +777,19 @@ def dynamic_acl_create_three_drop_rules(duthost, setup):
 
     expected_rule_3_content = ["DYNAMIC_ACL_TABLE",
                                "RULE_3",
-                               "9997",
+                               "898",
                                "DROP",
                                "IN_PORTS: " + extra_vars['blocked_port_1'],
                                "Active"]
     expected_rule_4_content = ["DYNAMIC_ACL_TABLE",
                                "RULE_4",
-                               "9996",
+                               "897",
                                "DROP",
                                "IN_PORTS: " + extra_vars['blocked_port_2'],
                                "Active"]
     expected_rule_5_content = ["DYNAMIC_ACL_TABLE",
                                "RULE_5",
-                               "9995",
+                               "896",
                                "DROP",
                                "IN_PORTS: " + extra_vars['blocked_port_3'],
                                "Active"]
@@ -810,7 +810,7 @@ def dynamic_acl_create_arp_forward_rule(duthost, setup):
     for output in outputs:
         expect_op_success(duthost, output)
 
-    expected_rule_content = ["DYNAMIC_ACL_TABLE", "ARP_RULE", "9997", "FORWARD", "ETHER_TYPE: 0x0806", "Active"]
+    expected_rule_content = ["DYNAMIC_ACL_TABLE", "ARP_RULE", "898", "FORWARD", "ETHER_TYPE: 0x0806", "Active"]
 
     expect_acl_rule_match(duthost, "ARP_RULE", expected_rule_content, setup)
 
@@ -823,7 +823,7 @@ def dynamic_acl_create_ndp_forward_rule(duthost, setup):
     for output in outputs:
         expect_op_success(duthost, output)
 
-    expected_rule_content = ["DYNAMIC_ACL_TABLE", "NDP_RULE", "9996", "FORWARD", "IP_PROTOCOL: 58", "Active"]
+    expected_rule_content = ["DYNAMIC_ACL_TABLE", "NDP_RULE", "897", "FORWARD", "IP_PROTOCOL: 58", "Active"]
 
     expect_acl_rule_match(duthost, "NDP_RULE", expected_rule_content, setup)
 
@@ -837,7 +837,7 @@ def dynamic_acl_create_dhcp_forward_rule(duthost, setup):
         expect_op_success(duthost, output)
 
     expected_v6_rule_content = ["DYNAMIC_ACL_TABLE",
-                                "DHCPV6_RULE", "9998",
+                                "DHCPV6_RULE", "899",
                                 "FORWARD",
                                 "IP_PROTOCOL: 17",
                                 "L4_DST_PORT_RANGE: 547-548",
@@ -845,7 +845,7 @@ def dynamic_acl_create_dhcp_forward_rule(duthost, setup):
                                 "Active"]
 
     expected_rule_content = ["DYNAMIC_ACL_TABLE",
-                             "DHCP_RULE", "9999",
+                             "DHCP_RULE", "900",
                              "FORWARD",
                              "IP_PROTOCOL: 17",
                              "L4_DST_PORT: 67",
@@ -918,13 +918,13 @@ def dynamic_acl_replace_rules(duthost, setup):
 
     expected_rule_1_content = ["DYNAMIC_ACL_TABLE",
                                "RULE_1",
-                               "9999",
+                               "900",
                                "FORWARD",
                                "DST_IP: " + REPLACEMENT_IPV4_SUBNET,
                                "Active"]
     expected_rule_2_content = ["DYNAMIC_ACL_TABLE",
                                "RULE_2",
-                               "9998",
+                               "899",
                                "FORWARD",
                                "DST_IPV6: " + REPLACEMENT_IPV6_SUBNET,
                                "Active"]


### PR DESCRIPTION

### Description of PR

Lowers rule priorities of dynamic acl test rules so that they correctly have less priority than the hardcoded rule in dualtor devices

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405
- [x] 202411