### PR TITLE
[vxlan]: Enhance vxlan decap test to support non-portchannel testcases

### DIFF
--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -61,6 +61,7 @@ def prepare_ptf(ptfhost, mg_facts, duthost, unslctd_mg_facts=None):
         "minigraph_lo_interfaces": mg_facts["minigraph_lo_interfaces"],
         "minigraph_vlans": mg_facts["minigraph_vlans"],
         "minigraph_vlan_interfaces": mg_facts["minigraph_vlan_interfaces"],
+        "minigraph_interfaces": mg_facts["minigraph_interfaces"],
         "dut_mac": duthost.facts["router_mac"],
         "vlan_mac": vlan_mac
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
The vxlan-decap testcases cannot be supported in some testbeds without port-channel

#### How did you do it?
Adapting the test parameters on both portchannel and non-portchannel scenarioes.

#### How did you verify/test it?
Run it on non-portchannel platform:

```
==================================================================================================================================== test session starts =====================================================================================================================================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.5.0
ansible: 2.13.13
rootdir: /data/sonic-mgmt-int/tests
configfile: pytest.ini
plugins: ansible-4.0.0, metadata-3.1.1, html-4.1.1, xdist-1.28.0, forked-1.6.0, repeat-0.9.3, allure-pytest-2.8.22
collecting ...
vxlan/test_vxlan_decap.py::test_vxlan_decap[NoVxLAN]  PASSED
vxlan/test_vxlan_decap.py::test_vxlan_decap[Enabled]  PASSED
vxlan/test_vxlan_decap.py::test_vxlan_decap[Removed]  PASSED

====================================================================================================================================== warnings summary ======================================================================================================================================
../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------------------------------------------------------------------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/vxlan/test_vxlan_decap.xml -------------------------------------------------------------------------------------------------------
----------------------------------------------------------------------------------------------------------------------------------- live log sessionfinish -----------------------------------------------------------------------------------------------------------------------------------
12:55:46 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
========================================================================================================================== 3 passed, 1 warning in 299.34s (0:04:59) ==========================================================================================================================

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
