### PR TITLE
Add "ring_thread_enabled" field in confdb_jsons/7nodes_cisco

### DIFF
--- a/ansible/vars/configdb_jsons/7nodes_cisco/P1.json
+++ b/ansible/vars/configdb_jsons/7nodes_cisco/P1.json
@@ -116,7 +116,8 @@
             "nexthop_group" : "enabled",
             "frr_mgmt_framework_config": "true",
             "docker_routing_config_mode": "unified",
-            "type": "LeafRouter"
+            "type": "LeafRouter",
+            "ring_thread_enabled": "true"
         }
     },
     "INTERFACE": {

--- a/ansible/vars/configdb_jsons/7nodes_cisco/P2.json
+++ b/ansible/vars/configdb_jsons/7nodes_cisco/P2.json
@@ -101,7 +101,8 @@
             "nexthop_group" : "enabled",
             "frr_mgmt_framework_config": "true",
             "docker_routing_config_mode": "unified",
-            "type": "LeafRouter"
+            "type": "LeafRouter",
+            "ring_thread_enabled": "true"
         }
     },
     "INTERFACE": {

--- a/ansible/vars/configdb_jsons/7nodes_cisco/P3.json
+++ b/ansible/vars/configdb_jsons/7nodes_cisco/P3.json
@@ -116,7 +116,8 @@
             "nexthop_group" : "enabled",
             "frr_mgmt_framework_config": "true",
             "docker_routing_config_mode": "unified",
-            "type": "LeafRouter"
+            "type": "LeafRouter",
+            "ring_thread_enabled": "true"
         }
     },
     "INTERFACE": {

--- a/ansible/vars/configdb_jsons/7nodes_cisco/P4.json
+++ b/ansible/vars/configdb_jsons/7nodes_cisco/P4.json
@@ -101,7 +101,8 @@
             "nexthop_group" : "enabled",
             "frr_mgmt_framework_config": "true",
             "docker_routing_config_mode": "unified",
-            "type": "LeafRouter"
+            "type": "LeafRouter",
+            "ring_thread_enabled": "true"
         }
     },
     "INTERFACE": {

--- a/ansible/vars/configdb_jsons/7nodes_cisco/PE1.json
+++ b/ansible/vars/configdb_jsons/7nodes_cisco/PE1.json
@@ -130,7 +130,8 @@
             "docker_routing_config_mode": "unified",
             "frr_mgmt_framework_config": "true",
             "nexthop_group" : "enabled",
-            "type": "LeafRouter"
+            "type": "LeafRouter",
+            "ring_thread_enabled": "true"
         }
     },
     "INTERFACE": {

--- a/ansible/vars/configdb_jsons/7nodes_cisco/PE2.json
+++ b/ansible/vars/configdb_jsons/7nodes_cisco/PE2.json
@@ -130,7 +130,8 @@
             "frr_mgmt_framework_config": "true",
             "docker_routing_config_mode": "unified",
             "nexthop_group" : "enabled",
-            "type": "LeafRouter"
+            "type": "LeafRouter",
+            "ring_thread_enabled": "true"
         }
     },
     "INTERFACE": {

--- a/ansible/vars/configdb_jsons/7nodes_cisco/PE3.json
+++ b/ansible/vars/configdb_jsons/7nodes_cisco/PE3.json
@@ -130,7 +130,8 @@
             "frr_mgmt_framework_config": "true",
             "docker_routing_config_mode": "unified",
             "nexthop_group" : "enabled",
-            "type": "LeafRouter"
+            "type": "LeafRouter",
+            "ring_thread_enabled": "true"
         }
     },
     "INTERFACE": {


### PR DESCRIPTION
…nodes_cisco

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add a field "ring_thread_enabled"  in every node in `confdb_jsons/7nodes_cisco`  to enable ring feature by default in this topology

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
ring buffer feature should be able to get turned on/off by a flag in configuration

#### How did you do it?
Add a field "ring_thread_enabled" in "DEVICE_METADATA"| "localhost" table

#### How did you verify/test it?
https://github.com/sonic-net/sonic-buildimage/pull/19652/

#### Any platform specific information?
No
