### PR TITLE
Support downloading buildimage from 202412 branch. 

### DIFF
--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -161,6 +161,10 @@ def find_latest_build_id(branch, success_flag="succeeded"):
                  "&resultFilter={}&statusFilter=completed&api-version=6.0".format(
                      branch, success_flag)
 
+    if branch == "202412":
+        builds_url = "https://dev.azure.com/mssonic/build/_apis/build/builds?definitions=2511&branchName=refs/heads/{}"\
+                     "&resultFilter={}&statusFilter=completed&api-version=6.0".format(branch, success_flag)
+
     resp = urlopen(builds_url)
 
     j = json.loads(resp.read().decode('utf-8'))

--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -157,13 +157,10 @@ def download_artifacts(url, content_type, platform, buildid, num_asic, access_to
 def find_latest_build_id(branch, success_flag="succeeded"):
     """find latest successful build id for a branch"""
 
-    builds_url = "https://dev.azure.com/mssonic/build/_apis/build/builds?definitions=1&branchName=refs/heads/{}" \
-                 "&resultFilter={}&statusFilter=completed&api-version=6.0".format(
-                     branch, success_flag)
+    definition_id = 2511 if branch == "202412" else 1
 
-    if branch == "202412":
-        builds_url = "https://dev.azure.com/mssonic/build/_apis/build/builds?definitions=2511&branchName=refs/heads/{}"\
-                     "&resultFilter={}&statusFilter=completed&api-version=6.0".format(branch, success_flag)
+    builds_url = "https://dev.azure.com/mssonic/build/_apis/build/builds?definitions={}&branchName=refs/heads/{}" \
+                 "&resultFilter={}&statusFilter=completed&api-version=6.0".format(definition_id, branch, success_flag)
 
     resp = urlopen(builds_url)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The previous code retrieved all images from the `Azure.sonic-buildimage` pipeline, which does not include the 202412 branch. This PR resolves the issue by adding a conditional check. If the branch is 202412, the image will be downloaded from the `Azure.sonic-buildimage-msft.PR` pipeline (definitionId: 2511).

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
The previous code retrieved all images from the `Azure.sonic-buildimage` pipeline, which does not include the 202412 branch. This PR resolves the issue by adding a conditional check. If the branch is 202412, the image will be downloaded from the `Azure.sonic-buildimage-msft.PR` pipeline (definitionId: 2511).

#### How did you do it?
This PR resolves the issue by adding a conditional check. If the branch is 202412, the image will be downloaded from the `Azure.sonic-buildimage-msft.PR` pipeline (definitionId: 2511).

#### How did you verify/test it?
Manually check the new added url. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
