### PR TITLE
Mark test_uDT46_config as only applicable to VS platform

### DIFF
--- a/tests/srv6/test_srv6_static_config.py
+++ b/tests/srv6/test_srv6_static_config.py
@@ -66,6 +66,7 @@ def test_uN_config(duthosts, enum_frontend_dut_hostname, enum_rand_one_asic_inde
         "SID entry in APPL_DB was not cleaned up"
 
 
+@pytest.mark.asic('vs')
 def test_uDT46_config(duthosts, enum_frontend_dut_hostname, enum_rand_one_asic_index):
     duthost = duthosts[enum_frontend_dut_hostname]
     asic_index = enum_rand_one_asic_index


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add a pytest asic marker to restrict test_uDT46_config to only run on the VS platform.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

The programming of uDT46 entries is currently not supported in physical hardware.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
