### PR TITLE
Restore configuration after test_vxlan_bfd_tsa.py

### DIFF
--- a/tests/vxlan/test_vxlan_bfd_tsa.py
+++ b/tests/vxlan/test_vxlan_bfd_tsa.py
@@ -18,6 +18,7 @@ from tests.ptf_runner import ptf_runner
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 from tests.common.config_reload import config_system_checks_passed
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts    # noqa F401
+from tests.common.config_reload import config_reload
 Logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()
 
@@ -223,6 +224,14 @@ def fixture_setUp(duthosts,
         data['duthost'].shell(
             "redis-cli -n 4 del \"VXLAN_TUNNEL|{}\"".format(tunnel))
     time.sleep(1)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def restore_config_by_config_reload(duthosts, rand_one_dut_hostname, localhost):
+    yield
+    duthost = duthosts[rand_one_dut_hostname]
+
+    config_reload(duthost, safe_reload=True)
 
 
 class Test_VxLAN_BFD_TSA():

--- a/tests/vxlan/test_vxlan_bfd_tsa.py
+++ b/tests/vxlan/test_vxlan_bfd_tsa.py
@@ -17,6 +17,7 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # no
 from tests.ptf_runner import ptf_runner
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 from tests.common.config_reload import config_system_checks_passed
+from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts    # noqa F401
 Logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()
 
@@ -69,7 +70,8 @@ def fixture_setUp(duthosts,
                   rand_one_dut_hostname,
                   minigraph_facts,
                   tbinfo,
-                  encap_type):
+                  encap_type,
+                  backup_and_restore_config_db_on_duts):        # noqa F811
     '''
         Setup for the entire script.
         The basic steps in VxLAN configs are:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In `test_vxlan_bfd_tsa`, it will do `config save` command and after enable bfd session, iptables will add the following iptables rules, and it didn't have any chance to restore the configuration after the test. These iptables rules will be left on the DUT, which will impact the test results for `test_cacl_application`.

```
 iptables -I INPUT 2 -p udp -m multiport --dports 3784,4784 -j ACCEPT
 ip6tables -I INPUT 2 -p udp -m multiport --dports 3784,4784 -j ACCEPT
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Backup and restore configuration for test_vxlan_bfd_tsa
#### How did you do it?
Call the existing function `backup_and_restore_config_db_on_dut`s in `fixture_setUp` fixture of `test_vxlan_bfd_tsa`  and do `config reload` after `config_db.json` restoration.

#### How did you verify/test it?
Run test_vxlan_bfd_tsa on dut and check if 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
