### PR TITLE
Update SNMP query delay to default

### DIFF
--- a/ansible/library/snmp_facts.py
+++ b/ansible/library/snmp_facts.py
@@ -344,9 +344,10 @@ def main():
         argument_spec=dict(
             host=dict(required=True),
             # https://github.com/sonic-net/sonic-buildimage/blob/7a21cab07dbd0ace80833a57e391dec0ebde9978/dockers/docker-snmp/snmpd.conf.j2#L197
-            # In snmpd.conf, we set the timeout as 5s and 4 retries.
-            # Total time window = 4 * 5 = 20 seconds
-            timeout=dict(reqired=False, type='int', default=20),
+            # In snmpd.conf, the timeout is 5 seconds and 4 retries.
+            # Here we are using default UdpTransportTarget timeout which is 1 second and 5 retries to speed up the
+            # sonic-mgmt tests.  Test case can tune the timeout value by passing the timeout parameter if needed.
+            timeout=dict(reqired=False, type='int', default=1),
             version=dict(required=True, choices=['v2', 'v2c', 'v3']),
             community=dict(required=False, default=False),
             username=dict(required=False),

--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 DEF_WAIT_TIMEOUT = 300
 DEF_CHECK_INTERVAL = 10
 SNMP_DEFAULT_TIMEOUT = 1
+SNMP_QUERY_LONG_TIMEOUT = 5
 
 global_snmp_facts = {}
 

--- a/tests/common/helpers/snmp_helpers.py
+++ b/tests/common/helpers/snmp_helpers.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 DEF_WAIT_TIMEOUT = 300
 DEF_CHECK_INTERVAL = 10
-SNMP_DEFAULT_TIMEOUT = 20
+SNMP_DEFAULT_TIMEOUT = 1
 
 global_snmp_facts = {}
 

--- a/tests/snmp/test_snmp_cpu.py
+++ b/tests/snmp/test_snmp_cpu.py
@@ -52,9 +52,12 @@ def test_snmp_cpu(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_a
         time.sleep(20)
 
         # Gather facts with SNMP version 2
+        # use 5 seconds timeout to align with snmpd.conf in
+        # https://github.com/sonic-net/sonic-buildimage/blob/7a21cab07dbd0ace80833a57e391dec0ebde9978/dockers/docker-snmp/snmpd.conf.j2#L197
         snmp_facts = get_snmp_facts(
             duthost, localhost, host=hostip, version="v2c",
-            community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], is_dell=True, wait=True)['ansible_facts']
+            community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], is_dell=True, wait=True,
+            snmp_timeout=5)['ansible_facts']
 
         # Pull CPU utilization via shell
         # Explanation: Run top command with 2 iterations, 5sec delay.

--- a/tests/snmp/test_snmp_cpu.py
+++ b/tests/snmp/test_snmp_cpu.py
@@ -2,7 +2,7 @@ import pytest
 import time
 import logging
 
-from tests.common.helpers.snmp_helpers import get_snmp_facts
+from tests.common.helpers.snmp_helpers import get_snmp_facts, SNMP_DEFAULT_TIMEOUT, SNMP_QUERY_LONG_TIMEOUT
 
 logger = logging.getLogger(__name__)
 
@@ -52,12 +52,13 @@ def test_snmp_cpu(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_a
         time.sleep(20)
 
         # Gather facts with SNMP version 2
-        # use 5 seconds timeout to align with snmpd.conf in
-        # https://github.com/sonic-net/sonic-buildimage/blob/7a21cab07dbd0ace80833a57e391dec0ebde9978/dockers/docker-snmp/snmpd.conf.j2#L197
+        snmp_timeout = SNMP_DEFAULT_TIMEOUT
+        if duthost.facts['switch_type'] == "chassis-packet":
+            snmp_timeout = SNMP_QUERY_LONG_TIMEOUT
         snmp_facts = get_snmp_facts(
             duthost, localhost, host=hostip, version="v2c",
             community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], is_dell=True, wait=True,
-            snmp_timeout=5)['ansible_facts']
+            snmp_timeout=snmp_timeout)['ansible_facts']
 
         # Pull CPU utilization via shell
         # Explanation: Run top command with 2 iterations, 5sec delay.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The latest SNMP default timeout is set to 20 seconds which caused a performance issue in getting snmp_facts when packet drops happens. UDP is not reliable protocol, every packet drop will increase 20 seconds delay in getting snmp_facts.
In our testbed, it may take one hour for snmp_facts to finish. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Reduce the SNMP test case running time.

#### How did you do it?

Change the default timeout back to 1 second. and for some test cases where snmp timeout was observed. increased the timeout for chassis only.

#### How did you verify/test it?

Verified on T0/T1 and T2 testbed. can see new timeout taking effect, and snmp_cpu passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
