### PR TITLE
Do not check the docker which is disabled in config reload test

### DIFF
--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -138,6 +138,8 @@ def execute_config_reload_cmd(duthost, timeout=120, check_interval=5):
 def check_docker_status(duthost):
     containers = duthost.get_all_containers()
     for container in containers:
+        if 'disabled' in duthost.get_feature_status()[0].get(container, ''):
+            continue
         if not duthost.is_service_fully_started(container):
             return False
     return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Test case platform_tests/test_reload_config.py::test_reload_configuration_checks fails on smartswitch dark mode because dhcp_relay and dhcp_server are disabled in dark mode.
The failure is in method check_docker_status(), it queries the dockers to check by command "docker ps -a" which includes the disabled dockers and then fails.

```
admin@mtvr-4280-03:~$ docker ps -a
CONTAINER ID   IMAGE                                COMMAND                  CREATED      STATUS                  PORTS     NAMES
f123d2f6a1b7   11e543c3bc4e                         "/usr/local/bin/supe…"   2 days ago   Up 22 minutes                     what-just-happened
e20f1d39f140   docker-snmp:latest                   "/usr/bin/docker-snm…"   2 days ago   Up 22 minutes                     snmp
3a350ce837d5   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe…"   2 days ago   Up 22 minutes                     mgmt-framework
e776b5a1088c   docker-lldp:latest                   "/usr/bin/docker-lld…"   2 days ago   Up 22 minutes                     lldp
49d2a8687359   docker-sonic-gnmi:latest             "/usr/local/bin/supe…"   2 days ago   Up 22 minutes                     gnmi
612288e345d5   docker-platform-monitor:latest       "/usr/bin/docker_ini…"   2 days ago   Up 22 minutes                     pmon
9554f34a0a84   docker-router-advertiser:latest      "/usr/bin/docker-ini…"   2 days ago   Up 22 minutes                     radv
598cbe04ebf9   docker-syncd-mlnx:latest             "/usr/local/bin/supe…"   2 days ago   Up 22 minutes                     syncd
1572f91f34ac   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   2 days ago   Up 23 minutes                     bgp
9b388a3a7253   docker-teamd:latest                  "/usr/local/bin/supe…"   2 days ago   Up 23 minutes                     teamd
bc80e1016eaf   docker-orchagent:latest              "/usr/bin/docker-ini…"   2 days ago   Up 23 minutes                     swss
c253452b1d38   docker-sonic-restapi:latest          "/usr/local/bin/supe…"   2 days ago   Up 23 minutes                     restapi
57b88225bf4c   docker-eventd:latest                 "/usr/local/bin/supe…"   2 days ago   Up 23 minutes                     eventd
1755e62d54e1   96831975e50e                         "/usr/bin/docker_ini…"   2 days ago   Exited (0) 2 days ago             dhcp_server
937baf6ade37   21aa68062e90                         "/usr/bin/docker_ini…"   2 days ago   Exited (0) 2 days ago             dhcp_relay
045cdee92188   docker-database:latest               "/usr/local/bin/dock…"   2 days ago   Up 32 minutes                     databasedpu2
1e2e9835e7b0   docker-database:latest               "/usr/local/bin/dock…"   2 days ago   Up 32 minutes                     databasedpu3
ce004d3c7038   docker-database:latest               "/usr/local/bin/dock…"   2 days ago   Up 32 minutes                     databasedpu1
937440ee6276   docker-database:latest               "/usr/local/bin/dock…"   2 days ago   Up 32 minutes                     databasedpu0
e2fc0baf894a   docker-database:latest               "/usr/local/bin/dock…"   2 days ago   Up 32 minutes                     database
ae6b095435f6   docker-database:latest               "/usr/local/bin/dock…"   2 days ago   Up 32 minutes                     database-chassis

```
So if the feature is admin disabled in config, we don't need to check it here.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Fix a test issue in test_reload_configuration_checks with smartswitch dark mode
#### How did you do it?
Don't check the status of the disabled dockers.
#### How did you verify/test it?
Run the test on 4280 platform with dark mode, test passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
