### PR TITLE
[dualtor-aa][sanity] Skip active-standby checks in sanity

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -710,6 +710,10 @@ def check_mux_simulator(tbinfo, duthosts, duts_minigraph_facts, get_mux_status, 
             results['action'] = _recover
             return results
 
+        # early exit for dualtor-aa testbed
+        if "dualtor-aa" in tbinfo["topo"]["name"]:
+            return results
+
         mux_simulator_status = get_mux_status()
         if active_standby_ports and mux_simulator_status is None:
             err_msg = "Failed to get mux status from mux simulator."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Skip the `mux_simulator` status check in sanity on `dualtor-aa` testbeds.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As the motivation.

#### How did you verify/test it?
run on `dualtor-aa` testbed:
```
dualtor_io/test_tor_failure.py::test_active_tor_reboot_downstream[active-active] PASSED                                                                                                                                                                                [100%]

============================================================================================================================== warnings summary ==============================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
