### PR TITLE
Add leeway for storm generation to pfcwd/test_pfcwd_cli.py

### DIFF
--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -364,6 +364,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             )
 
         # send traffic to egress port
+        time.sleep(10)    # Leeway for storm to be fully established
         self.traffic_inst.send_tx_egress(self.tx_action, False)
         pfcwd_stat_after_tx = parser_show_pfcwd_stat(dut, port, self.pfc_wd['queue_index'])
         logger.debug("pfcwd_stat_after_tx {}".format(pfcwd_stat_after_tx))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In `pfcwd/test_pfcwd_cli.py`, sometimes there will be around half of the dropped packets that are not accounted for, causing the test to be flaky. The flakiness is observed only on t1.

It is flaky if the test file is ran the first time. When run multiple times consecutively,  the issue will always occur and cause the test to fail.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Adding a delay before sending out egress traffic seems to fix most of the flakiness.

#### How did you verify/test it?
Consecutive test runs no longer always fail. The first run of the test file also becomes less flaky.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
