### PR TITLE
[dhcp_relay] Add test case to make sure dhcpmon wouldn't count bootp …

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -779,6 +779,62 @@ class DHCPTest(DataplaneBaseTest):
             self.assertTrue(
                 False, "DHCP Relay packet not matched or Padded extra on server side")
 
+    def create_bootp_packet(self, src_mac, src_ip, sport, giaddr, hops, dst_mac=BROADCAST_MAC):
+        # Bootp vendor specific options that not related to DHCP
+        vendor_options = bytes.fromhex("63865363350101111111111111111111111111111111111111111111111111111111111111" +
+                                       "111111111111111000000000000000000000000000000000000000")
+        my_chaddr = binascii.unhexlify(self.client_mac.replace(':', ''))
+        my_chaddr += b'\x00\x00\x00\x00\x00\x00'
+        bootp_packet = scapy.Ether(dst=dst_mac, src=src_mac, type=0x0800) / \
+            scapy.IP(src=src_ip, dst=self.BROADCAST_IP, flags="DF", ttl=255) / \
+            scapy.UDP(sport=sport, dport=self.DHCP_SERVER_PORT) / \
+            scapy.BOOTP(op=1, htype=1, hlen=6, hops=hops, xid=0, secs=0, flags=0x8000,
+                        ciaddr=self.DEFAULT_ROUTE_IP, yiaddr=self.DEFAULT_ROUTE_IP,
+                        siaddr=self.DEFAULT_ROUTE_IP, giaddr=giaddr, chaddr=my_chaddr) / \
+            vendor_options
+        return bootp_packet
+
+    def client_send_bootp(self):
+        bootp_packet = self.create_bootp_packet(src_mac=self.client_mac, src_ip=self.DEFAULT_ROUTE_IP,
+                                                giaddr=self.DEFAULT_ROUTE_IP, hops=1, sport=self.DHCP_CLIENT_PORT)
+        testutils.send_packet(self, self.client_port_index, bootp_packet)
+
+    def verify_relayed_bootp(self):
+        source_ip = self.relay_iface_ip if self.enable_source_port_ip_in_relay else self.switch_loopback_ip
+        giaddr = self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip
+        bootp_packet = self.create_bootp_packet(src_mac=self.uplink_mac, src_ip=source_ip, giaddr=giaddr,
+                                                sport=self.DHCP_SERVER_PORT, hops=2)
+
+        masked_bootp = Mask(bootp_packet)
+        masked_bootp.set_do_not_care_scapy(scapy.Ether, "dst")
+
+        masked_bootp.set_do_not_care_scapy(scapy.IP, "version")
+        masked_bootp.set_do_not_care_scapy(scapy.IP, "ihl")
+        masked_bootp.set_do_not_care_scapy(scapy.IP, "tos")
+        masked_bootp.set_do_not_care_scapy(scapy.IP, "len")
+        masked_bootp.set_do_not_care_scapy(scapy.IP, "id")
+        masked_bootp.set_do_not_care_scapy(scapy.IP, "flags")
+        masked_bootp.set_do_not_care_scapy(scapy.IP, "frag")
+        masked_bootp.set_do_not_care_scapy(scapy.IP, "ttl")
+        masked_bootp.set_do_not_care_scapy(scapy.IP, "proto")
+        masked_bootp.set_do_not_care_scapy(scapy.IP, "chksum")
+        masked_bootp.set_do_not_care_scapy(scapy.IP, "dst")
+        masked_bootp.set_do_not_care_scapy(scapy.IP, "options")
+
+        masked_bootp.set_do_not_care_scapy(scapy.UDP, "chksum")
+        masked_bootp.set_do_not_care_scapy(scapy.UDP, "len")
+
+        masked_bootp.set_do_not_care_scapy(scapy.BOOTP, "hops")
+        masked_bootp.set_do_not_care_scapy(scapy.BOOTP, "sname")
+        masked_bootp.set_do_not_care_scapy(scapy.BOOTP, "file")
+
+        # Count the number of these packets received on the ports connected to upstream
+        num_expected_packets = self.num_dhcp_servers
+        bootp_count = testutils.count_matched_packets_all_ports(
+            self, masked_bootp, self.server_port_indices)
+        self.assertTrue(bootp_count == num_expected_packets,
+                        "Failed: Bootp count of %d != %d" % (bootp_count, num_expected_packets))
+
     def runTest(self):
         # Start sniffer process for each server port to capture DHCP packet
         # and then verify option 82
@@ -797,6 +853,8 @@ class DHCPTest(DataplaneBaseTest):
         self.verify_relayed_request()
         self.server_send_ack()
         self.verify_ack_received()
+        self.client_send_bootp()
+        self.verify_relayed_bootp()
         self.assertTrue(self.verified_option82, "Failed: Verifying option 82")
 
         # Below verification will be done only when client port is set in ptf_runner

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -801,7 +801,10 @@ class DHCPTest(DataplaneBaseTest):
 
     def verify_relayed_bootp(self):
         source_ip = self.relay_iface_ip if self.enable_source_port_ip_in_relay else self.switch_loopback_ip
-        giaddr = self.relay_iface_ip if not self.dual_tor else self.switch_loopback_ip
+        # No need to distinguish single tor or dual tor, because isc-dhcp-relay wouldn't modify option82 and giaddr
+        # if it's bootp packets https://github.com/isc-projects/dhcp/blob/master/relay/dhcrelay.c#L1024
+        # Hence the giaddr in packet should always be vlan ip in both dual tor or singe tor scenario
+        giaddr = self.relay_iface_ip
         bootp_packet = self.create_bootp_packet(src_mac=self.uplink_mac, src_ip=source_ip, giaddr=giaddr,
                                                 sport=self.DHCP_SERVER_PORT, hops=2)
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -182,7 +182,7 @@ def verify_acl_drop_on_standby_tor(rand_unselected_dut, dut_dhcp_relay_data, tes
     if testing_mode == DUAL_TOR_MODE and "dualtor-aa" not in tbinfo["topo"]["name"]:
         for client_interface_name, item in pre_client_dhcp_acl_counts.items():
             after_count = get_acl_count_by_mark(rand_unselected_dut, item["mark"])
-            pytest_assert(after_count == item["count"] + 2, "Drop count of {} {} is unexpected, pre: {}, after: {}"
+            pytest_assert(after_count == item["count"] + 3, "Drop count of {} {} is unexpected, pre: {}, after: {}"
                           .format(client_interface_name, item["mark"], item["count"], after_count))
 
 


### PR DESCRIPTION
…packet

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Add test case to verify https://github.com/sonic-net/sonic-dhcpmon/pull/31
If switch receives bootp packets with vendor specific options rather than DHCP body, dhcpmon shouldn't treat them as DHCP packets and count them.

#### How did you do it?
Send bootp packets with vendor options rather than standard DHCP payload. It shouldn't break log analyzer in dhcp_relay test
![image](https://github.com/user-attachments/assets/98819ff3-470e-442c-8e23-45914a4020cf)

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
