### PR TITLE
Stabilize bgp suppress fib test on switch with low power CPU and a lot of BGP neighbors

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -63,7 +63,7 @@ STRESS = "stress"
 TRAFFIC_WAIT_TIME = 0.1
 BULK_TRAFFIC_WAIT_TIME = 0.004
 BGP_ROUTE_FLAP_TIMES = 5
-UPDATE_WITHDRAW_THRESHOLD = 2  # Use the threshold value defined in test_bgp_update_timer.py
+UPDATE_WITHDRAW_THRESHOLD = 5  # consider the switch with low power cpu and a lot of bgp neighbors
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Stabilize bgp suppress fib test on the switch with low power CPU(sn2700 A0) and a lot of BGP neighbors
Adjust performance threshold according to design suggestion and test result

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Stabilize bgp suppress fib test on the switch with low power CPU and a lot of BGP neighbors
#### How did you do it?
Based on the design suggestion and test result, update the time threshold for 1K BGP route average process.
#### How did you verify/test it?
Run it at local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
