### PR TITLE
Remove unexpected spaces or control characters while passing `INSTANCE_NUMBER` to azure pipeline

### DIFF
--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -76,6 +76,6 @@ steps:
       exit 1
     fi
 
-    echo "$INSTANCE_NUMBER"
-    echo -n "##vso[task.setvariable variable=INSTANCE_NUMBER]$INSTANCE_NUMBER"
+    INSTANCE_NUMBER=$(echo $INSTANCE_NUMBER | tr -d '\r' | tr -d ' ')
+    echo -n "##vso[task.setvariable variable=INSTANCE_NUMBER; isOutput=true]$INSTANCE_NUMBER"
   displayName: "Calculate instance number"

--- a/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
+++ b/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
@@ -125,7 +125,7 @@ def main(scripts, topology, branch, prepare_time):
     # As we need some time to prepare testbeds, the prepare time should be subtracted.
     # Obtain the number of instances by rounding up the calculation.
     # To prevent unexpected situations, we set the maximum number of instance
-    print(min(math.ceil(total_running_time / 60 / (120 - prepare_time)), MAX_INSTANCE_NUMBER))
+    print(int(min(math.ceil(total_running_time / 60 / (120 - prepare_time)), MAX_INSTANCE_NUMBER)))
 
 
 if __name__ == '__main__':

--- a/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
+++ b/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
@@ -64,6 +64,13 @@ def get_access_token():
         raise Exception(f"Failed to get token after {MAX_GET_TOKEN_RETRY_TIMES} attempts")
 
 
+def covert_to_int(value):
+    try:
+        return int(value)
+    except ValueError:
+        raise Exception("Instance number is illegal")
+
+
 def main(scripts, topology, branch, prepare_time):
     ingest_cluster = os.getenv("TEST_REPORT_QUERY_KUSTO_CLUSTER_BACKUP")
     access_token = get_access_token()
@@ -125,7 +132,7 @@ def main(scripts, topology, branch, prepare_time):
     # As we need some time to prepare testbeds, the prepare time should be subtracted.
     # Obtain the number of instances by rounding up the calculation.
     # To prevent unexpected situations, we set the maximum number of instance
-    print(int(min(math.ceil(total_running_time / 60 / (120 - prepare_time)), MAX_INSTANCE_NUMBER)))
+    print(covert_to_int(min(math.ceil(total_running_time / 60 / (120 - prepare_time)), MAX_INSTANCE_NUMBER)))
 
 
 if __name__ == '__main__':

--- a/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
+++ b/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
@@ -64,13 +64,6 @@ def get_access_token():
         raise Exception(f"Failed to get token after {MAX_GET_TOKEN_RETRY_TIMES} attempts")
 
 
-def covert_to_int(value):
-    try:
-        return int(value)
-    except ValueError:
-        raise Exception("Instance number is illegal")
-
-
 def main(scripts, topology, branch, prepare_time):
     ingest_cluster = os.getenv("TEST_REPORT_QUERY_KUSTO_CLUSTER_BACKUP")
     access_token = get_access_token()
@@ -132,7 +125,7 @@ def main(scripts, topology, branch, prepare_time):
     # As we need some time to prepare testbeds, the prepare time should be subtracted.
     # Obtain the number of instances by rounding up the calculation.
     # To prevent unexpected situations, we set the maximum number of instance
-    print(covert_to_int(min(math.ceil(total_running_time / 60 / (120 - prepare_time)), MAX_INSTANCE_NUMBER)))
+    print(min(math.ceil(total_running_time / 60 / (120 - prepare_time)), MAX_INSTANCE_NUMBER))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We occasionally encounter the error `test_plan.py create: error: argument --min-worker: invalid int value: '25+'` in the `Trigger Test` stage. 

It appears that the instance number is calculated correctly in the `Calculate instance number` step, suggesting that the issue likely occurs when transferring this variable within Azure Pipelines. We suspect that Azure Pipelines may misinterpret the value due to the presence of unexpected spaces or control characters.
```
echo "$INSTANCE_NUMBER"
echo -n "##vso[task.setvariable variable=INSTANCE_NUMBER]$INSTANCE_NUMBER"
```
<img width="1219" alt="image" src="https://github.com/user-attachments/assets/be439687-0026-4364-8050-fcc7c4794208" />

So in this PR, we try to resolve the above issue by removing such character. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
We occasionally encounter the error `test_plan.py create: error: argument --min-worker: invalid int value: '25+'` in the `Trigger Test` stage. 

It appears that the instance number is calculated correctly in the `Calculate instance number` step, suggesting that the issue likely occurs when transferring this variable within Azure Pipelines. We suspect that Azure Pipelines may misinterpret the value due to the presence of unexpected spaces or control characters.
```
echo "$INSTANCE_NUMBER"
echo -n "##vso[task.setvariable variable=INSTANCE_NUMBER]$INSTANCE_NUMBER"
```
<img width="1219" alt="image" src="https://github.com/user-attachments/assets/be439687-0026-4364-8050-fcc7c4794208" />

So in this PR, we try to resolve the above issue by removing unexpected spaces or control characters. 

#### How did you do it?
We try to resolve the above issue by removing such character. 

#### How did you verify/test it?
This issue occurs occasionally, not consistently. So after merging into master, we will observe the runtime behavior. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
