### PR TITLE
Test TX drop counter on oper down

### DIFF
--- a/tests/portstat/test_drop_counters_on_down_intf.py
+++ b/tests/portstat/test_drop_counters_on_down_intf.py
@@ -17,50 +17,44 @@ def test_tx_drop_counters_on_oper_down_intf(duthosts, enum_rand_one_per_hwsku_fr
     Test that TX_DROP counters are not incremented when the interface is oper down.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    interfaces_status = duthost.shell("show interface status")['stdout_lines'].split("\n")[2:]
+    interfaces = duthost.shell("show lldp table")['stdout_lines'][3:]
     # find an oper up and admin up interface
-    intf = ''
-    for line in interfaces_status:
-        if line.count('up') >= 2:
-            intf = line.split()[0]
-            break
-    if len(intf) == 0:
-        pytest.skip('No oper up and admin up interface found')
+    if len(interfaces) == 0:
+        pytest.skip('No interfaces connected to switch neighbors found')
+    intf = interfaces[0].split()[0]
+    neighbor = interfaces[0].split()[1]
+    neighbor_intf = interfaces[0].split()[2]
 
-    # get the corresponding neighbor and neighbor's interface
-    neighbor_info = duthost.shell("show lldp neighbors {}".format(intf))['stdout_lines'].split("\n")[3:]
-    for line in neighbor_info:
-        if "SysName" in line:
-            neighbor = line.split()[1]
-        elif "PortID" in line:
-            neighbor_intf = line.split()[2]
+    assert neighbor, "Cannot find the hostname of neighbor connected to {}".format(intf)
+    assert neighbor_intf, "Cannot find the interface name of neighbor connected to {}".format(intf)
 
     # get the neighbor's IP
-    bgp_neighbors = duthost.shell("show ip bgp summary")['stdout_lines'].split('\n')
+    bgp_neighbors = duthost.shell("show ip bgp summary")['stdout_lines']
     for line in bgp_neighbors:
         if neighbor in line:
             neighbor_ip = line.split()[0]
             break
+    assert neighbor_ip, "Cannot find the IP address of neighbor"
 
     logger.info('DUT Interface: {}, Neighbor: {}, Neighbor Interface: {}, Neighbor IP: {}'
                 .format(intf, neighbor, neighbor_intf, neighbor_ip))
 
     # shutdown the interface of neighbor
-    nbrhosts[neighbor].shutdown(neighbor_intf)
+    nbrhosts[neighbor]['host'].shutdown(neighbor_intf)
     time.sleep(2)
 
     # collect portstat before sleeping
     before_portstat = parse_portstat(duthost.command('portstat -i {}'.format(intf))['stdout_lines'])
 
     # Ping the neighbor from DUT
-    duthost.command('ping {} -c 10'.format(neighbor_ip), ignore_errors=True)
+    duthost.command('ping {} -c 10'.format(neighbor_ip), module_ignore_errors=True)
 
     # collect portstat after sleeping
     after_portstat = parse_portstat(duthost.command('portstat -i {}'.format(intf))['stdout_lines'])
 
     # Assert that TX_DROP counters are not incremented
-    pytest_assert(before_portstat[intf]['tx_drop'] == after_portstat[intf]['tx_drop'],
+    pytest_assert(before_portstat[intf]['tx_drp'] == after_portstat[intf]['tx_drp'],
                   'TX_DROP counters should not be incremented when the interface is administratively down')
 
     # recover the neighbor interface
-    nbrhosts[neighbor].no_shutdown(neighbor_intf)
+    nbrhosts[neighbor]['host'].no_shutdown(neighbor_intf)

--- a/tests/portstat/test_drop_counters_on_down_intf.py
+++ b/tests/portstat/test_drop_counters_on_down_intf.py
@@ -1,0 +1,66 @@
+import logging
+import pytest
+import time
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.portstat_utilities import parse_portstat
+
+logger = logging.getLogger('__name__')
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+
+def test_tx_drop_counters_on_oper_down_intf(duthosts, enum_rand_one_per_hwsku_frontend_hostname, nbrhosts):
+    """
+    Test that TX_DROP counters are not incremented when the interface is oper down.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    interfaces_status = duthost.shell("show interface status")['stdout_lines'].split("\n")[2:]
+    # find an oper up and admin up interface
+    intf = ''
+    for line in interfaces_status:
+        if line.count('up') >= 2:
+            intf = line.split()[0]
+            break
+    if len(intf) == 0:
+        pytest.skip('No oper up and admin up interface found')
+
+    # get the corresponding neighbor and neighbor's interface
+    neighbor_info = duthost.shell("show lldp neighbors {}".format(intf))['stdout_lines'].split("\n")[3:]
+    for line in neighbor_info:
+        if "SysName" in line:
+            neighbor = line.split()[1]
+        elif "PortID" in line:
+            neighbor_intf = line.split()[2]
+
+    # get the neighbor's IP
+    bgp_neighbors = duthost.shell("show ip bgp summary")['stdout_lines'].split('\n')
+    for line in bgp_neighbors:
+        if neighbor in line:
+            neighbor_ip = line.split()[0]
+            break
+
+    logger.info('DUT Interface: {}, Neighbor: {}, Neighbor Interface: {}, Neighbor IP: {}'
+                .format(intf, neighbor, neighbor_intf, neighbor_ip))
+
+    # shutdown the interface of neighbor
+    nbrhosts[neighbor].shutdown(neighbor_intf)
+    time.sleep(2)
+
+    # collect portstat before sleeping
+    before_portstat = parse_portstat(duthost.command('portstat -i {}'.format(intf))['stdout_lines'])
+
+    # Ping the neighbor from DUT
+    duthost.command('ping {} -c 10'.format(neighbor_ip), ignore_errors=True)
+
+    # collect portstat after sleeping
+    after_portstat = parse_portstat(duthost.command('portstat -i {}'.format(intf))['stdout_lines'])
+
+    # Assert that TX_DROP counters are not incremented
+    pytest_assert(before_portstat[intf]['tx_drop'] == after_portstat[intf]['tx_drop'],
+                  'TX_DROP counters should not be incremented when the interface is administratively down')
+
+    # recover the neighbor interface
+    nbrhosts[neighbor].no_shutdown(neighbor_intf)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add a test case that verifies the TX_DROP counter will not be increased when an interface is oper down.
Fixes #15874 (issue) 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
