### PR TITLE
Skip memory checker test due to issue#19295 for now on SN4280 only

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1476,6 +1476,16 @@ mclag/test_mclag_l3.py:
       - "asic_type in ['vs']"
 
 #######################################
+#####       memory_checker        #####
+#######################################
+memory_checker/test_memory_checker.py:
+  skip:
+    reason: "Testcase ignored due to GitHub issue: https://github.com/sonic-net/sonic-buildimage/issues/19295"
+    conditions:
+      - https://github.com/sonic-net/sonic-buildimage/issues/19295
+      - "'sn4280' in platform"
+
+#######################################
 #####            mpls             #####
 #######################################
 mpls/test_mpls.py:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Test memory_checker/test_memory_checker.py fails on smartswitch due to issue https://github.com/sonic-net/sonic-buildimage/issues/19295.
It fails to parse the monit output because of the error in it:
```
memory_checker_dut_and_container = (<MultiAsicSonicHost mtvr-sn4280-03>, <test_memory_checker.MemoryCheckerContainer object at 0x7ffaddca3bb0>)
test_setup_and_cleanup = None

    @pytest.mark.parametrize("test_setup_and_cleanup", [(1, 0, None)], indirect=True, ids=[''])
    def test_memory_checker(memory_checker_dut_and_container, test_setup_and_cleanup):
        """Checks whether the container can be restarted or not if the memory
        usage of it is beyond its threshold for specfic times within a sliding window.
        A command is used to generate memory allocations beyond the limits.
    
        Args:
            memory_checker_dut_and_container: Fixture providing a duthost and container to test
            test_setup_and_cleanup: Fixture setting up the test environment
    
        Returns:
            None.
        """
        duthost, container = memory_checker_dut_and_container
>       container.wait_ready()

container  = <test_memory_checker.MemoryCheckerContainer object at 0x7ffaddca3bb0>
duthost    = <MultiAsicSonicHost mtvr-sn4280-03>
memory_checker_dut_and_container = (<MultiAsicSonicHost mtvr-sn4280-03>, <test_memory_checker.MemoryCheckerContainer object at 0x7ffaddca3bb0>)
test_setup_and_cleanup = None

memory_checker/test_memory_checker.py:623: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
memory_checker/test_memory_checker.py:526: in wait_ready
    self.wait_monit_mem_ok()
        self       = <test_memory_checker.MemoryCheckerContainer object at 0x7ffaddca3bb0>
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <test_memory_checker.MemoryCheckerContainer object at 0x7ffaddca3bb0>
timeout = 700

    def wait_monit_mem_ok(self, timeout=MONIT_MEMORY_CHECK_TIMEOUT):
        logger.info("Waiting for monit status ok for %s", self.name)
        res = wait_until(timeout, 1, 0, self.is_monit_mem_ok)
>       pytest_assert(res, "Failed to wait for one monit cycle to be ok for {}".format(self.name))
E       Failed: Failed to wait for one monit cycle to be ok for gnmi

res        = False
self       = <test_memory_checker.MemoryCheckerContainer object at 0x7ffaddca3bb0>
timeout    = 700

memory_checker/test_memory_checker.py:505: Failed
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
Only for smartswitch platform.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
