### PR TITLE
Skip test_syslog_source_ip to avoid testbed unreachable issue

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2261,19 +2261,12 @@ syslog/test_syslog_source_ip.py:
       - "https://github.com/sonic-net/sonic-mgmt/issues/16997"
       - "asic_type in ['vs']"
 
-syslog/test_syslog_source_ip.py::TestSSIP::test_syslog_config_work_after_reboot:
-  skip:
-    reason: "Testcase consistent failed, raised issue to track / Vs setup doesn't work when creating mgmt vrf"
-    conditions_logical_operator: or
-    conditions:
-      - "https://github.com/sonic-net/sonic-buildimage/issues/19638"
-      - "asic_type in ['vs']"
-
 syslog/test_syslog_source_ip.py::TestSSIP::test_syslog_protocol_filter_severity:
   skip:
     reason: "Testcase consistent failed, raised issue to track / Vs setup doesn't work when creating mgmt vrf"
     conditions_logical_operator: or
     conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/16997"
       - "https://github.com/sonic-net/sonic-mgmt/issues/14493"
       - "asic_type in ['vs']"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
PR https://github.com/sonic-net/sonic-mgmt/pull/16998 was raised to skip the test on all platform because some testbeds were unreachable after running this test module `test_syslog_source_ip`.

However, test case `test_syslog_config_work_after_reboot` is still running because the the longest path matching policy. 
This PR addressed the issue by removing the condition for `syslog/test_syslog_source_ip.py::TestSSIP::test_syslog_config_work_after_reboot`, and adding the github issue to condition `syslog/test_syslog_source_ip.py::TestSSIP::test_syslog_protocol_filter_severity`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
This PR is to skip the test case `test_syslog_source_ip` to avoid testbed unreachable issue.

#### How did you do it?
1. Remove the condition for `syslog/test_syslog_source_ip.py::TestSSIP::test_syslog_config_work_after_reboot`
2. Add the github issue to condition `syslog/test_syslog_source_ip.py::TestSSIP::test_syslog_protocol_filter_severity`.

#### How did you verify/test it?
Verified on a pyhsical testbed
```
collected 15 items                                                                                                                                                                                                            

syslog/test_syslog_source_ip.py::TestSSIP::test_basic_syslog_config[str-msn2700-22-None-vrf_unset_source_unset_port_None] SKIPPED (Vs setup doesn't work when creating mgmt vrf)                                        [  6%]
syslog/test_syslog_source_ip.py::TestSSIP::test_basic_syslog_config[str-msn2700-22-None-vrf_unset_source_unset_port_600] SKIPPED (Vs setup doesn't work when creating mgmt vrf)                                         [ 13%]
syslog/test_syslog_source_ip.py::TestSSIP::test_basic_syslog_config[str-msn2700-22-None-vrf_unset_source_set_port_None] SKIPPED (Vs setup doesn't work when creating mgmt vrf)                                          [ 20%]
syslog/test_syslog_source_ip.py::TestSSIP::test_basic_syslog_config[str-msn2700-22-None-vrf_unset_source_set_port_650] SKIPPED (Vs setup doesn't work when creating mgmt vrf)                                           [ 26%]
syslog/test_syslog_source_ip.py::TestSSIP::test_basic_syslog_config[str-msn2700-22-None-vrf_set_source_unset_None] SKIPPED (Vs setup doesn't work when creating mgmt vrf)                                               [ 33%]
syslog/test_syslog_source_ip.py::TestSSIP::test_basic_syslog_config[str-msn2700-22-None-vrf_set_source_unset_700] SKIPPED (Vs setup doesn't work when creating mgmt vrf)                                                [ 40%]
syslog/test_syslog_source_ip.py::TestSSIP::test_basic_syslog_config[str-msn2700-22-None-vrf_set_source_set_None] SKIPPED (Vs setup doesn't work when creating mgmt vrf)                                                 [ 46%]
syslog/test_syslog_source_ip.py::TestSSIP::test_basic_syslog_config[str-msn2700-22-None-vrf_set_source_set_800] SKIPPED (Vs setup doesn't work when creating mgmt vrf)                                                  [ 53%]
syslog/test_syslog_source_ip.py::TestSSIP::test_config_syslog_non_existing_ip[str-msn2700-22-None-no_on_any_vrf] SKIPPED (Vs setup doesn't work when creating mgmt vrf)                                                 [ 60%]
syslog/test_syslog_source_ip.py::TestSSIP::test_config_syslog_non_existing_ip[str-msn2700-22-None-only_on_other_vrf] SKIPPED (Vs setup doesn't work when creating mgmt vrf)                                             [ 66%]
syslog/test_syslog_source_ip.py::TestSSIP::test_config_syslog_with_non_existing_vrf[str-msn2700-22-None] SKIPPED (Vs setup doesn't work when creating mgmt vrf)                                                         [ 73%]
syslog/test_syslog_source_ip.py::TestSSIP::test_syslog_config_work_after_reboot[str-msn2700-22-None] SKIPPED (Vs setup doesn't work when creating mgmt vrf)                                                             [ 80%]
syslog/test_syslog_source_ip.py::TestSSIP::test_remove_vrf_exist_syslog_config[str-msn2700-22-None-Vrf-data] SKIPPED (Vs setup doesn't work when creating mgmt vrf)                                                     [ 86%]
syslog/test_syslog_source_ip.py::TestSSIP::test_remove_vrf_exist_syslog_config[str-msn2700-22-None-mgmt] SKIPPED (Vs setup doesn't work when creating mgmt vrf)                                                         [ 93%]
syslog/test_syslog_source_ip.py::TestSSIP::test_syslog_protocol_filter_severity[str-msn2700-22-None] SKIPPED (Testcase consistent failed, raised issue to track / Vs setup doesn't work when creating mgmt vrf)         [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
