### PR TITLE
Update generic hash test to be supported on t1-isolated-d28u1 and t0-isolated-d16u16s1

### DIFF
--- a/tests/hash/generic_hash_helper.py
+++ b/tests/hash/generic_hash_helper.py
@@ -413,9 +413,12 @@ def get_interfaces_for_test(duthost, mg_facts, hash_field):
     # Find the uplink interfaces which are the nexthop interfaces of the default route
     for interface in get_ip_route_nexthops(duthost, "0.0.0.0/0"):
         uplink_interfaces[interface] = []
-        # All uplink interfaces are portchannels, need to find the members
-        portchannel_members = mg_facts['minigraph_portchannels'][interface]['members']
-        uplink_interfaces[interface].extend(portchannel_members)
+        if interface in mg_facts['minigraph_portchannels']:
+            # All uplink interfaces are portchannels, need to find the members
+            portchannel_members = mg_facts['minigraph_portchannels'][interface]['members']
+            uplink_interfaces[interface].extend(portchannel_members)
+        else:
+            uplink_interfaces[interface].append(interface)
     # Randomly choose a downlink interface
     downlink_interfaces = []
     if mg_facts['minigraph_vlan_interfaces']:
@@ -429,6 +432,7 @@ def get_interfaces_for_test(duthost, mg_facts, hash_field):
         for portchannel in portchannels.keys():
             if portchannel not in uplink_interfaces.keys():
                 downlink_interfaces.extend(portchannels[portchannel]['members'])
+    downlink_interfaces = [interface for interface in downlink_interfaces if interface not in uplink_interfaces]
     if hash_field != 'IN_PORT':
         downlink_interfaces = [random.choice(downlink_interfaces)]
     logger.info(


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Handle non portchannel in the upstream ports for generic hash test script at topology t1-isolated-d28u1 and t0-isolated-d16u16s1

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
No portchannels in topology t1-isolated-d28u1 and t0-isolated-d16u16s1, and generic hash test would be failed in this scenario.
#### How did you do it?
Handle non portchannel in the upstream ports
#### How did you verify/test it?
Run in it local testbed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
