### PR TITLE
Make stress/test_stress_routes.py robust in T2 testing

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1038,6 +1038,7 @@ def fib_dpu(topo, ptf_ip, action="announce"):
         change_routes(action, ptf_ip, port, routes_v4)
         change_routes(action, ptf_ip, port6, routes_v6)
 
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1047,7 +1047,7 @@ def main():
             action=dict(required=False, type='str',
                         default='announce', choices=["announce", "withdraw"]),
             selected_route_set=dict(required=False, type='str',
-                           default='all', choices=['all', 't1', 't3']),
+                                    default='all', choices=['all', 't1', 't3']),
             path=dict(required=False, type='str', default=''),
             log_path=dict(required=False, type='str', default='')
         ),

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -899,9 +899,9 @@ def fib_t2_lag(topo, ptf_ip, action="announce", selected_route_set='all'):
             if dut_index not in t3_vms:
                 t3_vms[dut_index] = list()
             t3_vms[dut_index].append(key)
-    if selected_route_set in ( 'all', 't1' ):
+    if selected_route_set in ('all', 't1'):
         route_set += generate_t2_routes(t1_vms, topo, ptf_ip, action)
-    if selected_route_set in ( 'all', 't3' ):
+    if selected_route_set in ('all', 't3'):
         route_set += generate_t2_routes(t3_vms, topo, ptf_ip, action)
     send_routes_in_parallel(route_set)
 
@@ -1037,7 +1037,6 @@ def fib_dpu(topo, ptf_ip, action="announce"):
 
         change_routes(action, ptf_ip, port, routes_v4)
         change_routes(action, ptf_ip, port6, routes_v6)
-
 
 def main():
     module = AnsibleModule(

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -20,9 +20,15 @@ pytestmark = [
 
 
 def announce_withdraw_routes(duthost, namespace, localhost, ptf_ip, topo_name):
+    route_set = 'all'
+    # Due to https://github.com/sonic-net/sonic-mgmt/issues/16541, only announce and withdraw a small
+    # amount of routes in T2 testing to make test robust.
+    if topo_name == 't2':
+        route_set = 't1'
+
     logger.info("announce ipv4 and ipv6 routes")
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/",
-                              log_path="logs")
+                              log_path="logs", selected_route_set=route_set)
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") is True)
 
@@ -32,7 +38,7 @@ def announce_withdraw_routes(duthost, namespace, localhost, ptf_ip, topo_name):
 
     logger.info("withdraw ipv4 and ipv6 routes")
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/",
-                              log_path="logs")
+                              log_path="logs", selected_route_set=route_set)
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") is True)
     sleep_to_wait(CRM_POLLING_INTERVAL * 5)


### PR DESCRIPTION
stress/test_stress_routes.py is flaky in T2 testing because ofhttps://github.com/sonic-net/sonic-mgmt/issues/16541. Only announce and withdraw a small amount of routes in T2 testing to make it robust.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
