### PR TITLE
[TACACS] Increase test_ro_user_banned_command test case tacacs config update check timeout

### DIFF
--- a/tests/common/helpers/tacacs/tacacs_helper.py
+++ b/tests/common/helpers/tacacs/tacacs_helper.py
@@ -39,7 +39,7 @@ def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip,
     """setup tacacs client"""
 
     # UT should failed when set reachable TACACS server with this setup_tacacs_client
-    retry = 5
+    retry = 20
     while retry > 0:
         ping_result = duthost.shell("ping {} -c 1 -W 3".format(tacacs_server_ip), module_ignore_errors=True)['stdout']
         logger.info("TACACS server ping result: {}".format(ping_result))

--- a/tests/common/helpers/tacacs/tacacs_helper.py
+++ b/tests/common/helpers/tacacs/tacacs_helper.py
@@ -39,7 +39,7 @@ def setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip,
     """setup tacacs client"""
 
     # UT should failed when set reachable TACACS server with this setup_tacacs_client
-    retry = 20
+    retry = 5
     while retry > 0:
         ping_result = duthost.shell("ping {} -c 1 -W 3".format(tacacs_server_ip), module_ignore_errors=True)['stdout']
         logger.info("TACACS server ping result: {}".format(ping_result))

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -15,7 +15,7 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 SLEEP_TIME = 10
-TIMEOUT_LIMIT = 120
+TIMEOUT_LIMIT = 240
 
 
 def does_command_exist(localhost, remote_ip, username, password, command):


### PR DESCRIPTION
Increase test_ro_user_banned_command test case tacacs config update check timeout

#### Why I did it
The test case test_ro_user_banned_command is not stable, randomly failed because hostcfgd not update tacacs config in 2 minutes

##### Work item tracking
- Microsoft ADO: 31344522

#### How I did it
Increase timeout to 4 minutes.

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Increase test_ro_user_banned_command test case tacacs config update check timeout

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
