### PR TITLE
add multidut support for enable_iface_naming_mode

### DIFF
--- a/tests/common/helpers/sonic_db.py
+++ b/tests/common/helpers/sonic_db.py
@@ -147,7 +147,7 @@ class SonicDbCli(object):
         else:
             raise AssertionError("sonic-db value error: %s != %s key was: %s" % (result, value, key))
 
-    def get_keys(self, table):
+    def get_keys(self, table, raise_error_when_not_found=True):
         """
         Gets the list of keys in a table.
 
@@ -164,7 +164,9 @@ class SonicDbCli(object):
         cmd = self._cli_prefix() + " keys {}".format(table)
         result = self._run_and_check(cmd)
         if result == {}:
-            raise SonicDbKeyNotFound("No keys for %s found in sonic-db cmd: %s" % (table, cmd))
+            if raise_error_when_not_found:
+                raise SonicDbKeyNotFound("No keys for %s found in sonic-db cmd: %s" % (table, cmd))
+            return []
         else:
             if six.PY2:
                 return result['stdout'].decode('unicode-escape').splitlines()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 

Add support for multi-asic compatible for this tests. This PR requires https://github.com/sonic-net/sonic-utilities/pull/3781 to be merged as it's support `-n <namespace>`

Fixes # (issue) 28837145 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Described above

#### How did you do it?
Utility improvement: https://github.com/sonic-net/sonic-utilities/pull/3781

Use namespace to get the information so that it's compatible with  multi-asic.

Enabled internal port when querying for port_alias_fact which was disabled before for compatibility

#### How did you verify/test it?

T2 testbed verified

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
