### PR TITLE
Check interfaces status after config reload

### DIFF
--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -123,7 +123,7 @@ def recover_ports(duthosts, fanouthosts):
 
     logger.info('Recovering port configuration for DUT...')
     for duthost in duthosts:
-        config_reload(duthost)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Check interfaces status after config reload
Fixes # 
In autoneg cases, fixture `recover_ports` will execute config reload in teardown process.
In current code, the config reload operation does not check if all interfaces are UP, which might affect later cases.
Update it from `config_reload(duthost)` to `config_reload(duthost, safe_reload=True, check_intf_up_ports=True)`

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
