### PR TITLE
Update bgp suppress fib script for vrf case

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -304,6 +304,23 @@ def setup_vrf_cfg(duthost, cfg_facts, nbrhosts, tbinfo):
     """
     cfg_t1 = deepcopy(cfg_facts)
     cfg_t1.pop('config_port_indices', None)
+    for loopback in cfg_t1['LOOPBACK_INTERFACE']:
+        loopback_items = loopback.split('|')
+        if len(loopback_items) == 2 and loopback_items[0] == 'Loopback0':
+            ipaddr = ipaddress.ip_address(loopback_items[1].split('/')[0])
+            if isinstance(ipaddr, ipaddress.IPv4Address):
+                router_id = str(ipaddr)
+                break
+    dut_asn = tbinfo['topo']['properties']['configuration_properties']['common']['dut_asn']
+    if 'BGP_GLOBALS' not in cfg_t1:
+        cfg_t1['BGP_GLOBALS'] = {}
+        if USER_DEFINED_VRF not in cfg_t1['BGP_GLOBALS']:
+            cfg_t1['BGP_GLOBALS'][USER_DEFINED_VRF] = {}
+            cfg_t1['BGP_GLOBALS'][USER_DEFINED_VRF]['router_id'] = router_id
+            cfg_t1['BGP_GLOBALS'][USER_DEFINED_VRF]['local_asn'] = dut_asn
+    for bgp_neighbor in cfg_t1['BGP_NEIGHBOR']:
+        cfg_t1['BGP_NEIGHBOR'][bgp_neighbor].pop('nhopself', None)
+        cfg_t1['BGP_NEIGHBOR'][bgp_neighbor].pop('rrclient', None)
     port_list = get_port_connected_with_vm(duthost, nbrhosts)
     vm_list = nbrhosts.keys()
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)

--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -314,10 +314,9 @@ def setup_vrf_cfg(duthost, cfg_facts, nbrhosts, tbinfo):
     dut_asn = tbinfo['topo']['properties']['configuration_properties']['common']['dut_asn']
     if 'BGP_GLOBALS' not in cfg_t1:
         cfg_t1['BGP_GLOBALS'] = {}
-        if USER_DEFINED_VRF not in cfg_t1['BGP_GLOBALS']:
-            cfg_t1['BGP_GLOBALS'][USER_DEFINED_VRF] = {}
-            cfg_t1['BGP_GLOBALS'][USER_DEFINED_VRF]['router_id'] = router_id
-            cfg_t1['BGP_GLOBALS'][USER_DEFINED_VRF]['local_asn'] = dut_asn
+        cfg_t1['BGP_GLOBALS'][USER_DEFINED_VRF] = {}
+        cfg_t1['BGP_GLOBALS'][USER_DEFINED_VRF]['router_id'] = router_id
+        cfg_t1['BGP_GLOBALS'][USER_DEFINED_VRF]['local_asn'] = dut_asn
     for bgp_neighbor in cfg_t1['BGP_NEIGHBOR']:
         cfg_t1['BGP_NEIGHBOR'][bgp_neighbor].pop('nhopself', None)
         cfg_t1['BGP_NEIGHBOR'][bgp_neighbor].pop('rrclient', None)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Update vrf configuration to pass the yang validation.
1. Add 'BGP_GLOBALS' into config db
2. Remove 'nhopself' and 'rrclient' from 'BGP_NEIGHBOR'

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Fix the yang validation failure of vrf configuration.
#### How did you do it?
1. Add 'BGP_GLOBALS' into config db
2. Remove 'nhopself' and 'rrclient' from 'BGP_NEIGHBOR'
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
