### PR TITLE
Enable skipped test due to extra param requirement

### DIFF
--- a/tests/clock/test_clock.py
+++ b/tests/clock/test_clock.py
@@ -24,6 +24,7 @@ class ClockConsts:
 
     TEST_TIMEZONE = "Asia/Jerusalem"
     TIME_MARGIN = 6
+    TIME_MARGIN_T2 = 16
     RANDOM_NUM = 6
 
     # sonic commands
@@ -352,7 +353,7 @@ def test_config_clock_date(duthosts, init_timezone, restore_time, tbinfo):
         4. Verify error and that time hasn't changed
     """
     # add extra time margin for t2 topo
-    time_margin = ClockConsts.TIME_MARGIN + 10 if tbinfo['topo']['name'] == 't2' else ClockConsts.TIME_MARGIN
+    time_margin = ClockConsts.TIME_MARGIN_T2 if 't2' in tbinfo['topo']['name'] else ClockConsts.TIME_MARGIN
     with allure.step('Select valid date and time to set'):
         new_date = ClockUtils.select_random_date()
         new_time = ClockUtils.select_random_time()

--- a/tests/clock/test_clock.py
+++ b/tests/clock/test_clock.py
@@ -111,10 +111,10 @@ class ClockUtils:
             find matching tz string and format pair by checking the year
             """
             tz_str1 = show_clock_output.split()[-1].strip()
-            tz_str2 = show_clock_output.split()[-2].strip()
+            tz_str2 = show_clock_output.split()[3].strip()
             # if given tz_str is a year, then return other tz_str
             if len(tz_str1) == 4 and tz_str1.isdigit():
-                return tz_str2, '%a %b %d %I:%M:%S %p %Y'
+                return show_clock_output.split()[-2].strip(), '%a %b %d %I:%M:%S %p %Y'
             elif len(tz_str2) == 4 and tz_str2.isdigit():
                 return tz_str1, '%a %d %b %Y %I:%M:%S %p'
             else:

--- a/tests/clock/test_clock.py
+++ b/tests/clock/test_clock.py
@@ -24,7 +24,7 @@ class ClockConsts:
 
     TEST_TIMEZONE = "Asia/Jerusalem"
     TIME_MARGIN = 6
-    TIME_MARGIN_T2 = 16
+    TIME_MARGIN_MODULAR = 16
     RANDOM_NUM = 6
 
     # sonic commands
@@ -353,7 +353,8 @@ def test_config_clock_date(duthosts, init_timezone, restore_time, tbinfo):
         4. Verify error and that time hasn't changed
     """
     # add extra time margin for t2 topo
-    time_margin = ClockConsts.TIME_MARGIN_T2 if 't2' in tbinfo['topo']['name'] else ClockConsts.TIME_MARGIN
+    is_modular_chassis = duthosts[0].get_facts().get("modular_chassis")
+    time_margin = ClockConsts.TIME_MARGIN_MODULAR if is_modular_chassis else ClockConsts.TIME_MARGIN
     with allure.step('Select valid date and time to set'):
         new_date = ClockUtils.select_random_date()
         new_time = ClockUtils.select_random_time()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
Enable test_clock.py in all chassis, as its currently being skipped due to param requirement
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #31478372
Enable test_clock.py in all chassis, as its currently being skipped due to param requirement
Currently it requires --ntp_server='ip_adrs' in extra parameters to run the test, but it can be improved by using ntp_server address from inventory files.

Also refactor some code to make it compatible with T2 chassis

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
clock/test_clock.py has been skipped in all nightly, due to missing parameter 'ntp_server'. Since ntp_server exist and recorded in inventory already, it makes sense to use that value to run this test in nightly.

#### How did you do it?
If extra parameter 'ntp_server' is not provided, use ntp_server from inventory instead.

#### How did you verify/test it?
checked the results against 202405 version and 202411 with this fix included. Test conducted in 3 T0 chassis, 3 T1 chassis, and 1 T2 Cisco chassis to confirm the fix will work in all chassis

All the test plans recorded in work item 31478372 but below is the result from Cisco T2 8800 chassis.

collected 3 items

clock/test_clock.py::test_show_clock PASSED                              [ 33%]
clock/test_clock.py::test_config_clock_timezone PASSED                   [ 66%]
clock/test_clock.py::test_config_clock_date PASSED                       [100%]

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
