### PR TITLE
[M0/Mx] Skip Vxlan hash and Nvgre hash test on M0/Mx testbeds

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -904,13 +904,13 @@ fib/test_fib.py::test_ipinip_hash:
 
 fib/test_fib.py::test_nvgre_hash:
   skip:
-    reason: 'Nvgre hash test is not fully supported on VS and Broadcom platform; Not supported on MGFX'
+    reason: 'Nvgre hash test is not fully supported on VS and Broadcom platform; Not supported on M*'
     conditions:
       - "asic_type in ['vs', 'broadcom'] or topo_type in ['m0', 'mx']"
 
 fib/test_fib.py::test_vxlan_hash:
   skip:
-    reason: 'Vxlan hash test is not fully supported on VS platform; Not supported on MGFX'
+    reason: 'Vxlan hash test is not fully supported on VS platform; Not supported on M*'
     conditions:
       - "asic_type in ['vs'] or topo_type in ['m0', 'mx']"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -904,15 +904,15 @@ fib/test_fib.py::test_ipinip_hash:
 
 fib/test_fib.py::test_nvgre_hash:
   skip:
-    reason: 'Nvgre hash test is not fully supported on VS and Broadcom platform'
+    reason: 'Nvgre hash test is not fully supported on VS and Broadcom platform; Not supported on MGFX'
     conditions:
-      - "asic_type in ['vs', 'broadcom']"
+      - "asic_type in ['vs', 'broadcom'] or topo_type in ['m0', 'mx']"
 
 fib/test_fib.py::test_vxlan_hash:
   skip:
-    reason: 'Vxlan hash test is not fully supported on VS platform'
+    reason: 'Vxlan hash test is not fully supported on VS platform; Not supported on MGFX'
     conditions:
-      - "asic_type in ['vs']"
+      - "asic_type in ['vs'] or topo_type in ['m0', 'mx']"
 
 #######################################
 #####   generic_config_updater    #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Vxlan hash and Nvgre hash are not supported on M* topology. So we skip the testcases.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Vxlan hash and Nvgre hash are not supported on M* topology. So we skip the testcases.

#### How did you do it?
Skip testcase via conditional mark.

#### How did you verify/test it?
Verified on Nokia-7215 M0 testbed.

```
fib/test_fib.py::test_basic_fib[True-True-1514] PASSED                                                                                  [  6%]
fib/test_fib.py::test_hash[ipv4] PASSED                                                                                                 [ 12%]
fib/test_fib.py::test_hash[ipv6] PASSED                                                                                                 [ 18%]
fib/test_fib.py::test_ipinip_hash[ipv4] SKIPPED (The test case runs on T1 topology)                                                     [ 25%]
fib/test_fib.py::test_ipinip_hash[ipv6] SKIPPED (The test case runs on T1 topology)                                                     [ 31%]
fib/test_fib.py::test_ipinip_hash_negative[ipv4] PASSED                                                                                 [ 37%]
fib/test_fib.py::test_ipinip_hash_negative[ipv6] PASSED                                                                                 [ 43%]
fib/test_fib.py::test_vxlan_hash[ipv4-ipv4] SKIPPED (Vxlan hash test is not fully supported on VS platform; Not supported on MGFX)      [ 50%]
fib/test_fib.py::test_vxlan_hash[ipv4-ipv6] SKIPPED (Vxlan hash test is not fully supported on VS platform; Not supported on MGFX)      [ 56%]
fib/test_fib.py::test_vxlan_hash[ipv6-ipv6] SKIPPED (Vxlan hash test is not fully supported on VS platform; Not supported on MGFX)      [ 62%]
fib/test_fib.py::test_vxlan_hash[ipv6-ipv4] SKIPPED (Vxlan hash test is not fully supported on VS platform; Not supported on MGFX)      [ 68%]
fib/test_fib.py::test_nvgre_hash[ipv4-ipv4] SKIPPED (Nvgre hash test is not fully supported on VS and Broadcom platform; Not suppor...) [ 75%]
fib/test_fib.py::test_nvgre_hash[ipv4-ipv6] SKIPPED (Nvgre hash test is not fully supported on VS and Broadcom platform; Not suppor...) [ 81%]
fib/test_fib.py::test_nvgre_hash[ipv6-ipv6] SKIPPED (Nvgre hash test is not fully supported on VS and Broadcom platform; Not suppor...) [ 87%]
fib/test_fib.py::test_nvgre_hash[ipv6-ipv4] SKIPPED (Nvgre hash test is not fully supported on VS and Broadcom platform; Not suppor...) [ 93%]
fib/test_fib.py::test_ecmp_group_member_flap[True-False-1514] PASSED                                                                    [100%]

=========================================================== short test summary info ===========================================================
SKIPPED [2] common/helpers/assertions.py:16: The test case runs on T1 topology
SKIPPED [4] fib/test_fib.py: Vxlan hash test is not fully supported on VS platform; Not supported on MGFX
SKIPPED [4] fib/test_fib.py: Nvgre hash test is not fully supported on VS and Broadcom platform; Not supported on MGFX
============================================ 6 passed, 10 skipped, 1 warning in 1291.25s (0:21:31) ============================================
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
