### PR TITLE
Modifying test_dynamic_acl.py to clear tcam space before adding new acl

### DIFF
--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -78,6 +78,7 @@ DST_IPV6_BLOCKED = "103:23:3:1::1"
 
 MAX_IP_RULE_PRIORITY = 800
 MAX_DROP_RULE_PRIORITY = 200
+MAX_ACL_RULE_SCALE = 45
 
 # DHCP Constants
 
@@ -113,6 +114,43 @@ dhcp6opts = {79: "OPTION_CLIENT_LINKLAYER_ADDR",  # RFC6939
 
 class _LLAddrField(MACField):
     pass
+
+
+@pytest.fixture(scope="module", autouse=True)
+def remove_dataacl_table(duthosts, rand_selected_dut):
+    """
+    Remove DATAACL to free TCAM resources.
+    The change is written to configdb as we don't want DATAACL recovered after reboot
+    """
+    TABLE_NAME_1 = "DATAACL"
+    for duthost in duthosts:
+        lines = duthost.shell(cmd="show acl table {}".format(TABLE_NAME_1))['stdout_lines']
+        data_acl_existing = False
+        for line in lines:
+            if TABLE_NAME_1 in line:
+                data_acl_existing = True
+                break
+
+        if data_acl_existing:
+            # Remove DATAACL
+            logger.info("Removing ACL table {}".format(TABLE_NAME_1))
+            rand_selected_dut.shell(cmd="config acl remove table {}".format(TABLE_NAME_1))
+
+    if not data_acl_existing:
+        yield
+        return
+
+    yield
+    # Recover DATAACL
+    config_db_json = "/etc/sonic/config_db.json"
+    output = rand_selected_dut.shell("sonic-cfggen -j {} --var-json \"ACL_TABLE\"".format(config_db_json))['stdout']
+    entry_json = json.loads(output)
+    if TABLE_NAME_1 in entry_json:
+        entry = entry_json[TABLE_NAME_1]
+        cmd_create_table = "config acl add table {} {} -p {} -s {}"\
+            .format(TABLE_NAME_1, entry['type'], ",".join(entry['ports']), entry['stage'])
+        logger.info("Restoring ACL table {}".format(TABLE_NAME_1))
+        rand_selected_dut.shell(cmd_create_table)
 
 
 class DHCP6OptClientLinkLayerAddr(_DHCP6OptGuessPayload):  # RFC6939
@@ -223,7 +261,7 @@ def setup(rand_selected_dut, rand_unselected_dut, tbinfo, vlan_name, topo_scenar
 
     # Generate destination IP's for scale test
     scale_dest_ips = {}
-    for i in range(1, 75):
+    for i in range(1, MAX_ACL_RULE_SCALE+1):
         ipv4_rule_name = "FORWARD_RULE_" + str(i)
         ipv6_rule_name = "V6_FORWARD_RULE_" + str(i)
         ipv4_address = DST_IP_FORWARDED_SCALE_PREFIX + str(i)

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -126,7 +126,6 @@ rules_per_hwsku = {
 def remove_dataacl_table(duthosts, rand_selected_dut):
     """
     Remove DATAACL to free TCAM resources.
-    The change is written to configdb as we don't want DATAACL recovered after reboot
     """
     TABLE_NAME_1 = "DATAACL"
     for duthost in duthosts:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Modifying test_dynamic_acl.py to clear tcam space before adding new acl

As sonic not supporting ACL table size(number of acl entries per table) to configure, chip may configure some minimum default size to save tcam space. Current scale configuration of 75 IPv4 + 75 I Pv6 + DROP ACL RULE may not fit for all platform and hence reducing the total size to 45 IPv4 + 45 IPv6 + DROP ACL RULE”.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
