### PR TITLE
Topology definition update of topo_t1-isolated-d28u1.yml for exabgp failed to announce route from t0 VM

### DIFF
--- a/ansible/vars/topo_t1-isolated-d28u1.yml
+++ b/ansible/vars/topo_t1-isolated-d28u1.yml
@@ -138,6 +138,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 1
     bgp:
       asn: 64001
       peers:
@@ -158,6 +159,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 2
     bgp:
       asn: 64002
       peers:
@@ -178,6 +180,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 3
     bgp:
       asn: 64003
       peers:
@@ -198,6 +201,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 4
     bgp:
       asn: 64004
       peers:
@@ -218,6 +222,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 5
     bgp:
       asn: 64005
       peers:
@@ -238,6 +243,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 6
     bgp:
       asn: 64006
       peers:
@@ -278,6 +284,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 7
     bgp:
       asn: 64007
       peers:
@@ -298,6 +305,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 8
     bgp:
       asn: 64008
       peers:
@@ -318,6 +326,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 9
     bgp:
       asn: 64009
       peers:
@@ -338,6 +347,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 10
     bgp:
       asn: 64010
       peers:
@@ -358,6 +368,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 11
     bgp:
       asn: 64011
       peers:
@@ -378,6 +389,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 12
     bgp:
       asn: 64012
       peers:
@@ -398,6 +410,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 13
     bgp:
       asn: 64013
       peers:
@@ -418,6 +431,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 14
     bgp:
       asn: 64014
       peers:
@@ -438,6 +452,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 15
     bgp:
       asn: 64015
       peers:
@@ -458,6 +473,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 16
     bgp:
       asn: 64016
       peers:
@@ -478,6 +494,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 17
     bgp:
       asn: 64017
       peers:
@@ -498,6 +515,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 18
     bgp:
       asn: 64018
       peers:
@@ -518,6 +536,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 19
     bgp:
       asn: 64019
       peers:
@@ -538,6 +557,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 20
     bgp:
       asn: 64020
       peers:
@@ -558,6 +578,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 21
     bgp:
       asn: 64021
       peers:
@@ -578,6 +599,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 22
     bgp:
       asn: 64022
       peers:
@@ -598,6 +620,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 23
     bgp:
       asn: 64023
       peers:
@@ -618,6 +641,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 24
     bgp:
       asn: 64024
       peers:
@@ -638,6 +662,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 25
     bgp:
       asn: 64025
       peers:
@@ -658,6 +683,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 26
     bgp:
       asn: 64026
       peers:
@@ -678,6 +704,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 27
     bgp:
       asn: 64027
       peers:
@@ -698,6 +725,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 28
     bgp:
       asn: 64028
       peers:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add "tornum" for t0 VM definition in ansible/vars/topo_t1-isolated-d28u1.yml to trigger exabgp announce route during topology deployment.
The "tornum" is necessary for generating routes from T0 VM:
https://github.com/sonic-net/sonic-mgmt/blob/221012beaac677677139fed1ab92cd0d5adad789/ansible/library/announce_routes.py#L417

>                 suffix = ((podset * tor_number * max_tor_subnet_number * tor_subnet_size) +
>                           (tor * max_tor_subnet_number * tor_subnet_size) +
>                           (subnet * tor_subnet_size))
>                 octet2 = (168 + int(suffix / (256 ** 2)))
>                 octet1 = (192 + int(octet2 / 256))
>                 octet2 = (octet2 % 256)
>                 octet3 = (int(suffix / 256) % 256)
>                 octet4 = (suffix % 256)
>                 prefixlen_v4 = (32 - int(math.log(tor_subnet_size, 2)))
> 
>                 prefix = "{}.{}.{}.{}/{}".format(octet1,
>                                                  octet2, octet3, octet4, prefixlen_v4)
>                 prefix_v6 = ipv6_address_pattern % (
>                     octet1, octet2, octet3, octet4)

Summary:
Fixes # (issue)
Exabgp of T0 VM failed to announce route during topology deployment
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Bug fix for the definition of ansible/vars/topo_t1-isolated-d28u1.yml
Exabgp of T0 VM failed to announce route during topology deployment
#### How did you do it?
"tornum" for t0 VM
#### How did you verify/test it?
Run it in internal testbed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
