### PR TITLE
[test_l2_configure] Ensure minigraph restore when the test fails

### DIFF
--- a/tests/l2/test_l2_configure.py
+++ b/tests/l2/test_l2_configure.py
@@ -163,14 +163,16 @@ def test_no_hardcoded_tables(duthosts, rand_one_dut_hostname, tbinfo):
     # Move minigraph away to avoid config coming from minigraph.
     MINIGRAPH_BAK = generate_backup_filename("minigraph.xml")
     duthost.shell("sudo mv {} {}".format(MINIGRAPH, MINIGRAPH_BAK))
-    config_reload(duthost)
-    wait_critical_processes(duthost)
-    db_version_after = get_db_version(duthost)
-    logger.info(
-        "Database version after L2 configuration reload: {}".format(db_version_after)
-    )
-    # Move minigraph back.
-    duthost.shell("sudo mv {} {}".format(MINIGRAPH_BAK, MINIGRAPH))
+    try:
+        config_reload(duthost)
+        wait_critical_processes(duthost)
+        db_version_after = get_db_version(duthost)
+        logger.info(
+            "Database version after L2 configuration reload: {}".format(db_version_after)
+        )
+    finally:
+        # Move minigraph back.
+        duthost.shell("sudo mv {} {}".format(MINIGRAPH_BAK, MINIGRAPH))
 
     # Verify no minigraph config is present.
     for table in ["TELEMETRY", "RESTAPI"]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
`test_l2_configure` moves the `/etc/sonic/minigraph.xml`, but when it fails, it won't restore the minigraph file.
let's ensure the minigraph is restored in this situation.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
Wrap the test operations in a `try ... finally` block, and put the minigraph restore in the `finally` clause.

#### How did you verify/test it?
Run on dualtor testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
