### PR TITLE
chore: enable parallel run for nbr health test

### DIFF
--- a/tests/test_parallel_modes/cisco_t2_8800.json
+++ b/tests/test_parallel_modes/cisco_t2_8800.json
@@ -38,5 +38,6 @@
     "snmp/test_snmp_memory.py": "FULL_PARALLEL",
     "snmp/test_snmp_queue.py": "RP_FIRST",
     "test_features.py": "FULL_PARALLEL",
-    "test_interfaces.py": "FULL_PARALLEL"
+    "test_interfaces.py": "FULL_PARALLEL",
+    "test_nbr_health.py": "FULL_PARALLEL"
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Enable parallel run for test_nbr_health.py

Summary:
Fixes # (issue) Microsoft ADO 28851202

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
We wanted to enable parallel run for `test_nbr_health.py` to reduce the time taken for the test to run

#### How did you do it?

#### How did you verify/test it?
I ran the updated code and can confirm it's working well. Elastictest [link](https://elastictest.org/scheduler/testplan/67b3fdf19e505949e9369f58?testcase=test_nbr_health.py_svcstr2-8800-lc2-1&type=console)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
