### PR TITLE
limit parallel_run cct tasks number from 24 to 8 for fixture setup_bgp_graceful_restart

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -46,7 +46,7 @@ def check_results(results):
 
 
 @pytest.fixture(scope='module')
-def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo, cct=24):
+def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo, cct=8):
     duthost = duthosts[rand_one_dut_hostname]
 
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']


### PR DESCRIPTION
…p_graceful_restart

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: limit parallel_run cct tasks number from 24 to 8 for fixture setup_bgp_graceful_restart
Fixes # 
PR [8084](https://github.com/sonic-net/sonic-mgmt/pull/8084) limit parallel_run cct tasks number to avoid connection issue. But it only limited the cct number for case `test_bgp_gr_helper_routes_perserved`. The cct counter for fixture `setup_bgp_graceful_restart` is still 24.

In our test, there are 24 VMs and encounter the below issue. So limit the cct for fixture `setup_bgp_graceful_restart`
```
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 11978 running target "configure_nbr_gr--<EosHost VM4005>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 11980 running target "configure_nbr_gr--<EosHost VM4007>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 11982 running target "configure_nbr_gr--<EosHost VM4004>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 11984 running target "configure_nbr_gr--<EosHost VM4001>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 11987 running target "configure_nbr_gr--<EosHost VM4008>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 11990 running target "configure_nbr_gr--<EosHost VM4006>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 11993 running target "configure_nbr_gr--<EosHost VM4002>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 11999 running target "configure_nbr_gr--<EosHost VM4003>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12004 running target "configure_nbr_gr--<EosHost VM4010>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12008 running target "configure_nbr_gr--<EosHost VM4013>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12012 running target "configure_nbr_gr--<EosHost VM4011>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12018 running target "configure_nbr_gr--<EosHost VM4012>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12035 running target "configure_nbr_gr--<EosHost VM4015>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12039 running target "configure_nbr_gr--<EosHost VM4014>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12041 running target "configure_nbr_gr--<EosHost VM4016>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12046 running target "configure_nbr_gr--<EosHost VM4009>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12049 running target "configure_nbr_gr--<EosHost VM4017>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12052 running target "configure_nbr_gr--<EosHost VM4020>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12055 running target "configure_nbr_gr--<EosHost VM4021>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12060 running target "configure_nbr_gr--<EosHost VM4023>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12066 running target "configure_nbr_gr--<EosHost VM4019>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12072 running target "configure_nbr_gr--<EosHost VM4022>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12077 running target "configure_nbr_gr--<EosHost VM4024>"
DEBUG    tests.common.helpers.parallel:parallel.py:153 Started process 12083 running target "configure_nbr_gr--<EosHost VM4018>"
DEBUG    tests.common.helpers.parallel:parallel.py:161 task completed 0, running 24
DEBUG    tests.common.helpers.parallel:parallel.py:166 all processes have timedout
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
