### PR TITLE
chore: replace warn with warning for logging

### DIFF
--- a/ansible/roles/vm_set/library/vlan_port.py
+++ b/ansible/roles/vm_set/library/vlan_port.py
@@ -124,9 +124,9 @@ class VlanPort(object):
                 logging.debug("Port %s has vlan interface %s with vlan id %s" % (
                     port, vlan_intf, vlan_id))
             except Exception:
-                logging.warn("Unexpected output:\n%s", out)
+                logging.warning("Unexpected output:\n%s", out)
         else:
-            logging.warn("Unexpected output:\n%s", out)
+            logging.warning("Unexpected output:\n%s", out)
 
     @staticmethod
     def iface_updown(iface_name, state, pid):

--- a/tests/bgp/route_checker.py
+++ b/tests/bgp/route_checker.py
@@ -45,14 +45,14 @@ def verify_loopback_route_with_community(dut_hosts, duthost, neigh_hosts, ip_ver
                 nbr_prefix_ipv6_subnet_len_set.add(prefix.split('/')[1])
             nbr_prefix_community_set.add(received_community)
         if nbr_prefix_set != device_lo_addr_prefix_set:
-            logger.warn("missing loopback address or some other routes present on neighbor")
+            logger.warning("missing loopback address or some other routes present on neighbor")
             return False
         if 6 == ip_ver and device_ipv6_lo_addr_subnet_len_set != nbr_prefix_ipv6_subnet_len_set:
-            logger.warn("ipv6 subnet is not /64 for loopback")
+            logger.warning("ipv6 subnet is not /64 for loopback")
             return False
         if isinstance(list(neigh_hosts.items())[0][1]['host'], EosHost):
             if nbr_prefix_community_set != device_traffic_shift_community_set:
-                logger.warn("traffic shift away community not present on neighbor")
+                logger.warning("traffic shift away community not present on neighbor")
                 return False
     return True
 
@@ -247,7 +247,7 @@ def check_and_log_routes_diff(duthost, neigh_hosts, orig_routes_on_all_nbrs, cur
     cur_nbrs = set(cur_routes_on_all_nbrs.keys())
     orig_nbrs = set(orig_routes_on_all_nbrs.keys())
     if cur_nbrs != orig_nbrs:
-        logger.warn("Neighbor list mismatch: {}".format(cur_nbrs ^ orig_nbrs))
+        logger.warning("Neighbor list mismatch: {}".format(cur_nbrs ^ orig_nbrs))
         return False
 
     routes_dut = parse_rib(duthost, ip_ver)
@@ -259,7 +259,7 @@ def check_and_log_routes_diff(duthost, neigh_hosts, orig_routes_on_all_nbrs, cur
             for route in routes_diff:
                 if route not in list(routes_dut.keys()):
                     all_diffs_in_host_aspath = False
-                    logger.warn(
+                    logger.warning(
                         "Missing route on host {}: {}".format(hostname, route))
                     continue
                 aspaths = routes_dut[route]
@@ -275,10 +275,10 @@ def check_and_log_routes_diff(duthost, neigh_hosts, orig_routes_on_all_nbrs, cur
                     if not skip:
                         all_diffs_in_host_aspath = False
                         if route in orig_routes_on_all_nbrs[hostname]:
-                            logger.warn(
+                            logger.warning(
                                 "Missing route on host {}: {}".format(hostname, route))
                         else:
-                            logger.warn(
+                            logger.warning(
                                 "Additional route on host {}: {}".format(hostname, route))
 
     return all_diffs_in_host_aspath

--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -313,12 +313,15 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
         logger.info('Check route for prefix {} on {}'.format(route.prefix, tor1))
         tor1_route = nbrhosts[tor1]['host'].get_route(route.prefix)
         if route.prefix not in list(tor1_route['vrfs']['default']['bgpRouteEntries'].keys()):
-            logging.warn('No route for {} found on {}'.format(route.prefix, tor1))
+            logging.warning('No route for {} found on {}'.format(route.prefix, tor1))
             return False
         tor1_route_aspath = tor1_route['vrfs']['default']['bgpRouteEntries'][route.prefix]['bgpRoutePaths'][0]\
             ['asPathEntry']['asPath']   # noqa E211
         if not tor1_route_aspath == route.aspath:
-            logging.warn('On {} expected aspath: {}, actual aspath: {}'.format(tor1, route.aspath, tor1_route_aspath))
+            logging.warning(
+                'On {} expected aspath: {}, actual aspath: {}'.format(tor1, route.aspath, tor1_route_aspath)
+            )
+
             return False
         return True
 
@@ -330,17 +333,22 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
 
         if accepted:
             if not dut_route:
-                logging.warn('No route for {} found on DUT'.format(route.prefix))
+                logging.warning('No route for {} found on DUT'.format(route.prefix))
                 return False
             dut_route_aspath = dut_route['paths'][0]['aspath']['string']
             # Route path from DUT: -> TOR1 -> aspath(other T1 -> DUMMY_ASN1)
             dut_route_aspath_expected = '{} {}'.format(tor1_asn, route.aspath)
             if not dut_route_aspath == dut_route_aspath_expected:
-                logging.warn('On DUT expected aspath: {}, actual aspath: {}'
-                             .format(dut_route_aspath_expected, dut_route_aspath))
+                logging.warning(
+                    'On DUT expected aspath: {}, actual aspath: {}'.format(
+                        dut_route_aspath_expected,
+                        dut_route_aspath,
+                    )
+                )
+
                 return False
             if 'advertisedTo' not in dut_route:
-                logging.warn("DUT didn't advertise the route")
+                logging.warning("DUT didn't advertise the route")
                 return False
             advertised_to = set()
             for _ in dut_route['advertisedTo']:
@@ -349,11 +357,11 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
                     advertised_to.add(bgp_neighbors[_]['name'])
             for vm in other_vms:
                 if vm not in advertised_to:
-                    logging.warn("DUT didn't advertise route to neighbor %s" % vm)
+                    logging.warning("DUT didn't advertise route to neighbor %s" % vm)
                     return False
         else:
             if dut_route:
-                logging.warn('Prefix {} should not be accepted by DUT'.format(route.prefix))
+                logging.warning('Prefix {} should not be accepted by DUT'.format(route.prefix))
         return True
 
     # Check route on other VMs
@@ -366,7 +374,7 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
 
         vm_route = nbrhosts[node]['host'].get_route(route.prefix)
         if not isinstance(vm_route, dict):
-            logging.warn("DEBUG: unexpected vm_route type {}, {}".format(type(vm_route), vm_route))
+            logging.warning("DEBUG: unexpected vm_route type {}, {}".format(type(vm_route), vm_route))
         vm_route['failed'] = False
         vm_route['message'] = 'Checking route {} on {} passed'.format(str(route), node)
         if accepted:

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -58,7 +58,7 @@ def verify_all_routes_announce_to_neighs(dut_host, neigh_hosts, routes_dut, ip_v
             if skip:
                 continue
             if route not in list(routes.keys()):
-                logger.warn("{} not found on {}".format(route, hostname))
+                logger.warning("{} not found on {}".format(route, hostname))
                 return False
     return True
 

--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -237,7 +237,7 @@ def save_pcap(request, pytestconfig):
         else:
             logging.info("Skip saving pcap file to log directory as log directory not set.")
     else:
-        logging.warn("No pcap file found at {}".format(pcap_file))
+        logging.warning("No pcap file found at {}".format(pcap_file))
 
 
 @pytest.fixture

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -115,7 +115,7 @@ class DualTorIO:
         # Inter-packet send-interval (minimum interval 3.5ms)
         if send_interval < 0.0035:
             if send_interval is not None:
-                logger.warn("Minimum packet send-interval is .0035s. \
+                logger.warning("Minimum packet send-interval is .0035s. \
                     Ignoring user-provided interval {}".format(send_interval))
             self.send_interval = 0.0035
         else:

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -168,9 +168,9 @@ def _get(server_url):
         if resp.status_code == 200:
             return resp.json()
         else:
-            logger.warn("GET {} failed with {}".format(server_url, resp.text))
+            logger.warning("GET {} failed with {}".format(server_url, resp.text))
     except Exception as e:
-        logger.warn("GET {} failed with {}".format(server_url, repr(e)))
+        logger.warning("GET {} failed with {}".format(server_url, repr(e)))
 
     return None
 
@@ -204,7 +204,7 @@ def _post(server_url, data):
         logger.debug('Received response {}/{} with content {}'.format(resp.status_code, resp.reason, resp.text))
         return resp.status_code == 200
     except Exception as e:
-        logger.warn("POST {} with data {} failed, err: {}".format(server_url, data, repr(e)))
+        logger.warning("POST {} with data {} failed, err: {}".format(server_url, data, repr(e)))
 
     return False
 
@@ -740,17 +740,17 @@ def toggle_all_simulator_ports_to_random_side(active_standby_ports, duthosts, mu
         simulator_mux_status = _get(mux_server_url)
 
         if not upper_tor_mux_status:
-            logging.warn("Failed to retrieve mux status from the upper tor")
+            logging.warning("Failed to retrieve mux status from the upper tor")
             return False
         if not lower_tor_mux_status:
-            logging.warn("Failed to retrieve mux status from the lower tor")
+            logging.warning("Failed to retrieve mux status from the lower tor")
             return False
         if not simulator_mux_status:
-            logging.warn("Failed to retrieve mux status from the mux simulator")
+            logging.warning("Failed to retrieve mux status from the mux simulator")
             return False
 
         if not set(upper_tor_mux_status.keys()) == set(lower_tor_mux_status.keys()):
-            logging.warn("Ports mismatch between the upper tor and lower tor")
+            logging.warning("Ports mismatch between the upper tor and lower tor")
             return False
 
         # get mapping from port indices to mux status
@@ -763,7 +763,7 @@ def toggle_all_simulator_ports_to_random_side(active_standby_ports, duthosts, mu
 
             intf_index = port_indices[intf]
             if intf_index not in simulator_port_mux_status:
-                logging.warn("No mux status for interface %s from mux simulator", intf)
+                logging.warning("No mux status for interface %s from mux simulator", intf)
                 return False
 
             simulator_status = simulator_port_mux_status[intf_index]
@@ -776,11 +776,11 @@ def toggle_all_simulator_ports_to_random_side(active_standby_ports, duthosts, mu
             if upper_tor_status == 'standby' and lower_tor_status == 'active' \
                     and simulator_status['active_side'] == 'lower_tor':
                 continue
-            logging.warn(
+            logging.warning(
                 "For interface %s, upper tor mux status: %s, lower tor mux status: %s, simulator status: %s",
                 intf, upper_tor_status, lower_tor_status, simulator_status
             )
-            logging.warn("Inconsistent mux status for interface %s", intf)
+            logging.warning("Inconsistent mux status for interface %s", intf)
             inconsistent_intfs.append(intf)
 
         # NOTE: if ICMP responder is not running, linkmgrd is stuck in waiting for heartbeats and
@@ -873,7 +873,7 @@ def simulator_clear_flap_counters(url):
 def reset_simulator_port(url):
 
     def _reset_simulator_port(interface_name=None):
-        logger.warn("Resetting simulator ports {}".format('all' if interface_name is None else interface_name))
+        logger.warning("Resetting simulator ports {}".format('all' if interface_name is None else interface_name))
         server_url = url(interface_name=interface_name, action=RESET)
         pytest_assert(_post(server_url, {}))
 

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -449,7 +449,7 @@ def sync_reboot_history_queue_with_dut(dut):
     # If retry logic did not yield reboot cause history from DUT,
     # return without clearing the existing reboot history queue.
     if not dut_reboot_history_received:
-        logger.warn("Unable to sync reboot history queue")
+        logger.warning("Unable to sync reboot history queue")
         return
 
     # If the reboot cause history is received from DUT,
@@ -518,8 +518,10 @@ def check_reboot_cause_history(dut, reboot_type_history_queue):
     if reboot_type_history_len <= len(reboot_cause_history_got):
         for index, reboot_type in enumerate(reboot_type_history_queue):
             if reboot_type not in reboot_ctrl_dict:
-                logger.warn("Reboot type: {} not in dictionary. Skipping history check for this entry.".
-                            format(reboot_type))
+                logger.warning(
+                    "Reboot type: {} not in dictionary. Skipping history check for this entry.".format(reboot_type)
+                )
+
                 continue
             logger.info("index:  %d, reboot cause: %s, reboot cause from DUT: %s" %
                         (index, reboot_ctrl_dict[reboot_type]["cause"],

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -181,8 +181,14 @@ def wait_tcp_connection(client, server_hostname, listening_port, timeout_s=30):
                           timeout=timeout_s,
                           module_ignore_errors=True)
     if 'exception' in res or res.get('failed') is True:
-        logger.warn("Failed to establish TCP connection to %s:%d, timeout=%d" %
-                    (str(server_hostname), listening_port, timeout_s))
+        logger.warning(
+            "Failed to establish TCP connection to %s:%d, timeout=%d" % (
+                str(server_hostname),
+                listening_port,
+                timeout_s,
+            )
+        )
+
         return False
     return True
 

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -67,7 +67,7 @@ def pytest_generate_tests(metafunc):
     for input_case in input_sad_cases.split(","):
         input_case = input_case.strip()
         if input_case.lower() not in SAD_CASE_LIST:
-            logging.warn(
+            logging.warning(
                 "Unknown SAD case ({}) - skipping it.".format(input_case))
             continue
         input_sad_list.append(input_case.lower())

--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -136,12 +136,12 @@ class ContinuousReboot:
                         continue
                     reboot_type = str(install_info.get('REBOOT_TYPE')).lower()
                     if reboot_type != 'warm' and reboot_type != 'fast':
-                        logging.warn(
+                        logging.warning(
                             "Unsupported reboot type - {}. Proceeding with {}.".format(reboot_type, self.reboot_type))
                     else:
                         self.reboot_type = reboot_type
                 except ValueError:
-                    logging.warn(
+                    logging.warning(
                         "Invalid json file, continuing the reboot test with old list of images")
                 break
         logging.info("Copy latest PTF test files to PTF host '{0}'".format(
@@ -166,10 +166,10 @@ class ContinuousReboot:
                 if file_exists != '200':
                     logging.info("Remote image file {} does not exist. Curl returned: {}".format(
                         image_path, file_exists))
-                    logging.warn("Continuing the test with current image")
+                    logging.warning("Continuing the test with current image")
                     self.new_image = "current"
             except ValueError:
-                logging.warn(
+                logging.warning(
                     "Invalid json file, continuing the reboot test with old list of images")
 
         if self.new_image == "current":

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -234,7 +234,7 @@ def check_all_psu_on(dut, psu_test_results):
                 power_off_psu_list.append(psu_info["index"])
 
     if power_off_psu_list:
-        logging.warn('Powered off PSUs: {}'.format(power_off_psu_list))
+        logging.warning('Powered off PSUs: {}'.format(power_off_psu_list))
 
     return len(power_off_psu_list) == 0
 

--- a/tests/scp/test_scp_copy.py
+++ b/tests/scp/test_scp_copy.py
@@ -61,7 +61,7 @@ def test_scp_copy(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, setup_tea
 
     # After PTF default password rotation is supported, need to figure out which password is currently working
     _passwords = _gather_passwords(ptfhost, duthost)
-    logger.warn("_password: " + str(_passwords))
+    logger.warning("_password: " + str(_passwords))
     current_password = get_dut_current_passwd(ptf_ip, "", creds["ptf_host_user"], _passwords)
 
     # Generate the file from /dev/urandom

--- a/tests/scripts/dual_tor_sniffer.py
+++ b/tests/scripts/dual_tor_sniffer.py
@@ -25,7 +25,7 @@ class Sniffer(object):
 
     def save_pcap(self, pcap_path):
         if not self.packets:
-            logging.warn("No packets were captured")
+            logging.warning("No packets were captured")
 
         scapyall.wrpcap(pcap_path, self.packets)
         logging.debug("Pcap file dumped to {}".format(pcap_path))

--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -61,7 +61,7 @@ def is_dark_mode_enabled(duthost, platform_api_conn, num_dpu_modules):   # noqa 
                            'redis-cli -p 6379 -h 127.0.0.1 \
                             -n 4 hgetall "CHASSIS_MODULE|{}"'.format(dpu))
         if output_config_db['stdout'] is None:
-            logging.warn("redis cli output for chassis module state is empty")
+            logging.warning("redis cli output for chassis module state is empty")
             break
         if 'down' in output_config_db['stdout']:
             count_admin_down += 1

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -55,7 +55,7 @@ def test_recover_rsyslog_rate_limit(duthosts, enum_dut_hostname):
     if not succeed:
         # Something unexpected happened.
         # We don't want to fail here because it's an util
-        logging.warn("Failed to retrieve feature status")
+        logging.warning("Failed to retrieve feature status")
         return
     for feature_name, state in list(features_dict.items()):
         if 'enabled' not in state:

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -41,7 +41,7 @@ def test_features_state(duthosts, enum_dut_hostname, localhost):
     duthost = duthosts[enum_dut_hostname]
     logger.info("Checking the state of each feature in 'CONFIG_DB' ...")
     if not wait_until(180, FEATURE_STATE_VERIFYING_INTERVAL_SECS, 0, verify_features_state, duthost):
-        logger.warn("Not all states of features in 'CONFIG_DB' are valid, rebooting DUT {}".format(duthost.hostname))
+        logger.warning("Not all states of features in 'CONFIG_DB' are valid, rebooting DUT {}".format(duthost.hostname))
         reboot(duthost, localhost)
         # Some services are not ready immeidately after reboot
         wait_critical_processes(duthost)
@@ -158,7 +158,7 @@ def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
     if not succeed:
         # Something unexpected happened.
         # We don't want to fail here because it's an util
-        logging.warn("Failed to retrieve feature status")
+        logging.warning("Failed to retrieve feature status")
         return
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")
     try:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Replace the deprecated `warn()` method with `warning()` for Python logging.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
The `warn()` method is deprecated since Python 3.3 and we will get the following warning if we still use the `warn()` method:
![image](https://github.com/user-attachments/assets/4886445d-1392-4d45-8fbc-84c9834c3343)

So we want to replace it with the `warning()` method. Reference: https://github.com/python/cpython/blob/3.3/Lib/logging/__init__.py#L1252-L1253

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
