### PR TITLE
Fix failures of test_dynamic_acl on dualtor

### DIFF
--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -220,10 +220,13 @@ def setup(rand_selected_dut, rand_unselected_dut, tbinfo, vlan_name, topo_scenar
     vlan_ips = {}
     for vlan_ip_address in config_facts['VLAN_INTERFACE'][vlan_name].keys():
         ip_address = vlan_ip_address.split("/")[0]
-        if netaddr.IPAddress(str(ip_address)).version == 6:
-            vlan_ips["V6"] = ip_address
-        elif netaddr.IPAddress(str(ip_address)).version == 4:
-            vlan_ips["V4"] = ip_address
+        try:
+            if netaddr.IPAddress(str(ip_address)).version == 6:
+                vlan_ips["V6"] = ip_address
+            elif netaddr.IPAddress(str(ip_address)).version == 4:
+                vlan_ips["V4"] = ip_address
+        except netaddr.core.AddrFormatError:
+            continue
 
     vlans = config_facts['VLAN']
     topology = tbinfo['topo']['name']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
GCU test_dynamic_acl  failed on dualtor after https://github.com/sonic-net/sonic-mgmt/pull/16637
```
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_arp_rule_creation[IPV4-str2-7050cx3-acs-06-None-default-Vlan1000] 
-------------------------------- live log setup --------------------------------
12:25:59 __init__._fixture_func_decorator         L0073 ERROR  | 
AddrFormatError("failed to detect a valid IP address from 'grat_arp'")
Traceback (most recent call last):
  File "/var/src/sonic-mgmt_vms24-dual-t0-7050-1_646f1405735219c3e54440f4/tests/common/plugins/log_section_start/__init__.py", line 71, in _fixture_func_decorator
    return fixture_func(*args, **kargs)
  File "/var/src/sonic-mgmt_vms24-dual-t0-7050-1_646f1405735219c3e54440f4/tests/generic_config_updater/test_dynamic_acl.py", line 223, in setup
    if netaddr.IPAddress(str(ip_address)).version == 6:
  File "/usr/local/lib/python3.8/dist-packages/netaddr/ip/__init__.py", line 341, in __init__
    raise AddrFormatError('failed to detect a valid IP ' 'address from %r' % addr)
netaddr.core.AddrFormatError: failed to detect a valid IP address from 'grat_arp'
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
For dualtor, the content of config_facts['VLAN_INTERFACE'] is like:
`grat_arp` is not ip address, need to catch the exception and continue to loop the next one until to get ip address
```
 "VLAN_INTERFACE": {
      "Vlan1000": {
        "grat_arp": "enabled",
        "proxy_arp": "enabled",
        "192.168.0.1/21": {
          
        },
        "fc02:1000::1/64": {
          
        }
      }
    },
```

#### How did you do it?
Add try catch to avoid such kind of exception.

#### How did you verify/test it?

Run test_dynamic_acl  on dualtor
Test evidence on dualtor:
```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-------------------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------------------
11:56:28 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
======================================================================================= 12 passed, 123 warnings in 2943.09s (0:49:03) =======================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_gcu_acl_nonexistent_table_removal[default-Vlan1000]>
INFO:root:Can not get Allure report URL. Please check logs
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
