### PR TITLE
Gnmi Test Case Fix

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -148,7 +148,7 @@ def check_system_time_sync(duthost):
     Checks if the DUT's time is synchronized with the NTP server.
     If not synchronized, it attempts to restart the NTP service.
     """
-    
+
     ntp_status_cmd = "ntpstat"
     restart_ntp_cmd = "sudo systemctl restart ntp"
 
@@ -156,7 +156,7 @@ def check_system_time_sync(duthost):
     if "synchronised" in ntp_status["stdout"]:
         logger.info("DUT %s is synchronized with NTP server.", duthost)
         return True
-    
+
     else:
         logger.info("DUT %s is NOT synchronized. Restarting NTP service...", duthost)
         duthost.shell(restart_ntp_cmd)

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -112,8 +112,8 @@ def apply_cert_config(duthost):
     time.sleep(GNMI_SERVER_START_WAIT_TIME)
     dut_command = "sudo netstat -nap | grep %d" % env.gnmi_port
     output = duthost.shell(dut_command, module_ignore_errors=True)
-    assert wait_until(60, 3, 0, check_system_time_sync, duthost), \
-    "Failed to synchronize DUT system time with NTP Server"
+    is_time_synced = wait_until(60, 3, 0, check_system_time_sync, duthost)
+    assert is_time_synced, "Failed to synchronize DUT system time with NTP Server"
     if env.gnmi_process not in output['stdout']:
         # Dump tcp port status and gnmi log
         logger.info("TCP port status: " + output['stdout'])

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -112,7 +112,8 @@ def apply_cert_config(duthost):
     time.sleep(GNMI_SERVER_START_WAIT_TIME)
     dut_command = "sudo netstat -nap | grep %d" % env.gnmi_port
     output = duthost.shell(dut_command, module_ignore_errors=True)
-    assert wait_until(60, 3, 0, check_system_time_sync, duthost), "Failed to synchronize DUT system time with NTP Server"
+    assert wait_until(60, 3, 0, check_system_time_sync, duthost), \
+    "Failed to synchronize DUT system time with NTP Server"
     if env.gnmi_process not in output['stdout']:
         # Dump tcp port status and gnmi log
         logger.info("TCP port status: " + output['stdout'])

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -112,6 +112,7 @@ def apply_cert_config(duthost):
     time.sleep(GNMI_SERVER_START_WAIT_TIME)
     dut_command = "sudo netstat -nap | grep %d" % env.gnmi_port
     output = duthost.shell(dut_command, module_ignore_errors=True)
+    assert wait_until(60, 3, 0, check_system_time_sync, duthost), "Failed to synchronize DUT system time with NTP Server"
     if env.gnmi_process not in output['stdout']:
         # Dump tcp port status and gnmi log
         logger.info("TCP port status: " + output['stdout'])
@@ -139,6 +140,34 @@ def recover_cert_config(duthost):
     del_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
     del_gnmi_client_common_name(duthost, "test.client.revoked.gnmi.sonic")
     assert wait_until(60, 3, 0, check_gnmi_status, duthost), "GNMI service failed to start"
+
+
+def check_system_time_sync(duthost):
+    """
+    Checks if the DUT's time is synchronized with the NTP server.
+    If not synchronized, it attempts to restart the NTP service.
+    """
+    
+    ntp_status_cmd = "ntpstat"
+    restart_ntp_cmd = "sudo systemctl restart ntp"
+
+    ntp_status = duthost.shell(ntp_status_cmd, module_ignore_errors=True)
+    if "synchronised" in ntp_status["stdout"]:
+        logger.info("DUT %s is synchronized with NTP server.", duthost)
+        return True
+    
+    else:
+        logger.info("DUT %s is NOT synchronized. Restarting NTP service...", duthost)
+        duthost.shell(restart_ntp_cmd)
+        time.sleep(5)
+        # Rechecking status after restarting NTP
+        ntp_status = duthost.shell(ntp_status_cmd, module_ignore_errors=True)
+        if "synchronised" in ntp_status["stdout"]:
+            logger.info("DUT %s is now synchronized with NTP server.", duthost)
+            return True
+        else:
+            logger.error("DUT %s: NTP synchronization failed. Please check manually.", duthost)
+            return False
 
 
 def gnmi_capabilities(duthost, localhost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
The test failed on the supervisor node because the DUT's system time was not synchronized with the NTP server. Since the GNMI certificates have a dependency on the system time, this discrepancy caused issues during the certificate application process. To resolve this, the DUT's time is synchronized with the NTP server before authentication part.
-->

Summary:
Fixes # (issue)
ADO: 30909878
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [] 202012
- [] 202205
- [] 202305
- [] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
The test will fail if the dut time is not in sync with the NTP Server because the gnmi certs have dependency upon system time.
#### How did you do it?
Syncing the dut time with NTP server while applying the certs
#### How did you verify/test it?
Ran it on Microsoft Lab testbed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
