### PR TITLE
fix: handle sanity check error DUT shell result

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -1120,7 +1120,11 @@ def check_orchagent_usage(duthosts):
         results = kwargs['results']
         logger.info("Checking orchagent CPU usage on %s..." % dut.hostname)
         check_result = {"failed": False, "check_item": "orchagent_usage", "host": dut.hostname}
-        res = dut.shell("COLUMNS=512 show processes cpu | grep orchagent | awk '{print $9}'")["stdout_lines"]
+        res = dut.shell(
+            "COLUMNS=512 show processes cpu | grep orchagent | awk '{print $9}'",
+            module_ignore_errors=True,
+        )["stdout_lines"]
+
         check_result["orchagent_usage"] = res
         logger.info("Done checking orchagent CPU usage on %s" % dut.hostname)
         results[dut.hostname] = check_result
@@ -1158,13 +1162,22 @@ def check_bfd_up_count(duthosts):
 
     def _check_bfd_up_count_on_asic(asic, dut, check_result):
         asic_id = "asic{}".format(asic.asic_index)
-        bfd_up_count_str = dut.shell("ip netns exec {} show bfd summary | grep -c 'Up'".format(asic_id))["stdout"]
-        logger.info("BFD up count on {} of {} is {}".format(asic_id, dut.hostname, bfd_up_count_str))
-        try:
-            bfd_up_count = int(bfd_up_count_str)
-        except Exception as e:
-            logger.error("Failed to parse BFD up count on {} of {}: {}".format(asic_id, dut.hostname, e))
+        res = dut.shell(
+            "ip netns exec {} show bfd summary | grep -c 'Up'".format(asic_id),
+            module_ignore_errors=True,
+        )
+
+        if res["rc"] != 0:
+            logger.error("Failed to get BFD up count on {} of {}: {}".format(asic_id, dut.hostname, res["stderr"]))
             bfd_up_count = -1
+        else:
+            bfd_up_count_str = res["stdout"]
+            logger.info("BFD up count on {} of {} is {}".format(asic_id, dut.hostname, bfd_up_count_str))
+            try:
+                bfd_up_count = int(bfd_up_count_str)
+            except Exception as e:
+                logger.error("Failed to parse BFD up count on {} of {}: {}".format(asic_id, dut.hostname, e))
+                bfd_up_count = -1
 
         with lock:
             check_result["bfd_up_count"][asic_id] = bfd_up_count
@@ -1212,13 +1225,17 @@ def check_mac_entry_count(duthosts):
 
     def _check_mac_entry_count_on_asic(asic, dut, check_result):
         asic_id = "asic{}".format(asic.asic_index)
-        show_mac_output = dut.shell("ip netns exec {} show mac".format(asic_id))["stdout"]
-        try:
-            match = re.search(r'Total number of entries (\d+)', show_mac_output)
-            mac_entry_count = int(match.group(1)) if match else 0
-        except Exception as e:
-            logger.error("Failed to parse MAC entry count on {} of {}: {}".format(asic_id, dut.hostname, e))
+        res = dut.shell("ip netns exec {} show mac".format(asic_id), module_ignore_errors=True)
+        if res["rc"] != 0:
+            logger.error("Failed to get MAC entry count on {} of {}: {}".format(asic_id, dut.hostname, res["stderr"]))
             mac_entry_count = -1
+        else:
+            try:
+                match = re.search(r'Total number of entries (\d+)', res["stdout"])
+                mac_entry_count = int(match.group(1)) if match else 0
+            except Exception as e:
+                logger.error("Failed to parse MAC entry count on {} of {}: {}".format(asic_id, dut.hostname, e))
+                mac_entry_count = -1
 
         with lock:
             check_result["mac_entry_count"][asic_id] = mac_entry_count


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Handle errored DUT shell result in sanity checks.

Summary:
Fixes # (issue) Microsoft ADO 31652009

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
There will be a chance that the DUT shell command returning error response. If we don't add `module_ignore_errors=True`, such error response could make a check exit early with exception, which leads to unexpected sanity check behavior. Hence, we want to handle the situation when there is an error with the shell command.

![image](https://github.com/user-attachments/assets/e51e6b75-ec33-4f5c-b11c-043ee4a36e21)

#### How did you do it?

#### How did you verify/test it?
I ran a sanity check with a DUT shell command that returns an error response and can confirm the sanity check will not raise an exception anymore.
![image](https://github.com/user-attachments/assets/fef70972-a058-49a2-a1a9-cf890b2c3a27)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
