### PR TITLE
Issue 16831 - SNMP test cases

### DIFF
--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -1,5 +1,7 @@
 import logging
 import ipaddress
+import subprocess
+from enum import Enum
 
 from tests.common.utilities import wait_until
 from tests.common.errors import RunAnsibleModuleFail
@@ -8,12 +10,106 @@ from tests.common.devices.eos import EosHost
 
 logger = logging.getLogger(__name__)
 
+class SnmpVersion(Enum):
+    V2C = "2c"
+    V3 = "3"
+    
+    def __str__(self):
+        return self.value
+
 DEF_WAIT_TIMEOUT = 300
 DEF_CHECK_INTERVAL = 10
 SNMP_DEFAULT_TIMEOUT = 20
+SNMPV3_DEFAULTS = {
+    'level': 'authPriv',
+    'integrity': 'sha',
+    'privacy': 'aes'
+}
+
+# Centralized SNMP OID definitions
+class SnmpOIDs:
+    """Centralized SNMP OID definitions"""
+    
+    # System MIB OIDs
+    SYSTEM = '1.3.6.1.2.1.1'
+    SYS_DESCR = '1.3.6.1.2.1.1.1.0'
+    SYS_OBJECT_ID = '1.3.6.1.2.1.1.2.0'
+    SYS_UPTIME = '1.3.6.1.2.1.1.3.0'
+    SYS_CONTACT = '1.3.6.1.2.1.1.4.0'
+    SYS_NAME = '1.3.6.1.2.1.1.5.0'
+    SYS_LOCATION = '1.3.6.1.2.1.1.6.0'
+    SYS_SERVICES = '1.3.6.1.2.1.1.7.0'
+    
+    # CPU Utilization OIDs
+    # Dell Enterprise MIB for 5-second CPU utilization
+    DELL_CPU_UTIL_5SEC = '1.3.6.1.4.1.6027.3.10.1.2.9.1.2.1'
+    # UCD-SNMP-MIB CPU metrics
+    CPU_IDLE = '1.3.6.1.4.1.2021.11.11.0'
+    CPU_USER = '1.3.6.1.4.1.2021.11.9.0'
+    CPU_SYSTEM = '1.3.6.1.4.1.2021.11.10.0'
+    # Load averages
+    HOST_CPU_LOAD_1 = '1.3.6.1.4.1.2021.10.1.3.1'
+    HOST_CPU_LOAD_5 = '1.3.6.1.4.1.2021.10.1.3.2'
+    HOST_CPU_LOAD_15 = '1.3.6.1.4.1.2021.10.1.3.3'
+    
+    # Interfaces MIB OIDs
+    INTERFACES = '1.3.6.1.2.1.2'
+    IF_NUMBER = '1.3.6.1.2.1.2.1.0'
+    IF_TABLE = '1.3.6.1.2.1.2.2'
+    IF_XTABLE = '1.3.6.1.2.1.31.1.1'
+    IF_DESCR = '1.3.6.1.2.1.2.2.1.2'
+    IF_TYPE = '1.3.6.1.2.1.2.2.1.3'
+    IF_MTU = '1.3.6.1.2.1.2.2.1.4'
+    IF_SPEED = '1.3.6.1.2.1.2.2.1.5'
+    IF_PHYS_ADDR = '1.3.6.1.2.1.2.2.1.6'
+    IF_ADMIN_STATUS = '1.3.6.1.2.1.2.2.1.7'
+    IF_OPER_STATUS = '1.3.6.1.2.1.2.2.1.8'
+    IF_IN_OCTETS = '1.3.6.1.2.1.2.2.1.10'
+    IF_OUT_OCTETS = '1.3.6.1.2.1.2.2.1.16'
+    IF_IN_ERRORS = '1.3.6.1.2.1.2.2.1.14'
+    IF_OUT_ERRORS = '1.3.6.1.2.1.2.2.1.20'
+    
+    # Host Resources MIB
+    HOST = '1.3.6.1.2.1.25'
+    HOST_STORAGE = '1.3.6.1.2.1.25.2'
+    HOST_MEMORY = '1.3.6.1.2.1.25.2.2'
+    HOST_SYSTEM_PROCESSES = '1.3.6.1.2.1.25.1.6.0'
+    HOST_CPU_LOAD_1 = '1.3.6.1.4.1.2021.10.1.3.1'
+    HOST_CPU_LOAD_5 = '1.3.6.1.4.1.2021.10.1.3.2'
+    HOST_CPU_LOAD_15 = '1.3.6.1.4.1.2021.10.1.3.3'
+    
+    # Bridge MIB (FDB)
+    DOT1D_BRIDGE = '1.3.6.1.2.1.17'
+    DOT1D_TP_FDB_TABLE = '1.3.6.1.2.1.17.4.3'
+    DOT1D_TP_FDB_ENTRY = '1.3.6.1.2.1.17.4.3.1'
+    DOT1D_BASE_PORT_TABLE = '1.3.6.1.2.1.17.1.4'
+    DOT1D_BASE_PORT_ENTRY = '1.3.6.1.2.1.17.1.4.1'
+    
+    # Entity MIB
+    ENTITY_MIB = '1.3.6.1.2.1.47'
+    ENT_PHYSICAL_TABLE = '1.3.6.1.2.1.47.1.1.1'
+    ENT_LOGICAL_TABLE = '1.3.6.1.2.1.47.1.2.1'
+    ENT_PHYSICAL_DESCR = '1.3.6.1.2.1.47.1.1.1.1.2'
+    ENT_PHYSICAL_CLASS = '1.3.6.1.2.1.47.1.1.1.1.5'
+    ENT_PHYSICAL_SERIAL_NUM = '1.3.6.1.2.1.47.1.1.1.1.11'
+    ENT_PHYSICAL_MFG_NAME = '1.3.6.1.2.1.47.1.1.1.1.12'
+    ENT_PHYSICAL_MODEL_NAME = '1.3.6.1.2.1.47.1.1.1.1.13'
+    
+    # LLDP MIB
+    LLDP = '1.0.8802.1.1.2'
+    LLDP_LOCAL_SYS_NAME = '1.0.8802.1.1.2.1.3.3'
+    LLDP_LOCAL_SYS_DESC = '1.0.8802.1.1.2.1.3.4'
+    LLDP_LOCAL_PORT_TABLE = '1.0.8802.1.1.2.1.3.7'
+    LLDP_REM_TABLE = '1.0.8802.1.1.2.1.4.1'
+    
+    # IP MIB
+    IP = '1.3.6.1.2.1.4'
+    IP_ADDR_TABLE = '1.3.6.1.2.1.4.20'
+    IP_NET_TO_MEDIA = '1.3.6.1.2.1.4.22'
+    IP_FORWARD_TABLE = '1.3.6.1.2.1.4.24'
 
 global_snmp_facts = {}
-
+global_snmpv3_facts = {}
 
 def is_snmp_subagent_running(duthost):
     cmd = "docker exec snmp supervisorctl status snmp-subagent"
@@ -24,6 +120,14 @@ def is_snmp_subagent_running(duthost):
     logger.info("SNMP Sub-Agent is Not Running")
     return False
 
+def is_snmp_subagent_running(duthost):
+    cmd = "docker exec snmp supervisorctl status snmp-subagent"
+    output = duthost.shell(cmd)
+    if "RUNNING" in output["stdout"]:
+        logger.info("SNMP Sub-Agent is Running")
+        return True
+    logger.info("SNMP Sub-Agent is Not Running")
+    return False
 
 def _get_snmp_facts(localhost, host, version, community, is_dell, include_swap, module_ignore_errors,
                     timeout=SNMP_DEFAULT_TIMEOUT):
@@ -31,7 +135,6 @@ def _get_snmp_facts(localhost, host, version, community, is_dell, include_swap, 
                                       module_ignore_errors=module_ignore_errors, include_swap=include_swap,
                                       timeout=timeout)
     return snmp_facts
-
 
 def _update_snmp_facts(localhost, host, version, community, is_dell, include_swap, duthost,
                        timeout=SNMP_DEFAULT_TIMEOUT):
@@ -48,7 +151,6 @@ def _update_snmp_facts(localhost, host, version, community, is_dell, include_swa
 
     return snmp_subagent_running and True
 
-
 def get_snmp_facts(duthost, localhost, host, version, community, is_dell=False, module_ignore_errors=False,
                    wait=False, include_swap=False, timeout=DEF_WAIT_TIMEOUT, interval=DEF_CHECK_INTERVAL,
                    snmp_timeout=SNMP_DEFAULT_TIMEOUT):
@@ -62,21 +164,201 @@ def get_snmp_facts(duthost, localhost, host, version, community, is_dell=False, 
                              community, is_dell, include_swap, duthost, snmp_timeout), "Timeout waiting for SNMP facts")
     return global_snmp_facts
 
-
-def get_snmp_output(ip, duthost, nbr, creds_all_duts, oid='.1.3.6.1.2.1.1.1.0'):
+def snmpwalk(duthosts, duthost, oid, version=SnmpVersion.V2C, timeout=30, **kwargs):
     """
-    Get snmp output from duthost using specific ip to query
-    snmp query is sent from neighboring ceos/vsonic
+    Performs an SNMP walk.
+    
+    Args:
+        duthosts: DUT hosts
+        duthost: DUT host
+        oid: OID to query
+        version: SNMP version (SnmpVersion.V2C or SnmpVersion.V3)
+        timeout: Command timeout
+        **kwargs: Additional arguments:
+            For v2c: community (str)
+            For v3: username, level, auth_protocol, priv_protocol, auth_key, priv_key
+    """
+    try:
+        management_ip = duthost.facts.get('ansible_host')
+        logger.debug(f"mgmt_ip from duthost.facts: {management_ip}")
 
-     Args:
-        ip(str): IP of dut to be used to send SNMP query
-        duthost: duthost
-        nbr: from where the snmp query should be executed
-        creds_all_duts: creds to get snmp_rocommunity of duthost
-        oid: to query
+        if management_ip is None:
+            management_ip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+        if not management_ip:
+            raise ValueError(f"Could not determine management IP for {duthost.hostname}")
 
+        command = ["snmpwalk", f"-v{version}", "-On", "-t", str(timeout)]
+        
+        if version == SnmpVersion.V2C:
+            if 'community' not in kwargs:
+                raise ValueError("community parameter is required for SNMPv2c")
+            command.extend(["-c", kwargs['community']])
+        elif version == SnmpVersion.V3:
+            required_params = ['username', 'level', 'auth_protocol', 'priv_protocol', 'auth_key', 'priv_key']
+            missing_params = [param for param in required_params if param not in kwargs]
+            if missing_params:
+                raise ValueError(f"Missing required SNMPv3 parameters: {missing_params}")
+            
+            command.extend([
+                "-l", kwargs['level'],
+                "-u", kwargs['username'],
+                "-a", kwargs['auth_protocol'],
+                "-A", kwargs['auth_key'],
+                "-x", kwargs['priv_protocol'],
+                "-X", kwargs['priv_key']
+            ])
+        else:
+            raise ValueError("version must be either '2c' or '3'")
+
+        command.extend([str(management_ip), str(oid)])
+        logger.debug(f"Executing SNMP command: {' '.join(command)}")
+        
+        process = subprocess.run(command, capture_output=True, text=True, timeout=timeout)
+        
+        if process.returncode != 0:
+            error_msg = process.stderr.strip()
+            logger.error(f"SNMP command failed: {error_msg}")
+            if "Timeout" in error_msg:
+                raise TimeoutError("SNMP request timed out")
+            raise RuntimeError(f"SNMP command failed: {error_msg}")
+
+        # Parse SNMP output lines into (oid_part, value) pairs
+        snmp_lines = [line.split(" = ", 1) for line in process.stdout.splitlines() if line and " = " in line]
+        
+        if not snmp_lines:
+            logger.warning("No SNMP data received in response")
+            return {}
+
+        # Process each value to remove quotes and type information
+        processed_values = {
+            oid_part.strip('.'): (value.split(':', 1)[1] if ':' in value else value).strip().strip('"')
+            for oid_part, value in snmp_lines
+        }
+        
+        # Create the final snmp_data dictionary with multiple OID formats
+        snmp_data = {
+            **{oid: value for oid, value in processed_values.items()},                          # Full OID
+            **{oid.lstrip('1.'): value for oid, value in processed_values.items()},            # Without leading '1.'
+            **{oid.split('.')[-1]: value for oid, value in processed_values.items()},          # Last OID part
+            **{oid.replace('.', ''): value                                                     # Without dots
+               for oid, value in processed_values.items() if '.' in oid}
+        }
+
+        logger.debug(f"Processed SNMP data keys: {list(snmp_data.keys())}")
+        return snmp_data
+
+    except subprocess.TimeoutExpired as e:
+        logger.error(f"SNMP command timed out after {timeout} seconds")
+        raise TimeoutError(f"SNMP command timed out: {str(e)}")
+    except Exception as e:
+        logger.error(f"SNMP command failed with error: {str(e)}")
+        raise
+
+
+def get_snmp_facts(duthost, localhost, host, version, community, is_dell=False, module_ignore_errors=False,
+                   wait=False, include_swap=False, timeout=DEF_WAIT_TIMEOUT, interval=DEF_CHECK_INTERVAL,
+                   snmp_timeout=SNMP_DEFAULT_TIMEOUT):
+    if not wait:
+        return _get_snmp_facts(localhost, host, version, community, is_dell, include_swap, module_ignore_errors,
+                               timeout=snmp_timeout)
+
+def get_snmp_facts_v3(localhost=None, wait=False, timeout=DEF_WAIT_TIMEOUT, 
+                      interval=DEF_CHECK_INTERVAL, **kwargs):
+    """
+    Get SNMP facts for SNMPv3 with optional wait.
+    
+    Args:
+        localhost: Ansible localhost object
+        wait: Whether to wait for facts to be available
+        timeout: Maximum wait time
+        interval: Wait interval
+        **kwargs: Additional SNMP parameters
+            version: SNMP version ('v3')
+            host: Target host IP
+            For v3: username, integrity (auth protocol), privacy (priv protocol),
+                   authkey, privkey, level
     Returns:
-        SNMP result
+        dict: SNMP facts from the device
+    Raises:
+        TimeoutError: If wait is True and facts cannot be retrieved within timeout
+        Exception: For other SNMP-related errors
+    """
+    def build_ansible_kwargs():
+        """
+        Helper function to build ansible_kwargs dictionary for SNMPv3 requests.
+        
+        Returns:
+            dict: Properly formatted kwargs for ansible SNMPv3 module
+        
+        Raises:
+            ValueError: If required SNMPv3 parameters are missing
+        """
+        # Validate required parameters
+        required_params = ['host', 'username', 'authkey', 'privkey']
+        missing_params = [param for param in required_params if not kwargs.get(param)]
+        if missing_params:
+            raise ValueError(f"Missing required SNMPv3 parameters: {missing_params}")
+
+        # Build kwargs dictionary with SNMPv3 parameters
+        ansible_kwargs = {
+            'version': 'v3',
+            'host': kwargs['host'],
+            'username': kwargs['username'],
+            'level': kwargs.get('level', SNMPV3_DEFAULTS['level']),
+            'integrity': kwargs.get('integrity', SNMPV3_DEFAULTS['integrity']),
+            'privacy': kwargs.get('privacy', SNMPV3_DEFAULTS['privacy']),
+            'authkey': kwargs['authkey'],
+            'privkey': kwargs['privkey'],
+            'timeout': kwargs.get('timeout', timeout),
+            'is_dell': kwargs.get('is_dell', False),
+            'is_eos': kwargs.get('is_eos', False),
+            'include_swap': kwargs.get('include_swap', False)
+        }
+    pytest_assert(wait_until(timeout, interval, 0, _update_snmp_facts, localhost, host, version,
+                             community, is_dell, include_swap, duthost, snmp_timeout), "Timeout waiting for SNMP facts")
+    return global_snmp_facts
+
+        # Remove any None values
+        return {k: v for k, v in ansible_kwargs.items() if v is not None}
+
+    def _get_facts():
+        """Helper function to get SNMP facts for wait_until"""
+        try:
+            facts = localhost.snmp_facts(**build_ansible_kwargs())
+            return bool(facts)
+        except Exception as e:
+            logger.warning(f"Failed to get SNMP facts: {str(e)}")
+            return False
+
+    try:
+        ansible_kwargs = build_ansible_kwargs()
+
+        if not wait:
+            return localhost.snmp_facts(**ansible_kwargs)
+
+        if not wait_until(timeout, interval, 0, _get_facts):
+            raise TimeoutError(f"Timeout waiting for SNMP facts after {timeout} seconds")
+
+        return localhost.snmp_facts(**ansible_kwargs)
+
+    except Exception as e:
+        logger.error(f"Error getting SNMP facts: {str(e)}")
+        if kwargs.get('module_ignore_errors', False):
+            return {}
+        raise
+
+def get_snmp_output(ip, duthost, nbr, creds_all_duts, oid=SnmpOIDs.SYS_DESCR, version=SnmpVersion.V2C):
+    """
+    Get SNMP output from duthost using specific ip to query.
+    Supports both SNMPv2c and SNMPv3.
+    
+    Args:
+        ip: IP of DUT to query
+        duthost: DUT host object
+        nbr: Neighbor from where to execute query
+        creds_all_duts: Credentials dictionary
+        oid: OID to query (default: SYS_DESCR)
+        version: SNMP version (SnmpVersion.V2C or SnmpVersion.V3)
     """
     ipaddr = ipaddress.ip_address(ip)
     iptables_cmd = "iptables"
@@ -88,17 +370,29 @@ def get_snmp_output(ip, duthost, nbr, creds_all_duts, oid='.1.3.6.1.2.1.1.1.0'):
         iptables_cmd, ip)
     duthost.shell(ip_tbl_rule_add)
 
-    if isinstance(nbr["host"], EosHost):
-        eos_snmpget = "bash snmpget -v2c -c {} {} {}".format(
-            creds_all_duts[duthost.hostname]['snmp_rocommunity'], ip, oid)
-        out = nbr['host'].eos_command(commands=[eos_snmpget])
-    else:
-        command = "docker exec snmp snmpwalk -v 2c -c {} {} {}".format(
-                  creds_all_duts[duthost.hostname]['snmp_rocommunity'], ip, oid)
-        out = nbr['host'].command(command)
+    try:
+        creds = creds_all_duts[duthost.hostname]
+        if isinstance(nbr["host"], EosHost):
+            if version == SnmpVersion.V2C:
+                command = f"bash snmpget -v2c -c {creds['snmp_rocommunity']} {ip} {oid}"
+            else:  # v3
+                command = (f"bash snmpget -v3 -l {creds['snmp_v3level']} -u {creds['snmp_v3user']} "
+                         f"-a {creds['snmp_v3authprotocol']} -A {creds['snmp_v3authpasswd']} "
+                         f"-x {creds['snmp_v3privprotocol']} -X {creds['snmp_v3privpasswd']} "
+                         f"{ip} {oid}")
+            out = nbr['host'].eos_command(commands=[command])
+        else:
+            if version == SnmpVersion.V2C:
+                command = f"docker exec snmp snmpwalk -v 2c -c {creds['snmp_rocommunity']} {ip} {oid}"
+            else:  # v3
+                command = (f"docker exec snmp snmpwalk -v3 -l {creds['snmp_v3level']} -u {creds['snmp_v3user']} "
+                         f"-a {creds['snmp_v3authprotocol']} -A {creds['snmp_v3authpasswd']} "
+                         f"-x {creds['snmp_v3privprotocol']} -X {creds['snmp_v3privpasswd']} "
+                         f"{ip} {oid}")
+            out = nbr['host'].command(command)
 
-    ip_tbl_rule_del = "sudo {} -D INPUT -p udp --dport 161 -d {} -j ACCEPT".format(
-        iptables_cmd, ip)
-    duthost.shell(ip_tbl_rule_del)
+        return out
+    finally:
+        ip_tbl_rule_del = f"sudo {iptables_cmd} -D INPUT -p udp --dport 161 -d {ip} -j ACCEPT"
+        duthost.shell(ip_tbl_rule_del)
 
-    return out

--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -10,12 +10,14 @@ from tests.common.devices.eos import EosHost
 
 logger = logging.getLogger(__name__)
 
+
 class SnmpVersion(Enum):
     V2C = "2c"
     V3 = "3"
-    
+
     def __str__(self):
         return self.value
+
 
 DEF_WAIT_TIMEOUT = 300
 DEF_CHECK_INTERVAL = 10
@@ -26,10 +28,11 @@ SNMPV3_DEFAULTS = {
     'privacy': 'aes'
 }
 
+
 # Centralized SNMP OID definitions
 class SnmpOIDs:
     """Centralized SNMP OID definitions"""
-    
+
     # System MIB OIDs
     SYSTEM = '1.3.6.1.2.1.1'
     SYS_DESCR = '1.3.6.1.2.1.1.1.0'
@@ -39,7 +42,7 @@ class SnmpOIDs:
     SYS_NAME = '1.3.6.1.2.1.1.5.0'
     SYS_LOCATION = '1.3.6.1.2.1.1.6.0'
     SYS_SERVICES = '1.3.6.1.2.1.1.7.0'
-    
+
     # CPU Utilization OIDs
     # Dell Enterprise MIB for 5-second CPU utilization
     DELL_CPU_UTIL_5SEC = '1.3.6.1.4.1.6027.3.10.1.2.9.1.2.1'
@@ -51,7 +54,7 @@ class SnmpOIDs:
     HOST_CPU_LOAD_1 = '1.3.6.1.4.1.2021.10.1.3.1'
     HOST_CPU_LOAD_5 = '1.3.6.1.4.1.2021.10.1.3.2'
     HOST_CPU_LOAD_15 = '1.3.6.1.4.1.2021.10.1.3.3'
-    
+
     # Interfaces MIB OIDs
     INTERFACES = '1.3.6.1.2.1.2'
     IF_NUMBER = '1.3.6.1.2.1.2.1.0'
@@ -68,7 +71,7 @@ class SnmpOIDs:
     IF_OUT_OCTETS = '1.3.6.1.2.1.2.2.1.16'
     IF_IN_ERRORS = '1.3.6.1.2.1.2.2.1.14'
     IF_OUT_ERRORS = '1.3.6.1.2.1.2.2.1.20'
-    
+
     # Host Resources MIB
     HOST = '1.3.6.1.2.1.25'
     HOST_STORAGE = '1.3.6.1.2.1.25.2'
@@ -77,14 +80,14 @@ class SnmpOIDs:
     HOST_CPU_LOAD_1 = '1.3.6.1.4.1.2021.10.1.3.1'
     HOST_CPU_LOAD_5 = '1.3.6.1.4.1.2021.10.1.3.2'
     HOST_CPU_LOAD_15 = '1.3.6.1.4.1.2021.10.1.3.3'
-    
+
     # Bridge MIB (FDB)
     DOT1D_BRIDGE = '1.3.6.1.2.1.17'
     DOT1D_TP_FDB_TABLE = '1.3.6.1.2.1.17.4.3'
     DOT1D_TP_FDB_ENTRY = '1.3.6.1.2.1.17.4.3.1'
     DOT1D_BASE_PORT_TABLE = '1.3.6.1.2.1.17.1.4'
     DOT1D_BASE_PORT_ENTRY = '1.3.6.1.2.1.17.1.4.1'
-    
+
     # Entity MIB
     ENTITY_MIB = '1.3.6.1.2.1.47'
     ENT_PHYSICAL_TABLE = '1.3.6.1.2.1.47.1.1.1'
@@ -94,31 +97,24 @@ class SnmpOIDs:
     ENT_PHYSICAL_SERIAL_NUM = '1.3.6.1.2.1.47.1.1.1.1.11'
     ENT_PHYSICAL_MFG_NAME = '1.3.6.1.2.1.47.1.1.1.1.12'
     ENT_PHYSICAL_MODEL_NAME = '1.3.6.1.2.1.47.1.1.1.1.13'
-    
+
     # LLDP MIB
     LLDP = '1.0.8802.1.1.2'
     LLDP_LOCAL_SYS_NAME = '1.0.8802.1.1.2.1.3.3'
     LLDP_LOCAL_SYS_DESC = '1.0.8802.1.1.2.1.3.4'
     LLDP_LOCAL_PORT_TABLE = '1.0.8802.1.1.2.1.3.7'
     LLDP_REM_TABLE = '1.0.8802.1.1.2.1.4.1'
-    
+
     # IP MIB
     IP = '1.3.6.1.2.1.4'
     IP_ADDR_TABLE = '1.3.6.1.2.1.4.20'
     IP_NET_TO_MEDIA = '1.3.6.1.2.1.4.22'
     IP_FORWARD_TABLE = '1.3.6.1.2.1.4.24'
 
+
 global_snmp_facts = {}
 global_snmpv3_facts = {}
 
-def is_snmp_subagent_running(duthost):
-    cmd = "docker exec snmp supervisorctl status snmp-subagent"
-    output = duthost.shell(cmd)
-    if "RUNNING" in output["stdout"]:
-        logger.info("SNMP Sub-Agent is Running")
-        return True
-    logger.info("SNMP Sub-Agent is Not Running")
-    return False
 
 def is_snmp_subagent_running(duthost):
     cmd = "docker exec snmp supervisorctl status snmp-subagent"
@@ -128,6 +124,7 @@ def is_snmp_subagent_running(duthost):
         return True
     logger.info("SNMP Sub-Agent is Not Running")
     return False
+
 
 def _get_snmp_facts(localhost, host, version, community, is_dell, include_swap, module_ignore_errors,
                     timeout=SNMP_DEFAULT_TIMEOUT):
@@ -135,6 +132,7 @@ def _get_snmp_facts(localhost, host, version, community, is_dell, include_swap, 
                                       module_ignore_errors=module_ignore_errors, include_swap=include_swap,
                                       timeout=timeout)
     return snmp_facts
+
 
 def _update_snmp_facts(localhost, host, version, community, is_dell, include_swap, duthost,
                        timeout=SNMP_DEFAULT_TIMEOUT):
@@ -151,6 +149,7 @@ def _update_snmp_facts(localhost, host, version, community, is_dell, include_swa
 
     return snmp_subagent_running and True
 
+
 def get_snmp_facts(duthost, localhost, host, version, community, is_dell=False, module_ignore_errors=False,
                    wait=False, include_swap=False, timeout=DEF_WAIT_TIMEOUT, interval=DEF_CHECK_INTERVAL,
                    snmp_timeout=SNMP_DEFAULT_TIMEOUT):
@@ -164,10 +163,11 @@ def get_snmp_facts(duthost, localhost, host, version, community, is_dell=False, 
                              community, is_dell, include_swap, duthost, snmp_timeout), "Timeout waiting for SNMP facts")
     return global_snmp_facts
 
+
 def snmpwalk(duthosts, duthost, oid, version=SnmpVersion.V2C, timeout=30, **kwargs):
     """
     Performs an SNMP walk.
-    
+
     Args:
         duthosts: DUT hosts
         duthost: DUT host
@@ -188,7 +188,7 @@ def snmpwalk(duthosts, duthost, oid, version=SnmpVersion.V2C, timeout=30, **kwar
             raise ValueError(f"Could not determine management IP for {duthost.hostname}")
 
         command = ["snmpwalk", f"-v{version}", "-On", "-t", str(timeout)]
-        
+
         if version == SnmpVersion.V2C:
             if 'community' not in kwargs:
                 raise ValueError("community parameter is required for SNMPv2c")
@@ -198,7 +198,7 @@ def snmpwalk(duthosts, duthost, oid, version=SnmpVersion.V2C, timeout=30, **kwar
             missing_params = [param for param in required_params if param not in kwargs]
             if missing_params:
                 raise ValueError(f"Missing required SNMPv3 parameters: {missing_params}")
-            
+
             command.extend([
                 "-l", kwargs['level'],
                 "-u", kwargs['username'],
@@ -212,9 +212,9 @@ def snmpwalk(duthosts, duthost, oid, version=SnmpVersion.V2C, timeout=30, **kwar
 
         command.extend([str(management_ip), str(oid)])
         logger.debug(f"Executing SNMP command: {' '.join(command)}")
-        
+
         process = subprocess.run(command, capture_output=True, text=True, timeout=timeout)
-        
+
         if process.returncode != 0:
             error_msg = process.stderr.strip()
             logger.error(f"SNMP command failed: {error_msg}")
@@ -224,7 +224,7 @@ def snmpwalk(duthosts, duthost, oid, version=SnmpVersion.V2C, timeout=30, **kwar
 
         # Parse SNMP output lines into (oid_part, value) pairs
         snmp_lines = [line.split(" = ", 1) for line in process.stdout.splitlines() if line and " = " in line]
-        
+
         if not snmp_lines:
             logger.warning("No SNMP data received in response")
             return {}
@@ -234,7 +234,7 @@ def snmpwalk(duthosts, duthost, oid, version=SnmpVersion.V2C, timeout=30, **kwar
             oid_part.strip('.'): (value.split(':', 1)[1] if ':' in value else value).strip().strip('"')
             for oid_part, value in snmp_lines
         }
-        
+
         # Create the final snmp_data dictionary with multiple OID formats
         snmp_data = {
             **{oid: value for oid, value in processed_values.items()},                          # Full OID
@@ -255,18 +255,11 @@ def snmpwalk(duthosts, duthost, oid, version=SnmpVersion.V2C, timeout=30, **kwar
         raise
 
 
-def get_snmp_facts(duthost, localhost, host, version, community, is_dell=False, module_ignore_errors=False,
-                   wait=False, include_swap=False, timeout=DEF_WAIT_TIMEOUT, interval=DEF_CHECK_INTERVAL,
-                   snmp_timeout=SNMP_DEFAULT_TIMEOUT):
-    if not wait:
-        return _get_snmp_facts(localhost, host, version, community, is_dell, include_swap, module_ignore_errors,
-                               timeout=snmp_timeout)
-
-def get_snmp_facts_v3(localhost=None, wait=False, timeout=DEF_WAIT_TIMEOUT, 
+def get_snmp_facts_v3(localhost=None, wait=False, timeout=DEF_WAIT_TIMEOUT,
                       interval=DEF_CHECK_INTERVAL, **kwargs):
     """
     Get SNMP facts for SNMPv3 with optional wait.
-    
+
     Args:
         localhost: Ansible localhost object
         wait: Whether to wait for facts to be available
@@ -286,10 +279,10 @@ def get_snmp_facts_v3(localhost=None, wait=False, timeout=DEF_WAIT_TIMEOUT,
     def build_ansible_kwargs():
         """
         Helper function to build ansible_kwargs dictionary for SNMPv3 requests.
-        
+
         Returns:
             dict: Properly formatted kwargs for ansible SNMPv3 module
-        
+
         Raises:
             ValueError: If required SNMPv3 parameters are missing
         """
@@ -314,9 +307,6 @@ def get_snmp_facts_v3(localhost=None, wait=False, timeout=DEF_WAIT_TIMEOUT,
             'is_eos': kwargs.get('is_eos', False),
             'include_swap': kwargs.get('include_swap', False)
         }
-    pytest_assert(wait_until(timeout, interval, 0, _update_snmp_facts, localhost, host, version,
-                             community, is_dell, include_swap, duthost, snmp_timeout), "Timeout waiting for SNMP facts")
-    return global_snmp_facts
 
         # Remove any None values
         return {k: v for k, v in ansible_kwargs.items() if v is not None}
@@ -347,11 +337,12 @@ def get_snmp_facts_v3(localhost=None, wait=False, timeout=DEF_WAIT_TIMEOUT,
             return {}
         raise
 
+
 def get_snmp_output(ip, duthost, nbr, creds_all_duts, oid=SnmpOIDs.SYS_DESCR, version=SnmpVersion.V2C):
     """
     Get SNMP output from duthost using specific ip to query.
     Supports both SNMPv2c and SNMPv3.
-    
+
     Args:
         ip: IP of DUT to query
         duthost: DUT host object
@@ -377,22 +368,21 @@ def get_snmp_output(ip, duthost, nbr, creds_all_duts, oid=SnmpOIDs.SYS_DESCR, ve
                 command = f"bash snmpget -v2c -c {creds['snmp_rocommunity']} {ip} {oid}"
             else:  # v3
                 command = (f"bash snmpget -v3 -l {creds['snmp_v3level']} -u {creds['snmp_v3user']} "
-                         f"-a {creds['snmp_v3authprotocol']} -A {creds['snmp_v3authpasswd']} "
-                         f"-x {creds['snmp_v3privprotocol']} -X {creds['snmp_v3privpasswd']} "
-                         f"{ip} {oid}")
+                           f"-a {creds['snmp_v3authprotocol']} -A {creds['snmp_v3authpasswd']} "
+                           f"-x {creds['snmp_v3privprotocol']} -X {creds['snmp_v3privpasswd']} "
+                           f"{ip} {oid}")
             out = nbr['host'].eos_command(commands=[command])
         else:
             if version == SnmpVersion.V2C:
                 command = f"docker exec snmp snmpwalk -v 2c -c {creds['snmp_rocommunity']} {ip} {oid}"
             else:  # v3
                 command = (f"docker exec snmp snmpwalk -v3 -l {creds['snmp_v3level']} -u {creds['snmp_v3user']} "
-                         f"-a {creds['snmp_v3authprotocol']} -A {creds['snmp_v3authpasswd']} "
-                         f"-x {creds['snmp_v3privprotocol']} -X {creds['snmp_v3privpasswd']} "
-                         f"{ip} {oid}")
+                           f"-a {creds['snmp_v3authprotocol']} -A {creds['snmp_v3authpasswd']} "
+                           f"-x {creds['snmp_v3privprotocol']} -X {creds['snmp_v3privpasswd']} "
+                           f"{ip} {oid}")
             out = nbr['host'].command(command)
 
         return out
     finally:
         ip_tbl_rule_del = f"sudo {iptables_cmd} -D INPUT -p udp --dport 161 -d {ip} -j ACCEPT"
         duthost.shell(ip_tbl_rule_del)
-

--- a/tests/snmp/test_snmp_sysinfo.py
+++ b/tests/snmp/test_snmp_sysinfo.py
@@ -1,0 +1,162 @@
+import pytest
+import re
+import logging
+import json
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.snmp
+]
+
+def test_snmp_system_info_matches_show_version(duthosts, rand_one_dut_hostname, creds_all_duts, localhost):
+    """
+    Verify that system information retrieved via SNMP matches the output of 'show version' command.
+    
+    This test performs the following steps:
+    1. Retrieves system information using 'show version' command
+    2. Performs SNMP walk to get system information
+    3. Compares both outputs to ensure consistency
+    
+    Args:
+        duthosts: Fixture providing access to all DUT hosts
+        rand_one_dut_hostname: Fixture selecting a random DUT
+        creds_all_duts: Fixture providing SNMP credentials for all DUTs
+        localhost: Fixture providing access to localhost
+    
+    Raises:
+        pytest.fail: If any verification step fails
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    community = creds_all_duts[duthost.hostname]["snmp_rocommunity"]
+    
+    logger.info("\n" + "="*50)
+    logger.info("STARTING SNMP SYSTEM INFO TEST")
+    logger.info("="*50)
+
+    # Log test parameters
+    logger.info("\nTEST PARAMETERS:")
+    logger.info("-"*30)
+    logger.info(f"DUT Hostname: {duthost.hostname}")
+    logger.info(f"DUT Management IP: {duthost.mgmt_ip}")
+    logger.info(f"SNMP Community: {community}")
+
+    # 1. Get and parse show version
+    logger.info("\nSTEP 1: EXECUTING SHOW VERSION")
+    logger.info("-"*30)
+    
+    show_version_cmd = 'show version'
+    logger.info(f"Executing command: {show_version_cmd}")
+    
+    show_version_result = duthost.shell(show_version_cmd)
+    logger.info("\nCommand Result:")
+    logger.info(f"RC: {show_version_result['rc']}")
+    logger.info(f"Stdout:\n{show_version_result['stdout']}")
+    if show_version_result['stderr']:
+        logger.warning(f"Stderr:\n{show_version_result['stderr']}")
+
+    show_version_output = show_version_result['stdout']
+
+    # Parse with detailed logging
+    logger.info("\nPARSING SHOW VERSION OUTPUT")
+    logger.info("-"*30)
+    
+    try:
+        # Define all regex patterns
+        patterns = {
+            'hwsku': r"HwSKU:\s+(\S+)",
+            'sonic_version': r"SONiC Software Version:\s+(\S+)",
+            'platform': r"Platform:\s+(\S+)",
+            'asic': r"ASIC:\s+(\S+)",
+            'serial': r"Serial Number:\s+(\S+)"
+        }
+
+        # Try to extract all values
+        parsed_values = {}
+        for key, pattern in patterns.items():
+            match = re.search(pattern, show_version_output)
+            if match:
+                parsed_values[key] = match.group(1)
+                logger.info(f"Found {key}: {parsed_values[key]}")
+            else:
+                parsed_values[key] = "N/A"
+                logger.warning(f"{key} not found in output")
+
+        # Required values assertion
+        assert 'hwsku' in parsed_values and parsed_values['hwsku'] != "N/A", "HwSKU not found"
+        assert 'sonic_version' in parsed_values and parsed_values['sonic_version'] != "N/A", "SONiC version not found"
+
+        logger.info("\nParsed Values Summary:")
+        logger.info(json.dumps(parsed_values, indent=2))
+
+    except Exception as e:
+        logger.error(f"Error parsing 'show version':")
+        logger.error(f"Exception type: {type(e).__name__}")
+        logger.error(f"Exception message: {str(e)}")
+        logger.error(f"Raw output that failed parsing:\n{show_version_output}")
+        pytest.fail(f"Error parsing 'show version': {e}")
+
+    # 2. Get SNMP facts using Ansible module
+    logger.info("\nSTEP 2: GATHERING SNMP FACTS")
+    logger.info("-"*30)
+    
+    try:
+        logger.info("Executing snmp_facts module with parameters:")
+        logger.info(f"Host: {duthost.mgmt_ip}")
+        logger.info(f"Version: v2c")
+        logger.info(f"Community: {community}")
+        
+        snmp_facts = localhost.snmp_facts(
+            host=duthost.mgmt_ip,
+            version='v2c',
+            community=community
+        )['ansible_facts']
+        
+        logger.info("\nSNMP Facts Results:")
+        logger.info("-"*20)
+        logger.info(f"System Description: {snmp_facts.get('ansible_sysdescr', 'N/A')}")
+        logger.info(f"System Name: {snmp_facts.get('ansible_sysname', 'N/A')}")
+        logger.info(f"System Object ID: {snmp_facts.get('ansible_sysobjectid', 'N/A')}")
+        logger.info(f"System Contact: {snmp_facts.get('ansible_syscontact', 'N/A')}")
+        logger.info(f"System Location: {snmp_facts.get('ansible_syslocation', 'N/A')}")
+        logger.info(f"System Uptime: {snmp_facts.get('ansible_sysuptime', 'N/A')}")
+
+        assert 'ansible_sysdescr' in snmp_facts, "System description not found in SNMP facts"
+
+    except Exception as e:
+        logger.error("SNMP facts gathering failed:")
+        logger.error(f"Exception type: {type(e).__name__}")
+        logger.error(f"Exception message: {str(e)}")
+        pytest.fail(f"SNMP facts gathering failed: {e}")
+
+    # 3. Verification
+    logger.info("\nSTEP 3: VERIFYING SNMP DATA")
+    logger.info("-"*30)
+    
+    try:
+        sysdescr = snmp_facts['ansible_sysdescr']
+        logger.info("Verification Details:")
+        logger.info(f"SNMP System Description:\n{sysdescr}")
+        
+        # Verify each value
+        for key, value in parsed_values.items():
+            if value != "N/A":
+                found = value in sysdescr
+                logger.info(f"Checking {key}: '{value}' - {'Found' if found else 'Not Found'}")
+                if key in ['hwsku', 'sonic_version']:  # Required checks
+                    assert found, f"{key} ({value}) not found in system description"
+
+        logger.info("\nAll verifications completed successfully!")
+
+    except Exception as e:
+        logger.error("Verification failed:")
+        logger.error(f"Exception type: {type(e).__name__}")
+        logger.error(f"Exception message: {str(e)}")
+        logger.error(f"SNMP System Description: {sysdescr}")
+        pytest.fail(f"SNMP data verification failed: {e}")
+
+    logger.info("\n" + "="*50)
+    logger.info("TEST COMPLETED SUCCESSFULLY")
+    logger.info("="*50 + "\n")
+

--- a/tests/snmp/test_snmpv3_basic_get.py
+++ b/tests/snmp/test_snmpv3_basic_get.py
@@ -1,0 +1,184 @@
+import pytest
+import logging
+import time
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.snmp_helpers import get_snmp_facts_v3, SnmpOIDs
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
+]
+
+logger = logging.getLogger(__name__)
+
+def setup_snmpv3_user(duthost, username=None, auth_pass=None, priv_pass=None):
+    """Setup SNMPv3 user on DUT"""
+    if not username:
+        username = f"snmpTest_{int(time.time())}"
+    if not auth_pass:
+        auth_pass = "password123"
+    if not priv_pass:
+        priv_pass = "password123"
+
+    try:
+        # Remove existing user if any
+        logger.info(f"Removing existing SNMPv3 user if exists: {username}")
+        duthost.shell(f"sudo config snmp user del {username}", module_ignore_errors=True)
+        time.sleep(2)
+
+        # Create new SNMPv3 user
+        create_cmd = f"sudo config snmp user add {username} Priv RO SHA {auth_pass} AES {priv_pass}"
+        logger.info(f"Creating SNMPv3 user with command: {create_cmd}")
+        result = duthost.shell(create_cmd)
+        pytest_assert(result['rc'] == 0, f"Failed to create SNMPv3 user: {result['stderr']}")
+
+        time.sleep(5)  # Wait for user creation
+
+        return {
+            "username": username,
+            "auth_protocol": "SHA",  # Changed to uppercase to match SNMP requirements
+            "auth_password": auth_pass,
+            "priv_protocol": "AES",  # Changed to uppercase to match SNMP requirements
+            "priv_password": priv_pass
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to setup SNMPv3 user: {str(e)}")
+        raise
+
+def cleanup_snmpv3_user(duthost, username):
+    """Cleanup SNMPv3 user from DUT"""
+    try:
+        logger.info(f"Cleaning up SNMPv3 user: {username}")
+        duthost.shell(f"sudo config snmp user del {username}", module_ignore_errors=True)
+    except Exception as e:
+        logger.error(f"Failed to cleanup SNMPv3 user: {str(e)}")
+
+@pytest.mark.parametrize("oid", [
+    SnmpOIDs.SYS_DESCR,
+    SnmpOIDs.SYS_UPTIME,
+    SnmpOIDs.SYS_NAME,
+    SnmpOIDs.HOST_CPU_LOAD_1,
+    SnmpOIDs.IF_NUMBER,
+    SnmpOIDs.ENT_PHYSICAL_DESCR
+])
+def test_snmpv3_get(duthosts, rand_one_dut_hostname, localhost, oid):
+    """Test SNMPv3 GET operation for various OIDs"""
+    duthost = duthosts[rand_one_dut_hostname]
+    
+    # Get DUT IP
+    hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+    logger.info(f"Testing SNMPv3 GET on host {hostip}")
+    
+    # Setup SNMPv3 user
+    v3_config = None
+    
+    try:
+        # Create SNMPv3 user
+        v3_config = setup_snmpv3_user(duthost)
+        logger.info(f"Created SNMPv3 user: {v3_config['username']}")
+
+        # Wait for SNMP to be ready
+        time.sleep(10)
+
+        # Perform SNMP GET with correct parameter names
+        logger.info(f"Performing SNMPv3 GET for OID: {oid}")
+        snmp_facts = get_snmp_facts_v3(
+            localhost=localhost,
+            wait=True,
+            version="v3",
+            host=hostip,
+            username=v3_config["username"],
+            integrity=v3_config["auth_protocol"].lower(),  # Convert to lowercase
+            privacy=v3_config["priv_protocol"].lower(),    # Convert to lowercase
+            authkey=v3_config["auth_password"],
+            privkey=v3_config["priv_password"],
+            level="authPriv",
+            timeout=20,
+            oid=oid
+        )
+
+        # Verify we got a response
+        pytest_assert(snmp_facts is not None, f"Failed to get SNMP facts for OID {oid}")
+        pytest_assert('ansible_facts' in snmp_facts, f"No ansible_facts in SNMP response for OID {oid}")
+        
+        facts = snmp_facts['ansible_facts']
+        logger.info(f"Retrieved SNMP facts for OID {oid}: {facts}")
+
+    except Exception as e:
+        logger.error(f"SNMPv3 GET test failed for OID {oid}")
+        logger.error(f"Error details: {str(e)}")
+        logger.error(f"SNMPv3 configuration used: {v3_config}")
+        pytest.fail(f"SNMPv3 GET test failed: {str(e)}")
+
+    finally:
+        # Cleanup
+        if v3_config:
+            cleanup_snmpv3_user(duthost, v3_config["username"])
+
+def test_snmpv3_get_custom(duthosts, rand_one_dut_hostname, localhost, request):
+    """Test SNMPv3 GET operation with custom parameters"""
+    duthost = duthosts[rand_one_dut_hostname]
+    
+    # Get custom parameters from pytest command line
+    oid = request.config.getoption("--oid", default=SnmpOIDs.SYS_DESCR)
+    username = request.config.getoption("--snmp-user", default=None)
+    auth_pass = request.config.getoption("--snmp-auth-pass", default=None)
+    priv_pass = request.config.getoption("--snmp-priv-pass", default=None)
+    
+    # Get DUT IP
+    hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+    
+    # Setup SNMPv3 user
+    v3_config = None
+    
+    try:
+        # Create SNMPv3 user
+        v3_config = setup_snmpv3_user(duthost, username, auth_pass, priv_pass)
+        logger.info(f"Created SNMPv3 user: {v3_config['username']}")
+
+        # Wait for SNMP to be ready
+        time.sleep(10)
+
+        # Perform SNMP GET with correct parameter names
+        logger.info(f"Performing SNMPv3 GET for OID: {oid}")
+        snmp_facts = get_snmp_facts_v3(
+            localhost=localhost,
+            wait=True,
+            version="v3",
+            host=hostip,
+            username=v3_config["username"],
+            integrity=v3_config["auth_protocol"].lower(),  # Convert to lowercase
+            privacy=v3_config["priv_protocol"].lower(),    # Convert to lowercase
+            authkey=v3_config["auth_password"],
+            privkey=v3_config["priv_password"],
+            level="authPriv",
+            timeout=20,
+            oid=oid
+        )
+
+        # Verify we got a response
+        pytest_assert(snmp_facts is not None, "Failed to get SNMP facts")
+        pytest_assert('ansible_facts' in snmp_facts, "No ansible_facts in SNMP response")
+        
+        facts = snmp_facts['ansible_facts']
+        logger.info(f"Retrieved SNMP facts for OID {oid}: {facts}")
+
+    except Exception as e:
+        logger.error(f"SNMPv3 GET test failed for OID {oid}")
+        logger.error(f"Error details: {str(e)}")
+        logger.error(f"SNMPv3 configuration used: {v3_config}")
+        pytest.fail(f"SNMPv3 GET test failed: {str(e)}")
+
+    finally:
+        # Cleanup
+        if v3_config:
+            cleanup_snmpv3_user(duthost, v3_config["username"])
+
+def pytest_addoption(parser):
+    """Add custom command line options"""
+    parser.addoption("--oid", action="store", help="OID to query")
+    parser.addoption("--snmp-user", action="store", help="SNMPv3 username")
+    parser.addoption("--snmp-auth-pass", action="store", help="SNMPv3 auth password")
+    parser.addoption("--snmp-priv-pass", action="store", help="SNMPv3 priv password")
+

--- a/tests/snmp/test_snmpv3_invalid_creds.py
+++ b/tests/snmp/test_snmpv3_invalid_creds.py
@@ -1,0 +1,169 @@
+import logging
+import pytest
+import time
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.snmp_helpers import get_snmp_facts, get_snmp_facts_v3, SnmpOIDs
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
+]
+
+def setup_snmpv3_user(duthost, username=None, auth_pass=None, priv_pass=None):
+    """Setup SNMPv3 user on DUT"""
+    if not username:
+        username = f"snmpTest_{int(time.time())}"
+    if not auth_pass:
+        auth_pass = "password123"
+    if not priv_pass:
+        priv_pass = "password123"
+
+    try:
+        # Remove existing user if any
+        logger.info(f"Removing existing SNMPv3 user if exists: {username}")
+        duthost.shell(f"sudo config snmp user del {username}", module_ignore_errors=True)
+        time.sleep(2)
+
+        # Create new SNMPv3 user
+        create_cmd = f"sudo config snmp user add {username} Priv RO SHA {auth_pass} AES {priv_pass}"
+        logger.info(f"Creating SNMPv3 user with command: {create_cmd}")
+        result = duthost.shell(create_cmd)
+        pytest_assert(result['rc'] == 0, f"Failed to create SNMPv3 user: {result['stderr']}")
+
+        time.sleep(5)  # Wait for user creation
+
+        return {
+            "username": username,
+            "auth_protocol": "SHA",  # Changed to uppercase to match SNMP requirements
+            "auth_password": auth_pass,
+            "priv_protocol": "AES",  # Changed to uppercase to match SNMP requirements
+            "priv_password": priv_pass
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to setup SNMPv3 user: {str(e)}")
+        raise
+
+def cleanup_snmpv3_user(duthost, username):
+    """Cleanup SNMPv3 user from DUT"""
+    try:
+        logger.info(f"Cleaning up SNMPv3 user: {username}")
+        duthost.shell(f"sudo config snmp user del {username}", module_ignore_errors=True)
+    except Exception as e:
+        logger.error(f"Failed to cleanup SNMPv3 user: {str(e)}")  # Removed extra parenthesis
+
+@pytest.mark.parametrize("test_case", [
+    {
+        "name": "wrong_username",
+        "modify": lambda c: {"username": "invalid_user"},
+        "error_msg": "Expected failure with invalid username"
+    },
+    {
+        "name": "wrong_auth_password",
+        "modify": lambda c: {"auth_key": "wrong_auth_pass"},
+        "error_msg": "Expected failure with invalid auth password"
+    },
+    {
+        "name": "wrong_priv_password",
+        "modify": lambda c: {"priv_key": "wrong_priv_pass"},
+        "error_msg": "Expected failure with invalid priv password"
+    },
+    {
+        "name": "wrong_auth_protocol",
+        "modify": lambda c: {"auth_protocol": "md5"},
+        "error_msg": "Expected failure with invalid auth protocol"
+    },
+    {
+        "name": "wrong_priv_protocol",
+        "modify": lambda c: {"priv_protocol": "des"},
+        "error_msg": "Expected failure with invalid priv protocol"
+    }
+])
+def test_snmpv3_invalid_credentials(duthosts, rand_one_dut_hostname, localhost, test_case):
+    """
+    Test SNMPv3 GET operation with invalid credentials
+    Will only run on virtual switch devices, but works with any topology
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+    v3_config = None
+
+    try:
+        # Create valid SNMPv3 user first
+        v3_config = setup_snmpv3_user(duthost)
+        logger.info(f"Created base SNMPv3 user: {v3_config['username']}")
+
+        # Create invalid credentials based on the test case
+        invalid_config = v3_config.copy()
+        invalid_config.update(test_case["modify"](v3_config))
+        
+        logger.info(f"Testing invalid credentials case: {test_case['name']}")
+        try:
+            snmp_facts = get_snmp_facts(
+                localhost,
+                host=hostip,
+                version="v3",
+                username=invalid_config.get("username", v3_config["username"]),
+                integrity=invalid_config.get("integrity", v3_config["auth_protocol"].lower()),
+                authkey=invalid_config.get("authkey", v3_config["auth_password"]),
+                privacy=invalid_config.get("privacy", v3_config["priv_protocol"]),
+                privkey=invalid_config.get("privpassword", v3_config["priv_password"]),
+                level="authPriv",
+                wait=True,
+                oid=SnmpOIDs.SYS_DESCR  # Using SnmpOIDs.SYS_DESCR directly
+            )
+            pytest.fail(f"SNMPv3 GET succeeded with invalid credentials for case: {test_case['name']}")
+            
+        except Exception as e:
+            logger.info(f"{test_case['error_msg']}: {str(e)}")
+
+    except Exception as e:
+        pytest.fail(f"SNMPv3 invalid credentials test failed: {str(e)}")
+
+    finally:
+        if v3_config:
+            cleanup_snmpv3_user(duthost, v3_config["username"])
+
+
+def test_snmpv3_valid_after_invalid(duthosts, rand_one_dut_hostname, localhost):
+    """
+    Verify that valid SNMPv3 credentials still work after invalid attempts
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    hostip = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']
+    v3_config = None
+
+    try:
+        # Create valid SNMPv3 user
+        v3_config = setup_snmpv3_user(duthost)
+        logger.info(f"Created SNMPv3 user: {v3_config['username']}")
+
+        # Now test with valid credentials
+        logger.info("Verifying valid credentials still work")
+        snmp_facts = get_snmp_facts_v3(
+            localhost=localhost,
+            wait=True,
+            version="v3",
+            host=hostip,
+            username=v3_config["username"],  # Using valid username
+            integrity=v3_config["auth_protocol"].lower(),
+            authkey=v3_config["auth_password"],
+            privacy=v3_config["priv_protocol"].lower(),
+            privkey=v3_config["priv_password"],
+            level="authPriv",
+            oid=SnmpOIDs.SYS_DESCR
+        )
+        
+        pytest_assert(snmp_facts is not None, "Failed to get SNMP facts with valid credentials")
+        pytest_assert('ansible_facts' in snmp_facts, "No ansible_facts in SNMP response with valid credentials")
+        logger.info("Successfully verified SNMPv3 access with valid credentials")
+
+    except Exception as e:
+        pytest.fail(f"SNMPv3 valid credentials verification failed: {str(e)}")
+
+    finally:
+        if v3_config:
+            cleanup_snmpv3_user(duthost, v3_config["username"])
+


### PR DESCRIPTION
This PR is to create a new test case in sonic-mgmt framework that tests the following scenarios:

**test_snmpv3_basic_get:**
Tests basic SNMPv3 GET operations
Verifies different security levels (authPriv, authNoPriv, noAuthNoPriv)
Checks basic system information retrieval
Validates expected successes and failures

**test_snmpv3_invalid_credentials**
This test verifies that SNMP operations fail appropriately when:Using an incorrect username

- Using an incorrect authentication password
- Using an incorrect privacy password
- Using an incorrect authentication protocol
- Using an incorrect privacy protocol

**test_snmp_sysinfo**
1.Get "show version" output and extract HwSKU and SONiC version
2. Perform SNMP walk on 1.3.6.1.2.1.1 
3. Verify SNMP data against "show version"

Files that has been **added and/or modifed:**
tests/snmp/test_snmpv3_basic_get.py -> test_snmpv3_basic_get
tests/snmp/test_snmpv3_invalid_creds.py -> test_snmpv3_invalid_credentials
tests/snmp/test_snmp_sysinfo.py -> test_snmp_sysinfo
common/helpers/snmp_helpers.py -> updated


Summary:
Issue # 16831

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ X] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
New test snmp test cases.

#### What is the motivation for this PR?
Currently there are no snmp v3 test cases, adding two new test cases for snmpv3

#### How did you do it?
Created test cases in sonic-mgmt framework

#### How did you verify/test it?
Ran the test successfully in a t0 topology

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
This test can be run on "any"topology

