### PR TITLE
Ignore gbsyncd invalid sai_api_t logs for pc/test_lag_member_forwarding.py

### DIFF
--- a/tests/pc/test_lag_member_forwarding.py
+++ b/tests/pc/test_lag_member_forwarding.py
@@ -16,6 +16,19 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
+
+    ignore_errors = [
+        r".* ERR gbsyncd#syncd:.* sai_api_query: :- Invalid sai_api_t \d* passed.*"
+        ]
+    if loganalyzer:
+        for duthost in duthosts:
+            loganalyzer[duthost.hostname].ignore_regex.extend(ignore_errors)
+
+    return None
+
+
 def build_pkt(dest_mac, ip_addr, ttl):
     pkt = testutils.simple_tcp_packet(
           eth_dst=dest_mac,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Ignore invalid sai_api_t logs that does not affect functionality of test. Mainly affecting pc/test_lag_member_forwarding.py testing on 720DT

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

pc/test_lag_member_forwarding.py is failing due this log in loganalyzer that does not affect functionality of test. Broadcom will patch this error in the next PAI release. We will ignore this error for now.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
