### PR TITLE
Add a new test case to verify that MAC addresses got aged out when the interface is down

### DIFF
--- a/tests/arp/test_neighbor_mac_aging.py
+++ b/tests/arp/test_neighbor_mac_aging.py
@@ -1,0 +1,54 @@
+import logging
+import pytest
+import time
+
+from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+
+class TestNeighborMacAging:
+    def testNeighborMacAgingAfterIntfDown(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                          enum_rand_one_frontend_asic_index):
+        """
+            Test whether neighbor MAC is aged out after interface down
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
+        ip_interfaces = asichost.show_ip_interface()["ansible_facts"]['ip_interfaces']
+        logger.debug("ip_interfaces: " + str(ip_interfaces))
+
+        dut_intf = None
+        neighbor_ip = None
+        for intf in ip_interfaces.keys():
+            if "peer_ipv4" in ip_interfaces[intf] and ip_interfaces[intf]["peer_ipv4"] != "N/A":
+                dut_intf = intf
+                neighbor_ip = ip_interfaces[intf]["peer_ipv4"]
+                break
+        pytest_assert(dut_intf is not None, "No IP interface found on DUT")
+        logger.debug("DUT interface: {}, neighbor IP: {}".format(dut_intf, neighbor_ip))
+
+        # Verify that the MAC address is present in the ARP table and ASIC_DB
+        arp_entry = duthost.command("{} neigh show {}".format(asichost.ip_cmd, neighbor_ip))['stdout_lines'][0]
+        redis_entry = duthost.command("{} ASIC_DB KEYS \"ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY*\\\"{}\\\"*\""
+                                      .format(asichost.sonic_db_cli, neighbor_ip))['stdout_lines'][0]
+        pytest_assert(arp_entry, "ARP entry not found")
+        pytest_assert(redis_entry, "Redis entry not found")
+
+        # Shutdown the interface on DUT
+        duthost.shutdown_interface(dut_intf)
+        time.sleep(30)
+
+        # Verify that the MAC address is aged out from the ARP table and ASIC_DB
+        assert not len(duthost.command("{} neigh show {}".format(asichost.ip_cmd, neighbor_ip))['stdout_lines']), \
+            "ARP entry not aged out"
+        assert not len(duthost.command("{} ASIC_DB KEYS \"ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY*{}*\""
+                       .format(asichost.sonic_db_cli, neighbor_ip))['stdout_lines']), \
+            "Redis entry not aged out"
+
+        # Bring the interface up on DUT
+        duthost.no_shutdown_interface(dut_intf)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add a new test case to verify that MAC entries in ARP table and ASIC DB got aged out when the interface is down
Fixes #15229 (issue) 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
