### PR TITLE
Fix the logic of getting pid of process inside container for BGP convergence testing

### DIFF
--- a/tests/snappi_tests/multidut/bgp/files/bgp_outbound_helper.py
+++ b/tests/snappi_tests/multidut/bgp/files/bgp_outbound_helper.py
@@ -1473,7 +1473,7 @@ def get_convergence_for_process_flap(duthosts,
                                 sum_t2_rx_frame_rate = sum_t2_rx_frame_rate + int(port_stat.frames_rx_rate)
                         logger.info('Killing {}:{} service in {}'.format(container, process_name, host_name))
                         PID = duthost.shell('docker exec {} pidof {} \n'.
-                                             format(container, process_name))['stdout']
+                                            format(container, process_name))['stdout']
                         all_containers = get_container_names(duthost)
                         logger.info('Runnnig containers before process kill: {}'.format(all_containers))
                         kill_process_inside_container(duthost, container, PID, creds)

--- a/tests/snappi_tests/multidut/bgp/files/bgp_outbound_helper.py
+++ b/tests/snappi_tests/multidut/bgp/files/bgp_outbound_helper.py
@@ -1472,8 +1472,8 @@ def get_convergence_for_process_flap(duthosts,
                             if 'Snappi_Uplink' in port_stat.name:
                                 sum_t2_rx_frame_rate = sum_t2_rx_frame_rate + int(port_stat.frames_rx_rate)
                         logger.info('Killing {}:{} service in {}'.format(container, process_name, host_name))
-                        PID = duthost.shell('docker exec {}  ps aux | grep {} \n'.
-                                            format(container, process_name))['stdout'].split(' ')[10]
+                        PID = duthost.shell('docker exec {} pidof {} \n'.
+                                             format(container, process_name))['stdout']
                         all_containers = get_container_names(duthost)
                         logger.info('Runnnig containers before process kill: {}'.format(all_containers))
                         kill_process_inside_container(duthost, container, PID, creds)


### PR DESCRIPTION
What I did:
Fix the logic of getting pid of process inside container for BGP convergence testing

Why I did:
Current logic to parse output and doing split is not reliable and was not working on packet-chassis.

How I verify:
After fixing test was working fine.